### PR TITLE
feat(subscriptions): add subscription center with unified billing management

### DIFF
--- a/.specs/subscription-center.md
+++ b/.specs/subscription-center.md
@@ -1,0 +1,414 @@
+# Subscription Center
+
+## Role of This Document
+
+This spec defines the business rules and invariants for the
+Subscription Center. It is the source of truth for _what_ the system
+must guarantee — valid states, ownership boundaries, correctness
+properties, and user-facing behavior. It deliberately does not
+prescribe _how_ to implement those guarantees: handler names, column
+layouts, conflict-resolution strategies, and other implementation
+choices belong in plan documents and code, not here.
+
+## Status
+
+Draft -- created 2026-03-31.
+
+## Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+"OPTIONAL" in this document are to be interpreted as described in
+BCP 14 [RFC 2119] [RFC 8174] when, and only when, they appear in all
+capitals, as shown here.
+
+## Definitions
+
+- **Subscription Center**: A unified page where users view and manage
+  all of their subscriptions in one place. It exists at both a personal
+  and organizational level.
+- **Subscription Group**: A category of subscriptions displayed as a
+  visual section on the page. Current groups are Kilo Pass, KiloClaw,
+  Coding Plans, and Teams/Enterprise Seats.
+- **Subscription Card**: A summary element within a group that
+  represents a single subscription instance and its current state.
+- **Available Product Card**: A card shown within a subscription group
+  when the user has no non-terminal subscription of that type,
+  presenting a call-to-action to subscribe.
+- **Detail Page**: A dedicated sub-page for a single subscription
+  instance, providing full management capabilities and billing history.
+- **Billing Admin**: An organization member with the `billing_manager`
+  role. Throughout this spec, "billing admin" refers to this role.
+- **Terminal state**: A subscription status that indicates the
+  subscription is definitively over and cannot be recovered without
+  creating a new subscription. Terminal statuses are: Kilo Pass —
+  `canceled`, `incomplete_expired`; KiloClaw — `canceled`; Coding
+  Plans — `canceled`; Teams/Enterprise — `ended`.
+- **Non-terminal state**: Any subscription status that is not a
+  terminal state. This includes active, trialing, past-due, unpaid,
+  incomplete, paused, and suspended states. A subscription in a
+  non-terminal state still represents an ongoing relationship between
+  the user and the product.
+- **Warning state**: A subscription requires attention when any of
+  the following is true: (a) its status is past-due, unpaid, or
+  suspended; (b) it is marked for cancellation at the end of the
+  current period; (c) it is trialing and the trial end date is
+  approaching. The exact threshold for "approaching" is an
+  implementation choice that MAY vary by subscription type.
+- **Price**: All prices are denominated in USD and MUST be displayed
+  with a dollar sign and two decimal places (e.g. "$9.99/mo").
+
+## Overview
+
+The Subscription Center is a centralized page where users can see
+every subscription they hold, grouped by product type: Kilo Pass,
+KiloClaw, Coding Plans, and Teams/Enterprise Seats. Each group contains individual
+subscription cards showing status, plan, pricing, and billing date at
+a glance. Clicking a subscription card navigates to a detail page with
+full management capabilities including plan changes, cancellation,
+usage history, and invoice viewing.
+
+The personal Subscription Center lives at `/subscriptions` and is
+accessible from the sidebar. Organization subscriptions live at
+`/organizations/[id]/subscriptions` and are restricted to billing
+admins and org owners. The two routes are independent — the personal
+page shows only individually-owned subscriptions; the org page shows
+only org-owned subscriptions.
+
+Subscription management UI may continue to appear in other parts of
+the app (e.g. Kilo Pass cards on the profile page, billing controls
+within the KiloClaw dashboard). The Subscription Center does not
+replace those surfaces but serves as the canonical hub where all
+subscriptions are consolidated.
+
+These routes form a stable URL contract. If any path changes in the
+future, the system MUST redirect from the old path to the new one.
+
+## Rules
+
+### Routes and Navigation
+
+1. The system MUST serve the personal Subscription Center at the route
+   `/subscriptions`.
+
+2. The system MUST serve the organization Subscription Center at the
+   route `/organizations/[id]/subscriptions`.
+
+3. The personal Subscription Center MUST appear as the topmost item
+   under the "Account" section in the application sidebar.
+
+4. The `/subscriptions` route MUST require authentication. Unauthenticated
+   users MUST be redirected to the sign-in flow.
+
+5. The `/organizations/[id]/subscriptions` route MUST require that the
+   current user is the org owner or a billing admin of that
+   organization. Users without sufficient permissions MUST NOT see the
+   route in navigation and MUST receive an authorization error if they
+   access the route directly.
+
+### Subscription Groups
+
+6. The page MUST display subscriptions organized into groups by product
+   type. The initial groups are:
+   - **Kilo Pass** (personal route only)
+   - **KiloClaw** (personal route only)
+   - **Coding Plans** (personal route only)
+   - **Teams/Enterprise Seats** (org route only)
+
+7. A group MUST always appear on its respective route regardless of
+   whether the user has a subscription of that type.
+
+8. When a group contains no subscriptions in a non-terminal state, the
+   system MUST display an Available Product Card with a call-to-action
+   to subscribe.
+
+9. When a group contains one or more subscriptions in a non-terminal
+   state, the system MUST display a Subscription Card for each
+   non-terminal subscription.
+
+10. Subscriptions in a terminal state (Kilo Pass: `canceled`,
+    `incomplete_expired`; KiloClaw: `canceled`; Coding Plans:
+    `canceled`; Teams/Enterprise: `ended`) MUST be hidden by default.
+    The page MUST provide a single page-level toggle that reveals or
+    hides all terminal subscriptions across all groups simultaneously.
+
+11. When revealed, terminal subscription cards MUST use a visually
+    muted treatment — reduced opacity or desaturated color — and MUST
+    display a status label indicating the terminal state (e.g.
+    "Cancelled", "Ended").
+
+### Subscription Cards
+
+12. Each Subscription Card MUST display at minimum:
+    - Subscription status (e.g. active, trialing, past_due, cancelled)
+    - Plan or tier name
+    - Next billing date (or end date for terminal subscriptions)
+    - Price per billing period
+    - Payment method summary (e.g. "Visa ending 4242" or "Credits")
+
+13. Cards for subscriptions in a warning state MUST use a colored left
+    border or background tint that differs from the default card style,
+    using the application's existing warning/destructive color tokens.
+    The system MUST NOT use badges or notification indicators in the
+    navigation.
+
+14. Each Subscription Card MUST be clickable and navigate to that
+    subscription's detail page, regardless of subscription status.
+
+15. Each subscription group MUST load independently. A failure or delay
+    in loading one group MUST NOT prevent other groups from rendering.
+
+16. While a group's data is loading, the system MUST display a
+    placeholder skeleton for that group's cards.
+
+### Kilo Pass Subscriptions (Personal Route)
+
+17. The Kilo Pass group displays either one Subscription Card (when the
+    user has a Kilo Pass subscription) or one Available Product Card
+    (when they do not). The at-most-one constraint is enforced by the
+    Kilo Pass billing system, not by the Subscription Center.
+
+18. The Kilo Pass detail page MUST be served at
+    `/subscriptions/kilo-pass`.
+
+19. The Kilo Pass detail page MUST support the following management
+    actions:
+    - Change subscription tier
+    - Change billing cadence (monthly / yearly)
+    - Cancel subscription
+    - Resume a subscription pending cancellation
+    - View scheduled changes and cancel a pending scheduled change
+
+20. The Kilo Pass detail page MUST display:
+    - Current tier and cadence
+    - Current billing period and next billing date
+    - Credit issuance history (base, bonus, promo line items)
+    - Bonus credit progression and current streak
+    - Inline billing history for this subscription (see Billing
+      History rules)
+    - Link to the Stripe customer portal for payment method management
+
+### KiloClaw Subscriptions (Personal Route)
+
+21. A user MAY have multiple KiloClaw subscriptions — one per KiloClaw
+    instance. The KiloClaw group MUST display one Subscription Card for
+    each instance that has an associated subscription.
+
+22. KiloClaw instances that have no associated subscription record
+    (e.g. destroyed instances with no billing relationship) MUST NOT
+    appear in the KiloClaw group.
+
+23. KiloClaw instances with a non-null organization identifier MUST NOT
+    appear on the personal `/subscriptions` route. They are managed
+    through the organization's context.
+
+24. KiloClaw instance detail pages MUST be served at
+    `/subscriptions/kiloclaw/[instanceId]`.
+
+25. Each KiloClaw detail page MUST support the following management
+    actions:
+    - View subscription status (active, trialing, past_due, suspended,
+      cancelled)
+    - Switch between hosting plans (standard / commit)
+    - Cancel subscription
+    - Switch payment source (Stripe / credits) where applicable
+
+26. Each KiloClaw detail page MUST display:
+    - Instance identifier and status
+    - Current plan and billing period
+    - Payment source
+    - Trial status and expiration date (if trialing)
+    - Suspension/destruction deadlines (if applicable)
+    - Inline billing history for this instance's subscription (see
+      Billing History rules)
+    - Link to the Stripe customer portal for payment method management
+      (if Stripe-funded)
+
+### Coding Plans Subscriptions (Personal Route)
+
+27. A user MAY have multiple Coding Plans subscriptions — one per
+    upstream provider. The Coding Plans group MUST display one
+    Subscription Card for each active coding plan subscription.
+
+28. The Coding Plans detail page MUST be served at
+    `/subscriptions/coding-plans/[subscriptionId]`.
+
+29. Each Coding Plans detail page MUST support the following management
+    actions:
+    - View subscription status (active, cancelled)
+    - Cancel subscription
+
+30. Each Coding Plans detail page MUST display:
+    - Provider name and status
+    - Billing period and next renewal date
+    - Cost in Kilo Credits per billing period
+    - Payment source (Kilo Credits)
+    - Traffic routing information (Kilo Gateway or direct)
+    - The user's assigned API key with view and copy controls (see
+      Coding Plans spec, rule 4.2.1)
+    - Inline billing history showing credit transactions (see Billing
+      History rules)
+
+31. When a coding plan is cancelled or the user's credit balance is
+    insufficient to renew, the system MUST remove the API key from the
+    user's BYOK configuration within Kilo. The system MUST NOT revoke
+    the key with the upstream provider — the key belongs to the user
+    (see Coding Plans spec, rule 5.1). The cancel confirmation dialog
+    MUST communicate this to the user.
+
+32. When a group contains no active coding plans, the system MUST
+    display the available provider catalog inline as Available Product
+    Cards — one per upstream provider — showing the provider name,
+    recurring cost in Kilo Credits, and billing period. Each card MUST
+    have a subscribe action that initiates subscription creation.
+
+### Teams/Enterprise Seats Subscriptions (Org Route)
+
+33. The organization Subscription Center MUST display the
+    Teams/Enterprise Seats group.
+
+34. An organization has at most one active or pending-cancel seats
+    purchase at a time. The Teams/Enterprise Seats detail page MUST
+    display the most recent non-ended purchase. Past ended records are
+    visible only through billing history.
+
+35. The Teams/Enterprise Seats detail page MUST be served at
+    `/organizations/[id]/subscriptions/seats`.
+
+36. The Teams/Enterprise Seats detail page MUST support the following
+    management actions:
+    - View current plan (teams / enterprise) and seat count
+    - Change seat count
+    - Change billing cycle (monthly / yearly)
+    - Cancel subscription
+    - Resume a subscription pending cancellation
+
+37. The Teams/Enterprise Seats detail page MUST display:
+    - Current plan and billing cycle
+    - Seat count and seat utilization
+    - Price per billing period
+    - Next billing date
+    - Inline billing history for this subscription (see Billing
+      History rules)
+    - Link to the Stripe customer portal for payment method management
+
+### Authorization
+
+38. The personal `/subscriptions` route and its sub-pages MUST only
+    display subscriptions owned by the authenticated user.
+
+39. A user MUST NOT be able to view or manage another user's personal
+    subscriptions.
+
+40. The organization `/organizations/[id]/subscriptions` route MUST
+    only be accessible to the organization owner or a billing admin.
+
+41. Organization members who are not owners or billing admins MUST NOT
+    see the organization Subscription Center in navigation and MUST
+    receive a 403 error if accessing the route directly.
+
+### Available Product Cards
+
+42. An Available Product Card MUST communicate what the product is and
+    provide a clear call-to-action to start a subscription.
+
+43. Clicking the call-to-action on an Available Product Card MUST
+    initiate the appropriate subscription checkout flow for that
+    product type.
+
+44. Until a checkout flow results in a confirmed subscription, the
+    group's displayed state MUST NOT change. An abandoned or failed
+    checkout MUST NOT alter what the page displays.
+
+45. When the user has no subscriptions of any type, the personal
+    Subscription Center MUST display Available Product Cards for every
+    group — it MUST NOT show an empty page.
+
+### Billing History
+
+46. Each subscription detail page MUST display an inline billing
+    history section.
+
+47. For subscriptions with Stripe-funded billing, the billing history
+    MUST display invoices from Stripe: invoice date, amount, payment
+    status, and a link to view or download the invoice.
+
+48. For subscriptions funded entirely by credits (no Stripe billing),
+    the billing history MUST display credit transaction history in
+    place of invoices — showing date, amount, and description for each
+    credit deduction.
+
+49. The billing history MUST be scoped to the individual subscription
+    being viewed — the system MUST NOT display entries from other
+    subscriptions.
+
+50. The billing history MUST be ordered by date descending (newest
+    first). When there are more than 25 entries, the system MUST
+    paginate or provide a "show more" mechanism.
+
+### Payment Method Management
+
+51. The system MUST provide a link to the Stripe customer portal from
+    each subscription detail page that has Stripe-funded billing.
+
+52. The user MUST manage payment methods through Stripe's hosted
+    customer portal. The system MUST NOT build native payment method
+    management UI.
+
+### Responsiveness
+
+53. The Subscription Center MUST be fully functional on mobile
+    viewports. Subscription Cards MUST stack vertically on narrow
+    screens.
+
+54. All management actions on detail pages MUST be accessible and
+    usable on mobile viewports.
+
+## Error Handling
+
+1. When subscription data fails to load for a group, the system MUST
+   display an error state within that group with a retry action. Other
+   groups MUST continue to function normally.
+
+2. When a management action fails (e.g. cancellation, plan change),
+   the system MUST display an error message describing the failure and
+   MUST NOT leave the subscription in an inconsistent visual state.
+
+3. When an unauthorized user attempts to access an organization
+   Subscription Center, the system MUST return an authorization error
+   and MUST NOT reveal any subscription data.
+
+4. When a user navigates to a subscription detail page for a
+   subscription that does not exist or that they do not own, the
+   system MUST display a not-found error.
+
+5. When the Stripe customer portal link cannot be generated, the
+   system MUST display an error message and MUST NOT silently fail.
+
+## Not Yet Implemented
+
+The following rules use SHOULD and reflect intended behavior that is
+not yet enforced in the current codebase:
+
+1. The system SHOULD support additional subscription types beyond the
+   initial four. The group-based layout SHOULD accommodate new product
+   types without structural changes to the page.
+
+2. The system SHOULD support multiple KiloClaw instances per user,
+   each with independent billing. (Currently the schema supports this
+   but the UI has not been built.)
+
+3. The system SHOULD surface upcoming renewals or billing events on
+   the landing page (e.g. "renews in 3 days") to help users
+   anticipate charges.
+
+4. The system SHOULD allow org members (non-billing-admins) to view a
+   read-only version of the organization Subscription Center showing
+   the current plan and seat count without management actions.
+
+## Changelog
+
+### 2026-03-31 -- Initial spec
+
+- Created from codebase analysis of existing Kilo Pass, KiloClaw,
+  Coding Plans, and Teams/Enterprise Seats subscription systems.

--- a/kiloclaw/scripts/dev-start.sh
+++ b/kiloclaw/scripts/dev-start.sh
@@ -182,6 +182,48 @@ if [ ! -f "$KILOCLAW_DIR/.dev.vars" ]; then
   cp "$KILOCLAW_DIR/.dev.vars.example" "$KILOCLAW_DIR/.dev.vars"
 fi
 
+DEV_VARS_FILE="$KILOCLAW_DIR/.dev.vars"
+DEV_VARS_TEMPLATE="$KILOCLAW_DIR/.dev.vars.example"
+
+set_dev_var() {
+  local key="$1"
+  local value="$2"
+
+  if grep -q "^${key}=" "$DEV_VARS_FILE"; then
+    sed "s|^${key}=.*|${key}=${value}|" "$DEV_VARS_FILE" > "$DEV_VARS_FILE.tmp"
+    mv "$DEV_VARS_FILE.tmp" "$DEV_VARS_FILE"
+  else
+    printf '%s=%s\n' "$key" "$value" >> "$DEV_VARS_FILE"
+  fi
+}
+
+backfill_dev_vars_from_example() {
+  local added=0
+  local key
+  local line
+
+  [ -f "$DEV_VARS_TEMPLATE" ] || return
+
+  while IFS= read -r line; do
+    case "$line" in
+      ''|'#'*) continue ;;
+      *=*)
+        key="${line%%=*}"
+        if ! grep -q "^${key}=" "$DEV_VARS_FILE"; then
+          if [ "$added" -eq 0 ]; then
+            echo "==> Backfilling missing .dev.vars defaults from .dev.vars.example..."
+          fi
+          printf '%s\n' "$line" >> "$DEV_VARS_FILE"
+          echo "    Added $key"
+          added=$((added + 1))
+        fi
+        ;;
+    esac
+  done < "$DEV_VARS_TEMPLATE"
+}
+
+backfill_dev_vars_from_example
+
 # ---------- Link & pull dev environment from Vercel ----------
 
 if [ ! -d "$MONOREPO_ROOT/.vercel" ] || [ ! -f "$MONOREPO_ROOT/.vercel/project.json" ]; then
@@ -432,6 +474,14 @@ compute_image_hash() {
 CURRENT_IMAGE_HASH="$(compute_image_hash)"
 STORED_IMAGE_HASH="$(grep '^FLY_IMAGE_CONTENT_HASH=' "$KILOCLAW_DIR/.dev.vars" \
   | head -1 | sed 's/^[^=]*=//' | sed 's/^"//;s/"$//' || true)"
+
+if [ -z "$STORED_IMAGE_HASH" ]; then
+  echo "==> No FLY_IMAGE_CONTENT_HASH found in .dev.vars."
+  echo "    Seeding current hash to avoid an accidental image push."
+  echo "    Pass --has-controller-changes or run ./scripts/push-dev.sh to force a rebuild."
+  set_dev_var FLY_IMAGE_CONTENT_HASH "$CURRENT_IMAGE_HASH"
+  STORED_IMAGE_HASH="$CURRENT_IMAGE_HASH"
+fi
 
 if [ "$CURRENT_IMAGE_HASH" != "$STORED_IMAGE_HASH" ]; then
   if [ "$HAS_CONTROLLER_CHANGES" = false ]; then

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -90,6 +90,11 @@ const nextConfig = {
         destination: '/get-started',
         permanent: true,
       },
+      {
+        source: '/organizations/:id/subscription',
+        destination: '/organizations/:id/subscriptions',
+        permanent: true,
+      },
     ];
   },
 

--- a/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
+++ b/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
@@ -19,6 +19,8 @@ import {
   STANDARD_FIRST_MONTH_MICRODOLLARS,
   type ClawPlan,
 } from './billing-types';
+import { KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF } from '@/lib/kilo-pass/constants';
+import { dayjs } from '@/lib/kilo-pass/dayjs';
 
 type Cadence = 'monthly' | 'yearly';
 type Tier = '19' | '49' | '199';
@@ -295,6 +297,7 @@ function HostingOnlyPlanCard({
 
 function CreditsHowItWorks() {
   const [open, setOpen] = useState(false);
+  const showTwoMonthPromo = dayjs().utc().isBefore(KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF);
 
   return (
     <div className="border-border/50 mb-3.5 overflow-hidden rounded-lg border">
@@ -321,13 +324,15 @@ function CreditsHowItWorks() {
               expire monthly.
             </span>
           </div>
-          <div className="text-muted-foreground flex items-start gap-2 py-0.5 text-xs">
-            <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-400" />
-            <span>
-              First-time subscribers receive <span className="text-emerald-300">50%</span> free
-              bonus credits for the first two months.
-            </span>
-          </div>
+          {showTwoMonthPromo ? (
+            <div className="text-muted-foreground flex items-start gap-2 py-0.5 text-xs">
+              <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-400" />
+              <span>
+                First-time subscribers receive <span className="text-emerald-300">50%</span>{' '}
+                free bonus credits for the first two months.
+              </span>
+            </div>
+          ) : null}
         </div>
       )}
     </div>

--- a/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
+++ b/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
@@ -328,8 +328,8 @@ function CreditsHowItWorks() {
             <div className="text-muted-foreground flex items-start gap-2 py-0.5 text-xs">
               <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-400" />
               <span>
-                First-time subscribers receive <span className="text-emerald-300">50%</span>{' '}
-                free bonus credits for the first two months.
+                First-time subscribers receive <span className="text-emerald-300">50%</span> free
+                bonus credits for the first two months.
               </span>
             </div>
           ) : null}

--- a/src/app/(app)/claw/components/billing/WelcomePage.tsx
+++ b/src/app/(app)/claw/components/billing/WelcomePage.tsx
@@ -18,6 +18,8 @@ import {
   STANDARD_FIRST_MONTH_MICRODOLLARS,
   type ClawPlan,
 } from './billing-types';
+import { KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF } from '@/lib/kilo-pass/constants';
+import { dayjs } from '@/lib/kilo-pass/dayjs';
 
 type Cadence = 'monthly' | 'yearly';
 type Tier = '19' | '49' | '199';
@@ -288,6 +290,7 @@ function HostingOnlyPlanCard({
 
 function CreditsHowItWorks() {
   const [open, setOpen] = useState(false);
+  const showTwoMonthPromo = dayjs().utc().isBefore(KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF);
 
   return (
     <div className="border-border/50 mb-3.5 overflow-hidden rounded-lg border">
@@ -314,13 +317,15 @@ function CreditsHowItWorks() {
               expire monthly.
             </span>
           </div>
-          <div className="text-muted-foreground flex items-start gap-2 py-0.5 text-xs">
-            <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-400" />
-            <span>
-              First-time subscribers receive <span className="text-emerald-300">50%</span> free
-              bonus credits for the first two months.
-            </span>
-          </div>
+          {showTwoMonthPromo ? (
+            <div className="text-muted-foreground flex items-start gap-2 py-0.5 text-xs">
+              <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-400" />
+              <span>
+                First-time subscribers receive <span className="text-emerald-300">50%</span>{' '}
+                free bonus credits for the first two months.
+              </span>
+            </div>
+          ) : null}
         </div>
       )}
     </div>

--- a/src/app/(app)/claw/components/billing/WelcomePage.tsx
+++ b/src/app/(app)/claw/components/billing/WelcomePage.tsx
@@ -321,8 +321,8 @@ function CreditsHowItWorks() {
             <div className="text-muted-foreground flex items-start gap-2 py-0.5 text-xs">
               <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-400" />
               <span>
-                First-time subscribers receive <span className="text-emerald-300">50%</span>{' '}
-                free bonus credits for the first two months.
+                First-time subscribers receive <span className="text-emerald-300">50%</span> free
+                bonus credits for the first two months.
               </span>
             </div>
           ) : null}

--- a/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -224,6 +224,15 @@ export default function OrganizationAppSidebar({
     url: string;
     className?: string;
   }> = [
+    ...(hasOwnerLevelAccess
+      ? [
+          {
+            title: 'Subscriptions',
+            icon: Users,
+            url: `/organizations/${organizationId}/subscriptions`,
+          },
+        ]
+      : []),
     ...(ENABLE_DEPLOY_FEATURE
       ? [
           {
@@ -258,11 +267,6 @@ export default function OrganizationAppSidebar({
       : []),
     ...(hasOwnerLevelAccess
       ? [
-          {
-            title: 'Subscriptions',
-            icon: Users,
-            url: `/organizations/${organizationId}/subscriptions`,
-          },
           {
             title: 'Invoices',
             icon: CreditCard,

--- a/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -259,9 +259,9 @@ export default function OrganizationAppSidebar({
     ...(hasOwnerLevelAccess
       ? [
           {
-            title: 'Subscription',
+            title: 'Subscriptions',
             icon: Users,
-            url: `/organizations/${organizationId}/subscription`,
+            url: `/organizations/${organizationId}/subscriptions`,
           },
           {
             title: 'Invoices',
@@ -277,10 +277,7 @@ export default function OrganizationAppSidebar({
       : []),
   ];
 
-  const allUrls = useMemo(
-    () => [...dashboardItems, ...kiloClawItems, ...cloudItems, ...accountItems].map(i => i.url),
-    [dashboardItems, kiloClawItems, cloudItems, accountItems]
-  );
+  const allUrls = [...dashboardItems, ...kiloClawItems, ...cloudItems, ...accountItems].map(item => item.url);
 
   // Determine if we should show the OrganizationSwitcher
   // Hide it when an admin user is viewing an organization they're not a member of

--- a/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -281,7 +281,9 @@ export default function OrganizationAppSidebar({
       : []),
   ];
 
-  const allUrls = [...dashboardItems, ...kiloClawItems, ...cloudItems, ...accountItems].map(item => item.url);
+  const allUrls = [...dashboardItems, ...kiloClawItems, ...cloudItems, ...accountItems].map(
+    item => item.url
+  );
 
   // Determine if we should show the OrganizationSwitcher
   // Hide it when an admin user is viewing an organization they're not a member of

--- a/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -169,6 +169,11 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
     url: string;
     className?: string;
   }> = [
+    {
+      title: 'Subscriptions',
+      icon: CreditCard,
+      url: '/subscriptions',
+    },
     ...(ENABLE_DEPLOY_FEATURE
       ? [
           {
@@ -178,11 +183,6 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
           },
         ]
       : []),
-    {
-      title: 'Subscriptions',
-      icon: CreditCard,
-      url: '/subscriptions',
-    },
     {
       title: 'Invoices',
       icon: Receipt,

--- a/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -2,6 +2,7 @@
 
 import { Sidebar, SidebarContent, SidebarHeader } from '@/components/ui/sidebar';
 import { useUser } from '@/hooks/useUser';
+import { useMemo } from 'react';
 import {
   Code,
   Coins,
@@ -25,8 +26,8 @@ import {
   Webhook,
   Factory,
   Settings,
+  CreditCard,
 } from 'lucide-react';
-import { useMemo } from 'react';
 import HeaderLogo from '@/components/HeaderLogo';
 import OrganizationSwitcher from './OrganizationSwitcher';
 import SidebarMenuList from './SidebarMenuList';
@@ -177,6 +178,11 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
           },
         ]
       : []),
+    {
+      title: 'Subscriptions',
+      icon: CreditCard,
+      url: '/subscriptions',
+    },
     {
       title: 'Invoices',
       icon: Receipt,

--- a/src/app/(app)/organizations/[id]/subscriptions/page.tsx
+++ b/src/app/(app)/organizations/[id]/subscriptions/page.tsx
@@ -1,0 +1,16 @@
+import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import { OrgSubscriptions } from '@/components/subscriptions/OrgSubscriptions';
+
+export default async function OrganizationSubscriptionsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  return (
+    <OrganizationByPageLayout
+      params={params}
+      roles={['owner', 'billing_manager']}
+      render={({ organization }) => <OrgSubscriptions organizationId={organization.id} />}
+    />
+  );
+}

--- a/src/app/(app)/organizations/[id]/subscriptions/seats/page.tsx
+++ b/src/app/(app)/organizations/[id]/subscriptions/seats/page.tsx
@@ -1,0 +1,16 @@
+import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import { SeatsDetail } from '@/components/subscriptions/seats/SeatsDetail';
+
+export default async function OrganizationSeatsSubscriptionPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  return (
+    <OrganizationByPageLayout
+      params={params}
+      roles={['owner', 'billing_manager']}
+      render={({ organization }) => <SeatsDetail organizationId={organization.id} />}
+    />
+  );
+}

--- a/src/app/(app)/subscriptions/coding-plans/[subscriptionId]/page.tsx
+++ b/src/app/(app)/subscriptions/coding-plans/[subscriptionId]/page.tsx
@@ -1,5 +1,10 @@
+import { PageContainer } from '@/components/layouts/PageContainer';
 import { CodingPlanDetail } from '@/components/subscriptions/coding-plans/CodingPlanDetail';
 
 export default function CodingPlanSubscriptionPage() {
-  return <CodingPlanDetail />;
+  return (
+    <PageContainer>
+      <CodingPlanDetail />
+    </PageContainer>
+  );
 }

--- a/src/app/(app)/subscriptions/coding-plans/[subscriptionId]/page.tsx
+++ b/src/app/(app)/subscriptions/coding-plans/[subscriptionId]/page.tsx
@@ -1,0 +1,5 @@
+import { CodingPlanDetail } from '@/components/subscriptions/coding-plans/CodingPlanDetail';
+
+export default function CodingPlanSubscriptionPage() {
+  return <CodingPlanDetail />;
+}

--- a/src/app/(app)/subscriptions/kilo-pass/page.tsx
+++ b/src/app/(app)/subscriptions/kilo-pass/page.tsx
@@ -1,5 +1,10 @@
+import { PageContainer } from '@/components/layouts/PageContainer';
 import { KiloPassDetail } from '@/components/subscriptions/kilo-pass/KiloPassDetail';
 
 export default function KiloPassSubscriptionPage() {
-  return <KiloPassDetail />;
+  return (
+    <PageContainer>
+      <KiloPassDetail />
+    </PageContainer>
+  );
 }

--- a/src/app/(app)/subscriptions/kilo-pass/page.tsx
+++ b/src/app/(app)/subscriptions/kilo-pass/page.tsx
@@ -1,0 +1,5 @@
+import { KiloPassDetail } from '@/components/subscriptions/kilo-pass/KiloPassDetail';
+
+export default function KiloPassSubscriptionPage() {
+  return <KiloPassDetail />;
+}

--- a/src/app/(app)/subscriptions/kiloclaw/[instanceId]/page.tsx
+++ b/src/app/(app)/subscriptions/kiloclaw/[instanceId]/page.tsx
@@ -1,0 +1,10 @@
+import { KiloClawDetail } from '@/components/subscriptions/kiloclaw/KiloClawDetail';
+
+export default async function KiloclawSubscriptionPage({
+  params,
+}: {
+  params: Promise<{ instanceId: string }>;
+}) {
+  const { instanceId } = await params;
+  return <KiloClawDetail instanceId={instanceId} />;
+}

--- a/src/app/(app)/subscriptions/kiloclaw/[instanceId]/page.tsx
+++ b/src/app/(app)/subscriptions/kiloclaw/[instanceId]/page.tsx
@@ -1,3 +1,4 @@
+import { PageContainer } from '@/components/layouts/PageContainer';
 import { KiloClawDetail } from '@/components/subscriptions/kiloclaw/KiloClawDetail';
 
 export default async function KiloclawSubscriptionPage({
@@ -6,5 +7,9 @@ export default async function KiloclawSubscriptionPage({
   params: Promise<{ instanceId: string }>;
 }) {
   const { instanceId } = await params;
-  return <KiloClawDetail instanceId={instanceId} />;
+  return (
+    <PageContainer>
+      <KiloClawDetail instanceId={instanceId} />
+    </PageContainer>
+  );
 }

--- a/src/app/(app)/subscriptions/layout.tsx
+++ b/src/app/(app)/subscriptions/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from 'react';
+
+export default function SubscriptionsLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/(app)/subscriptions/page.tsx
+++ b/src/app/(app)/subscriptions/page.tsx
@@ -1,0 +1,5 @@
+import { PersonalSubscriptions } from '@/components/subscriptions/PersonalSubscriptions';
+
+export default function SubscriptionsPage() {
+  return <PersonalSubscriptions />;
+}

--- a/src/components/organizations/FreeTrialWarningBanner.tsx
+++ b/src/components/organizations/FreeTrialWarningBanner.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
 import { Button } from '@/components/Button';
 import type { ButtonVariant } from '@/components/Button';
 import { AlertCircle, AlertTriangle, Clock } from 'lucide-react';
@@ -121,12 +122,14 @@ export function FreeTrialWarningBanner({
   userRole,
   onUpgradeClick,
 }: FreeTrialWarningBannerProps) {
+  const pathname = usePathname();
   const state = getOrgTrialStatusFromDays(daysRemaining);
   const planName = capitalize(organization.plan);
   const styles = getStylesForState(state, planName);
   const isOwner = userRole === 'owner';
   const buttonVariant = getButtonVariantForState(state);
   const message = getTrialMessage(daysRemaining, isOwner);
+  const shouldShowUpgradeButton = isOwner && !pathname.endsWith('/subscriptions');
 
   return (
     <div
@@ -159,7 +162,7 @@ export function FreeTrialWarningBanner({
       </div>
 
       {/* Upgrade button for owners */}
-      {isOwner && (
+      {shouldShowUpgradeButton && (
         <Button onClick={onUpgradeClick} variant={buttonVariant} className="shrink-0">
           Upgrade Now
         </Button>

--- a/src/components/organizations/OrganizationByPageLayout.tsx
+++ b/src/components/organizations/OrganizationByPageLayout.tsx
@@ -11,6 +11,7 @@ export async function OrganizationByPageLayout({
   params,
   render,
   fullBleed = false,
+  roles,
 }: {
   params: Promise<{ id: string }>;
   render: ({
@@ -24,10 +25,11 @@ export async function OrganizationByPageLayout({
   }) => JSX.Element;
   /** When true, skip the PageContainer wrapper (used by gastown fullscreen pages). */
   fullBleed?: boolean;
+  roles?: OrganizationRole[];
 }) {
   const { id } = await params;
   const organizationId = decodeURIComponent(id);
-  const result = await getAuthorizedOrgContext(organizationId);
+  const result = await getAuthorizedOrgContext(organizationId, roles);
   if (!result.success) {
     if (result.nextResponse.status === 401) {
       redirect(await signInUrlWithCallbackPath());

--- a/src/components/organizations/SeatUsageCard.tsx
+++ b/src/components/organizations/SeatUsageCard.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import Link from 'next/link';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Users, ArrowUpRight } from 'lucide-react';
+import { Users } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { ErrorCard } from '../ErrorCard';
 import { LoadingCard } from '../LoadingCard';
 import { useUserOrganizationRole } from '@/components/organizations/OrganizationContext';
-import { LinkButton } from '@/components/Button';
 import { SeatsUsageProgress } from './SeatsUsageProgress';
 import {
   useOrganizationSeatUsage,
@@ -83,14 +84,11 @@ export function SeatUsageCard({ organizationId }: Props) {
             <CardTitle>Seat Usage</CardTitle>
           </div>
           {(currentUserRole === 'owner' || currentUserRole === 'billing_manager') && (
-            <LinkButton
-              href={`/organizations/${organizationId}/subscription`}
-              className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors"
-              variant="link"
-            >
-              Manage
-              <ArrowUpRight className="h-3 w-3" />
-            </LinkButton>
+            <Button asChild variant="outline" size="sm">
+              <Link href={`/organizations/${organizationId}/subscriptions/seats`}>
+                Manage Subscription
+              </Link>
+            </Button>
           )}
         </div>
         <CardDescription className="text-xs">

--- a/src/components/organizations/UpgradeTrialDialog.tsx
+++ b/src/components/organizations/UpgradeTrialDialog.tsx
@@ -6,32 +6,13 @@ import { PlanCard } from './subscription/PlanCard';
 import { Button } from '@/components/Button';
 import type { BillingCycle, OrganizationPlan } from '@/lib/organizations/organization-types';
 import { seatPrice } from '@/lib/organizations/constants';
+import { ENTERPRISE_FEATURES, TEAMS_FEATURES } from './subscription/plan-features';
 import {
   useOrganizationSubscriptionLink,
   useOrganizationSeatUsage,
   useResubscribeDefaults,
 } from '@/app/api/organizations/hooks';
 import { usePostHog } from 'posthog-js/react';
-
-export const TEAMS_FEATURES = [
-  'All the features from open source',
-  'Centralized billing',
-  'Team management dashboard',
-  'Project-level usage analytics and reporting',
-  'AI Adoption Score',
-  'Shared Modes',
-  'Role-based access permissions',
-  'Control data collection policy',
-];
-
-export const ENTERPRISE_FEATURES = [
-  'All the features from teams',
-  'Limit models and/or providers',
-  'Audit logs',
-  'SSO, OIDC, & SCIM support',
-  'SLA commitments',
-  'Dedicated support channels',
-];
 
 type UpgradeTrialDialogProps = {
   open: boolean;
@@ -166,8 +147,10 @@ export function UpgradeTrialDialog({
               </button>
             </div>
             <span
-              className={`rounded-full border border-green-400/30 bg-green-400/10 px-2.5 py-0.5 text-xs font-semibold text-green-400 transition-opacity ${
-                billingCycle === 'annual' ? 'opacity-100' : 'opacity-30'
+              className={`rounded-full border border-green-400/30 bg-green-400/10 px-2.5 py-0.5 text-xs font-semibold text-green-400 transition-[opacity,text-decoration-color] ${
+                billingCycle === 'annual'
+                  ? 'opacity-100'
+                  : 'opacity-30 line-through decoration-current'
               }`}
             >
               Save 17%
@@ -175,7 +158,7 @@ export function UpgradeTrialDialog({
           </div>
 
           {/* Plan Cards */}
-          <div className="flex justify-center gap-4">
+          <div className="grid gap-4 md:grid-cols-2">
             <PlanCard
               plan="teams"
               pricePerMonth={teamPrice}

--- a/src/components/organizations/subscription/PlanCard.tsx
+++ b/src/components/organizations/subscription/PlanCard.tsx
@@ -7,6 +7,7 @@ import {
   type OrganizationPlan,
   type BillingCycle,
 } from '@/lib/organizations/organization-types';
+import { cn } from '@/lib/utils';
 
 type PlanCardProps = {
   plan: OrganizationPlan;
@@ -37,59 +38,80 @@ export function PlanCard({
   const isUpgrade = currentIndex < cardIndex;
   const isDowngrade = currentIndex > cardIndex;
 
+  const badgeLabel = isCurrent
+    ? 'Current plan'
+    : isUpgrade
+      ? 'Upgrade'
+      : isDowngrade
+        ? 'Downgrade'
+        : null;
+
+  const badgeClassName = isCurrent
+    ? 'border border-amber-300/70 bg-amber-300 text-amber-950 shadow-sm'
+    : isUpgrade
+      ? 'bg-emerald-500 text-black'
+      : 'bg-muted text-foreground';
+
   return (
-    <div
+    <button
+      type="button"
       onClick={onSelect}
-      className={`relative w-84 rounded-lg border-2 p-6 transition-all ${
+      className={cn(
+        'group relative flex h-full w-full flex-col rounded-2xl border p-6 text-left transition-all',
+        'hover:border-blue-400/70 hover:shadow-[0_0_0_1px_rgba(59,130,246,0.2)]',
         isSelected
-          ? 'border-blue-500 bg-blue-950/20'
-          : 'border-gray-700 bg-gray-900 hover:border-gray-600'
-      } ${!isSelected ? 'cursor-pointer opacity-50' : ''} ${className}`}
+          ? 'border-blue-500/70 bg-blue-500/10 shadow-[0_0_0_1px_rgba(59,130,246,0.25)]'
+          : 'border-border/70 bg-background',
+        className
+      )}
     >
-      {/* Plan Badge */}
-      {isCurrent && (
-        <Badge className="absolute -top-3 left-1/2 -translate-x-1/2 bg-orange-600">
-          CURRENT PLAN
+      {badgeLabel ? (
+        <Badge
+          className={cn(
+            'absolute -top-3 left-1/2 -translate-x-1/2 rounded-full px-3',
+            badgeClassName
+          )}
+        >
+          {badgeLabel.toUpperCase()}
         </Badge>
-      )}
-      {isUpgrade && (
-        <Badge className="absolute -top-3 left-1/2 -translate-x-1/2 bg-green-600">UPGRADE</Badge>
-      )}
-      {isDowngrade && (
-        <Badge className="absolute -top-3 left-1/2 -translate-x-1/2 bg-gray-600">DOWNGRADE</Badge>
-      )}
+      ) : null}
 
-      {/* Plan Name */}
-      <h3 className="mb-2 text-center text-xl font-semibold text-white">{planName}</h3>
+      <div className="flex h-full flex-col gap-6">
+        <div className="space-y-4 text-center">
+          <h3 className="text-xl font-semibold">{planName}</h3>
 
-      {/* Price */}
-      <div className="mb-6 text-center">
-        <div className="text-4xl font-bold text-white">
-          ${pricePerMonth}
-          <span className="text-lg font-normal text-gray-400">/user/month</span>
+          <div>
+            <div className="flex items-end justify-center gap-1">
+              <span className="text-4xl font-bold">${pricePerMonth}</span>
+              <span className="text-muted-foreground pb-1 text-base font-normal">/user/month</span>
+            </div>
+            <div className="text-muted-foreground mt-2 text-sm">
+              {billingCycle === 'monthly' ? 'Billed monthly' : 'Billed annually'}
+            </div>
+          </div>
         </div>
-        <div className="mt-1 text-sm text-gray-400">
-          {billingCycle === 'monthly' ? 'Billed monthly' : 'Billed annually'}
+
+        <ul className="space-y-3">
+          {features.map(feature => (
+            <li key={feature} className="text-muted-foreground flex items-start gap-2 text-sm">
+              <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
+              <span>{feature}</span>
+            </li>
+          ))}
+        </ul>
+
+        <div
+          className={cn(
+            'mt-auto flex items-center justify-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-colors',
+            isSelected
+              ? 'border-blue-500/40 bg-blue-500/10 text-blue-400'
+              : 'border-border/70 text-muted-foreground group-hover:border-blue-400/40 group-hover:text-foreground'
+          )}
+        >
+          {isSelected ? <Check className="h-4 w-4" /> : null}
+          {isSelected ? 'Selected' : 'Select plan'}
         </div>
       </div>
-
-      {/* Features List */}
-      <ul className="mb-6 space-y-3">
-        {features.map((feature, index) => (
-          <li key={index} className="flex items-start gap-2 text-sm text-gray-300">
-            <Check className="mt-0.5 h-4 w-4 shrink-0 text-green-500" />
-            <span>{feature}</span>
-          </li>
-        ))}
-      </ul>
-
-      {/* Selection Indicator */}
-      {isSelected && (
-        <div className="flex items-center justify-center gap-2 text-sm font-medium text-blue-400">
-          <Check className="h-4 w-4" />
-          Selected
-        </div>
-      )}
-    </div>
+    </button>
   );
 }

--- a/src/components/organizations/subscription/plan-features.ts
+++ b/src/components/organizations/subscription/plan-features.ts
@@ -1,0 +1,19 @@
+export const TEAMS_FEATURES = [
+  'All the features from open source',
+  'Centralized billing',
+  'Team management dashboard',
+  'Project-level usage analytics and reporting',
+  'AI Adoption Score',
+  'Shared Modes',
+  'Role-based access permissions',
+  'Control data collection policy',
+];
+
+export const ENTERPRISE_FEATURES = [
+  'All the features from teams',
+  'Limit models and/or providers',
+  'Audit logs',
+  'SSO, OIDC, & SCIM support',
+  'SLA commitments',
+  'Dedicated support channels',
+];

--- a/src/components/profile/ProfileKiloPassSection.tsx
+++ b/src/components/profile/ProfileKiloPassSection.tsx
@@ -15,7 +15,9 @@ import { KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF } from '@/lib/kilo-pass/c
 import { dayjs } from '@/lib/kilo-pass/dayjs';
 
 function getShowKiloPassTwoMonthPromo(showFirstMonthPromo: boolean): boolean {
-  return showFirstMonthPromo && dayjs().utc().isBefore(KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF);
+  return (
+    showFirstMonthPromo && dayjs().utc().isBefore(KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF)
+  );
 }
 
 export function ProfileKiloPassSection() {

--- a/src/components/profile/ProfileKiloPassSection.tsx
+++ b/src/components/profile/ProfileKiloPassSection.tsx
@@ -14,6 +14,10 @@ import { recommendKiloPassTierFromAverageMonthlyUsageUsd } from '@/lib/kilo-pass
 import { KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF } from '@/lib/kilo-pass/constants';
 import { dayjs } from '@/lib/kilo-pass/dayjs';
 
+function getShowKiloPassTwoMonthPromo(showFirstMonthPromo: boolean): boolean {
+  return showFirstMonthPromo && dayjs().utc().isBefore(KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF);
+}
+
 export function ProfileKiloPassSection() {
   const trpc = useTRPC();
   const query = useQuery(trpc.kiloPass.getState.queryOptions());
@@ -59,8 +63,7 @@ export function ProfileKiloPassSection() {
   if (!activeSubscription) {
     const pending = checkoutMutation.isPending;
     const showFirstMonthPromo = query.data.isEligibleForFirstMonthPromo;
-    const showSecondMonthPromo =
-      showFirstMonthPromo && dayjs().utc().isBefore(KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF);
+    const showSecondMonthPromo = getShowKiloPassTwoMonthPromo(showFirstMonthPromo);
     const averageMonthlyUsageUsd = averageMonthlyUsageQuery.data?.averageMonthlyUsageUsd;
     const recommendedTier =
       typeof averageMonthlyUsageUsd === 'number'

--- a/src/components/profile/kilo-pass/KiloPassBonusRampDialog.tsx
+++ b/src/components/profile/kilo-pass/KiloPassBonusRampDialog.tsx
@@ -54,6 +54,7 @@ export function KiloPassBonusRampDialog(props: {
   const [sliderMonth, setSliderMonth] = useState(resolvedMonth);
   const effectiveMonth = showSlider ? sliderMonth : resolvedMonth;
   const config = KILO_PASS_TIER_CONFIG[tier];
+  const showPromoCallout = showSlider && showFirstMonthPromo;
 
   const sliderPercent = computeMonthlyCadenceBonusPercent({
     tier,
@@ -169,7 +170,7 @@ export function KiloPassBonusRampDialog(props: {
               </div>
             </div>
 
-            {showSlider && showFirstMonthPromo && (
+            {showPromoCallout && (
               <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 px-3 py-2 text-emerald-100">
                 As a new subscriber, your{' '}
                 <strong>first {showSecondMonthPromo ? '2 paid months' : 'paid month'}</strong> get a

--- a/src/components/profile/kilo-pass/KiloPassSubscribeCard.tsx
+++ b/src/components/profile/kilo-pass/KiloPassSubscribeCard.tsx
@@ -20,19 +20,25 @@ export function KiloPassSubscribeCard(props: {
   cadence: KiloPassCadence;
   setCadence: (cadence: KiloPassCadence) => void;
   pending: boolean;
-  showFirstMonthPromo: boolean;
+  showFirstMonthPromo?: boolean;
   showSecondMonthPromo: boolean;
   recommendedTier: KiloPassTier | null;
   onSelectTier: (tier: KiloPassTier) => void;
+  showHeader?: boolean;
+  className?: string;
+  contentClassName?: string;
 }) {
   const {
     cadence,
     setCadence,
     pending,
-    showFirstMonthPromo,
+    showFirstMonthPromo = false,
     showSecondMonthPromo,
     recommendedTier,
     onSelectTier,
+    showHeader = true,
+    className,
+    contentClassName,
   } = props;
 
   const tiers = Object.keys(KILO_PASS_TIER_CONFIG) as KiloPassTier[];
@@ -40,43 +46,50 @@ export function KiloPassSubscribeCard(props: {
   const promoCutoffLabel = formatIsoDateString_UsaDateOnlyFormat(
     KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF.toISOString()
   );
+  const monthlyPromoDescription = showFirstMonthPromo
+    ? showSecondMonthPromo
+      ? `First-time subscribers receive 50% free bonus credits for the first two months. Offer expires ${promoCutoffLabel}.`
+      : 'First-time subscribers receive 50% free bonus credits for the first month.'
+    : null;
   const cadenceOptions = [
     { value: KiloPassCadence.Monthly, label: 'Monthly' },
     { value: KiloPassCadence.Yearly, label: 'Yearly' },
   ] as const;
 
   return (
-    <Card className="border-border/60 w-full overflow-hidden rounded-xl shadow-sm">
-      <CardHeader>
-        <div className="flex items-start justify-between gap-3">
-          <CardTitle className="flex items-center gap-2">
-            <span className="bg-muted/40 ring-border/60 grid h-9 w-9 place-items-center rounded-lg ring-1">
-              <Crown className="h-5 w-5" />
-            </span>
-
-            <span className="leading-none">
-              <span className="block text-base">Kilo Pass</span>
-              <span className="text-muted-foreground block text-sm font-normal">
-                Unlock up to <span className="text-emerald-300/90">50% free credits</span>. Checkout
-                securely with Stripe.
+    <Card className={cn('border-border/60 w-full overflow-hidden rounded-xl shadow-sm', className)}>
+      {showHeader ? (
+        <CardHeader>
+          <div className="flex items-start justify-between gap-3">
+            <CardTitle className="flex items-center gap-2">
+              <span className="bg-muted/40 ring-border/60 grid h-9 w-9 place-items-center rounded-lg ring-1">
+                <Crown className="h-5 w-5" />
               </span>
-            </span>
-          </CardTitle>
 
-          {pending ? (
-            <Badge variant="secondary" className="gap-1.5">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              Processing
-            </Badge>
-          ) : (
-            <Badge variant="secondary">Subscribe</Badge>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent className="grid gap-5 pt-4">
-        <div className="bg-muted/20 border-border/60 flex flex-wrap items-center justify-between gap-3 rounded-lg border px-3 py-2">
+              <span className="leading-none">
+                <span className="block text-base">Kilo Pass</span>
+                <span className="text-muted-foreground block text-sm font-normal">
+                  Unlock up to <span className="text-emerald-300/90">50% free credits</span>.
+                  Checkout securely with Stripe.
+                </span>
+              </span>
+            </CardTitle>
+
+            {pending ? (
+              <Badge variant="secondary" className="gap-1.5">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Processing
+              </Badge>
+            ) : (
+              <Badge variant="secondary">Subscribe</Badge>
+            )}
+          </div>
+        </CardHeader>
+      ) : null}
+      <CardContent className={cn('grid gap-5', showHeader ? 'pt-4' : 'p-0 pt-0', contentClassName)}>
+        <div className="bg-muted/20 border-border/60 flex flex-wrap items-center justify-between gap-3 overflow-hidden rounded-lg border px-3 py-2">
           <div className="text-muted-foreground text-sm">Billing cadence</div>
-          <div className="bg-muted/40 ring-border/60 flex w-full items-center gap-1 rounded-lg p-1 ring-1 sm:w-56">
+          <div className="flex w-full items-center gap-1 rounded-lg bg-white/[0.04] p-0.5 sm:w-56">
             {cadenceOptions.map(option => (
               <Button
                 key={option.value}
@@ -88,7 +101,7 @@ export function KiloPassSubscribeCard(props: {
                 className={cn(
                   'h-8 flex-1 rounded-md px-3 text-xs font-semibold transition',
                   cadence === option.value
-                    ? 'bg-blue-500 text-white shadow hover:bg-blue-500'
+                    ? 'bg-blue-500 text-white hover:bg-blue-500'
                     : 'text-muted-foreground hover:text-foreground hover:bg-white/5'
                 )}
               >
@@ -98,7 +111,7 @@ export function KiloPassSubscribeCard(props: {
           </div>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-3">
+        <div className="grid gap-4 sm:grid-cols-3 lg:gap-5">
           {tiers.map(tier => {
             return (
               <KiloPassTierCard
@@ -127,13 +140,10 @@ export function KiloPassSubscribeCard(props: {
               credits expire every month.
             </span>
           </div>
-          {cadence === KiloPassCadence.Monthly && showSecondMonthPromo && (
+          {cadence === KiloPassCadence.Monthly && monthlyPromoDescription && (
             <div className="text-muted-foreground flex items-start gap-2">
               <Check className="mt-0.5 h-4 w-4 flex-none text-emerald-400" />
-              <span>
-                First-time subscribers receive <span className="text-emerald-300">50%</span> free
-                bonus credits for the first two months. Offer expires {promoCutoffLabel}.
-              </span>
+              <span>{monthlyPromoDescription}</span>
             </div>
           )}
         </div>

--- a/src/components/profile/kilo-pass/KiloPassSubscriptionSettingsModal.tsx
+++ b/src/components/profile/kilo-pass/KiloPassSubscriptionSettingsModal.tsx
@@ -83,12 +83,7 @@ export function KiloPassSubscriptionSettingsModal(props: SettingsModalProps) {
       setTargetTier(subscription.tier);
       setTargetCadence(subscription.cadence);
     }
-  }, [
-    isOpen,
-    scheduledChange,
-    subscription.tier,
-    subscription.cadence,
-  ]);
+  }, [isOpen, scheduledChange, subscription.tier, subscription.cadence]);
 
   useEffect(() => {
     if (isOpen && scheduledChange) {

--- a/src/components/profile/kilo-pass/KiloPassSubscriptionSettingsModal.tsx
+++ b/src/components/profile/kilo-pass/KiloPassSubscriptionSettingsModal.tsx
@@ -52,7 +52,7 @@ export function KiloPassSubscriptionSettingsModal(props: SettingsModalProps) {
   const scheduleChange = useMutation(trpc.kiloPass.scheduleChange.mutationOptions());
   const cancelScheduledChange = useMutation(trpc.kiloPass.cancelScheduledChange.mutationOptions());
 
-  const [panel, setPanel] = useState<'main' | 'update'>('main');
+  const [panel, setPanel] = useState<'main' | 'update'>('update');
   const [cancelOpen, setCancelOpen] = useState(false);
   const [cancellationFeedbackOpen, setCancellationFeedbackOpen] = useState(false);
   const [selectedCancellationReasons, setSelectedCancellationReasons] = useState<string[]>([]);
@@ -63,6 +63,11 @@ export function KiloPassSubscriptionSettingsModal(props: SettingsModalProps) {
     useState(false);
 
   const scheduledChange = scheduledChangeQuery.data?.scheduledChange ?? null;
+
+  const closeModal = () => {
+    setPanel('update');
+    onClose();
+  };
 
   const [targetTier, setTargetTier] = useState<KiloPassTier>(subscription.tier);
   const [targetCadence, setTargetCadence] = useState<KiloPassCadence>(subscription.cadence);
@@ -80,12 +85,16 @@ export function KiloPassSubscriptionSettingsModal(props: SettingsModalProps) {
     }
   }, [
     isOpen,
-    scheduledChange?.status,
-    scheduledChange?.toTier,
-    scheduledChange?.toCadence,
+    scheduledChange,
     subscription.tier,
     subscription.cadence,
   ]);
+
+  useEffect(() => {
+    if (isOpen && scheduledChange) {
+      setPanel('main');
+    }
+  }, [isOpen, scheduledChange]);
 
   const isCancelingPendingChange =
     cancelScheduledChange.isPending || isCancelingPendingChangeUntilRefetch;
@@ -164,7 +173,7 @@ export function KiloPassSubscriptionSettingsModal(props: SettingsModalProps) {
           };
     }
 
-    let message;
+    let message: string;
 
     if (isCadenceChange) {
       message = `Cadence changes take effect on ${effectiveAtLabel}.`;
@@ -223,11 +232,11 @@ export function KiloPassSubscriptionSettingsModal(props: SettingsModalProps) {
         targetCadence,
       });
       toast(`Change scheduled for ${formatIsoDateString_UsaDateOnlyFormat(result.effectiveAt)}`);
+      closeModal();
       await queryClient.invalidateQueries({ queryKey: trpc.kiloPass.getState.queryKey() });
       await queryClient.invalidateQueries({
         queryKey: trpc.kiloPass.getScheduledChange.queryKey(),
       });
-      setPanel('main');
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to schedule change';
       toast.error(message);
@@ -259,7 +268,7 @@ export function KiloPassSubscriptionSettingsModal(props: SettingsModalProps) {
   const isUpdateSubscriptionDisabled = view.status.isPendingCancellation;
 
   const pendingChange = Boolean(scheduledChange);
-  const showUpdatePanel = panel === 'update';
+  const showUpdatePanel = panel === 'update' && !pendingChange;
 
   const cancellationReasons = useMemo(() => {
     const reasons = [
@@ -363,8 +372,7 @@ export function KiloPassSubscriptionSettingsModal(props: SettingsModalProps) {
       open={isOpen}
       onOpenChange={open => {
         if (!open) {
-          setPanel('main');
-          onClose();
+          closeModal();
         }
       }}
     >
@@ -372,7 +380,7 @@ export function KiloPassSubscriptionSettingsModal(props: SettingsModalProps) {
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Settings className="h-5 w-5 text-blue-400" />
-            Manage Kilo Pass
+            {showUpdatePanel ? 'Update Subscription' : 'Manage Kilo Pass'}
           </DialogTitle>
           {showUpdatePanel ? null : (
             <DialogDescription className="text-muted-foreground">
@@ -417,7 +425,7 @@ export function KiloPassSubscriptionSettingsModal(props: SettingsModalProps) {
         <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-between">
           {showUpdatePanel ? (
             <UpdateFooter
-              onBack={() => setPanel('main')}
+              onBack={closeModal}
               onCancelPendingChange={handleCancelScheduledChange}
               onScheduleChange={handleScheduleChange}
               isMutating={isMutating}
@@ -427,7 +435,7 @@ export function KiloPassSubscriptionSettingsModal(props: SettingsModalProps) {
               isSameSelection={isSameSelection}
             />
           ) : (
-            <Button variant="outline" onClick={onClose} disabled={isMutating}>
+            <Button variant="outline" onClick={closeModal} disabled={isMutating}>
               Close
             </Button>
           )}

--- a/src/components/profile/kilo-pass/KiloPassSubscriptionSettingsUpdatePanel.tsx
+++ b/src/components/profile/kilo-pass/KiloPassSubscriptionSettingsUpdatePanel.tsx
@@ -1,4 +1,4 @@
-import { Check, Loader2 } from 'lucide-react';
+import { ArrowRight, Check, Loader2 } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -49,20 +49,22 @@ export function UpdatePanel(props: UpdatePanelProps) {
 
   return (
     <div className="grid gap-4">
-      <div className="bg-muted/20 border-border/60 rounded-lg border px-3 py-2">
-        <div className="text-sm font-semibold">Current plan</div>
-        <div className="text-muted-foreground text-sm">
-          {currentTierLabel} · {currentCadenceLabel}
+      <div className="flex items-center justify-center gap-3">
+        <div className="bg-muted/20 border-border/60 flex-1 rounded-lg border px-3 py-2 text-center">
+          <div className="text-muted-foreground text-xs">Current plan</div>
+          <div className="text-sm font-semibold">
+            {currentTierLabel} · {currentCadenceLabel}
+          </div>
+          <div className="text-muted-foreground text-xs">{currentPriceLabel}</div>
         </div>
-        <div className="text-sm font-semibold text-white">{currentPriceLabel}</div>
-      </div>
-
-      <div className="bg-muted/20 border-border/60 rounded-lg border px-3 py-2">
-        <div className="text-sm font-semibold">New plan</div>
-        <div className="text-muted-foreground text-sm">
-          {getTierName(targetTier)} · {getCadenceLabel(targetCadence)}
+        <ArrowRight className="text-muted-foreground h-4 w-4 shrink-0" />
+        <div className="bg-muted/20 border-border/60 flex-1 rounded-lg border px-3 py-2 text-center">
+          <div className="text-muted-foreground text-xs">New plan</div>
+          <div className="text-sm font-semibold">
+            {getTierName(targetTier)} · {getCadenceLabel(targetCadence)}
+          </div>
+          <div className="text-muted-foreground text-xs">{newPriceLabel}</div>
         </div>
-        <div className="text-sm font-semibold text-white">{newPriceLabel}</div>
       </div>
 
       <div className="grid gap-2">

--- a/src/components/profile/kilo-pass/KiloPassTierCard.tsx
+++ b/src/components/profile/kilo-pass/KiloPassTierCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Check } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import {
   KILO_PASS_FIRST_MONTH_PROMO_BONUS_PERCENT,
@@ -21,7 +22,7 @@ export function KiloPassTierCard(props: {
   tier: KiloPassTier;
   cadence: KiloPassCadence;
   pending: boolean;
-  showFirstMonthPromo: boolean;
+  showFirstMonthPromo?: boolean;
   showSecondMonthPromo?: boolean;
   isRecommended: boolean;
   onSelect: (tier: KiloPassTier) => void;
@@ -30,7 +31,7 @@ export function KiloPassTierCard(props: {
     tier,
     cadence,
     pending,
-    showFirstMonthPromo,
+    showFirstMonthPromo = false,
     showSecondMonthPromo = false,
     isRecommended,
     onSelect,
@@ -58,7 +59,7 @@ export function KiloPassTierCard(props: {
       )}
     >
       {isRecommended && (
-        <Badge className="absolute -top-2 left-1/2 -translate-x-1/2 rounded-full bg-blue-600 px-3">
+        <Badge className="absolute -top-2 left-1/2 -translate-x-1/2 rounded-full bg-blue-600 px-3 text-white">
           Recommended
         </Badge>
       )}
@@ -77,22 +78,28 @@ export function KiloPassTierCard(props: {
         <div className="text-muted-foreground text-xs">{cadenceLabel}</div>
       </div>
 
-      <div className="mt-4 space-y-1">
+      <div className="mt-4 space-y-2">
         {cadence === KiloPassCadence.Monthly ? (
           <>
-            <div className="text-muted-foreground text-xs leading-5">
-              Includes <span className="text-amber-300">{getBaseCreditsLabel({ tier })}</span> paid
-              credits
+            <div className="text-muted-foreground flex items-start gap-2 text-xs leading-5">
+              <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+              <span>
+                Includes <span className="text-amber-300">{getBaseCreditsLabel({ tier })}</span>{' '}
+                paid credits
+              </span>
             </div>
 
-            <div className="text-muted-foreground flex items-center justify-between gap-2 text-xs leading-5">
-              <span className="leading-5">
-                Up to{' '}
-                <span className="text-emerald-300">
-                  {formatPercent(config.monthlyCapBonusPercent)}
-                </span>{' '}
-                free bonus credits
-              </span>
+            <div className="text-muted-foreground flex items-start justify-between gap-2 text-xs leading-5">
+              <div className="flex items-start gap-2">
+                <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+                <span className="leading-5">
+                  Up to{' '}
+                  <span className="text-emerald-300">
+                    {formatPercent(config.monthlyCapBonusPercent)}
+                  </span>{' '}
+                  free bonus credits
+                </span>
+              </div>
               <KiloPassBonusRampDialog
                 tier={tier}
                 showFirstMonthPromo={showFirstMonthPromo}
@@ -101,21 +108,31 @@ export function KiloPassTierCard(props: {
             </div>
 
             {showFirstMonthPromo && (
-              <div className="text-xs leading-5 text-emerald-300">
-                {showSecondMonthPromo ? 'First 2 months:' : 'First month:'} +
-                {formatPercent(KILO_PASS_FIRST_MONTH_PROMO_BONUS_PERCENT)} free bonus credits
+              <div className="flex items-start gap-2 text-xs leading-5 text-emerald-300">
+                <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+                <span>
+                  {showSecondMonthPromo ? 'First 2 months:' : 'First month:'} +
+                  {formatPercent(KILO_PASS_FIRST_MONTH_PROMO_BONUS_PERCENT)} free bonus credits
+                </span>
               </div>
             )}
           </>
         ) : (
           <>
-            <div className="text-muted-foreground text-xs leading-5">
-              Includes <span className="text-amber-300">{getBaseCreditsLabel({ tier })}</span> pass
-              credits
+            <div className="text-muted-foreground flex items-start gap-2 text-xs leading-5">
+              <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+              <span>
+                Includes <span className="text-amber-300">{getBaseCreditsLabel({ tier })}</span>{' '}
+                pass credits
+              </span>
             </div>
-            <div className="text-muted-foreground text-xs leading-5">
-              Includes <span className="text-emerald-300">{getYearlyMonthlyBonusLabel(tier)}</span>{' '}
-              bonus credits
+            <div className="text-muted-foreground flex items-start gap-2 text-xs leading-5">
+              <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+              <span>
+                Includes{' '}
+                <span className="text-emerald-300">{getYearlyMonthlyBonusLabel(tier)}</span> bonus
+                credits
+              </span>
             </div>
           </>
         )}

--- a/src/components/subscriptions/AvailableProductCard.tsx
+++ b/src/components/subscriptions/AvailableProductCard.tsx
@@ -21,10 +21,12 @@ export function AvailableProductCard({
   badge?: string;
   action?: ReactNode;
 }) {
+  const badgeVariant = badge === 'Recommended' ? 'default' : 'secondary-outline';
+
   const button = cta ? (
     <Button
       type="button"
-      variant={badge === 'Recommended' ? 'primary' : 'outline'}
+      variant="outline"
       className="w-full"
       onClick={cta.onClick}
       disabled={cta.disabled}
@@ -40,7 +42,7 @@ export function AvailableProductCard({
           <div className="bg-muted flex h-11 w-11 shrink-0 items-center justify-center rounded-xl">
             {icon}
           </div>
-          {badge ? <Badge variant="secondary-outline">{badge}</Badge> : null}
+          {badge ? <Badge variant={badgeVariant}>{badge}</Badge> : null}
         </div>
         <div className="space-y-2">
           <h3 className="font-semibold">{title}</h3>

--- a/src/components/subscriptions/AvailableProductCard.tsx
+++ b/src/components/subscriptions/AvailableProductCard.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+
+export function AvailableProductCard({
+  icon,
+  title,
+  description,
+  price,
+  cta,
+  badge,
+  action,
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  price: string;
+  cta?: { label: string; href?: string; onClick?: () => void; disabled?: boolean };
+  badge?: string;
+  action?: ReactNode;
+}) {
+  const button = cta ? (
+    <Button
+      type="button"
+      variant={badge === 'Recommended' ? 'primary' : 'outline'}
+      className="w-full"
+      onClick={cta.onClick}
+      disabled={cta.disabled}
+    >
+      {cta.label}
+    </Button>
+  ) : null;
+
+  return (
+    <Card className="border-dashed">
+      <CardContent className="flex h-full flex-col gap-4 p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="bg-muted flex h-11 w-11 shrink-0 items-center justify-center rounded-xl">
+            {icon}
+          </div>
+          {badge ? <Badge variant="secondary-outline">{badge}</Badge> : null}
+        </div>
+        <div className="space-y-2">
+          <h3 className="font-semibold">{title}</h3>
+          <p className="text-muted-foreground text-sm">{description}</p>
+        </div>
+        <div className="mt-auto space-y-3">
+          <div className="text-sm font-medium">{price}</div>
+          {action ?? (cta?.href && button ? <Link href={cta.href}>{button}</Link> : button)}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/subscriptions/BillingHistoryTable.tsx
+++ b/src/components/subscriptions/BillingHistoryTable.tsx
@@ -1,0 +1,101 @@
+import type { BillingHistoryEntry } from '@/lib/subscriptions/subscription-center';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { formatCents, formatIsoDateString_UsaDateOnlyFormat } from '@/lib/utils';
+
+function formatCreditAmount(amountMicrodollars: number): string {
+  return `$${(amountMicrodollars / 1_000_000).toFixed(2)}`;
+}
+
+export function BillingHistoryTable({
+  variant,
+  entries,
+  hasMore,
+  onLoadMore,
+  isLoading = false,
+}: {
+  variant: 'stripe' | 'credits';
+  entries: BillingHistoryEntry[];
+  hasMore: boolean;
+  onLoadMore: () => void;
+  isLoading?: boolean;
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="overflow-hidden rounded-xl border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Date</TableHead>
+              {variant === 'stripe' ? (
+                <TableHead>Amount</TableHead>
+              ) : (
+                <TableHead>Description</TableHead>
+              )}
+              <TableHead>{variant === 'stripe' ? 'Status' : 'Amount'}</TableHead>
+              {variant === 'stripe' ? <TableHead>Invoice</TableHead> : null}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {entries.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={variant === 'stripe' ? 4 : 3}
+                  className="text-muted-foreground py-8 text-center"
+                >
+                  No billing history yet.
+                </TableCell>
+              </TableRow>
+            ) : (
+              entries.map(entry => (
+                <TableRow key={entry.id}>
+                  <TableCell>{formatIsoDateString_UsaDateOnlyFormat(entry.date)}</TableCell>
+                  {entry.kind === 'stripe' ? (
+                    <>
+                      <TableCell>{formatCents(entry.amountCents, entry.currency)}</TableCell>
+                      <TableCell className="capitalize">
+                        {entry.status.replace(/_/g, ' ')}
+                      </TableCell>
+                      <TableCell>
+                        {entry.invoiceUrl ? (
+                          <a
+                            href={entry.invoiceUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-primary hover:underline"
+                          >
+                            View
+                          </a>
+                        ) : (
+                          '—'
+                        )}
+                      </TableCell>
+                    </>
+                  ) : (
+                    <>
+                      <TableCell>{entry.description}</TableCell>
+                      <TableCell>{formatCreditAmount(entry.amountMicrodollars)}</TableCell>
+                    </>
+                  )}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {hasMore ? (
+        <Button variant="outline" onClick={onLoadMore} disabled={isLoading}>
+          {isLoading ? 'Loading...' : 'Show more'}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/subscriptions/BillingHistoryTable.tsx
+++ b/src/components/subscriptions/BillingHistoryTable.tsx
@@ -7,8 +7,9 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { formatCents, formatIsoDateString_UsaDateOnlyFormat } from '@/lib/utils';
+import { cn, formatCents, formatIsoDateString_UsaDateOnlyFormat } from '@/lib/utils';
 
 function formatCreditAmount(amountMicrodollars: number): string {
   return `$${(amountMicrodollars / 1_000_000).toFixed(2)}`;
@@ -27,20 +28,27 @@ export function BillingHistoryTable({
   onLoadMore: () => void;
   isLoading?: boolean;
 }) {
+  const headerCellClassName = 'h-14 bg-muted/20 px-4 text-sm font-semibold';
+  const bodyCellClassName = 'px-4 py-4';
+
   return (
     <div className="space-y-3">
       <div className="overflow-hidden rounded-xl border">
         <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Date</TableHead>
+          <TableHeader className="bg-muted/20">
+            <TableRow className="hover:bg-transparent">
+              <TableHead className={headerCellClassName}>Date</TableHead>
               {variant === 'stripe' ? (
-                <TableHead>Amount</TableHead>
+                <TableHead className={headerCellClassName}>Amount</TableHead>
               ) : (
-                <TableHead>Description</TableHead>
+                <TableHead className={headerCellClassName}>Description</TableHead>
               )}
-              <TableHead>{variant === 'stripe' ? 'Status' : 'Amount'}</TableHead>
-              {variant === 'stripe' ? <TableHead>Invoice</TableHead> : null}
+              <TableHead className={headerCellClassName}>
+                {variant === 'stripe' ? 'Status' : 'Amount'}
+              </TableHead>
+              {variant === 'stripe' ? (
+                <TableHead className={headerCellClassName}>Invoice</TableHead>
+              ) : null}
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -48,7 +56,7 @@ export function BillingHistoryTable({
               <TableRow>
                 <TableCell
                   colSpan={variant === 'stripe' ? 4 : 3}
-                  className="text-muted-foreground py-8 text-center"
+                  className="text-muted-foreground px-4 py-10 text-center"
                 >
                   No billing history yet.
                 </TableCell>
@@ -56,14 +64,18 @@ export function BillingHistoryTable({
             ) : (
               entries.map(entry => (
                 <TableRow key={entry.id}>
-                  <TableCell>{formatIsoDateString_UsaDateOnlyFormat(entry.date)}</TableCell>
+                  <TableCell className={bodyCellClassName}>
+                    {formatIsoDateString_UsaDateOnlyFormat(entry.date)}
+                  </TableCell>
                   {entry.kind === 'stripe' ? (
                     <>
-                      <TableCell>{formatCents(entry.amountCents, entry.currency)}</TableCell>
-                      <TableCell className="capitalize">
-                        {entry.status.replace(/_/g, ' ')}
+                      <TableCell className={bodyCellClassName}>
+                        {formatCents(entry.amountCents, entry.currency)}
                       </TableCell>
-                      <TableCell>
+                      <TableCell className={bodyCellClassName}>
+                        <InvoiceStatusBadge status={entry.status} />
+                      </TableCell>
+                      <TableCell className={bodyCellClassName}>
                         {entry.invoiceUrl ? (
                           <a
                             href={entry.invoiceUrl}
@@ -80,8 +92,10 @@ export function BillingHistoryTable({
                     </>
                   ) : (
                     <>
-                      <TableCell>{entry.description}</TableCell>
-                      <TableCell>{formatCreditAmount(entry.amountMicrodollars)}</TableCell>
+                      <TableCell className={bodyCellClassName}>{entry.description}</TableCell>
+                      <TableCell className={bodyCellClassName}>
+                        {formatCreditAmount(entry.amountMicrodollars)}
+                      </TableCell>
                     </>
                   )}
                 </TableRow>
@@ -97,5 +111,25 @@ export function BillingHistoryTable({
         </Button>
       ) : null}
     </div>
+  );
+}
+
+function InvoiceStatusBadge({ status }: { status: string }) {
+  const label = status.replace(/_/g, ' ');
+  const colorClass =
+    status === 'paid'
+      ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400'
+      : status === 'open'
+        ? 'border-amber-500/30 bg-amber-500/10 text-amber-400'
+        : status === 'draft'
+          ? 'border-muted-foreground/30 bg-muted/20 text-muted-foreground'
+          : status === 'void' || status === 'uncollectible'
+            ? 'border-destructive/30 bg-destructive/10 text-destructive'
+            : 'border-muted-foreground/30 bg-muted/20 text-muted-foreground';
+
+  return (
+    <Badge variant="outline" className={cn('capitalize', colorClass)}>
+      {label}
+    </Badge>
   );
 }

--- a/src/components/subscriptions/DetailPageHeader.tsx
+++ b/src/components/subscriptions/DetailPageHeader.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { BackButton } from '@/components/BackButton';
+import { SetPageTitle } from '@/components/SetPageTitle';
+import { SubscriptionStatusBadge } from './SubscriptionStatusBadge';
+
+export function DetailPageHeader({
+  backHref,
+  backLabel,
+  title,
+  status,
+  actions,
+}: {
+  backHref: string;
+  backLabel: string;
+  title: string;
+  status: string;
+  actions?: ReactNode;
+}) {
+  return (
+    <div className="space-y-4">
+      <SetPageTitle title={title} />
+      <BackButton href={backHref}>{backLabel}</BackButton>
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-2xl font-bold md:text-3xl">{title}</h1>
+          <SubscriptionStatusBadge status={status} />
+        </div>
+        {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/subscriptions/OrgSubscriptions.tsx
+++ b/src/components/subscriptions/OrgSubscriptions.tsx
@@ -1,30 +1,50 @@
 'use client';
 
+import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { PageLayout } from '@/components/PageLayout';
 import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
+import { useTRPC } from '@/lib/trpc/utils';
+import { isSeatsTerminal } from './helpers';
 import { TerminalToggle } from './TerminalToggle';
 import { SeatsGroup } from './seats/SeatsGroup';
 
 export function OrgSubscriptions({ organizationId }: { organizationId: string }) {
   const [showTerminal, setShowTerminal] = useState(false);
+  const trpc = useTRPC();
   const organizationQuery = useOrganizationWithMembers(organizationId, {
     enabled: !!organizationId,
   });
+  const subscriptionQuery = useQuery(
+    trpc.organizations.subscription.get.queryOptions(
+      { organizationId },
+      { enabled: !!organizationId }
+    )
+  );
+
+  const hasTerminalSubscriptions =
+    subscriptionQuery.data?.subscription != null &&
+    isSeatsTerminal(subscriptionQuery.data.subscription.status);
 
   return (
     <PageLayout
       title="Subscriptions"
       subtitle={`Manage subscriptions for ${organizationQuery.data?.name ?? 'your organization'}.`}
       headerActions={
-        <TerminalToggle
-          label="Show ended"
-          checked={showTerminal}
-          onCheckedChange={setShowTerminal}
-        />
+        hasTerminalSubscriptions ? (
+          <TerminalToggle
+            label="Show ended"
+            checked={showTerminal}
+            onCheckedChange={setShowTerminal}
+          />
+        ) : null
       }
     >
-      <SeatsGroup organizationId={organizationId} showTerminal={showTerminal} />
+      <SeatsGroup
+        organizationId={organizationId}
+        organizationPlan={organizationQuery.data?.plan ?? 'teams'}
+        showTerminal={showTerminal}
+      />
     </PageLayout>
   );
 }

--- a/src/components/subscriptions/OrgSubscriptions.tsx
+++ b/src/components/subscriptions/OrgSubscriptions.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useState } from 'react';
+import { PageLayout } from '@/components/PageLayout';
+import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
+import { TerminalToggle } from './TerminalToggle';
+import { SeatsGroup } from './seats/SeatsGroup';
+
+export function OrgSubscriptions({ organizationId }: { organizationId: string }) {
+  const [showTerminal, setShowTerminal] = useState(false);
+  const organizationQuery = useOrganizationWithMembers(organizationId, {
+    enabled: !!organizationId,
+  });
+
+  return (
+    <PageLayout
+      title="Subscriptions"
+      subtitle={`Manage subscriptions for ${organizationQuery.data?.name ?? 'your organization'}.`}
+      headerActions={
+        <TerminalToggle
+          label="Show ended"
+          checked={showTerminal}
+          onCheckedChange={setShowTerminal}
+        />
+      }
+    >
+      <SeatsGroup organizationId={organizationId} showTerminal={showTerminal} />
+    </PageLayout>
+  );
+}

--- a/src/components/subscriptions/PersonalSubscriptions.tsx
+++ b/src/components/subscriptions/PersonalSubscriptions.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState } from 'react';
+import { PageLayout } from '@/components/PageLayout';
+import { TerminalToggle } from './TerminalToggle';
+import { KiloPassGroup } from './kilo-pass/KiloPassGroup';
+import { KiloClawGroup } from './kiloclaw/KiloClawGroup';
+import { CodingPlansGroup } from './coding-plans/CodingPlansGroup';
+import { ENABLE_CODING_PLAN_SUBSCRIPTIONS } from '@/lib/constants';
+
+export function PersonalSubscriptions() {
+  const [showTerminal, setShowTerminal] = useState(false);
+
+  return (
+    <PageLayout
+      title="Subscriptions"
+      subtitle="Manage your subscriptions and billing in one place."
+      headerActions={
+        <TerminalToggle
+          label="Show cancelled"
+          checked={showTerminal}
+          onCheckedChange={setShowTerminal}
+        />
+      }
+    >
+      <KiloPassGroup showTerminal={showTerminal} />
+      <KiloClawGroup showTerminal={showTerminal} />
+      {ENABLE_CODING_PLAN_SUBSCRIPTIONS ? <CodingPlansGroup /> : null}
+    </PageLayout>
+  );
+}

--- a/src/components/subscriptions/PersonalSubscriptions.tsx
+++ b/src/components/subscriptions/PersonalSubscriptions.tsx
@@ -1,7 +1,11 @@
 'use client';
 
+import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { PageLayout } from '@/components/PageLayout';
+import { Accordion } from '@/components/ui/accordion';
+import { useTRPC } from '@/lib/trpc/utils';
+import { isKiloclawTerminal, isKiloPassTerminal } from './helpers';
 import { TerminalToggle } from './TerminalToggle';
 import { KiloPassGroup } from './kilo-pass/KiloPassGroup';
 import { KiloClawGroup } from './kiloclaw/KiloClawGroup';
@@ -10,22 +14,46 @@ import { ENABLE_CODING_PLAN_SUBSCRIPTIONS } from '@/lib/constants';
 
 export function PersonalSubscriptions() {
   const [showTerminal, setShowTerminal] = useState(false);
+  const [expandedSection, setExpandedSection] = useState('kilo-pass');
+  const trpc = useTRPC();
+  const kiloPassQuery = useQuery(trpc.kiloPass.getState.queryOptions());
+  const kiloClawQuery = useQuery(trpc.kiloclaw.listPersonalSubscriptions.queryOptions());
+
+  const hasTerminalSubscriptions =
+    (kiloPassQuery.data?.subscription != null &&
+      isKiloPassTerminal(kiloPassQuery.data.subscription.status)) ||
+    (kiloClawQuery.data?.subscriptions.some(subscription =>
+      isKiloclawTerminal(subscription.status)
+    ) ??
+      false);
 
   return (
     <PageLayout
       title="Subscriptions"
       subtitle="Manage your subscriptions and billing in one place."
       headerActions={
-        <TerminalToggle
-          label="Show cancelled"
-          checked={showTerminal}
-          onCheckedChange={setShowTerminal}
-        />
+        hasTerminalSubscriptions ? (
+          <TerminalToggle
+            label="Show ended"
+            checked={showTerminal}
+            onCheckedChange={setShowTerminal}
+          />
+        ) : null
       }
     >
-      <KiloPassGroup showTerminal={showTerminal} />
-      <KiloClawGroup showTerminal={showTerminal} />
-      {ENABLE_CODING_PLAN_SUBSCRIPTIONS ? <CodingPlansGroup /> : null}
+      <Accordion
+        type="single"
+        collapsible
+        value={expandedSection}
+        onValueChange={setExpandedSection}
+        className="space-y-8"
+      >
+        <KiloPassGroup showTerminal={showTerminal} accordionValue="kilo-pass" />
+        <KiloClawGroup showTerminal={showTerminal} accordionValue="kiloclaw" />
+        {ENABLE_CODING_PLAN_SUBSCRIPTIONS ? (
+          <CodingPlansGroup accordionValue="coding-plans" />
+        ) : null}
+      </Accordion>
     </PageLayout>
   );
 }

--- a/src/components/subscriptions/StripePortalLink.tsx
+++ b/src/components/subscriptions/StripePortalLink.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState } from 'react';
+import { CreditCard } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+
+export function StripePortalLink({
+  onOpenPortal,
+  label = 'Manage Payment Method',
+  variant = 'outline',
+}: {
+  onOpenPortal: () => Promise<string>;
+  label?: string;
+  variant?: React.ComponentProps<typeof Button>['variant'];
+}) {
+  const [isPending, setIsPending] = useState(false);
+
+  async function handleClick() {
+    if (isPending) return;
+    setIsPending(true);
+    try {
+      const url = await onOpenPortal();
+      window.location.href = url;
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to open Stripe portal');
+      setIsPending(false);
+    }
+  }
+
+  return (
+    <Button variant={variant} onClick={handleClick} disabled={isPending}>
+      <CreditCard className="h-4 w-4" />
+      {isPending ? 'Opening...' : label}
+    </Button>
+  );
+}

--- a/src/components/subscriptions/SubscriptionCard.tsx
+++ b/src/components/subscriptions/SubscriptionCard.tsx
@@ -52,14 +52,14 @@ export function SubscriptionCard({
                 />
               </div>
               <p className="text-muted-foreground text-sm">{subtitle}</p>
-              <div className="text-muted-foreground grid gap-1 text-sm sm:grid-cols-2 sm:gap-x-8">
+              <div className="text-muted-foreground flex flex-wrap gap-x-6 gap-y-1 text-sm">
                 <div>
                   <span className="text-foreground font-medium">Price:</span> {price}
                 </div>
                 <div>
-                  <span className="text-foreground font-medium">Billing:</span> {billingDate}
+                  <span className="text-foreground font-medium">Renews at:</span> {billingDate}
                 </div>
-                <div className="sm:col-span-2">
+                <div>
                   <span className="text-foreground font-medium">Payment:</span> {paymentMethod}
                 </div>
               </div>

--- a/src/components/subscriptions/SubscriptionCard.tsx
+++ b/src/components/subscriptions/SubscriptionCard.tsx
@@ -1,0 +1,73 @@
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { SubscriptionStatusBadge } from './SubscriptionStatusBadge';
+import { cn } from '@/lib/utils';
+
+export function SubscriptionCard({
+  icon,
+  title,
+  subtitle,
+  status,
+  price,
+  billingDate,
+  paymentMethod,
+  href,
+  isTerminal = false,
+  warningTone,
+}: {
+  icon: ReactNode;
+  title: string;
+  subtitle: string;
+  status: string;
+  price: string;
+  billingDate: string;
+  paymentMethod: string;
+  href: string;
+  isTerminal?: boolean;
+  warningTone?: 'warning' | 'info';
+}) {
+  return (
+    <Link href={href} className="block">
+      <Card
+        className={cn(
+          'transition-all hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-md',
+          isTerminal && 'opacity-55',
+          warningTone === 'warning' && 'border-amber-500/40 bg-amber-500/5',
+          warningTone === 'info' && 'border-blue-500/40 bg-blue-500/5'
+        )}
+      >
+        <CardContent className="flex flex-col gap-4 p-5 md:flex-row md:items-start md:justify-between">
+          <div className="flex min-w-0 gap-3">
+            <div className="bg-muted flex h-11 w-11 shrink-0 items-center justify-center rounded-xl">
+              {icon}
+            </div>
+            <div className="min-w-0 space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <h3 className="truncate font-semibold">{title}</h3>
+                <SubscriptionStatusBadge
+                  status={status}
+                  variant={isTerminal ? 'muted' : 'default'}
+                />
+              </div>
+              <p className="text-muted-foreground text-sm">{subtitle}</p>
+              <div className="text-muted-foreground grid gap-1 text-sm sm:grid-cols-2 sm:gap-x-8">
+                <div>
+                  <span className="text-foreground font-medium">Price:</span> {price}
+                </div>
+                <div>
+                  <span className="text-foreground font-medium">Billing:</span> {billingDate}
+                </div>
+                <div className="sm:col-span-2">
+                  <span className="text-foreground font-medium">Payment:</span> {paymentMethod}
+                </div>
+              </div>
+            </div>
+          </div>
+          <ChevronRight className="text-muted-foreground h-5 w-5 shrink-0 self-center md:mt-3" />
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/subscriptions/SubscriptionGroup.tsx
+++ b/src/components/subscriptions/SubscriptionGroup.tsx
@@ -1,10 +1,6 @@
 import type { ReactNode } from 'react';
 import { RefreshCw, AlertTriangle } from 'lucide-react';
-import {
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@/components/ui/accordion';
+import { AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';

--- a/src/components/subscriptions/SubscriptionGroup.tsx
+++ b/src/components/subscriptions/SubscriptionGroup.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from 'react';
+import { RefreshCw, AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function SubscriptionGroup({
+  title,
+  description,
+  children,
+  isLoading = false,
+  isError = false,
+  error,
+  onRetry,
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+  isLoading?: boolean;
+  isError?: boolean;
+  error?: unknown;
+  onRetry?: () => void;
+}) {
+  return (
+    <section className="space-y-3">
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold">{title}</h2>
+        {description ? <p className="text-muted-foreground text-sm">{description}</p> : null}
+      </div>
+
+      {isLoading ? (
+        <div className="grid gap-3 lg:grid-cols-2">
+          {['skeleton-1', 'skeleton-2'].map(key => (
+            <Card key={key}>
+              <CardContent className="space-y-4 p-5">
+                <div className="flex items-center gap-3">
+                  <Skeleton className="h-11 w-11 rounded-xl" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-4 w-36" />
+                    <Skeleton className="h-4 w-24" />
+                  </div>
+                </div>
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-3/4" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : isError ? (
+        <Card className="border-red-500/40 bg-red-500/5">
+          <CardContent className="flex flex-col gap-3 p-5 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="mt-0.5 h-5 w-5 text-red-300" />
+              <div>
+                <p className="font-medium">Unable to load {title.toLowerCase()}</p>
+                <p className="text-muted-foreground text-sm">
+                  {error instanceof Error
+                    ? error.message
+                    : 'Something went wrong while loading this section.'}
+                </p>
+              </div>
+            </div>
+            {onRetry ? (
+              <Button variant="outline" onClick={onRetry} className="self-start sm:self-auto">
+                <RefreshCw className="h-4 w-4" />
+                Retry
+              </Button>
+            ) : null}
+          </CardContent>
+        </Card>
+      ) : (
+        children
+      )}
+    </section>
+  );
+}

--- a/src/components/subscriptions/SubscriptionGroup.tsx
+++ b/src/components/subscriptions/SubscriptionGroup.tsx
@@ -1,76 +1,118 @@
 import type { ReactNode } from 'react';
 import { RefreshCw, AlertTriangle } from 'lucide-react';
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Separator } from '@/components/ui/separator';
 
 export function SubscriptionGroup({
   title,
   description,
   children,
+  headerIcon,
   isLoading = false,
   isError = false,
   error,
   onRetry,
+  accordionValue,
 }: {
   title: string;
   description?: string;
   children: ReactNode;
+  headerIcon?: ReactNode;
   isLoading?: boolean;
   isError?: boolean;
   error?: unknown;
   onRetry?: () => void;
+  accordionValue?: string;
 }) {
-  return (
-    <section className="space-y-3">
-      <div className="space-y-1">
+  const header = (
+    <div className="flex min-w-0 items-center gap-4">
+      {headerIcon ? (
+        <div className="bg-muted flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border">
+          {headerIcon}
+        </div>
+      ) : null}
+      <div className="min-w-0 space-y-1">
         <h2 className="text-lg font-semibold">{title}</h2>
         {description ? <p className="text-muted-foreground text-sm">{description}</p> : null}
       </div>
+    </div>
+  );
 
-      {isLoading ? (
-        <div className="grid gap-3 lg:grid-cols-2">
-          {['skeleton-1', 'skeleton-2'].map(key => (
-            <Card key={key}>
-              <CardContent className="space-y-4 p-5">
-                <div className="flex items-center gap-3">
-                  <Skeleton className="h-11 w-11 rounded-xl" />
-                  <div className="space-y-2">
-                    <Skeleton className="h-4 w-36" />
-                    <Skeleton className="h-4 w-24" />
-                  </div>
-                </div>
-                <Skeleton className="h-4 w-full" />
-                <Skeleton className="h-4 w-3/4" />
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      ) : isError ? (
-        <Card className="border-red-500/40 bg-red-500/5">
-          <CardContent className="flex flex-col gap-3 p-5 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-start gap-3">
-              <AlertTriangle className="mt-0.5 h-5 w-5 text-red-300" />
-              <div>
-                <p className="font-medium">Unable to load {title.toLowerCase()}</p>
-                <p className="text-muted-foreground text-sm">
-                  {error instanceof Error
-                    ? error.message
-                    : 'Something went wrong while loading this section.'}
-                </p>
+  const body = isLoading ? (
+    <div className="grid gap-3 lg:grid-cols-2">
+      {['skeleton-1', 'skeleton-2'].map(key => (
+        <Card key={key}>
+          <CardContent className="space-y-4 p-5">
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-11 w-11 rounded-xl" />
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-36" />
+                <Skeleton className="h-4 w-24" />
               </div>
             </div>
-            {onRetry ? (
-              <Button variant="outline" onClick={onRetry} className="self-start sm:self-auto">
-                <RefreshCw className="h-4 w-4" />
-                Retry
-              </Button>
-            ) : null}
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
           </CardContent>
         </Card>
-      ) : (
-        children
-      )}
+      ))}
+    </div>
+  ) : isError ? (
+    <Card className="border-red-500/40 bg-red-500/5">
+      <CardContent className="flex flex-col gap-3 p-5 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <AlertTriangle className="mt-0.5 h-5 w-5 text-red-300" />
+          <div>
+            <p className="font-medium">Unable to load {title.toLowerCase()}</p>
+            <p className="text-muted-foreground text-sm">
+              {error instanceof Error
+                ? error.message
+                : 'Something went wrong while loading this section.'}
+            </p>
+          </div>
+        </div>
+        {onRetry ? (
+          <Button variant="outline" onClick={onRetry} className="self-start sm:self-auto">
+            <RefreshCw className="h-4 w-4" />
+            Retry
+          </Button>
+        ) : null}
+      </CardContent>
+    </Card>
+  ) : (
+    children
+  );
+
+  if (accordionValue) {
+    return (
+      <AccordionItem
+        value={accordionValue}
+        className="rounded-3xl border bg-card/30 px-5 py-5 shadow-sm last:border-b md:px-6 md:py-6"
+      >
+        <AccordionTrigger className="flex-row-reverse items-center justify-between gap-4 pt-0 hover:no-underline [&>svg]:size-5 [&>svg]:translate-y-0">
+          {header}
+        </AccordionTrigger>
+        <AccordionContent className="pb-0 pt-4">
+          <Separator />
+          <div className="pt-5">{body}</div>
+        </AccordionContent>
+      </AccordionItem>
+    );
+  }
+
+  return (
+    <section className="rounded-3xl border bg-card/30 p-5 shadow-sm md:p-6">
+      <div className="space-y-5">
+        {header}
+        <Separator />
+        {body}
+      </div>
     </section>
   );
 }

--- a/src/components/subscriptions/SubscriptionStatusBadge.tsx
+++ b/src/components/subscriptions/SubscriptionStatusBadge.tsx
@@ -1,0 +1,41 @@
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+const statusStyles: Record<string, string> = {
+  active: 'bg-emerald-500/10 text-emerald-300 border-emerald-500/20',
+  trialing: 'bg-blue-500/10 text-blue-300 border-blue-500/20',
+  past_due: 'bg-amber-500/10 text-amber-300 border-amber-500/20',
+  unpaid: 'bg-red-500/10 text-red-300 border-red-500/20',
+  paused: 'bg-amber-500/10 text-amber-300 border-amber-500/20',
+  suspended: 'bg-red-500/10 text-red-300 border-red-500/20',
+  canceled: 'bg-muted text-muted-foreground border-border',
+  cancelled: 'bg-muted text-muted-foreground border-border',
+  ended: 'bg-muted text-muted-foreground border-border',
+  incomplete_expired: 'bg-muted text-muted-foreground border-border',
+  incomplete: 'bg-amber-500/10 text-amber-300 border-amber-500/20',
+};
+
+function formatStatusLabel(status: string): string {
+  return status.replace(/_/g, ' ').replace(/\b\w/g, char => char.toUpperCase());
+}
+
+export function SubscriptionStatusBadge({
+  status,
+  variant = 'default',
+}: {
+  status: string;
+  variant?: 'default' | 'muted';
+}) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        'rounded-full px-2.5 py-1 text-[11px] font-medium',
+        statusStyles[status] ?? 'bg-secondary text-secondary-foreground border-transparent',
+        variant === 'muted' && 'opacity-70'
+      )}
+    >
+      {formatStatusLabel(status)}
+    </Badge>
+  );
+}

--- a/src/components/subscriptions/TerminalToggle.tsx
+++ b/src/components/subscriptions/TerminalToggle.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Switch } from '@/components/ui/switch';
+
+export function TerminalToggle({
+  label,
+  checked,
+  onCheckedChange,
+}: {
+  label: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 text-sm">
+      <Switch checked={checked} onCheckedChange={onCheckedChange} />
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/src/components/subscriptions/coding-plans/CodingPlanDetail.tsx
+++ b/src/components/subscriptions/coding-plans/CodingPlanDetail.tsx
@@ -1,0 +1,23 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { DetailPageHeader } from '@/components/subscriptions/DetailPageHeader';
+
+export function CodingPlanDetail() {
+  return (
+    <div className="space-y-6">
+      <DetailPageHeader
+        backHref="/subscriptions"
+        backLabel="Back to subscriptions"
+        title="Coding Plans"
+        status="coming_soon"
+      />
+      <Card>
+        <CardHeader>
+          <CardTitle>Coming soon</CardTitle>
+        </CardHeader>
+        <CardContent>
+          Coding Plans subscriptions are deferred and will ship in a follow-up change.
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/subscriptions/coding-plans/CodingPlansGroup.tsx
+++ b/src/components/subscriptions/coding-plans/CodingPlansGroup.tsx
@@ -1,0 +1,20 @@
+import { Code2 } from 'lucide-react';
+import { AvailableProductCard } from '@/components/subscriptions/AvailableProductCard';
+import { SubscriptionGroup } from '@/components/subscriptions/SubscriptionGroup';
+
+export function CodingPlansGroup() {
+  return (
+    <SubscriptionGroup
+      title="Coding Plans"
+      description="Coding Plans subscriptions are shipping in a follow-up change."
+    >
+      <AvailableProductCard
+        icon={<Code2 className="h-5 w-5" />}
+        title="Coding Plans"
+        description="Provider-backed coding plan subscriptions are coming soon."
+        price="Coming soon"
+        cta={{ label: 'Learn more', href: '/byok' }}
+      />
+    </SubscriptionGroup>
+  );
+}

--- a/src/components/subscriptions/coding-plans/CodingPlansGroup.tsx
+++ b/src/components/subscriptions/coding-plans/CodingPlansGroup.tsx
@@ -2,11 +2,13 @@ import { Code2 } from 'lucide-react';
 import { AvailableProductCard } from '@/components/subscriptions/AvailableProductCard';
 import { SubscriptionGroup } from '@/components/subscriptions/SubscriptionGroup';
 
-export function CodingPlansGroup() {
+export function CodingPlansGroup({ accordionValue }: { accordionValue?: string }) {
   return (
     <SubscriptionGroup
       title="Coding Plans"
       description="Coding Plans subscriptions are shipping in a follow-up change."
+      headerIcon={<Code2 className="h-5 w-5" />}
+      accordionValue={accordionValue}
     >
       <AvailableProductCard
         icon={<Code2 className="h-5 w-5" />}

--- a/src/components/subscriptions/helpers.ts
+++ b/src/components/subscriptions/helpers.ts
@@ -30,6 +30,20 @@ export function formatKiloPassPrice(tier: KiloPassTier, cadence: KiloPassCadence
     : `${formatDollars(monthlyPrice)}/month`;
 }
 
+export function formatKiloPassTierLabel(tier: KiloPassTier): string {
+  if (tier === 'tier_19') return 'Starter';
+  if (tier === 'tier_49') return 'Pro';
+  return 'Expert';
+}
+
+export function formatKiloPassCadenceLabel(cadence: KiloPassCadence): string {
+  return cadence === KiloPassCadence.Yearly ? 'Yearly' : 'Monthly';
+}
+
+export function formatMonthCountLabel(months: number): string {
+  return `${months} month${months === 1 ? '' : 's'}`;
+}
+
 export function getPaidSeatSubscriptionItem(
   subscription: Pick<Stripe.Subscription, 'items'>
 ): Stripe.SubscriptionItem | null {

--- a/src/components/subscriptions/helpers.ts
+++ b/src/components/subscriptions/helpers.ts
@@ -1,0 +1,71 @@
+import type Stripe from 'stripe';
+import { formatDollars, formatIsoDateString_UsaDateOnlyFormat } from '@/lib/utils';
+import { getMonthlyPriceUsd } from '@/lib/kilo-pass/bonus';
+import { KiloPassCadence, type KiloPassTier } from '@/lib/kilo-pass/enums';
+
+export function isKiloPassTerminal(status: string): boolean {
+  return status === 'canceled' || status === 'incomplete_expired';
+}
+
+export function isKiloclawTerminal(status: string): boolean {
+  return status === 'canceled';
+}
+
+export function isSeatsTerminal(status: string): boolean {
+  return status === 'ended' || status === 'canceled';
+}
+
+export function isWarningStatus(status: string): boolean {
+  return status === 'past_due' || status === 'unpaid' || status === 'suspended';
+}
+
+export function isInfoStatus(status: string): boolean {
+  return status === 'trialing';
+}
+
+export function formatKiloPassPrice(tier: KiloPassTier, cadence: KiloPassCadence): string {
+  const monthlyPrice = getMonthlyPriceUsd(tier);
+  return cadence === KiloPassCadence.Yearly
+    ? `${formatDollars(monthlyPrice * 12)}/year`
+    : `${formatDollars(monthlyPrice)}/month`;
+}
+
+export function getPaidSeatSubscriptionItem(
+  subscription: Pick<Stripe.Subscription, 'items'>
+): Stripe.SubscriptionItem | null {
+  return (
+    subscription.items.data.find(
+      item => (item.price?.unit_amount ?? 0) > 0 && (item.quantity ?? 0) > 0
+    ) ??
+    subscription.items.data.find(item => (item.price?.unit_amount ?? 0) > 0) ??
+    subscription.items.data.find(item => item.price?.recurring?.interval) ??
+    null
+  );
+}
+
+export function formatKiloclawPrice(plan: string): string {
+  if (plan === 'trial') {
+    return 'Free trial';
+  }
+  if (plan === 'commit') {
+    return '$48.00 / 6 months';
+  }
+  return '$9.00/month';
+}
+
+export function formatDateLabel(date: string | null, fallback: string = '—'): string {
+  return date ? formatIsoDateString_UsaDateOnlyFormat(date) : fallback;
+}
+
+export function formatPaymentSummary(params: {
+  paymentSource: string | null;
+  hasStripeFunding?: boolean;
+}): string {
+  if (params.paymentSource === 'credits') {
+    return 'Credits';
+  }
+  if (params.hasStripeFunding) {
+    return 'Stripe';
+  }
+  return '—';
+}

--- a/src/components/subscriptions/kilo-pass/CreditHistory.tsx
+++ b/src/components/subscriptions/kilo-pass/CreditHistory.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { formatDollars, formatIsoDateString_UsaDateOnlyFormat } from '@/lib/utils';
+
+type CreditHistoryEntry = {
+  id: string;
+  date: string;
+  amountUsd: number;
+  kind: string;
+  description: string;
+};
+
+export function CreditHistory({
+  entries,
+  hasMore,
+  onLoadMore,
+  isLoading = false,
+}: {
+  entries: CreditHistoryEntry[];
+  hasMore: boolean;
+  onLoadMore: () => void;
+  isLoading?: boolean;
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="overflow-hidden rounded-xl border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Date</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead>Amount</TableHead>
+              <TableHead>Description</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {entries.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="text-muted-foreground py-8 text-center">
+                  No credit issuances yet.
+                </TableCell>
+              </TableRow>
+            ) : (
+              entries.map(entry => (
+                <TableRow key={entry.id}>
+                  <TableCell>{formatIsoDateString_UsaDateOnlyFormat(entry.date)}</TableCell>
+                  <TableCell className="capitalize">{entry.kind.replace(/_/g, ' ')}</TableCell>
+                  <TableCell>{formatDollars(entry.amountUsd)}</TableCell>
+                  <TableCell>{entry.description}</TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {hasMore ? (
+        <Button variant="outline" onClick={onLoadMore} disabled={isLoading}>
+          {isLoading ? 'Loading...' : 'Show more'}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/subscriptions/kilo-pass/CreditHistory.tsx
+++ b/src/components/subscriptions/kilo-pass/CreditHistory.tsx
@@ -11,6 +11,16 @@ import {
 } from '@/components/ui/table';
 import { formatDollars, formatIsoDateString_UsaDateOnlyFormat } from '@/lib/utils';
 
+const TIER_DISPLAY_NAMES: Record<string, string> = {
+  tier_19: 'Starter',
+  tier_49: 'Pro',
+  tier_199: 'Expert',
+};
+
+function humanizeCreditDescription(description: string): string {
+  return description.replace(/tier_\d+/g, match => TIER_DISPLAY_NAMES[match] ?? match);
+}
+
 type CreditHistoryEntry = {
   id: string;
   date: string;
@@ -30,32 +40,43 @@ export function CreditHistory({
   onLoadMore: () => void;
   isLoading?: boolean;
 }) {
+  const headerCellClassName = 'h-14 bg-muted/20 px-4 text-sm font-semibold';
+  const bodyCellClassName = 'px-4 py-4';
+
   return (
     <div className="space-y-3">
       <div className="overflow-hidden rounded-xl border">
         <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Date</TableHead>
-              <TableHead>Type</TableHead>
-              <TableHead>Amount</TableHead>
-              <TableHead>Description</TableHead>
+          <TableHeader className="bg-muted/20">
+            <TableRow className="hover:bg-transparent">
+              <TableHead className={headerCellClassName}>Date</TableHead>
+              <TableHead className={headerCellClassName}>Type</TableHead>
+              <TableHead className={headerCellClassName}>Amount</TableHead>
+              <TableHead className={headerCellClassName}>Description</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {entries.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={4} className="text-muted-foreground py-8 text-center">
+                <TableCell colSpan={4} className="text-muted-foreground px-4 py-10 text-center">
                   No credit issuances yet.
                 </TableCell>
               </TableRow>
             ) : (
               entries.map(entry => (
                 <TableRow key={entry.id}>
-                  <TableCell>{formatIsoDateString_UsaDateOnlyFormat(entry.date)}</TableCell>
-                  <TableCell className="capitalize">{entry.kind.replace(/_/g, ' ')}</TableCell>
-                  <TableCell>{formatDollars(entry.amountUsd)}</TableCell>
-                  <TableCell>{entry.description}</TableCell>
+                  <TableCell className={bodyCellClassName}>
+                    {formatIsoDateString_UsaDateOnlyFormat(entry.date)}
+                  </TableCell>
+                  <TableCell className={`${bodyCellClassName} capitalize`}>
+                    {entry.kind.replace(/_/g, ' ')}
+                  </TableCell>
+                  <TableCell className={bodyCellClassName}>
+                    {formatDollars(entry.amountUsd)}
+                  </TableCell>
+                  <TableCell className={bodyCellClassName}>
+                    {humanizeCreditDescription(entry.description)}
+                  </TableCell>
                 </TableRow>
               ))
             )}

--- a/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
+++ b/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
@@ -41,6 +41,7 @@ import {
   formatKiloPassPrice,
   formatKiloPassTierLabel,
   formatMonthCountLabel,
+  isKiloPassTerminal,
 } from '@/components/subscriptions/helpers';
 
 export function KiloPassDetail() {
@@ -267,11 +268,13 @@ export function KiloPassDetail() {
           </Card>
         </div>
 
-        <KiloPassInlineActions
-          onOpenSettings={() => setSettingsOpen(true)}
-          onResume={handleResume}
-          hasScheduledChange={Boolean(scheduledChange)}
-        />
+        {isKiloPassTerminal(subscription.status) ? null : (
+          <KiloPassInlineActions
+            onOpenSettings={() => setSettingsOpen(true)}
+            onResume={handleResume}
+            hasScheduledChange={Boolean(scheduledChange)}
+          />
+        )}
 
         <Card>
           <CardHeader className="pb-4">

--- a/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
+++ b/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
@@ -3,19 +3,45 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Crown, Settings2 } from 'lucide-react';
+import { Calendar, Coins, Crown, ExternalLink } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Progress } from '@/components/ui/progress';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { cn } from '@/lib/utils';
 import { useRawTRPCClient, useTRPC } from '@/lib/trpc/utils';
 import { formatDollars, formatIsoDateString_UsaDateOnlyFormat } from '@/lib/utils';
 import { DetailPageHeader } from '@/components/subscriptions/DetailPageHeader';
-import { StripePortalLink } from '@/components/subscriptions/StripePortalLink';
 import { BillingHistoryTable } from '@/components/subscriptions/BillingHistoryTable';
 import { CreditHistory } from './CreditHistory';
-import { KiloPassSubscriptionInfoProvider } from '@/components/profile/kilo-pass/useKiloPassSubscriptionInfo';
+import {
+  KiloPassSubscriptionInfoProvider,
+  useKiloPassSubscriptionInfo,
+} from '@/components/profile/kilo-pass/useKiloPassSubscriptionInfo';
+import type { KiloPassSubscription } from '@/components/profile/kilo-pass/kiloPassSubscription';
 import { KiloPassSubscriptionSettingsModal } from '@/components/profile/kilo-pass/KiloPassSubscriptionSettingsModal';
 import { KiloPassBonusRampDialog } from '@/components/profile/kilo-pass/KiloPassBonusRampDialog';
+import { computeMonthlyCadenceBonusPercent } from '@/lib/kilo-pass/bonus';
+import { KiloPassCadence } from '@/lib/kilo-pass/enums';
+import { KILO_PASS_FIRST_MONTH_PROMO_BONUS_PERCENT } from '@/lib/kilo-pass/constants';
+import {
+  computeUsageProgressModel,
+  computeRenewInfoRowModel,
+} from '@/components/profile/kilo-pass/KiloPassActiveSubscriptionCard.logic';
+import {
+  formatKiloPassCadenceLabel,
+  formatKiloPassPrice,
+  formatKiloPassTierLabel,
+  formatMonthCountLabel,
+} from '@/components/subscriptions/helpers';
 
 export function KiloPassDetail() {
   const trpc = useTRPC();
@@ -84,13 +110,15 @@ export function KiloPassDetail() {
   const subscription = stateQuery.data?.subscription ?? null;
   const scheduledChange = scheduledChangeQuery.data?.scheduledChange ?? null;
 
-  const bonusProgress = useMemo(() => {
-    if (!subscription) return 0;
-    const total =
-      (subscription.currentPeriodBaseCreditsUsd ?? 0) +
-      (subscription.currentPeriodBonusCreditsUsd ?? 0);
-    if (total <= 0) return 0;
-    return Math.min(100, Math.round((subscription.currentPeriodUsageUsd / total) * 100));
+  const showFirstMonthPromoInDialog = useMemo(() => {
+    if (!subscription || subscription.cadence !== 'monthly') return false;
+    const promoPercent = computeMonthlyCadenceBonusPercent({
+      tier: subscription.tier,
+      streakMonths: Math.max(1, subscription.currentStreakMonths),
+      isFirstTimeSubscriberEver: subscription.isFirstTimeSubscriberEver,
+      subscriptionStartedAtIso: subscription.startedAt,
+    });
+    return promoPercent === KILO_PASS_FIRST_MONTH_PROMO_BONUS_PERCENT;
   }, [subscription]);
 
   async function refreshData() {
@@ -164,30 +192,26 @@ export function KiloPassDetail() {
           backLabel="Back to subscriptions"
           title="Kilo Pass"
           status={subscription.status}
-          actions={
-            <StripePortalLink
-              onOpenPortal={async () => {
-                const result = await trpcClient.kiloPass.getCustomerPortalUrl.mutate({
-                  returnUrl: window.location.href,
-                });
-                return result.url;
-              }}
-            />
-          }
         />
 
-        <div className="grid gap-6 xl:grid-cols-[2fr_1fr]">
+        <div className="grid items-stretch gap-6 xl:grid-cols-2">
           <Card>
-            <CardHeader>
-              <CardTitle>Subscription details</CardTitle>
+            <CardHeader className="pb-4">
+              <CardTitle className="flex items-center gap-2">
+                <Coins className="h-5 w-5" />
+                Subscription details
+              </CardTitle>
             </CardHeader>
             <CardContent className="space-y-6">
               <div className="grid gap-4 sm:grid-cols-2">
-                <DetailRow label="Tier" value={subscription.tier} />
-                <DetailRow label="Cadence" value={subscription.cadence} />
+                <DetailRow label="Tier" value={formatKiloPassTierLabel(subscription.tier)} />
+                <DetailRow
+                  label="Cadence"
+                  value={formatKiloPassCadenceLabel(subscription.cadence)}
+                />
                 <DetailRow
                   label="Price"
-                  value={formatDollars(subscription.currentPeriodBaseCreditsUsd)}
+                  value={formatKiloPassPrice(subscription.tier, subscription.cadence)}
                 />
                 <DetailRow
                   label="Next billing"
@@ -199,7 +223,7 @@ export function KiloPassDetail() {
                 />
                 <DetailRow
                   label="Current streak"
-                  value={`${subscription.currentStreakMonths} months`}
+                  value={formatMonthCountLabel(subscription.currentStreakMonths)}
                 />
               </div>
 
@@ -209,7 +233,8 @@ export function KiloPassDetail() {
                     <div>
                       <p className="font-medium">Scheduled change</p>
                       <p className="text-muted-foreground text-sm">
-                        {scheduledChange.toTier} {scheduledChange.toCadence} on{' '}
+                        {formatKiloPassTierLabel(scheduledChange.toTier)}{' '}
+                        {formatKiloPassCadenceLabel(scheduledChange.toCadence)} on{' '}
                         {formatIsoDateString_UsaDateOnlyFormat(scheduledChange.effectiveAt)}
                       </p>
                     </div>
@@ -219,69 +244,40 @@ export function KiloPassDetail() {
                   </CardContent>
                 </Card>
               ) : null}
-
-              <div className="flex flex-wrap gap-2">
-                <Button variant="outline" onClick={() => setSettingsOpen(true)}>
-                  <Settings2 className="h-4 w-4" />
-                  Manage subscription
-                </Button>
-                {subscription.cancelAtPeriodEnd ? (
-                  <Button variant="outline" onClick={() => void handleResume()}>
-                    Resume Subscription
-                  </Button>
-                ) : null}
-              </div>
             </CardContent>
           </Card>
 
           <Card>
-            <CardHeader>
+            <CardHeader className="pb-4">
               <CardTitle className="flex items-center gap-2">
                 <Crown className="h-5 w-5" />
                 Bonus streak
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-muted-foreground">Current period usage</span>
-                  <span>{formatDollars(subscription.currentPeriodUsageUsd)}</span>
-                </div>
-                <Progress value={bonusProgress} />
-              </div>
-              <div className="space-y-2 text-sm">
-                <p>
-                  Base credits:{' '}
-                  <span className="font-medium">
-                    {formatDollars(subscription.currentPeriodBaseCreditsUsd)}
-                  </span>
-                </p>
-                <p>
-                  Bonus credits:{' '}
-                  <span className="font-medium">
-                    {subscription.currentPeriodBonusCreditsUsd != null
-                      ? formatDollars(subscription.currentPeriodBonusCreditsUsd)
-                      : '—'}
-                  </span>
-                </p>
-              </div>
-              <div className="flex items-center justify-between rounded-xl border p-3 text-sm">
-                <span>Bonus ramp preview</span>
                 <KiloPassBonusRampDialog
                   tier={subscription.tier}
+                  showFirstMonthPromo={showFirstMonthPromoInDialog}
+                  showSecondMonthPromo={subscription.currentStreakMonths === 1}
                   streakMonths={subscription.currentStreakMonths}
                   subscriptionStartedAtIso={subscription.startedAt ?? undefined}
                 />
-              </div>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <BonusStreakContent subscription={subscription} />
             </CardContent>
           </Card>
         </div>
 
+        <KiloPassInlineActions
+          onOpenSettings={() => setSettingsOpen(true)}
+          onResume={handleResume}
+          hasScheduledChange={Boolean(scheduledChange)}
+        />
+
         <Card>
-          <CardHeader>
+          <CardHeader className="pb-4">
             <CardTitle>Credit history</CardTitle>
           </CardHeader>
-          <CardContent>
+          <CardContent className="pt-1">
             <CreditHistory
               entries={creditEntries}
               hasMore={creditHasMore}
@@ -292,10 +288,10 @@ export function KiloPassDetail() {
         </Card>
 
         <Card>
-          <CardHeader>
+          <CardHeader className="pb-4">
             <CardTitle>Billing history</CardTitle>
           </CardHeader>
-          <CardContent>
+          <CardContent className="pt-1">
             <BillingHistoryTable
               variant="stripe"
               entries={billingEntries}
@@ -312,6 +308,269 @@ export function KiloPassDetail() {
         />
       </div>
     </KiloPassSubscriptionInfoProvider>
+  );
+}
+
+type KiloPassConfirmationAction = 'cancel' | 'resume';
+
+function KiloPassInlineActions({
+  onOpenSettings,
+  onResume,
+  hasScheduledChange,
+}: {
+  onOpenSettings: () => void;
+  onResume: () => Promise<void>;
+  hasScheduledChange: boolean;
+}) {
+  const { view, actions } = useKiloPassSubscriptionInfo();
+  const [confirmationAction, setConfirmationAction] =
+    useState<KiloPassConfirmationAction | null>(null);
+  const [pendingAction, setPendingAction] = useState<KiloPassConfirmationAction | null>(null);
+
+  const confirmationDetails =
+    confirmationAction === 'cancel'
+      ? {
+          title: 'Cancel subscription at period end?',
+          description:
+            'Your Kilo Pass subscription stays active through the current billing period, then the subscription ends. You will lose your bonus streak.',
+          confirmLabel: 'Cancel Subscription',
+          pendingLabel: 'Canceling subscription',
+          confirmVariant: 'destructive' as const,
+          action: () =>
+            new Promise<void>(resolve => {
+              actions.cancelSubscription({ onSuccess: resolve });
+            }),
+        }
+      : confirmationAction === 'resume'
+        ? {
+            title: 'Resume subscription?',
+            description:
+              'This removes the pending cancellation so your Kilo Pass subscription keeps renewing automatically.',
+            confirmLabel: 'Resume Subscription',
+            pendingLabel: 'Resuming subscription',
+            confirmVariant: 'default' as const,
+            action: async () => {
+              await onResume();
+            },
+          }
+        : null;
+
+  function confirmAction() {
+    if (!confirmationAction || !confirmationDetails) return;
+    setPendingAction(confirmationAction);
+    void confirmationDetails
+      .action()
+      .then(() => setConfirmationAction(null))
+      .catch(() => {})
+      .finally(() => setPendingAction(null));
+  }
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-2">
+        <Button variant="outline" onClick={onOpenSettings} disabled={hasScheduledChange}>
+          Change Plan
+        </Button>
+        {view.actions.resume ? (
+          <Button variant="outline" onClick={() => setConfirmationAction('resume')}>
+            Resume Subscription
+          </Button>
+        ) : view.actions.cancel ? (
+          <Button
+            variant="outline"
+            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+            onClick={() => setConfirmationAction('cancel')}
+          >
+            Cancel Subscription
+          </Button>
+        ) : null}
+        <Button
+          variant="outline"
+          onClick={actions.openCustomerPortal}
+          disabled={actions.isOpeningCustomerPortal}
+        >
+          <ExternalLink className="h-4 w-4" />
+          {actions.isOpeningCustomerPortal ? 'Opening...' : 'Manage Payment Method'}
+        </Button>
+      </div>
+
+      <AlertDialog
+        open={confirmationAction !== null}
+        onOpenChange={open => {
+          if (!open && pendingAction === null) {
+            setConfirmationAction(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{confirmationDetails?.title}</AlertDialogTitle>
+            <AlertDialogDescription>{confirmationDetails?.description}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={pendingAction !== null}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant={confirmationDetails?.confirmVariant ?? 'default'}
+              onClick={confirmAction}
+              disabled={pendingAction !== null}
+            >
+              {pendingAction !== null
+                ? confirmationDetails?.pendingLabel
+                : confirmationDetails?.confirmLabel}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function BonusStreakContent({
+  subscription,
+}: {
+  subscription: KiloPassSubscription;
+}) {
+  const trpc = useTRPC();
+  const scheduledChangeQuery = useQuery(trpc.kiloPass.getScheduledChange.queryOptions());
+  const scheduledChange = scheduledChangeQuery.data?.scheduledChange ?? null;
+  const { view } = useKiloPassSubscriptionInfo();
+
+  const model = computeUsageProgressModel({
+    baseUsd: subscription.currentPeriodBaseCreditsUsd,
+    usageUsd: subscription.currentPeriodUsageUsd,
+    bonusUsd: subscription.currentPeriodBonusCreditsUsd,
+    isBonusUnlocked: subscription.isBonusUnlocked,
+  });
+
+  const renewRows = computeRenewInfoRowModel({
+    subscription,
+    isPendingCancellation: Boolean(view.pendingCancellation),
+    scheduledChange,
+  });
+
+  const expiresAt = subscription.refillAt ?? subscription.nextBillingAt;
+  const expiresAtLabel = expiresAt ? formatIsoDateString_UsaDateOnlyFormat(expiresAt) : null;
+
+  return (
+    <div className="space-y-4">
+      {model ? (
+        <div className="bg-muted/20 border-border/60 grid gap-3 rounded-lg border p-3">
+          <div className="flex items-center justify-between gap-3 text-sm">
+            <span className="text-muted-foreground">This month&apos;s usage</span>
+            <span className={cn('font-mono font-semibold', model.statusClass)}>
+              {formatDollars(model.nonNegativeUsageUsd)} / {formatDollars(model.totalAvailableUsd)}
+            </span>
+          </div>
+
+          <div className="space-y-2">
+            <div className="bg-muted/50 relative h-3 overflow-visible rounded-full">
+              <div
+                className="absolute inset-y-0 left-0 opacity-40"
+                style={{
+                  width: `${model.pctOfBaseInTotal}%`,
+                  background: 'rgba(245,158,11,0.20)',
+                }}
+              />
+              <div
+                className="absolute inset-y-0 opacity-40"
+                style={{
+                  left: `${model.pctOfBaseInTotal}%`,
+                  width: `${100 - model.pctOfBaseInTotal}%`,
+                  background: 'rgba(16,185,129,0.20)',
+                }}
+              />
+              <div
+                className="absolute inset-y-0 left-0 rounded-l-full bg-linear-to-r from-amber-500 to-amber-300 transition-[width]"
+                style={{ width: `${model.paidFillPct}%` }}
+              />
+              <div
+                className="absolute inset-y-0 rounded-r-full bg-linear-to-r from-emerald-500 to-emerald-300 transition-[width]"
+                style={{ left: `${model.pctOfBaseInTotal}%`, width: `${model.bonusFillPct}%` }}
+              />
+              <div
+                className="absolute top-full mt-0.5 h-1.5 w-0.5 rounded bg-white/40"
+                style={{ left: `calc(${model.pctOfBaseInTotal}% - 1px)` }}
+              />
+            </div>
+
+            <div className="relative h-4">
+              <span
+                className="absolute -translate-x-1/2 font-mono text-xs font-semibold text-amber-300"
+                style={{ left: `${model.pctOfBaseInTotal}%` }}
+              >
+                {formatDollars(model.baseUsd)}
+              </span>
+              <span className="absolute right-0 font-mono text-xs font-semibold text-emerald-300">
+                {formatDollars(model.bonusUsd)}
+              </span>
+            </div>
+
+            <div className="text-muted-foreground flex items-center justify-between text-xs">
+              <div className="flex items-center gap-2">
+                <span className="h-2 w-2 rounded-sm bg-amber-400/80" />
+                Paid
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="h-2 w-2 rounded-sm bg-emerald-400/80" />
+                Free bonus
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {renewRows.map(row => {
+        const dateLabel = formatIsoDateString_UsaDateOnlyFormat(row.refillAtIso);
+
+        if (row.kind === 'active_until') {
+          return (
+            <div
+              key={`active_until:${row.refillAtIso}`}
+              className="bg-muted/20 border-border/60 flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-sm"
+            >
+              <div className="flex items-start gap-2">
+                <Calendar className="mt-0.5 h-4 w-4 text-white/40" />
+                <div className="text-muted-foreground">Active until</div>
+              </div>
+              <span className="text-muted-foreground">{dateLabel}</span>
+            </div>
+          );
+        }
+
+        return (
+          <div
+            key={`renews_and_adds_bonus:${row.refillAtIso}`}
+            className="bg-muted/20 border-border/60 rounded-lg border px-3 py-2 text-sm"
+          >
+            <div className="flex items-start gap-2">
+              <Calendar className="mt-0.5 h-4 w-4 text-white/40" />
+              <div className="text-muted-foreground">
+                <div>{row.labelPrefix}: <span className="text-foreground">{dateLabel}</span></div>
+                <div className="mt-1">
+                  Adds{' '}
+                  <span className="font-mono font-semibold text-amber-300">
+                    {formatDollars(row.baseUsd)}
+                  </span>{' '}
+                  paid +{' '}
+                  <span className="font-mono font-semibold text-emerald-300">
+                    {formatDollars(row.bonusUsd)}
+                  </span>{' '}
+                  free bonus credits
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+
+      {subscription.cadence === KiloPassCadence.Monthly ? (
+        <div className="text-muted-foreground text-xs">
+          Unused paid credits never expire and roll over every month into your total. Free bonus
+          credits are earned after using the month&apos;s paid credits. Unused free bonus credits do
+          not roll over{expiresAtLabel ? ` and will expire on ${expiresAtLabel}.` : '.'}
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
+++ b/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
@@ -323,8 +323,9 @@ function KiloPassInlineActions({
   hasScheduledChange: boolean;
 }) {
   const { view, actions } = useKiloPassSubscriptionInfo();
-  const [confirmationAction, setConfirmationAction] =
-    useState<KiloPassConfirmationAction | null>(null);
+  const [confirmationAction, setConfirmationAction] = useState<KiloPassConfirmationAction | null>(
+    null
+  );
   const [pendingAction, setPendingAction] = useState<KiloPassConfirmationAction | null>(null);
 
   const confirmationDetails =
@@ -425,11 +426,7 @@ function KiloPassInlineActions({
   );
 }
 
-function BonusStreakContent({
-  subscription,
-}: {
-  subscription: KiloPassSubscription;
-}) {
+function BonusStreakContent({ subscription }: { subscription: KiloPassSubscription }) {
   const trpc = useTRPC();
   const scheduledChangeQuery = useQuery(trpc.kiloPass.getScheduledChange.queryOptions());
   const scheduledChange = scheduledChangeQuery.data?.scheduledChange ?? null;
@@ -545,7 +542,9 @@ function BonusStreakContent({
             <div className="flex items-start gap-2">
               <Calendar className="mt-0.5 h-4 w-4 text-white/40" />
               <div className="text-muted-foreground">
-                <div>{row.labelPrefix}: <span className="text-foreground">{dateLabel}</span></div>
+                <div>
+                  {row.labelPrefix}: <span className="text-foreground">{dateLabel}</span>
+                </div>
                 <div className="mt-1">
                   Adds{' '}
                   <span className="font-mono font-semibold text-amber-300">

--- a/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
+++ b/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
@@ -1,0 +1,325 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Crown, Settings2 } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { useRawTRPCClient, useTRPC } from '@/lib/trpc/utils';
+import { formatDollars, formatIsoDateString_UsaDateOnlyFormat } from '@/lib/utils';
+import { DetailPageHeader } from '@/components/subscriptions/DetailPageHeader';
+import { StripePortalLink } from '@/components/subscriptions/StripePortalLink';
+import { BillingHistoryTable } from '@/components/subscriptions/BillingHistoryTable';
+import { CreditHistory } from './CreditHistory';
+import { KiloPassSubscriptionInfoProvider } from '@/components/profile/kilo-pass/useKiloPassSubscriptionInfo';
+import { KiloPassSubscriptionSettingsModal } from '@/components/profile/kilo-pass/KiloPassSubscriptionSettingsModal';
+import { KiloPassBonusRampDialog } from '@/components/profile/kilo-pass/KiloPassBonusRampDialog';
+
+export function KiloPassDetail() {
+  const trpc = useTRPC();
+  const trpcClient = useRawTRPCClient();
+  const queryClient = useQueryClient();
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [billingEntries, setBillingEntries] = useState<
+    Array<
+      Awaited<ReturnType<typeof trpcClient.kiloPass.getBillingHistory.query>>['entries'][number]
+    >
+  >([]);
+  const [billingCursor, setBillingCursor] = useState<string | null>(null);
+  const [billingHasMore, setBillingHasMore] = useState(false);
+  const [billingLoadingMore, setBillingLoadingMore] = useState(false);
+  const [creditEntries, setCreditEntries] = useState<
+    Array<Awaited<ReturnType<typeof trpcClient.kiloPass.getCreditHistory.query>>['entries'][number]>
+  >([]);
+  const [creditCursor, setCreditCursor] = useState<string | null>(null);
+  const [creditHasMore, setCreditHasMore] = useState(false);
+  const [creditLoadingMore, setCreditLoadingMore] = useState(false);
+
+  const stateQuery = useQuery(trpc.kiloPass.getState.queryOptions());
+  const scheduledChangeQuery = useQuery(trpc.kiloPass.getScheduledChange.queryOptions());
+  const billingQuery = useQuery(trpc.kiloPass.getBillingHistory.queryOptions({}));
+  const creditHistoryQuery = useQuery(trpc.kiloPass.getCreditHistory.queryOptions({}));
+
+  const subscriptionId = stateQuery.data?.subscription?.stripeSubscriptionId ?? null;
+
+  useEffect(() => {
+    if (!subscriptionId) {
+      setBillingEntries([]);
+      setBillingCursor(null);
+      setBillingHasMore(false);
+      setBillingLoadingMore(false);
+      setCreditEntries([]);
+      setCreditCursor(null);
+      setCreditHasMore(false);
+      setCreditLoadingMore(false);
+      return;
+    }
+
+    setBillingEntries([]);
+    setBillingCursor(null);
+    setBillingHasMore(false);
+    setBillingLoadingMore(false);
+    setCreditEntries([]);
+    setCreditCursor(null);
+    setCreditHasMore(false);
+    setCreditLoadingMore(false);
+  }, [subscriptionId]);
+
+  useEffect(() => {
+    if (!billingQuery.data) return;
+    setBillingEntries(billingQuery.data.entries);
+    setBillingCursor(billingQuery.data.cursor);
+    setBillingHasMore(billingQuery.data.hasMore);
+  }, [billingQuery.data]);
+
+  useEffect(() => {
+    if (!creditHistoryQuery.data) return;
+    setCreditEntries(creditHistoryQuery.data.entries);
+    setCreditCursor(creditHistoryQuery.data.cursor);
+    setCreditHasMore(creditHistoryQuery.data.hasMore);
+  }, [creditHistoryQuery.data]);
+
+  const subscription = stateQuery.data?.subscription ?? null;
+  const scheduledChange = scheduledChangeQuery.data?.scheduledChange ?? null;
+
+  const bonusProgress = useMemo(() => {
+    if (!subscription) return 0;
+    const total =
+      (subscription.currentPeriodBaseCreditsUsd ?? 0) +
+      (subscription.currentPeriodBonusCreditsUsd ?? 0);
+    if (total <= 0) return 0;
+    return Math.min(100, Math.round((subscription.currentPeriodUsageUsd / total) * 100));
+  }, [subscription]);
+
+  async function refreshData() {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: trpc.kiloPass.getState.queryKey() }),
+      queryClient.invalidateQueries({ queryKey: trpc.kiloPass.getScheduledChange.queryKey() }),
+      queryClient.invalidateQueries({ queryKey: trpc.kiloPass.getBillingHistory.queryKey({}) }),
+      queryClient.invalidateQueries({ queryKey: trpc.kiloPass.getCreditHistory.queryKey({}) }),
+    ]);
+  }
+
+  async function handleResume() {
+    await trpcClient.kiloPass.resumeSubscription.mutate();
+    toast.success('Subscription resumed');
+    await refreshData();
+  }
+
+  async function handleCancelScheduledChange() {
+    await trpcClient.kiloPass.cancelScheduledChange.mutate();
+    toast.success('Scheduled change canceled');
+    await refreshData();
+  }
+
+  async function loadMoreBilling() {
+    if (!billingCursor || billingLoadingMore) return;
+    setBillingLoadingMore(true);
+    try {
+      const result = await trpcClient.kiloPass.getBillingHistory.query({ cursor: billingCursor });
+      setBillingEntries(current => [...current, ...result.entries]);
+      setBillingCursor(result.cursor);
+      setBillingHasMore(result.hasMore);
+    } finally {
+      setBillingLoadingMore(false);
+    }
+  }
+
+  async function loadMoreCreditHistory() {
+    if (!creditCursor || creditLoadingMore) return;
+    setCreditLoadingMore(true);
+    try {
+      const result = await trpcClient.kiloPass.getCreditHistory.query({ cursor: creditCursor });
+      setCreditEntries(current => [...current, ...result.entries]);
+      setCreditCursor(result.cursor);
+      setCreditHasMore(result.hasMore);
+    } finally {
+      setCreditLoadingMore(false);
+    }
+  }
+
+  if (stateQuery.isLoading) {
+    return (
+      <Card>
+        <CardContent className="p-6">Loading subscription...</CardContent>
+      </Card>
+    );
+  }
+
+  if (!subscription) {
+    return (
+      <Card>
+        <CardContent className="p-6">Kilo Pass subscription not found.</CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <KiloPassSubscriptionInfoProvider subscription={subscription}>
+      <div className="space-y-6">
+        <DetailPageHeader
+          backHref="/subscriptions"
+          backLabel="Back to subscriptions"
+          title="Kilo Pass"
+          status={subscription.status}
+          actions={
+            <StripePortalLink
+              onOpenPortal={async () => {
+                const result = await trpcClient.kiloPass.getCustomerPortalUrl.mutate({
+                  returnUrl: window.location.href,
+                });
+                return result.url;
+              }}
+            />
+          }
+        />
+
+        <div className="grid gap-6 xl:grid-cols-[2fr_1fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Subscription details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <DetailRow label="Tier" value={subscription.tier} />
+                <DetailRow label="Cadence" value={subscription.cadence} />
+                <DetailRow
+                  label="Price"
+                  value={formatDollars(subscription.currentPeriodBaseCreditsUsd)}
+                />
+                <DetailRow
+                  label="Next billing"
+                  value={formatIsoDateString_UsaDateOnlyFormat(subscription.nextBillingAt)}
+                />
+                <DetailRow
+                  label="Started"
+                  value={formatIsoDateString_UsaDateOnlyFormat(subscription.startedAt)}
+                />
+                <DetailRow
+                  label="Current streak"
+                  value={`${subscription.currentStreakMonths} months`}
+                />
+              </div>
+
+              {scheduledChange ? (
+                <Card className="border-blue-500/30 bg-blue-500/5">
+                  <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <p className="font-medium">Scheduled change</p>
+                      <p className="text-muted-foreground text-sm">
+                        {scheduledChange.toTier} {scheduledChange.toCadence} on{' '}
+                        {formatIsoDateString_UsaDateOnlyFormat(scheduledChange.effectiveAt)}
+                      </p>
+                    </div>
+                    <Button variant="outline" onClick={() => void handleCancelScheduledChange()}>
+                      Cancel Scheduled Change
+                    </Button>
+                  </CardContent>
+                </Card>
+              ) : null}
+
+              <div className="flex flex-wrap gap-2">
+                <Button variant="outline" onClick={() => setSettingsOpen(true)}>
+                  <Settings2 className="h-4 w-4" />
+                  Manage subscription
+                </Button>
+                {subscription.cancelAtPeriodEnd ? (
+                  <Button variant="outline" onClick={() => void handleResume()}>
+                    Resume Subscription
+                  </Button>
+                ) : null}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Crown className="h-5 w-5" />
+                Bonus streak
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-muted-foreground">Current period usage</span>
+                  <span>{formatDollars(subscription.currentPeriodUsageUsd)}</span>
+                </div>
+                <Progress value={bonusProgress} />
+              </div>
+              <div className="space-y-2 text-sm">
+                <p>
+                  Base credits:{' '}
+                  <span className="font-medium">
+                    {formatDollars(subscription.currentPeriodBaseCreditsUsd)}
+                  </span>
+                </p>
+                <p>
+                  Bonus credits:{' '}
+                  <span className="font-medium">
+                    {subscription.currentPeriodBonusCreditsUsd != null
+                      ? formatDollars(subscription.currentPeriodBonusCreditsUsd)
+                      : '—'}
+                  </span>
+                </p>
+              </div>
+              <div className="flex items-center justify-between rounded-xl border p-3 text-sm">
+                <span>Bonus ramp preview</span>
+                <KiloPassBonusRampDialog
+                  tier={subscription.tier}
+                  streakMonths={subscription.currentStreakMonths}
+                  subscriptionStartedAtIso={subscription.startedAt ?? undefined}
+                />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Credit history</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CreditHistory
+              entries={creditEntries}
+              hasMore={creditHasMore}
+              onLoadMore={() => void loadMoreCreditHistory()}
+              isLoading={creditLoadingMore}
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Billing history</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <BillingHistoryTable
+              variant="stripe"
+              entries={billingEntries}
+              hasMore={billingHasMore}
+              onLoadMore={() => void loadMoreBilling()}
+              isLoading={billingLoadingMore}
+            />
+          </CardContent>
+        </Card>
+
+        <KiloPassSubscriptionSettingsModal
+          isOpen={settingsOpen}
+          onClose={() => setSettingsOpen(false)}
+        />
+      </div>
+    </KiloPassSubscriptionInfoProvider>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-1">
+      <div className="text-muted-foreground text-sm">{label}</div>
+      <div className="font-medium">{value}</div>
+    </div>
+  );
+}

--- a/src/components/subscriptions/kilo-pass/KiloPassGroup.tsx
+++ b/src/components/subscriptions/kilo-pass/KiloPassGroup.tsx
@@ -1,78 +1,95 @@
 'use client';
 
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import { Crown } from 'lucide-react';
 import { useTRPC } from '@/lib/trpc/utils';
-import { KiloPassCadence, KiloPassTier } from '@/lib/kilo-pass/enums';
-import { AvailableProductCard } from '@/components/subscriptions/AvailableProductCard';
+import { KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF } from '@/lib/kilo-pass/constants';
+import { dayjs } from '@/lib/kilo-pass/dayjs';
+import { KiloPassCadence } from '@/lib/kilo-pass/enums';
+import type { KiloPassTier } from '@/lib/kilo-pass/enums';
+import { recommendKiloPassTierFromAverageMonthlyUsageUsd } from '@/lib/kilo-pass/recommend-tier';
+import { KiloPassSubscribeCard } from '@/components/profile/kilo-pass/KiloPassSubscribeCard';
 import { SubscriptionCard } from '@/components/subscriptions/SubscriptionCard';
 import { SubscriptionGroup } from '@/components/subscriptions/SubscriptionGroup';
 import {
   formatDateLabel,
+  formatKiloPassCadenceLabel,
   formatKiloPassPrice,
+  formatKiloPassTierLabel,
   isInfoStatus,
   isKiloPassTerminal,
   isWarningStatus,
 } from '@/components/subscriptions/helpers';
 
-const kiloPassPlans: Array<{
-  tier: KiloPassTier;
-  title: string;
-  description: string;
-  price: string;
-  badge?: string;
-}> = [
-  {
-    tier: KiloPassTier.Tier19,
-    title: 'Kilo Pass Starter',
-    description: 'Get paid credits for personal usage and hosting.',
-    price: '$19.00/month',
-  },
-  {
-    tier: KiloPassTier.Tier49,
-    title: 'Kilo Pass Pro',
-    description: 'Higher monthly credits with stronger bonus ramps.',
-    price: '$49.00/month',
-    badge: 'Recommended',
-  },
-  {
-    tier: KiloPassTier.Tier199,
-    title: 'Kilo Pass Ultra',
-    description: 'Maximum monthly credits for heavy usage.',
-    price: '$199.00/month',
-  },
-];
+function getShowKiloPassTwoMonthPromo(showFirstMonthPromo: boolean): boolean {
+  return showFirstMonthPromo && dayjs().utc().isBefore(KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF);
+}
 
-export function KiloPassGroup({ showTerminal }: { showTerminal: boolean }) {
+export function KiloPassGroup({
+  showTerminal,
+  accordionValue,
+}: {
+  showTerminal: boolean;
+  accordionValue?: string;
+}) {
   const trpc = useTRPC();
   const query = useQuery(trpc.kiloPass.getState.queryOptions());
-  const checkout = useMutation(trpc.kiloPass.createCheckoutSession.mutationOptions());
-
-  async function startCheckout(tier: KiloPassTier) {
-    const result = await checkout.mutateAsync({ tier, cadence: KiloPassCadence.Monthly });
-    if (result.url) {
-      window.location.href = result.url;
-    }
-  }
+  const [cadence, setCadence] = useState<KiloPassCadence>(KiloPassCadence.Monthly);
 
   const subscription = query.data?.subscription ?? null;
   const shouldShowSubscription =
     subscription && (!isKiloPassTerminal(subscription.status) || showTerminal);
 
+  const averageMonthlyUsageQuery = useQuery({
+    ...trpc.kiloPass.getAverageMonthlyUsageLast3Months.queryOptions(),
+    enabled: query.isSuccess && !shouldShowSubscription,
+  });
+
+  const checkout = useMutation(
+    trpc.kiloPass.createCheckoutSession.mutationOptions({
+      onSuccess: result => {
+        if (!result.url) {
+          toast.error('Failed to create Stripe checkout session');
+          return;
+        }
+        window.location.href = result.url;
+      },
+      onError: error => {
+        toast.error(error.message || 'Failed to start checkout');
+      },
+    })
+  );
+
+  async function startCheckout(tier: KiloPassTier) {
+    await checkout.mutateAsync({ tier, cadence });
+  }
+
+  const showFirstMonthPromo = query.data?.isEligibleForFirstMonthPromo ?? false;
+  const showSecondMonthPromo = getShowKiloPassTwoMonthPromo(showFirstMonthPromo);
+  const averageMonthlyUsageUsd = averageMonthlyUsageQuery.data?.averageMonthlyUsageUsd;
+  const recommendedTier =
+    typeof averageMonthlyUsageUsd === 'number'
+      ? recommendKiloPassTierFromAverageMonthlyUsageUsd({ averageMonthlyUsageUsd })
+      : null;
+
   return (
     <SubscriptionGroup
       title="Kilo Pass"
       description="Manage your Kilo Pass subscription and credit entitlements."
+      headerIcon={<Crown className="h-5 w-5" />}
       isLoading={query.isLoading}
       isError={query.isError}
       error={query.error}
       onRetry={() => void query.refetch()}
+      accordionValue={accordionValue}
     >
       {shouldShowSubscription ? (
         <SubscriptionCard
           icon={<Crown className="h-5 w-5" />}
-          title={`Kilo Pass ${subscription.tier}`}
-          subtitle={`${subscription.tier} tier • ${subscription.cadence}`}
+          title={`Kilo Pass ${formatKiloPassTierLabel(subscription.tier)}`}
+          subtitle={`${formatKiloPassTierLabel(subscription.tier)} tier • ${formatKiloPassCadenceLabel(subscription.cadence)}`}
           status={subscription.status}
           price={formatKiloPassPrice(subscription.tier, subscription.cadence)}
           billingDate={formatDateLabel(subscription.nextBillingAt, 'Subscription ended')}
@@ -88,23 +105,17 @@ export function KiloPassGroup({ showTerminal }: { showTerminal: boolean }) {
           }
         />
       ) : (
-        <div className="grid gap-3 lg:grid-cols-3">
-          {kiloPassPlans.map(plan => (
-            <AvailableProductCard
-              key={plan.tier}
-              icon={<Crown className="h-5 w-5" />}
-              title={plan.title}
-              description={plan.description}
-              price={plan.price}
-              badge={plan.badge}
-              cta={{
-                label: checkout.isPending ? 'Opening...' : 'Subscribe',
-                onClick: () => void startCheckout(plan.tier),
-                disabled: checkout.isPending,
-              }}
-            />
-          ))}
-        </div>
+        <KiloPassSubscribeCard
+          cadence={cadence}
+          setCadence={setCadence}
+          pending={checkout.isPending}
+          showFirstMonthPromo={showFirstMonthPromo}
+          showSecondMonthPromo={showSecondMonthPromo}
+          recommendedTier={recommendedTier}
+          onSelectTier={tier => void startCheckout(tier)}
+          showHeader={false}
+          contentClassName="p-6"
+        />
       )}
     </SubscriptionGroup>
   );

--- a/src/components/subscriptions/kilo-pass/KiloPassGroup.tsx
+++ b/src/components/subscriptions/kilo-pass/KiloPassGroup.tsx
@@ -24,7 +24,9 @@ import {
 } from '@/components/subscriptions/helpers';
 
 function getShowKiloPassTwoMonthPromo(showFirstMonthPromo: boolean): boolean {
-  return showFirstMonthPromo && dayjs().utc().isBefore(KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF);
+  return (
+    showFirstMonthPromo && dayjs().utc().isBefore(KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF)
+  );
 }
 
 export function KiloPassGroup({

--- a/src/components/subscriptions/kilo-pass/KiloPassGroup.tsx
+++ b/src/components/subscriptions/kilo-pass/KiloPassGroup.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { Crown } from 'lucide-react';
+import { useTRPC } from '@/lib/trpc/utils';
+import { KiloPassCadence, KiloPassTier } from '@/lib/kilo-pass/enums';
+import { AvailableProductCard } from '@/components/subscriptions/AvailableProductCard';
+import { SubscriptionCard } from '@/components/subscriptions/SubscriptionCard';
+import { SubscriptionGroup } from '@/components/subscriptions/SubscriptionGroup';
+import {
+  formatDateLabel,
+  formatKiloPassPrice,
+  isInfoStatus,
+  isKiloPassTerminal,
+  isWarningStatus,
+} from '@/components/subscriptions/helpers';
+
+const kiloPassPlans: Array<{
+  tier: KiloPassTier;
+  title: string;
+  description: string;
+  price: string;
+  badge?: string;
+}> = [
+  {
+    tier: KiloPassTier.Tier19,
+    title: 'Kilo Pass Starter',
+    description: 'Get paid credits for personal usage and hosting.',
+    price: '$19.00/month',
+  },
+  {
+    tier: KiloPassTier.Tier49,
+    title: 'Kilo Pass Pro',
+    description: 'Higher monthly credits with stronger bonus ramps.',
+    price: '$49.00/month',
+    badge: 'Recommended',
+  },
+  {
+    tier: KiloPassTier.Tier199,
+    title: 'Kilo Pass Ultra',
+    description: 'Maximum monthly credits for heavy usage.',
+    price: '$199.00/month',
+  },
+];
+
+export function KiloPassGroup({ showTerminal }: { showTerminal: boolean }) {
+  const trpc = useTRPC();
+  const query = useQuery(trpc.kiloPass.getState.queryOptions());
+  const checkout = useMutation(trpc.kiloPass.createCheckoutSession.mutationOptions());
+
+  async function startCheckout(tier: KiloPassTier) {
+    const result = await checkout.mutateAsync({ tier, cadence: KiloPassCadence.Monthly });
+    if (result.url) {
+      window.location.href = result.url;
+    }
+  }
+
+  const subscription = query.data?.subscription ?? null;
+  const shouldShowSubscription =
+    subscription && (!isKiloPassTerminal(subscription.status) || showTerminal);
+
+  return (
+    <SubscriptionGroup
+      title="Kilo Pass"
+      description="Manage your Kilo Pass subscription and credit entitlements."
+      isLoading={query.isLoading}
+      isError={query.isError}
+      error={query.error}
+      onRetry={() => void query.refetch()}
+    >
+      {shouldShowSubscription ? (
+        <SubscriptionCard
+          icon={<Crown className="h-5 w-5" />}
+          title={`Kilo Pass ${subscription.tier}`}
+          subtitle={`${subscription.tier} tier • ${subscription.cadence}`}
+          status={subscription.status}
+          price={formatKiloPassPrice(subscription.tier, subscription.cadence)}
+          billingDate={formatDateLabel(subscription.nextBillingAt, 'Subscription ended')}
+          paymentMethod="Stripe"
+          href="/subscriptions/kilo-pass"
+          isTerminal={isKiloPassTerminal(subscription.status)}
+          warningTone={
+            isWarningStatus(subscription.status)
+              ? 'warning'
+              : isInfoStatus(subscription.status)
+                ? 'info'
+                : undefined
+          }
+        />
+      ) : (
+        <div className="grid gap-3 lg:grid-cols-3">
+          {kiloPassPlans.map(plan => (
+            <AvailableProductCard
+              key={plan.tier}
+              icon={<Crown className="h-5 w-5" />}
+              title={plan.title}
+              description={plan.description}
+              price={plan.price}
+              badge={plan.badge}
+              cta={{
+                label: checkout.isPending ? 'Opening...' : 'Subscribe',
+                onClick: () => void startCheckout(plan.tier),
+                disabled: checkout.isPending,
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </SubscriptionGroup>
+  );
+}

--- a/src/components/subscriptions/kiloclaw/KiloClawDetail.tsx
+++ b/src/components/subscriptions/kiloclaw/KiloClawDetail.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import KiloCrabIcon from '@/components/KiloCrabIcon';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useRawTRPCClient, useTRPC } from '@/lib/trpc/utils';
+import { DetailPageHeader } from '@/components/subscriptions/DetailPageHeader';
+import { StripePortalLink } from '@/components/subscriptions/StripePortalLink';
+import { BillingHistoryTable } from '@/components/subscriptions/BillingHistoryTable';
+import {
+  formatDateLabel,
+  formatKiloclawPrice,
+  formatPaymentSummary,
+} from '@/components/subscriptions/helpers';
+
+export function KiloClawDetail({ instanceId }: { instanceId: string }) {
+  const trpc = useTRPC();
+  const trpcClient = useRawTRPCClient();
+  const queryClient = useQueryClient();
+  const [billingEntries, setBillingEntries] = useState<
+    Array<
+      Awaited<ReturnType<typeof trpcClient.kiloclaw.getBillingHistory.query>>['entries'][number]
+    >
+  >([]);
+  const [billingCursor, setBillingCursor] = useState<string | null>(null);
+  const [billingHasMore, setBillingHasMore] = useState(false);
+  const [billingLoadingMore, setBillingLoadingMore] = useState(false);
+
+  const detailQuery = useQuery(trpc.kiloclaw.getSubscriptionDetail.queryOptions({ instanceId }));
+  const billingQuery = useQuery(trpc.kiloclaw.getBillingHistory.queryOptions({ instanceId }));
+
+  useEffect(() => {
+    if (!instanceId) {
+      setBillingEntries([]);
+      setBillingCursor(null);
+      setBillingHasMore(false);
+      setBillingLoadingMore(false);
+      return;
+    }
+
+    setBillingEntries([]);
+    setBillingCursor(null);
+    setBillingHasMore(false);
+    setBillingLoadingMore(false);
+  }, [instanceId]);
+
+  useEffect(() => {
+    if (!billingQuery.data) return;
+    setBillingEntries(billingQuery.data.entries);
+    setBillingCursor(billingQuery.data.cursor);
+    setBillingHasMore(billingQuery.data.hasMore);
+  }, [billingQuery.data]);
+
+  async function refreshData() {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.listPersonalSubscriptions.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getSubscriptionDetail.queryKey({ instanceId }),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getBillingHistory.queryKey({ instanceId }),
+      }),
+    ]);
+  }
+
+  async function loadMoreBilling() {
+    if (!billingCursor || billingLoadingMore) return;
+    setBillingLoadingMore(true);
+    try {
+      const result = await trpcClient.kiloclaw.getBillingHistory.query({
+        instanceId,
+        cursor: billingCursor,
+      });
+      setBillingEntries(current => [...current, ...result.entries]);
+      setBillingCursor(result.cursor);
+      setBillingHasMore(result.hasMore);
+    } finally {
+      setBillingLoadingMore(false);
+    }
+  }
+
+  async function runAction(action: () => Promise<unknown>, successMessage: string) {
+    await action();
+    toast.success(successMessage);
+    await refreshData();
+  }
+
+  const subscription = detailQuery.data;
+
+  if (detailQuery.isLoading) {
+    return (
+      <Card>
+        <CardContent className="p-6">Loading subscription...</CardContent>
+      </Card>
+    );
+  }
+
+  if (!subscription) {
+    return (
+      <Card>
+        <CardContent className="p-6">KiloClaw subscription not found.</CardContent>
+      </Card>
+    );
+  }
+
+  const otherPlan = subscription.plan === 'commit' ? 'standard' : 'commit';
+
+  return (
+    <div className="space-y-6">
+      <DetailPageHeader
+        backHref="/subscriptions"
+        backLabel="Back to subscriptions"
+        title={subscription.instanceName ?? 'KiloClaw'}
+        status={subscription.status}
+        actions={
+          subscription.hasStripeFunding ? (
+            <StripePortalLink
+              onOpenPortal={async () => {
+                const result = await trpcClient.kiloclaw.getCustomerPortalUrl.mutate({
+                  instanceId,
+                  returnUrl: window.location.href,
+                });
+                return result.url;
+              }}
+            />
+          ) : null
+        }
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <KiloCrabIcon className="h-5 w-5" />
+            Instance details
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <DetailRow label="Instance ID" value={subscription.instanceId} />
+            <DetailRow label="Sandbox ID" value={subscription.sandboxId} />
+            <DetailRow label="Plan" value={subscription.plan} />
+            <DetailRow label="Price" value={formatKiloclawPrice(subscription.plan)} />
+            <DetailRow
+              label="Payment source"
+              value={formatPaymentSummary({
+                paymentSource: subscription.paymentSource,
+                hasStripeFunding: subscription.hasStripeFunding,
+              })}
+            />
+            <DetailRow
+              label="Next renewal"
+              value={formatDateLabel(
+                subscription.creditRenewalAt ??
+                  subscription.currentPeriodEnd ??
+                  subscription.trialEndsAt,
+                '—'
+              )}
+            />
+            <DetailRow
+              label="Commit ends"
+              value={formatDateLabel(subscription.commitEndsAt, '—')}
+            />
+            <DetailRow label="Trial ends" value={formatDateLabel(subscription.trialEndsAt, '—')} />
+            <DetailRow
+              label="Suspended at"
+              value={formatDateLabel(subscription.suspendedAt, '—')}
+            />
+            <DetailRow
+              label="Destruction deadline"
+              value={formatDateLabel(subscription.destructionDeadline, '—')}
+            />
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {subscription.plan !== 'trial' ? (
+              subscription.scheduledPlan ? (
+                <Button
+                  variant="outline"
+                  onClick={() =>
+                    void runAction(
+                      () => trpcClient.kiloclaw.cancelPlanSwitchAtInstance.mutate({ instanceId }),
+                      'Plan switch canceled'
+                    )
+                  }
+                >
+                  Cancel Plan Switch
+                </Button>
+              ) : (
+                <Button
+                  variant="outline"
+                  onClick={() =>
+                    void runAction(
+                      () =>
+                        trpcClient.kiloclaw.switchPlanAtInstance.mutate({
+                          instanceId,
+                          toPlan: otherPlan,
+                        }),
+                      'Plan switch scheduled'
+                    )
+                  }
+                >
+                  Switch to {otherPlan}
+                </Button>
+              )
+            ) : null}
+
+            {subscription.showConversionPrompt ? (
+              <Button
+                variant="outline"
+                onClick={() =>
+                  void runAction(
+                    () => trpcClient.kiloclaw.acceptConversionAtInstance.mutate({ instanceId }),
+                    'Stripe billing will switch to credits at period end'
+                  )
+                }
+              >
+                Switch to Credits
+              </Button>
+            ) : null}
+
+            {subscription.cancelAtPeriodEnd ? (
+              <Button
+                variant="outline"
+                onClick={() =>
+                  void runAction(
+                    () =>
+                      trpcClient.kiloclaw.reactivateSubscriptionAtInstance.mutate({ instanceId }),
+                    'Subscription reactivated'
+                  )
+                }
+              >
+                Reactivate
+              </Button>
+            ) : (
+              <Button
+                variant="outline"
+                onClick={() => {
+                  if (!window.confirm('Cancel this KiloClaw subscription at period end?')) return;
+                  void runAction(
+                    () => trpcClient.kiloclaw.cancelSubscriptionAtInstance.mutate({ instanceId }),
+                    'Subscription will cancel at period end'
+                  );
+                }}
+              >
+                Cancel Subscription
+              </Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Billing history</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <BillingHistoryTable
+            variant={subscription.hasStripeFunding ? 'stripe' : 'credits'}
+            entries={billingEntries}
+            hasMore={billingHasMore}
+            onLoadMore={() => void loadMoreBilling()}
+            isLoading={billingLoadingMore}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-1">
+      <div className="text-muted-foreground text-sm">{label}</div>
+      <div className="font-medium break-all">{value}</div>
+    </div>
+  );
+}

--- a/src/components/subscriptions/kiloclaw/KiloClawDetail.tsx
+++ b/src/components/subscriptions/kiloclaw/KiloClawDetail.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { ArrowRight } from 'lucide-react';
 import { toast } from 'sonner';
 import KiloCrabIcon from '@/components/KiloCrabIcon';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -11,10 +12,39 @@ import { DetailPageHeader } from '@/components/subscriptions/DetailPageHeader';
 import { StripePortalLink } from '@/components/subscriptions/StripePortalLink';
 import { BillingHistoryTable } from '@/components/subscriptions/BillingHistoryTable';
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
   formatDateLabel,
   formatKiloclawPrice,
   formatPaymentSummary,
 } from '@/components/subscriptions/helpers';
+import { capitalize } from '@/lib/utils';
+
+type SubscriptionConfirmationAction =
+  | 'cancelPlanSwitch'
+  | 'switchPlan'
+  | 'switchToCredits'
+  | 'reactivate'
+  | 'cancelSubscription';
+
+type ConfirmationDetails = {
+  title: string;
+  description: string;
+  confirmLabel: string;
+  pendingLabel: string;
+  action: () => Promise<unknown>;
+  successMessage: string;
+  confirmVariant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
+  extraContent?: ReactNode;
+};
 
 export function KiloClawDetail({ instanceId }: { instanceId: string }) {
   const trpc = useTRPC();
@@ -28,6 +58,10 @@ export function KiloClawDetail({ instanceId }: { instanceId: string }) {
   const [billingCursor, setBillingCursor] = useState<string | null>(null);
   const [billingHasMore, setBillingHasMore] = useState(false);
   const [billingLoadingMore, setBillingLoadingMore] = useState(false);
+  const [confirmationAction, setConfirmationAction] =
+    useState<SubscriptionConfirmationAction | null>(null);
+  const [pendingConfirmationAction, setPendingConfirmationAction] =
+    useState<SubscriptionConfirmationAction | null>(null);
 
   const detailQuery = useQuery(trpc.kiloclaw.getSubscriptionDetail.queryOptions({ instanceId }));
   const billingQuery = useQuery(trpc.kiloclaw.getBillingHistory.queryOptions({ instanceId }));
@@ -109,6 +143,156 @@ export function KiloClawDetail({ instanceId }: { instanceId: string }) {
   }
 
   const otherPlan = subscription.plan === 'commit' ? 'standard' : 'commit';
+  const nextRenewalLabel = formatDateLabel(
+    subscription.creditRenewalAt ?? subscription.currentPeriodEnd ?? subscription.trialEndsAt,
+    'At your next renewal'
+  );
+  const targetPlanLabel = capitalize(otherPlan);
+  const targetPlanDetails =
+    otherPlan === 'commit'
+      ? {
+          price: formatKiloclawPrice(otherPlan),
+          cadence: 'Renews every 6 months',
+          summary: 'Lower effective rate at $8.00/month, billed $48.00 upfront for each 6-month term.',
+        }
+      : {
+          price: formatKiloclawPrice(otherPlan),
+          cadence: 'Renews monthly',
+          summary: 'Flexible month-to-month billing with no long-term commitment.',
+        };
+
+  const confirmationDetails: ConfirmationDetails | null =
+    confirmationAction === 'cancelPlanSwitch'
+      ? {
+          title: 'Cancel scheduled plan switch?',
+          description:
+            'This keeps your KiloClaw subscription on its current plan and removes the pending change.',
+          confirmLabel: 'Cancel plan switch',
+          pendingLabel: 'Canceling plan switch',
+          action: () => trpcClient.kiloclaw.cancelPlanSwitchAtInstance.mutate({ instanceId }),
+          successMessage: 'Plan switch canceled',
+        }
+      : confirmationAction === 'switchPlan'
+        ? {
+            title: `Switch to ${targetPlanLabel}?`,
+            description: `This schedules your KiloClaw subscription to switch plans at the next renewal while keeping your current plan active until then.`,
+            confirmLabel: `Switch to ${otherPlan}`,
+            pendingLabel: `Switching to ${otherPlan}`,
+            action: () =>
+              trpcClient.kiloclaw.switchPlanAtInstance.mutate({
+                instanceId,
+                toPlan: otherPlan,
+              }),
+            successMessage: 'Plan switch scheduled',
+            extraContent: (
+              <div className="space-y-3 rounded-lg border px-4 py-3 text-left text-sm">
+                <div className="flex items-center justify-center gap-4">
+                  <div className="flex-1 rounded-md bg-muted/40 px-3 py-2 text-center">
+                    <div className="text-muted-foreground text-xs">Current plan</div>
+                    <div className="font-medium">{capitalize(subscription.plan)}</div>
+                    <div className="text-muted-foreground text-xs">{formatKiloclawPrice(subscription.plan)}</div>
+                  </div>
+                  <ArrowRight className="text-muted-foreground h-4 w-4 shrink-0" />
+                  <div className="flex-1 rounded-md bg-muted/40 px-3 py-2 text-center">
+                    <div className="text-muted-foreground text-xs">New plan</div>
+                    <div className="font-medium">{targetPlanLabel}</div>
+                    <div className="text-muted-foreground text-xs">{targetPlanDetails.price}</div>
+                  </div>
+                </div>
+                <div className="grid gap-x-6 gap-y-3 sm:grid-cols-2">
+                  <ConfirmationDetailRow label="Takes effect" value={nextRenewalLabel} />
+                  <ConfirmationDetailRow label="Cadence" value={targetPlanDetails.cadence} />
+                </div>
+                <p className="text-muted-foreground leading-relaxed">{targetPlanDetails.summary}</p>
+              </div>
+            ),
+          }
+        : confirmationAction === 'switchToCredits'
+          ? {
+              title: 'Switch hosting billing to credits?',
+              description:
+                'Stripe billing stays active through the current period, then this subscription renews against your credit balance.',
+              confirmLabel: 'Switch to Credits',
+              pendingLabel: 'Switching to credits',
+              action: () => trpcClient.kiloclaw.acceptConversionAtInstance.mutate({ instanceId }),
+              successMessage: 'Stripe billing will switch to credits at period end',
+            }
+          : confirmationAction === 'reactivate'
+            ? {
+                title: 'Reactivate subscription?',
+                description:
+                  'This removes the pending cancellation so the subscription keeps renewing automatically.',
+                confirmLabel: 'Reactivate',
+                pendingLabel: 'Reactivating subscription',
+                action: () =>
+                  trpcClient.kiloclaw.reactivateSubscriptionAtInstance.mutate({ instanceId }),
+                successMessage: 'Subscription reactivated',
+              }
+            : confirmationAction === 'cancelSubscription'
+              ? {
+                  title: 'Cancel subscription at period end?',
+                  description:
+                    'Your KiloClaw instance stays active through the current billing period, then the subscription ends.',
+                  confirmLabel: 'Cancel Subscription',
+                  pendingLabel: 'Canceling subscription',
+                  action: () =>
+                    trpcClient.kiloclaw.cancelSubscriptionAtInstance.mutate({ instanceId }),
+                  successMessage: 'Subscription will cancel at period end',
+                  confirmVariant: 'destructive' as const,
+                }
+              : null;
+
+  function confirmSubscriptionAction() {
+    if (!confirmationAction || !confirmationDetails) {
+      return;
+    }
+
+    setPendingConfirmationAction(confirmationAction);
+
+    void runAction(confirmationDetails.action, confirmationDetails.successMessage)
+      .then(() => {
+        setConfirmationAction(null);
+      })
+      .catch(() => {
+        toast.error('Unable to update subscription');
+      })
+      .finally(() => {
+        setPendingConfirmationAction(null);
+      });
+  }
+
+  const primaryDetailRows: Array<{ label: string; value: string }> = [
+    { label: 'Plan', value: capitalize(subscription.plan) },
+    { label: 'Price', value: formatKiloclawPrice(subscription.plan) },
+    {
+      label: 'Payment source',
+      value: formatPaymentSummary({
+        paymentSource: subscription.paymentSource,
+        hasStripeFunding: subscription.hasStripeFunding,
+      }),
+    },
+    {
+      label: 'Next renewal',
+      value: nextRenewalLabel === 'At your next renewal' ? '—' : nextRenewalLabel,
+    },
+  ];
+  const secondaryDetailRows: Array<{ label: string; value: string }> = [
+    subscription.commitEndsAt
+      ? { label: 'Commit ends', value: formatDateLabel(subscription.commitEndsAt) }
+      : null,
+    subscription.status === 'trialing' && subscription.trialEndsAt
+      ? { label: 'Trial ends', value: formatDateLabel(subscription.trialEndsAt) }
+      : null,
+    subscription.suspendedAt
+      ? { label: 'Suspended at', value: formatDateLabel(subscription.suspendedAt) }
+      : null,
+    subscription.destructionDeadline
+      ? {
+          label: 'Destruction deadline',
+          value: formatDateLabel(subscription.destructionDeadline),
+        }
+      : null,
+  ].filter((row): row is { label: string; value: string } => row !== null);
 
   return (
     <div className="space-y-6">
@@ -117,148 +301,100 @@ export function KiloClawDetail({ instanceId }: { instanceId: string }) {
         backLabel="Back to subscriptions"
         title={subscription.instanceName ?? 'KiloClaw'}
         status={subscription.status}
-        actions={
-          subscription.hasStripeFunding ? (
-            <StripePortalLink
-              onOpenPortal={async () => {
-                const result = await trpcClient.kiloclaw.getCustomerPortalUrl.mutate({
-                  instanceId,
-                  returnUrl: window.location.href,
-                });
-                return result.url;
-              }}
-            />
-          ) : null
-        }
       />
 
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <KiloCrabIcon className="h-5 w-5" />
-            Instance details
+            Subscription details
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
-          <div className="grid gap-4 sm:grid-cols-2">
-            <DetailRow label="Instance ID" value={subscription.instanceId} />
-            <DetailRow label="Sandbox ID" value={subscription.sandboxId} />
-            <DetailRow label="Plan" value={subscription.plan} />
-            <DetailRow label="Price" value={formatKiloclawPrice(subscription.plan)} />
-            <DetailRow
-              label="Payment source"
-              value={formatPaymentSummary({
-                paymentSource: subscription.paymentSource,
-                hasStripeFunding: subscription.hasStripeFunding,
-              })}
-            />
-            <DetailRow
-              label="Next renewal"
-              value={formatDateLabel(
-                subscription.creditRenewalAt ??
-                  subscription.currentPeriodEnd ??
-                  subscription.trialEndsAt,
-                '—'
-              )}
-            />
-            <DetailRow
-              label="Commit ends"
-              value={formatDateLabel(subscription.commitEndsAt, '—')}
-            />
-            <DetailRow label="Trial ends" value={formatDateLabel(subscription.trialEndsAt, '—')} />
-            <DetailRow
-              label="Suspended at"
-              value={formatDateLabel(subscription.suspendedAt, '—')}
-            />
-            <DetailRow
-              label="Destruction deadline"
-              value={formatDateLabel(subscription.destructionDeadline, '—')}
-            />
+          <div className="space-y-5">
+            <DetailRow label="Instance" value={subscription.instanceName || subscription.instanceId} />
+
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              {primaryDetailRows.map(row => (
+                <DetailRow key={row.label} label={row.label} value={row.value} />
+              ))}
+            </div>
+
+            {secondaryDetailRows.length > 0 ? (
+              <div className="grid gap-4 sm:grid-cols-2">
+                {secondaryDetailRows.map(row => (
+                  <DetailRow key={row.label} label={row.label} value={row.value} />
+                ))}
+              </div>
+            ) : null}
           </div>
 
-          <div className="flex flex-wrap gap-2">
-            {subscription.plan !== 'trial' ? (
-              subscription.scheduledPlan ? (
-                <Button
-                  variant="outline"
-                  onClick={() =>
-                    void runAction(
-                      () => trpcClient.kiloclaw.cancelPlanSwitchAtInstance.mutate({ instanceId }),
-                      'Plan switch canceled'
-                    )
-                  }
-                >
-                  Cancel Plan Switch
-                </Button>
-              ) : (
-                <Button
-                  variant="outline"
-                  onClick={() =>
-                    void runAction(
-                      () =>
-                        trpcClient.kiloclaw.switchPlanAtInstance.mutate({
-                          instanceId,
-                          toPlan: otherPlan,
-                        }),
-                      'Plan switch scheduled'
-                    )
-                  }
-                >
-                  Switch to {otherPlan}
-                </Button>
-              )
-            ) : null}
-
-            {subscription.showConversionPrompt ? (
-              <Button
-                variant="outline"
-                onClick={() =>
-                  void runAction(
-                    () => trpcClient.kiloclaw.acceptConversionAtInstance.mutate({ instanceId }),
-                    'Stripe billing will switch to credits at period end'
-                  )
-                }
-              >
-                Switch to Credits
-              </Button>
-            ) : null}
-
-            {subscription.cancelAtPeriodEnd ? (
-              <Button
-                variant="outline"
-                onClick={() =>
-                  void runAction(
-                    () =>
-                      trpcClient.kiloclaw.reactivateSubscriptionAtInstance.mutate({ instanceId }),
-                    'Subscription reactivated'
-                  )
-                }
-              >
-                Reactivate
-              </Button>
-            ) : (
-              <Button
-                variant="outline"
-                onClick={() => {
-                  if (!window.confirm('Cancel this KiloClaw subscription at period end?')) return;
-                  void runAction(
-                    () => trpcClient.kiloclaw.cancelSubscriptionAtInstance.mutate({ instanceId }),
-                    'Subscription will cancel at period end'
-                  );
-                }}
-              >
-                Cancel Subscription
-              </Button>
-            )}
-          </div>
         </CardContent>
       </Card>
 
+      <div className="flex flex-wrap gap-2">
+        {subscription.plan !== 'trial' ? (
+          subscription.scheduledPlan ? (
+            <Button
+              variant="outline"
+              onClick={() => setConfirmationAction('cancelPlanSwitch')}
+            >
+              Cancel Plan Switch
+            </Button>
+          ) : (
+            <Button
+              variant="outline"
+              onClick={() => setConfirmationAction('switchPlan')}
+            >
+              Switch to {capitalize(otherPlan)} Plan
+            </Button>
+          )
+        ) : null}
+
+        {subscription.cancelAtPeriodEnd ? (
+          <Button
+            variant="outline"
+            onClick={() => setConfirmationAction('reactivate')}
+          >
+            Reactivate
+          </Button>
+        ) : (
+          <Button
+            variant="outline"
+            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+            onClick={() => setConfirmationAction('cancelSubscription')}
+          >
+            Cancel Subscription
+          </Button>
+        )}
+
+        {subscription.showConversionPrompt ? (
+          <Button
+            variant="outline"
+            onClick={() => setConfirmationAction('switchToCredits')}
+          >
+            Switch to Credits
+          </Button>
+        ) : null}
+
+        {subscription.hasStripeFunding ? (
+          <StripePortalLink
+            onOpenPortal={async () => {
+              const result = await trpcClient.kiloclaw.getCustomerPortalUrl.mutate({
+                instanceId,
+                returnUrl: window.location.href,
+              });
+              return result.url;
+            }}
+          />
+        ) : null}
+      </div>
+
       <Card>
-        <CardHeader>
+        <CardHeader className="pb-4">
           <CardTitle>Billing history</CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent className="pt-1">
           <BillingHistoryTable
             variant={subscription.hasStripeFunding ? 'stripe' : 'credits'}
             entries={billingEntries}
@@ -268,6 +404,46 @@ export function KiloClawDetail({ instanceId }: { instanceId: string }) {
           />
         </CardContent>
       </Card>
+
+      <AlertDialog
+        open={confirmationAction !== null}
+        onOpenChange={open => {
+          if (!open && pendingConfirmationAction === null) {
+            setConfirmationAction(null);
+          }
+        }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{confirmationDetails?.title}</AlertDialogTitle>
+              <AlertDialogDescription>
+                {confirmationDetails?.description}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+          {confirmationDetails?.extraContent ?? null}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={pendingConfirmationAction !== null}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant={confirmationDetails?.confirmVariant ?? 'default'}
+              onClick={confirmSubscriptionAction}
+              disabled={pendingConfirmationAction !== null}
+            >
+              {pendingConfirmationAction !== null
+                ? confirmationDetails?.pendingLabel
+                : confirmationDetails?.confirmLabel}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+function ConfirmationDetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-muted-foreground text-xs">{label}</div>
+      <div className="font-medium">{value}</div>
     </div>
   );
 }

--- a/src/components/subscriptions/kiloclaw/KiloClawDetail.tsx
+++ b/src/components/subscriptions/kiloclaw/KiloClawDetail.tsx
@@ -153,7 +153,8 @@ export function KiloClawDetail({ instanceId }: { instanceId: string }) {
       ? {
           price: formatKiloclawPrice(otherPlan),
           cadence: 'Renews every 6 months',
-          summary: 'Lower effective rate at $8.00/month, billed $48.00 upfront for each 6-month term.',
+          summary:
+            'Lower effective rate at $8.00/month, billed $48.00 upfront for each 6-month term.',
         }
       : {
           price: formatKiloclawPrice(otherPlan),
@@ -190,7 +191,9 @@ export function KiloClawDetail({ instanceId }: { instanceId: string }) {
                   <div className="flex-1 rounded-md bg-muted/40 px-3 py-2 text-center">
                     <div className="text-muted-foreground text-xs">Current plan</div>
                     <div className="font-medium">{capitalize(subscription.plan)}</div>
-                    <div className="text-muted-foreground text-xs">{formatKiloclawPrice(subscription.plan)}</div>
+                    <div className="text-muted-foreground text-xs">
+                      {formatKiloclawPrice(subscription.plan)}
+                    </div>
                   </div>
                   <ArrowRight className="text-muted-foreground h-4 w-4 shrink-0" />
                   <div className="flex-1 rounded-md bg-muted/40 px-3 py-2 text-center">
@@ -312,7 +315,10 @@ export function KiloClawDetail({ instanceId }: { instanceId: string }) {
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="space-y-5">
-            <DetailRow label="Instance" value={subscription.instanceName || subscription.instanceId} />
+            <DetailRow
+              label="Instance"
+              value={subscription.instanceName || subscription.instanceId}
+            />
 
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
               {primaryDetailRows.map(row => (
@@ -328,34 +334,24 @@ export function KiloClawDetail({ instanceId }: { instanceId: string }) {
               </div>
             ) : null}
           </div>
-
         </CardContent>
       </Card>
 
       <div className="flex flex-wrap gap-2">
         {subscription.plan !== 'trial' ? (
           subscription.scheduledPlan ? (
-            <Button
-              variant="outline"
-              onClick={() => setConfirmationAction('cancelPlanSwitch')}
-            >
+            <Button variant="outline" onClick={() => setConfirmationAction('cancelPlanSwitch')}>
               Cancel Plan Switch
             </Button>
           ) : (
-            <Button
-              variant="outline"
-              onClick={() => setConfirmationAction('switchPlan')}
-            >
+            <Button variant="outline" onClick={() => setConfirmationAction('switchPlan')}>
               Switch to {capitalize(otherPlan)} Plan
             </Button>
           )
         ) : null}
 
         {subscription.cancelAtPeriodEnd ? (
-          <Button
-            variant="outline"
-            onClick={() => setConfirmationAction('reactivate')}
-          >
+          <Button variant="outline" onClick={() => setConfirmationAction('reactivate')}>
             Reactivate
           </Button>
         ) : (
@@ -369,10 +365,7 @@ export function KiloClawDetail({ instanceId }: { instanceId: string }) {
         )}
 
         {subscription.showConversionPrompt ? (
-          <Button
-            variant="outline"
-            onClick={() => setConfirmationAction('switchToCredits')}
-          >
+          <Button variant="outline" onClick={() => setConfirmationAction('switchToCredits')}>
             Switch to Credits
           </Button>
         ) : null}
@@ -412,17 +405,17 @@ export function KiloClawDetail({ instanceId }: { instanceId: string }) {
             setConfirmationAction(null);
           }
         }}
-        >
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>{confirmationDetails?.title}</AlertDialogTitle>
-              <AlertDialogDescription>
-                {confirmationDetails?.description}
-              </AlertDialogDescription>
-            </AlertDialogHeader>
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{confirmationDetails?.title}</AlertDialogTitle>
+            <AlertDialogDescription>{confirmationDetails?.description}</AlertDialogDescription>
+          </AlertDialogHeader>
           {confirmationDetails?.extraContent ?? null}
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={pendingConfirmationAction !== null}>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={pendingConfirmationAction !== null}>
+              Cancel
+            </AlertDialogCancel>
             <AlertDialogAction
               variant={confirmationDetails?.confirmVariant ?? 'default'}
               onClick={confirmSubscriptionAction}

--- a/src/components/subscriptions/kiloclaw/KiloClawDetail.tsx
+++ b/src/components/subscriptions/kiloclaw/KiloClawDetail.tsx
@@ -25,6 +25,7 @@ import {
   formatDateLabel,
   formatKiloclawPrice,
   formatPaymentSummary,
+  isKiloclawTerminal,
 } from '@/components/subscriptions/helpers';
 import { capitalize } from '@/lib/utils';
 
@@ -337,51 +338,53 @@ export function KiloClawDetail({ instanceId }: { instanceId: string }) {
         </CardContent>
       </Card>
 
-      <div className="flex flex-wrap gap-2">
-        {subscription.plan !== 'trial' ? (
-          subscription.scheduledPlan ? (
-            <Button variant="outline" onClick={() => setConfirmationAction('cancelPlanSwitch')}>
-              Cancel Plan Switch
+      {isKiloclawTerminal(subscription.status) ? null : (
+        <div className="flex flex-wrap gap-2">
+          {subscription.plan !== 'trial' ? (
+            subscription.scheduledPlan ? (
+              <Button variant="outline" onClick={() => setConfirmationAction('cancelPlanSwitch')}>
+                Cancel Plan Switch
+              </Button>
+            ) : (
+              <Button variant="outline" onClick={() => setConfirmationAction('switchPlan')}>
+                Switch to {capitalize(otherPlan)} Plan
+              </Button>
+            )
+          ) : null}
+
+          {subscription.cancelAtPeriodEnd ? (
+            <Button variant="outline" onClick={() => setConfirmationAction('reactivate')}>
+              Reactivate
             </Button>
           ) : (
-            <Button variant="outline" onClick={() => setConfirmationAction('switchPlan')}>
-              Switch to {capitalize(otherPlan)} Plan
+            <Button
+              variant="outline"
+              className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+              onClick={() => setConfirmationAction('cancelSubscription')}
+            >
+              Cancel Subscription
             </Button>
-          )
-        ) : null}
+          )}
 
-        {subscription.cancelAtPeriodEnd ? (
-          <Button variant="outline" onClick={() => setConfirmationAction('reactivate')}>
-            Reactivate
-          </Button>
-        ) : (
-          <Button
-            variant="outline"
-            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-            onClick={() => setConfirmationAction('cancelSubscription')}
-          >
-            Cancel Subscription
-          </Button>
-        )}
+          {subscription.showConversionPrompt ? (
+            <Button variant="outline" onClick={() => setConfirmationAction('switchToCredits')}>
+              Switch to Credits
+            </Button>
+          ) : null}
 
-        {subscription.showConversionPrompt ? (
-          <Button variant="outline" onClick={() => setConfirmationAction('switchToCredits')}>
-            Switch to Credits
-          </Button>
-        ) : null}
-
-        {subscription.hasStripeFunding ? (
-          <StripePortalLink
-            onOpenPortal={async () => {
-              const result = await trpcClient.kiloclaw.getCustomerPortalUrl.mutate({
-                instanceId,
-                returnUrl: window.location.href,
-              });
-              return result.url;
-            }}
-          />
-        ) : null}
-      </div>
+          {subscription.hasStripeFunding ? (
+            <StripePortalLink
+              onOpenPortal={async () => {
+                const result = await trpcClient.kiloclaw.getCustomerPortalUrl.mutate({
+                  instanceId,
+                  returnUrl: window.location.href,
+                });
+                return result.url;
+              }}
+            />
+          ) : null}
+        </div>
+      )}
 
       <Card>
         <CardHeader className="pb-4">

--- a/src/components/subscriptions/kiloclaw/KiloClawGroup.tsx
+++ b/src/components/subscriptions/kiloclaw/KiloClawGroup.tsx
@@ -3,9 +3,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import KiloCrabIcon from '@/components/KiloCrabIcon';
-import { AvailableProductCard } from '@/components/subscriptions/AvailableProductCard';
 import { SubscriptionCard } from '@/components/subscriptions/SubscriptionCard';
 import { SubscriptionGroup } from '@/components/subscriptions/SubscriptionGroup';
+import { KiloClawSubscribeCard } from './KiloClawSubscribeCard';
 import {
   formatDateLabel,
   formatKiloclawPrice,
@@ -15,9 +15,16 @@ import {
   isWarningStatus,
 } from '@/components/subscriptions/helpers';
 
-export function KiloClawGroup({ showTerminal }: { showTerminal: boolean }) {
+export function KiloClawGroup({
+  showTerminal,
+  accordionValue,
+}: {
+  showTerminal: boolean;
+  accordionValue?: string;
+}) {
   const trpc = useTRPC();
   const query = useQuery(trpc.kiloclaw.listPersonalSubscriptions.queryOptions());
+  const billingQuery = useQuery(trpc.kiloclaw.getBillingStatus.queryOptions());
   const subscriptions = query.data?.subscriptions ?? [];
 
   const visibleSubscriptions = subscriptions.filter(
@@ -31,19 +38,21 @@ export function KiloClawGroup({ showTerminal }: { showTerminal: boolean }) {
     <SubscriptionGroup
       title="KiloClaw"
       description="View hosting subscriptions for your personal KiloClaw instances."
+      headerIcon={<KiloCrabIcon className="h-5 w-5" />}
       isLoading={query.isLoading}
       isError={query.isError}
       error={query.error}
       onRetry={() => void query.refetch()}
+      accordionValue={accordionValue}
     >
       {visibleSubscriptions.length > 0 ? (
-        <div className="grid gap-3 lg:grid-cols-2">
+        <div className="grid gap-3">
           {visibleSubscriptions.map(subscription => (
             <SubscriptionCard
               key={subscription.instanceId}
               icon={<KiloCrabIcon className="h-5 w-5" />}
               title={subscription.instanceName ?? 'KiloClaw instance'}
-              subtitle={subscription.sandboxId}
+              subtitle={subscription.instanceName || subscription.instanceId}
               status={subscription.status}
               price={formatKiloclawPrice(subscription.plan)}
               billingDate={formatDateLabel(
@@ -69,23 +78,10 @@ export function KiloClawGroup({ showTerminal }: { showTerminal: boolean }) {
           ))}
         </div>
       ) : nonTerminalSubscriptions.length === 0 ? (
-        <div className="grid gap-3 lg:grid-cols-2">
-          <AvailableProductCard
-            icon={<KiloCrabIcon className="h-5 w-5" />}
-            title="KiloClaw Standard"
-            description="Month-to-month hosting for your personal KiloClaw instance."
-            price="$9.00/month"
-            cta={{ label: 'Open KiloClaw', href: '/claw' }}
-          />
-          <AvailableProductCard
-            icon={<KiloCrabIcon className="h-5 w-5" />}
-            title="KiloClaw Commit"
-            description="Lower effective monthly cost with a 6-month commitment."
-            price="$48.00 / 6 months"
-            badge="Best value"
-            cta={{ label: 'Open KiloClaw', href: '/claw' }}
-          />
-        </div>
+        <KiloClawSubscribeCard
+          creditIntroEligible={billingQuery.data?.creditIntroEligible ?? false}
+          hasActiveKiloPass={billingQuery.data?.hasActiveKiloPass ?? false}
+        />
       ) : null}
     </SubscriptionGroup>
   );

--- a/src/components/subscriptions/kiloclaw/KiloClawGroup.tsx
+++ b/src/components/subscriptions/kiloclaw/KiloClawGroup.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import KiloCrabIcon from '@/components/KiloCrabIcon';
+import { AvailableProductCard } from '@/components/subscriptions/AvailableProductCard';
+import { SubscriptionCard } from '@/components/subscriptions/SubscriptionCard';
+import { SubscriptionGroup } from '@/components/subscriptions/SubscriptionGroup';
+import {
+  formatDateLabel,
+  formatKiloclawPrice,
+  formatPaymentSummary,
+  isInfoStatus,
+  isKiloclawTerminal,
+  isWarningStatus,
+} from '@/components/subscriptions/helpers';
+
+export function KiloClawGroup({ showTerminal }: { showTerminal: boolean }) {
+  const trpc = useTRPC();
+  const query = useQuery(trpc.kiloclaw.listPersonalSubscriptions.queryOptions());
+  const subscriptions = query.data?.subscriptions ?? [];
+
+  const visibleSubscriptions = subscriptions.filter(
+    subscription => !isKiloclawTerminal(subscription.status) || showTerminal
+  );
+  const nonTerminalSubscriptions = subscriptions.filter(
+    subscription => !isKiloclawTerminal(subscription.status)
+  );
+
+  return (
+    <SubscriptionGroup
+      title="KiloClaw"
+      description="View hosting subscriptions for your personal KiloClaw instances."
+      isLoading={query.isLoading}
+      isError={query.isError}
+      error={query.error}
+      onRetry={() => void query.refetch()}
+    >
+      {visibleSubscriptions.length > 0 ? (
+        <div className="grid gap-3 lg:grid-cols-2">
+          {visibleSubscriptions.map(subscription => (
+            <SubscriptionCard
+              key={subscription.instanceId}
+              icon={<KiloCrabIcon className="h-5 w-5" />}
+              title={subscription.instanceName ?? 'KiloClaw instance'}
+              subtitle={subscription.sandboxId}
+              status={subscription.status}
+              price={formatKiloclawPrice(subscription.plan)}
+              billingDate={formatDateLabel(
+                subscription.creditRenewalAt ??
+                  subscription.currentPeriodEnd ??
+                  subscription.trialEndsAt,
+                '—'
+              )}
+              paymentMethod={formatPaymentSummary({
+                paymentSource: subscription.paymentSource,
+                hasStripeFunding: subscription.hasStripeFunding,
+              })}
+              href={`/subscriptions/kiloclaw/${subscription.instanceId}`}
+              isTerminal={isKiloclawTerminal(subscription.status)}
+              warningTone={
+                isWarningStatus(subscription.status)
+                  ? 'warning'
+                  : isInfoStatus(subscription.status)
+                    ? 'info'
+                    : undefined
+              }
+            />
+          ))}
+        </div>
+      ) : nonTerminalSubscriptions.length === 0 ? (
+        <div className="grid gap-3 lg:grid-cols-2">
+          <AvailableProductCard
+            icon={<KiloCrabIcon className="h-5 w-5" />}
+            title="KiloClaw Standard"
+            description="Month-to-month hosting for your personal KiloClaw instance."
+            price="$9.00/month"
+            cta={{ label: 'Open KiloClaw', href: '/claw' }}
+          />
+          <AvailableProductCard
+            icon={<KiloCrabIcon className="h-5 w-5" />}
+            title="KiloClaw Commit"
+            description="Lower effective monthly cost with a 6-month commitment."
+            price="$48.00 / 6 months"
+            badge="Best value"
+            cta={{ label: 'Open KiloClaw', href: '/claw' }}
+          />
+        </div>
+      ) : null}
+    </SubscriptionGroup>
+  );
+}

--- a/src/components/subscriptions/kiloclaw/KiloClawSubscribeCard.tsx
+++ b/src/components/subscriptions/kiloclaw/KiloClawSubscribeCard.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import Link from 'next/link';
+import { Check } from 'lucide-react';
+import {
+  COMMIT_PERIOD_MONTHS,
+  PLAN_DISPLAY,
+  STANDARD_FIRST_MONTH_DOLLARS,
+} from '@/app/(app)/claw/components/billing/billing-types';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+type KiloClawSubscribeCardProps = {
+  creditIntroEligible: boolean;
+  hasActiveKiloPass: boolean;
+};
+
+type KiloClawPlanCardProps = {
+  title: string;
+  cadenceLabel: string;
+  badge?: string;
+  price: string;
+  priceDetail?: string;
+  details: string[];
+  accentDetail?: string;
+  ctaLabel: string;
+  isRecommended?: boolean;
+};
+
+function KiloClawPlanCard({
+  title,
+  cadenceLabel,
+  badge,
+  price,
+  priceDetail,
+  details,
+  accentDetail,
+  ctaLabel,
+  isRecommended = false,
+}: KiloClawPlanCardProps) {
+  return (
+    <div
+      className={cn(
+        'group bg-background relative flex h-full flex-col rounded-xl border p-4 text-left transition-colors',
+        'hover:border-blue-400/70 hover:shadow-[0_0_0_1px_rgba(59,130,246,0.25)]',
+        isRecommended
+          ? 'border-blue-500/60 shadow-[0_0_0_1px_rgba(59,130,246,0.35)]'
+          : 'border-border/70'
+      )}
+    >
+      {isRecommended && badge ? (
+        <Badge className="absolute -top-2 left-1/2 -translate-x-1/2 rounded-full bg-blue-600 px-3 text-white">
+          {badge}
+        </Badge>
+      ) : null}
+
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-sm font-semibold">{title}</div>
+        </div>
+        <div className="flex items-center gap-2">
+          {!isRecommended && badge ? <Badge variant="secondary-outline">{badge}</Badge> : null}
+          <div className="text-muted-foreground mt-0.5 text-xs">{cadenceLabel}</div>
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-baseline gap-1">
+        <div className="text-2xl font-semibold text-white">{price}</div>
+        {priceDetail ? <div className="text-muted-foreground text-xs">{priceDetail}</div> : null}
+      </div>
+
+      <div className="mt-4 flex-1 space-y-2">
+        {details.map(detail => (
+          <div
+            key={detail}
+            className="text-muted-foreground flex items-start gap-2 text-xs leading-5"
+          >
+            <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+            <span>{detail}</span>
+          </div>
+        ))}
+        {accentDetail ? (
+          <div className="flex items-start gap-2 text-xs leading-5 text-emerald-300">
+            <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+            <span>{accentDetail}</span>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="mt-4 flex items-center justify-end pt-2">
+        <Link
+          href="/claw"
+          className={cn(
+            'inline-flex items-center gap-2 rounded-full border border-blue-500/40 bg-blue-500/10 px-4 py-1.5 text-sm font-semibold text-blue-100 transition',
+            'hover:border-blue-400 hover:bg-blue-500/20 hover:text-white',
+            'focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-blue-400/60 focus-visible:ring-offset-2 focus-visible:outline-none'
+          )}
+        >
+          {ctaLabel}
+          <span className="text-base">→</span>
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export function KiloClawSubscribeCard({
+  creditIntroEligible,
+  hasActiveKiloPass,
+}: KiloClawSubscribeCardProps) {
+  const standardDetails = [
+    'Month-to-month hosting for one personal KiloClaw instance.',
+    creditIntroEligible
+      ? `Billed at $${PLAN_DISPLAY.standard.monthlyDollars}/month after the intro month.`
+      : `$${PLAN_DISPLAY.standard.monthlyDollars}/month with no long-term commitment.`,
+    hasActiveKiloPass
+      ? 'Use Kilo Pass credits during activation or pay directly with Stripe.'
+      : 'Activate and manage the instance inside KiloClaw.',
+  ];
+
+  const commitDetails = [
+    'Six-month hosting commitment for one personal KiloClaw instance.',
+    `Lower effective cost at $${PLAN_DISPLAY.commit.monthlyDollars}/month, billed $${PLAN_DISPLAY.commit.totalDollars} upfront.`,
+    hasActiveKiloPass
+      ? 'Works well when your Kilo Pass balance can cover the full commit period.'
+      : 'Best for steady usage when you want the lowest effective monthly rate.',
+  ];
+
+  const benefits = [
+    'Choose a plan in KiloClaw when you are ready to activate a personal instance.',
+    hasActiveKiloPass
+      ? 'Your active Kilo Pass can fund hosting from credits or you can still pay with Stripe.'
+      : 'You can start with hosting only and add Kilo Pass later for AI credits and bonus ramps.',
+    'Each subscription is tied to a specific KiloClaw instance, so activation happens inside KiloClaw.',
+  ];
+
+  return (
+    <div className="space-y-5">
+      <div className="grid gap-4 sm:grid-cols-2 lg:gap-5">
+        <KiloClawPlanCard
+          title="Standard"
+          cadenceLabel="Monthly"
+          price={
+            creditIntroEligible
+              ? `$${STANDARD_FIRST_MONTH_DOLLARS}`
+              : `$${PLAN_DISPLAY.standard.monthlyDollars}`
+          }
+          priceDetail={
+            creditIntroEligible
+              ? `first month, then $${PLAN_DISPLAY.standard.monthlyDollars}/month`
+              : '/month'
+          }
+          details={standardDetails}
+          accentDetail={
+            creditIntroEligible
+              ? `First month: $${STANDARD_FIRST_MONTH_DOLLARS} intro price`
+              : undefined
+          }
+          ctaLabel="Sign up in KiloClaw"
+        />
+        <KiloClawPlanCard
+          title="Commit"
+          cadenceLabel={`${COMMIT_PERIOD_MONTHS} months`}
+          badge="Best value"
+          price={`$${PLAN_DISPLAY.commit.totalDollars}`}
+          priceDetail={`/ ${COMMIT_PERIOD_MONTHS} months`}
+          details={commitDetails}
+          ctaLabel="Sign up in KiloClaw"
+          isRecommended
+        />
+      </div>
+
+      <div className="space-y-2 text-xs">
+        {benefits.map(benefit => (
+          <div key={benefit} className="text-muted-foreground flex items-start gap-2">
+            <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
+            <span>{benefit}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/subscriptions/seats/SeatsDetail.tsx
+++ b/src/components/subscriptions/seats/SeatsDetail.tsx
@@ -187,10 +187,7 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
               label="Organization"
               value={organizationQuery.data?.name ?? 'Organization'}
             />
-            <DetailRow
-              label="Plan"
-              value={capitalize(organizationQuery.data?.plan ?? 'teams')}
-            />
+            <DetailRow label="Plan" value={capitalize(organizationQuery.data?.plan ?? 'teams')} />
             <DetailRow label="Billing cycle" value={capitalize(currentInterval)} />
             <DetailRow
               label="Price"
@@ -212,8 +209,7 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
             <div className="flex items-center justify-between text-sm">
               <span className="text-muted-foreground">Seat utilization</span>
               <span>
-                {subscriptionQuery.data?.seatsUsed ?? 0} /{' '}
-                {subscriptionQuery.data?.totalSeats ?? 0}
+                {subscriptionQuery.data?.seatsUsed ?? 0} / {subscriptionQuery.data?.totalSeats ?? 0}
               </span>
             </div>
             <Progress
@@ -240,9 +236,11 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
                     setIsCancelingCycleChange(true);
                     void (async () => {
                       try {
-                        await trpcClient.organizations.subscription.cancelBillingCycleChange.mutate({
-                          organizationId,
-                        });
+                        await trpcClient.organizations.subscription.cancelBillingCycleChange.mutate(
+                          {
+                            organizationId,
+                          }
+                        );
                         toast.success('Billing cycle change canceled');
                         await refreshData();
                       } catch (error) {
@@ -468,17 +466,13 @@ function BillingCycleChangeContent({
         <div className="bg-muted/20 border-border/60 flex-1 rounded-lg border px-3 py-2 text-center">
           <div className="text-muted-foreground text-xs">Current cycle</div>
           <div className="font-medium">{capitalize(currentInterval)}</div>
-          <div className="text-muted-foreground text-xs">
-            ${currentPerSeat.toFixed(2)}/seat/mo
-          </div>
+          <div className="text-muted-foreground text-xs">${currentPerSeat.toFixed(2)}/seat/mo</div>
         </div>
         <ArrowRight className="text-muted-foreground h-4 w-4 shrink-0" />
         <div className="bg-muted/20 border-border/60 flex-1 rounded-lg border px-3 py-2 text-center">
           <div className="text-muted-foreground text-xs">New cycle</div>
           <div className="font-medium">{capitalize(targetInterval)}</div>
-          <div className="text-muted-foreground text-xs">
-            ${targetPerSeat.toFixed(2)}/seat/mo
-          </div>
+          <div className="text-muted-foreground text-xs">${targetPerSeat.toFixed(2)}/seat/mo</div>
         </div>
       </div>
       <p className="text-muted-foreground">

--- a/src/components/subscriptions/seats/SeatsDetail.tsx
+++ b/src/components/subscriptions/seats/SeatsDetail.tsx
@@ -21,7 +21,11 @@ import { SEAT_PRICING } from '@/lib/organizations/constants';
 import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
 import { DetailPageHeader } from '@/components/subscriptions/DetailPageHeader';
 import { BillingHistoryTable } from '@/components/subscriptions/BillingHistoryTable';
-import { formatDateLabel, getPaidSeatSubscriptionItem } from '@/components/subscriptions/helpers';
+import {
+  formatDateLabel,
+  getPaidSeatSubscriptionItem,
+  isSeatsTerminal,
+} from '@/components/subscriptions/helpers';
 
 export function SeatsDetail({ organizationId }: { organizationId: string }) {
   const trpc = useTRPC();
@@ -264,53 +268,55 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
         </CardContent>
       </Card>
 
-      <div className="flex flex-wrap gap-2">
-        <Button variant="outline" onClick={() => setSeatDialogOpen(true)}>
-          Change Seat Count
-        </Button>
-        <Button
-          variant="outline"
-          onClick={() => setBillingCycleDialogOpen(true)}
-          disabled={hasPendingCycleChange}
-        >
-          Change Billing Cycle
-        </Button>
-        {subscription.cancel_at_period_end ? (
+      {isSeatsTerminal(subscription.status) ? null : (
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" onClick={() => setSeatDialogOpen(true)}>
+            Change Seat Count
+          </Button>
           <Button
             variant="outline"
-            onClick={() =>
-              void (async () => {
-                await trpcClient.organizations.subscription.stopCancellation.mutate({
-                  organizationId,
-                });
-                toast.success('Subscription resumed');
-                await refreshData();
-              })()
-            }
+            onClick={() => setBillingCycleDialogOpen(true)}
+            disabled={hasPendingCycleChange}
           >
-            Resume Subscription
+            Change Billing Cycle
           </Button>
-        ) : (
-          <Button
-            variant="outline"
-            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-            onClick={() => {
-              if (!window.confirm('Cancel this seats subscription at period end?')) return;
-              void (async () => {
-                await trpcClient.organizations.subscription.cancel.mutate({ organizationId });
-                toast.success('Subscription will cancel at period end');
-                await refreshData();
-              })();
-            }}
-          >
-            Cancel Subscription
+          {subscription.cancel_at_period_end ? (
+            <Button
+              variant="outline"
+              onClick={() =>
+                void (async () => {
+                  await trpcClient.organizations.subscription.stopCancellation.mutate({
+                    organizationId,
+                  });
+                  toast.success('Subscription resumed');
+                  await refreshData();
+                })()
+              }
+            >
+              Resume Subscription
+            </Button>
+          ) : (
+            <Button
+              variant="outline"
+              className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+              onClick={() => {
+                if (!window.confirm('Cancel this seats subscription at period end?')) return;
+                void (async () => {
+                  await trpcClient.organizations.subscription.cancel.mutate({ organizationId });
+                  toast.success('Subscription will cancel at period end');
+                  await refreshData();
+                })();
+              }}
+            >
+              Cancel Subscription
+            </Button>
+          )}
+          <Button variant="outline" onClick={openCustomerPortal} disabled={isOpeningPortal}>
+            <ExternalLink className="h-4 w-4" />
+            {isOpeningPortal ? 'Opening...' : 'Manage Payment Method'}
           </Button>
-        )}
-        <Button variant="outline" onClick={openCustomerPortal} disabled={isOpeningPortal}>
-          <ExternalLink className="h-4 w-4" />
-          {isOpeningPortal ? 'Opening...' : 'Manage Payment Method'}
-        </Button>
-      </div>
+        </div>
+      )}
 
       <Card>
         <CardHeader className="pb-4">

--- a/src/components/subscriptions/seats/SeatsDetail.tsx
+++ b/src/components/subscriptions/seats/SeatsDetail.tsx
@@ -1,0 +1,349 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Users } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Progress } from '@/components/ui/progress';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useRawTRPCClient, useTRPC } from '@/lib/trpc/utils';
+import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
+import { DetailPageHeader } from '@/components/subscriptions/DetailPageHeader';
+import { StripePortalLink } from '@/components/subscriptions/StripePortalLink';
+import { BillingHistoryTable } from '@/components/subscriptions/BillingHistoryTable';
+import { formatDateLabel, getPaidSeatSubscriptionItem } from '@/components/subscriptions/helpers';
+
+export function SeatsDetail({ organizationId }: { organizationId: string }) {
+  const trpc = useTRPC();
+  const trpcClient = useRawTRPCClient();
+  const queryClient = useQueryClient();
+  const [billingEntries, setBillingEntries] = useState<
+    Array<
+      Awaited<
+        ReturnType<typeof trpcClient.organizations.subscription.getBillingHistory.query>
+      >['entries'][number]
+    >
+  >([]);
+  const [billingCursor, setBillingCursor] = useState<string | null>(null);
+  const [billingHasMore, setBillingHasMore] = useState(false);
+  const [billingLoadingMore, setBillingLoadingMore] = useState(false);
+  const [seatDialogOpen, setSeatDialogOpen] = useState(false);
+  const [billingCycleDialogOpen, setBillingCycleDialogOpen] = useState(false);
+  const [seatCount, setSeatCount] = useState('1');
+
+  const organizationQuery = useOrganizationWithMembers(organizationId, {
+    enabled: !!organizationId,
+  });
+  const subscriptionQuery = useQuery(
+    trpc.organizations.subscription.get.queryOptions(
+      { organizationId },
+      { enabled: !!organizationId }
+    )
+  );
+  const billingQuery = useQuery(
+    trpc.organizations.subscription.getBillingHistory.queryOptions(
+      { organizationId },
+      { enabled: !!organizationId }
+    )
+  );
+
+  useEffect(() => {
+    if (!organizationId) {
+      setBillingEntries([]);
+      setBillingCursor(null);
+      setBillingHasMore(false);
+      setBillingLoadingMore(false);
+      return;
+    }
+
+    setBillingEntries([]);
+    setBillingCursor(null);
+    setBillingHasMore(false);
+    setBillingLoadingMore(false);
+  }, [organizationId]);
+
+  useEffect(() => {
+    if (!billingQuery.data) return;
+    setBillingEntries(billingQuery.data.entries);
+    setBillingCursor(billingQuery.data.cursor);
+    setBillingHasMore(billingQuery.data.hasMore);
+  }, [billingQuery.data]);
+
+  useEffect(() => {
+    if (!subscriptionQuery.data) return;
+    setSeatCount(String(subscriptionQuery.data.totalSeats || 1));
+  }, [subscriptionQuery.data]);
+
+  async function refreshData() {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: trpc.organizations.subscription.get.queryKey({ organizationId }),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.organizations.subscription.getBillingHistory.queryKey({ organizationId }),
+      }),
+    ]);
+  }
+
+  async function loadMoreBilling() {
+    if (!billingCursor || billingLoadingMore) return;
+    setBillingLoadingMore(true);
+    try {
+      const result = await trpcClient.organizations.subscription.getBillingHistory.query({
+        organizationId,
+        cursor: billingCursor,
+      });
+      setBillingEntries(current => [...current, ...result.entries]);
+      setBillingCursor(result.cursor);
+      setBillingHasMore(result.hasMore);
+    } finally {
+      setBillingLoadingMore(false);
+    }
+  }
+
+  const subscription = subscriptionQuery.data?.subscription ?? null;
+  const seatUsagePercent = useMemo(() => {
+    const used = subscriptionQuery.data?.seatsUsed ?? 0;
+    const total = subscriptionQuery.data?.totalSeats ?? 0;
+    if (total <= 0) return 0;
+    return Math.min(100, Math.round((used / total) * 100));
+  }, [subscriptionQuery.data]);
+
+  if (subscriptionQuery.isLoading) {
+    return (
+      <Card>
+        <CardContent className="p-6">Loading subscription...</CardContent>
+      </Card>
+    );
+  }
+
+  if (!subscription) {
+    return (
+      <Card>
+        <CardContent className="p-6">
+          No seats subscription found for this organization.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const paidSeatItem = getPaidSeatSubscriptionItem(subscription);
+  const currentInterval =
+    paidSeatItem?.price?.recurring?.interval === 'year' ? 'annual' : 'monthly';
+  const totalAmount = subscription.items.data.reduce(
+    (sum, item) => sum + (item.price?.unit_amount ?? 0) * (item.quantity ?? 0),
+    0
+  );
+
+  return (
+    <div className="space-y-6">
+      <DetailPageHeader
+        backHref={`/organizations/${organizationId}/subscriptions`}
+        backLabel="Back to subscriptions"
+        title="Teams / Enterprise Seats"
+        status={subscription.status}
+        actions={
+          <StripePortalLink
+            onOpenPortal={async () => {
+              const result =
+                await trpcClient.organizations.subscription.getCustomerPortalUrl.mutate({
+                  organizationId,
+                  returnUrl: window.location.href,
+                });
+              return result.url;
+            }}
+          />
+        }
+      />
+
+      <div className="grid gap-6 xl:grid-cols-[2fr_1fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Users className="h-5 w-5" />
+              Subscription details
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <DetailRow
+                label="Organization"
+                value={organizationQuery.data?.name ?? 'Organization'}
+              />
+              <DetailRow label="Plan" value={organizationQuery.data?.plan ?? 'teams'} />
+              <DetailRow label="Billing cycle" value={currentInterval} />
+              <DetailRow
+                label="Price"
+                value={`$${(totalAmount / 100).toFixed(2)}/${currentInterval === 'annual' ? 'year' : 'month'}`}
+              />
+              <DetailRow
+                label="Next billing"
+                value={formatDateLabel(
+                  paidSeatItem?.current_period_end
+                    ? new Date(paidSeatItem.current_period_end * 1000).toISOString()
+                    : null,
+                  '—'
+                )}
+              />
+              <DetailRow label="Seats" value={String(subscriptionQuery.data?.totalSeats ?? 0)} />
+            </div>
+
+            <div className="space-y-3 rounded-xl border p-4">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Seat utilization</span>
+                <span>
+                  {subscriptionQuery.data?.seatsUsed ?? 0} /{' '}
+                  {subscriptionQuery.data?.totalSeats ?? 0}
+                </span>
+              </div>
+              <Progress value={seatUsagePercent} />
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" onClick={() => setSeatDialogOpen(true)}>
+                Change Seat Count
+              </Button>
+              <Button variant="outline" onClick={() => setBillingCycleDialogOpen(true)}>
+                Change Billing Cycle
+              </Button>
+              {subscription.cancel_at_period_end ? (
+                <Button
+                  variant="outline"
+                  onClick={() =>
+                    void (async () => {
+                      await trpcClient.organizations.subscription.stopCancellation.mutate({
+                        organizationId,
+                      });
+                      toast.success('Subscription resumed');
+                      await refreshData();
+                    })()
+                  }
+                >
+                  Resume Subscription
+                </Button>
+              ) : (
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    if (!window.confirm('Cancel this seats subscription at period end?')) return;
+                    void (async () => {
+                      await trpcClient.organizations.subscription.cancel.mutate({ organizationId });
+                      toast.success('Subscription will cancel at period end');
+                      await refreshData();
+                    })();
+                  }}
+                >
+                  Cancel Subscription
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Reviewer notes</CardTitle>
+          </CardHeader>
+          <CardContent className="text-muted-foreground text-sm">
+            Billing admins and owners can update seats, switch cadence, or manage cancellation from
+            this page.
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Billing history</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <BillingHistoryTable
+            variant="stripe"
+            entries={billingEntries}
+            hasMore={billingHasMore}
+            onLoadMore={() => void loadMoreBilling()}
+            isLoading={billingLoadingMore}
+          />
+        </CardContent>
+      </Card>
+
+      <Dialog open={seatDialogOpen} onOpenChange={setSeatDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Change seat count</DialogTitle>
+          </DialogHeader>
+          <Input
+            value={seatCount}
+            onChange={event => setSeatCount(event.target.value)}
+            inputMode="numeric"
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setSeatDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() =>
+                void (async () => {
+                  await trpcClient.organizations.subscription.updateSeatCount.mutate({
+                    organizationId,
+                    newSeatCount: Number(seatCount),
+                  });
+                  toast.success('Seat count updated');
+                  setSeatDialogOpen(false);
+                  await refreshData();
+                })()
+              }
+            >
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={billingCycleDialogOpen} onOpenChange={setBillingCycleDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Change billing cycle</DialogTitle>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setBillingCycleDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() =>
+                void (async () => {
+                  await trpcClient.organizations.subscription.changeBillingCycle.mutate({
+                    organizationId,
+                    targetCycle: currentInterval === 'annual' ? 'monthly' : 'annual',
+                  });
+                  toast.success('Billing cycle change scheduled');
+                  setBillingCycleDialogOpen(false);
+                  await refreshData();
+                })()
+              }
+            >
+              Switch to {currentInterval === 'annual' ? 'monthly' : 'annual'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-1">
+      <div className="text-muted-foreground text-sm">{label}</div>
+      <div className="font-medium break-all">{value}</div>
+    </div>
+  );
+}

--- a/src/components/subscriptions/seats/SeatsDetail.tsx
+++ b/src/components/subscriptions/seats/SeatsDetail.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Users } from 'lucide-react';
+import { ArrowRight, ExternalLink, Minus, Plus, Users } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -16,9 +16,10 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { useRawTRPCClient, useTRPC } from '@/lib/trpc/utils';
+import { capitalize } from '@/lib/utils';
+import { SEAT_PRICING } from '@/lib/organizations/constants';
 import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
 import { DetailPageHeader } from '@/components/subscriptions/DetailPageHeader';
-import { StripePortalLink } from '@/components/subscriptions/StripePortalLink';
 import { BillingHistoryTable } from '@/components/subscriptions/BillingHistoryTable';
 import { formatDateLabel, getPaidSeatSubscriptionItem } from '@/components/subscriptions/helpers';
 
@@ -39,6 +40,8 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
   const [seatDialogOpen, setSeatDialogOpen] = useState(false);
   const [billingCycleDialogOpen, setBillingCycleDialogOpen] = useState(false);
   const [seatCount, setSeatCount] = useState('1');
+  const [isOpeningPortal, setIsOpeningPortal] = useState(false);
+  const [isCancelingCycleChange, setIsCancelingCycleChange] = useState(false);
 
   const organizationQuery = useOrganizationWithMembers(organizationId, {
     enabled: !!organizationId,
@@ -110,6 +113,23 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
     }
   }
 
+  function openCustomerPortal() {
+    if (isOpeningPortal) return;
+    setIsOpeningPortal(true);
+    void (async () => {
+      try {
+        const result = await trpcClient.organizations.subscription.getCustomerPortalUrl.mutate({
+          organizationId,
+          returnUrl: window.location.href,
+        });
+        window.location.href = result.url;
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : 'Failed to open Stripe portal');
+        setIsOpeningPortal(false);
+      }
+    })();
+  }
+
   const subscription = subscriptionQuery.data?.subscription ?? null;
   const seatUsagePercent = useMemo(() => {
     const used = subscriptionQuery.data?.seatsUsed ?? 0;
@@ -143,6 +163,7 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
     (sum, item) => sum + (item.price?.unit_amount ?? 0) * (item.quantity ?? 0),
     0
   );
+  const hasPendingCycleChange = subscription.schedule != null;
 
   return (
     <div className="space-y-6">
@@ -151,120 +172,153 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
         backLabel="Back to subscriptions"
         title="Teams / Enterprise Seats"
         status={subscription.status}
-        actions={
-          <StripePortalLink
-            onOpenPortal={async () => {
-              const result =
-                await trpcClient.organizations.subscription.getCustomerPortalUrl.mutate({
-                  organizationId,
-                  returnUrl: window.location.href,
-                });
-              return result.url;
-            }}
-          />
-        }
       />
 
-      <div className="grid gap-6 xl:grid-cols-[2fr_1fr]">
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Users className="h-5 w-5" />
-              Subscription details
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <div className="grid gap-4 sm:grid-cols-2">
-              <DetailRow
-                label="Organization"
-                value={organizationQuery.data?.name ?? 'Organization'}
-              />
-              <DetailRow label="Plan" value={organizationQuery.data?.plan ?? 'teams'} />
-              <DetailRow label="Billing cycle" value={currentInterval} />
-              <DetailRow
-                label="Price"
-                value={`$${(totalAmount / 100).toFixed(2)}/${currentInterval === 'annual' ? 'year' : 'month'}`}
-              />
-              <DetailRow
-                label="Next billing"
-                value={formatDateLabel(
-                  paidSeatItem?.current_period_end
-                    ? new Date(paidSeatItem.current_period_end * 1000).toISOString()
-                    : null,
-                  '—'
-                )}
-              />
-              <DetailRow label="Seats" value={String(subscriptionQuery.data?.totalSeats ?? 0)} />
-            </div>
+      <Card>
+        <CardHeader className="pb-4">
+          <CardTitle className="flex items-center gap-2">
+            <Users className="h-5 w-5" />
+            Subscription details
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <DetailRow
+              label="Organization"
+              value={organizationQuery.data?.name ?? 'Organization'}
+            />
+            <DetailRow
+              label="Plan"
+              value={capitalize(organizationQuery.data?.plan ?? 'teams')}
+            />
+            <DetailRow label="Billing cycle" value={capitalize(currentInterval)} />
+            <DetailRow
+              label="Price"
+              value={`$${(totalAmount / 100).toFixed(2)}/${currentInterval === 'annual' ? 'year' : 'month'}`}
+            />
+            <DetailRow
+              label="Next billing"
+              value={formatDateLabel(
+                paidSeatItem?.current_period_end
+                  ? new Date(paidSeatItem.current_period_end * 1000).toISOString()
+                  : null,
+                '—'
+              )}
+            />
+            <DetailRow label="Seats" value={String(subscriptionQuery.data?.totalSeats ?? 0)} />
+          </div>
 
-            <div className="space-y-3 rounded-xl border p-4">
-              <div className="flex items-center justify-between text-sm">
-                <span className="text-muted-foreground">Seat utilization</span>
-                <span>
-                  {subscriptionQuery.data?.seatsUsed ?? 0} /{' '}
-                  {subscriptionQuery.data?.totalSeats ?? 0}
-                </span>
-              </div>
-              <Progress value={seatUsagePercent} />
+          <div className="space-y-3 rounded-xl border p-4">
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">Seat utilization</span>
+              <span>
+                {subscriptionQuery.data?.seatsUsed ?? 0} /{' '}
+                {subscriptionQuery.data?.totalSeats ?? 0}
+              </span>
             </div>
+            <Progress
+              value={seatUsagePercent}
+              className="bg-amber-500/20"
+              indicatorClassName="bg-linear-to-r from-amber-500 to-amber-300"
+            />
+          </div>
 
-            <div className="flex flex-wrap gap-2">
-              <Button variant="outline" onClick={() => setSeatDialogOpen(true)}>
-                Change Seat Count
-              </Button>
-              <Button variant="outline" onClick={() => setBillingCycleDialogOpen(true)}>
-                Change Billing Cycle
-              </Button>
-              {subscription.cancel_at_period_end ? (
-                <Button
-                  variant="outline"
-                  onClick={() =>
-                    void (async () => {
-                      await trpcClient.organizations.subscription.stopCancellation.mutate({
-                        organizationId,
-                      });
-                      toast.success('Subscription resumed');
-                      await refreshData();
-                    })()
-                  }
-                >
-                  Resume Subscription
-                </Button>
-              ) : (
+          {hasPendingCycleChange ? (
+            <Card className="border-blue-500/30 bg-blue-500/5">
+              <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="font-medium">Scheduled billing cycle change</p>
+                  <p className="text-muted-foreground text-sm">
+                    Switching to {currentInterval === 'annual' ? 'monthly' : 'annual'} billing at
+                    the next renewal
+                  </p>
+                </div>
                 <Button
                   variant="outline"
                   onClick={() => {
-                    if (!window.confirm('Cancel this seats subscription at period end?')) return;
+                    if (isCancelingCycleChange) return;
+                    setIsCancelingCycleChange(true);
                     void (async () => {
-                      await trpcClient.organizations.subscription.cancel.mutate({ organizationId });
-                      toast.success('Subscription will cancel at period end');
-                      await refreshData();
+                      try {
+                        await trpcClient.organizations.subscription.cancelBillingCycleChange.mutate({
+                          organizationId,
+                        });
+                        toast.success('Billing cycle change canceled');
+                        await refreshData();
+                      } catch (error) {
+                        toast.error(
+                          error instanceof Error
+                            ? error.message
+                            : 'Failed to cancel billing cycle change'
+                        );
+                      } finally {
+                        setIsCancelingCycleChange(false);
+                      }
                     })();
                   }}
+                  disabled={isCancelingCycleChange}
                 >
-                  Cancel Subscription
+                  {isCancelingCycleChange ? 'Canceling...' : 'Cancel Scheduled Change'}
                 </Button>
-              )}
-            </div>
-          </CardContent>
-        </Card>
+              </CardContent>
+            </Card>
+          ) : null}
+        </CardContent>
+      </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Reviewer notes</CardTitle>
-          </CardHeader>
-          <CardContent className="text-muted-foreground text-sm">
-            Billing admins and owners can update seats, switch cadence, or manage cancellation from
-            this page.
-          </CardContent>
-        </Card>
+      <div className="flex flex-wrap gap-2">
+        <Button variant="outline" onClick={() => setSeatDialogOpen(true)}>
+          Change Seat Count
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => setBillingCycleDialogOpen(true)}
+          disabled={hasPendingCycleChange}
+        >
+          Change Billing Cycle
+        </Button>
+        {subscription.cancel_at_period_end ? (
+          <Button
+            variant="outline"
+            onClick={() =>
+              void (async () => {
+                await trpcClient.organizations.subscription.stopCancellation.mutate({
+                  organizationId,
+                });
+                toast.success('Subscription resumed');
+                await refreshData();
+              })()
+            }
+          >
+            Resume Subscription
+          </Button>
+        ) : (
+          <Button
+            variant="outline"
+            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+            onClick={() => {
+              if (!window.confirm('Cancel this seats subscription at period end?')) return;
+              void (async () => {
+                await trpcClient.organizations.subscription.cancel.mutate({ organizationId });
+                toast.success('Subscription will cancel at period end');
+                await refreshData();
+              })();
+            }}
+          >
+            Cancel Subscription
+          </Button>
+        )}
+        <Button variant="outline" onClick={openCustomerPortal} disabled={isOpeningPortal}>
+          <ExternalLink className="h-4 w-4" />
+          {isOpeningPortal ? 'Opening...' : 'Manage Payment Method'}
+        </Button>
       </div>
 
       <Card>
-        <CardHeader>
+        <CardHeader className="pb-4">
           <CardTitle>Billing history</CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent className="pt-1">
           <BillingHistoryTable
             variant="stripe"
             entries={billingEntries}
@@ -276,14 +330,36 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
       </Card>
 
       <Dialog open={seatDialogOpen} onOpenChange={setSeatDialogOpen}>
-        <DialogContent>
+        <DialogContent className="sm:max-w-sm">
           <DialogHeader>
             <DialogTitle>Change seat count</DialogTitle>
           </DialogHeader>
-          <Input
-            value={seatCount}
-            onChange={event => setSeatCount(event.target.value)}
-            inputMode="numeric"
+          <div className="flex items-center justify-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setSeatCount(String(Math.max(1, Number(seatCount) - 1)))}
+              disabled={Number(seatCount) <= 1}
+            >
+              <Minus className="h-4 w-4" />
+            </Button>
+            <Input
+              className="w-20 text-center"
+              value={seatCount}
+              onChange={event => setSeatCount(event.target.value)}
+              inputMode="numeric"
+            />
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setSeatCount(String(Number(seatCount) + 1))}
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
+          </div>
+          <SeatCountChangeMessage
+            currentSeats={subscriptionQuery.data?.totalSeats ?? 0}
+            newSeats={Number(seatCount)}
           />
           <DialogFooter>
             <Button variant="outline" onClick={() => setSeatDialogOpen(false)}>
@@ -309,10 +385,16 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
       </Dialog>
 
       <Dialog open={billingCycleDialogOpen} onOpenChange={setBillingCycleDialogOpen}>
-        <DialogContent>
+        <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Change billing cycle</DialogTitle>
           </DialogHeader>
+          <BillingCycleChangeContent
+            currentInterval={currentInterval}
+            perSeatCents={paidSeatItem?.price?.unit_amount ?? 0}
+            seatCount={subscriptionQuery.data?.totalSeats ?? 0}
+            plan={(organizationQuery.data?.plan as 'teams' | 'enterprise') ?? 'teams'}
+          />
           <DialogFooter>
             <Button variant="outline" onClick={() => setBillingCycleDialogOpen(false)}>
               Cancel
@@ -335,6 +417,75 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+    </div>
+  );
+}
+
+function SeatCountChangeMessage({
+  currentSeats,
+  newSeats,
+}: {
+  currentSeats: number;
+  newSeats: number;
+}) {
+  if (isNaN(newSeats) || newSeats === currentSeats) return null;
+
+  if (newSeats > currentSeats) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        Adding {newSeats - currentSeats} seat{newSeats - currentSeats === 1 ? '' : 's'}. You will be
+        billed a prorated amount immediately.
+      </p>
+    );
+  }
+
+  return (
+    <p className="text-muted-foreground text-sm">
+      Removing {currentSeats - newSeats} seat{currentSeats - newSeats === 1 ? '' : 's'}. This will
+      take effect at the start of your next billing cycle.
+    </p>
+  );
+}
+
+function BillingCycleChangeContent({
+  currentInterval,
+  perSeatCents,
+  seatCount,
+  plan,
+}: {
+  currentInterval: 'monthly' | 'annual';
+  perSeatCents: number;
+  seatCount: number;
+  plan: 'teams' | 'enterprise';
+}) {
+  const targetInterval = currentInterval === 'annual' ? 'monthly' : 'annual';
+  const currentPerSeat = perSeatCents / 100;
+  const targetPerSeat = SEAT_PRICING[plan][targetInterval === 'annual' ? 'annual' : 'monthly'];
+
+  return (
+    <div className="space-y-3 text-sm">
+      <div className="flex items-center justify-center gap-3">
+        <div className="bg-muted/20 border-border/60 flex-1 rounded-lg border px-3 py-2 text-center">
+          <div className="text-muted-foreground text-xs">Current cycle</div>
+          <div className="font-medium">{capitalize(currentInterval)}</div>
+          <div className="text-muted-foreground text-xs">
+            ${currentPerSeat.toFixed(2)}/seat/mo
+          </div>
+        </div>
+        <ArrowRight className="text-muted-foreground h-4 w-4 shrink-0" />
+        <div className="bg-muted/20 border-border/60 flex-1 rounded-lg border px-3 py-2 text-center">
+          <div className="text-muted-foreground text-xs">New cycle</div>
+          <div className="font-medium">{capitalize(targetInterval)}</div>
+          <div className="text-muted-foreground text-xs">
+            ${targetPerSeat.toFixed(2)}/seat/mo
+          </div>
+        </div>
+      </div>
+      <p className="text-muted-foreground">
+        {targetInterval === 'annual'
+          ? `Switching to annual billing takes effect at your next renewal. You will be billed $${(targetPerSeat * seatCount * 12).toFixed(2)}/year upfront for ${seatCount} seat${seatCount === 1 ? '' : 's'}.`
+          : `Switching to monthly billing takes effect at your next renewal. You will be billed $${(targetPerSeat * seatCount).toFixed(2)}/month for ${seatCount} seat${seatCount === 1 ? '' : 's'}.`}
+      </p>
     </div>
   );
 }

--- a/src/components/subscriptions/seats/SeatsGroup.tsx
+++ b/src/components/subscriptions/seats/SeatsGroup.tsx
@@ -3,10 +3,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { Users } from 'lucide-react';
 import type Stripe from 'stripe';
-import { Card, CardContent } from '@/components/ui/card';
 import { useTRPC } from '@/lib/trpc/utils';
-import { CreateSubscriptionButton } from '@/components/organizations/subscription/CreateSubscriptionButton';
-import { AvailableProductCard } from '@/components/subscriptions/AvailableProductCard';
 import { SubscriptionCard } from '@/components/subscriptions/SubscriptionCard';
 import { SubscriptionGroup } from '@/components/subscriptions/SubscriptionGroup';
 import {
@@ -15,6 +12,8 @@ import {
   isSeatsTerminal,
   isWarningStatus,
 } from '@/components/subscriptions/helpers';
+import type { OrganizationPlan } from '@/lib/organizations/organization-types';
+import { SeatsSubscribeCard } from './SeatsSubscribeCard';
 
 function getSeatPrice(subscription: Stripe.Subscription) {
   const paidSeatItem = getPaidSeatSubscriptionItem(subscription);
@@ -29,9 +28,11 @@ function getSeatPrice(subscription: Stripe.Subscription) {
 
 export function SeatsGroup({
   organizationId,
+  organizationPlan,
   showTerminal,
 }: {
   organizationId: string;
+  organizationPlan: OrganizationPlan;
   showTerminal: boolean;
 }) {
   const trpc = useTRPC();
@@ -51,6 +52,7 @@ export function SeatsGroup({
     <SubscriptionGroup
       title="Teams / Enterprise Seats"
       description="Manage seats and renewal details for this organization."
+      headerIcon={<Users className="h-5 w-5" />}
       isLoading={query.isLoading}
       isError={query.isError}
       error={query.error}
@@ -78,20 +80,11 @@ export function SeatsGroup({
               : undefined
           }
         />
-      ) : subscription ? (
-        <Card>
-          <CardContent className="text-muted-foreground p-5 text-sm">
-            This organization has an ended seats subscription. Turn on &quot;Show ended&quot; to
-            review it.
-          </CardContent>
-        </Card>
       ) : (
-        <AvailableProductCard
-          icon={<Users className="h-5 w-5" />}
-          title="Teams / Enterprise Seats"
-          description="Create a seats subscription for this organization."
-          price="Flexible monthly or annual billing"
-          action={<CreateSubscriptionButton organizationId={organizationId} className="w-full" />}
+        <SeatsSubscribeCard
+          key={organizationId}
+          organizationId={organizationId}
+          currentPlan={organizationPlan}
         />
       )}
     </SubscriptionGroup>

--- a/src/components/subscriptions/seats/SeatsGroup.tsx
+++ b/src/components/subscriptions/seats/SeatsGroup.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { Users } from 'lucide-react';
+import type Stripe from 'stripe';
+import { Card, CardContent } from '@/components/ui/card';
+import { useTRPC } from '@/lib/trpc/utils';
+import { CreateSubscriptionButton } from '@/components/organizations/subscription/CreateSubscriptionButton';
+import { AvailableProductCard } from '@/components/subscriptions/AvailableProductCard';
+import { SubscriptionCard } from '@/components/subscriptions/SubscriptionCard';
+import { SubscriptionGroup } from '@/components/subscriptions/SubscriptionGroup';
+import {
+  formatDateLabel,
+  getPaidSeatSubscriptionItem,
+  isSeatsTerminal,
+  isWarningStatus,
+} from '@/components/subscriptions/helpers';
+
+function getSeatPrice(subscription: Stripe.Subscription) {
+  const paidSeatItem = getPaidSeatSubscriptionItem(subscription);
+  const totalAmount = subscription.items.data.reduce(
+    (sum: number, item: Stripe.SubscriptionItem) =>
+      sum + (item.price?.unit_amount ?? 0) * (item.quantity ?? 0),
+    0
+  );
+  const interval = paidSeatItem?.price?.recurring?.interval === 'year' ? 'year' : 'month';
+  return `$${(totalAmount / 100).toFixed(2)}/${interval}`;
+}
+
+export function SeatsGroup({
+  organizationId,
+  showTerminal,
+}: {
+  organizationId: string;
+  showTerminal: boolean;
+}) {
+  const trpc = useTRPC();
+  const query = useQuery(
+    trpc.organizations.subscription.get.queryOptions(
+      { organizationId },
+      { enabled: !!organizationId }
+    )
+  );
+
+  const subscription = query.data?.subscription ?? null;
+  const status = subscription?.status ?? 'ended';
+  const isVisible = subscription && (!isSeatsTerminal(status) || showTerminal);
+  const paidSeatItem = subscription ? getPaidSeatSubscriptionItem(subscription) : null;
+
+  return (
+    <SubscriptionGroup
+      title="Teams / Enterprise Seats"
+      description="Manage seats and renewal details for this organization."
+      isLoading={query.isLoading}
+      isError={query.isError}
+      error={query.error}
+      onRetry={() => void query.refetch()}
+    >
+      {isVisible && subscription ? (
+        <SubscriptionCard
+          icon={<Users className="h-5 w-5" />}
+          title="Teams / Enterprise Seats"
+          subtitle={`${query.data?.seatsUsed ?? 0} of ${query.data?.totalSeats ?? 0} seats in use`}
+          status={subscription.status}
+          price={getSeatPrice(subscription)}
+          billingDate={formatDateLabel(
+            paidSeatItem?.current_period_end
+              ? new Date(paidSeatItem.current_period_end * 1000).toISOString()
+              : null,
+            '—'
+          )}
+          paymentMethod="Stripe"
+          href={`/organizations/${organizationId}/subscriptions/seats`}
+          isTerminal={isSeatsTerminal(subscription.status)}
+          warningTone={
+            isWarningStatus(subscription.status) || subscription.cancel_at_period_end
+              ? 'warning'
+              : undefined
+          }
+        />
+      ) : subscription ? (
+        <Card>
+          <CardContent className="text-muted-foreground p-5 text-sm">
+            This organization has an ended seats subscription. Turn on &quot;Show ended&quot; to
+            review it.
+          </CardContent>
+        </Card>
+      ) : (
+        <AvailableProductCard
+          icon={<Users className="h-5 w-5" />}
+          title="Teams / Enterprise Seats"
+          description="Create a seats subscription for this organization."
+          price="Flexible monthly or annual billing"
+          action={<CreateSubscriptionButton organizationId={organizationId} className="w-full" />}
+        />
+      )}
+    </SubscriptionGroup>
+  );
+}

--- a/src/components/subscriptions/seats/SeatsSubscribeCard.tsx
+++ b/src/components/subscriptions/seats/SeatsSubscribeCard.tsx
@@ -191,11 +191,11 @@ export function SeatsSubscribeCard({
                   onChange={event => {
                     const nextValue = Number.parseInt(event.target.value, 10);
                     if (Number.isNaN(nextValue)) return;
-                     seededFromDefaults.current = true;
-                     setSeatCount(Math.max(1, Math.min(100, nextValue)));
-                   }}
-                   className="bg-blue-500/10 h-11 w-24 rounded-xl border-0 text-center text-lg font-semibold shadow-none focus-visible:border-transparent focus-visible:ring-0 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                 />
+                    seededFromDefaults.current = true;
+                    setSeatCount(Math.max(1, Math.min(100, nextValue)));
+                  }}
+                  className="bg-blue-500/10 h-11 w-24 rounded-xl border-0 text-center text-lg font-semibold shadow-none focus-visible:border-transparent focus-visible:ring-0 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                />
 
                 <Button
                   type="button"
@@ -279,7 +279,10 @@ export function SeatsSubscribeCard({
               <h4 className="text-sm font-medium text-white/90">Pay-as-you-go</h4>
               <p className="text-muted-foreground/90 mt-1 text-xs leading-5">
                 Purchase credits as needed. Only pay for what you use with no commitments.{' '}
-                <Link href="/credits" className="text-blue-400/90 hover:text-blue-300 hover:underline">
+                <Link
+                  href="/credits"
+                  className="text-blue-400/90 hover:text-blue-300 hover:underline"
+                >
                   Learn more
                 </Link>
               </p>
@@ -305,7 +308,6 @@ export function SeatsSubscribeCard({
             </a>
           </div>
         </div>
-
       </CardContent>
     </Card>
   );

--- a/src/components/subscriptions/seats/SeatsSubscribeCard.tsx
+++ b/src/components/subscriptions/seats/SeatsSubscribeCard.tsx
@@ -1,0 +1,312 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import { usePostHog } from 'posthog-js/react';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+import {
+  useOrganizationSeatUsage,
+  useOrganizationSubscriptionLink,
+  useResubscribeDefaults,
+} from '@/app/api/organizations/hooks';
+import { PlanCard } from '@/components/organizations/subscription/PlanCard';
+import {
+  ENTERPRISE_FEATURES,
+  TEAMS_FEATURES,
+} from '@/components/organizations/subscription/plan-features';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { seatPrice } from '@/lib/organizations/constants';
+import type { BillingCycle, OrganizationPlan } from '@/lib/organizations/organization-types';
+import { cn } from '@/lib/utils';
+
+const BILLING_CADENCE_OPTIONS = [
+  { value: 'monthly', label: 'Monthly' },
+  { value: 'annual', label: 'Annual' },
+] as const satisfies ReadonlyArray<{ value: BillingCycle; label: string }>;
+
+export function SeatsSubscribeCard({
+  organizationId,
+  currentPlan,
+}: {
+  organizationId: string;
+  currentPlan: OrganizationPlan;
+}) {
+  const [selectedPlan, setSelectedPlan] = useState<OrganizationPlan>(currentPlan);
+  const [billingCycle, setBillingCycle] = useState<BillingCycle>('annual');
+  const [seatCount, setSeatCount] = useState<number | null>(null);
+  const seededFromDefaults = useRef(false);
+  const hog = usePostHog();
+
+  const seatUsageQuery = useOrganizationSeatUsage(organizationId);
+  const resubscribeDefaultsQuery = useResubscribeDefaults(organizationId);
+  const subscriptionLink = useOrganizationSubscriptionLink();
+
+  useEffect(() => {
+    setSelectedPlan(currentPlan);
+  }, [currentPlan]);
+
+  useEffect(() => {
+    if (seededFromDefaults.current) return;
+
+    const seatUsage = seatUsageQuery.data;
+    const resubscribeDefaults = resubscribeDefaultsQuery.data;
+    if (!seatUsage || !resubscribeDefaults) return;
+
+    seededFromDefaults.current = true;
+    setBillingCycle(resubscribeDefaults.billingCycle);
+    setSeatCount(Math.max(resubscribeDefaults.defaultSeatCount, seatUsage.usedSeats));
+  }, [resubscribeDefaultsQuery.data, seatUsageQuery.data]);
+
+  const defaultSeatCount = Math.max(1, Math.min(100, seatUsageQuery.data?.usedSeats ?? 1));
+  const effectiveSeatCount = seatCount ?? defaultSeatCount;
+  const selectedPlanName = selectedPlan === 'teams' ? 'Teams' : 'Enterprise';
+  const isPending = subscriptionLink.isPending;
+
+  async function handlePurchase() {
+    hog?.capture('trial_upgrade_purchase_clicked', {
+      organizationId,
+      selectedPlan,
+      billingCycle,
+      seatCount: effectiveSeatCount,
+      source: 'subscriptions_page',
+    });
+
+    try {
+      const result = await subscriptionLink.mutateAsync({
+        organizationId,
+        seats: effectiveSeatCount,
+        cancelUrl: window.location.href,
+        plan: selectedPlan,
+        billingCycle,
+      });
+
+      if (!result.url) {
+        toast.error('Failed to create Stripe checkout session');
+        return;
+      }
+
+      window.location.href = result.url;
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to start checkout');
+    }
+  }
+
+  const decrementDisabled = effectiveSeatCount <= 1 || isPending;
+  const incrementDisabled = effectiveSeatCount >= 100 || isPending;
+  const purchaseDisabled = isPending || seatUsageQuery.data == null;
+
+  return (
+    <Card className="border-border/60 w-full overflow-hidden rounded-xl shadow-sm">
+      <CardContent className="grid gap-5 p-5 md:p-6">
+        <div className="bg-muted/20 border-border/60 flex flex-wrap items-center justify-between gap-3 overflow-hidden rounded-lg border px-3 py-2">
+          <div className="text-sm font-medium">Choose plan and billing cadence</div>
+
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-1 rounded-lg bg-white/[0.04] p-0.5">
+              {BILLING_CADENCE_OPTIONS.map(option => (
+                <Button
+                  key={option.value}
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={isPending}
+                  onClick={() => {
+                    seededFromDefaults.current = true;
+                    setBillingCycle(option.value);
+                  }}
+                  className={cn(
+                    'h-8 min-w-24 rounded-md px-3 text-xs font-semibold transition',
+                    billingCycle === option.value
+                      ? 'bg-blue-500 text-white hover:bg-blue-500'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-white/5'
+                  )}
+                >
+                  {option.label}
+                </Button>
+              ))}
+            </div>
+
+            <span
+              className={cn(
+                'rounded-full border px-2.5 py-1 text-xs font-semibold transition-[opacity,text-decoration-color]',
+                billingCycle === 'annual'
+                  ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400 opacity-100'
+                  : 'border-border/60 text-muted-foreground opacity-70 line-through decoration-current'
+              )}
+            >
+              Save 17%
+            </span>
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-5 lg:grid-cols-2 lg:gap-6">
+          <PlanCard
+            plan="teams"
+            pricePerMonth={seatPrice('teams', billingCycle)}
+            billingCycle={billingCycle}
+            features={TEAMS_FEATURES}
+            isSelected={selectedPlan === 'teams'}
+            currentPlan={currentPlan}
+            onSelect={() => setSelectedPlan('teams')}
+          />
+
+          <PlanCard
+            plan="enterprise"
+            pricePerMonth={seatPrice('enterprise', billingCycle)}
+            billingCycle={billingCycle}
+            features={ENTERPRISE_FEATURES}
+            isSelected={selectedPlan === 'enterprise'}
+            currentPlan={currentPlan}
+            onSelect={() => setSelectedPlan('enterprise')}
+          />
+        </div>
+
+        <div className="bg-muted/5 rounded-xl p-3 md:p-4">
+          <div className="flex flex-col items-center justify-center gap-3 text-center md:flex-row md:gap-4">
+            <div className="text-base font-medium md:text-sm">Number of seats</div>
+
+            <div className="flex flex-col items-center gap-2.5 md:flex-row md:gap-3">
+              <div className="flex items-center gap-1.5">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={decrementDisabled}
+                  onClick={() => {
+                    seededFromDefaults.current = true;
+                    setSeatCount(Math.max(1, effectiveSeatCount - 1));
+                  }}
+                  className="bg-background/80 h-11 w-11 rounded-xl px-0 text-sm hover:bg-background"
+                >
+                  <span className="text-lg leading-none">-</span>
+                </Button>
+
+                <Input
+                  value={effectiveSeatCount}
+                  inputMode="numeric"
+                  disabled={isPending}
+                  onChange={event => {
+                    const nextValue = Number.parseInt(event.target.value, 10);
+                    if (Number.isNaN(nextValue)) return;
+                     seededFromDefaults.current = true;
+                     setSeatCount(Math.max(1, Math.min(100, nextValue)));
+                   }}
+                   className="bg-blue-500/10 h-11 w-24 rounded-xl border-0 text-center text-lg font-semibold shadow-none focus-visible:border-transparent focus-visible:ring-0 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                 />
+
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={incrementDisabled}
+                  onClick={() => {
+                    seededFromDefaults.current = true;
+                    setSeatCount(Math.min(100, effectiveSeatCount + 1));
+                  }}
+                  className="bg-background/80 h-11 w-11 rounded-xl px-0 text-sm hover:bg-background"
+                >
+                  <span className="text-lg leading-none">+</span>
+                </Button>
+              </div>
+
+              <div className="text-muted-foreground text-xs whitespace-nowrap md:text-[11px]">
+                {seatUsageQuery.data
+                  ? `(${seatUsageQuery.data.usedSeats} currently in use)`
+                  : 'Checking current seat usage'}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex justify-center">
+            <Button
+              type="button"
+              variant="primary"
+              disabled={purchaseDisabled}
+              onClick={() => void handlePurchase()}
+              className="h-11 w-full max-w-xl text-sm font-semibold md:h-12 md:text-base"
+            >
+              {isPending ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Processing...
+                </>
+              ) : (
+                `Purchase ${selectedPlanName} Plan`
+              )}
+            </Button>
+          </div>
+
+          <p className="text-muted-foreground text-center text-xs">
+            You&apos;ll be redirected to Stripe to complete your purchase.
+          </p>
+        </div>
+
+        <div className="border-border/40 bg-muted/6 rounded-xl border p-3.5 md:p-4">
+          <div className="mx-auto max-w-3xl text-center">
+            <p className="text-muted-foreground/80 text-[10px] font-semibold tracking-[0.14em] uppercase">
+              Credits and model access
+            </p>
+            <h3 className="mt-1 text-sm font-medium leading-5 text-white/90">
+              Credits are not included with seat subscriptions.
+            </h3>
+            <p className="text-muted-foreground/90 mt-1 text-xs leading-5">
+              Pair Teams or Enterprise seats with the credit setup that fits your team.
+            </p>
+          </div>
+
+          <div className="mt-3 grid gap-2.5 md:grid-cols-3">
+            <div className="border-border/40 bg-background/35 rounded-xl border p-3">
+              <h4 className="text-sm font-medium text-white/90">Kilo Pass</h4>
+              <p className="text-muted-foreground/90 mt-1 text-xs leading-5">
+                Credit subscription with bonus credits.{' '}
+                <a
+                  href="https://kilo.ai/features/kilo-pass"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-400/90 hover:text-blue-300 hover:underline"
+                >
+                  Learn more
+                </a>
+              </p>
+            </div>
+
+            <div className="border-border/40 bg-background/35 rounded-xl border p-3">
+              <h4 className="text-sm font-medium text-white/90">Pay-as-you-go</h4>
+              <p className="text-muted-foreground/90 mt-1 text-xs leading-5">
+                Purchase credits as needed. Only pay for what you use with no commitments.{' '}
+                <Link href="/credits" className="text-blue-400/90 hover:text-blue-300 hover:underline">
+                  Learn more
+                </Link>
+              </p>
+            </div>
+
+            <div className="border-border/40 bg-background/35 rounded-xl border p-3">
+              <h4 className="text-sm font-medium text-white/90">Bring Your Own Key</h4>
+              <p className="text-muted-foreground/90 mt-1 text-xs leading-5">
+                Use API keys from your existing AI provider accounts.{' '}
+                <Link href="/byok" className="text-blue-400/90 hover:text-blue-300 hover:underline">
+                  Learn more
+                </Link>
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-3 text-center">
+            <a
+              href="mailto:sales@kilocode.ai"
+              className="text-muted-foreground/80 text-xs hover:text-muted-foreground"
+            >
+              Questions? Contact Support.
+            </a>
+          </div>
+        </div>
+
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -7,9 +7,10 @@ import { cn } from '@/lib/utils';
 
 function Progress({
   className,
+  indicatorClassName,
   value,
   ...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}: React.ComponentProps<typeof ProgressPrimitive.Root> & { indicatorClassName?: string }) {
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
@@ -18,7 +19,7 @@ function Progress({
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="bg-primary h-full w-full flex-1 transition-all"
+        className={cn('bg-primary h-full w-full flex-1 transition-all', indicatorClassName)}
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -35,6 +35,7 @@ export const TRIAL_DURATION_DAYS = 14;
 export const AUTOCOMPLETE_MODEL = 'codestral-2508';
 
 export const ENABLE_DEPLOY_FEATURE = true;
+export const ENABLE_CODING_PLAN_SUBSCRIPTIONS = false;
 
 export const IS_DEVELOPMENT = process.env.NODE_ENV === 'development';
 

--- a/src/lib/subscriptions/subscription-center.ts
+++ b/src/lib/subscriptions/subscription-center.ts
@@ -1,0 +1,68 @@
+import type Stripe from 'stripe';
+import * as z from 'zod';
+import { capitalize } from '@/lib/utils';
+
+export const stripeBillingHistoryEntrySchema = z.object({
+  kind: z.literal('stripe'),
+  id: z.string(),
+  date: z.string(),
+  amountCents: z.number().int(),
+  currency: z.string(),
+  status: z.string(),
+  invoiceUrl: z.string().nullable(),
+  invoicePdfUrl: z.string().nullable(),
+  description: z.string().nullable(),
+});
+
+export const creditsBillingHistoryEntrySchema = z.object({
+  kind: z.literal('credits'),
+  id: z.string(),
+  date: z.string(),
+  amountMicrodollars: z.number().int(),
+  description: z.string(),
+});
+
+export const billingHistoryEntrySchema = z.union([
+  stripeBillingHistoryEntrySchema,
+  creditsBillingHistoryEntrySchema,
+]);
+
+export const billingHistoryResponseSchema = z.object({
+  entries: z.array(billingHistoryEntrySchema),
+  hasMore: z.boolean(),
+  cursor: z.string().nullable(),
+});
+
+export type StripeBillingHistoryEntry = z.infer<typeof stripeBillingHistoryEntrySchema>;
+export type CreditsBillingHistoryEntry = z.infer<typeof creditsBillingHistoryEntrySchema>;
+export type BillingHistoryEntry = z.infer<typeof billingHistoryEntrySchema>;
+
+export function formatStoredPaymentMethodSummary(
+  paymentMethod: {
+    brand: string | null;
+    last4: string | null;
+  } | null
+): string {
+  if (!paymentMethod?.last4) {
+    return 'Stripe';
+  }
+
+  const brand = paymentMethod.brand ? capitalize(paymentMethod.brand) : 'Card';
+  return `${brand} ending in ${paymentMethod.last4}`;
+}
+
+export function mapStripeInvoiceToBillingHistoryEntry(
+  invoice: Stripe.Invoice
+): StripeBillingHistoryEntry {
+  return {
+    kind: 'stripe',
+    id: invoice.id,
+    date: new Date(invoice.created * 1000).toISOString(),
+    amountCents: invoice.amount_due ?? 0,
+    currency: invoice.currency ?? 'usd',
+    status: invoice.status ?? 'unknown',
+    invoiceUrl: invoice.hosted_invoice_url ?? null,
+    invoicePdfUrl: invoice.invoice_pdf ?? null,
+    description: invoice.lines.data[0]?.description ?? null,
+  };
+}

--- a/src/routers/kilo-pass-router.test.ts
+++ b/src/routers/kilo-pass-router.test.ts
@@ -733,10 +733,6 @@ describe('kiloPassRouter', () => {
   });
 
   describe('isEligibleForFirstMonthPromo in getState', () => {
-    afterEach(() => {
-      jest.useRealTimers();
-    });
-
     it('returns isEligibleForFirstMonthPromo=true when user has no subscriptions', async () => {
       const user = await insertTestUser({
         google_user_email: 'kilo-pass-promo-eligible-no-sub@example.com',
@@ -750,18 +746,36 @@ describe('kiloPassRouter', () => {
     });
 
     it('returns isEligibleForFirstMonthPromo=false when user has no subscriptions after the promo cutoff', async () => {
-      jest.useFakeTimers();
-      jest.setSystemTime(KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF.add(1, 'second').toDate());
-
       const user = await insertTestUser({
         google_user_email: 'kilo-pass-promo-ineligible-no-sub-after-cutoff@example.com',
       });
-
       const caller = await createCallerForUser(user.id);
-      const result = await caller.kiloPass.getState();
 
-      expect(result.isEligibleForFirstMonthPromo).toBe(false);
-      expect(result.subscription).toBeNull();
+      const afterCutoff = KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF.add(1, 'second').toDate();
+      const OrigDate = globalThis.Date;
+      const MockDate = class extends OrigDate {
+        constructor(...args: Parameters<typeof OrigDate>) {
+          if (args.length === 0) {
+            super(afterCutoff);
+          } else {
+            super(...args);
+          }
+        }
+
+        static override now() {
+          return afterCutoff.getTime();
+        }
+      } as DateConstructor;
+      globalThis.Date = MockDate;
+
+      try {
+        const result = await caller.kiloPass.getState();
+
+        expect(result.isEligibleForFirstMonthPromo).toBe(false);
+        expect(result.subscription).toBeNull();
+      } finally {
+        globalThis.Date = OrigDate;
+      }
     });
 
     it('returns isEligibleForFirstMonthPromo=false when user has a canceled subscription', async () => {

--- a/src/routers/kilo-pass-router.test.ts
+++ b/src/routers/kilo-pass-router.test.ts
@@ -733,6 +733,10 @@ describe('kiloPassRouter', () => {
   });
 
   describe('isEligibleForFirstMonthPromo in getState', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('returns isEligibleForFirstMonthPromo=true when user has no subscriptions', async () => {
       const user = await insertTestUser({
         google_user_email: 'kilo-pass-promo-eligible-no-sub@example.com',
@@ -742,6 +746,21 @@ describe('kiloPassRouter', () => {
       const result = await caller.kiloPass.getState();
 
       expect(result.isEligibleForFirstMonthPromo).toBe(true);
+      expect(result.subscription).toBeNull();
+    });
+
+    it('returns isEligibleForFirstMonthPromo=false when user has no subscriptions after the promo cutoff', async () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF.add(1, 'second').toDate());
+
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-promo-ineligible-no-sub-after-cutoff@example.com',
+      });
+
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.kiloPass.getState();
+
+      expect(result.isEligibleForFirstMonthPromo).toBe(false);
       expect(result.subscription).toBeNull();
     });
 

--- a/src/routers/kilo-pass-router.test.ts
+++ b/src/routers/kilo-pass-router.test.ts
@@ -27,6 +27,7 @@ import {
   KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_BONUS_PERCENT,
   KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF,
 } from '@/lib/kilo-pass/constants';
+import type { BillingHistoryEntry } from '@/lib/subscriptions/subscription-center';
 
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import type Stripe from 'stripe';
@@ -35,6 +36,9 @@ type StripeMock = {
   subscriptions: {
     retrieve: ReturnType<typeof jest.fn>;
     update: ReturnType<typeof jest.fn>;
+  };
+  invoices: {
+    list: ReturnType<typeof jest.fn>;
   };
   subscriptionSchedules: {
     create: ReturnType<typeof jest.fn>;
@@ -93,6 +97,22 @@ type KiloPassCaller = {
     creditsAwarded: boolean;
   }>;
   getCustomerPortalUrl: (input: { returnUrl?: string }) => Promise<{ url: string }>;
+  getBillingHistory: (input: { cursor?: string }) => Promise<{
+    entries: BillingHistoryEntry[];
+    hasMore: boolean;
+    cursor: string | null;
+  }>;
+  getCreditHistory: (input: { cursor?: string }) => Promise<{
+    entries: Array<{
+      id: string;
+      date: string;
+      amountUsd: number;
+      kind: KiloPassIssuanceItemKind;
+      description: string;
+    }>;
+    hasMore: boolean;
+    cursor: string | null;
+  }>;
   cancelSubscription: () => Promise<{ success: boolean }>;
   resumeSubscription: () => Promise<{ success: boolean }>;
   scheduleChange: (input: {
@@ -115,6 +135,9 @@ jest.mock('@/lib/stripe-client', () => {
     subscriptions: {
       retrieve: jest.fn(),
       update: jest.fn(),
+    },
+    invoices: {
+      list: jest.fn(),
     },
     subscriptionSchedules: {
       create: jest.fn(),
@@ -145,6 +168,10 @@ jest.mock('@/lib/kilo-pass/stripe-price-ids.server', () => {
     getStripePriceIdForKiloPass: getStripePriceIdForKiloPassMock,
   };
 });
+
+jest.mock('@/lib/rewardful', () => ({
+  getRewardfulReferral: jest.fn(async () => undefined),
+}));
 
 async function insertSubscription(params: {
   kiloUserId: string;
@@ -252,6 +279,7 @@ describe('kiloPassRouter', () => {
     const stripeMock = getStripeMock();
     stripeMock.subscriptions.retrieve.mockReset();
     stripeMock.subscriptions.update.mockReset();
+    stripeMock.invoices.list.mockReset();
     stripeMock.subscriptionSchedules.create.mockReset();
     stripeMock.subscriptionSchedules.update.mockReset();
     stripeMock.subscriptionSchedules.release.mockReset();
@@ -910,6 +938,189 @@ describe('kiloPassRouter', () => {
     });
   });
 
+  describe('getBillingHistory', () => {
+    it('lists Stripe invoices scoped to the Kilo Pass subscription', async () => {
+      const stripeMock = getStripeMock();
+      stripeMock.invoices.list.mockResolvedValue({
+        data: [
+          {
+            id: 'inv_kp_1',
+            created: 1_700_000_000,
+            amount_due: 4900,
+            currency: 'usd',
+            status: 'paid',
+            hosted_invoice_url: 'https://stripe.example.test/inv_kp_1',
+            invoice_pdf: 'https://stripe.example.test/inv_kp_1.pdf',
+            lines: { data: [{ description: 'Kilo Pass Pro monthly' }] },
+          },
+        ],
+        has_more: true,
+      });
+
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-billing-history@example.com',
+      });
+      await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: 'sub_kp_billing_history',
+        tier: KiloPassTier.Tier49,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+      });
+
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.kiloPass.getBillingHistory({});
+
+      expect(stripeMock.invoices.list).toHaveBeenCalledWith({
+        subscription: 'sub_kp_billing_history',
+        limit: 25,
+      });
+      expect(result).toEqual({
+        entries: [
+          {
+            kind: 'stripe',
+            id: 'inv_kp_1',
+            date: new Date(1_700_000_000 * 1000).toISOString(),
+            amountCents: 4900,
+            currency: 'usd',
+            status: 'paid',
+            invoiceUrl: 'https://stripe.example.test/inv_kp_1',
+            invoicePdfUrl: 'https://stripe.example.test/inv_kp_1.pdf',
+            description: 'Kilo Pass Pro monthly',
+          },
+        ],
+        hasMore: true,
+        cursor: 'inv_kp_1',
+      });
+    });
+
+    it('passes the pagination cursor to Stripe', async () => {
+      const stripeMock = getStripeMock();
+      stripeMock.invoices.list.mockResolvedValue({ data: [], has_more: false });
+
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-billing-history-cursor@example.com',
+      });
+      await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: 'sub_kp_billing_cursor',
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+      });
+
+      const caller = await createCallerForUser(user.id);
+      await caller.kiloPass.getBillingHistory({ cursor: 'inv_prev' });
+
+      expect(stripeMock.invoices.list).toHaveBeenCalledWith({
+        subscription: 'sub_kp_billing_cursor',
+        limit: 25,
+        starting_after: 'inv_prev',
+      });
+    });
+  });
+
+  describe('getCreditHistory', () => {
+    it('returns issuance items ordered by newest credit transaction first', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-credit-history@example.com',
+      });
+      const { id: subscriptionId } = await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: 'sub_kp_credit_history',
+        tier: KiloPassTier.Tier49,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+      });
+
+      const [issuance] = await db
+        .insert(kilo_pass_issuances)
+        .values({
+          kilo_pass_subscription_id: subscriptionId,
+          issue_month: '2026-04-01',
+          source: KiloPassIssuanceSource.StripeInvoice,
+          stripe_invoice_id: 'inv_credit_history',
+        })
+        .returning({ id: kilo_pass_issuances.id });
+
+      if (!issuance) {
+        throw new Error('Failed to insert issuance for credit history test');
+      }
+
+      const [baseTxn] = await db
+        .insert(credit_transactions)
+        .values({
+          id: crypto.randomUUID(),
+          kilo_user_id: user.id,
+          amount_microdollars: 49_000_000,
+          is_free: false,
+          description: 'Base credits',
+          created_at: '2026-04-01T10:00:00.000Z',
+        })
+        .returning({ id: credit_transactions.id });
+      const [bonusTxn] = await db
+        .insert(credit_transactions)
+        .values({
+          id: crypto.randomUUID(),
+          kilo_user_id: user.id,
+          amount_microdollars: 12_000_000,
+          is_free: true,
+          description: 'Bonus credits',
+          created_at: '2026-04-02T10:00:00.000Z',
+        })
+        .returning({ id: credit_transactions.id });
+
+      if (!baseTxn || !bonusTxn) {
+        throw new Error('Failed to insert credit transactions for credit history test');
+      }
+
+      const issuanceId = issuance.id;
+      const baseTxnId = baseTxn.id;
+      const bonusTxnId = bonusTxn.id;
+
+      await db.insert(kilo_pass_issuance_items).values([
+        {
+          kilo_pass_issuance_id: issuanceId,
+          kind: KiloPassIssuanceItemKind.Base,
+          credit_transaction_id: baseTxnId,
+          amount_usd: 49,
+          bonus_percent_applied: null,
+        },
+        {
+          kilo_pass_issuance_id: issuanceId,
+          kind: KiloPassIssuanceItemKind.Bonus,
+          credit_transaction_id: bonusTxnId,
+          amount_usd: 12,
+          bonus_percent_applied: 0.25,
+        },
+      ]);
+
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.kiloPass.getCreditHistory({});
+
+      expect(result).toEqual({
+        entries: [
+          {
+            id: expect.any(String),
+            date: '2026-04-02T10:00:00.000Z',
+            amountUsd: 12,
+            kind: KiloPassIssuanceItemKind.Bonus,
+            description: 'Bonus credits',
+          },
+          {
+            id: expect.any(String),
+            date: '2026-04-01T10:00:00.000Z',
+            amountUsd: 49,
+            kind: KiloPassIssuanceItemKind.Base,
+            description: 'Base credits',
+          },
+        ],
+        hasMore: false,
+        cursor: null,
+      });
+    });
+  });
+
   describe('cancelSubscription', () => {
     it('throws when no Kilo Pass subscription exists', async () => {
       const user = await insertTestUser({
@@ -1110,9 +1321,13 @@ describe('kiloPassRouter', () => {
         ),
       });
       expect(rows).toHaveLength(1);
-      expect(rows[0]?.status).toBe(KiloPassScheduledChangeStatus.NotStarted);
-      expect(rows[0]?.stripe_schedule_id).toBe(scheduleId);
-      expect(new Date(rows[0]?.effective_at ?? '').toISOString()).toBe(
+      const row = rows[0];
+      if (!row) {
+        throw new Error('Expected scheduled change row');
+      }
+      expect(row.status).toBe(KiloPassScheduledChangeStatus.NotStarted);
+      expect(row.stripe_schedule_id).toBe(scheduleId);
+      expect(new Date(row.effective_at).toISOString()).toBe(
         new Date(stripePeriodEndSeconds * 1000).toISOString()
       );
     });
@@ -1292,8 +1507,11 @@ describe('kiloPassRouter', () => {
         where: eq(kilo_pass_scheduled_changes.id, existing.id),
       });
       expect(oldRow).toBeTruthy();
-      expect(oldRow?.deleted_at).not.toBeNull();
-      expect(oldRow?.status).toBe(KiloPassScheduledChangeStatus.Released);
+      if (!oldRow) {
+        throw new Error('Expected historical scheduled change row');
+      }
+      expect(oldRow.deleted_at).not.toBeNull();
+      expect(oldRow.status).toBe(KiloPassScheduledChangeStatus.Released);
 
       const rows = await db.query.kilo_pass_scheduled_changes.findMany({
         where: eq(
@@ -1305,7 +1523,11 @@ describe('kiloPassRouter', () => {
       // We keep historical rows, but enforce a single active scheduled change per subscription.
       const active = rows.filter(r => r.deleted_at === null);
       expect(active).toHaveLength(1);
-      expect(active[0]?.stripe_schedule_id).toBe(newScheduleId);
+      const activeRow = active[0];
+      if (!activeRow) {
+        throw new Error('Expected active scheduled change row');
+      }
+      expect(activeRow.stripe_schedule_id).toBe(newScheduleId);
     });
 
     it('yearly tier upgrade resets billing cycle anchor and does not prorate (remaining credits issued separately)', async () => {
@@ -1348,8 +1570,11 @@ describe('kiloPassRouter', () => {
       });
 
       const updateCall = stripeMock.subscriptionSchedules.update.mock.calls[0];
-      const phases = updateCall?.[1]?.phases;
-      const newPhase = phases?.[1];
+      if (!updateCall) {
+        throw new Error('Expected subscription schedule update call');
+      }
+      const phases = updateCall[1].phases;
+      const newPhase = phases[1];
 
       // Yearly tier upgrades should NOT prorate — remaining credits at the old tier
       // are issued via maybeIssueYearlyRemainingCredits when the new invoice is paid.
@@ -1407,8 +1632,11 @@ describe('kiloPassRouter', () => {
       });
 
       const updateCall = stripeMock.subscriptionSchedules.update.mock.calls[0];
-      const phases = updateCall?.[1]?.phases;
-      const newPhase = phases?.[1];
+      if (!updateCall) {
+        throw new Error('Expected subscription schedule update call');
+      }
+      const phases = updateCall[1].phases;
+      const newPhase = phases[1];
 
       // Cadence changes (monthly→yearly) must reset the billing anchor so Stripe
       // generates an invoice for the new yearly subscription at the transition point.

--- a/src/routers/kilo-pass-router.ts
+++ b/src/routers/kilo-pass-router.ts
@@ -34,6 +34,7 @@ import { releaseScheduledChangeForSubscription } from '@/lib/kilo-pass/scheduled
 import { appendKiloPassAuditLog } from '@/lib/kilo-pass/issuance';
 import {
   KILO_PASS_FIRST_MONTH_PROMO_BONUS_PERCENT,
+  KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF,
   KILO_PASS_TIER_CONFIG,
 } from '@/lib/kilo-pass/constants';
 import { fromMicrodollars } from '@/lib/utils';
@@ -133,6 +134,10 @@ function roundToCents(usd: number): number {
 
 function secondsToIso(seconds: number): string {
   return dayjs.unix(seconds).utc().toISOString();
+}
+
+function isTwoMonthPromoOfferActive(): boolean {
+  return dayjs().utc().isBefore(KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF);
 }
 
 function getStripePeriodEndSeconds(subscription: Stripe.Subscription): number | null {
@@ -376,7 +381,7 @@ export const kiloPassRouter = createTRPCRouter({
   getState: baseProcedure.output(GetStateOutputSchema).query(async ({ ctx }) => {
     const subscriptionBase = await getKiloPassStateForUser(db, ctx.user.id);
     if (!subscriptionBase) {
-      return { subscription: null, isEligibleForFirstMonthPromo: true };
+      return { subscription: null, isEligibleForFirstMonthPromo: isTwoMonthPromoOfferActive() };
     }
 
     const stripeCustomerId = ctx.user.stripe_customer_id;
@@ -468,9 +473,10 @@ export const kiloPassRouter = createTRPCRouter({
     if (subscriptionBase.cadence === KiloPassCadence.Yearly) {
       const usd = computeYearlyCadenceMonthlyBonusUsd(subscriptionBase.tier);
       currentPeriodBonusCreditsUsd = roundToCents(usd);
-    } else {
-      const streakMonths = Math.max(1, subscriptionBase.currentStreakMonths);
-      const shouldShowFirstMonthPromo = streakMonths === 1 && isFirstTimeSubscriberEver;
+      } else {
+        const streakMonths = Math.max(1, subscriptionBase.currentStreakMonths);
+        const shouldShowFirstMonthPromo =
+          streakMonths === 1 && isFirstTimeSubscriberEver && isTwoMonthPromoOfferActive();
 
       if (shouldShowFirstMonthPromo) {
         const cents = Math.round(baseAmountUsd * KILO_PASS_FIRST_MONTH_PROMO_BONUS_PERCENT * 100);

--- a/src/routers/kilo-pass-router.ts
+++ b/src/routers/kilo-pass-router.ts
@@ -473,10 +473,10 @@ export const kiloPassRouter = createTRPCRouter({
     if (subscriptionBase.cadence === KiloPassCadence.Yearly) {
       const usd = computeYearlyCadenceMonthlyBonusUsd(subscriptionBase.tier);
       currentPeriodBonusCreditsUsd = roundToCents(usd);
-      } else {
-        const streakMonths = Math.max(1, subscriptionBase.currentStreakMonths);
-        const shouldShowFirstMonthPromo =
-          streakMonths === 1 && isFirstTimeSubscriberEver && isTwoMonthPromoOfferActive();
+    } else {
+      const streakMonths = Math.max(1, subscriptionBase.currentStreakMonths);
+      const shouldShowFirstMonthPromo =
+        streakMonths === 1 && isFirstTimeSubscriberEver && isTwoMonthPromoOfferActive();
 
       if (shouldShowFirstMonthPromo) {
         const cents = Math.round(baseAmountUsd * KILO_PASS_FIRST_MONTH_PROMO_BONUS_PERCENT * 100);

--- a/src/routers/kilo-pass-router.ts
+++ b/src/routers/kilo-pass-router.ts
@@ -41,6 +41,10 @@ import { timedUsageQuery } from '@/lib/usage-query';
 import type Stripe from 'stripe';
 import { dayjs } from '@/lib/kilo-pass/dayjs';
 import { getRewardfulReferral } from '@/lib/rewardful';
+import {
+  billingHistoryResponseSchema,
+  mapStripeInvoiceToBillingHistoryEntry,
+} from '@/lib/subscriptions/subscription-center';
 
 const KiloPassTierSchema = z.enum(KiloPassTier);
 
@@ -93,6 +97,35 @@ const GetStateOutputSchema = z.object({
 const GetAverageMonthlyUsageLast3MonthsOutputSchema = z.object({
   averageMonthlyUsageUsd: z.number(),
 });
+
+const CursorInputSchema = z.object({
+  cursor: z.string().optional(),
+});
+
+const KiloPassCreditHistoryEntrySchema = z.object({
+  id: z.string(),
+  date: z.string(),
+  amountUsd: z.number(),
+  kind: z.enum([
+    KiloPassIssuanceItemKind.Base,
+    KiloPassIssuanceItemKind.Bonus,
+    KiloPassIssuanceItemKind.PromoFirstMonth50Pct,
+  ]),
+  description: z.string(),
+});
+
+const KiloPassCreditHistoryResponseSchema = z.object({
+  entries: z.array(KiloPassCreditHistoryEntrySchema),
+  hasMore: z.boolean(),
+  cursor: z.string().nullable(),
+});
+
+function parseOffsetCursor(cursor: string | undefined): number {
+  if (!cursor) return 0;
+
+  const parsed = Number.parseInt(cursor, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
 
 function roundToCents(usd: number): number {
   return Math.round(usd * 100) / 100;
@@ -728,6 +761,75 @@ export const kiloPassRouter = createTRPCRouter({
           effectiveAt: scheduledChange.effective_at,
           status: scheduledChange.status,
         },
+      };
+    }),
+
+  getBillingHistory: baseProcedure
+    .input(CursorInputSchema)
+    .output(billingHistoryResponseSchema)
+    .query(async ({ ctx, input }) => {
+      const subscription = await getKiloPassStateForUser(db, ctx.user.id);
+      if (!subscription) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'No Kilo Pass subscription found.' });
+      }
+
+      const invoices = await stripe.invoices.list({
+        subscription: subscription.stripeSubscriptionId,
+        limit: 25,
+        ...(input.cursor ? { starting_after: input.cursor } : {}),
+      });
+
+      return {
+        entries: invoices.data.map(mapStripeInvoiceToBillingHistoryEntry),
+        hasMore: invoices.has_more,
+        cursor: invoices.has_more ? (invoices.data.at(-1)?.id ?? null) : null,
+      };
+    }),
+
+  getCreditHistory: baseProcedure
+    .input(CursorInputSchema)
+    .output(KiloPassCreditHistoryResponseSchema)
+    .query(async ({ ctx, input }) => {
+      const subscription = await getKiloPassStateForUser(db, ctx.user.id);
+      if (!subscription) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'No Kilo Pass subscription found.' });
+      }
+
+      const offset = parseOffsetCursor(input.cursor);
+      const rows = await db
+        .select({
+          id: kilo_pass_issuance_items.id,
+          kind: kilo_pass_issuance_items.kind,
+          amountUsd: kilo_pass_issuance_items.amount_usd,
+          createdAt: credit_transactions.created_at,
+          description: credit_transactions.description,
+        })
+        .from(kilo_pass_issuance_items)
+        .innerJoin(
+          kilo_pass_issuances,
+          eq(kilo_pass_issuance_items.kilo_pass_issuance_id, kilo_pass_issuances.id)
+        )
+        .innerJoin(
+          credit_transactions,
+          eq(kilo_pass_issuance_items.credit_transaction_id, credit_transactions.id)
+        )
+        .where(eq(kilo_pass_issuances.kilo_pass_subscription_id, subscription.subscriptionId))
+        .orderBy(desc(credit_transactions.created_at), desc(kilo_pass_issuance_items.id))
+        .limit(26)
+        .offset(offset);
+
+      const entries = rows.slice(0, 25).map(row => ({
+        id: row.id,
+        date: dayjs(row.createdAt).utc().toISOString(),
+        amountUsd: row.amountUsd,
+        kind: row.kind,
+        description: row.description ?? `${row.kind} credits`,
+      }));
+
+      return {
+        entries,
+        hasMore: rows.length > 25,
+        cursor: rows.length > 25 ? String(offset + 25) : null,
       };
     }),
 

--- a/src/routers/kiloclaw-billing-router.test.ts
+++ b/src/routers/kiloclaw-billing-router.test.ts
@@ -530,7 +530,7 @@ describe('subscription center procedures', () => {
         amount_microdollars: -9_000_000,
         is_free: false,
         description: 'Standard renewal',
-        credit_category: `kiloclaw-subscription:${instance.id}`,
+        credit_category: `kiloclaw-subscription:${instance.id}:2026-04`,
         created_at: '2026-04-01T12:00:00.000Z',
       },
       {
@@ -539,7 +539,7 @@ describe('subscription center procedures', () => {
         amount_microdollars: -48_000_000,
         is_free: false,
         description: 'Commit renewal',
-        credit_category: `kiloclaw-subscription-commit:${oldInstance.id}`,
+        credit_category: `kiloclaw-subscription-commit:${oldInstance.id}:2026-05`,
         created_at: '2026-05-01T12:00:00.000Z',
       },
       {
@@ -548,7 +548,7 @@ describe('subscription center procedures', () => {
         amount_microdollars: -9_000_000,
         is_free: false,
         description: 'Other instance renewal',
-        credit_category: `kiloclaw-subscription:${otherInstance.id}`,
+        credit_category: `kiloclaw-subscription:${otherInstance.id}:2026-06`,
         created_at: '2026-06-01T12:00:00.000Z',
       },
     ]);

--- a/src/routers/kiloclaw-billing-router.test.ts
+++ b/src/routers/kiloclaw-billing-router.test.ts
@@ -24,6 +24,7 @@ import {
 } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 import { sandboxIdFromUserId } from '@/lib/kiloclaw/sandbox-id';
+import { createOrganization } from '@/lib/organizations/organizations';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import type { User } from '@kilocode/db/schema';
 import type Stripe from 'stripe';
@@ -32,6 +33,8 @@ import { KiloPassTier, KiloPassCadence } from '@/lib/kilo-pass/enums';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyMock = jest.Mock<(...args: any[]) => any>;
 
+jest.setTimeout(15_000);
+
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
 jest.mock('@/lib/stripe-client', () => {
@@ -39,6 +42,7 @@ jest.mock('@/lib/stripe-client', () => {
   const { errors } = require('stripe').default ?? require('stripe');
   const stripeMock = {
     subscriptions: { retrieve: jest.fn(), update: jest.fn(), list: jest.fn() },
+    invoices: { list: jest.fn() },
     subscriptionSchedules: {
       create: jest.fn(),
       update: jest.fn(),
@@ -108,6 +112,7 @@ type StripeMockShape = {
   checkout: { sessions: { create: AnyMock; list: AnyMock; expire: AnyMock } };
   billingPortal: { sessions: { create: AnyMock } };
   subscriptions: { retrieve: AnyMock; update: AnyMock; list: AnyMock };
+  invoices: { list: AnyMock };
   subscriptionSchedules: { create: AnyMock; update: AnyMock; release: AnyMock; retrieve: AnyMock };
   errors: Stripe['errors'];
 };
@@ -142,6 +147,8 @@ beforeEach(async () => {
   stripeMock.subscriptions.update.mockReset();
   stripeMock.subscriptions.list.mockReset();
   stripeMock.subscriptions.list.mockResolvedValue({ data: [] });
+  stripeMock.invoices.list.mockReset();
+  stripeMock.invoices.list.mockResolvedValue({ data: [], has_more: false });
   stripeMock.subscriptionSchedules.create.mockReset();
   stripeMock.subscriptionSchedules.update.mockReset();
   stripeMock.subscriptionSchedules.release.mockReset();
@@ -267,6 +274,382 @@ describe('getBillingStatus', () => {
 
     expect(result).not.toBeNull();
     expect(result.trialEligible).toBe(false);
+  });
+});
+
+describe('subscription center procedures', () => {
+  async function createInstanceRow(params: {
+    userId: string;
+    organizationId?: string;
+    name?: string;
+    destroyedAt?: string;
+    sandboxId?: string;
+  }) {
+    const [instance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        user_id: params.userId,
+        organization_id: params.organizationId,
+        name: params.name,
+        destroyed_at: params.destroyedAt,
+        sandbox_id: params.sandboxId ?? `sandbox-${crypto.randomUUID()}`,
+      })
+      .returning();
+
+    if (!instance) {
+      throw new Error('Failed to insert KiloClaw instance');
+    }
+
+    return instance;
+  }
+
+  async function insertSubscriptionRow(params: {
+    userId: string;
+    instanceId: string;
+    stripeSubscriptionId?: string;
+    paymentSource?: 'credits';
+    plan: 'standard' | 'commit' | 'trial';
+    status: 'active' | 'past_due' | 'canceled' | 'unpaid' | 'trialing';
+    createdAt?: string;
+    currentPeriodStart?: string;
+    currentPeriodEnd?: string;
+    creditRenewalAt?: string;
+    cancelAtPeriodEnd?: boolean;
+  }) {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: params.userId,
+      instance_id: params.instanceId,
+      stripe_subscription_id: params.stripeSubscriptionId,
+      payment_source: params.paymentSource,
+      plan: params.plan,
+      status: params.status,
+      created_at: params.createdAt,
+      current_period_start: params.currentPeriodStart,
+      current_period_end: params.currentPeriodEnd,
+      credit_renewal_at: params.creditRenewalAt,
+      cancel_at_period_end: params.cancelAtPeriodEnd ?? false,
+    });
+  }
+
+  it('lists only personal subscriptions for the current user', async () => {
+    const organization = await createOrganization('Subscription Center Org', user.id);
+    const olderPersonalInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Older Personal',
+    });
+    const newerPersonalInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Newer Personal',
+    });
+    const orgInstance = await createInstanceRow({
+      userId: user.id,
+      organizationId: organization.id,
+      name: 'Org Instance',
+    });
+
+    await insertSubscriptionRow({
+      userId: user.id,
+      instanceId: olderPersonalInstance.id,
+      stripeSubscriptionId: 'sub_personal_old',
+      plan: 'standard',
+      status: 'active',
+      createdAt: '2026-04-01T00:00:00.000Z',
+    });
+    await insertSubscriptionRow({
+      userId: user.id,
+      instanceId: newerPersonalInstance.id,
+      paymentSource: 'credits',
+      plan: 'commit',
+      status: 'active',
+      createdAt: '2026-04-02T00:00:00.000Z',
+      creditRenewalAt: '2026-10-02T00:00:00.000Z',
+    });
+    await insertSubscriptionRow({
+      userId: user.id,
+      instanceId: orgInstance.id,
+      stripeSubscriptionId: 'sub_org_owned',
+      plan: 'standard',
+      status: 'active',
+      createdAt: '2026-04-03T00:00:00.000Z',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.listPersonalSubscriptions();
+
+    expect(result.subscriptions).toHaveLength(2);
+    expect(
+      result.subscriptions.map((subscription: { instanceId: string }) => subscription.instanceId)
+    ).toEqual([newerPersonalInstance.id, olderPersonalInstance.id]);
+    expect(result.subscriptions[0]).toMatchObject({
+      instanceId: newerPersonalInstance.id,
+      plan: 'commit',
+      paymentSource: 'credits',
+      hasStripeFunding: false,
+    });
+    expect(result.subscriptions[1]).toMatchObject({
+      instanceId: olderPersonalInstance.id,
+      plan: 'standard',
+      paymentSource: null,
+      hasStripeFunding: true,
+    });
+  });
+
+  it('returns detail for the requested personal subscription', async () => {
+    const instance = await createInstanceRow({
+      userId: user.id,
+      name: 'Target Personal Instance',
+    });
+
+    await insertSubscriptionRow({
+      userId: user.id,
+      instanceId: instance.id,
+      paymentSource: 'credits',
+      plan: 'standard',
+      status: 'active',
+      currentPeriodStart: '2026-04-01T00:00:00.000Z',
+      currentPeriodEnd: '2026-05-01T00:00:00.000Z',
+      creditRenewalAt: '2026-05-01T00:00:00.000Z',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.getSubscriptionDetail({ instanceId: instance.id });
+
+    expect(result).toMatchObject({
+      instanceId: instance.id,
+      instanceName: 'Target Personal Instance',
+      plan: 'standard',
+      status: 'active',
+      paymentSource: 'credits',
+      hasStripeFunding: false,
+      creditRenewalAt: '2026-05-01T00:00:00.000Z',
+    });
+  });
+
+  it('rejects detail requests for org-owned instances', async () => {
+    const organization = await createOrganization('Org Owned Detail', user.id);
+    const instance = await createInstanceRow({
+      userId: user.id,
+      organizationId: organization.id,
+      name: 'Org Detail Instance',
+    });
+
+    await insertSubscriptionRow({
+      userId: user.id,
+      instanceId: instance.id,
+      stripeSubscriptionId: 'sub_org_detail',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.kiloclaw.getSubscriptionDetail({ instanceId: instance.id })
+    ).rejects.toThrow('Subscription not found.');
+  });
+
+  it('lists Stripe billing history for the requested Stripe-funded instance', async () => {
+    stripeMock.invoices.list.mockResolvedValue({
+      data: [
+        {
+          id: 'inv_kiloclaw_1',
+          created: 1_711_965_600,
+          amount_due: 900,
+          currency: 'usd',
+          status: 'paid',
+          hosted_invoice_url: 'https://stripe.example.test/inv_kiloclaw_1',
+          invoice_pdf: 'https://stripe.example.test/inv_kiloclaw_1.pdf',
+          lines: { data: [{ description: 'KiloClaw standard plan' }] },
+        },
+      ],
+      has_more: false,
+    });
+
+    const instance = await createInstanceRow({ userId: user.id, name: 'Stripe Instance' });
+    await insertSubscriptionRow({
+      userId: user.id,
+      instanceId: instance.id,
+      stripeSubscriptionId: 'sub_kiloclaw_stripe',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.getBillingHistory({ instanceId: instance.id });
+
+    expect(stripeMock.invoices.list).toHaveBeenCalledWith({
+      subscription: 'sub_kiloclaw_stripe',
+      limit: 25,
+    });
+    expect(result).toEqual({
+      entries: [
+        {
+          kind: 'stripe',
+          id: 'inv_kiloclaw_1',
+          date: new Date(1_711_965_600 * 1000).toISOString(),
+          amountCents: 900,
+          currency: 'usd',
+          status: 'paid',
+          invoiceUrl: 'https://stripe.example.test/inv_kiloclaw_1',
+          invoicePdfUrl: 'https://stripe.example.test/inv_kiloclaw_1.pdf',
+          description: 'KiloClaw standard plan',
+        },
+      ],
+      hasMore: false,
+      cursor: null,
+    });
+  });
+
+  it('lists credit-funded billing history for the requested instance', async () => {
+    const sandboxId = `sandbox-${crypto.randomUUID()}`;
+    const oldInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Old Credits Instance',
+      sandboxId,
+      destroyedAt: '2026-04-15T00:00:00.000Z',
+    });
+    const instance = await createInstanceRow({
+      userId: user.id,
+      name: 'Credits Instance',
+      sandboxId,
+    });
+    const otherInstance = await createInstanceRow({ userId: user.id, name: 'Other Instance' });
+
+    await insertSubscriptionRow({
+      userId: user.id,
+      instanceId: instance.id,
+      paymentSource: 'credits',
+      plan: 'standard',
+      status: 'active',
+      creditRenewalAt: '2026-06-01T00:00:00.000Z',
+    });
+
+    await db.insert(credit_transactions).values([
+      {
+        id: crypto.randomUUID(),
+        kilo_user_id: user.id,
+        amount_microdollars: -9_000_000,
+        is_free: false,
+        description: 'Standard renewal',
+        credit_category: `kiloclaw-subscription:${instance.id}`,
+        created_at: '2026-04-01T12:00:00.000Z',
+      },
+      {
+        id: crypto.randomUUID(),
+        kilo_user_id: user.id,
+        amount_microdollars: -48_000_000,
+        is_free: false,
+        description: 'Commit renewal',
+        credit_category: `kiloclaw-subscription-commit:${oldInstance.id}`,
+        created_at: '2026-05-01T12:00:00.000Z',
+      },
+      {
+        id: crypto.randomUUID(),
+        kilo_user_id: user.id,
+        amount_microdollars: -9_000_000,
+        is_free: false,
+        description: 'Other instance renewal',
+        credit_category: `kiloclaw-subscription:${otherInstance.id}`,
+        created_at: '2026-06-01T12:00:00.000Z',
+      },
+    ]);
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.getBillingHistory({ instanceId: instance.id });
+
+    expect(result).toEqual({
+      entries: [
+        {
+          kind: 'credits',
+          id: expect.any(String),
+          date: '2026-05-01T12:00:00.000Z',
+          amountMicrodollars: 48_000_000,
+          description: 'Commit renewal',
+        },
+        {
+          kind: 'credits',
+          id: expect.any(String),
+          date: '2026-04-01T12:00:00.000Z',
+          amountMicrodollars: 9_000_000,
+          description: 'Standard renewal',
+        },
+      ],
+      hasMore: false,
+      cursor: null,
+    });
+  });
+
+  it('creates a customer portal session for the requested Stripe-funded instance', async () => {
+    stripeMock.billingPortal.sessions.create.mockResolvedValue({
+      url: 'https://stripe.example.test/kiloclaw-portal',
+    });
+
+    const instance = await createInstanceRow({ userId: user.id, name: 'Portal Instance' });
+    await insertSubscriptionRow({
+      userId: user.id,
+      instanceId: instance.id,
+      stripeSubscriptionId: 'sub_kiloclaw_portal',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.getCustomerPortalUrl({
+      instanceId: instance.id,
+      returnUrl: 'https://example.test/subscriptions/kiloclaw',
+    });
+
+    expect(result).toEqual({ url: 'https://stripe.example.test/kiloclaw-portal' });
+    expect(stripeMock.billingPortal.sessions.create).toHaveBeenCalledWith({
+      customer: user.stripe_customer_id,
+      return_url: 'https://example.test/subscriptions/kiloclaw',
+    });
+  });
+
+  it('cancels only the targeted instance subscription', async () => {
+    stripeMock.subscriptions.retrieve.mockResolvedValue({ schedule: null });
+    stripeMock.subscriptions.update.mockResolvedValue({});
+
+    const targetInstance = await createInstanceRow({ userId: user.id, name: 'Target Instance' });
+    const otherInstance = await createInstanceRow({ userId: user.id, name: 'Other Instance' });
+
+    await insertSubscriptionRow({
+      userId: user.id,
+      instanceId: targetInstance.id,
+      stripeSubscriptionId: 'sub_target_instance',
+      plan: 'standard',
+      status: 'active',
+    });
+    await insertSubscriptionRow({
+      userId: user.id,
+      instanceId: otherInstance.id,
+      stripeSubscriptionId: 'sub_other_instance',
+      plan: 'commit',
+      status: 'active',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.cancelSubscriptionAtInstance({
+      instanceId: targetInstance.id,
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptions.update).toHaveBeenCalledWith('sub_target_instance', {
+      cancel_at_period_end: true,
+    });
+
+    const [targetRow] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.instance_id, targetInstance.id))
+      .limit(1);
+    const [otherRow] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.instance_id, otherInstance.id))
+      .limit(1);
+
+    expect(targetRow.cancel_at_period_end).toBe(true);
+    expect(otherRow.cancel_at_period_end).toBe(false);
   });
 });
 

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -33,7 +33,7 @@ import {
   kiloclaw_email_log,
   kiloclaw_cli_runs,
 } from '@kilocode/db/schema';
-import { and, eq, ne, desc, isNotNull, isNull, inArray, sql } from 'drizzle-orm';
+import { and, eq, ne, desc, isNotNull, isNull, inArray, like, or, sql } from 'drizzle-orm';
 import { sentryLogger } from '@/lib/utils.server';
 import type { KiloClawDashboardStatus, KiloCodeConfigResponse } from '@/lib/kiloclaw/types';
 import {
@@ -2637,9 +2637,9 @@ export const kiloclawRouter = createTRPCRouter({
           )
         );
       const relatedInstanceIds = relatedInstances.map(instance => instance.id);
-      const deductionCategories = [
-        ...relatedInstanceIds.map(instanceId => `kiloclaw-subscription:${instanceId}`),
-        ...relatedInstanceIds.map(instanceId => `kiloclaw-subscription-commit:${instanceId}`),
+      const deductionCategoryPrefixes = [
+        ...relatedInstanceIds.map(instanceId => `kiloclaw-subscription:${instanceId}:%`),
+        ...relatedInstanceIds.map(instanceId => `kiloclaw-subscription-commit:${instanceId}:%`),
       ];
 
       const transactions = await db
@@ -2654,7 +2654,11 @@ export const kiloclawRouter = createTRPCRouter({
           and(
             eq(credit_transactions.kilo_user_id, ctx.user.id),
             isNull(credit_transactions.organization_id),
-            inArray(credit_transactions.credit_category, deductionCategories)
+            or(
+              ...deductionCategoryPrefixes.map(prefix =>
+                like(credit_transactions.credit_category, prefix)
+              )
+            )
           )
         )
         .orderBy(desc(credit_transactions.created_at), desc(credit_transactions.id))

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -24,6 +24,7 @@ import {
 } from '@/lib/config.server';
 import { db } from '@/lib/drizzle';
 import {
+  credit_transactions,
   kiloclaw_version_pins,
   kiloclaw_image_catalog,
   kiloclaw_earlybird_purchases,
@@ -56,6 +57,7 @@ import {
 } from '@/lib/kiloclaw/stripe-price-ids.server';
 import { getStripePriceIdForKiloPass } from '@/lib/kilo-pass/stripe-price-ids.server';
 import { KiloPassTier, KiloPassCadence } from '@/lib/kilo-pass/enums';
+import { dayjs } from '@/lib/kilo-pass/dayjs';
 import { isStripeSubscriptionEnded } from '@/lib/kilo-pass/stripe-subscription-status';
 import { getKiloPassStateForUser } from '@/lib/kilo-pass/state';
 import { ensureAutoIntroSchedule, resolvePhasePrice } from '@/lib/kiloclaw/stripe-handlers';
@@ -72,6 +74,10 @@ import {
 import type { ClawBillingStatus } from '@/app/(app)/claw/components/billing/billing-types';
 import PostHogClient from '@/lib/posthog';
 import { CHANGELOG_ENTRIES } from '@/app/(app)/claw/components/changelog-data';
+import {
+  billingHistoryResponseSchema,
+  mapStripeInvoiceToBillingHistoryEntry,
+} from '@/lib/subscriptions/subscription-center';
 
 /**
  * Error codes whose messages may contain raw internal details (e.g. filesystem
@@ -429,6 +435,648 @@ function resolveScheduleId(schedule: string | { id: string } | null | undefined)
   return typeof schedule === 'string' ? schedule : schedule.id;
 }
 
+const KiloclawInstanceInputSchema = z.object({
+  instanceId: z.uuid(),
+});
+
+const KiloclawInstanceSwitchPlanInputSchema = KiloclawInstanceInputSchema.extend({
+  toPlan: z.enum(['commit', 'standard']),
+});
+
+const KiloclawPersonalSubscriptionSchema = z.object({
+  instanceId: z.string().uuid(),
+  sandboxId: z.string(),
+  instanceName: z.string().nullable(),
+  destroyedAt: z.string().nullable(),
+  plan: z.string(),
+  status: z.string(),
+  cancelAtPeriodEnd: z.boolean(),
+  pendingConversion: z.boolean(),
+  scheduledPlan: z.string().nullable(),
+  scheduledBy: z.string().nullable(),
+  trialStartedAt: z.string().nullable(),
+  trialEndsAt: z.string().nullable(),
+  currentPeriodStart: z.string().nullable(),
+  currentPeriodEnd: z.string().nullable(),
+  creditRenewalAt: z.string().nullable(),
+  commitEndsAt: z.string().nullable(),
+  suspendedAt: z.string().nullable(),
+  destructionDeadline: z.string().nullable(),
+  paymentSource: z.string().nullable(),
+  hasStripeFunding: z.boolean(),
+  renewalCostMicrodollars: z.number().nullable(),
+  showConversionPrompt: z.boolean(),
+});
+
+const KiloclawPersonalSubscriptionsOutputSchema = z.object({
+  subscriptions: z.array(KiloclawPersonalSubscriptionSchema),
+});
+
+const KiloclawBillingHistoryInputSchema = KiloclawInstanceInputSchema.extend({
+  cursor: z.string().optional(),
+});
+
+const KiloclawCustomerPortalInputSchema = KiloclawInstanceInputSchema.extend({
+  returnUrl: z.url().optional(),
+});
+
+const KiloclawMutationResultSchema = z.object({
+  success: z.boolean(),
+});
+
+type KiloclawPersonalSubscriptionRow = {
+  subscription: typeof kiloclaw_subscriptions.$inferSelect;
+  instance: {
+    id: string;
+    sandboxId: string;
+    name: string | null;
+    destroyedAt: string | null;
+  };
+};
+
+async function getHasActiveKiloPassForUser(userId: string): Promise<boolean> {
+  const kiloPassState = await getKiloPassStateForUser(db, userId);
+  return Boolean(kiloPassState && !isStripeSubscriptionEnded(kiloPassState.status));
+}
+
+function getKiloclawRenewalCostMicrodollars(plan: string): number | null {
+  if (plan !== 'commit' && plan !== 'standard') {
+    return null;
+  }
+
+  return KILOCLAW_PLAN_COST_MICRODOLLARS[plan];
+}
+
+function normalizeTimestamp(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = dayjs(value).utc();
+  return parsed.isValid() ? parsed.toISOString() : value;
+}
+
+function serializeKiloclawPersonalSubscription(
+  row: KiloclawPersonalSubscriptionRow,
+  hasActiveKiloPass: boolean
+) {
+  const hasStripeFunding = Boolean(row.subscription.stripe_subscription_id);
+
+  return {
+    instanceId: row.instance.id,
+    sandboxId: row.instance.sandboxId,
+    instanceName: row.instance.name,
+    destroyedAt: normalizeTimestamp(row.instance.destroyedAt),
+    plan: row.subscription.plan,
+    status: row.subscription.status,
+    cancelAtPeriodEnd: row.subscription.cancel_at_period_end,
+    pendingConversion: row.subscription.pending_conversion,
+    scheduledPlan: row.subscription.scheduled_plan ?? null,
+    scheduledBy: row.subscription.scheduled_by ?? null,
+    trialStartedAt: normalizeTimestamp(row.subscription.trial_started_at),
+    trialEndsAt: normalizeTimestamp(row.subscription.trial_ends_at),
+    currentPeriodStart: normalizeTimestamp(row.subscription.current_period_start),
+    currentPeriodEnd: normalizeTimestamp(row.subscription.current_period_end),
+    creditRenewalAt: normalizeTimestamp(row.subscription.credit_renewal_at),
+    commitEndsAt: normalizeTimestamp(row.subscription.commit_ends_at),
+    suspendedAt: normalizeTimestamp(row.subscription.suspended_at),
+    destructionDeadline: normalizeTimestamp(row.subscription.destruction_deadline),
+    paymentSource: row.subscription.payment_source ?? null,
+    hasStripeFunding,
+    renewalCostMicrodollars: getKiloclawRenewalCostMicrodollars(row.subscription.plan),
+    showConversionPrompt: hasStripeFunding && hasActiveKiloPass,
+  };
+}
+
+async function listKiloclawPersonalSubscriptionRows(
+  userId: string
+): Promise<KiloclawPersonalSubscriptionRow[]> {
+  const rows = await db
+    .select({
+      subscription: kiloclaw_subscriptions,
+      instance: {
+        id: kiloclaw_instances.id,
+        sandboxId: kiloclaw_instances.sandbox_id,
+        name: kiloclaw_instances.name,
+        destroyedAt: kiloclaw_instances.destroyed_at,
+      },
+    })
+    .from(kiloclaw_subscriptions)
+    .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, userId),
+        eq(kiloclaw_instances.user_id, userId),
+        isNull(kiloclaw_instances.organization_id)
+      )
+    )
+    .orderBy(desc(kiloclaw_subscriptions.created_at));
+
+  return rows;
+}
+
+async function getKiloclawPersonalSubscriptionRow(params: {
+  userId: string;
+  instanceId: string;
+}): Promise<KiloclawPersonalSubscriptionRow> {
+  const [row] = await db
+    .select({
+      subscription: kiloclaw_subscriptions,
+      instance: {
+        id: kiloclaw_instances.id,
+        sandboxId: kiloclaw_instances.sandbox_id,
+        name: kiloclaw_instances.name,
+        destroyedAt: kiloclaw_instances.destroyed_at,
+      },
+    })
+    .from(kiloclaw_subscriptions)
+    .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, params.userId),
+        eq(kiloclaw_instances.user_id, params.userId),
+        eq(kiloclaw_instances.id, params.instanceId),
+        isNull(kiloclaw_instances.organization_id)
+      )
+    )
+    .limit(1);
+
+  if (!row) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Subscription not found.' });
+  }
+
+  return row;
+}
+
+async function cancelKiloclawSubscriptionForRow(params: {
+  subscription: typeof kiloclaw_subscriptions.$inferSelect;
+  userId: string;
+}) {
+  const { subscription, userId } = params;
+
+  if (subscription.status !== 'active') {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active subscription to cancel.' });
+  }
+
+  if (subscription.cancel_at_period_end) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Subscription is already set to cancel.',
+    });
+  }
+
+  if (subscription.stripe_subscription_id) {
+    const liveSub = await stripe.subscriptions.retrieve(subscription.stripe_subscription_id);
+    const scheduleIdToRelease =
+      subscription.stripe_schedule_id ?? resolveScheduleId(liveSub.schedule);
+
+    if (scheduleIdToRelease) {
+      const released = await releaseScheduleIfActive(scheduleIdToRelease);
+      if (!released) {
+        logBillingError('Failed to release subscription schedule — aborting cancellation', {
+          user_id: userId,
+          schedule_id: scheduleIdToRelease,
+        });
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Unable to cancel: failed to release pending plan schedule. Please try again.',
+        });
+      }
+    }
+
+    await stripe.subscriptions.update(subscription.stripe_subscription_id, {
+      cancel_at_period_end: true,
+    });
+
+    await db
+      .update(kiloclaw_subscriptions)
+      .set({
+        cancel_at_period_end: true,
+        ...(scheduleIdToRelease
+          ? { stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null }
+          : {}),
+      })
+      .where(eq(kiloclaw_subscriptions.id, subscription.id));
+    return;
+  }
+
+  if (subscription.payment_source === 'credits') {
+    await db
+      .update(kiloclaw_subscriptions)
+      .set({
+        cancel_at_period_end: true,
+        stripe_schedule_id: null,
+        scheduled_plan: null,
+        scheduled_by: null,
+      })
+      .where(eq(kiloclaw_subscriptions.id, subscription.id));
+    return;
+  }
+
+  throw new TRPCError({
+    code: 'INTERNAL_SERVER_ERROR',
+    message: 'Subscription is in an invalid state: no Stripe subscription and not credit-funded.',
+  });
+}
+
+async function acceptKiloclawConversionForRow(params: {
+  subscription: typeof kiloclaw_subscriptions.$inferSelect;
+  userId: string;
+}) {
+  const { subscription, userId } = params;
+
+  if (subscription.status !== 'active') {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active subscription to convert.' });
+  }
+
+  if (!subscription.stripe_subscription_id) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Subscription is not Stripe-funded — nothing to convert.',
+    });
+  }
+
+  if (subscription.cancel_at_period_end) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Subscription is already set to cancel.',
+    });
+  }
+
+  const kiloPassState = await getKiloPassStateForUser(db, userId);
+  if (!kiloPassState || isStripeSubscriptionEnded(kiloPassState.status)) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Active Kilo Pass required to convert to credit-funded billing.',
+    });
+  }
+
+  const liveSub = await stripe.subscriptions.retrieve(subscription.stripe_subscription_id);
+  const scheduleIdToRelease =
+    subscription.stripe_schedule_id ?? resolveScheduleId(liveSub.schedule);
+
+  if (scheduleIdToRelease) {
+    const released = await releaseScheduleIfActive(scheduleIdToRelease);
+    if (!released) {
+      logBillingError('Failed to release subscription schedule — aborting conversion', {
+        user_id: userId,
+        schedule_id: scheduleIdToRelease,
+      });
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Unable to convert: failed to release pending plan schedule. Please try again.',
+      });
+    }
+  }
+
+  await db
+    .update(kiloclaw_subscriptions)
+    .set({
+      pending_conversion: true,
+      ...(scheduleIdToRelease
+        ? { stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null }
+        : {}),
+    })
+    .where(eq(kiloclaw_subscriptions.id, subscription.id));
+
+  try {
+    await stripe.subscriptions.update(subscription.stripe_subscription_id, {
+      cancel_at_period_end: true,
+    });
+  } catch (stripeError) {
+    let stripeApplied: boolean | undefined;
+    try {
+      const refreshed = await stripe.subscriptions.retrieve(subscription.stripe_subscription_id);
+      stripeApplied = refreshed.cancel_at_period_end === true;
+    } catch {
+      stripeApplied = undefined;
+    }
+
+    if (stripeApplied === false) {
+      await db
+        .update(kiloclaw_subscriptions)
+        .set({ pending_conversion: false })
+        .where(eq(kiloclaw_subscriptions.id, subscription.id));
+
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to schedule Stripe cancellation. Please try again.',
+        cause: stripeError,
+      });
+    }
+
+    if (stripeApplied === undefined) {
+      logBillingError(
+        'acceptConversion: Stripe update threw and re-fetch also failed — state ambiguous, will retry',
+        {
+          user_id: userId,
+          stripe_subscription_id: subscription.stripe_subscription_id,
+          error: stripeError instanceof Error ? stripeError.message : String(stripeError),
+        }
+      );
+
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Unable to confirm Stripe cancellation. Please try again.',
+        cause: stripeError,
+      });
+    }
+  }
+
+  await db
+    .update(kiloclaw_subscriptions)
+    .set({ cancel_at_period_end: true })
+    .where(eq(kiloclaw_subscriptions.id, subscription.id));
+}
+
+async function reactivateKiloclawSubscriptionForRow(params: {
+  subscription: typeof kiloclaw_subscriptions.$inferSelect;
+  userId: string;
+}) {
+  const { subscription, userId } = params;
+
+  if (subscription.status !== 'active' || !subscription.cancel_at_period_end) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'No pending cancellation to reactivate.',
+    });
+  }
+
+  if (subscription.stripe_subscription_id) {
+    await stripe.subscriptions.update(subscription.stripe_subscription_id, {
+      cancel_at_period_end: false,
+    });
+    await db
+      .update(kiloclaw_subscriptions)
+      .set({ cancel_at_period_end: false, pending_conversion: false })
+      .where(eq(kiloclaw_subscriptions.id, subscription.id));
+
+    try {
+      await ensureAutoIntroSchedule(subscription.stripe_subscription_id, userId);
+    } catch (error) {
+      logBillingError('Failed to restore auto intro schedule after reactivation', {
+        user_id: userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return;
+  }
+
+  if (subscription.payment_source === 'credits') {
+    await db
+      .update(kiloclaw_subscriptions)
+      .set({ cancel_at_period_end: false, pending_conversion: false })
+      .where(eq(kiloclaw_subscriptions.id, subscription.id));
+    return;
+  }
+
+  throw new TRPCError({
+    code: 'INTERNAL_SERVER_ERROR',
+    message: 'Subscription is in an invalid state: no Stripe subscription and not credit-funded.',
+  });
+}
+
+async function switchKiloclawPlanForRow(params: {
+  subscription: typeof kiloclaw_subscriptions.$inferSelect;
+  toPlan: 'commit' | 'standard';
+}) {
+  const { subscription, toPlan } = params;
+
+  if (subscription.status !== 'active') {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active subscription to switch.' });
+  }
+
+  if (subscription.plan === toPlan) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Already on this plan.' });
+  }
+
+  if (subscription.plan !== 'commit' && subscription.plan !== 'standard') {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot switch from a trial plan.' });
+  }
+
+  if (subscription.stripe_subscription_id) {
+    const liveSub = await stripe.subscriptions.retrieve(subscription.stripe_subscription_id);
+    const effectiveScheduleId =
+      subscription.stripe_schedule_id ?? resolveScheduleId(liveSub.schedule);
+
+    let effectiveScheduledBy = subscription.scheduled_by;
+    if (!subscription.stripe_schedule_id && effectiveScheduleId) {
+      const hiddenSchedule = await stripe.subscriptionSchedules.retrieve(effectiveScheduleId);
+      if (hiddenSchedule.metadata?.origin === 'auto-intro') {
+        effectiveScheduledBy = 'auto';
+      } else {
+        const released = await releaseScheduleIfActive(effectiveScheduleId);
+        if (!released) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message:
+              'Unable to switch plan: failed to release existing schedule. Please try again.',
+          });
+        }
+        effectiveScheduledBy = null;
+      }
+    }
+
+    if (effectiveScheduledBy === 'user') {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'A plan switch is already pending. Cancel it before requesting a new one.',
+      });
+    }
+
+    const targetPriceId = getStripePriceIdForClawPlan(toPlan);
+
+    if (effectiveScheduledBy === 'auto' && effectiveScheduleId) {
+      try {
+        const existingSchedule = await stripe.subscriptionSchedules.retrieve(effectiveScheduleId);
+        const autoCurrentPhase = existingSchedule.phases[0];
+        const phase1Price = autoCurrentPhase ? resolvePhasePrice(autoCurrentPhase) : null;
+
+        if (!autoCurrentPhase || !phase1Price) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'Cannot determine current phase price from schedule.',
+          });
+        }
+
+        await stripe.subscriptionSchedules.update(effectiveScheduleId, {
+          end_behavior: 'release',
+          phases: [
+            {
+              items: [{ price: phase1Price }],
+              start_date: autoCurrentPhase.start_date,
+              end_date: autoCurrentPhase.end_date,
+            },
+            { items: [{ price: targetPriceId }] },
+          ],
+        });
+
+        await db
+          .update(kiloclaw_subscriptions)
+          .set({
+            stripe_schedule_id: effectiveScheduleId,
+            scheduled_plan: toPlan,
+            scheduled_by: 'user',
+          })
+          .where(eq(kiloclaw_subscriptions.id, subscription.id));
+
+        return;
+      } catch (error) {
+        if (!isScheduleAlreadyInactive(error)) {
+          throw error;
+        }
+
+        await db
+          .update(kiloclaw_subscriptions)
+          .set({ stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null })
+          .where(eq(kiloclaw_subscriptions.id, subscription.id));
+      }
+    }
+
+    let stripeScheduleId: string | null = null;
+    try {
+      const schedule = await stripe.subscriptionSchedules.create({
+        from_subscription: subscription.stripe_subscription_id,
+      });
+      stripeScheduleId = schedule.id;
+
+      const currentPhase = schedule.phases[0];
+      if (!currentPhase) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Stripe schedule has no current phase.',
+        });
+      }
+
+      const freshPhase1Price = resolvePhasePrice(currentPhase);
+      if (!freshPhase1Price) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Cannot determine current subscription price from schedule.',
+        });
+      }
+
+      await stripe.subscriptionSchedules.update(schedule.id, {
+        metadata: { origin: 'user-switch' },
+        end_behavior: 'release',
+        phases: [
+          {
+            items: [{ price: freshPhase1Price }],
+            start_date: currentPhase.start_date,
+            end_date: currentPhase.end_date,
+          },
+          { items: [{ price: targetPriceId }] },
+        ],
+      });
+
+      const updated = await db
+        .update(kiloclaw_subscriptions)
+        .set({
+          stripe_schedule_id: schedule.id,
+          scheduled_plan: toPlan,
+          scheduled_by: 'user',
+        })
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.id, subscription.id),
+            isNull(kiloclaw_subscriptions.stripe_schedule_id)
+          )
+        )
+        .returning({ id: kiloclaw_subscriptions.id });
+
+      if (updated.length === 0) {
+        await stripe.subscriptionSchedules.release(schedule.id);
+        stripeScheduleId = null;
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'A plan switch is already pending. Cancel it before requesting a new one.',
+        });
+      }
+
+      return;
+    } catch (error) {
+      if (stripeScheduleId) {
+        try {
+          await stripe.subscriptionSchedules.release(stripeScheduleId);
+        } catch {
+          // Ignore best-effort cleanup errors.
+        }
+      }
+      throw error;
+    }
+  }
+
+  if (subscription.payment_source === 'credits') {
+    if (subscription.scheduled_plan && subscription.scheduled_by === 'user') {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'A plan switch is already pending. Cancel it before requesting a new one.',
+      });
+    }
+
+    await db
+      .update(kiloclaw_subscriptions)
+      .set({ scheduled_plan: toPlan, scheduled_by: 'user' })
+      .where(eq(kiloclaw_subscriptions.id, subscription.id));
+    return;
+  }
+
+  throw new TRPCError({
+    code: 'INTERNAL_SERVER_ERROR',
+    message: 'Subscription is in an invalid state: no Stripe subscription and not credit-funded.',
+  });
+}
+
+async function cancelKiloclawPlanSwitchForRow(params: {
+  subscription: typeof kiloclaw_subscriptions.$inferSelect;
+  userId: string;
+}) {
+  const { subscription, userId } = params;
+
+  if (!subscription.scheduled_plan) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'No pending plan switch to cancel.' });
+  }
+
+  if (subscription.scheduled_by !== 'user') {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'No user-initiated plan switch to cancel.',
+    });
+  }
+
+  if (subscription.stripe_schedule_id) {
+    const released = await releaseScheduleIfActive(subscription.stripe_schedule_id);
+    if (!released) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to release pending plan schedule. Please try again.',
+      });
+    }
+
+    await db
+      .update(kiloclaw_subscriptions)
+      .set({ stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null })
+      .where(eq(kiloclaw_subscriptions.id, subscription.id));
+
+    try {
+      if (subscription.stripe_subscription_id) {
+        await ensureAutoIntroSchedule(subscription.stripe_subscription_id, userId);
+      }
+    } catch (error) {
+      logBillingError('Failed to restore auto intro schedule after cancel plan switch', {
+        user_id: userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return;
+  }
+
+  await db
+    .update(kiloclaw_subscriptions)
+    .set({ scheduled_plan: null, scheduled_by: null })
+    .where(eq(kiloclaw_subscriptions.id, subscription.id));
+}
+
 async function fetchKiloClawServiceDegraded(): Promise<boolean> {
   try {
     const response = await fetch('https://status.kilo.ai/index.json', {
@@ -723,7 +1371,7 @@ export const kiloclawRouter = createTRPCRouter({
   destroy: baseProcedure.mutation(async ({ ctx }) => {
     const destroyedRow = await markActiveInstanceDestroyed(ctx.user.id);
     const client = new KiloClawInternalClient();
-    let result;
+    let result: Awaited<ReturnType<KiloClawInternalClient['destroy']>>;
     try {
       result = await client.destroy(ctx.user.id, workerInstanceId(destroyedRow));
     } catch (error) {
@@ -1150,7 +1798,7 @@ export const kiloclawRouter = createTRPCRouter({
       const instance = await getActiveInstance(ctx.user.id);
       const client = new KiloClawInternalClient();
 
-      let result;
+      let result: Awaited<ReturnType<KiloClawInternalClient['startKiloCliRun']>>;
       try {
         result = await client.startKiloCliRun(
           ctx.user.id,
@@ -1926,6 +2574,209 @@ export const kiloclawRouter = createTRPCRouter({
       instance: instanceData,
     } satisfies ClawBillingStatus;
   }),
+
+  listPersonalSubscriptions: baseProcedure
+    .output(KiloclawPersonalSubscriptionsOutputSchema)
+    .query(async ({ ctx }) => {
+      const [rows, hasActiveKiloPass] = await Promise.all([
+        listKiloclawPersonalSubscriptionRows(ctx.user.id),
+        getHasActiveKiloPassForUser(ctx.user.id),
+      ]);
+
+      return {
+        subscriptions: rows.map(row =>
+          serializeKiloclawPersonalSubscription(row, hasActiveKiloPass)
+        ),
+      };
+    }),
+
+  getSubscriptionDetail: baseProcedure
+    .input(KiloclawInstanceInputSchema)
+    .output(KiloclawPersonalSubscriptionSchema)
+    .query(async ({ ctx, input }) => {
+      const [row, hasActiveKiloPass] = await Promise.all([
+        getKiloclawPersonalSubscriptionRow({ userId: ctx.user.id, instanceId: input.instanceId }),
+        getHasActiveKiloPassForUser(ctx.user.id),
+      ]);
+
+      return serializeKiloclawPersonalSubscription(row, hasActiveKiloPass);
+    }),
+
+  getBillingHistory: baseProcedure
+    .input(KiloclawBillingHistoryInputSchema)
+    .output(billingHistoryResponseSchema)
+    .query(async ({ ctx, input }) => {
+      const row = await getKiloclawPersonalSubscriptionRow({
+        userId: ctx.user.id,
+        instanceId: input.instanceId,
+      });
+
+      if (row.subscription.stripe_subscription_id) {
+        const invoices = await stripe.invoices.list({
+          subscription: row.subscription.stripe_subscription_id,
+          limit: 25,
+          ...(input.cursor ? { starting_after: input.cursor } : {}),
+        });
+
+        return {
+          entries: invoices.data.map(mapStripeInvoiceToBillingHistoryEntry),
+          hasMore: invoices.has_more,
+          cursor: invoices.has_more ? (invoices.data.at(-1)?.id ?? null) : null,
+        };
+      }
+
+      const offset = input.cursor ? Number.parseInt(input.cursor, 10) || 0 : 0;
+      const relatedInstances = await db
+        .select({ id: kiloclaw_instances.id })
+        .from(kiloclaw_instances)
+        .where(
+          and(
+            eq(kiloclaw_instances.user_id, ctx.user.id),
+            isNull(kiloclaw_instances.organization_id),
+            eq(kiloclaw_instances.sandbox_id, row.instance.sandboxId)
+          )
+        );
+      const relatedInstanceIds = relatedInstances.map(instance => instance.id);
+      const deductionCategories = [
+        ...relatedInstanceIds.map(instanceId => `kiloclaw-subscription:${instanceId}`),
+        ...relatedInstanceIds.map(instanceId => `kiloclaw-subscription-commit:${instanceId}`),
+      ];
+
+      const transactions = await db
+        .select({
+          id: credit_transactions.id,
+          date: credit_transactions.created_at,
+          description: credit_transactions.description,
+          amountMicrodollars: credit_transactions.amount_microdollars,
+        })
+        .from(credit_transactions)
+        .where(
+          and(
+            eq(credit_transactions.kilo_user_id, ctx.user.id),
+            isNull(credit_transactions.organization_id),
+            inArray(credit_transactions.credit_category, deductionCategories)
+          )
+        )
+        .orderBy(desc(credit_transactions.created_at), desc(credit_transactions.id))
+        .limit(26)
+        .offset(offset);
+
+      return {
+        entries: transactions.slice(0, 25).map(transaction => ({
+          kind: 'credits' as const,
+          id: transaction.id,
+          date: normalizeTimestamp(transaction.date) ?? transaction.date,
+          amountMicrodollars: Math.abs(transaction.amountMicrodollars),
+          description: transaction.description ?? 'Hosting renewal',
+        })),
+        hasMore: transactions.length > 25,
+        cursor: transactions.length > 25 ? String(offset + 25) : null,
+      };
+    }),
+
+  getCustomerPortalUrl: baseProcedure
+    .input(KiloclawCustomerPortalInputSchema)
+    .output(z.object({ url: z.url() }))
+    .mutation(async ({ ctx, input }) => {
+      const row = await getKiloclawPersonalSubscriptionRow({
+        userId: ctx.user.id,
+        instanceId: input.instanceId,
+      });
+
+      if (!row.subscription.stripe_subscription_id) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'This subscription is not Stripe-funded.',
+        });
+      }
+
+      const stripeCustomerId = ctx.user.stripe_customer_id;
+      if (!stripeCustomerId) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Stripe customer.' });
+      }
+
+      const session = await stripe.billingPortal.sessions.create({
+        customer: stripeCustomerId,
+        return_url: input.returnUrl ?? `${APP_URL}/subscriptions/kiloclaw/${input.instanceId}`,
+      });
+
+      return { url: session.url };
+    }),
+
+  cancelSubscriptionAtInstance: baseProcedure
+    .input(KiloclawInstanceInputSchema)
+    .output(KiloclawMutationResultSchema)
+    .mutation(async ({ ctx, input }) => {
+      const row = await getKiloclawPersonalSubscriptionRow({
+        userId: ctx.user.id,
+        instanceId: input.instanceId,
+      });
+      await cancelKiloclawSubscriptionForRow({
+        subscription: row.subscription,
+        userId: ctx.user.id,
+      });
+      return { success: true };
+    }),
+
+  acceptConversionAtInstance: baseProcedure
+    .input(KiloclawInstanceInputSchema)
+    .output(KiloclawMutationResultSchema)
+    .mutation(async ({ ctx, input }) => {
+      const row = await getKiloclawPersonalSubscriptionRow({
+        userId: ctx.user.id,
+        instanceId: input.instanceId,
+      });
+      await acceptKiloclawConversionForRow({
+        subscription: row.subscription,
+        userId: ctx.user.id,
+      });
+      return { success: true };
+    }),
+
+  reactivateSubscriptionAtInstance: baseProcedure
+    .input(KiloclawInstanceInputSchema)
+    .output(KiloclawMutationResultSchema)
+    .mutation(async ({ ctx, input }) => {
+      const row = await getKiloclawPersonalSubscriptionRow({
+        userId: ctx.user.id,
+        instanceId: input.instanceId,
+      });
+      await reactivateKiloclawSubscriptionForRow({
+        subscription: row.subscription,
+        userId: ctx.user.id,
+      });
+      return { success: true };
+    }),
+
+  switchPlanAtInstance: baseProcedure
+    .input(KiloclawInstanceSwitchPlanInputSchema)
+    .output(KiloclawMutationResultSchema)
+    .mutation(async ({ ctx, input }) => {
+      const row = await getKiloclawPersonalSubscriptionRow({
+        userId: ctx.user.id,
+        instanceId: input.instanceId,
+      });
+      await switchKiloclawPlanForRow({
+        subscription: row.subscription,
+        toPlan: input.toPlan,
+      });
+      return { success: true };
+    }),
+
+  cancelPlanSwitchAtInstance: baseProcedure
+    .input(KiloclawInstanceInputSchema)
+    .output(KiloclawMutationResultSchema)
+    .mutation(async ({ ctx, input }) => {
+      const row = await getKiloclawPersonalSubscriptionRow({
+        userId: ctx.user.id,
+        instanceId: input.instanceId,
+      });
+      await cancelKiloclawPlanSwitchForRow({
+        subscription: row.subscription,
+        userId: ctx.user.id,
+      });
+      return { success: true };
+    }),
 
   createSubscriptionCheckout: baseProcedure
     .input(z.object({ plan: z.enum(['commit', 'standard']) }))

--- a/src/routers/organizations/organization-subscription-router.test.ts
+++ b/src/routers/organizations/organization-subscription-router.test.ts
@@ -103,6 +103,16 @@ describe('organizations subscription trpc router', () => {
         })
       ).rejects.toThrow();
     });
+
+    it('rejects non-owner members from reading subscription details', async () => {
+      const caller = await createCallerForUser(memberUser.id);
+
+      await expect(
+        caller.organizations.subscription.get({
+          organizationId: testOrganization.id,
+        })
+      ).rejects.toThrow('You do not have the required organizational role to access this feature');
+    });
   });
 
   describe('getSubscriptionStripeUrl procedure', () => {
@@ -195,7 +205,7 @@ describe('organizations subscription trpc router', () => {
       ).rejects.toThrow('You do not have the required organizational role to access this feature');
     });
 
-    it('lists organization invoices for the Stripe customer across seat subscriptions', async () => {
+    it('lists invoices only for the latest seats subscription', async () => {
       await db.insert(organization_seats_purchases).values([
         {
           organization_id: testOrganization.id,
@@ -205,6 +215,7 @@ describe('organizations subscription trpc router', () => {
           starts_at: '2026-01-01T00:00:00.000Z',
           expires_at: '2026-02-01T00:00:00.000Z',
           billing_cycle: 'monthly',
+          created_at: '2026-01-01T00:00:00.000Z',
         },
         {
           organization_id: testOrganization.id,
@@ -214,6 +225,7 @@ describe('organizations subscription trpc router', () => {
           starts_at: '2026-02-01T00:00:00.000Z',
           expires_at: '2026-03-01T00:00:00.000Z',
           billing_cycle: 'monthly',
+          created_at: '2026-02-01T00:00:00.000Z',
         },
       ]);
       stripeMock.invoices.list.mockResolvedValue({
@@ -239,6 +251,7 @@ describe('organizations subscription trpc router', () => {
 
       expect(stripeMock.invoices.list).toHaveBeenCalledWith({
         customer: 'cus_test_org',
+        subscription: 'sub_org_new',
         limit: 25,
       });
       expect(result).toEqual({

--- a/src/routers/organizations/organization-subscription-router.test.ts
+++ b/src/routers/organizations/organization-subscription-router.test.ts
@@ -1,7 +1,41 @@
-import { createCallerForUser } from '@/routers/test-utils';
+import { beforeEach, jest } from '@jest/globals';
+import { db } from '@/lib/drizzle';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createOrganization, addUserToOrganization } from '@/lib/organizations/organizations';
+import { organization_seats_purchases } from '@kilocode/db/schema';
 import type { User, Organization } from '@kilocode/db/schema';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyMock = jest.Mock<(...args: any[]) => any>;
+
+jest.mock('@/lib/stripe-client', () => {
+  const stripeMock = {
+    billingPortal: { sessions: { create: jest.fn() } },
+    invoices: { list: jest.fn() },
+    checkout: { sessions: { create: jest.fn() } },
+    createStripeCustomer: jest.fn(async () => ({ id: 'cus_test_org' })),
+  };
+
+  return {
+    client: stripeMock,
+    createStripeCustomer: stripeMock.createStripeCustomer,
+    __stripeMock: stripeMock,
+  };
+});
+
+type StripeMock = {
+  billingPortal: { sessions: { create: AnyMock } };
+  invoices: { list: AnyMock };
+  checkout: { sessions: { create: AnyMock } };
+  createStripeCustomer: AnyMock;
+};
+
+const stripeMock = jest.requireMock<{ __stripeMock: StripeMock }>(
+  '@/lib/stripe-client'
+).__stripeMock;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let createCallerForUser: (userId: string) => Promise<any>;
 
 // Test users and organization will be created dynamically
 let regularUser: User;
@@ -11,7 +45,25 @@ let _nonMemberUser: User;
 let testOrganization: Organization;
 
 describe('organizations subscription trpc router', () => {
+  beforeEach(() => {
+    stripeMock.billingPortal.sessions.create.mockReset();
+    stripeMock.billingPortal.sessions.create.mockResolvedValue({
+      url: 'https://stripe.example.test/portal',
+    });
+    stripeMock.invoices.list.mockReset();
+    stripeMock.invoices.list.mockResolvedValue({ data: [], has_more: false });
+    stripeMock.checkout.sessions.create.mockReset();
+    stripeMock.checkout.sessions.create.mockResolvedValue({
+      url: 'https://stripe.example.test/checkout',
+    });
+    stripeMock.createStripeCustomer.mockReset();
+    stripeMock.createStripeCustomer.mockImplementation(async () => ({ id: 'cus_test_org' }));
+  });
+
   beforeAll(async () => {
+    const mod = await import('@/routers/test-utils');
+    createCallerForUser = mod.createCallerForUser;
+
     // Create test users using the helper function (no hardcoded emails to avoid cross-run collisions)
     regularUser = await insertTestUser({
       google_user_name: 'Regular Subscription User',
@@ -100,7 +152,6 @@ describe('organizations subscription trpc router', () => {
       const caller = await createCallerForUser(regularUser.id);
 
       // billingCycle is required (Seat Purchase 2) — omitting it must fail validation.
-      // @ts-expect-error intentionally omitting billingCycle to test validation
       const result = caller.organizations.subscription.getSubscriptionStripeUrl({
         organizationId: testOrganization.id,
         seats: 1,
@@ -120,6 +171,93 @@ describe('organizations subscription trpc router', () => {
           organizationId: testOrganization.id,
         })
       ).rejects.toThrow('You do not have the required organizational role to access this feature');
+    });
+  });
+
+  describe('getBillingHistory procedure', () => {
+    it('returns empty history when the organization has no seat purchases', async () => {
+      const caller = await createCallerForUser(regularUser.id);
+      const result = await caller.organizations.subscription.getBillingHistory({
+        organizationId: testOrganization.id,
+      });
+
+      expect(result).toEqual({ entries: [], hasMore: false, cursor: null });
+      expect(stripeMock.invoices.list).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-owner members', async () => {
+      const caller = await createCallerForUser(memberUser.id);
+
+      await expect(
+        caller.organizations.subscription.getBillingHistory({
+          organizationId: testOrganization.id,
+        })
+      ).rejects.toThrow('You do not have the required organizational role to access this feature');
+    });
+
+    it('lists organization invoices for the Stripe customer across seat subscriptions', async () => {
+      await db.insert(organization_seats_purchases).values([
+        {
+          organization_id: testOrganization.id,
+          subscription_stripe_id: 'sub_org_old',
+          seat_count: 5,
+          amount_usd: 25,
+          starts_at: '2026-01-01T00:00:00.000Z',
+          expires_at: '2026-02-01T00:00:00.000Z',
+          billing_cycle: 'monthly',
+        },
+        {
+          organization_id: testOrganization.id,
+          subscription_stripe_id: 'sub_org_new',
+          seat_count: 8,
+          amount_usd: 40,
+          starts_at: '2026-02-01T00:00:00.000Z',
+          expires_at: '2026-03-01T00:00:00.000Z',
+          billing_cycle: 'monthly',
+        },
+      ]);
+      stripeMock.invoices.list.mockResolvedValue({
+        data: [
+          {
+            id: 'inv_org_2',
+            created: 1_706_745_600,
+            amount_due: 4000,
+            currency: 'usd',
+            status: 'paid',
+            hosted_invoice_url: 'https://stripe.example.test/inv_org_2',
+            invoice_pdf: 'https://stripe.example.test/inv_org_2.pdf',
+            lines: { data: [{ description: 'Organization seats renewal' }] },
+          },
+        ],
+        has_more: false,
+      });
+
+      const caller = await createCallerForUser(regularUser.id);
+      const result = await caller.organizations.subscription.getBillingHistory({
+        organizationId: testOrganization.id,
+      });
+
+      expect(stripeMock.invoices.list).toHaveBeenCalledWith({
+        customer: 'cus_test_org',
+        limit: 25,
+      });
+      expect(result).toEqual({
+        entries: [
+          {
+            kind: 'stripe',
+            id: 'inv_org_2',
+            date: new Date(1_706_745_600 * 1000).toISOString(),
+            amountCents: 4000,
+            currency: 'usd',
+            status: 'paid',
+            invoiceUrl: 'https://stripe.example.test/inv_org_2',
+            invoicePdfUrl: 'https://stripe.example.test/inv_org_2.pdf',
+            description: 'Organization seats renewal',
+          },
+        ],
+        hasMore: false,
+        cursor: null,
+      });
     });
   });
 

--- a/src/routers/organizations/organization-subscription-router.ts
+++ b/src/routers/organizations/organization-subscription-router.ts
@@ -87,7 +87,7 @@ const CursorInputSchema = OrganizationIdInputSchema.extend({
 });
 
 export const organizationsSubscriptionRouter = createTRPCRouter({
-  get: organizationMemberProcedure
+  get: organizationBillingProcedure
     .input(OrganizationIdInputSchema)
     .output(OrganizationSubscriptionResponseSchema)
     .query(async ({ input }): Promise<OrganizationSubscriptionResponse> => {
@@ -358,6 +358,7 @@ export const organizationsSubscriptionRouter = createTRPCRouter({
 
       const invoices = await client.invoices.list({
         customer: customerId,
+        subscription: latestPurchase.subscription_stripe_id,
         limit: 25,
         ...(input.cursor ? { starting_after: input.cursor } : {}),
       });

--- a/src/routers/organizations/organization-subscription-router.ts
+++ b/src/routers/organizations/organization-subscription-router.ts
@@ -32,6 +32,10 @@ import { getOrCreateStripeCustomerIdForOrganization } from '@/lib/organizations/
 import { BillingCycleSchema } from '@/lib/organizations/organization-types';
 import { successResult } from '@/lib/maybe-result';
 import { client } from '@/lib/stripe-client';
+import {
+  billingHistoryResponseSchema,
+  mapStripeInvoiceToBillingHistoryEntry,
+} from '@/lib/subscriptions/subscription-center';
 
 const SubscriptionRequestSchema = OrganizationIdInputSchema.extend({
   seats: z.number().int().min(1).max(100),
@@ -76,6 +80,10 @@ const BillingCycleChangeResponseSchema = z.object({
 const ResubscribeDefaultsResponseSchema = z.object({
   defaultSeatCount: z.number(),
   billingCycle: BillingCycleSchema,
+});
+
+const CursorInputSchema = OrganizationIdInputSchema.extend({
+  cursor: z.string().optional(),
 });
 
 export const organizationsSubscriptionRouter = createTRPCRouter({
@@ -335,6 +343,30 @@ export const organizationsSubscriptionRouter = createTRPCRouter({
       });
 
       return { url: session.url };
+    }),
+
+  getBillingHistory: organizationBillingProcedure
+    .input(CursorInputSchema)
+    .output(billingHistoryResponseSchema)
+    .query(async ({ input }) => {
+      const latestPurchase = await getMostRecentSeatPurchase(input.organizationId);
+      if (!latestPurchase) {
+        return { entries: [], hasMore: false, cursor: null };
+      }
+
+      const customerId = await getOrCreateStripeCustomerIdForOrganization(input.organizationId);
+
+      const invoices = await client.invoices.list({
+        customer: customerId,
+        limit: 25,
+        ...(input.cursor ? { starting_after: input.cursor } : {}),
+      });
+
+      return {
+        entries: invoices.data.map(mapStripeInvoiceToBillingHistoryEntry),
+        hasMore: invoices.has_more,
+        cursor: invoices.has_more ? (invoices.data.at(-1)?.id ?? null) : null,
+      };
     }),
 
   changeBillingCycle: organizationBillingMutationProcedure

--- a/storybook/stories/PlanCard.stories.tsx
+++ b/storybook/stories/PlanCard.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
 import { PlanCard } from '@/components/organizations/subscription/PlanCard';
-import { TEAMS_FEATURES, ENTERPRISE_FEATURES } from '@/components/organizations/UpgradeTrialDialog';
+import {
+  TEAMS_FEATURES,
+  ENTERPRISE_FEATURES,
+} from '@/components/organizations/subscription/plan-features';
 import {
   TEAM_SEAT_PRICE_MONTHLY_USD,
   ENTERPRISE_SEAT_PRICE_MONTHLY_USD,


### PR DESCRIPTION
## Summary

- Adds a subscription center at `/subscriptions` (personal) and `/organizations/[id]/subscriptions` (org) with shared overview and detail UI for Kilo Pass, KiloClaw, and organization seats.
- Extends billing routers so each product exposes billing history, customer portal links, and instance-scoped subscription actions (cancel, resume, plan switch, billing cycle change).
- Detail pages follow a consistent layout: page header with status badge, subscription details card, action buttons below cards, and billing/credit history tables with colored status badges.
- All destructive or state-changing actions (cancel, resume, plan switch, billing cycle change) use AlertDialog confirmation modals with contextual descriptions and pending states.
- Plan switch and billing cycle change modals show current → new plan side-by-side with an arrow transition, including pricing and cadence details.
- Seats detail page detects pending billing cycle changes via `subscription.schedule` and shows a blue banner with cancel option, disabling the Change Billing Cycle button while a change is pending.
- Seat count modal has stepper buttons (±) with contextual billing messages: prorated immediately for increases, next billing cycle for decreases.
- Kilo Pass bonus streak card shows segmented usage bar, renewal info rows, and clarification text for monthly cadence.
- Preserves legacy organization billing URL with a redirect. Coding Plans remain behind `ENABLE_CODING_PLAN_SUBSCRIPTIONS = false`.

## Verification

- [x] `pnpm typecheck` — pass
- [x] `pnpm test -- src/routers/kilo-pass-router.test.ts --runInBand` — pass
- [x] `pnpm test -- src/routers/kiloclaw-billing-router.test.ts --runInBand` — pass
- [x] `pnpm test -- src/routers/organizations/organization-subscription-router.test.ts --runInBand` — pass
- [x] Browser pass on `/subscriptions`, `/subscriptions/kilo-pass`, `/subscriptions/kiloclaw/[id]`, `/organizations/[id]/subscriptions`, `/organizations/[id]/subscriptions/seats`
- [x] Verified confirmation modals for cancel, resume, plan switch, and billing cycle change flows
- [x] Verified pending billing cycle change detection and cancel flow on seats page

## Visual Changes

| Page | Screenshot |
| ------ | ----- |
| Kilo Pass Subscriptions |<img width="2440" height="1182" alt="Helium 2026-04-02 20 31 40" src="https://github.com/user-attachments/assets/4738bc68-c68f-4549-83e1-807dd4666f23" />|
| Kilo Pass Detail |<img width="2444" height="2104" alt="Helium 2026-04-02 20 31 38" src="https://github.com/user-attachments/assets/ed6032dc-f9b0-43bb-93b6-cb6158bc9b82" />|
| KiloClaw Subscriptions |<img width="2444" height="1284" alt="Helium 2026-04-02 20 31 39" src="https://github.com/user-attachments/assets/2fc2a104-535d-4f0b-829f-9289dc421802" />|
| KiloClaw Subscription Detail |<img width="2426" height="1610" alt="Helium 2026-04-02 20 31 37" src="https://github.com/user-attachments/assets/4d9b61bb-6e57-41a5-a569-2b3852200f30" />|
| Org Seats Subscriptions|<img width="2448" height="1328" alt="Helium 2026-04-02 20 31 35" src="https://github.com/user-attachments/assets/89c9e822-df2f-44f7-b3bd-2fc271db1dba" />|
|Org Seats Subscription|<img width="2444" height="1842" alt="Helium 2026-04-02 20 31 36" src="https://github.com/user-attachments/assets/6ed0adfd-79a9-4d7e-a006-510e082f7a85" />|

