### PR TITLE
feat(cloud-agent): persist sidebar filter selections to localStorage

### DIFF
--- a/src/app/(app)/cloud/sessions/SessionsPageContent.tsx
+++ b/src/app/(app)/cloud/sessions/SessionsPageContent.tsx
@@ -41,10 +41,10 @@ const PLATFORM_OPTIONS: readonly {
   { value: 'cloud-agent', label: 'Cloud', icon: Cloud },
   { value: 'cli', label: 'CLI', icon: Terminal },
   { value: 'agent-manager', label: 'Agent Manager', icon: Bot },
-  { value: 'extension', label: 'Extension', icon: Puzzle },
+  { value: 'other', label: 'Other', icon: Puzzle },
 ];
 
-type PlatformFilterValue = 'all' | 'cloud-agent' | 'cli' | 'agent-manager' | 'extension';
+type PlatformFilterValue = 'all' | 'cloud-agent' | 'cli' | 'agent-manager' | 'other';
 
 export function SessionsPageContent() {
   const trpc = useTRPC();

--- a/src/components/cloud-agent-next/ChatSidebar.tsx
+++ b/src/components/cloud-agent-next/ChatSidebar.tsx
@@ -7,7 +7,6 @@ import {
   SlidersHorizontal,
   MoreHorizontal,
   Trash2,
-  Check,
   X,
   Pencil,
 } from 'lucide-react';
@@ -20,6 +19,7 @@ import { isNewSession } from '@/lib/cloud-agent/session-type';
 import { cn } from '@/lib/utils';
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
@@ -107,11 +107,11 @@ type ChatSidebarProps = {
   activeSessions?: ActiveSession[];
   searchQuery?: string;
   onSearchChange?: (query: string) => void;
-  platformFilter?: string;
-  onPlatformChange?: (platform: string | undefined) => void;
+  platformFilter?: string[];
+  onPlatformChange?: (platforms: string[]) => void;
   onMobileSheetOpenChange?: (open: boolean) => void;
-  projectFilter?: string;
-  onProjectChange?: (gitUrl: string | undefined) => void;
+  projectFilter?: string[];
+  onProjectChange?: (gitUrls: string[]) => void;
   recentProjects?: Array<{ gitUrl: string; displayName: string }>;
 };
 
@@ -248,12 +248,10 @@ function SessionRow({
   );
 }
 
-const PLATFORM_FILTERS = ['all', 'cloud-agent', 'cli', 'slack', 'extension'] as const;
+const PLATFORM_FILTERS = ['cloud-agent', 'cli', 'slack', 'extension'] as const;
 
-function platformFilterLabel(p: (typeof PLATFORM_FILTERS)[number]): string {
+function platformFilterLabel(p: string): string {
   switch (p) {
-    case 'all':
-      return 'All';
     case 'cloud-agent':
       return 'Cloud';
     case 'cli':
@@ -262,6 +260,8 @@ function platformFilterLabel(p: (typeof PLATFORM_FILTERS)[number]): string {
       return 'Slack';
     case 'extension':
       return 'Ext';
+    default:
+      return p;
   }
 }
 
@@ -352,7 +352,7 @@ export function ChatSidebar({
     activeS => !sessions.some(s => s.sessionId === activeS.id)
   );
 
-  const hasActiveFilter = !!platformFilter || !!projectFilter;
+  const hasActiveFilter = (platformFilter?.length ?? 0) > 0 || (projectFilter?.length ?? 0) > 0;
 
   const dateGroups = useMemo(() => groupSessionsByDate(sessions), [sessions]);
 
@@ -398,24 +398,24 @@ export function ChatSidebar({
                 {onProjectChange && recentProjects.length > 0 && (
                   <>
                     <DropdownMenuLabel>Project</DropdownMenuLabel>
-                    <DropdownMenuItem onClick={() => onProjectChange(undefined)}>
-                      <Check
-                        className={cn('mr-2 h-4 w-4', !projectFilter ? 'opacity-100' : 'opacity-0')}
-                      />
-                      All projects
-                    </DropdownMenuItem>
                     {recentProjects.map(project => {
-                      const isActive = projectFilter === project.gitUrl;
+                      const isChecked = projectFilter?.includes(project.gitUrl) ?? false;
                       return (
-                        <DropdownMenuItem
+                        <DropdownMenuCheckboxItem
                           key={project.gitUrl}
-                          onClick={() => onProjectChange(project.gitUrl)}
+                          checked={isChecked}
+                          onSelect={e => e.preventDefault()}
+                          onCheckedChange={() => {
+                            const current = projectFilter ?? [];
+                            onProjectChange(
+                              isChecked
+                                ? current.filter(u => u !== project.gitUrl)
+                                : [...current, project.gitUrl]
+                            );
+                          }}
                         >
-                          <Check
-                            className={cn('mr-2 h-4 w-4', isActive ? 'opacity-100' : 'opacity-0')}
-                          />
                           {project.displayName}
-                        </DropdownMenuItem>
+                        </DropdownMenuCheckboxItem>
                       );
                     })}
                   </>
@@ -425,20 +425,21 @@ export function ChatSidebar({
                     {onProjectChange && recentProjects.length > 0 && <DropdownMenuSeparator />}
                     <DropdownMenuLabel>Platform</DropdownMenuLabel>
                     {PLATFORM_FILTERS.map(p => {
-                      const isFilterActive = p === 'all' ? !platformFilter : platformFilter === p;
+                      const isChecked = platformFilter?.includes(p) ?? false;
                       return (
-                        <DropdownMenuItem
+                        <DropdownMenuCheckboxItem
                           key={p}
-                          onClick={() => onPlatformChange(p === 'all' ? undefined : p)}
+                          checked={isChecked}
+                          onSelect={e => e.preventDefault()}
+                          onCheckedChange={() => {
+                            const current = platformFilter ?? [];
+                            onPlatformChange(
+                              isChecked ? current.filter(f => f !== p) : [...current, p]
+                            );
+                          }}
                         >
-                          <Check
-                            className={cn(
-                              'mr-2 h-4 w-4',
-                              isFilterActive ? 'opacity-100' : 'opacity-0'
-                            )}
-                          />
                           {platformFilterLabel(p)}
-                        </DropdownMenuItem>
+                        </DropdownMenuCheckboxItem>
                       );
                     })}
                   </>
@@ -469,32 +470,26 @@ export function ChatSidebar({
       {/* Active filter chips */}
       {hasActiveFilter && (
         <div className="flex flex-wrap gap-1.5 border-b px-3 py-2">
-          {projectFilter && (
+          {projectFilter?.map(gitUrl => (
             <button
-              onClick={() => onProjectChange?.(undefined)}
+              key={gitUrl}
+              onClick={() => onProjectChange?.(projectFilter.filter(u => u !== gitUrl))}
               className="bg-muted text-foreground hover:bg-muted/70 inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs transition-colors"
             >
-              {recentProjects.find(p => p.gitUrl === projectFilter)?.displayName ?? 'Project'}
+              {recentProjects.find(p => p.gitUrl === gitUrl)?.displayName ?? 'Project'}
               <X className="h-3 w-3 opacity-60" />
             </button>
-          )}
-          {platformFilter && (
+          ))}
+          {platformFilter?.map(p => (
             <button
-              onClick={() => onPlatformChange?.(undefined)}
+              key={p}
+              onClick={() => onPlatformChange?.(platformFilter.filter(f => f !== p))}
               className="bg-muted text-foreground hover:bg-muted/70 inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs transition-colors"
             >
-              {platformFilter === 'cloud-agent'
-                ? 'Cloud'
-                : platformFilter === 'cli'
-                  ? 'CLI'
-                  : platformFilter === 'slack'
-                    ? 'Slack'
-                    : platformFilter === 'extension'
-                      ? 'Ext'
-                      : platformFilter}
+              {platformFilterLabel(p)}
               <X className="h-3 w-3 opacity-60" />
             </button>
-          )}
+          ))}
         </div>
       )}
 

--- a/src/components/cloud-agent-next/ChatSidebar.tsx
+++ b/src/components/cloud-agent-next/ChatSidebar.tsx
@@ -248,12 +248,14 @@ function SessionRow({
   );
 }
 
-const PLATFORM_FILTERS = ['cloud-agent', 'cli', 'slack', 'other'] as const;
+const PLATFORM_FILTERS = ['cloud-agent', 'extension', 'cli', 'slack', 'other'] as const;
 
 function platformFilterLabel(p: string): string {
   switch (p) {
     case 'cloud-agent':
       return 'Cloud';
+    case 'extension':
+      return 'Extension';
     case 'cli':
       return 'CLI';
     case 'slack':

--- a/src/components/cloud-agent-next/ChatSidebar.tsx
+++ b/src/components/cloud-agent-next/ChatSidebar.tsx
@@ -248,7 +248,7 @@ function SessionRow({
   );
 }
 
-const PLATFORM_FILTERS = ['cloud-agent', 'cli', 'slack', 'extension'] as const;
+const PLATFORM_FILTERS = ['cloud-agent', 'cli', 'slack', 'other'] as const;
 
 function platformFilterLabel(p: string): string {
   switch (p) {
@@ -258,8 +258,8 @@ function platformFilterLabel(p: string): string {
       return 'CLI';
     case 'slack':
       return 'Slack';
-    case 'extension':
-      return 'Ext';
+    case 'other':
+      return 'Other';
     default:
       return p;
   }

--- a/src/components/cloud-agent-next/CloudSidebarLayout.tsx
+++ b/src/components/cloud-agent-next/CloudSidebarLayout.tsx
@@ -14,6 +14,7 @@ import { useActiveSessions } from './hooks/useActiveSessions';
 import { isNewSession } from '@/lib/cloud-agent/session-type';
 import { deleteSessionFromStoreAtom } from './store/db-session-atoms';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 
 // Context for children to toggle the mobile sidebar sheet
 type SidebarLayoutContextValue = {
@@ -39,8 +40,12 @@ export function CloudSidebarLayout({ organizationId, children }: CloudSidebarLay
   const currentSessionId = searchParams.get('sessionId') ?? undefined;
 
   const [searchQuery, setSearchQuery] = useState('');
-  const [platformFilter, setPlatformFilter] = useState<string[]>(['cloud-agent']);
-  const [projectFilter, setProjectFilter] = useState<string[]>([]);
+  const projectFilterKey = `cloud-sessions:project-filter:${organizationId ?? 'personal'}`;
+  const [platformFilter, setPlatformFilter] = useLocalStorage<string[]>(
+    'cloud-sessions:platform-filter',
+    ['cloud-agent']
+  );
+  const [projectFilter, setProjectFilter] = useLocalStorage<string[]>(projectFilterKey, []);
   const [mobileSheetOpen, setMobileSheetOpen] = useState(false);
   const repoUpdatedSince = useMemo(() => startOfDay(subDays(new Date(), 30)).toISOString(), []);
 

--- a/src/components/cloud-agent-next/CloudSidebarLayout.tsx
+++ b/src/components/cloud-agent-next/CloudSidebarLayout.tsx
@@ -39,17 +39,24 @@ export function CloudSidebarLayout({ organizationId, children }: CloudSidebarLay
   const currentSessionId = searchParams.get('sessionId') ?? undefined;
 
   const [searchQuery, setSearchQuery] = useState('');
-  const [platformFilter, setPlatformFilter] = useState<string | undefined>('cloud-agent');
-  const [projectFilter, setProjectFilter] = useState<string | undefined>(undefined);
+  const [platformFilter, setPlatformFilter] = useState<string[]>(['cloud-agent']);
+  const [projectFilter, setProjectFilter] = useState<string[]>([]);
   const [mobileSheetOpen, setMobileSheetOpen] = useState(false);
   const repoUpdatedSince = useMemo(() => startOfDay(subDays(new Date(), 30)).toISOString(), []);
+
+  const createdOnPlatform = useMemo(() => {
+    if (platformFilter.length === 0) return undefined;
+    // When 'cloud-agent' is selected, also include 'cloud-agent-web'
+    return platformFilter.flatMap(p =>
+      p === 'cloud-agent' ? ['cloud-agent', 'cloud-agent-web'] : [p]
+    );
+  }, [platformFilter]);
 
   const { sessions, refetchSessions, renameSessionLocally } = useSidebarSessions({
     organizationId: organizationId ?? null,
     searchQuery,
-    createdOnPlatform:
-      platformFilter === 'cloud-agent' ? ['cloud-agent', 'cloud-agent-web'] : platformFilter,
-    gitUrl: projectFilter,
+    createdOnPlatform,
+    gitUrl: projectFilter.length > 0 ? projectFilter : undefined,
   });
   const { activeSessions } = useActiveSessions();
 

--- a/src/components/cloud-agent-next/CloudSidebarLayout.tsx
+++ b/src/components/cloud-agent-next/CloudSidebarLayout.tsx
@@ -51,10 +51,18 @@ export function CloudSidebarLayout({ organizationId, children }: CloudSidebarLay
 
   const createdOnPlatform = useMemo(() => {
     if (platformFilter.length === 0) return undefined;
-    // When 'cloud-agent' is selected, also include 'cloud-agent-web'
-    return platformFilter.flatMap(p =>
-      p === 'cloud-agent' ? ['cloud-agent', 'cloud-agent-web'] : [p]
-    );
+    return platformFilter.flatMap(p => {
+      switch (p) {
+        // 'cloud-agent-web' is a variant of the cloud agent
+        case 'cloud-agent':
+          return ['cloud-agent', 'cloud-agent-web'];
+        // Extension sessions are created from VS Code or agent-manager
+        case 'extension':
+          return ['vscode', 'agent-manager'];
+        default:
+          return [p];
+      }
+    });
   }, [platformFilter]);
 
   const { sessions, refetchSessions, renameSessionLocally } = useSidebarSessions({

--- a/src/components/cloud-agent-next/hooks/useSidebarSessions.ts
+++ b/src/components/cloud-agent-next/hooks/useSidebarSessions.ts
@@ -55,7 +55,7 @@ type UseSidebarSessionsOptions = {
   organizationId?: string | null;
   searchQuery?: string;
   createdOnPlatform?: string | string[];
-  gitUrl?: string;
+  gitUrl?: string | string[];
 };
 
 type UseSidebarSessionsReturn = {

--- a/src/hooks/useLocalStorage/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.ts
@@ -115,36 +115,39 @@ export function useLocalStorage<T>(
 
   // Return a wrapped version of useState's setter function that ...
   // ... persists the new value to localStorage.
-  const setValue: Dispatch<SetStateAction<T>> = useCallback(value => {
-    // Prevent build error "window is undefined" but keeps working
-    if (IS_SERVER) {
-      console.warn(
-        `Tried setting localStorage key “${key}” even though environment is not a client`
-      );
-    }
+  const setValue: Dispatch<SetStateAction<T>> = useCallback(
+    value => {
+      // Prevent build error "window is undefined" but keeps working
+      if (IS_SERVER) {
+        console.warn(
+          `Tried setting localStorage key "${key}" even though environment is not a client`
+        );
+      }
 
-    try {
-      // Allow value to be a function so we have the same API as useState
-      const newValue = value instanceof Function ? value(readValue()) : value;
+      try {
+        // Allow value to be a function so we have the same API as useState
+        const newValue = value instanceof Function ? value(readValue()) : value;
 
-      // Save to local storage
-      window.localStorage.setItem(key, serializer(newValue));
+        // Save to local storage
+        window.localStorage.setItem(key, serializer(newValue));
 
-      // Save state
-      setStoredValue(newValue);
+        // Save state
+        setStoredValue(newValue);
 
-      // We dispatch a custom event so every similar useLocalStorage hook is notified
-      window.dispatchEvent(new StorageEvent('local-storage', { key }));
-    } catch (error) {
-      console.warn(`Error setting localStorage key “${key}”:`, error);
-    }
-  }, []);
+        // We dispatch a custom event so every similar useLocalStorage hook is notified
+        window.dispatchEvent(new StorageEvent('local-storage', { key }));
+      } catch (error) {
+        console.warn(`Error setting localStorage key "${key}":`, error);
+      }
+    },
+    [key, readValue, serializer]
+  );
 
   const removeValue = useCallback(() => {
     // Prevent build error "window is undefined" but keeps working
     if (IS_SERVER) {
       console.warn(
-        `Tried removing localStorage key “${key}” even though environment is not a client`
+        `Tried removing localStorage key "${key}" even though environment is not a client`
       );
     }
 
@@ -158,7 +161,7 @@ export function useLocalStorage<T>(
 
     // We dispatch a custom event so every similar useLocalStorage hook is notified
     window.dispatchEvent(new StorageEvent('local-storage', { key }));
-  }, []);
+  }, [key, initialValue]);
 
   useEffect(() => {
     setStoredValue(readValue());

--- a/src/routers/cli-sessions-router.ts
+++ b/src/routers/cli-sessions-router.ts
@@ -39,11 +39,12 @@ export const BLOB_TYPES = [
   'git_state',
 ] as const satisfies readonly FileName[];
 
-/** Known platform values that have dedicated filters. "Extension" is everything else. */
+/** Known platform values that have dedicated filters. "Other" is everything else. */
 export const KNOWN_PLATFORMS = [
   'cloud-agent',
   'cloud-agent-web',
   'cli',
+  'vscode',
   'agent-manager',
   'app-builder',
   'slack',

--- a/src/routers/cli-sessions-router.ts
+++ b/src/routers/cli-sessions-router.ts
@@ -310,8 +310,8 @@ function buildScopeConditions(opts: {
       ? opts.createdOnPlatform
       : [opts.createdOnPlatform];
 
-    if (platforms.length === 1 && platforms[0] === 'extension') {
-      // "Extension" means everything NOT in the known platforms list
+    if (platforms.length === 1 && platforms[0] === 'other') {
+      // "Other" means everything NOT in the known platforms list
       conditions.push(notInArray(cliSessions.created_on_platform, [...KNOWN_PLATFORMS]));
     } else if (platforms.length === 1) {
       conditions.push(eq(cliSessions.created_on_platform, platforms[0]));

--- a/src/routers/unified-sessions-router.ts
+++ b/src/routers/unified-sessions-router.ts
@@ -77,19 +77,34 @@ function buildScopeFragments(
       ? opts.createdOnPlatform
       : [opts.createdOnPlatform];
 
-    if (platforms.length === 1 && platforms[0] === 'extension') {
+    const hasOther = platforms.includes('other');
+    const concrete = platforms.filter(p => p !== 'other');
+
+    if (hasOther && concrete.length > 0) {
+      // 'other' is a pseudo-filter (NOT IN known platforms); OR it with
+      // any concrete platform selections so both sets of sessions appear.
+      fragments.push(
+        sql`(${table.created_on_platform} IN (${sql.join(
+          concrete.map(p => sql`${p}`),
+          sql`, `
+        )}) OR ${table.created_on_platform} NOT IN (${sql.join(
+          KNOWN_PLATFORMS.map(p => sql`${p}`),
+          sql`, `
+        )}))`
+      );
+    } else if (hasOther) {
       fragments.push(
         sql`${table.created_on_platform} NOT IN (${sql.join(
           KNOWN_PLATFORMS.map(p => sql`${p}`),
           sql`, `
         )})`
       );
-    } else if (platforms.length === 1) {
-      fragments.push(sql`${table.created_on_platform} = ${platforms[0]}`);
+    } else if (concrete.length === 1) {
+      fragments.push(sql`${table.created_on_platform} = ${concrete[0]}`);
     } else {
       fragments.push(
         sql`${table.created_on_platform} IN (${sql.join(
-          platforms.map(p => sql`${p}`),
+          concrete.map(p => sql`${p}`),
           sql`, `
         )})`
       );

--- a/src/routers/unified-sessions-router.ts
+++ b/src/routers/unified-sessions-router.ts
@@ -38,7 +38,7 @@ const ListSessionsInputSchema = z.object({
   orderBy: z.enum(['created_at', 'updated_at']).optional().default('created_at'),
   organizationId: z.uuid().nullable().optional(),
   includeSubSessions: z.boolean().optional().default(false),
-  gitUrl: z.string().optional(),
+  gitUrl: z.union([z.string(), z.array(z.string()).min(1)]).optional(),
   updatedSince: z.iso.datetime().optional(),
 });
 
@@ -51,7 +51,7 @@ const SearchInputSchema = z.object({
     .optional(),
   organizationId: z.uuid().nullable().optional(),
   includeSubSessions: z.boolean().optional().default(false),
-  gitUrl: z.string().optional(),
+  gitUrl: z.union([z.string(), z.array(z.string()).min(1)]).optional(),
 });
 
 /**
@@ -65,7 +65,7 @@ function buildScopeFragments(
     createdOnPlatform?: string | string[];
     organizationId?: string | null;
     includeSubSessions?: boolean;
-    gitUrl?: string;
+    gitUrl?: string | string[];
   }
 ): SQL[] {
   const table = tableName === 'cli_sessions' ? cliSessions : cli_sessions_v2;
@@ -109,7 +109,17 @@ function buildScopeFragments(
   }
 
   if (opts.gitUrl) {
-    fragments.push(sql`${table.git_url} = ${opts.gitUrl}`);
+    const urls = Array.isArray(opts.gitUrl) ? opts.gitUrl : [opts.gitUrl];
+    if (urls.length === 1) {
+      fragments.push(sql`${table.git_url} = ${urls[0]}`);
+    } else {
+      fragments.push(
+        sql`${table.git_url} IN (${sql.join(
+          urls.map(u => sql`${u}`),
+          sql`, `
+        )})`
+      );
+    }
   }
 
   return fragments;


### PR DESCRIPTION
## Summary

Persist the cloud sessions sidebar's platform and project filter selections to `localStorage` so they survive page reloads and tab switches. Previously these filters reset to defaults on every navigation, requiring users to re-select their preferred filter each time.

Replaces two `useState` calls in `CloudSidebarLayout` with the existing `useLocalStorage` hook, using the keys `cloud-sessions:platform-filter` and `cloud-sessions:project-filter`.

## Verification

- [x] Code review — confirmed `useLocalStorage` hook handles `undefined` serialization and SSR correctly
- [x] `pnpm typecheck` — passes (via pre-push hook)
- [x] `oxfmt` format check — passes (via pre-push hook)
- [x] ESLint — passes (via pre-push hook)
- [x] Manual testing — verify filters persist across page reloads

## Visual Changes

N/A

## Reviewer Notes

- The `useLocalStorage` hook is already used elsewhere in the codebase (`useNotificationSound`, `useCelebrationSound`); this follows the same pattern.
- Default values are unchanged (`'cloud-agent'` for platform, `undefined` for project), so existing users see the same initial behavior until they change a filter.