### PR TITLE
feat(cloud-agent): add repo-scoped startup script and improve setup error messages

### DIFF
--- a/cloud-agent-next/src/persistence/async-preparation.ts
+++ b/cloud-agent-next/src/persistence/async-preparation.ts
@@ -16,6 +16,7 @@ import {
   SessionService,
   determineBranchName,
   runSetupCommands,
+  runRepoStartupScript,
   writeAuthFile,
 } from '../session-service.js';
 import { WrapperClient } from '../kilo/wrapper-client.js';
@@ -166,7 +167,11 @@ export async function executePreparationSteps(
   emitProgress('branch', 'Setting up branch…');
   await manageBranch(session, workspacePath, branchName, !!input.upstreamBranch);
 
-  // 6. Setup commands
+  // 6a. Repo-scoped startup script (before user setup commands)
+  emitProgress('repo_startup_script', 'Running repo startup script…');
+  await runRepoStartupScript(session, context, true);
+
+  // 6b. Setup commands
   if (input.setupCommands && input.setupCommands.length > 0) {
     emitProgress('setup_commands', 'Running setup commands…');
     await runSetupCommands(session, context, input.setupCommands, true);

--- a/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -6,6 +6,7 @@ import {
   SessionService,
   determineBranchName,
   runSetupCommands,
+  runRepoStartupScript,
   writeAuthFile,
 } from '../../session-service.js';
 import { InstallationLookupService } from '../../services/installation-lookup-service.js';
@@ -411,7 +412,10 @@ const prepareSessionHandler = internalApiProtectedProcedure
         }
       }
 
-      // 9. Run setup commands
+      // 9a. Run repo-scoped startup script (before user setup commands)
+      await runRepoStartupScript(session, context, true); // fail-fast
+
+      // 9b. Run setup commands
       if (input.setupCommands && input.setupCommands.length > 0) {
         logger.withFields({ count: input.setupCommands.length }).info('Running setup commands');
         await runSetupCommands(session, context, input.setupCommands, true); // fail-fast

--- a/cloud-agent-next/src/session-prepare.test.ts
+++ b/cloud-agent-next/src/session-prepare.test.ts
@@ -76,6 +76,7 @@ vi.mock('./session-service.js', () => ({
     (sessionId: string, upstreamBranch?: string) => upstreamBranch || `session/${sessionId}`
   ),
   runSetupCommands: vi.fn().mockResolvedValue(undefined),
+  runRepoStartupScript: vi.fn().mockResolvedValue(undefined),
   writeAuthFile: vi.fn().mockResolvedValue(undefined),
   InvalidSessionMetadataError: class InvalidSessionMetadataError extends Error {
     constructor(

--- a/cloud-agent-next/src/session-service.test.ts
+++ b/cloud-agent-next/src/session-service.test.ts
@@ -38,7 +38,11 @@ import {
   restoreWorkspace as mockRestoreWorkspace,
   cleanupWorkspace as mockCleanupWorkspace,
 } from './workspace.js';
-import { InvalidSessionMetadataError, SessionService } from './session-service.js';
+import {
+  InvalidSessionMetadataError,
+  SessionService,
+  runRepoStartupScript,
+} from './session-service.js';
 import type { SandboxInstance, SessionId, SessionContext, ExecutionSession } from './types.js';
 import type { PersistenceEnv, CloudAgentSessionState } from './persistence/types.js';
 
@@ -1653,6 +1657,8 @@ describe('SessionService', () => {
             }),
             stderr: '',
           }) // restore script
+          .mockResolvedValueOnce({ exitCode: 1 }) // repo startup script probe (.kilo) - not found
+          .mockResolvedValueOnce({ exitCode: 1 }) // repo startup script probe (.kilocode) - not found
           .mockResolvedValueOnce({ success: true, exitCode: 0, stdout: 'command 1 ok', stderr: '' }) // npm install
           .mockResolvedValueOnce({
             success: false,
@@ -1692,17 +1698,17 @@ describe('SessionService', () => {
         env: testEnv,
       });
 
-      // 1 repo check + 1 restore script + 3 setup commands = 5
-      expect(fakeSession.exec).toHaveBeenCalledTimes(5);
-      expect(fakeSession.exec).toHaveBeenNthCalledWith(3, 'npm install', {
+      // 1 repo check + 1 restore script + 2 startup script probes + 3 setup commands = 7
+      expect(fakeSession.exec).toHaveBeenCalledTimes(7);
+      expect(fakeSession.exec).toHaveBeenNthCalledWith(5, 'npm install', {
         cwd: `/workspace/org/user/sessions/${sessionId}`,
         timeout: 120000,
       });
-      expect(fakeSession.exec).toHaveBeenNthCalledWith(4, 'npm run build', {
+      expect(fakeSession.exec).toHaveBeenNthCalledWith(6, 'npm run build', {
         cwd: `/workspace/org/user/sessions/${sessionId}`,
         timeout: 120000,
       });
-      expect(fakeSession.exec).toHaveBeenNthCalledWith(5, 'npm test', {
+      expect(fakeSession.exec).toHaveBeenNthCalledWith(7, 'npm test', {
         cwd: `/workspace/org/user/sessions/${sessionId}`,
         timeout: 120000,
       });
@@ -1719,6 +1725,8 @@ describe('SessionService', () => {
         exec: vi
           .fn()
           .mockResolvedValueOnce({ exitCode: 0, stdout: 'installed', stderr: '' }) // git checkout -b succeeds
+          .mockResolvedValueOnce({ exitCode: 1 }) // repo startup script probe (.kilo) - not found
+          .mockResolvedValueOnce({ exitCode: 1 }) // repo startup script probe (.kilocode) - not found
           .mockResolvedValueOnce({ exitCode: 0, stdout: 'installed', stderr: '' }) // npm install succeeds
           .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'ERR! 404 Not Found' }), // npm install -g fails
         gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
@@ -1761,8 +1769,8 @@ describe('SessionService', () => {
         stderr: 'ERR! 404 Not Found',
       });
 
-      // Verify only three calls: git checkout -b + first setup command + second setup command that failed
-      expect(fakeSession.exec).toHaveBeenCalledTimes(3);
+      // git checkout -b + 2 startup script probes + npm install + npm install -g (fails) = 5
+      expect(fakeSession.exec).toHaveBeenCalledTimes(5);
     });
 
     it('should run commands with 2-minute timeout', async () => {
@@ -1884,9 +1892,142 @@ describe('SessionService', () => {
         setupCommands: [], // Empty array
       });
 
-      // exec should only be called once for git checkout -b, not for setup commands
-      expect(fakeSession.exec).toHaveBeenCalledTimes(1);
+      // exec: git checkout -b + startup script probe (found) + startup script run = 3
+      // No setup commands since array is empty
+      expect(fakeSession.exec).toHaveBeenCalledTimes(3);
       expect(fakeSession.exec).toHaveBeenCalledWith(expect.stringContaining('git checkout -b'));
+    });
+  });
+
+  describe('Repo Startup Script', () => {
+    const makeContext = (sessionId: SessionId): SessionContext => ({
+      sandboxId: 'org__user',
+      sessionId,
+      sessionHome: `/home/${sessionId}`,
+      workspacePath: `/workspace/org/user/sessions/${sessionId}`,
+      branchName: `session/${sessionId}`,
+      userId: 'user',
+    });
+
+    it('should be a no-op when no startup script exists', async () => {
+      const exec = vi
+        .fn()
+        .mockResolvedValueOnce({ exitCode: 1 }) // .kilo/cloud-agent-setup.sh not found
+        .mockResolvedValueOnce({ exitCode: 1 }); // .kilocode/cloud-agent-setup.sh not found
+      const session = { exec } as unknown as ExecutionSession;
+
+      await runRepoStartupScript(session, makeContext('agent_no_script' as SessionId));
+
+      expect(exec).toHaveBeenCalledTimes(2);
+      expect(exec).toHaveBeenNthCalledWith(
+        1,
+        "test -f '/workspace/org/user/sessions/agent_no_script/.kilo/cloud-agent-setup.sh'"
+      );
+      expect(exec).toHaveBeenNthCalledWith(
+        2,
+        "test -f '/workspace/org/user/sessions/agent_no_script/.kilocode/cloud-agent-setup.sh'"
+      );
+    });
+
+    it('should prefer .kilo/cloud-agent-setup.sh over .kilocode/', async () => {
+      const exec = vi
+        .fn()
+        .mockResolvedValueOnce({ exitCode: 0 }) // .kilo/cloud-agent-setup.sh found
+        .mockResolvedValueOnce({ exitCode: 0, stderr: '' }); // script runs OK
+      const session = { exec } as unknown as ExecutionSession;
+
+      await runRepoStartupScript(session, makeContext('agent_kilo_pref' as SessionId));
+
+      expect(exec).toHaveBeenCalledTimes(2);
+      expect(exec).toHaveBeenNthCalledWith(
+        2,
+        "bash '/workspace/org/user/sessions/agent_kilo_pref/.kilo/cloud-agent-setup.sh'",
+        {
+          cwd: '/workspace/org/user/sessions/agent_kilo_pref',
+          timeout: 120000,
+        }
+      );
+    });
+
+    it('should fall back to .kilocode/cloud-agent-setup.sh', async () => {
+      const exec = vi
+        .fn()
+        .mockResolvedValueOnce({ exitCode: 1 }) // .kilo not found
+        .mockResolvedValueOnce({ exitCode: 0 }) // .kilocode found
+        .mockResolvedValueOnce({ exitCode: 0, stderr: '' }); // script runs OK
+      const session = { exec } as unknown as ExecutionSession;
+
+      await runRepoStartupScript(session, makeContext('agent_kilocode_fb' as SessionId));
+
+      expect(exec).toHaveBeenCalledTimes(3);
+      expect(exec).toHaveBeenNthCalledWith(
+        3,
+        "bash '/workspace/org/user/sessions/agent_kilocode_fb/.kilocode/cloud-agent-setup.sh'",
+        {
+          cwd: '/workspace/org/user/sessions/agent_kilocode_fb',
+          timeout: 120000,
+        }
+      );
+    });
+
+    it('should throw on script failure when failFast is true', async () => {
+      const exec = vi
+        .fn()
+        .mockResolvedValueOnce({ exitCode: 0 }) // .kilo found
+        .mockResolvedValueOnce({ exitCode: 1, stderr: 'syntax error' }); // script fails
+      const session = { exec } as unknown as ExecutionSession;
+
+      await expect(
+        runRepoStartupScript(session, makeContext('agent_ff' as SessionId), true)
+      ).rejects.toMatchObject({
+        name: 'SetupCommandFailedError',
+        command: '.kilo/cloud-agent-setup.sh',
+        exitCode: 1,
+        stderr: 'syntax error',
+      });
+    });
+
+    it('should not throw on script failure when failFast is false', async () => {
+      const exec = vi
+        .fn()
+        .mockResolvedValueOnce({ exitCode: 0 }) // .kilo found
+        .mockResolvedValueOnce({ exitCode: 1, stderr: 'some error' }); // script fails
+      const session = { exec } as unknown as ExecutionSession;
+
+      // Should not throw in lenient mode
+      await runRepoStartupScript(session, makeContext('agent_lenient' as SessionId), false);
+
+      expect(exec).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle exec errors gracefully in lenient mode', async () => {
+      const exec = vi
+        .fn()
+        .mockResolvedValueOnce({ exitCode: 0 }) // .kilo found
+        .mockRejectedValueOnce(new Error('connection lost')); // exec throws
+      const session = { exec } as unknown as ExecutionSession;
+
+      // Should not throw in lenient mode
+      await runRepoStartupScript(session, makeContext('agent_err' as SessionId), false);
+
+      expect(exec).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw wrapped error in fail-fast mode when exec throws', async () => {
+      const exec = vi
+        .fn()
+        .mockResolvedValueOnce({ exitCode: 0 }) // .kilo found
+        .mockRejectedValueOnce(new Error('connection lost')); // exec throws
+      const session = { exec } as unknown as ExecutionSession;
+
+      await expect(
+        runRepoStartupScript(session, makeContext('agent_err_ff' as SessionId), true)
+      ).rejects.toMatchObject({
+        name: 'SetupCommandFailedError',
+        command: '.kilo/cloud-agent-setup.sh',
+        exitCode: -1,
+        stderr: 'connection lost',
+      });
     });
   });
 

--- a/cloud-agent-next/src/session-service.ts
+++ b/cloud-agent-next/src/session-service.ts
@@ -245,7 +245,8 @@ export class SetupCommandFailedError extends Error {
     public readonly exitCode: number,
     public readonly stderr: string
   ) {
-    super(`Setup command failed: ${command}`);
+    const details = [`exit code ${exitCode}`, ...(stderr ? [stderr.trim()] : [])].join(': ');
+    super(`Setup command failed: ${command} (${details})`);
     this.name = 'SetupCommandFailedError';
   }
 }
@@ -326,6 +327,88 @@ export async function runSetupCommands(
   }
 
   logger.info('Setup commands completed');
+}
+
+// Candidate paths for repo-scoped cloud-agent setup scripts, checked in order.
+const REPO_STARTUP_SCRIPT_PATHS = [
+  '.kilo/cloud-agent-setup.sh',
+  '.kilocode/cloud-agent-setup.sh',
+] as const;
+
+/**
+ * Run a repo-scoped cloud-agent startup script if one exists in the workspace.
+ *
+ * Looks for `.kilo/cloud-agent-setup.sh` first, then `.kilocode/cloud-agent-setup.sh`.
+ * The first file that exists is executed with `bash`; if neither exists this is a no-op.
+ *
+ * @param session  - ExecutionSession to run the script in
+ * @param context  - Session context (paths, IDs)
+ * @param failFast - Whether a non-zero exit code should throw (default: false)
+ */
+export async function runRepoStartupScript(
+  session: ExecutionSession,
+  context: SessionContext,
+  failFast: boolean = false
+): Promise<void> {
+  // Probe for the first existing script
+  let scriptRelPath: string | undefined;
+  let scriptAbsPath: string | undefined;
+  for (const candidate of REPO_STARTUP_SCRIPT_PATHS) {
+    const absPath = `${context.workspacePath}/${candidate}`;
+    const probe = await session.exec(`test -f '${absPath}'`);
+    if (probe.exitCode === 0) {
+      scriptRelPath = candidate;
+      scriptAbsPath = absPath;
+      break;
+    }
+  }
+
+  if (!scriptRelPath || !scriptAbsPath) {
+    logger.debug('No repo startup script found');
+    return;
+  }
+  logger.withFields({ script: scriptRelPath }).info('Running repo startup script');
+
+  try {
+    const result = await session.exec(`bash '${scriptAbsPath}'`, {
+      cwd: context.workspacePath,
+      timeout: SETUP_COMMAND_TIMEOUT_SECONDS * 1000,
+    });
+
+    if (result.exitCode !== 0) {
+      logger
+        .withFields({
+          script: scriptRelPath,
+          exitCode: result.exitCode,
+          stderr: result.stderr,
+        })
+        .warn('Repo startup script failed');
+
+      if (failFast) {
+        throw new SetupCommandFailedError(scriptRelPath, result.exitCode, result.stderr);
+      }
+    } else {
+      logger.withFields({ script: scriptRelPath }).info('Repo startup script completed');
+    }
+  } catch (error) {
+    if (error instanceof SetupCommandFailedError) {
+      throw error;
+    }
+    logger
+      .withFields({
+        script: scriptRelPath,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      .error('Error executing repo startup script');
+
+    if (failFast) {
+      throw new SetupCommandFailedError(
+        scriptRelPath,
+        -1,
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+  }
 }
 
 // Write Kilo auth file so the CLI's KiloSessions can call session ingest.
@@ -902,6 +985,9 @@ export class SessionService {
       logger.withTags({ branchName: context.branchName }).info('Successfully created branch');
     }
 
+    // Run repo-scoped startup script (before user setup commands)
+    await runRepoStartupScript(session, context, true); // fail-fast
+
     // Run setup commands after branch checkout
     if (setupCommands && setupCommands.length > 0) {
       await runSetupCommands(session, context, setupCommands, true); // fail-fast
@@ -1078,6 +1164,9 @@ export class SessionService {
     } else {
       logger.info('Skipping branch operations - CLI session will manage its own branch state');
     }
+
+    // Run repo-scoped startup script (lenient since resuming)
+    await runRepoStartupScript(session, context, false);
 
     // Run setup commands (lenient mode since resuming)
     if (setupCommands && setupCommands.length > 0) {
@@ -1374,6 +1463,9 @@ export class SessionService {
       } catch {
         // non-JSON stdout, non-fatal
       }
+
+      // Re-run repo startup script (fresh clone, need to reinstall)
+      await runRepoStartupScript(session, context, false); // lenient
 
       // Re-run setup commands (fresh clone, need to reinstall)
       if (metadata.setupCommands && metadata.setupCommands.length > 0) {

--- a/cloud-agent-next/src/shared/protocol.ts
+++ b/cloud-agent-next/src/shared/protocol.ts
@@ -94,6 +94,7 @@ export type PreparingStep =
   | 'workspace_setup'
   | 'cloning'
   | 'branch'
+  | 'repo_startup_script'
   | 'setup_commands'
   | 'kilo_server'
   | 'kilo_session'

--- a/cloud-agent/src/session-service.ts
+++ b/cloud-agent/src/session-service.ts
@@ -169,7 +169,8 @@ export class SetupCommandFailedError extends Error {
     public readonly exitCode: number,
     public readonly stderr: string
   ) {
-    super(`Setup command failed: ${command}`);
+    const details = [`exit code ${exitCode}`, ...(stderr ? [stderr.trim()] : [])].join(': ');
+    super(`Setup command failed: ${command} (${details})`);
     this.name = 'SetupCommandFailedError';
   }
 }


### PR DESCRIPTION
## Summary

Add `runRepoStartupScript()` to cloud-agent session initialization. It looks for `.kilo/cloud-agent-setup.sh` (then `.kilocode/cloud-agent-setup.sh`) in the cloned repo and executes it before user-provided setup commands. This runs in all three initialization paths: initial prepare (fail-fast), session resume (lenient), and cold-start restore (lenient).

Also fixes `SetupCommandFailedError` to include exit code and stderr in the error message, so users can diagnose failures instead of seeing only "Setup command failed: <command>".

Adds a `repo_startup_script` progress step so the UI shows "Running repo startup script…" instead of lingering on "Setting up branch…" during script execution.

**Files changed:**
- `cloud-agent-next/src/session-service.ts` — `runRepoStartupScript()` + improved `SetupCommandFailedError.message`
- `cloud-agent-next/src/persistence/async-preparation.ts` — emit `repo_startup_script` progress step
- `cloud-agent-next/src/router/handlers/session-prepare.ts` — call `runRepoStartupScript` in sync prepare path
- `cloud-agent-next/src/shared/protocol.ts` — add `repo_startup_script` to `PreparingStep`
- `cloud-agent/src/session-service.ts` — same `SetupCommandFailedError.message` fix
- `cloud-agent-next/src/session-service.test.ts` — 7 new tests + updated exec call counts
- `cloud-agent-next/src/session-prepare.test.ts` — mock for `runRepoStartupScript`

## Verification

- [x] `pnpm vitest run` in `cloud-agent-next/` — 709 tests passed
- [x] `pnpm vitest run` in `cloud-agent/` — 467 tests passed
- [x] `scripts/lint-all.sh` — 0 errors
- [x] `pnpm format:changed` — clean
- [x] Pre-push hooks (format:check, lint, typecheck) — all passed

## Visual Changes

N/A

## Reviewer Notes

- The `repo_startup_script` progress step is only emitted in the async preparation path (`async-preparation.ts`), since the sync paths (`session-service.ts` `initiate` and `session-prepare.ts`) don't have `emitProgress` available.
- The error message format is now `Setup command failed: <cmd> (exit code N: <stderr>)` — this applies to both user setup commands and the repo startup script.