### PR TITLE
fix(kiloclaw): pass instanceId to worker for instance-keyed DO routing

### DIFF
--- a/src/app/api/kiloclaw/chat-credentials/route.ts
+++ b/src/app/api/kiloclaw/chat-credentials/route.ts
@@ -5,6 +5,7 @@ import { KiloClawUserClient } from '@/lib/kiloclaw/kiloclaw-user-client';
 import { KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
 import { requireKiloClawAccess } from '@/lib/kiloclaw/access-gate';
+import { getActiveInstance, workerInstanceId } from '@/lib/kiloclaw/instance-registry';
 
 export async function GET() {
   const { user, authFailedResponse } = await getUserFromAuth({
@@ -22,11 +23,15 @@ export async function GET() {
   }
 
   try {
+    const instance = await getActiveInstance(user.id);
     const token = generateApiToken(user, undefined, {
       expiresIn: TOKEN_EXPIRY.fiveMinutes,
     });
     const client = new KiloClawUserClient(token);
-    const creds = await client.getChatCredentials({ userId: user.id });
+    const creds = await client.getChatCredentials({
+      userId: user.id,
+      instanceId: workerInstanceId(instance),
+    });
     return NextResponse.json(creds);
   } catch (err) {
     const status = err instanceof KiloClawApiError ? err.statusCode : 502;

--- a/src/app/api/kiloclaw/status/route.ts
+++ b/src/app/api/kiloclaw/status/route.ts
@@ -3,6 +3,7 @@ import { getUserFromAuth } from '@/lib/user.server';
 import { KiloClawUserClient } from '@/lib/kiloclaw/kiloclaw-user-client';
 import { KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
+import { getActiveInstance, workerInstanceId } from '@/lib/kiloclaw/instance-registry';
 
 export async function GET() {
   const { user, authFailedResponse } = await getUserFromAuth({
@@ -11,11 +12,15 @@ export async function GET() {
   if (authFailedResponse) return authFailedResponse;
 
   try {
+    const instance = await getActiveInstance(user.id);
     const token = generateApiToken(user, undefined, {
       expiresIn: TOKEN_EXPIRY.fiveMinutes,
     });
     const client = new KiloClawUserClient(token);
-    const status = await client.getStatus({ userId: user.id });
+    const status = await client.getStatus({
+      userId: user.id,
+      instanceId: workerInstanceId(instance),
+    });
     return NextResponse.json(status);
   } catch (err) {
     const status = err instanceof KiloClawApiError ? err.statusCode : 502;

--- a/src/lib/kiloclaw/billing-lifecycle-cron.ts
+++ b/src/lib/kiloclaw/billing-lifecycle-cron.ts
@@ -22,6 +22,7 @@ import type {
 import type { TemplateName } from '@/lib/email';
 import { send as sendEmail } from '@/lib/email';
 import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { workerInstanceId } from '@/lib/kiloclaw/instance-registry';
 import { autoResumeIfSuspended, ensureAutoIntroSchedule } from '@/lib/kiloclaw/stripe-handlers';
 import {
   KILOCLAW_PLAN_COST_MICRODOLLARS,
@@ -675,10 +676,12 @@ export async function runKiloClawBillingLifecycleCron(
       id: kiloclaw_subscriptions.id,
       user_id: kiloclaw_subscriptions.user_id,
       instance_id: kiloclaw_subscriptions.instance_id,
+      sandbox_id: kiloclaw_instances.sandbox_id,
       email: kilocode_users.google_user_email,
     })
     .from(kiloclaw_subscriptions)
     .innerJoin(kilocode_users, eq(kiloclaw_subscriptions.user_id, kilocode_users.id))
+    .leftJoin(kiloclaw_instances, eq(kiloclaw_subscriptions.instance_id, kiloclaw_instances.id))
     .where(
       and(
         eq(kiloclaw_subscriptions.status, 'trialing'),
@@ -696,7 +699,10 @@ export async function runKiloClawBillingLifecycleCron(
       // with instance_id=null has nothing to stop.
       if (row.instance_id)
         try {
-          await client.stop(row.user_id, row.instance_id);
+          await client.stop(
+            row.user_id,
+            workerInstanceId({ id: row.instance_id, sandbox_id: row.sandbox_id ?? undefined })
+          );
         } catch (stopError) {
           const isExpected =
             stopError instanceof KiloClawApiError &&
@@ -754,10 +760,12 @@ export async function runKiloClawBillingLifecycleCron(
       id: kiloclaw_subscriptions.id,
       user_id: kiloclaw_subscriptions.user_id,
       instance_id: kiloclaw_subscriptions.instance_id,
+      sandbox_id: kiloclaw_instances.sandbox_id,
       email: kilocode_users.google_user_email,
     })
     .from(kiloclaw_subscriptions)
     .innerJoin(kilocode_users, eq(kiloclaw_subscriptions.user_id, kilocode_users.id))
+    .leftJoin(kiloclaw_instances, eq(kiloclaw_subscriptions.instance_id, kiloclaw_instances.id))
     .where(
       and(
         eq(kiloclaw_subscriptions.status, 'canceled'),
@@ -770,7 +778,10 @@ export async function runKiloClawBillingLifecycleCron(
     try {
       if (row.instance_id)
         try {
-          await client.stop(row.user_id, row.instance_id);
+          await client.stop(
+            row.user_id,
+            workerInstanceId({ id: row.instance_id, sandbox_id: row.sandbox_id ?? undefined })
+          );
         } catch (stopError) {
           const isExpected =
             stopError instanceof KiloClawApiError &&
@@ -871,10 +882,12 @@ export async function runKiloClawBillingLifecycleCron(
       id: kiloclaw_subscriptions.id,
       user_id: kiloclaw_subscriptions.user_id,
       instance_id: kiloclaw_subscriptions.instance_id,
+      sandbox_id: kiloclaw_instances.sandbox_id,
       email: kilocode_users.google_user_email,
     })
     .from(kiloclaw_subscriptions)
     .innerJoin(kilocode_users, eq(kiloclaw_subscriptions.user_id, kilocode_users.id))
+    .leftJoin(kiloclaw_instances, eq(kiloclaw_subscriptions.instance_id, kiloclaw_instances.id))
     .where(
       and(
         lt(kiloclaw_subscriptions.destruction_deadline, now),
@@ -886,7 +899,10 @@ export async function runKiloClawBillingLifecycleCron(
     try {
       if (row.instance_id)
         try {
-          await client.destroy(row.user_id, row.instance_id);
+          await client.destroy(
+            row.user_id,
+            workerInstanceId({ id: row.instance_id, sandbox_id: row.sandbox_id ?? undefined })
+          );
         } catch (destroyError) {
           const isExpected =
             destroyError instanceof KiloClawApiError &&
@@ -961,10 +977,12 @@ export async function runKiloClawBillingLifecycleCron(
       id: kiloclaw_subscriptions.id,
       user_id: kiloclaw_subscriptions.user_id,
       instance_id: kiloclaw_subscriptions.instance_id,
+      sandbox_id: kiloclaw_instances.sandbox_id,
       email: kilocode_users.google_user_email,
     })
     .from(kiloclaw_subscriptions)
     .innerJoin(kilocode_users, eq(kiloclaw_subscriptions.user_id, kilocode_users.id))
+    .leftJoin(kiloclaw_instances, eq(kiloclaw_subscriptions.instance_id, kiloclaw_instances.id))
     .where(
       and(
         eq(kiloclaw_subscriptions.status, 'past_due'),
@@ -977,7 +995,10 @@ export async function runKiloClawBillingLifecycleCron(
     try {
       if (row.instance_id)
         try {
-          await client.stop(row.user_id, row.instance_id);
+          await client.stop(
+            row.user_id,
+            workerInstanceId({ id: row.instance_id, sandbox_id: row.sandbox_id ?? undefined })
+          );
         } catch (stopError) {
           const isExpected =
             stopError instanceof KiloClawApiError &&

--- a/src/lib/kiloclaw/instance-lifecycle.ts
+++ b/src/lib/kiloclaw/instance-lifecycle.ts
@@ -10,6 +10,7 @@ import {
 } from '@kilocode/db/schema';
 import { sentryLogger } from '@/lib/utils.server';
 import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { workerInstanceId } from '@/lib/kiloclaw/instance-registry';
 
 const logInfo = sentryLogger('kiloclaw-instance-lifecycle', 'info');
 const logError = sentryLogger('kiloclaw-instance-lifecycle', 'error');
@@ -39,20 +40,19 @@ export async function autoResumeIfSuspended(
     : and(eq(kiloclaw_instances.user_id, kiloUserId), isNull(kiloclaw_instances.destroyed_at));
 
   const [targetInstance] = await db
-    .select({ id: kiloclaw_instances.id })
+    .select({ id: kiloclaw_instances.id, sandbox_id: kiloclaw_instances.sandbox_id })
     .from(kiloclaw_instances)
     .where(instanceFilter)
     .limit(1);
-  const targetInstanceId = targetInstance?.id;
 
-  if (targetInstanceId) {
+  if (targetInstance) {
     try {
       const client = new KiloClawInternalClient();
-      await client.start(kiloUserId, targetInstanceId);
+      await client.start(kiloUserId, workerInstanceId(targetInstance));
     } catch (startError) {
       logError('Failed to auto-resume instance', {
         user_id: kiloUserId,
-        instance_id: targetInstanceId,
+        instance_id: targetInstance.id,
         error: startError instanceof Error ? startError.message : String(startError),
       });
       // Preserve suspension state so the interrupted-auto-resume retry
@@ -97,6 +97,6 @@ export async function autoResumeIfSuspended(
   logInfo('Auto-resume completed', {
     user_id: kiloUserId,
     instance_id: instanceId ?? null,
-    had_active_instance: !!targetInstanceId,
+    had_active_instance: !!targetInstance,
   });
 }

--- a/src/lib/kiloclaw/kiloclaw-user-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-user-client.ts
@@ -33,7 +33,7 @@ export class KiloClawUserClient {
 
   private async request<T>(path: string, options?: RequestInit, ctx?: RequestContext): Promise<T> {
     const url = ctx?.instanceId
-      ? `${this.baseUrl}${path}?instanceId=${ctx.instanceId}`
+      ? `${this.baseUrl}${path}?instanceId=${encodeURIComponent(ctx.instanceId)}`
       : `${this.baseUrl}${path}`;
     const res = await fetch(url, {
       ...options,

--- a/src/lib/kiloclaw/kiloclaw-user-client.ts
+++ b/src/lib/kiloclaw/kiloclaw-user-client.ts
@@ -9,11 +9,15 @@ import type {
   ChatCredentials,
 } from './types';
 
-type RequestContext = { userId: string };
+type RequestContext = { userId: string; instanceId?: string };
 
 /**
  * KiloClaw worker client for user-facing routes.
  * Uses Bearer JWT auth (forwarding the user's token). Server-only.
+ *
+ * When `instanceId` is provided in RequestContext, it is appended as a
+ * query parameter so the worker resolves the correct DO (instance-keyed
+ * vs legacy userId-keyed).
  */
 export class KiloClawUserClient {
   private authToken: string;
@@ -28,7 +32,10 @@ export class KiloClawUserClient {
   }
 
   private async request<T>(path: string, options?: RequestInit, ctx?: RequestContext): Promise<T> {
-    const res = await fetch(`${this.baseUrl}${path}`, {
+    const url = ctx?.instanceId
+      ? `${this.baseUrl}${path}?instanceId=${ctx.instanceId}`
+      : `${this.baseUrl}${path}`;
+    const res = await fetch(url, {
       ...options,
       headers: {
         Authorization: `Bearer ${this.authToken}`,

--- a/src/routers/admin-kiloclaw-instances-router.ts
+++ b/src/routers/admin-kiloclaw-instances-router.ts
@@ -519,8 +519,9 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     .mutation(async ({ input }) => {
       const fallbackMessage = 'Failed to start kilo CLI run';
       try {
+        const instance = await getActiveInstance(input.userId);
         const client = new KiloClawInternalClient();
-        return await client.startKiloCliRun(input.userId, input.prompt);
+        return await client.startKiloCliRun(input.userId, input.prompt, workerInstanceId(instance));
       } catch (err) {
         console.error('Failed to start kilo CLI run for user:', input.userId, err);
         throwKiloclawAdminError(err, fallbackMessage);
@@ -530,8 +531,9 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
   getKiloCliRunStatus: adminProcedure.input(GatewayProcessSchema).query(async ({ input }) => {
     const fallbackMessage = 'Failed to get kilo CLI run status';
     try {
+      const instance = await getActiveInstance(input.userId);
       const client = new KiloClawInternalClient();
-      return await client.getKiloCliRunStatus(input.userId);
+      return await client.getKiloCliRunStatus(input.userId, workerInstanceId(instance));
     } catch (err) {
       console.error('Failed to get kilo CLI run status for user:', input.userId, err);
       throwKiloclawAdminError(err, fallbackMessage);
@@ -751,7 +753,13 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     )
     .mutation(async ({ input }) => {
       const [row] = await db
-        .select({ user: kilocode_users })
+        .select({
+          user: kilocode_users,
+          instance: {
+            id: kiloclaw_instances.id,
+            sandbox_id: kiloclaw_instances.sandbox_id,
+          },
+        })
         .from(kiloclaw_instances)
         .innerJoin(kilocode_users, eq(kiloclaw_instances.user_id, kilocode_users.id))
         .where(eq(kiloclaw_instances.id, input.instanceId))
@@ -767,7 +775,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       try {
         return await client.restartMachine(
           input.imageTag ? { imageTag: input.imageTag } : undefined,
-          { userId: row.user.id }
+          { userId: row.user.id, instanceId: workerInstanceId(row.instance) }
         );
       } catch (err) {
         console.error('Failed to restart machine for user:', row.user.id, err);

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -922,17 +922,22 @@ export const kiloclawRouter = createTRPCRouter({
 
   // User-facing (user client -- forwards user's short-lived JWT)
   getConfig: baseProcedure.query(async ({ ctx }) => {
+    const instance = await getActiveInstance(ctx.user.id);
     const client = new KiloClawUserClient(
       generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
     );
-    return client.getConfig({ userId: ctx.user.id });
+    return client.getConfig({ userId: ctx.user.id, instanceId: workerInstanceId(instance) });
   }),
 
   getChannelCatalog: baseProcedure.query(async ({ ctx }) => {
+    const instance = await getActiveInstance(ctx.user.id);
     const client = new KiloClawUserClient(
       generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
     );
-    const config = await client.getConfig({ userId: ctx.user.id });
+    const config = await client.getConfig({
+      userId: ctx.user.id,
+      instanceId: workerInstanceId(instance),
+    });
     const channels = getEntriesByCategory('channel');
 
     return channels.map(entry => ({
@@ -954,10 +959,14 @@ export const kiloclawRouter = createTRPCRouter({
   }),
 
   getSecretCatalog: baseProcedure.query(async ({ ctx }) => {
+    const instance = await getActiveInstance(ctx.user.id);
     const client = new KiloClawUserClient(
       generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
     );
-    const config = await client.getConfig({ userId: ctx.user.id });
+    const config = await client.getConfig({
+      userId: ctx.user.id,
+      instanceId: workerInstanceId(instance),
+    });
     const tools = getEntriesByCategory('tool');
 
     return tools.map(entry => ({
@@ -994,12 +1003,13 @@ export const kiloclawRouter = createTRPCRouter({
         .optional()
     )
     .mutation(async ({ ctx, input }) => {
+      const instance = await getActiveInstance(ctx.user.id);
       const client = new KiloClawUserClient(
         generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
       );
       const result = await client.restartMachine(
         input?.imageTag ? { imageTag: input.imageTag } : undefined,
-        { userId: ctx.user.id }
+        { userId: ctx.user.id, instanceId: workerInstanceId(instance) }
       );
       if (result.success) {
         PostHogClient().capture({


### PR DESCRIPTION
## Summary

After the multi-instance migration (to support org users), new KiloClaw instances use `ki_`-prefixed sandbox IDs and DOs keyed by `instanceId` (DB UUID) instead of `userId`. Several Next.js → worker call paths were not passing `?instanceId=` to the worker, causing the worker's `resolveStub()` to fall back to `idFromName(userId)` — resolving a wrong, empty DO. This produced `"No machine exists"` errors on restart and would silently return stale/empty data from other endpoints.

**What changed:**
- `KiloClawUserClient` now accepts `instanceId` in `RequestContext` and appends it as a query param to all worker requests.
- 13 call sites across 6 files updated to look up the active instance and pass `workerInstanceId()`:
  - **User-facing tRPC:** `getConfig`, `getChannelCatalog`, `getSecretCatalog`, `restartMachine`
  - **Admin tRPC:** `restartMachine`, `startKiloCliRun`, `getKiloCliRunStatus`
  - **API routes:** `/api/kiloclaw/status`, `/api/kiloclaw/chat-credentials`
  - **Billing lifecycle cron:** all 4 sweeps (trial expiry, subscription expiry, instance destruction, past-due cleanup) — added `leftJoin` on `kiloclaw_instances` to get `sandbox_id`
  - **Instance lifecycle:** `autoResumeIfSuspended`

Legacy instances (non-`ki_` prefix) are unaffected — `workerInstanceId()` returns `undefined` for them, preserving the existing userId-keyed DO resolution.

## Verification

- [x] `pnpm typecheck` — passes (only pre-existing `csv-parse/sync` error in unrelated migration script)
- [x] `pnpm format` — passes
- [x] `pnpm lint` — passes for changed files (pre-existing lint errors in `kilo-app/` only)
- [x] Confirmed via Axiom logs that the error is `{"success":false,"error":"No machine exists"}` for both the reported user (`f2f72af0-...`) and test instance (`f1a848ca-...`), despite DOs having valid `flyMachineId`

## Visual Changes

N/A

## Reviewer Notes

- The worker side already accepts `?instanceId=` on all routes — no worker changes needed.
- The `workerInstanceId()` helper is the existing bridge function that returns the DB UUID for `ki_`-prefixed instances and `undefined` for legacy ones. All fixed call sites follow the same pattern already used by `KiloClawInternalClient` callers (e.g., `getStatus`, `start`, `stop`).
- The billing cron sweeps add a `leftJoin` on `kiloclaw_instances` — this is safe because the `instance_id` guard (`if (row.instance_id)`) already exists before each worker call, and the join is on the PK.
- Risk: low. All changes are additive — passing an extra query param that the worker already handles. Legacy instances pass `undefined` and behave identically to before.