### PR TITLE
fix(admin): invalidate controllerVersion on machineRedeploy and machineUpgrade success

### DIFF
--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1221,6 +1221,13 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         toast.success('Redeploy requested');
         invalidateMachineQueries();
         invalidateGatewayQueries();
+        if (data?.user_id) {
+          void queryClient.invalidateQueries({
+            queryKey: trpc.admin.kiloclawInstances.controllerVersion.queryKey({
+              userId: data.user_id,
+            }),
+          });
+        }
         setAwaitingRestartCompletion(true);
       },
       onError: err => {
@@ -1235,6 +1242,13 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         toast.success('Upgrade to latest requested');
         invalidateMachineQueries();
         invalidateGatewayQueries();
+        if (data?.user_id) {
+          void queryClient.invalidateQueries({
+            queryKey: trpc.admin.kiloclawInstances.controllerVersion.queryKey({
+              userId: data.user_id,
+            }),
+          });
+        }
         setAwaitingRestartCompletion(true);
       },
       onError: err => {


### PR DESCRIPTION
## Summary

Adds an immediate `controllerVersion` query invalidation to the `onSuccess` callbacks of both `machineRedeploy` and `machineUpgrade` mutations in `KiloclawInstanceDetail.tsx`.

Previously, after clicking Redeploy or Upgrade to Latest, the Gateway section could show stale data (e.g. "Unavailable until redeploy") because `controllerVersion` was only re-fetched once the machine returned to `running` state (via the deferred `useEffect` polling mechanism). This change adds an immediate invalidation alongside the existing deferred one, so the UI is refreshed promptly after the mutation succeeds.

The deferred re-invalidation via `useEffect` (which fires once the machine transitions back to `running`) is preserved unchanged.

## Verification

- Code review only; no automated tests were run (this is a UI query invalidation fix with no testable side effects at unit level).
- The change follows the exact same pattern as the existing `controllerVersion` invalidation in the `awaitingRestartCompletion` `useEffect`.
- Rebases cleanly onto current `main`.

## Visual Changes

N/A

## Reviewer Notes

The guard `if (data?.user_id)` is required because `controllerVersion.queryKey` requires a `userId` — this matches the pattern used in the deferred re-invalidation block. The mutation `data` parameter already carries `user_id` from the server response, so this is safe.