### PR TITLE
fix(admin): invalidate controllerVersion on machineRedeploy and machineUpgrade success

### DIFF
--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1221,6 +1221,13 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         toast.success('Redeploy requested');
         invalidateMachineQueries();
         invalidateGatewayQueries();
+        if (data?.user_id) {
+          void queryClient.invalidateQueries({
+            queryKey: trpc.admin.kiloclawInstances.controllerVersion.queryKey({
+              userId: data.user_id,
+            }),
+          });
+        }
         setAwaitingRestartCompletion(true);
       },
       onError: err => {
@@ -1235,6 +1242,13 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         toast.success('Upgrade to latest requested');
         invalidateMachineQueries();
         invalidateGatewayQueries();
+        if (data?.user_id) {
+          void queryClient.invalidateQueries({
+            queryKey: trpc.admin.kiloclawInstances.controllerVersion.queryKey({
+              userId: data.user_id,
+            }),
+          });
+        }
         setAwaitingRestartCompletion(true);
       },
       onError: err => {


### PR DESCRIPTION
## Summary

Adds `controllerVersion` query invalidation to the `onSuccess` callbacks of both `machineRedeploy` and `machineUpgrade` mutations in `KiloclawInstanceDetail.tsx`.

Previously, only `gatewayStatus` (via `invalidateGatewayQueries()`) and machine queries were invalidated on mutation success. This meant the `controllerVersion` query — used to determine whether features like config restore are supported — could be stale immediately after a redeploy or upgrade, before the machine had returned to `running`. The fix adds an eager invalidation at mutation success time, following the same pattern as the existing deferred re-invalidation via `useEffect` (which fires once the machine returns to `running`).

## Verification

- Code review of the diff against existing patterns in `KiloclawInstanceDetail.tsx`
- Confirmed the `controllerVersion` query key shape matches what is used elsewhere in the file (userId-scoped via `trpc.admin.kiloclawInstances.controllerVersion.queryKey({ userId })`)
- Confirmed `data?.user_id` guard is consistent with `invalidateGatewayQueries()` guard
- No quality gates configured for this rig

## Visual Changes

N/A

## Reviewer Notes

The change is additive and low-risk: it eagerly invalidates `controllerVersion` at mutation success, which triggers a re-fetch. The deferred `useEffect`-based invalidation (polling until machine is `running`) is preserved unchanged. The guard `if (data?.user_id)` matches the guard in `invalidateGatewayQueries()` for consistency.