### PR TITLE
fix(gastown): stop false-positive invariant violations in reconciler

### DIFF
--- a/cloudflare-gastown/src/dos/town/reconciler.ts
+++ b/cloudflare-gastown/src/dos/town/reconciler.ts
@@ -1494,6 +1494,7 @@ export function checkInvariants(sql: SqlStorage): Violation[] {
   const violations: Violation[] = [];
 
   // Invariant 7: Working agents must have hooks
+  // Mayors are always 'working' and intentionally have no hook — exclude them.
   const unhookedWorkers = z
     .object({ bead_id: z.string() })
     .array()
@@ -1505,6 +1506,7 @@ export function checkInvariants(sql: SqlStorage): Violation[] {
         FROM ${agent_metadata}
         WHERE ${agent_metadata.status} = 'working'
           AND ${agent_metadata.current_hook_bead_id} IS NULL
+          AND ${agent_metadata.role} != 'mayor'
       `,
         []
       ),
@@ -1516,26 +1518,27 @@ export function checkInvariants(sql: SqlStorage): Violation[] {
     });
   }
 
-  // Invariant 5: Convoy beads should not be in_progress
-  const inProgressConvoys = z
-    .object({ bead_id: z.string() })
+  // Invariant 5: Convoy beads should not be in unexpected states.
+  // Valid transient states: open, in_progress, in_review, closed.
+  const badStateConvoys = z
+    .object({ bead_id: z.string(), status: z.string() })
     .array()
     .parse([
       ...query(
         sql,
         /* sql */ `
-        SELECT ${beads.bead_id}
+        SELECT ${beads.bead_id}, ${beads.status}
         FROM ${beads}
         WHERE ${beads.type} = 'convoy'
-          AND ${beads.status} = 'in_progress'
+          AND ${beads.status} NOT IN ('open', 'in_progress', 'in_review', 'closed')
       `,
         []
       ),
     ]);
-  for (const c of inProgressConvoys) {
+  for (const c of badStateConvoys) {
     violations.push({
       invariant: 5,
-      message: `Convoy bead ${c.bead_id} is in_progress (should only be open or closed)`,
+      message: `Convoy bead ${c.bead_id} is in unexpected state '${c.status}'`,
     });
   }
 


### PR DESCRIPTION
## Summary

- **Invariant 7**: Exclude mayors from the "working agent must have a hook" check — mayors are always `working` and intentionally have no hook, causing false-positive violations every 5s.
- **Invariant 5**: Widen the valid convoy bead states from just `open`/`closed` to include `in_progress` and `in_review` as valid transient states. Only flag truly unexpected states instead of all in-progress convoys.

## Verification

- Typecheck passes (`pnpm typecheck` via pre-push hook)
- Lint passes (oxlint via pre-push hook)
- Format check passes (oxfmt via pre-push hook)
- Manual review of SQL query changes for correctness

## Visual Changes

N/A

## Reviewer Notes

These two invariant checks were firing every reconciler tick (5s), spamming logs with false positives. The fixes are minimal SQL filter changes with clear semantics.