### PR TITLE
fix(gastown): preserve org billing context across model changes

### DIFF
--- a/cloudflare-gastown/container/src/control-server.ts
+++ b/cloudflare-gastown/container/src/control-server.ts
@@ -142,6 +142,11 @@ app.post('/agents/start', async c => {
     return c.json({ error: 'Invalid request body', issues: parsed.error.issues }, 400);
   }
 
+  // Persist the organization ID as a standalone env var so it survives
+  // config rebuilds (e.g. model hot-swap). The env var is the primary
+  // source of truth; KILO_CONFIG_CONTENT extraction is the fallback.
+  process.env.GASTOWN_ORGANIZATION_ID = parsed.data.organizationId ?? '';
+
   console.log(
     `[control-server] /agents/start: role=${parsed.data.role} name=${parsed.data.name} rigId=${parsed.data.rigId} agentId=${parsed.data.agentId}`
   );
@@ -211,6 +216,11 @@ app.patch('/agents/:agentId/model', async c => {
     return c.json({ error: 'Invalid request body', issues: parsed.error.issues }, 400);
   }
 
+  // Update org billing context from the request body if provided.
+  if (parsed.data.organizationId) {
+    process.env.GASTOWN_ORGANIZATION_ID = parsed.data.organizationId;
+  }
+
   // Sync config-derived env vars from X-Town-Config into process.env so
   // the SDK server restart picks up fresh tokens and git identity.
   // The middleware already parsed the header into lastKnownTownConfig.
@@ -251,6 +261,12 @@ app.patch('/agents/:agentId/model', async c => {
       process.env.GASTOWN_DISABLE_AI_COAUTHOR = '1';
     } else {
       delete process.env.GASTOWN_DISABLE_AI_COAUTHOR;
+    }
+    // organization_id — keep the standalone env var in sync with the
+    // town config so org billing context is never lost.
+    const orgId = cfg.organization_id;
+    if (typeof orgId === 'string' && orgId) {
+      process.env.GASTOWN_ORGANIZATION_ID = orgId;
     }
   }
 

--- a/cloudflare-gastown/container/src/process-manager.ts
+++ b/cloudflare-gastown/container/src/process-manager.ts
@@ -750,6 +750,12 @@ export async function sendMessage(agentId: string, prompt: string): Promise<void
  * by `buildKiloConfigContent` at agent startup.
  */
 function extractOrganizationId(): string | undefined {
+  // Primary source: standalone env var set by control-server on /agents/start
+  // and updated on every PATCH /model via X-Town-Config.
+  const envOrgId = process.env.GASTOWN_ORGANIZATION_ID;
+  if (envOrgId) return envOrgId;
+
+  // Fallback: extract from KILO_CONFIG_CONTENT (legacy path)
   const raw = process.env.KILO_CONFIG_CONTENT;
   if (!raw) return undefined;
   try {

--- a/cloudflare-gastown/container/src/types.ts
+++ b/cloudflare-gastown/container/src/types.ts
@@ -80,6 +80,8 @@ export const UpdateAgentModelRequest = z.object({
   smallModel: z.string().optional(),
   /** Pre-formatted conversation history to inject into the new session prompt. */
   conversationHistory: z.string().optional(),
+  /** Organization ID — ensures org billing context is preserved across model changes. */
+  organizationId: z.string().optional(),
 });
 export type UpdateAgentModelRequest = z.infer<typeof UpdateAgentModelRequest>;
 

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -2067,6 +2067,11 @@ export class TownDO extends DurableObject<Env> {
       // before restarting the SDK server (tokens, git identity, etc.).
       const containerConfig = await config.buildContainerConfig(this.ctx.storage, this.env);
 
+      // Resolve townConfig to thread the organization_id into the request body
+      // (belt-and-suspenders: ensures org billing survives even if X-Town-Config
+      // header parsing fails on the container side).
+      const townConfig = await config.getTownConfig(this.ctx.storage);
+
       const updated = await dispatch.updateAgentModelInContainer(
         this.env,
         townId,
@@ -2074,7 +2079,8 @@ export class TownDO extends DurableObject<Env> {
         model,
         smallModel,
         conversationHistory || undefined,
-        containerConfig
+        containerConfig,
+        townConfig.organization_id
       );
       if (updated) {
         console.log(

--- a/cloudflare-gastown/src/dos/town/config.ts
+++ b/cloudflare-gastown/src/dos/town/config.ts
@@ -150,5 +150,6 @@ export async function buildContainerConfig(
     disable_ai_coauthor: config.disable_ai_coauthor,
     kilo_api_url: env.KILO_API_URL ?? '',
     gastown_api_url: env.GASTOWN_API_URL ?? '',
+    organization_id: config.organization_id,
   };
 }

--- a/cloudflare-gastown/src/dos/town/container-dispatch.ts
+++ b/cloudflare-gastown/src/dos/town/container-dispatch.ts
@@ -676,7 +676,8 @@ export async function updateAgentModelInContainer(
   model: string,
   smallModel?: string,
   conversationHistory?: string,
-  containerConfig?: Record<string, unknown>
+  containerConfig?: Record<string, unknown>,
+  organizationId?: string
 ): Promise<boolean> {
   try {
     const container = getTownContainerStub(env, townId);
@@ -691,6 +692,7 @@ export async function updateAgentModelInContainer(
         model,
         ...(smallModel ? { smallModel } : {}),
         ...(conversationHistory ? { conversationHistory } : {}),
+        ...(organizationId ? { organizationId } : {}),
       }),
     });
     return response.ok;


### PR DESCRIPTION
## Summary

When a model hot-swap occurs via `PATCH /agents/:agentId/model`, the `KILO_CONFIG_CONTENT` env var gets rebuilt and the organization ID embedded within it could be lost, breaking billing attribution.

This adds three defense layers to ensure the org billing context survives model changes:

1. **Standalone env var** (`GASTOWN_ORGANIZATION_ID`): Set on `/agents/start` and read first in `extractOrganizationId()` before falling back to `KILO_CONFIG_CONTENT` extraction.
2. **Request body passthrough**: `organizationId` field added to `UpdateAgentModelRequest`; `Town.do.ts` resolves `townConfig.organization_id` and threads it through `container-dispatch.ts` into the PATCH body.
3. **X-Town-Config sync**: `organization_id` added to `buildContainerConfig()` output; the PATCH handler extracts it from the header and updates the env var.

**Files changed:** `control-server.ts`, `process-manager.ts`, `types.ts`, `Town.do.ts`, `config.ts`, `container-dispatch.ts`

## Verification

- [x] `pnpm typecheck` — passes (0 errors)
- [x] `pnpm format:check` — passes
- [x] `pnpm lint` — passes
- [x] Code review: verified env var precedence (X-Town-Config > body > initial start), empty string handling, and fallback paths

## Visual Changes

N/A

## Reviewer Notes

- The X-Town-Config `organization_id` value writes last in the PATCH handler (after the body value), which is intentional — the header is the authoritative source while the body serves as a belt-and-suspenders fallback if header parsing fails.
- `parsed.data.organizationId ?? ''` on the `/agents/start` path means missing values produce an empty string, which `extractOrganizationId()` treats as falsy, correctly falling through to the `KILO_CONFIG_CONTENT` legacy extraction.