### PR TITLE
fix(dev): remove -- separator that broke wrangler CLI flags

### DIFF
--- a/dev/local/env-sync/plan.ts
+++ b/dev/local/env-sync/plan.ts
@@ -249,7 +249,9 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
 
     if (existingContent !== null) {
       const oldVars = parseEnvFile(existingContent);
+      const missingSet = new Set(missingValues);
       for (const [key, newVal] of resolvedVars) {
+        if (missingSet.has(key)) continue;
         const oldVal = oldVars.get(key);
         if (oldVal !== newVal) {
           keyChanges.push({ key, oldValue: oldVal, newValue: newVal });

--- a/dev/local/services.ts
+++ b/dev/local/services.ts
@@ -276,7 +276,6 @@ function buildServiceDefs(): ServiceDef[] {
         'pnpm',
         'run',
         'dev',
-        '--',
         '--port',
         String(port),
         '--inspector-port',


### PR DESCRIPTION
## Summary

Two fixes to the local dev orchestrator:

1. **Remove `--` separator from wrangler commands** (`dev/local/services.ts`) — pnpm v10 forwards `--` literally to the child process, causing wrangler's yargs parser to treat all subsequent flags (`--port`, `--inspector-port`, `--ip`) as positional arguments. This made `--inspector-port` silently ignored and `--port`/`--ip` only appeared to work because `wrangler.jsonc` had matching default values.

2. **Skip missing-value keys in env sync diff** (`dev/local/env-sync/plan.ts`) — Keys listed in `missingValues` have no resolved value yet. Including them in the key-change diff produced spurious "changed" entries that could overwrite manually-set values with empty strings during env sync.

## Verification

- [x] Manually verified `--inspector-port` is respected after the fix (`curl http://127.0.0.1:<port>/json` returns valid devtools URLs)
- [x] Confirmed `--port` and `--ip` flags are correctly parsed by wrangler
- [x] Pre-push hooks pass (typecheck, format, lint)

## Visual Changes

N/A

## Reviewer Notes

The `--` was originally added for pnpm v8/v9 compatibility to separate pnpm args from script args. In pnpm v10, `pnpm run <script> <args>` forwards args directly without needing `--`. When `--` is included, it's forwarded literally, breaking yargs-based CLIs like wrangler.