### PR TITLE
refactor(chat): replace New Session button with icon in sidebar header

### DIFF
--- a/src/components/cloud-agent-next/ChatSidebar.tsx
+++ b/src/components/cloud-agent-next/ChatSidebar.tsx
@@ -382,66 +382,66 @@ export function ChatSidebar({
           </button>
           {(onPlatformChange || onProjectChange) && (
             <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                className={cn(
-                  'hover:bg-accent rounded-md p-1.5 transition-colors',
-                  hasActiveFilter && 'bg-accent'
+              <DropdownMenuTrigger asChild>
+                <button
+                  className={cn(
+                    'hover:bg-accent rounded-md p-1.5 transition-colors',
+                    hasActiveFilter && 'bg-accent'
+                  )}
+                >
+                  <SlidersHorizontal className="text-muted-foreground h-4 w-4" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {onProjectChange && recentProjects.length > 0 && (
+                  <>
+                    <DropdownMenuLabel>Project</DropdownMenuLabel>
+                    <DropdownMenuItem onClick={() => onProjectChange(undefined)}>
+                      <Check
+                        className={cn('mr-2 h-4 w-4', !projectFilter ? 'opacity-100' : 'opacity-0')}
+                      />
+                      All projects
+                    </DropdownMenuItem>
+                    {recentProjects.map(project => {
+                      const isActive = projectFilter === project.gitUrl;
+                      return (
+                        <DropdownMenuItem
+                          key={project.gitUrl}
+                          onClick={() => onProjectChange(project.gitUrl)}
+                        >
+                          <Check
+                            className={cn('mr-2 h-4 w-4', isActive ? 'opacity-100' : 'opacity-0')}
+                          />
+                          {project.displayName}
+                        </DropdownMenuItem>
+                      );
+                    })}
+                  </>
                 )}
-              >
-                <SlidersHorizontal className="text-muted-foreground h-4 w-4" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {onProjectChange && recentProjects.length > 0 && (
-                <>
-                  <DropdownMenuLabel>Project</DropdownMenuLabel>
-                  <DropdownMenuItem onClick={() => onProjectChange(undefined)}>
-                    <Check
-                      className={cn('mr-2 h-4 w-4', !projectFilter ? 'opacity-100' : 'opacity-0')}
-                    />
-                    All projects
-                  </DropdownMenuItem>
-                  {recentProjects.map(project => {
-                    const isActive = projectFilter === project.gitUrl;
-                    return (
-                      <DropdownMenuItem
-                        key={project.gitUrl}
-                        onClick={() => onProjectChange(project.gitUrl)}
-                      >
-                        <Check
-                          className={cn('mr-2 h-4 w-4', isActive ? 'opacity-100' : 'opacity-0')}
-                        />
-                        {project.displayName}
-                      </DropdownMenuItem>
-                    );
-                  })}
-                </>
-              )}
-              {onPlatformChange && (
-                <>
-                  {onProjectChange && recentProjects.length > 0 && <DropdownMenuSeparator />}
-                  <DropdownMenuLabel>Platform</DropdownMenuLabel>
-                  {PLATFORM_FILTERS.map(p => {
-                    const isFilterActive = p === 'all' ? !platformFilter : platformFilter === p;
-                    return (
-                      <DropdownMenuItem
-                        key={p}
-                        onClick={() => onPlatformChange(p === 'all' ? undefined : p)}
-                      >
-                        <Check
-                          className={cn(
-                            'mr-2 h-4 w-4',
-                            isFilterActive ? 'opacity-100' : 'opacity-0'
-                          )}
-                        />
-                        {platformFilterLabel(p)}
-                      </DropdownMenuItem>
-                    );
-                  })}
-                </>
-              )}
-            </DropdownMenuContent>
+                {onPlatformChange && (
+                  <>
+                    {onProjectChange && recentProjects.length > 0 && <DropdownMenuSeparator />}
+                    <DropdownMenuLabel>Platform</DropdownMenuLabel>
+                    {PLATFORM_FILTERS.map(p => {
+                      const isFilterActive = p === 'all' ? !platformFilter : platformFilter === p;
+                      return (
+                        <DropdownMenuItem
+                          key={p}
+                          onClick={() => onPlatformChange(p === 'all' ? undefined : p)}
+                        >
+                          <Check
+                            className={cn(
+                              'mr-2 h-4 w-4',
+                              isFilterActive ? 'opacity-100' : 'opacity-0'
+                            )}
+                          />
+                          {platformFilterLabel(p)}
+                        </DropdownMenuItem>
+                      );
+                    })}
+                  </>
+                )}
+              </DropdownMenuContent>
             </DropdownMenu>
           )}
         </div>

--- a/src/components/cloud-agent-next/ChatSidebar.tsx
+++ b/src/components/cloud-agent-next/ChatSidebar.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Button } from '@/components/Button';
 import {
-  Plus,
+  SquarePen,
   Search,
   SlidersHorizontal,
   MoreHorizontal,
@@ -12,6 +11,7 @@ import {
   X,
   Pencil,
 } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { TimeAgo } from '@/components/shared/TimeAgo';
 import { usePathname, useRouter } from 'next/navigation';
 import { isToday, isYesterday, startOfDay, differenceInCalendarDays, format } from 'date-fns';
@@ -358,21 +358,30 @@ export function ChatSidebar({
     <div className="flex h-full flex-col">
       {/* Header */}
       <div className={cn('flex items-center gap-2 border-b px-3 py-2.5', isInSheet && 'pt-14')}>
-        <Button onClick={handleNewSession} className="flex-1" variant="primary" size="sm">
-          <Plus className="mr-2 h-4 w-4" />
-          New Session
-        </Button>
-        <button
-          onClick={toggleSearch}
-          className={cn(
-            'hover:bg-accent rounded-md p-1.5 transition-colors',
-            showSearch && 'bg-accent'
-          )}
-        >
-          <Search className="text-muted-foreground h-4 w-4" />
-        </button>
-        {(onPlatformChange || onProjectChange) && (
-          <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={handleNewSession}
+              className="hover:bg-accent rounded-md p-1.5 transition-colors"
+              aria-label="New session"
+            >
+              <SquarePen className="text-muted-foreground h-4 w-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">New session</TooltipContent>
+        </Tooltip>
+        <div className="ml-auto flex items-center gap-1">
+          <button
+            onClick={toggleSearch}
+            className={cn(
+              'hover:bg-accent rounded-md p-1.5 transition-colors',
+              showSearch && 'bg-accent'
+            )}
+          >
+            <Search className="text-muted-foreground h-4 w-4" />
+          </button>
+          {(onPlatformChange || onProjectChange) && (
+            <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <button
                 className={cn(
@@ -433,8 +442,9 @@ export function ChatSidebar({
                 </>
               )}
             </DropdownMenuContent>
-          </DropdownMenu>
-        )}
+            </DropdownMenu>
+          )}
+        </div>
       </div>
 
       {/* Collapsible search */}


### PR DESCRIPTION
## Summary

Replace the prominent "New Session" button in the chat sidebar header with a compact `SquarePen` icon button wrapped in a tooltip. The search and filter controls are moved to the right side of the header using `ml-auto`, creating a cleaner, more minimal sidebar layout.

Changes:
- Remove the `Button` component import and `Plus` icon; add `SquarePen` icon and `Tooltip` components
- Replace the full-width "New Session" button with a small icon button + tooltip
- Group search and filter dropdown to the right with `ml-auto`

## Verification

- [x] `pnpm typecheck` — passed
- [x] `pnpm format` — passed

## Visual Changes

<img width="320" height="287" alt="Screenshot 2026-04-01 at 13 11 15" src="https://github.com/user-attachments/assets/937ede7b-f273-4401-84af-a08f502bd910" />


## Reviewer Notes

- The `Button` component import from `@/components/Button` is removed entirely — no other usage in this file.
- New dependency on `@/components/ui/tooltip` (already used elsewhere in the codebase).
- The `handleNewSession` callback is unchanged; only the trigger element changed.