### PR TITLE
fix(cloud-agent): arm SSE transport timer on initial subscription

### DIFF
--- a/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
+++ b/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
@@ -508,5 +508,18 @@ describe('createLifecycleManager', () => {
       await vi.advanceTimersByTimeAsync(15_000);
       expect(connectionFns.reconnectEventSubscription).not.toHaveBeenCalled();
     });
+
+    it('initial arming triggers reconnect when stream never yields', async () => {
+      const mgr = createManager();
+      state.startJob(createJobContext());
+
+      // Simulate the initial arming added in startEventSubscription()
+      // before the for-await loop — no stream events follow.
+      mgr.onSseEvent();
+
+      // After 15s with no further onSseEvent calls, the timer should fire.
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(connectionFns.reconnectEventSubscription).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/cloud-agent-next/wrapper/src/connection.ts
+++ b/cloud-agent-next/wrapper/src/connection.ts
@@ -396,6 +396,11 @@ export function createConnectionManager(
 
     void (async () => {
       try {
+        // Arm the transport timer before subscribe() so a hung HTTP
+        // request (or a stalled initial SSE handshake) is detected
+        // within SSE_TRANSPORT_TIMEOUT_MS.
+        callbacks.onSseEvent?.();
+
         const result = await config.kiloClient.sdkClient.event.subscribe({
           signal: abortController.signal,
         });
@@ -407,9 +412,6 @@ export function createConnectionManager(
         }
 
         logToFile('SDK event subscription started');
-        // Arm the transport timer immediately so a stalled initial
-        // SSE handshake (no server.connected event) is detected.
-        callbacks.onSseEvent?.();
 
         for await (const event of result.stream) {
           if (abortController.signal.aborted || myGeneration !== eventSubscriptionGeneration) break;

--- a/cloud-agent-next/wrapper/src/connection.ts
+++ b/cloud-agent-next/wrapper/src/connection.ts
@@ -407,6 +407,9 @@ export function createConnectionManager(
         }
 
         logToFile('SDK event subscription started');
+        // Arm the transport timer immediately so a stalled initial
+        // SSE handshake (no server.connected event) is detected.
+        callbacks.onSseEvent?.();
 
         for await (const event of result.stream) {
           if (abortController.signal.aborted || myGeneration !== eventSubscriptionGeneration) break;


### PR DESCRIPTION
## Summary

The 15-second SSE transport timer (`SSE_TRANSPORT_TIMEOUT_MS`) detects stalled event streams and triggers `reconnectEventSubscription()`. However, the timer was only armed by `onSseEvent()` inside the `for await` loop — which never executes if the stream stalls before delivering the first event (e.g., the `fetch()` hangs or the server accepts but never flushes data).

This was observed in production (`ses_2b8063de9fffsAntHMt0i5Unyg`) where the wrapper logged "SDK event subscription started" then went silent for 15+ minutes while the kilo server was actively publishing events. The DO's hung-execution detector eventually killed both executions.

The fix calls `callbacks.onSseEvent?.()` immediately after starting the event subscription, before entering the `for await` loop. This ensures a stalled initial SSE handshake is detected within 15 seconds and triggers reconnection.

## Verification

- [x] `pnpm run typecheck` — passed (main + wrapper)
- [x] `pnpm run test` — 703 tests passed across 28 files (including new test)

## Visual Changes

N/A

## Reviewer Notes

- The production fix is a single `callbacks.onSseEvent?.()` call in `connection.ts` — minimal surface area.
- `server.connected` already calls `onSseEvent` on a healthy stream, so initial arming is a safety net for when that event never arrives.
- Persistently broken SSE endpoints will reconnect every 15s until the DO's hung-execution detector (2-min timeout) kills the execution — better than hanging silently.