### PR TITLE
feat(wasteland): Phase 2 — Core API + Onboarding (Issue #1810)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -194,6 +194,7 @@
         "cloud-agent/src/session/queries/*.ts",
         "cloud-agent-next/src/session/queries/*.ts",
         "cloudflare-gastown/**/*.ts",
+        "cloudflare-wasteland/**/*.ts",
         "cloudflare-webhook-agent-ingest/**/*.ts",
         "kiloclaw/**/*.ts"
       ],

--- a/cloudflare-wasteland/package.json
+++ b/cloudflare-wasteland/package.json
@@ -22,6 +22,7 @@
     "@cloudflare/containers": "^0.1.0",
     "@kilocode/worker-utils": "workspace:*",
     "@sentry/cloudflare": "^9",
+    "@hono/trpc-server": "^0.4.2",
     "@trpc/server": "catalog:",
     "hono": "catalog:",
     "itty-time": "^1.0.6",

--- a/cloudflare-wasteland/src/db/tables/wasteland-registry.table.ts
+++ b/cloudflare-wasteland/src/db/tables/wasteland-registry.table.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { getTableFromZodSchema, getCreateTableQueryFromTable } from '../../util/table';
+
+export const WastelandRegistryRecord = z.object({
+  wasteland_id: z.string(),
+  owner_type: z.enum(['user', 'org']),
+  owner_user_id: z.string().nullable(),
+  organization_id: z.string().nullable(),
+  name: z.string(),
+  created_at: z.string(),
+});
+
+export type WastelandRegistryRecord = z.output<typeof WastelandRegistryRecord>;
+
+export const wasteland_registry = getTableFromZodSchema(
+  'wasteland_registry',
+  WastelandRegistryRecord
+);
+
+export function createTableWastelandRegistry(): string {
+  return getCreateTableQueryFromTable(wasteland_registry, {
+    wasteland_id: `text primary key`,
+    owner_type: `text not null check(owner_type in ('user', 'org'))`,
+    owner_user_id: `text`,
+    organization_id: `text`,
+    name: `text not null`,
+    created_at: `text not null default (datetime('now'))`,
+  });
+}

--- a/cloudflare-wasteland/src/dos/WastelandDO.stub.ts
+++ b/cloudflare-wasteland/src/dos/WastelandDO.stub.ts
@@ -1,9 +1,24 @@
 import { DurableObject } from 'cloudflare:workers';
 
+/** Shape returned by WastelandDO.getConfig() — matches the wasteland_config table. */
+export type WastelandConfigResult = {
+  wasteland_id: string;
+  name: string;
+  owner_type: 'user' | 'org';
+  owner_user_id: string | null;
+  organization_id: string | null;
+  dolthub_upstream: string | null;
+  visibility: 'public' | 'private';
+  status: 'active' | 'deleted';
+  created_at: string;
+  updated_at: string;
+};
+
 /**
  * Stub WastelandDO — placeholder until the full implementation lands.
  * Provides the class export that wrangler.jsonc requires for the
- * WASTELAND durable_objects binding.
+ * WASTELAND durable_objects binding, plus RPC method signatures that
+ * downstream tRPC code depends on.
  */
 export class WastelandDO extends DurableObject<Env> {
   async fetch(): Promise<Response> {
@@ -11,6 +26,10 @@ export class WastelandDO extends DurableObject<Env> {
       status: 501,
       headers: { 'Content-Type': 'application/json' },
     });
+  }
+
+  async getConfig(): Promise<WastelandConfigResult | null> {
+    throw new Error('WastelandDO not yet implemented');
   }
 }
 

--- a/cloudflare-wasteland/src/dos/WastelandDO.stub.ts
+++ b/cloudflare-wasteland/src/dos/WastelandDO.stub.ts
@@ -42,6 +42,15 @@ export type UpdateWastelandConfigInput = {
   status?: 'active' | 'deleted';
 };
 
+/** Shape returned by WastelandDO credential RPCs — matches the wasteland_credentials table. */
+export type WastelandCredentialResult = {
+  user_id: string;
+  encrypted_token: string;
+  dolthub_org: string;
+  rig_handle: string | null;
+  connected_at: string;
+};
+
 /**
  * Stub WastelandDO — placeholder until the full implementation lands.
  * Provides the class export that wrangler.jsonc requires for the
@@ -90,6 +99,25 @@ export class WastelandDO extends DurableObject<Env> {
     _memberId: string,
     _update: { role?: string; trust_level?: number }
   ): Promise<WastelandMemberResult | null> {
+    throw new Error('WastelandDO not yet implemented');
+  }
+
+  // ── Credential management RPCs ──────────────────────────────────────
+
+  async storeCredential(
+    _userId: string,
+    _encryptedToken: string,
+    _dolthubOrg: string,
+    _rigHandle?: string
+  ): Promise<WastelandCredentialResult> {
+    throw new Error('WastelandDO not yet implemented');
+  }
+
+  async getCredential(_userId: string): Promise<WastelandCredentialResult | null> {
+    throw new Error('WastelandDO not yet implemented');
+  }
+
+  async deleteCredential(_userId: string): Promise<void> {
     throw new Error('WastelandDO not yet implemented');
   }
 }

--- a/cloudflare-wasteland/src/dos/WastelandDO.stub.ts
+++ b/cloudflare-wasteland/src/dos/WastelandDO.stub.ts
@@ -14,6 +14,25 @@ export type WastelandConfigResult = {
   updated_at: string;
 };
 
+/** Input for initializeWasteland — creates the wasteland config row. */
+export type InitializeWastelandInput = {
+  wasteland_id: string;
+  name: string;
+  owner_type: 'user' | 'org';
+  owner_user_id: string | null;
+  organization_id: string | null;
+  dolthub_upstream: string | null;
+  visibility: 'public' | 'private';
+};
+
+/** Partial update fields for updateConfig. */
+export type UpdateWastelandConfigInput = {
+  name?: string;
+  visibility?: 'public' | 'private';
+  dolthub_upstream?: string | null;
+  status?: 'active' | 'deleted';
+};
+
 /**
  * Stub WastelandDO — placeholder until the full implementation lands.
  * Provides the class export that wrangler.jsonc requires for the
@@ -28,7 +47,15 @@ export class WastelandDO extends DurableObject<Env> {
     });
   }
 
+  async initializeWasteland(_input: InitializeWastelandInput): Promise<WastelandConfigResult> {
+    throw new Error('WastelandDO not yet implemented');
+  }
+
   async getConfig(): Promise<WastelandConfigResult | null> {
+    throw new Error('WastelandDO not yet implemented');
+  }
+
+  async updateConfig(_input: UpdateWastelandConfigInput): Promise<WastelandConfigResult> {
     throw new Error('WastelandDO not yet implemented');
   }
 }

--- a/cloudflare-wasteland/src/dos/WastelandDO.stub.ts
+++ b/cloudflare-wasteland/src/dos/WastelandDO.stub.ts
@@ -47,11 +47,7 @@ export class WastelandDO extends DurableObject<Env> {
     throw new Error('WastelandDO not yet implemented');
   }
 
-  async addMember(
-    _userId: string,
-    _role: string,
-    _trustLevel: number
-  ): Promise<string> {
+  async addMember(_userId: string, _role: string, _trustLevel: number): Promise<string> {
     throw new Error('WastelandDO not yet implemented');
   }
 

--- a/cloudflare-wasteland/src/dos/WastelandDO.stub.ts
+++ b/cloudflare-wasteland/src/dos/WastelandDO.stub.ts
@@ -14,6 +14,15 @@ export type WastelandConfigResult = {
   updated_at: string;
 };
 
+/** Shape returned by WastelandDO member RPCs — matches the wasteland_members table. */
+export type WastelandMemberResult = {
+  member_id: string;
+  user_id: string;
+  trust_level: number;
+  role: 'contributor' | 'maintainer' | 'owner';
+  joined_at: string;
+};
+
 /**
  * Stub WastelandDO — placeholder until the full implementation lands.
  * Provides the class export that wrangler.jsonc requires for the
@@ -29,6 +38,35 @@ export class WastelandDO extends DurableObject<Env> {
   }
 
   async getConfig(): Promise<WastelandConfigResult | null> {
+    throw new Error('WastelandDO not yet implemented');
+  }
+
+  // ── Member management RPCs ──────────────────────────────────────────
+
+  async listMembers(): Promise<WastelandMemberResult[]> {
+    throw new Error('WastelandDO not yet implemented');
+  }
+
+  async addMember(
+    _userId: string,
+    _role: string,
+    _trustLevel: number
+  ): Promise<string> {
+    throw new Error('WastelandDO not yet implemented');
+  }
+
+  async removeMember(_memberId: string): Promise<void> {
+    throw new Error('WastelandDO not yet implemented');
+  }
+
+  async getMember(_userId: string): Promise<WastelandMemberResult | null> {
+    throw new Error('WastelandDO not yet implemented');
+  }
+
+  async updateMember(
+    _memberId: string,
+    _update: { role?: string; trust_level?: number }
+  ): Promise<WastelandMemberResult | null> {
     throw new Error('WastelandDO not yet implemented');
   }
 }

--- a/cloudflare-wasteland/src/dos/WastelandRegistry.do.ts
+++ b/cloudflare-wasteland/src/dos/WastelandRegistry.do.ts
@@ -1,0 +1,145 @@
+import { DurableObject } from 'cloudflare:workers';
+import { query } from '../util/query.util';
+import {
+  createTableWastelandRegistry,
+  wasteland_registry,
+  WastelandRegistryRecord,
+} from '../db/tables/wasteland-registry.table';
+
+const LOG = '[WastelandRegistry.do]';
+
+/**
+ * WastelandRegistryDO — singleton registry that indexes wasteland ownership.
+ *
+ * Because each WastelandDO is per-wasteland, we need a central index to
+ * answer "which wastelands does user X own?" or "which wastelands belong
+ * to org Y?". This singleton (keyed by fixed name 'registry') maintains
+ * that mapping.
+ *
+ * All creates/deletes in the tRPC router update this registry so
+ * listWastelands can resolve ownership without scanning every WastelandDO.
+ */
+export class WastelandRegistryDO extends DurableObject<Env> {
+  private sql: SqlStorage;
+  private initPromise: Promise<void> | null = null;
+
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    this.sql = ctx.storage.sql;
+
+    void ctx.blockConcurrencyWhile(async () => {
+      await this.ensureInitialized();
+    });
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.initPromise) {
+      this.initPromise = this.initializeDatabase();
+    }
+    await this.initPromise;
+  }
+
+  private async initializeDatabase(): Promise<void> {
+    query(this.sql, createTableWastelandRegistry(), []);
+  }
+
+  async register(input: {
+    wasteland_id: string;
+    owner_type: 'user' | 'org';
+    owner_user_id: string | null;
+    organization_id: string | null;
+    name: string;
+  }): Promise<void> {
+    await this.ensureInitialized();
+    const timestamp = new Date().toISOString();
+    console.log(
+      `${LOG} register: wasteland_id=${input.wasteland_id} owner_type=${input.owner_type}`
+    );
+
+    query(
+      this.sql,
+      /* sql */ `
+        INSERT OR REPLACE INTO ${wasteland_registry} (
+          ${wasteland_registry.columns.wasteland_id},
+          ${wasteland_registry.columns.owner_type},
+          ${wasteland_registry.columns.owner_user_id},
+          ${wasteland_registry.columns.organization_id},
+          ${wasteland_registry.columns.name},
+          ${wasteland_registry.columns.created_at}
+        ) VALUES (?, ?, ?, ?, ?, ?)
+      `,
+      [
+        input.wasteland_id,
+        input.owner_type,
+        input.owner_user_id,
+        input.organization_id,
+        input.name,
+        timestamp,
+      ]
+    );
+  }
+
+  async unregister(wastelandId: string): Promise<void> {
+    await this.ensureInitialized();
+    console.log(`${LOG} unregister: wasteland_id=${wastelandId}`);
+
+    query(
+      this.sql,
+      /* sql */ `DELETE FROM ${wasteland_registry} WHERE ${wasteland_registry.wasteland_id} = ?`,
+      [wastelandId]
+    );
+  }
+
+  async listByUser(userId: string): Promise<WastelandRegistryRecord[]> {
+    await this.ensureInitialized();
+    const rows = [
+      ...query(
+        this.sql,
+        /* sql */ `
+          SELECT * FROM ${wasteland_registry}
+          WHERE ${wasteland_registry.owner_type} = 'user'
+            AND ${wasteland_registry.owner_user_id} = ?
+          ORDER BY ${wasteland_registry.created_at} DESC
+        `,
+        [userId]
+      ),
+    ];
+    return WastelandRegistryRecord.array().parse(rows);
+  }
+
+  async listByOrg(orgId: string): Promise<WastelandRegistryRecord[]> {
+    await this.ensureInitialized();
+    const rows = [
+      ...query(
+        this.sql,
+        /* sql */ `
+          SELECT * FROM ${wasteland_registry}
+          WHERE ${wasteland_registry.owner_type} = 'org'
+            AND ${wasteland_registry.organization_id} = ?
+          ORDER BY ${wasteland_registry.created_at} DESC
+        `,
+        [orgId]
+      ),
+    ];
+    return WastelandRegistryRecord.array().parse(rows);
+  }
+
+  async listAll(): Promise<WastelandRegistryRecord[]> {
+    await this.ensureInitialized();
+    const rows = [
+      ...query(
+        this.sql,
+        /* sql */ `
+          SELECT * FROM ${wasteland_registry}
+          ORDER BY ${wasteland_registry.created_at} DESC
+        `,
+        []
+      ),
+    ];
+    return WastelandRegistryRecord.array().parse(rows);
+  }
+}
+
+export function getWastelandRegistryStub(env: Env) {
+  return env.WASTELAND_REGISTRY.get(env.WASTELAND_REGISTRY.idFromName('registry'));
+}

--- a/cloudflare-wasteland/src/trpc/init.ts
+++ b/cloudflare-wasteland/src/trpc/init.ts
@@ -1,0 +1,67 @@
+import { initTRPC, TRPCError } from '@trpc/server';
+import { writeEvent } from '../util/analytics.util';
+
+import type { JwtOrgMembership } from '../middleware/auth.middleware';
+
+export type TRPCContext = {
+  env: Env;
+  userId: string;
+  isAdmin: boolean;
+  apiTokenPepper: string | null;
+  orgMemberships: JwtOrgMembership[];
+};
+
+const t = initTRPC.context<TRPCContext>().create();
+
+export const router = t.router;
+
+/**
+ * Analytics middleware — wraps every tRPC procedure to emit an analytics
+ * event with timing and error capture. Runs before auth so even rejected
+ * requests are tracked.
+ */
+const analyticsProcedure = t.procedure.use(async ({ ctx, path, type, next }) => {
+  const start = performance.now();
+  let error: string | undefined;
+  try {
+    const result = await next({ ctx });
+    return result;
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+    throw err;
+  } finally {
+    const durationMs = performance.now() - start;
+    writeEvent(ctx.env, {
+      event: path,
+      delivery: 'trpc',
+      route: `${type} ${path}`,
+      error,
+      userId: ctx.userId || undefined,
+      durationMs,
+    });
+  }
+});
+
+/**
+ * Base procedure — requires a valid Kilo JWT (enforced by kiloAuthMiddleware
+ * running before tRPC). The userId is extracted from the JWT and set on the
+ * Hono context by kiloAuthMiddleware, then forwarded into the tRPC context
+ * by the createContext callback in wasteland.worker.ts.
+ */
+export const procedure = analyticsProcedure.use(async ({ ctx, next }) => {
+  if (!ctx.userId) {
+    throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Authentication required' });
+  }
+  return next({ ctx });
+});
+
+/**
+ * Admin-only procedure — requires `isAdmin` on the JWT. Used for admin
+ * endpoints that bypass per-user ownership checks.
+ */
+export const adminProcedure = procedure.use(async ({ ctx, next }) => {
+  if (!ctx.isAdmin) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'Admin access required' });
+  }
+  return next({ ctx });
+});

--- a/cloudflare-wasteland/src/trpc/ownership.ts
+++ b/cloudflare-wasteland/src/trpc/ownership.ts
@@ -1,0 +1,41 @@
+import { TRPCError } from '@trpc/server';
+import { getWastelandDOStub } from '../dos/WastelandDO.stub';
+import type { TRPCContext } from './init';
+
+type WastelandOwnershipResult =
+  | { type: 'user'; userId: string }
+  | { type: 'org'; orgId: string }
+  | { type: 'admin' };
+
+export async function resolveWastelandOwnership(
+  env: Env,
+  ctx: TRPCContext,
+  wastelandId: string
+): Promise<WastelandOwnershipResult> {
+  const stub = getWastelandDOStub(env, wastelandId);
+  const config = await stub.getConfig();
+
+  if (!config || config.status === 'deleted') {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Wasteland not found' });
+  }
+
+  if (config.owner_type === 'user') {
+    if (config.owner_user_id !== ctx.userId) {
+      if (ctx.isAdmin) return { type: 'admin' };
+      throw new TRPCError({ code: 'FORBIDDEN' });
+    }
+    return { type: 'user', userId: ctx.userId };
+  }
+
+  if (config.owner_type === 'org' && config.organization_id) {
+    const membership = ctx.orgMemberships.find(m => m.orgId === config.organization_id);
+    if (!membership || membership.role === 'billing_manager') {
+      if (ctx.isAdmin) return { type: 'admin' };
+      throw new TRPCError({ code: 'FORBIDDEN' });
+    }
+    return { type: 'org', orgId: config.organization_id };
+  }
+
+  if (ctx.isAdmin) return { type: 'admin' };
+  throw new TRPCError({ code: 'NOT_FOUND' });
+}

--- a/cloudflare-wasteland/src/trpc/router.ts
+++ b/cloudflare-wasteland/src/trpc/router.ts
@@ -9,8 +9,16 @@ import { z } from 'zod';
 import { router, procedure, adminProcedure } from './init';
 import { resolveWastelandOwnership } from './ownership';
 import { getWastelandDOStub, type WastelandMemberResult } from '../dos/WastelandDO.stub';
+import { getWastelandContainerStub } from '../dos/WastelandContainer.do';
 import { getWastelandRegistryStub } from '../dos/WastelandRegistry.do';
-import { RpcWastelandOutput, RpcWastelandMemberOutput } from './schemas';
+import { deriveEncryptionKey, encryptToken } from '../util/crypto.util';
+import { resolveSecret } from '../util/secret.util';
+import {
+  RpcWastelandOutput,
+  RpcWastelandMemberOutput,
+  RpcWastelandConfigOutput,
+  RpcWastelandCredentialStatusOutput,
+} from './schemas';
 import type { TRPCContext } from './init';
 import type { JwtOrgMembership } from '../middleware/auth.middleware';
 
@@ -318,6 +326,121 @@ export const wastelandRouter = router({
       }
 
       return updated;
+    }),
+
+  // ── Config Update ──────────────────────────────────────────────────
+
+  updateWastelandConfig: procedure
+    .input(
+      z.object({
+        wastelandId: z.string().uuid(),
+        name: z.string().min(1).max(128).optional(),
+        visibility: z.enum(['public', 'private']).optional(),
+        dolthubUpstream: z.string().optional(),
+      })
+    )
+    .output(RpcWastelandConfigOutput)
+    .mutation(async ({ ctx, input }) => {
+      // Owner or org admin only
+      await requireOwnerAccess(ctx.env, ctx, input.wastelandId);
+
+      const stub = getWastelandDOStub(ctx.env, input.wastelandId);
+      const config = await stub.updateConfig({
+        ...(input.name !== undefined ? { name: input.name } : {}),
+        ...(input.visibility !== undefined ? { visibility: input.visibility } : {}),
+        ...(input.dolthubUpstream !== undefined
+          ? { dolthub_upstream: input.dolthubUpstream }
+          : {}),
+      });
+
+      return config;
+    }),
+
+  // ── Credential: Store ──────────────────────────────────────────────
+
+  storeCredential: procedure
+    .input(
+      z.object({
+        wastelandId: z.string().uuid(),
+        dolthubToken: z.string().min(1),
+        dolthubOrg: z.string().min(1),
+        rigHandle: z.string().optional(),
+      })
+    )
+    .output(RpcWastelandCredentialStatusOutput)
+    .mutation(async ({ ctx, input }) => {
+      // Any member can store their own credential
+      await resolveWastelandOwnership(ctx.env, ctx, input.wastelandId);
+
+      // Derive encryption key from WASTELAND_ENCRYPTION_KEY secret
+      const rawKey = await resolveSecret(ctx.env.WASTELAND_ENCRYPTION_KEY);
+      if (!rawKey) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Encryption key unavailable',
+        });
+      }
+      const cryptoKey = await deriveEncryptionKey(rawKey);
+      const encryptedToken = await encryptToken(input.dolthubToken, cryptoKey);
+
+      const stub = getWastelandDOStub(ctx.env, input.wastelandId);
+      const credential = await stub.storeCredential(
+        ctx.userId,
+        encryptedToken,
+        input.dolthubOrg,
+        input.rigHandle
+      );
+
+      // If the caller is the wasteland owner, inject the token into
+      // the container so it's available in the OS environment.
+      const config = await stub.getConfig();
+      if (config && config.owner_user_id === ctx.userId) {
+        const container = getWastelandContainerStub(ctx.env, input.wastelandId);
+        await container.setEnvVar('DOLTHUB_TOKEN', input.dolthubToken);
+      }
+
+      return {
+        user_id: credential.user_id,
+        dolthub_org: credential.dolthub_org,
+        rig_handle: credential.rig_handle,
+        connected_at: credential.connected_at,
+      };
+    }),
+
+  // ── Credential: Get Status ─────────────────────────────────────────
+
+  getCredentialStatus: procedure
+    .input(z.object({ wastelandId: z.string().uuid() }))
+    .output(RpcWastelandCredentialStatusOutput.nullable())
+    .query(async ({ ctx, input }) => {
+      // Any member can check their own credential status
+      await resolveWastelandOwnership(ctx.env, ctx, input.wastelandId);
+
+      const stub = getWastelandDOStub(ctx.env, input.wastelandId);
+      const credential = await stub.getCredential(ctx.userId);
+
+      if (!credential) return null;
+
+      // Never expose the encrypted token
+      return {
+        user_id: credential.user_id,
+        dolthub_org: credential.dolthub_org,
+        rig_handle: credential.rig_handle,
+        connected_at: credential.connected_at,
+      };
+    }),
+
+  // ── Credential: Delete ─────────────────────────────────────────────
+
+  deleteCredential: procedure
+    .input(z.object({ wastelandId: z.string().uuid() }))
+    .output(z.object({ success: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      // Users can only delete their own credentials — no ownership
+      // check needed beyond auth (userId comes from the JWT).
+      const stub = getWastelandDOStub(ctx.env, input.wastelandId);
+      await stub.deleteCredential(ctx.userId);
+      return { success: true };
     }),
 });
 

--- a/cloudflare-wasteland/src/trpc/router.ts
+++ b/cloudflare-wasteland/src/trpc/router.ts
@@ -1,0 +1,205 @@
+/**
+ * Wasteland tRPC router — served directly by the Wasteland worker.
+ *
+ * Single flat router with all procedures inline, following the Gastown pattern.
+ */
+/* eslint-disable @typescript-eslint/await-thenable -- DO RPC stubs return Rpc.Promisified which is thenable at runtime */
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+import { router, procedure, adminProcedure } from './init';
+import { resolveWastelandOwnership } from './ownership';
+import { getWastelandDOStub } from '../dos/WastelandDO.stub';
+import { getWastelandRegistryStub } from '../dos/WastelandRegistry.do';
+import { RpcWastelandOutput } from './schemas';
+import type { TRPCContext } from './init';
+import type { JwtOrgMembership } from '../middleware/auth.middleware';
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/** Look up a user's membership for a specific org from the JWT claims. */
+function getOrgMembership(
+  memberships: JwtOrgMembership[],
+  orgId: string
+): JwtOrgMembership | undefined {
+  return memberships.find(m => m.orgId === orgId);
+}
+
+/**
+ * Verify the user has org membership that allows wasteland operations.
+ * billing_manager role is excluded.
+ */
+function verifyOrgAccess(ctx: TRPCContext, organizationId: string): JwtOrgMembership {
+  const membership = getOrgMembership(ctx.orgMemberships, organizationId);
+  if (!membership || membership.role === 'billing_manager') {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Not an org member or insufficient permissions',
+    });
+  }
+  return membership;
+}
+
+// ── Router ─────────────────────────────────────────────────────────────
+
+export const wastelandRouter = router({
+  // ── Create ──────────────────────────────────────────────────────────
+
+  createWasteland: procedure
+    .input(
+      z.object({
+        name: z.string().min(1).max(128),
+        ownerType: z.enum(['user', 'org']),
+        organizationId: z.string().uuid().optional(),
+        dolthubUpstream: z.string().optional(),
+        visibility: z.enum(['public', 'private']).default('private'),
+      })
+    )
+    .output(RpcWastelandOutput)
+    .mutation(async ({ ctx, input }) => {
+      // Org ownership: verify membership (not billing_manager)
+      if (input.ownerType === 'org') {
+        if (!input.organizationId) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'organizationId is required when ownerType is org',
+          });
+        }
+        verifyOrgAccess(ctx, input.organizationId);
+      }
+
+      const wastelandId = crypto.randomUUID();
+      const stub = getWastelandDOStub(ctx.env, wastelandId);
+
+      const config = await stub.initializeWasteland({
+        wasteland_id: wastelandId,
+        name: input.name,
+        owner_type: input.ownerType,
+        owner_user_id: ctx.userId,
+        organization_id: input.organizationId ?? null,
+        dolthub_upstream: input.dolthubUpstream ?? null,
+        visibility: input.visibility,
+      });
+
+      // Register in the central wasteland registry for listing
+      const registryStub = getWastelandRegistryStub(ctx.env);
+      await registryStub.register({
+        wasteland_id: wastelandId,
+        owner_type: input.ownerType,
+        owner_user_id: ctx.userId,
+        organization_id: input.organizationId ?? null,
+        name: input.name,
+      });
+
+      return config;
+    }),
+
+  // ── List ────────────────────────────────────────────────────────────
+
+  listWastelands: procedure
+    .input(
+      z.object({
+        organizationId: z.string().uuid().optional(),
+      })
+    )
+    .output(z.array(RpcWastelandOutput))
+    .query(async ({ ctx, input }) => {
+      const registryStub = getWastelandRegistryStub(ctx.env);
+
+      const entries = input.organizationId
+        ? await registryStub.listByOrg(input.organizationId)
+        : await registryStub.listByUser(ctx.userId);
+
+      // If listing org wastelands, verify the user has org membership
+      if (input.organizationId) {
+        verifyOrgAccess(ctx, input.organizationId);
+      }
+
+      // Resolve each wasteland's full config from its DO
+      const results = await Promise.all(
+        entries.map(async entry => {
+          const stub = getWastelandDOStub(ctx.env, entry.wasteland_id);
+          const config = await stub.getConfig();
+          // Skip deleted or missing wastelands
+          if (!config || config.status === 'deleted') return null;
+          return config;
+        })
+      );
+
+      return results.filter((r): r is NonNullable<typeof r> => r !== null);
+    }),
+
+  // ── Get ─────────────────────────────────────────────────────────────
+
+  getWasteland: procedure
+    .input(z.object({ wastelandId: z.string().uuid() }))
+    .output(RpcWastelandOutput)
+    .query(async ({ ctx, input }) => {
+      await resolveWastelandOwnership(ctx.env, ctx, input.wastelandId);
+      const stub = getWastelandDOStub(ctx.env, input.wastelandId);
+      const config = await stub.getConfig();
+      if (!config) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Wasteland not found' });
+      }
+      return config;
+    }),
+
+  // ── Delete ──────────────────────────────────────────────────────────
+
+  deleteWasteland: procedure
+    .input(z.object({ wastelandId: z.string().uuid() }))
+    .output(z.object({ success: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      const ownership = await resolveWastelandOwnership(ctx.env, ctx, input.wastelandId);
+
+      // For org wastelands, only owners/admins can delete — not regular members
+      if (ownership.type === 'org') {
+        const membership = getOrgMembership(ctx.orgMemberships, ownership.orgId);
+        if (!membership || membership.role !== 'owner') {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'Only org owners can delete wastelands',
+          });
+        }
+      }
+
+      // Soft-delete: mark as deleted in the WastelandDO
+      const stub = getWastelandDOStub(ctx.env, input.wastelandId);
+      await stub.updateConfig({ status: 'deleted' });
+
+      // Remove from the central registry
+      const registryStub = getWastelandRegistryStub(ctx.env);
+      await registryStub.unregister(input.wastelandId);
+
+      return { success: true };
+    }),
+
+  // ── Admin: List All ─────────────────────────────────────────────────
+
+  adminListWastelands: adminProcedure
+    .output(z.array(RpcWastelandOutput))
+    .query(async ({ ctx }) => {
+      const registryStub = getWastelandRegistryStub(ctx.env);
+      const entries = await registryStub.listAll();
+
+      const results = await Promise.all(
+        entries.map(async entry => {
+          const stub = getWastelandDOStub(ctx.env, entry.wasteland_id);
+          const config = await stub.getConfig();
+          if (!config) return null;
+          return config;
+        })
+      );
+
+      return results.filter((r): r is NonNullable<typeof r> => r !== null);
+    }),
+});
+
+export type WastelandRouter = typeof wastelandRouter;
+
+/**
+ * Wrapped router that nests wastelandRouter under a `wasteland` key.
+ * This preserves the `trpc.wasteland.X` call pattern on the frontend,
+ * matching the Gastown wrapping convention.
+ */
+export const wrappedWastelandRouter = router({ wasteland: wastelandRouter });
+export type WrappedWastelandRouter = typeof wrappedWastelandRouter;

--- a/cloudflare-wasteland/src/trpc/router.ts
+++ b/cloudflare-wasteland/src/trpc/router.ts
@@ -1,0 +1,152 @@
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+import { router, procedure } from './init';
+import type { TRPCContext } from './init';
+import { resolveWastelandOwnership } from './ownership';
+import { getWastelandDOStub, type WastelandMemberResult } from '../dos/WastelandDO.stub';
+import { RpcWastelandMemberOutput } from './schemas';
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Verify the caller has owner-level access to the wasteland.
+ * Resolves ownership then checks that the caller is:
+ *   - the direct user-owner, OR
+ *   - an org owner (not just a regular org member), OR
+ *   - a site admin.
+ * Throws FORBIDDEN if the caller only has member-level org access.
+ */
+async function requireOwnerAccess(
+  env: Env,
+  ctx: TRPCContext,
+  wastelandId: string
+) {
+  const ownership = await resolveWastelandOwnership(env, ctx, wastelandId);
+
+  if (ownership.type === 'user' || ownership.type === 'admin') {
+    return ownership;
+  }
+
+  // For org-owned wastelands, resolveWastelandOwnership allows any
+  // non-billing_manager org member through. Write operations require
+  // org owner role specifically.
+  const membership = ctx.orgMemberships.find(m => m.orgId === ownership.orgId);
+  if (!membership || membership.role !== 'owner') {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Only wasteland owners or org admins can perform this action',
+    });
+  }
+
+  return ownership;
+}
+
+// ── Router ──────────────────────────────────────────────────────────────
+
+export const wastelandRouter = router({
+  listMembers: procedure
+    .input(z.object({ wastelandId: z.string() }))
+    .output(z.array(RpcWastelandMemberOutput))
+    .query(async ({ ctx, input }) => {
+      // Any member or owner can list members
+      await resolveWastelandOwnership(ctx.env, ctx, input.wastelandId);
+      const stub = getWastelandDOStub(ctx.env, input.wastelandId);
+      return stub.listMembers();
+    }),
+
+  addMember: procedure
+    .input(
+      z.object({
+        wastelandId: z.string(),
+        userId: z.string(),
+        role: z.enum(['contributor', 'maintainer', 'owner']).optional(),
+        trustLevel: z.number().int().min(1).max(3).optional(),
+      })
+    )
+    .output(RpcWastelandMemberOutput)
+    .mutation(async ({ ctx, input }) => {
+      await requireOwnerAccess(ctx.env, ctx, input.wastelandId);
+
+      const stub = getWastelandDOStub(ctx.env, input.wastelandId);
+      const memberId = await stub.addMember(
+        input.userId,
+        input.role ?? 'contributor',
+        input.trustLevel ?? 1
+      );
+
+      // Fetch the newly created member record to return
+      const members: WastelandMemberResult[] = await stub.listMembers();
+      const member = members.find(m => m.member_id === memberId);
+      if (!member) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to retrieve newly created member',
+        });
+      }
+      return member;
+    }),
+
+  removeMember: procedure
+    .input(
+      z.object({
+        wastelandId: z.string(),
+        memberId: z.string(),
+      })
+    )
+    .output(z.object({ success: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      await requireOwnerAccess(ctx.env, ctx, input.wastelandId);
+
+      const stub = getWastelandDOStub(ctx.env, input.wastelandId);
+
+      // Owners cannot remove themselves — fetch members to check
+      const members: WastelandMemberResult[] = await stub.listMembers();
+      const target = members.find(m => m.member_id === input.memberId);
+      if (!target) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Member not found' });
+      }
+      if (target.user_id === ctx.userId && target.role === 'owner') {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Owners cannot remove themselves',
+        });
+      }
+
+      await stub.removeMember(input.memberId);
+      return { success: true };
+    }),
+
+  updateMember: procedure
+    .input(
+      z.object({
+        wastelandId: z.string(),
+        memberId: z.string(),
+        role: z.enum(['contributor', 'maintainer', 'owner']).optional(),
+        trustLevel: z.number().int().min(1).max(3).optional(),
+      })
+    )
+    .output(RpcWastelandMemberOutput)
+    .mutation(async ({ ctx, input }) => {
+      await requireOwnerAccess(ctx.env, ctx, input.wastelandId);
+
+      const stub = getWastelandDOStub(ctx.env, input.wastelandId);
+      const updated = await stub.updateMember(input.memberId, {
+        role: input.role,
+        trust_level: input.trustLevel,
+      });
+
+      if (!updated) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Member not found' });
+      }
+
+      return updated;
+    }),
+});
+
+export type WastelandRouter = typeof wastelandRouter;
+
+export const wrappedWastelandRouter = router({
+  wasteland: wastelandRouter,
+});
+
+export type WrappedWastelandRouter = typeof wrappedWastelandRouter;

--- a/cloudflare-wasteland/src/trpc/router.ts
+++ b/cloudflare-wasteland/src/trpc/router.ts
@@ -16,11 +16,7 @@ import { RpcWastelandMemberOutput } from './schemas';
  *   - a site admin.
  * Throws FORBIDDEN if the caller only has member-level org access.
  */
-async function requireOwnerAccess(
-  env: Env,
-  ctx: TRPCContext,
-  wastelandId: string
-) {
+async function requireOwnerAccess(env: Env, ctx: TRPCContext, wastelandId: string) {
   const ownership = await resolveWastelandOwnership(env, ctx, wastelandId);
 
   if (ownership.type === 'user' || ownership.type === 'admin') {

--- a/cloudflare-wasteland/src/trpc/schemas.ts
+++ b/cloudflare-wasteland/src/trpc/schemas.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+
+/**
+ * Wraps a Zod schema in z.any().pipe(schema) so the TS input type is `any`
+ * (avoiding "excessively deep" instantiation with Rpc.Promisified DO stubs)
+ * while still performing full runtime validation via the piped schema.
+ */
+function rpcSafe<T extends z.ZodTypeAny>(schema: T): z.ZodPipe<z.ZodAny, T> {
+  return z.any().pipe(schema);
+}
+
+// ── Wasteland (config output for API consumers) ─────────────────────────
+
+export const WastelandOutput = z.object({
+  wasteland_id: z.string(),
+  name: z.string(),
+  owner_type: z.enum(['user', 'org']),
+  owner_user_id: z.string().nullable(),
+  organization_id: z.string().nullable(),
+  dolthub_upstream: z.string().nullable(),
+  visibility: z.enum(['public', 'private']),
+  status: z.enum(['active', 'deleted']),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+// ── Wasteland Member ────────────────────────────────────────────────────
+
+export const WastelandMemberOutput = z.object({
+  member_id: z.string(),
+  user_id: z.string(),
+  trust_level: z.number(),
+  role: z.enum(['contributor', 'maintainer', 'owner']),
+  joined_at: z.string(),
+});
+
+// ── Credential Status (never expose encrypted_token) ────────────────────
+
+export const WastelandCredentialStatusOutput = z.object({
+  user_id: z.string(),
+  dolthub_org: z.string(),
+  rig_handle: z.string().nullable(),
+  connected_at: z.string(),
+});
+
+// ── Full Config (same shape as WastelandOutput for now) ─────────────────
+
+export const WastelandConfigOutput = z.object({
+  wasteland_id: z.string(),
+  name: z.string(),
+  owner_type: z.enum(['user', 'org']),
+  owner_user_id: z.string().nullable(),
+  organization_id: z.string().nullable(),
+  dolthub_upstream: z.string().nullable(),
+  visibility: z.enum(['public', 'private']),
+  status: z.enum(['active', 'deleted']),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+// ── rpcSafe wrappers ────────────────────────────────────────────────────
+// tRPC's .output() forces TypeScript to check that the handler return type
+// is assignable to the schema's input type. When handlers return values from
+// Cloudflare Rpc.Promisified DO stubs, the deeply recursive proxy types
+// exceed TS's instantiation depth limit. Wrapping with rpcSafe() (z.any().pipe)
+// short-circuits the type check while preserving identical runtime validation.
+
+export const RpcWastelandOutput = rpcSafe(WastelandOutput);
+export const RpcWastelandMemberOutput = rpcSafe(WastelandMemberOutput);
+export const RpcWastelandCredentialStatusOutput = rpcSafe(WastelandCredentialStatusOutput);
+export const RpcWastelandConfigOutput = rpcSafe(WastelandConfigOutput);

--- a/cloudflare-wasteland/src/util/analytics.util.ts
+++ b/cloudflare-wasteland/src/util/analytics.util.ts
@@ -18,7 +18,7 @@ export type WastelandEventName =
   // a massive union — event names are derived from route patterns.
   | (string & {});
 
-export type WastelandDelivery = 'http' | 'internal';
+export type WastelandDelivery = 'http' | 'trpc' | 'internal';
 
 export type WastelandEventData = {
   event: WastelandEventName;

--- a/cloudflare-wasteland/src/wasteland.worker.ts
+++ b/cloudflare-wasteland/src/wasteland.worker.ts
@@ -1,5 +1,7 @@
 import * as Sentry from '@sentry/cloudflare';
 import { withSentry } from '@sentry/cloudflare';
+import { TRPCError } from '@trpc/server';
+import { trpcServer } from '@hono/trpc-server';
 import { Hono } from 'hono';
 import type { Context } from 'hono';
 import { cors } from 'hono/cors';
@@ -10,6 +12,7 @@ import type { MiddlewareHandler } from 'hono';
 import type { AuthVariables } from './middleware/auth.middleware';
 import { kiloAuthMiddleware } from './middleware/kilo-auth.middleware';
 import { timingMiddleware } from './middleware/analytics.middleware';
+import { wrappedWastelandRouter } from './trpc/router';
 
 // ── DO Exports ──────────────────────────────────────────────────────────
 // Wrangler requires these exports to match the class_name bindings in wrangler.jsonc.
@@ -68,6 +71,7 @@ const corsMiddleware = cors({
 });
 
 app.use('/api/*', corsMiddleware);
+app.use('/trpc/*', corsMiddleware);
 
 // ── Health ──────────────────────────────────────────────────────────────
 
@@ -82,27 +86,33 @@ app.use('/api/*', async (c: Context<WastelandEnv, string>, next) =>
   c.env.ENVIRONMENT === 'development' ? next() : kiloAuthMiddleware(c, next)
 );
 
-// ── Route stubs ─────────────────────────────────────────────────────────
-// Phase 2: Wasteland CRUD
-// POST /api/wastelands — create
-// GET  /api/wastelands — list (user's wastelands)
-// GET  /api/wastelands/:wastelandId — get
-// DELETE /api/wastelands/:wastelandId — delete
+// ── tRPC ────────────────────────────────────────────────────────────────
+// Serve the wasteland tRPC router directly. The frontend tRPC client
+// connects here instead of going through the Next.js proxy layer.
 
-// Phase 2: Wasteland Settings
-// PATCH /api/wastelands/:wastelandId/config
-// POST  /api/wastelands/:wastelandId/credentials — store DoltHub token
-
-// Phase 2: Members
-// GET  /api/wastelands/:wastelandId/members
-// POST /api/wastelands/:wastelandId/members
-// DELETE /api/wastelands/:wastelandId/members/:memberId
-
-// Phase 3: Wanted Board
-// GET  /api/wastelands/:wastelandId/wanted — browse
-// POST /api/wastelands/:wastelandId/wanted — post new item
-// POST /api/wastelands/:wastelandId/wanted/:itemId/claim
-// POST /api/wastelands/:wastelandId/wanted/:itemId/done
+app.use('/trpc/*', async (c: Context<WastelandEnv, string>, next) =>
+  c.env.ENVIRONMENT === 'development' ? next() : kiloAuthMiddleware(c, next)
+);
+app.use(
+  '/trpc/*',
+  trpcServer({
+    router: wrappedWastelandRouter,
+    endpoint: '/trpc',
+    createContext: (_opts: unknown, c: Context<WastelandEnv>) => ({
+      env: c.env,
+      userId: c.get('kiloUserId') ?? '',
+      isAdmin: c.get('kiloIsAdmin') ?? false,
+      apiTokenPepper: c.get('kiloApiTokenPepper') ?? null,
+      orgMemberships: c.get('kiloOrgMemberships') ?? [],
+    }),
+    onError: ({ error, path }: { error: Error; path?: string }) => {
+      console.error(`[wasteland-trpc] error on ${path ?? 'unknown'}:`, error.message);
+      if (!(error instanceof TRPCError)) {
+        Sentry.captureException(error);
+      }
+    },
+  })
+);
 
 // ── Error handling ──────────────────────────────────────────────────────
 

--- a/cloudflare-wasteland/src/wasteland.worker.ts
+++ b/cloudflare-wasteland/src/wasteland.worker.ts
@@ -16,6 +16,7 @@ import { timingMiddleware } from './middleware/analytics.middleware';
 
 export { WastelandDO } from './dos/WastelandDO.stub';
 export { WastelandContainerDO } from './dos/WastelandContainer.do';
+export { WastelandRegistryDO } from './dos/WastelandRegistry.do';
 
 // ── Types ───────────────────────────────────────────────────────────────
 

--- a/cloudflare-wasteland/worker-configuration.d.ts
+++ b/cloudflare-wasteland/worker-configuration.d.ts
@@ -3,7 +3,7 @@
 declare namespace Cloudflare {
 	interface GlobalProps {
 		mainModule: typeof import("./src/wasteland.worker");
-		durableNamespaces: "WastelandDO" | "WastelandContainerDO";
+		durableNamespaces: "WastelandDO" | "WastelandContainerDO" | "WastelandRegistryDO";
 	}
 	interface DevEnv {
 		WASTELAND_AE: AnalyticsEngineDataset;
@@ -15,6 +15,7 @@ declare namespace Cloudflare {
 		WASTELAND_API_URL: "http://192.168.65.254:8787";
 		WASTELAND: DurableObjectNamespace<import("./src/wasteland.worker").WastelandDO>;
 		WASTELAND_CONTAINER: DurableObjectNamespace<import("./src/wasteland.worker").WastelandContainerDO>;
+		WASTELAND_REGISTRY: DurableObjectNamespace<import("./src/wasteland.worker").WastelandRegistryDO>;
 	}
 	interface Env {
 		WASTELAND_AE: AnalyticsEngineDataset;
@@ -26,6 +27,7 @@ declare namespace Cloudflare {
 		WASTELAND_API_URL: "http://192.168.65.254:8787" | "https://wasteland.kiloapps.io";
 		WASTELAND: DurableObjectNamespace<import("./src/wasteland.worker").WastelandDO>;
 		WASTELAND_CONTAINER: DurableObjectNamespace<import("./src/wasteland.worker").WastelandContainerDO>;
+		WASTELAND_REGISTRY: DurableObjectNamespace<import("./src/wasteland.worker").WastelandRegistryDO>;
 		CF_VERSION_METADATA?: WorkerVersionMetadata;
 		SENTRY_DSN?: string; // worker secret
 		SENTRY_RELEASE?: string; // deploy-time --var

--- a/cloudflare-wasteland/wrangler.jsonc
+++ b/cloudflare-wasteland/wrangler.jsonc
@@ -43,6 +43,7 @@
     "bindings": [
       { "name": "WASTELAND", "class_name": "WastelandDO" },
       { "name": "WASTELAND_CONTAINER", "class_name": "WastelandContainerDO" },
+      { "name": "WASTELAND_REGISTRY", "class_name": "WastelandRegistryDO" },
     ],
   },
 
@@ -50,6 +51,10 @@
     {
       "tag": "v1",
       "new_sqlite_classes": ["WastelandDO", "WastelandContainerDO"],
+    },
+    {
+      "tag": "v2",
+      "new_sqlite_classes": ["WastelandRegistryDO"],
     },
   ],
 
@@ -104,6 +109,7 @@
         "bindings": [
           { "name": "WASTELAND", "class_name": "WastelandDO" },
           { "name": "WASTELAND_CONTAINER", "class_name": "WastelandContainerDO" },
+          { "name": "WASTELAND_REGISTRY", "class_name": "WastelandRegistryDO" },
         ],
       },
       "analytics_engine_datasets": [{ "binding": "WASTELAND_AE", "dataset": "wasteland_events" }],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1335,6 +1335,9 @@ importers:
       '@cloudflare/containers':
         specifier: ^0.1.0
         version: 0.1.1
+      '@hono/trpc-server':
+        specifier: ^0.4.2
+        version: 0.4.2(@trpc/server@11.13.0(typescript@5.9.3))(hono@4.12.8)
       '@kilocode/worker-utils':
         specifier: workspace:*
         version: link:../packages/worker-utils


### PR DESCRIPTION
## Summary

Phase 2 of the Wasteland feature (#1810) — implements the core API layer, onboarding infrastructure, and wanted board polling. This PR merges the completed Phase 2 convoy branch into `wasteland-staging`.

**Changes (14 files, +964/-24 lines):**

- **WastelandDO stub extended** (`WastelandDO.stub.ts`): Added real RPC method signatures for config, member management, and credential management (all throw "not yet implemented" — implementations land in Phase 3)
- **WastelandDO sub-module types**: Config, credentials, members, wanted-cache type definitions
- **WastelandRegistryDO** (`WastelandRegistry.do.ts`): New singleton Durable Object for listing wastelands by user/org, backed by SQLite table `wasteland_registry`
- **tRPC layer**:
  - `init.ts` — tRPC context creation with auth middleware
  - `schemas.ts` — Zod validation schemas for all procedures
  - `ownership.ts` — `resolveWastelandOwnership` helper for authorization
  - `router.ts` — Full procedure set:
    - CRUD: `createWasteland`, `listWastelands`, `getWasteland`, `deleteWasteland`, `adminListWastelands`
    - Config: `updateWastelandConfig`
    - Credentials: `storeCredential`, `getCredentialStatus`, `deleteCredential`
    - Members: `listMembers`, `addMember`, `removeMember`, `updateMember`
    - Wanted board: `browseWantedBoard`, `getWantedItem`, `refreshWantedBoard`
- **Worker integration** (`wasteland.worker.ts`): tRPC mounted with CORS and auth middleware via `@hono/trpc-server`
- **DoltHub REST API utility**: For wanted board polling from WastelandDO alarm loop
- **Infrastructure**: `@hono/trpc-server` dependency added, `WASTELAND_REGISTRY` binding added to `wrangler.jsonc`

Resolves Phase 2 of #1810.

## Verification

- TypeScript typecheck passed (`pnpm typecheck`)
- All 7 Phase 2 convoy beads completed successfully
- Branch diff reviewed: 14 files changed, no conflicts with wasteland-staging

## Visual Changes

N/A

## Reviewer Notes

- The convoy head branch aggregates work from 5 sub-branches (birch, maple, shadow, toast) merged in sequence
- WastelandDO.stub.ts was intentionally kept as a stub with RPC signatures rather than replaced with a full implementation — the real SQLite-backed DO implementation is planned for Phase 3
- WastelandRegistryDO is a new singleton DO not in the original Phase 2 plan but was proposed during bead planning as necessary for efficient listing queries