### PR TITLE
chore(gastown): bump max_instances from 500 to 600

### DIFF
--- a/cloudflare-gastown/wrangler.jsonc
+++ b/cloudflare-gastown/wrangler.jsonc
@@ -36,7 +36,7 @@
       "class_name": "TownContainerDO",
       "image": "./container/Dockerfile",
       "instance_type": "standard-4",
-      "max_instances": 500,
+      "max_instances": 600,
     },
   ],
 


### PR DESCRIPTION
## Summary

- Increases Gastown `TownContainerDO` Durable Object container `max_instances` from 500 to 600 to accommodate growing capacity needs.

## Verification

- Confirmed the change is a single-line config bump in `cloudflare-gastown/wrangler.jsonc`.
- No code logic changes; deployment will pick up the new limit automatically.

## Visual Changes

N/A

## Reviewer Notes

N/A