### PR TITLE
feat(kiloclaw): hide Kilo Pass upsell for subscribed users

### DIFF
--- a/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
+++ b/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
@@ -13,7 +13,6 @@ import { useTRPC } from '@/lib/trpc/utils';
 import {
   COMMIT_PERIOD_MONTHS,
   formatMicrodollars,
-  PLAN_COST_MICRODOLLARS,
   PLAN_DISPLAY,
   planPriceLabel,
   STANDARD_FIRST_MONTH_DOLLARS,
@@ -337,23 +336,26 @@ function CreditsHowItWorks() {
 
 function CreditEnrollmentSection({
   selectedPlan,
-  creditBalanceMicrodollars,
-  creditIntroEligible,
+  rawCreditBalanceMicrodollars,
+  effectiveBalanceMicrodollars,
+  projectedKiloPassBonusMicrodollars,
+  costMicrodollars,
   onEnroll,
   isPending,
 }: {
   selectedPlan: ClawPlan;
-  creditBalanceMicrodollars: number;
-  creditIntroEligible: boolean;
+  rawCreditBalanceMicrodollars: number;
+  effectiveBalanceMicrodollars: number;
+  projectedKiloPassBonusMicrodollars: number;
+  costMicrodollars: number;
   onEnroll: () => void;
   isPending: boolean;
 }) {
-  const isIntro = selectedPlan === 'standard' && creditIntroEligible;
-  const planCost = isIntro
-    ? STANDARD_FIRST_MONTH_MICRODOLLARS
-    : PLAN_COST_MICRODOLLARS[selectedPlan];
-  const hasSufficientBalance = creditBalanceMicrodollars >= planCost;
-  const shortfall = planCost - creditBalanceMicrodollars;
+  const isIntro =
+    selectedPlan === 'standard' && costMicrodollars === STANDARD_FIRST_MONTH_MICRODOLLARS;
+  const hasProjectedBonus = projectedKiloPassBonusMicrodollars > 0;
+  const hasSufficientBalance = effectiveBalanceMicrodollars >= costMicrodollars;
+  const shortfall = Math.max(0, costMicrodollars - effectiveBalanceMicrodollars);
   const planLabel = selectedPlan === 'commit' ? 'Commit' : 'Standard';
   const priceLabel = isIntro
     ? `$${STANDARD_FIRST_MONTH_DOLLARS} first month, then ${planPriceLabel(selectedPlan)}`
@@ -369,16 +371,27 @@ function CreditEnrollmentSection({
         <p className="text-muted-foreground mb-1 text-sm">
           {planLabel} Plan — {priceLabel} from your credit balance
         </p>
-        <p className="mb-3 text-xs text-emerald-400/80">
-          Balance: {formatMicrodollars(creditBalanceMicrodollars)}
-        </p>
+        {hasProjectedBonus ? (
+          <div className="mb-3 space-y-1 text-xs text-emerald-400/80">
+            <p>Current balance: {formatMicrodollars(rawCreditBalanceMicrodollars)}</p>
+            <p>
+              Projected Kilo Pass bonus for this charge:{' '}
+              {formatMicrodollars(projectedKiloPassBonusMicrodollars)}
+            </p>
+            <p>Effective balance: {formatMicrodollars(effectiveBalanceMicrodollars)}</p>
+          </div>
+        ) : (
+          <p className="mb-3 text-xs text-emerald-400/80">
+            Balance: {formatMicrodollars(rawCreditBalanceMicrodollars)}
+          </p>
+        )}
         <Button
           onClick={onEnroll}
           disabled={isPending}
           variant="primary"
           className="w-full py-3 font-semibold"
         >
-          {isPending ? 'Activating…' : `Pay ${formatMicrodollars(planCost)} with Credits`}
+          {isPending ? 'Activating…' : `Pay ${formatMicrodollars(costMicrodollars)} with Credits`}
         </Button>
       </div>
     );
@@ -393,13 +406,31 @@ function CreditEnrollmentSection({
       <div className="text-muted-foreground space-y-1 text-sm">
         <div className="flex justify-between">
           <span>Balance</span>
-          <span className="text-foreground">{formatMicrodollars(creditBalanceMicrodollars)}</span>
+          <span className="text-foreground">
+            {formatMicrodollars(rawCreditBalanceMicrodollars)}
+          </span>
         </div>
+        {hasProjectedBonus && (
+          <div className="flex justify-between">
+            <span>Projected Kilo Pass bonus</span>
+            <span className="text-foreground">
+              {formatMicrodollars(projectedKiloPassBonusMicrodollars)}
+            </span>
+          </div>
+        )}
+        {hasProjectedBonus && (
+          <div className="flex justify-between">
+            <span>Effective balance</span>
+            <span className="text-foreground">
+              {formatMicrodollars(effectiveBalanceMicrodollars)}
+            </span>
+          </div>
+        )}
         <div className="flex justify-between">
           <span>
             {planLabel} plan cost{isIntro ? ' (first month)' : ''}
           </span>
-          <span className="text-foreground">{formatMicrodollars(planCost)}</span>
+          <span className="text-foreground">{formatMicrodollars(costMicrodollars)}</span>
         </div>
         <div className="flex justify-between border-t border-amber-500/20 pt-1 font-medium text-amber-400">
           <span>Shortfall</span>
@@ -455,6 +486,13 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
   const creditBalance = billing?.creditBalanceMicrodollars ?? null;
   const hasCredits = creditBalance !== null && creditBalance > 0;
   const creditIntroEligible = billing?.creditIntroEligible ?? false;
+  const hasActiveKiloPass = billing?.hasActiveKiloPass ?? false;
+  const creditEnrollmentPreview = billing?.creditEnrollmentPreview ?? null;
+  const showKiloPassUpsell = !hasActiveKiloPass;
+  const selectedCreditEnrollmentPreview =
+    hostingOnlyPlan !== null ? (creditEnrollmentPreview?.[hostingOnlyPlan] ?? null) : null;
+  const showCreditEnrollment =
+    !!selectedCreditEnrollmentPreview && (hasCredits || hasActiveKiloPass);
 
   const hostingOnlyActive = hostingOnlyPlan !== null;
   const commitDisabled = !isCommitAvailable(selectedTier, cadence);
@@ -534,6 +572,11 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
   const hostingOnlyLabel = hostingOnlyPlan
     ? `Subscribe to ${hostingOnlyPlan === 'commit' ? 'Commit' : 'Standard'} Plan – $${hostingOnlyPlan === 'commit' ? PLAN_DISPLAY.commit.totalDollars : PLAN_DISPLAY.standard.monthlyDollars}`
     : 'Select a plan above';
+  const hostingSectionTitle = hasActiveKiloPass ? 'Choose a Hosting Plan' : 'Hosting Only';
+  const hostingSectionDescription = hasActiveKiloPass
+    ? 'You already have Kilo Pass. Choose a hosting plan and fund it from your credit balance or pay directly via Stripe.'
+    : 'Pay for hosting directly via Stripe. You can buy credits separately for AI inference.';
+  const highlightHostingSection = hasActiveKiloPass || hostingOnlyActive;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -548,102 +591,104 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
             </p>
           </div>
 
-          {/* Section 1: Kilo Pass (Recommended) */}
+          {showKiloPassUpsell && (
+            <>
+              {/* Section 1: Kilo Pass (Recommended) */}
+              <div
+                className={cn(
+                  'rounded-xl border p-5 transition-all',
+                  'border-blue-500/30 bg-gradient-to-b from-blue-500/[0.04] to-transparent shadow-[0_0_0_1px_rgba(59,130,246,0.08)]'
+                )}
+              >
+                <div className="mb-3 flex items-center gap-2.5">
+                  <Crown className="h-5 w-5 text-amber-400" />
+                  <h3 className="flex-1 text-base font-semibold">Activate with Kilo Pass</h3>
+                  <Badge className="rounded-full border-transparent bg-blue-500/15 px-2.5 py-0.5 text-[11px] font-semibold text-blue-300 ring-1 ring-blue-500/30">
+                    Recommended
+                  </Badge>
+                </div>
+
+                <p className="text-muted-foreground mb-4 text-[13px]">
+                  Credits for KiloClaw hosting + AI inference. Earn up to{' '}
+                  <span className="text-emerald-300">50% free bonus credits</span>.
+                </p>
+
+                <CadenceToggle cadence={cadence} onChange={handleCadenceChange} />
+
+                {/* Tier cards */}
+                <div className="mb-3.5 grid grid-cols-1 gap-2 sm:grid-cols-3 sm:gap-2.5">
+                  {TIERS.map(tier => (
+                    <TierCard
+                      key={tier}
+                      tier={tier}
+                      cadence={cadence}
+                      isSelected={selectedTier === tier}
+                      onSelect={() => handleTierSelect(tier)}
+                    />
+                  ))}
+                </div>
+
+                <CreditsHowItWorks />
+
+                {/* Warning */}
+                <div className="mb-4 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5">
+                  <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+                  <p className="text-xs leading-relaxed text-amber-300">
+                    Kilo Pass is a <strong className="font-normal">credits subscription</strong>.
+                    Hosting is charged as a credit deduction from your balance. Cancelling Kilo Pass
+                    does <strong className="font-normal">not</strong> cancel KiloClaw hosting.
+                  </p>
+                </div>
+
+                {/* Hosting plan radios */}
+                {selectedTier && (
+                  <HostingRadioGroup
+                    hostingPlan={hostingPlan}
+                    onSelect={handleHostingPlanSelect}
+                    commitDisabled={commitDisabled}
+                    creditIntroEligible={creditIntroEligible}
+                  />
+                )}
+
+                <Button
+                  onClick={handleKiloPassCheckout}
+                  disabled={!kiloPassReady || kiloPassUpsell.isPending}
+                  variant="primary"
+                  className="w-full py-3.5 text-base font-semibold"
+                >
+                  {kiloPassUpsell.isPending ? 'Redirecting to Stripe…' : kiloPassButtonLabel}
+                </Button>
+                <p className="text-muted-foreground mt-2 text-center text-xs">
+                  You&apos;ll be redirected to Stripe to pay for Kilo Pass
+                </p>
+              </div>
+
+              {/* Divider */}
+              <div className="flex items-center gap-3">
+                <div className="bg-border h-px flex-1" />
+                <span className="text-muted-foreground text-xs uppercase tracking-wider">
+                  or pay for KiloClaw hosting only
+                </span>
+                <div className="bg-border h-px flex-1" />
+              </div>
+            </>
+          )}
+
+          {/* Section 2: Hosting selection / standalone checkout */}
           <div
             className={cn(
               'rounded-xl border p-5 transition-all',
-              'border-blue-500/30 bg-gradient-to-b from-blue-500/[0.04] to-transparent shadow-[0_0_0_1px_rgba(59,130,246,0.08)]'
-            )}
-          >
-            <div className="mb-3 flex items-center gap-2.5">
-              <Crown className="h-5 w-5 text-amber-400" />
-              <h3 className="flex-1 text-base font-semibold">Activate with Kilo Pass</h3>
-              <Badge className="rounded-full bg-blue-500/15 px-2.5 py-0.5 text-[11px] font-semibold text-blue-300 ring-1 ring-blue-500/30 border-transparent">
-                Recommended
-              </Badge>
-            </div>
-
-            <p className="text-muted-foreground mb-4 text-[13px]">
-              Credits for KiloClaw hosting + AI inference. Earn up to{' '}
-              <span className="text-emerald-300">50% free bonus credits</span>.
-            </p>
-
-            <CadenceToggle cadence={cadence} onChange={handleCadenceChange} />
-
-            {/* Tier cards */}
-            <div className="mb-3.5 grid grid-cols-1 gap-2 sm:grid-cols-3 sm:gap-2.5">
-              {TIERS.map(tier => (
-                <TierCard
-                  key={tier}
-                  tier={tier}
-                  cadence={cadence}
-                  isSelected={selectedTier === tier}
-                  onSelect={() => handleTierSelect(tier)}
-                />
-              ))}
-            </div>
-
-            <CreditsHowItWorks />
-
-            {/* Warning */}
-            <div className="mb-4 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5">
-              <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
-              <p className="text-xs leading-relaxed text-amber-300">
-                Kilo Pass is a <strong className="font-normal">credits subscription</strong>.
-                Hosting is charged as a credit deduction from your balance. Cancelling Kilo Pass
-                does <strong className="font-normal">not</strong> cancel KiloClaw hosting.
-              </p>
-            </div>
-
-            {/* Hosting plan radios */}
-            {selectedTier && (
-              <HostingRadioGroup
-                hostingPlan={hostingPlan}
-                onSelect={handleHostingPlanSelect}
-                commitDisabled={commitDisabled}
-                creditIntroEligible={creditIntroEligible}
-              />
-            )}
-
-            <Button
-              onClick={handleKiloPassCheckout}
-              disabled={!kiloPassReady || kiloPassUpsell.isPending}
-              variant="primary"
-              className="w-full py-3.5 text-base font-semibold"
-            >
-              {kiloPassUpsell.isPending ? 'Redirecting to Stripe…' : kiloPassButtonLabel}
-            </Button>
-            <p className="text-muted-foreground mt-2 text-center text-xs">
-              You&apos;ll be redirected to Stripe to pay for Kilo Pass
-            </p>
-          </div>
-
-          {/* Divider */}
-          <div className="flex items-center gap-3">
-            <div className="bg-border h-px flex-1" />
-            <span className="text-muted-foreground text-xs uppercase tracking-wider">
-              or pay for KiloClaw hosting only
-            </span>
-            <div className="bg-border h-px flex-1" />
-          </div>
-
-          {/* Section 2: Hosting Only (Secondary) */}
-          <div
-            className={cn(
-              'rounded-xl border p-5 transition-all',
-              hostingOnlyActive
+              highlightHostingSection
                 ? 'border-border opacity-100'
                 : 'border-border/50 opacity-70 hover:opacity-90 hover:border-border'
             )}
           >
             <div className="mb-3 flex items-center gap-2.5">
               <Server className="text-muted-foreground h-[18px] w-[18px]" />
-              <h3 className="text-base font-semibold">Hosting Only</h3>
+              <h3 className="text-base font-semibold">{hostingSectionTitle}</h3>
             </div>
 
-            <p className="text-muted-foreground mb-3.5 text-[13px]">
-              Pay for hosting directly via Stripe. You can buy credits separately for AI inference.
-            </p>
+            <p className="text-muted-foreground mb-3.5 text-[13px]">{hostingSectionDescription}</p>
 
             <div className="mb-4 grid grid-cols-2 gap-2">
               <HostingOnlyPlanCard
@@ -660,13 +705,19 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
               />
             </div>
 
-            {/* Credit enrollment option — shown when user has credits and a hosting-only plan is selected */}
-            {hasCredits && hostingOnlyPlan && (
+            {/* Credit enrollment option — shown when a hosting plan is selected and credits are available or Kilo Pass is active */}
+            {showCreditEnrollment && hostingOnlyPlan && (
               <>
                 <CreditEnrollmentSection
                   selectedPlan={hostingOnlyPlan}
-                  creditBalanceMicrodollars={creditBalance}
-                  creditIntroEligible={creditIntroEligible}
+                  rawCreditBalanceMicrodollars={creditBalance ?? 0}
+                  effectiveBalanceMicrodollars={
+                    selectedCreditEnrollmentPreview.effectiveBalanceMicrodollars
+                  }
+                  projectedKiloPassBonusMicrodollars={
+                    selectedCreditEnrollmentPreview.projectedKiloPassBonusMicrodollars
+                  }
+                  costMicrodollars={selectedCreditEnrollmentPreview.costMicrodollars}
                   onEnroll={handleEnrollWithCredits}
                   isPending={enrollWithCredits.isPending}
                 />

--- a/src/app/(app)/claw/components/billing/WelcomePage.tsx
+++ b/src/app/(app)/claw/components/billing/WelcomePage.tsx
@@ -12,7 +12,6 @@ import { useTRPC } from '@/lib/trpc/utils';
 import {
   COMMIT_PERIOD_MONTHS,
   formatMicrodollars,
-  PLAN_COST_MICRODOLLARS,
   PLAN_DISPLAY,
   planPriceLabel,
   STANDARD_FIRST_MONTH_DOLLARS,
@@ -330,23 +329,26 @@ function CreditsHowItWorks() {
 
 function CreditEnrollmentBanner({
   selectedPlan,
-  creditBalanceMicrodollars,
-  creditIntroEligible,
+  rawCreditBalanceMicrodollars,
+  effectiveBalanceMicrodollars,
+  projectedKiloPassBonusMicrodollars,
+  costMicrodollars,
   onEnroll,
   isPending,
 }: {
   selectedPlan: ClawPlan;
-  creditBalanceMicrodollars: number;
-  creditIntroEligible: boolean;
+  rawCreditBalanceMicrodollars: number;
+  effectiveBalanceMicrodollars: number;
+  projectedKiloPassBonusMicrodollars: number;
+  costMicrodollars: number;
   onEnroll: () => void;
   isPending: boolean;
 }) {
-  const isIntro = selectedPlan === 'standard' && creditIntroEligible;
-  const planCost = isIntro
-    ? STANDARD_FIRST_MONTH_MICRODOLLARS
-    : PLAN_COST_MICRODOLLARS[selectedPlan];
-  const hasSufficientBalance = creditBalanceMicrodollars >= planCost;
-  const shortfall = planCost - creditBalanceMicrodollars;
+  const isIntro =
+    selectedPlan === 'standard' && costMicrodollars === STANDARD_FIRST_MONTH_MICRODOLLARS;
+  const hasProjectedBonus = projectedKiloPassBonusMicrodollars > 0;
+  const hasSufficientBalance = effectiveBalanceMicrodollars >= costMicrodollars;
+  const shortfall = Math.max(0, costMicrodollars - effectiveBalanceMicrodollars);
   const planLabel = selectedPlan === 'commit' ? 'Commit' : 'Standard';
   const priceLabel = isIntro
     ? `$${STANDARD_FIRST_MONTH_DOLLARS} first month, then ${planPriceLabel(selectedPlan)}`
@@ -362,16 +364,27 @@ function CreditEnrollmentBanner({
         <p className="text-muted-foreground mb-1 text-sm">
           {planLabel} Plan — {priceLabel} from your credit balance
         </p>
-        <p className="mb-3 text-xs text-emerald-400/80">
-          Balance: {formatMicrodollars(creditBalanceMicrodollars)}
-        </p>
+        {hasProjectedBonus ? (
+          <div className="mb-3 space-y-1 text-xs text-emerald-400/80">
+            <p>Current balance: {formatMicrodollars(rawCreditBalanceMicrodollars)}</p>
+            <p>
+              Projected Kilo Pass bonus for this charge:{' '}
+              {formatMicrodollars(projectedKiloPassBonusMicrodollars)}
+            </p>
+            <p>Effective balance: {formatMicrodollars(effectiveBalanceMicrodollars)}</p>
+          </div>
+        ) : (
+          <p className="mb-3 text-xs text-emerald-400/80">
+            Balance: {formatMicrodollars(rawCreditBalanceMicrodollars)}
+          </p>
+        )}
         <Button
           onClick={onEnroll}
           disabled={isPending}
           variant="primary"
           className="w-full py-3 font-semibold"
         >
-          {isPending ? 'Activating…' : `Pay ${formatMicrodollars(planCost)} with Credits`}
+          {isPending ? 'Activating…' : `Pay ${formatMicrodollars(costMicrodollars)} with Credits`}
         </Button>
       </div>
     );
@@ -386,13 +399,31 @@ function CreditEnrollmentBanner({
       <div className="text-muted-foreground space-y-1 text-sm">
         <div className="flex justify-between">
           <span>Balance</span>
-          <span className="text-foreground">{formatMicrodollars(creditBalanceMicrodollars)}</span>
+          <span className="text-foreground">
+            {formatMicrodollars(rawCreditBalanceMicrodollars)}
+          </span>
         </div>
+        {hasProjectedBonus && (
+          <div className="flex justify-between">
+            <span>Projected Kilo Pass bonus</span>
+            <span className="text-foreground">
+              {formatMicrodollars(projectedKiloPassBonusMicrodollars)}
+            </span>
+          </div>
+        )}
+        {hasProjectedBonus && (
+          <div className="flex justify-between">
+            <span>Effective balance</span>
+            <span className="text-foreground">
+              {formatMicrodollars(effectiveBalanceMicrodollars)}
+            </span>
+          </div>
+        )}
         <div className="flex justify-between">
           <span>
             {planLabel} plan cost{isIntro ? ' (first month)' : ''}
           </span>
-          <span className="text-foreground">{formatMicrodollars(planCost)}</span>
+          <span className="text-foreground">{formatMicrodollars(costMicrodollars)}</span>
         </div>
         <div className="flex justify-between border-t border-amber-500/20 pt-1 font-medium text-amber-400">
           <span>Shortfall</span>
@@ -447,6 +478,13 @@ export function WelcomePage() {
   const creditBalance = billing?.creditBalanceMicrodollars ?? null;
   const hasCredits = creditBalance !== null && creditBalance > 0;
   const creditIntroEligible = billing?.creditIntroEligible ?? false;
+  const hasActiveKiloPass = billing?.hasActiveKiloPass ?? false;
+  const creditEnrollmentPreview = billing?.creditEnrollmentPreview ?? null;
+  const showKiloPassUpsell = !hasActiveKiloPass;
+  const selectedCreditEnrollmentPreview =
+    hostingOnlyPlan !== null ? (creditEnrollmentPreview?.[hostingOnlyPlan] ?? null) : null;
+  const showCreditEnrollment =
+    !!selectedCreditEnrollmentPreview && (hasCredits || hasActiveKiloPass);
 
   const commitDisabled = !isCommitAvailable(selectedTier, cadence);
   const hostingOnlyActive = hostingOnlyPlan !== null;
@@ -525,6 +563,11 @@ export function WelcomePage() {
   const hostingOnlyLabel = hostingOnlyPlan
     ? `Subscribe to ${hostingOnlyPlan === 'commit' ? 'Commit' : 'Standard'} Plan – $${hostingOnlyPlan === 'commit' ? PLAN_DISPLAY.commit.totalDollars : PLAN_DISPLAY.standard.monthlyDollars}`
     : 'Select a plan above';
+  const hostingSectionTitle = hasActiveKiloPass ? 'Choose a Hosting Plan' : 'Hosting Only';
+  const hostingSectionDescription = hasActiveKiloPass
+    ? 'You already have Kilo Pass. Choose a hosting plan and fund it from your credit balance or pay directly via Stripe.'
+    : 'Pay for hosting directly via Stripe. You can buy credits separately for AI inference.';
+  const highlightHostingSection = hasActiveKiloPass || hostingOnlyActive;
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center px-4 py-12">
@@ -536,102 +579,104 @@ export function WelcomePage() {
       </div>
 
       <div className="w-full max-w-[680px] space-y-4">
-        {/* Section 1: Kilo Pass (Recommended) */}
+        {showKiloPassUpsell && (
+          <>
+            {/* Section 1: Kilo Pass (Recommended) */}
+            <div
+              className={cn(
+                'rounded-xl border p-6 transition-all',
+                'border-blue-500/30 bg-gradient-to-b from-blue-500/[0.04] to-transparent shadow-[0_0_0_1px_rgba(59,130,246,0.08)]'
+              )}
+            >
+              <div className="mb-3 flex items-center gap-2.5">
+                <Crown className="h-5 w-5 text-amber-400" />
+                <h3 className="flex-1 text-base font-semibold">Activate with Kilo Pass</h3>
+                <Badge className="rounded-full border-transparent bg-blue-500/15 px-2.5 py-0.5 text-[11px] font-semibold text-blue-300 ring-1 ring-blue-500/30">
+                  Recommended
+                </Badge>
+              </div>
+
+              <p className="text-muted-foreground mb-4 text-[13px]">
+                Credits for KiloClaw hosting + AI inference. Earn up to{' '}
+                <span className="text-emerald-300">50% free bonus credits</span>.
+              </p>
+
+              <CadenceToggle cadence={cadence} onChange={handleCadenceChange} />
+
+              {/* Tier cards */}
+              <div className="mb-3.5 grid grid-cols-3 gap-2.5">
+                {TIERS.map(tier => (
+                  <TierCard
+                    key={tier}
+                    tier={tier}
+                    cadence={cadence}
+                    isSelected={selectedTier === tier}
+                    onSelect={() => handleTierSelect(tier)}
+                  />
+                ))}
+              </div>
+
+              <CreditsHowItWorks />
+
+              {/* Warning */}
+              <div className="mb-4 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5">
+                <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+                <p className="text-xs leading-relaxed text-amber-300">
+                  Kilo Pass is a <strong className="font-normal">credits subscription</strong>.
+                  Hosting is charged as a credit deduction from your balance. Cancelling Kilo Pass
+                  does <strong className="font-normal">not</strong> cancel KiloClaw hosting.
+                </p>
+              </div>
+
+              {/* Hosting plan radios */}
+              {selectedTier && (
+                <HostingRadioGroup
+                  hostingPlan={hostingPlan}
+                  onSelect={handleHostingPlanSelect}
+                  commitDisabled={commitDisabled}
+                  creditIntroEligible={creditIntroEligible}
+                />
+              )}
+
+              <Button
+                onClick={handleKiloPassCheckout}
+                disabled={!kiloPassReady || kiloPassUpsell.isPending}
+                variant="primary"
+                className="w-full py-3.5 text-base font-semibold"
+              >
+                {kiloPassUpsell.isPending ? 'Redirecting to Stripe…' : kiloPassButtonLabel}
+              </Button>
+              <p className="text-muted-foreground mt-2 text-center text-xs">
+                You&apos;ll be redirected to Stripe to pay for Kilo Pass
+              </p>
+            </div>
+
+            {/* Divider */}
+            <div className="flex items-center gap-3">
+              <div className="bg-border h-px flex-1" />
+              <span className="text-muted-foreground text-xs uppercase tracking-wider">
+                or pay for KiloClaw hosting only
+              </span>
+              <div className="bg-border h-px flex-1" />
+            </div>
+          </>
+        )}
+
+        {/* Section 2: Hosting selection / standalone checkout */}
         <div
           className={cn(
             'rounded-xl border p-6 transition-all',
-            'border-blue-500/30 bg-gradient-to-b from-blue-500/[0.04] to-transparent shadow-[0_0_0_1px_rgba(59,130,246,0.08)]'
-          )}
-        >
-          <div className="mb-3 flex items-center gap-2.5">
-            <Crown className="h-5 w-5 text-amber-400" />
-            <h3 className="flex-1 text-base font-semibold">Activate with Kilo Pass</h3>
-            <Badge className="rounded-full bg-blue-500/15 px-2.5 py-0.5 text-[11px] font-semibold text-blue-300 ring-1 ring-blue-500/30 border-transparent">
-              Recommended
-            </Badge>
-          </div>
-
-          <p className="text-muted-foreground mb-4 text-[13px]">
-            Credits for KiloClaw hosting + AI inference. Earn up to{' '}
-            <span className="text-emerald-300">50% free bonus credits</span>.
-          </p>
-
-          <CadenceToggle cadence={cadence} onChange={handleCadenceChange} />
-
-          {/* Tier cards */}
-          <div className="mb-3.5 grid grid-cols-3 gap-2.5">
-            {TIERS.map(tier => (
-              <TierCard
-                key={tier}
-                tier={tier}
-                cadence={cadence}
-                isSelected={selectedTier === tier}
-                onSelect={() => handleTierSelect(tier)}
-              />
-            ))}
-          </div>
-
-          <CreditsHowItWorks />
-
-          {/* Warning */}
-          <div className="mb-4 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5">
-            <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
-            <p className="text-xs leading-relaxed text-amber-300">
-              Kilo Pass is a <strong className="font-normal">credits subscription</strong>. Hosting
-              is charged as a credit deduction from your balance. Cancelling Kilo Pass does{' '}
-              <strong className="font-normal">not</strong> cancel KiloClaw hosting.
-            </p>
-          </div>
-
-          {/* Hosting plan radios */}
-          {selectedTier && (
-            <HostingRadioGroup
-              hostingPlan={hostingPlan}
-              onSelect={handleHostingPlanSelect}
-              commitDisabled={commitDisabled}
-              creditIntroEligible={creditIntroEligible}
-            />
-          )}
-
-          <Button
-            onClick={handleKiloPassCheckout}
-            disabled={!kiloPassReady || kiloPassUpsell.isPending}
-            variant="primary"
-            className="w-full py-3.5 text-base font-semibold"
-          >
-            {kiloPassUpsell.isPending ? 'Redirecting to Stripe…' : kiloPassButtonLabel}
-          </Button>
-          <p className="text-muted-foreground mt-2 text-center text-xs">
-            You&apos;ll be redirected to Stripe to pay for Kilo Pass
-          </p>
-        </div>
-
-        {/* Divider */}
-        <div className="flex items-center gap-3">
-          <div className="bg-border h-px flex-1" />
-          <span className="text-muted-foreground text-xs uppercase tracking-wider">
-            or pay for KiloClaw hosting only
-          </span>
-          <div className="bg-border h-px flex-1" />
-        </div>
-
-        {/* Section 2: Hosting Only (Secondary) */}
-        <div
-          className={cn(
-            'rounded-xl border p-6 transition-all',
-            hostingOnlyActive
+            highlightHostingSection
               ? 'border-border opacity-100'
               : 'border-border/50 opacity-70 hover:opacity-90 hover:border-border'
           )}
         >
           <div className="mb-3 flex items-center gap-2.5">
             <Server className="text-muted-foreground h-[18px] w-[18px]" />
-            <h3 className="text-base font-semibold">Hosting Only</h3>
+            <h3 className="text-base font-semibold">{hostingSectionTitle}</h3>
           </div>
 
-          <p className="text-muted-foreground mb-3.5 text-[13px]">
-            Pay for hosting directly via Stripe. You can buy credits separately for AI inference.
-          </p>
+          <p className="text-muted-foreground mb-3.5 text-[13px]">{hostingSectionDescription}</p>
 
           <div className="mb-4 grid grid-cols-2 gap-2">
             <HostingOnlyPlanCard
@@ -648,13 +693,19 @@ export function WelcomePage() {
             />
           </div>
 
-          {/* Credit enrollment option — shown when user has credits and a hosting-only plan is selected */}
-          {hasCredits && hostingOnlyPlan && (
+          {/* Credit enrollment option — shown when a hosting plan is selected and credits are available or Kilo Pass is active */}
+          {showCreditEnrollment && hostingOnlyPlan && (
             <>
               <CreditEnrollmentBanner
                 selectedPlan={hostingOnlyPlan}
-                creditBalanceMicrodollars={creditBalance}
-                creditIntroEligible={creditIntroEligible}
+                rawCreditBalanceMicrodollars={creditBalance ?? 0}
+                effectiveBalanceMicrodollars={
+                  selectedCreditEnrollmentPreview.effectiveBalanceMicrodollars
+                }
+                projectedKiloPassBonusMicrodollars={
+                  selectedCreditEnrollmentPreview.projectedKiloPassBonusMicrodollars
+                }
+                costMicrodollars={selectedCreditEnrollmentPreview.costMicrodollars}
                 onEnroll={handleEnrollWithCredits}
                 isPending={enrollWithCredits.isPending}
               />

--- a/src/app/(app)/claw/components/billing/billing-types.ts
+++ b/src/app/(app)/claw/components/billing/billing-types.ts
@@ -62,6 +62,16 @@ export type ClawBillingStatus = {
 
   /** True when the user qualifies for the $4 first-month discount on standard credit enrollment. */
   creditIntroEligible: boolean;
+  /** True when the user has a non-ended Kilo Pass subscription. */
+  hasActiveKiloPass: boolean;
+  creditEnrollmentPreview: Record<
+    ClawPlan,
+    {
+      costMicrodollars: number;
+      projectedKiloPassBonusMicrodollars: number;
+      effectiveBalanceMicrodollars: number;
+    }
+  >;
 
   trial: {
     startedAt: string;

--- a/src/lib/kiloclaw/credit-billing.ts
+++ b/src/lib/kiloclaw/credit-billing.ts
@@ -16,7 +16,7 @@ import {
   computeUsageTriggeredMonthlyBonusDecision,
   maybeIssueKiloPassBonusFromUsageThreshold,
 } from '@/lib/kilo-pass/usage-triggered-bonus';
-import { getKiloPassStateForUser } from '@/lib/kilo-pass/state';
+import { getKiloPassStateForUser, type KiloPassSubscriptionState } from '@/lib/kilo-pass/state';
 import { getEffectiveKiloPassThreshold } from '@/lib/kilo-pass/threshold';
 import { KiloPassCadence } from '@/lib/kilo-pass/enums';
 import {
@@ -52,13 +52,22 @@ export async function projectPendingKiloPassBonusMicrodollars(params: {
   userId: string;
   microdollarsUsed: number;
   kiloPassThreshold: number | null;
+  subscription?: KiloPassSubscriptionState | null;
 }): Promise<number> {
-  const { userId, microdollarsUsed, kiloPassThreshold } = params;
+  const {
+    userId,
+    microdollarsUsed,
+    kiloPassThreshold,
+    subscription: providedSubscription,
+  } = params;
 
   const effectiveThreshold = getEffectiveKiloPassThreshold(kiloPassThreshold);
   if (effectiveThreshold === null || microdollarsUsed < effectiveThreshold) return 0;
 
-  const subscription = await getKiloPassStateForUser(db, userId);
+  const subscription =
+    providedSubscription !== undefined
+      ? providedSubscription
+      : await getKiloPassStateForUser(db, userId);
   if (!subscription || subscription.status !== 'active') return 0;
 
   const tierConfig = KILO_PASS_TIER_CONFIG[subscription.tier];
@@ -84,6 +93,30 @@ export async function projectPendingKiloPassBonusMicrodollars(params: {
   }
 
   return Math.round(monthlyBaseAmountUsd * bonusPercent * 1_000_000);
+}
+
+export async function getEffectiveCreditBalancePreview(params: {
+  userId: string;
+  balanceMicrodollars: number;
+  microdollarsUsed: number;
+  kiloPassThreshold: number | null;
+  costMicrodollars: number;
+  subscription?: KiloPassSubscriptionState | null;
+}): Promise<{
+  projectedKiloPassBonusMicrodollars: number;
+  effectiveBalanceMicrodollars: number;
+}> {
+  const projectedKiloPassBonusMicrodollars = await projectPendingKiloPassBonusMicrodollars({
+    userId: params.userId,
+    microdollarsUsed: params.microdollarsUsed + params.costMicrodollars,
+    kiloPassThreshold: params.kiloPassThreshold,
+    subscription: params.subscription,
+  });
+
+  return {
+    projectedKiloPassBonusMicrodollars,
+    effectiveBalanceMicrodollars: params.balanceMicrodollars + projectedKiloPassBonusMicrodollars,
+  };
 }
 
 /**
@@ -397,12 +430,15 @@ export async function enrollWithCredits(params: {
   // The deduction increments microdollars_used, so project the post-deduction
   // value to correctly evaluate whether the spend crosses the bonus threshold.
   const balance = user.total_microdollars_acquired - user.microdollars_used;
-  const projectedBonus = await projectPendingKiloPassBonusMicrodollars({
-    userId,
-    microdollarsUsed: user.microdollars_used + costMicrodollars,
-    kiloPassThreshold: user.kilo_pass_threshold,
-  });
-  const effectiveBalance = balance + projectedBonus;
+  const { effectiveBalanceMicrodollars: effectiveBalance } = await getEffectiveCreditBalancePreview(
+    {
+      userId,
+      balanceMicrodollars: balance,
+      microdollarsUsed: user.microdollars_used,
+      kiloPassThreshold: user.kilo_pass_threshold,
+      costMicrodollars,
+    }
+  );
 
   if (effectiveBalance < costMicrodollars) {
     const shortfall = costMicrodollars - effectiveBalance;

--- a/src/routers/kiloclaw-billing-router.test.ts
+++ b/src/routers/kiloclaw-billing-router.test.ts
@@ -2186,6 +2186,26 @@ describe('enrollWithCredits', () => {
 // ── Billing Status with Credits ────────────────────────────────────────────
 
 describe('getBillingStatus with credits', () => {
+  async function createKiloPassSubscription(params: {
+    userId: string;
+    status: Stripe.Subscription.Status;
+    cancelAtPeriodEnd?: boolean;
+    endedAt?: string | null;
+  }) {
+    await db.insert(kilo_pass_subscriptions).values({
+      kilo_user_id: params.userId,
+      stripe_subscription_id: `kp-stripe-sub-${crypto.randomUUID()}`,
+      tier: KiloPassTier.Tier19,
+      cadence: KiloPassCadence.Monthly,
+      status: params.status,
+      cancel_at_period_end: params.cancelAtPeriodEnd ?? false,
+      started_at: new Date().toISOString(),
+      ended_at: params.endedAt ?? null,
+      current_streak_months: 1,
+      next_yearly_issue_at: null,
+    });
+  }
+
   it('includes hasStripeFunding=true for Stripe-funded subscription', async () => {
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
@@ -2309,6 +2329,69 @@ describe('getBillingStatus with credits', () => {
     const result = await caller.kiloclaw.getBillingStatus();
 
     expect(result.creditIntroEligible).toBe(false);
+  });
+
+  it('reports hasActiveKiloPass=true for a non-ended Kilo Pass subscription', async () => {
+    await createKiloPassSubscription({
+      userId: user.id,
+      status: 'active',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.getBillingStatus();
+
+    expect(result.hasActiveKiloPass).toBe(true);
+  });
+
+  it('reports hasActiveKiloPass=false for an ended Kilo Pass subscription', async () => {
+    await createKiloPassSubscription({
+      userId: user.id,
+      status: 'canceled',
+      endedAt: new Date().toISOString(),
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.getBillingStatus();
+
+    expect(result.hasActiveKiloPass).toBe(false);
+  });
+
+  it('includes plan-specific effective balance previews with projected Kilo Pass bonus', async () => {
+    await db
+      .update(kilocode_users)
+      .set({
+        total_microdollars_acquired: 0,
+        microdollars_used: 0,
+        kilo_pass_threshold: 4_000_000,
+      })
+      .where(eq(kilocode_users.id, user.id));
+
+    await db.insert(kilo_pass_subscriptions).values({
+      kilo_user_id: user.id,
+      stripe_subscription_id: `kp-stripe-sub-${crypto.randomUUID()}`,
+      tier: KiloPassTier.Tier19,
+      cadence: KiloPassCadence.Yearly,
+      status: 'active',
+      cancel_at_period_end: false,
+      started_at: new Date().toISOString(),
+      current_streak_months: 1,
+      next_yearly_issue_at: null,
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.getBillingStatus();
+
+    expect(result.creditEnrollmentPreview.standard.costMicrodollars).toBe(4_000_000);
+    expect(result.creditEnrollmentPreview.standard.projectedKiloPassBonusMicrodollars).toBe(
+      9_500_000
+    );
+    expect(result.creditEnrollmentPreview.standard.effectiveBalanceMicrodollars).toBe(9_500_000);
+
+    expect(result.creditEnrollmentPreview.commit.costMicrodollars).toBe(48_000_000);
+    expect(result.creditEnrollmentPreview.commit.projectedKiloPassBonusMicrodollars).toBe(
+      9_500_000
+    );
+    expect(result.creditEnrollmentPreview.commit.effectiveBalanceMicrodollars).toBe(9_500_000);
   });
 });
 

--- a/src/routers/kiloclaw-router.ts
+++ b/src/routers/kiloclaw-router.ts
@@ -65,7 +65,9 @@ import {
 } from '@/lib/kiloclaw/constants';
 import {
   enrollWithCredits as enrollWithCreditsImpl,
+  getEffectiveCreditBalancePreview,
   KILOCLAW_PLAN_COST_MICRODOLLARS,
+  KILOCLAW_STANDARD_FIRST_MONTH_MICRODOLLARS,
 } from '@/lib/kiloclaw/credit-billing';
 import type { ClawBillingStatus } from '@/app/(app)/claw/components/billing/billing-types';
 import PostHogClient from '@/lib/posthog';
@@ -1812,15 +1814,12 @@ export const kiloclawRouter = createTRPCRouter({
       sub.status !== 'trialing' &&
       (sub.stripe_subscription_id || sub.payment_source === 'credits');
 
-    // Compute Stripe-funding indicator and conversion prompt.
+    // Compute Stripe-funding indicator and Kilo Pass state.
     // See Billing Status Reporting rules 6-7.
     const hasStripeFunding = hasPaidSubscription ? !!sub.stripe_subscription_id : false;
-
-    let showConversionPrompt = false;
-    if (hasStripeFunding) {
-      const kiloPassState = await getKiloPassStateForUser(db, ctx.user.id);
-      showConversionPrompt = !!kiloPassState && !isStripeSubscriptionEnded(kiloPassState.status);
-    }
+    const kiloPassState = await getKiloPassStateForUser(db, ctx.user.id);
+    const hasActiveKiloPass = !!kiloPassState && !isStripeSubscriptionEnded(kiloPassState.status);
+    const showConversionPrompt = hasStripeFunding && hasActiveKiloPass;
 
     // Renewal cost for the next billing period.
     // For hybrid subscriptions the actual amount is Stripe-determined; report
@@ -1869,12 +1868,31 @@ export const kiloclawRouter = createTRPCRouter({
       };
     }
 
-    // Credit balance: microdollars available for credit enrollment
-    const creditBalanceMicrodollars =
-      ctx.user.total_microdollars_acquired - ctx.user.microdollars_used;
-
     // First-month credit discount eligibility (spec Credit Enrollment rule 3).
     const creditIntroEligible = !(await hadPriorPaidSubscription(ctx.user.id));
+    const creditBalanceMicrodollars =
+      ctx.user.total_microdollars_acquired - ctx.user.microdollars_used;
+    const standardCreditCostMicrodollars = creditIntroEligible
+      ? KILOCLAW_STANDARD_FIRST_MONTH_MICRODOLLARS
+      : KILOCLAW_PLAN_COST_MICRODOLLARS.standard;
+    const [standardCreditEnrollmentPreview, commitCreditEnrollmentPreview] = await Promise.all([
+      getEffectiveCreditBalancePreview({
+        userId: ctx.user.id,
+        balanceMicrodollars: creditBalanceMicrodollars,
+        microdollarsUsed: ctx.user.microdollars_used,
+        kiloPassThreshold: ctx.user.kilo_pass_threshold,
+        costMicrodollars: standardCreditCostMicrodollars,
+        subscription: kiloPassState,
+      }),
+      getEffectiveCreditBalancePreview({
+        userId: ctx.user.id,
+        balanceMicrodollars: creditBalanceMicrodollars,
+        microdollarsUsed: ctx.user.microdollars_used,
+        kiloPassThreshold: ctx.user.kilo_pass_threshold,
+        costMicrodollars: KILOCLAW_PLAN_COST_MICRODOLLARS.commit,
+        subscription: kiloPassState,
+      }),
+    ]);
 
     return {
       hasAccess,
@@ -1882,6 +1900,17 @@ export const kiloclawRouter = createTRPCRouter({
       trialEligible: !activeInstance && !sub && !earlybird,
       creditBalanceMicrodollars,
       creditIntroEligible,
+      hasActiveKiloPass,
+      creditEnrollmentPreview: {
+        standard: {
+          costMicrodollars: standardCreditCostMicrodollars,
+          ...standardCreditEnrollmentPreview,
+        },
+        commit: {
+          costMicrodollars: KILOCLAW_PLAN_COST_MICRODOLLARS.commit,
+          ...commitCreditEnrollmentPreview,
+        },
+      },
       trial: trialData,
       subscription: subscriptionData,
       earlybird: earlybirdData,


### PR DESCRIPTION
## Summary

### Problem

Users who already have an active Kilo Pass subscription still see the full Kilo Pass upsell section (tier cards, cadence toggle, checkout button) when subscribing to KiloClaw hosting. This is confusing — they don't need to buy Kilo Pass again. Additionally, the credit enrollment UI computes plan costs client-side, which cannot account for the projected Kilo Pass bonus that would be unlocked by the hosting deduction.

### Solution

- Hide the entire Kilo Pass upsell section (tier selection, "Recommended" badge, Stripe checkout) when the user already has a non-ended Kilo Pass subscription. The "Hosting Only" section is renamed to "Choose a Hosting Plan" with updated copy.
- The `getBillingStatus` endpoint now returns `hasActiveKiloPass` and a per-plan `creditEnrollmentPreview` containing `costMicrodollars`, `projectedKiloPassBonusMicrodollars`, and `effectiveBalanceMicrodollars`.
- Credit enrollment UI shows a balance breakdown (current balance + projected Kilo Pass bonus = effective balance) instead of a single balance line, when a bonus would apply.
- **Architecture:** Extracted `getEffectiveCreditBalancePreview` from inline logic in `enrollWithCredits` so the same projection can be reused by the billing status endpoint. `projectPendingKiloPassBonusMicrodollars` accepts an optional pre-fetched `subscription` param to avoid redundant DB lookups.

### Why this approach

The alternative was computing effective balance client-side using the existing bonus percentage data, but that would duplicate the server-side bonus projection logic (streak calculations, threshold checks, tier config) and risk divergence. Returning the preview from the server keeps the source of truth in one place.

## Verification

- [x] `pnpm typecheck` — passed
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format:changed` — passed
- [x] `pnpm test -- kiloclaw-billing-router` — 91/91 tests passed (includes 3 new tests)

## Visual Changes

| Before | After |
| ------ | ----- |
| Kilo Pass upsell shown to all users | Kilo Pass section hidden when user has active subscription; hosting section promoted as primary |
| Single "Balance" line in credit enrollment | Balance breakdown: current balance + projected Kilo Pass bonus = effective balance |

## Reviewer Notes

- The `creditEnrollmentPreview` adds two `getEffectiveCreditBalancePreview` calls to `getBillingStatus`. Both reuse the already-fetched `kiloPassState` to avoid extra DB queries.
- The `showCreditEnrollment` condition broadens from `hasCredits` to `hasCredits || hasActiveKiloPass` — a user with zero credit balance but an active Kilo Pass can still enroll if the projected bonus covers the cost.
- Both `PlanSelectionDialog.tsx` and `WelcomePage.tsx` have near-identical changes; they share the same component structure but are rendered in different contexts (dialog vs full page).