### PR TITLE
fix(kiloclaw): fix a few bugs in webhooks handling

### DIFF
--- a/cloudflare-webhook-agent-ingest/src/queue-consumer.ts
+++ b/cloudflare-webhook-agent-ingest/src/queue-consumer.ts
@@ -137,20 +137,6 @@ async function processKiloclawChatMessage(
   }
   const userId = triggerConfig.userId;
 
-  // Mark as inprogress before sending to prevent duplicate delivery on retry.
-  // On retry, the outer guard in processWebhookMessage sees processStatus === 'inprogress'
-  // without a cloudAgentSessionId, which falls into the `processStatus !== 'captured'` branch
-  // and acks the message without re-sending.
-  await withDORetry(
-    () => stub,
-    doStub =>
-      doStub.updateRequest(webhook.requestId, {
-        process_status: 'inprogress',
-        started_at: new Date().toISOString(),
-      }),
-    'updateRequest'
-  );
-
   const renderedPrompt = renderPromptTemplate(triggerConfig.promptTemplate, {
     body: request.body,
     method: request.method,
@@ -167,6 +153,21 @@ async function processKiloclawChatMessage(
   });
 
   const internalApiSecret = await env.INTERNAL_API_SECRET.get();
+
+  // Mark as inprogress immediately before the fetch to prevent duplicate delivery on retry.
+  // This is placed after all preparatory work (template rendering, secret fetch) so that
+  // failures in those steps leave the status as 'captured' and allow normal retries.
+  // On retry after this point, the outer guard in processWebhookMessage sees
+  // processStatus === 'inprogress' without a cloudAgentSessionId and acks the message.
+  await withDORetry(
+    () => stub,
+    doStub =>
+      doStub.updateRequest(webhook.requestId, {
+        process_status: 'inprogress',
+        started_at: new Date().toISOString(),
+      }),
+    'updateRequest'
+  );
 
   const response = await fetch(`${env.KILOCLAW_API_URL}/api/platform/send-chat-message`, {
     method: 'POST',

--- a/cloudflare-webhook-agent-ingest/src/queue-consumer.ts
+++ b/cloudflare-webhook-agent-ingest/src/queue-consumer.ts
@@ -137,6 +137,20 @@ async function processKiloclawChatMessage(
   }
   const userId = triggerConfig.userId;
 
+  // Mark as inprogress before sending to prevent duplicate delivery on retry.
+  // On retry, the outer guard in processWebhookMessage sees processStatus === 'inprogress'
+  // without a cloudAgentSessionId, which falls into the `processStatus !== 'captured'` branch
+  // and acks the message without re-sending.
+  await withDORetry(
+    () => stub,
+    doStub =>
+      doStub.updateRequest(webhook.requestId, {
+        process_status: 'inprogress',
+        started_at: new Date().toISOString(),
+      }),
+    'updateRequest'
+  );
+
   const renderedPrompt = renderPromptTemplate(triggerConfig.promptTemplate, {
     body: request.body,
     method: request.method,

--- a/src/app/(app)/claw/components/WebhookIntegrationSection.tsx
+++ b/src/app/(app)/claw/components/WebhookIntegrationSection.tsx
@@ -152,9 +152,9 @@ export function WebhookIntegrationSection() {
     if (!clawTrigger || !instanceId) return;
     // If auth is enabled, the secret must be re-entered since rotation creates a new trigger
     // and the existing secret hash can't be carried forward
-    if (authEnabled && authHeader && !authSecret) {
+    if (authEnabled && (!authHeader || !authSecret)) {
       toast.error(
-        'Please re-enter the shared secret before rotating — the new URL needs a fresh secret'
+        'Both header name and secret are required when authentication is enabled — the new URL needs a fresh secret'
       );
       setConfirmRotateOpen(false);
       return;
@@ -342,6 +342,7 @@ export function WebhookIntegrationSection() {
                       setPromptDirty(true);
                     }}
                     rows={5}
+                    maxLength={10000}
                     className="font-mono text-xs"
                     placeholder="Enter your prompt template..."
                   />

--- a/src/components/webhook-triggers/TriggerForm.tsx
+++ b/src/components/webhook-triggers/TriggerForm.tsx
@@ -24,6 +24,7 @@ import {
 import {
   normalizeTriggerId,
   triggerIdSchema,
+  triggerIdCreateSchema,
   RESERVED_TRIGGER_IDS,
 } from '@/lib/webhook-trigger-validation';
 import { cn } from '@/lib/utils';
@@ -166,16 +167,20 @@ export function TriggerForm({
       ? 'Webhook auth secret is required when enabling authentication'
       : null;
 
-  // Trigger ID validation
-  const validateTriggerId = useCallback((value: string) => {
-    const result = triggerIdSchema.safeParse(value);
-    if (!result.success) {
-      setTriggerIdError(result.error.issues[0].message);
-      return false;
-    }
-    setTriggerIdError(null);
-    return true;
-  }, []);
+  // Trigger ID validation — use stricter schema for new triggers
+  const activeTriggerIdSchema = isEditMode ? triggerIdSchema : triggerIdCreateSchema;
+  const validateTriggerId = useCallback(
+    (value: string) => {
+      const result = activeTriggerIdSchema.safeParse(value);
+      if (!result.success) {
+        setTriggerIdError(result.error.issues[0].message);
+        return false;
+      }
+      setTriggerIdError(null);
+      return true;
+    },
+    [activeTriggerIdSchema]
+  );
 
   // Handle trigger ID change with auto-transform
   const handleTriggerIdChange = useCallback(
@@ -209,7 +214,7 @@ export function TriggerForm({
     if (!triggerId) {
       errors.push('Trigger Name is required');
     } else {
-      const result = triggerIdSchema.safeParse(triggerId);
+      const result = activeTriggerIdSchema.safeParse(triggerId);
       if (!result.success) {
         errors.push(result.error.issues[0].message);
       }
@@ -241,6 +246,7 @@ export function TriggerForm({
 
     return errors;
   }, [
+    activeTriggerIdSchema,
     triggerId,
     githubRepo,
     model,

--- a/src/lib/webhook-trigger-validation.ts
+++ b/src/lib/webhook-trigger-validation.ts
@@ -15,7 +15,8 @@ export const RESERVED_TRIGGER_IDS = [
 ] as const;
 
 /**
- * Validation schema for trigger IDs.
+ * Validation schema for trigger IDs (used by get/update/delete/list endpoints).
+ * Accepts min(1) to remain compatible with any existing short IDs in production.
  *
  * Requirements:
  * - 1-64 characters
@@ -31,6 +32,16 @@ export const triggerIdSchema = z
     id => !RESERVED_TRIGGER_IDS.includes(id as (typeof RESERVED_TRIGGER_IDS)[number]),
     'This trigger ID is reserved'
   );
+
+/**
+ * Stricter schema for new trigger creation.
+ * Derives from triggerIdSchema to stay in sync, then adds a min-length guard
+ * to prevent trivially guessable IDs in the webhook URL.
+ */
+export const triggerIdCreateSchema = triggerIdSchema.refine(
+  id => id.length >= 8,
+  'Trigger ID must be at least 8 characters'
+);
 
 /**
  * Transform user input to a valid trigger ID format.

--- a/src/routers/webhook-triggers-router.ts
+++ b/src/routers/webhook-triggers-router.ts
@@ -10,7 +10,7 @@ import {
   kiloclaw_instances,
 } from '@kilocode/db/schema';
 import { resolveCloudAgentSessionIds } from '@/lib/webhook-session-resolution';
-import { triggerIdSchema } from '@/lib/webhook-trigger-validation';
+import { triggerIdSchema, triggerIdCreateSchema } from '@/lib/webhook-trigger-validation';
 import {
   createWorkerTrigger,
   getWorkerTrigger,
@@ -24,7 +24,7 @@ import {
 // Input schemas
 const WebhookTriggerCreateInput = z
   .object({
-    triggerId: triggerIdSchema,
+    triggerId: triggerIdCreateSchema,
     organizationId: z.string().uuid().optional(),
     targetType: z.enum(['cloud_agent', 'kiloclaw_chat']).default('cloud_agent'),
     // KiloClaw Chat target fields
@@ -35,7 +35,10 @@ const WebhookTriggerCreateInput = z
     model: z.string().min(1, 'Model is required').optional(),
     profileId: z.string().uuid().optional(),
     // Shared fields
-    promptTemplate: z.string().min(1, 'Prompt template is required'),
+    promptTemplate: z
+      .string()
+      .min(1, 'Prompt template is required')
+      .max(10000, 'Prompt template must be 10,000 characters or less'),
     autoCommit: z.boolean().optional(),
     condenseOnComplete: z.boolean().optional(),
     webhookAuth: z
@@ -72,7 +75,7 @@ const WebhookTriggerUpdateInput = z.object({
   organizationId: z.string().uuid().optional(),
   mode: z.enum(['architect', 'code', 'ask', 'debug', 'orchestrator']).optional(),
   model: z.string().min(1).optional(),
-  promptTemplate: z.string().min(1).optional(),
+  promptTemplate: z.string().min(1).max(10000).optional(),
   profileId: z.string().uuid().optional(),
   autoCommit: z.boolean().nullable().optional(),
   condenseOnComplete: z.boolean().nullable().optional(),


### PR DESCRIPTION
## Summary                                                                       

Addresses four findings from the kiloclaw webhook code review:                

- double delivery: KiloClaw chat messages could be sent twice if the DO status update after delivery failed. Now marks requests as inprogress before   sending, so the outer idempotency guard skips retries.                        
- prompt template limits: Added max(10,000) to both create and update Zod schemas for promptTemplate, and maxLength={10000} on the frontend textarea to enforce input validation parity.
- auth bypass on rotation: The rotation handler allowed creating a trigger without webhook auth if the user cleared the header name field while auth was enabled. Changed the guard from authEnabled && authHeader &&    !authSecret to authEnabled && (!authHeader || !authSecret), matching the existing setup handler.                                      
- trigger ID entropy: Introduced triggerIdCreateSchema (min 8 chars) derived from triggerIdSchema via .refine(), applied only on the create path. Existing triggers with short IDs remain accessible — triggerIdSchema (min 1)   is unchanged for get/update/delete. Client-side TriggerForm switches schema based on isEditMode.                                         

## Verification
- pnpm run format:check — passes (only unrelated plans/ file flagged)         
- pnpm run typecheck — only pre-existing errors (archiver, csv-parse/sync   module declarations)                                                          
- npx tsc --noEmit in cloudflare-webhook-agent-ingest/ — clean
- Confirmed no existing test fixtures or code creates trigger IDs shorter than    8 characters                                                                 

## Visual Changes                                                                

  N/A                                               

## Reviewer Notes

- The fix relies on the existing outer guard in processWebhookMessage (line ~285) which acks any message where processStatus    !== 'captured' and there's no cloudAgentSessionId. KiloClaw chat never sets      cloudAgentSessionId, so inprogress status causes the retry to skip. This matches the pattern already used by the Cloud Agent path.
- Backward compatibility: If any production trigger IDs are shorter than 8   chars, they'll still work for all operations except creating a new trigger with the same short format. The triggerIdCreateSchema is derived from   triggerIdSchema (not duplicated) so constraint changes only need to happen in one place.                                                   
- Edge case: The bug required a user to deliberately clear the   pre-populated header field (x-webhook-secret) during URL rotation — unlikely but possible.

