### PR TITLE
fix(kiloclaw): include claw-chat.css on organization claw page

### DIFF
--- a/src/app/(app)/organizations/[id]/claw/layout.tsx
+++ b/src/app/(app)/organizations/[id]/claw/layout.tsx
@@ -1,0 +1,5 @@
+import '@/app/(app)/claw/claw-chat.css';
+
+export default function OrgClawLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary

- The Stream Chat CSS overrides (`claw-chat.css`) were only imported in the personal `/claw` route layout. The organization claw route (`/organizations/[id]/claw`) reuses the same `ClawDashboard` component but had no layout file, so the chat UI was rendered without the Stream Chat theme overrides.
- Added a minimal `layout.tsx` at `src/app/(app)/organizations/[id]/claw/` that imports `claw-chat.css` via path alias, mirroring the pattern in the personal claw layout.

## Verification

- [x] `pnpm typecheck` — passed with no errors
- [x] Pre-push hooks (format, lint, typecheck) — all passed

## Visual Changes

N/A

## Reviewer Notes

The new layout intentionally omits the `getUserFromAuthOrRedirect()` call present in the personal claw layout (`src/app/(app)/claw/layout.tsx`) because the organization page already handles auth via `OrganizationByPageLayout` in its `page.tsx`.