### PR TITLE
fix(cloud-agent): restore canSend/canInterrupt on interrupt failure

### DIFF
--- a/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -608,6 +608,22 @@ describe('createSessionManager', () => {
       );
     });
 
+    it('restores canSend and canInterrupt on interrupt failure', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-1'));
+      expect(atomValue<boolean>(config.store, mgr.atoms.canSend)).toBe(true);
+      expect(atomValue<boolean>(config.store, mgr.atoms.canInterrupt)).toBe(true);
+
+      mockSession.interrupt.mockRejectedValueOnce(new Error('transient failure'));
+      await mgr.interrupt();
+
+      // After a failed interrupt, atoms should be restored from session state
+      expect(atomValue<boolean>(config.store, mgr.atoms.canSend)).toBe(true);
+      expect(atomValue<boolean>(config.store, mgr.atoms.canInterrupt)).toBe(true);
+    });
+
     it('is a no-op without active session', async () => {
       const config = createMockConfig();
       const mgr = createSessionManager(config);

--- a/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/src/lib/cloud-agent-sdk/session-manager.ts
@@ -601,6 +601,8 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
 
   async function interrupt(): Promise<void> {
     if (!currentSession) return;
+    // Snapshot before await — switchSession()/destroy() can swap currentSession while in flight.
+    const session = currentSession;
     // Eagerly disable send/interrupt to prevent the user from sending a
     // message while the async interrupt HTTP call is in flight. We do NOT
     // call disconnect() — interrupt stops the agent but keeps the transport
@@ -608,16 +610,18 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     store.set(canSendAtom, false);
     store.set(canInterruptAtom, false);
     try {
-      if (currentSession.canInterrupt) {
-        await currentSession.interrupt();
+      if (session.canInterrupt) {
+        await session.interrupt();
       }
       setIndicator({ type: 'info', message: 'Session stopped', timestamp: Date.now() });
     } catch {
-      // Restore atoms from the session's actual state so the UI isn't stuck.
-      store.set(canInterruptAtom, currentSession.canInterrupt);
-      const cs = store.get(cloudStatusAtom);
-      const cloudReady = cs === null || cs.type === 'ready';
-      store.set(canSendAtom, currentSession.canSend && cloudReady);
+      // Only restore atoms if the session wasn't swapped during the await.
+      if (currentSession === session) {
+        store.set(canInterruptAtom, session.canInterrupt);
+        const cs = store.get(cloudStatusAtom);
+        const cloudReady = cs === null || cs.type === 'ready';
+        store.set(canSendAtom, session.canSend && cloudReady);
+      }
       store.set(errorAtom, 'Failed to stop execution');
     }
   }

--- a/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/src/lib/cloud-agent-sdk/session-manager.ts
@@ -613,6 +613,11 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       }
       setIndicator({ type: 'info', message: 'Session stopped', timestamp: Date.now() });
     } catch {
+      // Restore atoms from the session's actual state so the UI isn't stuck.
+      store.set(canInterruptAtom, currentSession.canInterrupt);
+      const cs = store.get(cloudStatusAtom);
+      const cloudReady = cs === null || cs.type === 'ready';
+      store.set(canSendAtom, currentSession.canSend && cloudReady);
       store.set(errorAtom, 'Failed to stop execution');
     }
   }

--- a/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/src/lib/cloud-agent-sdk/session-manager.ts
@@ -613,16 +613,17 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       if (session.canInterrupt) {
         await session.interrupt();
       }
-      setIndicator({ type: 'info', message: 'Session stopped', timestamp: Date.now() });
+      if (currentSession === session) {
+        setIndicator({ type: 'info', message: 'Session stopped', timestamp: Date.now() });
+      }
     } catch {
-      // Only restore atoms if the session wasn't swapped during the await.
       if (currentSession === session) {
         store.set(canInterruptAtom, session.canInterrupt);
         const cs = store.get(cloudStatusAtom);
         const cloudReady = cs === null || cs.type === 'ready';
         store.set(canSendAtom, session.canSend && cloudReady);
+        store.set(errorAtom, 'Failed to stop execution');
       }
-      store.set(errorAtom, 'Failed to stop execution');
     }
   }
 


### PR DESCRIPTION
## Summary

`interrupt()` eagerly sets `canSendAtom` and `canInterruptAtom` to `false` before the HTTP call, but the `catch` block never restored them. A transient API failure would leave the session permanently disabled until page refresh. The catch block now restores both atoms from the session's actual state (matching the subscription handler logic).

## Verification

- [x] `pnpm jest --testPathPatterns='session-manager\.test'` — 51 tests pass
- [x] New test: `restores canSend and canInterrupt on interrupt failure`

## Visual Changes

N/A

## Reviewer Notes

Addresses the WARNING from the code review on #1845. The recovery logic mirrors the subscription handler at `session-manager.ts:383-384`, reading `canSend`/`canInterrupt` from the session and factoring in `cloudStatusAtom`.