### PR TITLE
Feat/kiloclaw bump openclaw 2026.3.24

### DIFF
--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -54,7 +54,7 @@ FLY_IMAGE_TAG=latest
 # Used by the worker to self-register the version → image tag mapping in KV,
 # enabling per-user version tracking. Without this, version tracking fields
 # will be null and instances fall back to FLY_IMAGE_TAG directly.
-OPENCLAW_VERSION=2026.3.22
+OPENCLAW_VERSION=2026.3.23
 
 # Legacy fallback for existing instances without per-user apps.
 # New instances get per-user apps (acct-{hash}) created automatically.

--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -54,7 +54,7 @@ FLY_IMAGE_TAG=latest
 # Used by the worker to self-register the version → image tag mapping in KV,
 # enabling per-user version tracking. Without this, version tracking fields
 # will be null and instances fall back to FLY_IMAGE_TAG directly.
-OPENCLAW_VERSION=2026.3.23
+OPENCLAW_VERSION=2026.3.24
 
 # Legacy fallback for existing instances without per-user apps.
 # New instances get per-user apps (acct-{hash}) created automatically.

--- a/kiloclaw/.dev.vars.example
+++ b/kiloclaw/.dev.vars.example
@@ -54,7 +54,7 @@ FLY_IMAGE_TAG=latest
 # Used by the worker to self-register the version → image tag mapping in KV,
 # enabling per-user version tracking. Without this, version tracking fields
 # will be null and instances fall back to FLY_IMAGE_TAG directly.
-OPENCLAW_VERSION=2026.2.9
+OPENCLAW_VERSION=2026.3.22
 
 # Legacy fallback for existing instances without per-user apps.
 # New instances get per-user apps (acct-{hash}) created automatically.

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -42,7 +42,7 @@ RUN npm install -g pnpm
 
 # Install OpenClaw
 # Pin to specific version for reproducible builds
-RUN npm install -g openclaw@2026.3.22 \
+RUN npm install -g openclaw@2026.3.23 \
     && openclaw --version
 
 # Install ClawHub CLI
@@ -113,7 +113,7 @@ RUN mkdir -p /root/.openclaw \
 
 # Copy helper scripts (used at runtime by the controller/gateway)
 # Build cache bust: 2026-03-17-v65-remove-startup-script
-RUN echo "11"
+RUN echo "12"
 COPY openclaw-pairing-list.js /usr/local/bin/openclaw-pairing-list.js
 COPY openclaw-device-pairing-list.js /usr/local/bin/openclaw-device-pairing-list.js
 

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -42,7 +42,7 @@ RUN npm install -g pnpm
 
 # Install OpenClaw
 # Pin to specific version for reproducible builds
-RUN npm install -g openclaw@2026.3.13 \
+RUN npm install -g openclaw@2026.3.22 \
     && openclaw --version
 
 # Install ClawHub CLI

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -42,7 +42,7 @@ RUN npm install -g pnpm
 
 # Install OpenClaw
 # Pin to specific version for reproducible builds
-RUN npm install -g openclaw@2026.3.23 \
+RUN npm install -g openclaw@2026.3.24 \
     && openclaw --version
 
 # Install ClawHub CLI

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -113,7 +113,7 @@ RUN mkdir -p /root/.openclaw \
 
 # Copy helper scripts (used at runtime by the controller/gateway)
 # Build cache bust: 2026-03-17-v65-remove-startup-script
-RUN echo "12"
+RUN echo "11"
 COPY openclaw-pairing-list.js /usr/local/bin/openclaw-pairing-list.js
 COPY openclaw-device-pairing-list.js /usr/local/bin/openclaw-device-pairing-list.js
 

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -402,7 +402,7 @@ export const DEFAULT_MCPORTER_CONFIG_PATH = '/root/.openclaw/workspace/config/mc
  *
  * TODO: When OpenClaw's Pi MCP bridge gains HTTP/SSE transport, migrate these
  * definitions into generateBaseConfig() using `config.mcp.servers` and remove
- * mcporter. See PR #48611 in openclaw/openclaw.
+ * mcporter.
  */
 export function writeMcporterConfig(
   env: EnvLike,

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -393,12 +393,16 @@ export const DEFAULT_MCPORTER_CONFIG_PATH = '/root/.openclaw/workspace/config/mc
 /**
  * Write mcporter.json with MCP server definitions derived from environment variables.
  * MCPorter is the middleware layer that lets OpenClaw agents call MCP server tools
- * via `mcporter call <server>.<tool>`. This bypasses openclaw.json's strict schema
- * validation, which does not yet support `mcp.servers` (requires OpenClaw >= 2026.3.14).
+ * via `mcporter call <server>.<tool>`.
  *
- * TODO: When the Dockerfile pins OpenClaw >= 2026.3.14, migrate MCP server config
- * into generateBaseConfig() using `config.mcp.servers` in openclaw.json instead.
- * The mcporter approach can then be removed. See PR #48611 in openclaw/openclaw.
+ * The `config.mcp.servers` schema exists in openclaw.json (since v2026.3.14), but
+ * OpenClaw's embedded Pi MCP runtime only supports StdioClientTransport — it has no
+ * HTTP/SSE transport. Since our MCP servers (AgentCard, Linear) are remote HTTP
+ * endpoints, mcporter must stay until OpenClaw adds HTTP transport support.
+ *
+ * TODO: When OpenClaw's Pi MCP bridge gains HTTP/SSE transport, migrate these
+ * definitions into generateBaseConfig() using `config.mcp.servers` and remove
+ * mcporter. See PR #48611 in openclaw/openclaw.
  */
 export function writeMcporterConfig(
   env: EnvLike,

--- a/kiloclaw/controller/src/pairing-cache.ts
+++ b/kiloclaw/controller/src/pairing-cache.ts
@@ -190,12 +190,10 @@ export function detectChannels(config: unknown): string[] {
   const tg = isRecord(ch.telegram) ? ch.telegram : {};
   const dc = isRecord(ch.discord) ? ch.discord : {};
   const sl = isRecord(ch.slack) ? ch.slack : {};
-  const sc = isRecord(ch.streamchat) ? ch.streamchat : {};
   const channels: string[] = [];
   if (tg.enabled && tg.botToken) channels.push('telegram');
   if (dc.enabled && dc.token) channels.push('discord');
   if (sl.enabled && (sl.botToken || sl.appToken)) channels.push('slack');
-  if (sc.enabled && sc.apiKey) channels.push('streamchat');
   return channels;
 }
 

--- a/kiloclaw/controller/src/pairing-cache.ts
+++ b/kiloclaw/controller/src/pairing-cache.ts
@@ -93,16 +93,11 @@ function approveFail(message: string, statusHint: 400 | 500): ApproveResult {
 export const OPENCLAW_BIN = '/usr/local/bin/openclaw';
 
 // Mirrors resolveStateDir() / resolveOAuthDir() in openclaw/src/config/paths.ts
-// Includes legacy CLAWDBOT_STATE_DIR fallback (openclaw paths.ts:65)
 // Note: openclaw's full resolveStateDir() also does filesystem-existence checks for
-// legacy .clawdbot dirs — those are omitted here because the container Dockerfile
-// always creates /root/.openclaw, making the existence check unreachable in practice.
+// legacy dirs — those are omitted here because the container Dockerfile always
+// creates /root/.openclaw, making the existence check unreachable in practice.
 export function resolveOpenClawStateDir(): string {
-  return (
-    process.env.OPENCLAW_STATE_DIR?.trim() ||
-    process.env.CLAWDBOT_STATE_DIR?.trim() ||
-    '/root/.openclaw'
-  );
+  return process.env.OPENCLAW_STATE_DIR?.trim() || '/root/.openclaw';
 }
 
 export function resolveCredentialsDir(): string {
@@ -195,10 +190,12 @@ export function detectChannels(config: unknown): string[] {
   const tg = isRecord(ch.telegram) ? ch.telegram : {};
   const dc = isRecord(ch.discord) ? ch.discord : {};
   const sl = isRecord(ch.slack) ? ch.slack : {};
+  const sc = isRecord(ch.streamchat) ? ch.streamchat : {};
   const channels: string[] = [];
   if (tg.enabled && tg.botToken) channels.push('telegram');
   if (dc.enabled && dc.token) channels.push('discord');
   if (sl.enabled && (sl.botToken || sl.appToken)) channels.push('slack');
+  if (sc.enabled && sc.apiKey) channels.push('streamchat');
   return channels;
 }
 

--- a/kiloclaw/e2e/docker-image-testing.md
+++ b/kiloclaw/e2e/docker-image-testing.md
@@ -141,7 +141,7 @@ docker rm kiloclaw-gateway
 ```bash
 # Check versions
 docker run --rm kiloclaw:test node --version        # v22.13.1
-docker run --rm kiloclaw:test openclaw --version    # 2026.2.9
+docker run --rm kiloclaw:test openclaw --version    # 2026.3.22
 
 # Check directories
 docker run --rm kiloclaw:test ls -la /root/.openclaw

--- a/kiloclaw/e2e/docker-image-testing.md
+++ b/kiloclaw/e2e/docker-image-testing.md
@@ -141,7 +141,7 @@ docker rm kiloclaw-gateway
 ```bash
 # Check versions
 docker run --rm kiloclaw:test node --version        # v22.13.1
-docker run --rm kiloclaw:test openclaw --version    # 2026.3.22
+docker run --rm kiloclaw:test openclaw --version    # 2026.3.23
 
 # Check directories
 docker run --rm kiloclaw:test ls -la /root/.openclaw

--- a/kiloclaw/e2e/docker-image-testing.md
+++ b/kiloclaw/e2e/docker-image-testing.md
@@ -141,7 +141,7 @@ docker rm kiloclaw-gateway
 ```bash
 # Check versions
 docker run --rm kiloclaw:test node --version        # v22.13.1
-docker run --rm kiloclaw:test openclaw --version    # 2026.3.23
+docker run --rm kiloclaw:test openclaw --version    # 2026.3.24
 
 # Check directories
 docker run --rm kiloclaw:test ls -la /root/.openclaw

--- a/kiloclaw/src/routes/controller.test.ts
+++ b/kiloclaw/src/routes/controller.test.ts
@@ -72,7 +72,7 @@ function makeBody(overrides?: Record<string, unknown>) {
   return {
     sandboxId,
     machineId: 'machine-1',
-    controllerVersion: '2026.3.22',
+    controllerVersion: '2026.3.23',
     controllerCommit: 'abc1234',
     openclawVersion: '2026.3.13',
     openclawCommit: 'def5678',

--- a/kiloclaw/src/routes/controller.test.ts
+++ b/kiloclaw/src/routes/controller.test.ts
@@ -72,7 +72,7 @@ function makeBody(overrides?: Record<string, unknown>) {
   return {
     sandboxId,
     machineId: 'machine-1',
-    controllerVersion: '2026.3.23',
+    controllerVersion: '2026.3.22',
     controllerCommit: 'abc1234',
     openclawVersion: '2026.3.13',
     openclawCommit: 'def5678',


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

Bump supported OpenClaw version for KiloClaw to 2026.3.24. There are zero breaking changes since 2026.3.13. 

## Verification

In-depth manual research was done, and then I created skills to automate it for the following versions. Manual testing was performed for both individual and org KiloClaw instances:

1. Provision a fresh instance running 2026.3.13
2. Configured Telegram
3. Configured Linear
4. Verified that WebUI/Telegram were working; Verified Linear was working
5. Upgraded to 2026.3.24
7. Re-verified the same as Step 4.

**Note**: I separately tested each of the following as well:
- 3.13 --> 3.22
- 3.22 --> 3.23
- 3.23 --> 3.24

Other test cases
- Verified kilo models appear and can be selected on both platforms
- verified token is still required for access

## Visual Changes
N/A

## Reviewer Notes
- All research and the skills are stored here: https://github.com/Kilo-Org/KiloClaw-Version-Upgrade-Artifacts
