### PR TITLE
fix(kiloclaw): set baseUrl when creating kilocode provider entry for org instances

### DIFF
--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -251,6 +251,9 @@ describe('generateBaseConfig', () => {
     expect(config.models.providers.kilocode.headers['X-KiloCode-OrganizationId']).toBe(
       'org_abc123'
     );
+    // baseUrl must be a string (OpenClaw schema requires it); fall back to
+    // the production URL when no KILOCODE_API_BASE_URL override is active.
+    expect(config.models.providers.kilocode.baseUrl).toBe('https://api.kilo.ai/api/gateway/');
     expect(config.models.providers.kilocode.models).toEqual([]);
   });
 

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -187,6 +187,10 @@ export function generateBaseConfig(
     config.models = config.models ?? {};
     config.models.providers = config.models.providers ?? {};
     config.models.providers.kilocode = config.models.providers.kilocode ?? {};
+    // OpenClaw's provider schema requires baseUrl to be a string. Preserve an
+    // existing dev override (KILOCODE_API_BASE_URL), otherwise use the production URL.
+    config.models.providers.kilocode.baseUrl =
+      config.models.providers.kilocode.baseUrl ?? 'https://api.kilo.ai/api/gateway/';
     config.models.providers.kilocode.headers = config.models.providers.kilocode.headers ?? {};
     config.models.providers.kilocode.headers['X-KiloCode-OrganizationId'] =
       env.KILOCODE_ORGANIZATION_ID;


### PR DESCRIPTION
## Summary

This fixes a bug introduced in #1836 earlier today, which caused a zod validation to fail in OpenClaw itself (not our own infra). This missing field in openclaw.json is unfixable by the doctor, and results in the instance restarting itself until it crashes. This affects org instances only.

---

Org instances boot with `KILOCODE_ORGANIZATION_ID` set, which causes `generateBaseConfig` to create a `models.providers.kilocode` entry to inject the `X-KiloCode-OrganizationId` header. That entry was missing `baseUrl`, which OpenClaw's `ModelProviderSchema` has required as a non-empty string since at least January 2026. Every org instance boot failed with:

```
models.providers.kilocode.baseUrl: Invalid input: expected string, received undefined
```

The fix is a single line: set `baseUrl` to the production URL (`https://api.kilo.ai/api/gateway/`) when creating the entry, falling back from any existing dev override set earlier by `KILOCODE_API_BASE_URL`.

Personal instances are unaffected — they never set `KILOCODE_ORGANIZATION_ID` so the entry is never created.

<img width="1180" height="396" alt="image" src="https://github.com/user-attachments/assets/e8112ae1-1a74-4e42-a9b5-2304db8f17e3" />

Logs (truncated):
```
00:54:02
Invalid config at /root/.openclaw/openclaw.json:\n- models.providers.kilocode.baseUrl: Invalid input: expected string, received undefined
00:54:03
Config invalid
00:54:03
File: ~/.openclaw/openclaw.json
00:54:03
Problem:
00:54:03
  - models.providers.kilocode.baseUrl: Invalid input: expected string, received undefined
00:54:03
Run: openclaw doctor --fix
00:54:33
[pairing-cache] periodic refresh
00:54:47
Invalid config at /root/.openclaw/openclaw.json:\n- models.providers.kilocode.baseUrl: Invalid input: expected string, received undefined
# ... etc
```
## Verification

-  Updated prod instance's config file with the file editor, and the death loop stopped. Instance immediately became responsive
- Reproduced the bug several times by destroying and provisioning

## Visual Changes

N/A

## Reviewer Notes

Confirmed via the openclaw/openclaw GitHub history that `baseUrl: z.string().min(1)` has been required since commit `d1e9490f` (Jan 19 2026) — this is not an upstream regression, it was just missed when the org header feature was written.