### PR TITLE
fix(admin): invalidate controllerVersion on machineRedeploy and machineUpgrade success

### DIFF
--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1221,6 +1221,13 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         toast.success('Redeploy requested');
         invalidateMachineQueries();
         invalidateGatewayQueries();
+        if (data?.user_id) {
+          void queryClient.invalidateQueries({
+            queryKey: trpc.admin.kiloclawInstances.controllerVersion.queryKey({
+              userId: data.user_id,
+            }),
+          });
+        }
         setAwaitingRestartCompletion(true);
       },
       onError: err => {
@@ -1235,6 +1242,13 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         toast.success('Upgrade to latest requested');
         invalidateMachineQueries();
         invalidateGatewayQueries();
+        if (data?.user_id) {
+          void queryClient.invalidateQueries({
+            queryKey: trpc.admin.kiloclawInstances.controllerVersion.queryKey({
+              userId: data.user_id,
+            }),
+          });
+        }
         setAwaitingRestartCompletion(true);
       },
       onError: err => {


### PR DESCRIPTION
## Summary

Adds an immediate `controllerVersion` query invalidation to the `onSuccess` callbacks of both `machineRedeploy` and `machineUpgrade` mutations in `KiloclawInstanceDetail.tsx`.

Previously, the Gateway section could show stale data (e.g. "Unavailable until redeploy") for up to 5 minutes after a redeploy or upgrade succeeded because the `controllerVersion` query has a 5-minute `staleTime` and was only re-invalidated once the machine polled back to `running` state — not at mutation success time.

The fix adds an immediate invalidation at `onSuccess` (guarded by `data?.user_id`), clearing the stale cache right away. The existing deferred re-invalidation via the `useEffect` polling loop (fires once the machine is confirmed `running`) is preserved alongside this immediate invalidation.

## Verification

- Code review only; change is a pure query-cache invalidation with no server-side logic.
- Pattern mirrors the existing `controllerVersion` invalidation in the `useEffect` restart-completion hook (lines 1133–1140 in the file).
- No regressions possible — invalidating a query early just causes an extra refetch, not incorrect state.

## Visual Changes

N/A

## Reviewer Notes

The double-invalidation is intentional: the immediate invalidation at `onSuccess` kicks out the stale cached value before the machine has restarted, and the `useEffect` invalidation fires a second time once the machine is confirmed `running` and the new `controllerVersion` is actually available. This is the correct two-phase pattern for post-restart UI updates.