### PR TITLE
feat(kiloclaw): show earlybird subscription details on claw page

### DIFF
--- a/src/app/(app)/claw/components/SubscriptionTab.tsx
+++ b/src/app/(app)/claw/components/SubscriptionTab.tsx
@@ -18,7 +18,10 @@ export function SubscriptionTab() {
 
   if (!billing) return null;
 
-  if (!billing.subscription) {
+  const subscription = billing.subscription;
+  const showInactiveSubscriptionState = !subscription || subscription.status === 'canceled';
+
+  if (showInactiveSubscriptionState) {
     if (billing.earlybird && billing.earlybird.daysRemaining > 0) {
       return (
         <>

--- a/src/app/(app)/claw/components/SubscriptionTab.tsx
+++ b/src/app/(app)/claw/components/SubscriptionTab.tsx
@@ -5,6 +5,7 @@ import { CreditCard } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Button } from '@/components/ui/button';
+import { EarlybirdCard } from './billing/EarlybirdCard';
 import { SubscriptionCard } from './billing/SubscriptionCard';
 import { CancelDialog } from './billing/CancelDialog';
 import { PlanSelectionDialog } from './billing/PlanSelectionDialog';
@@ -18,6 +19,18 @@ export function SubscriptionTab() {
   if (!billing) return null;
 
   if (!billing.subscription) {
+    if (billing.earlybird && billing.earlybird.daysRemaining > 0) {
+      return (
+        <>
+          <EarlybirdCard
+            earlybird={billing.earlybird}
+            onSubscribeClick={() => setShowPlanDialog(true)}
+          />
+          <PlanSelectionDialog open={showPlanDialog} onOpenChange={setShowPlanDialog} />
+        </>
+      );
+    }
+
     const trialDays = billing.trial && !billing.trial.expired ? billing.trial.daysRemaining : null;
 
     return (

--- a/src/app/(app)/claw/components/billing/EarlybirdCard.tsx
+++ b/src/app/(app)/claw/components/billing/EarlybirdCard.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { Gift } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { formatBillingDate, type ClawBillingStatus } from './billing-types';
+
+type EarlybirdCardProps = {
+  earlybird: NonNullable<ClawBillingStatus['earlybird']>;
+  onSubscribeClick: () => void;
+};
+
+export function EarlybirdCard({ earlybird, onSubscribeClick }: EarlybirdCardProps) {
+  const isEndingSoon = earlybird.daysRemaining > 0 && earlybird.daysRemaining <= 30;
+
+  if (isEndingSoon) {
+    return (
+      <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="text-xl">🦀</span>
+            <span className="text-foreground text-sm font-semibold">KiloClaw Hosting</span>
+          </div>
+          <span className="inline-flex items-center gap-1 rounded-full bg-violet-500/15 px-2 py-0.5 text-xs font-medium text-violet-400">
+            <Gift className="h-3 w-3" />
+            Early Bird
+          </span>
+        </div>
+
+        <div className="text-muted-foreground space-y-1 text-sm">
+          <div>
+            <span>Status:</span> <span className="text-amber-400">Active</span>
+          </div>
+          <div>
+            <span>Access expires:</span>{' '}
+            <span className="text-foreground">{formatBillingDate(earlybird.expiresAt)}</span>
+          </div>
+          <div>
+            <span>Days remaining:</span>{' '}
+            <span className="text-foreground">{earlybird.daysRemaining}</span>
+          </div>
+        </div>
+
+        <div className="mt-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
+          <p className="text-sm text-amber-300">
+            Your early bird access is ending soon. Subscribe to a hosting plan to keep your instance
+            running after {formatBillingDate(earlybird.expiresAt)}.
+          </p>
+          <div className="mt-2">
+            <Button variant="outline" size="sm" onClick={onSubscribeClick}>
+              View Plans
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-xl">🦀</span>
+          <span className="text-foreground text-sm font-semibold">KiloClaw Hosting</span>
+        </div>
+        <span className="inline-flex items-center gap-1 rounded-full bg-violet-500/15 px-2 py-0.5 text-xs font-medium text-violet-400">
+          <Gift className="h-3 w-3" />
+          Early Bird
+        </span>
+      </div>
+
+      <div className="text-muted-foreground space-y-1 text-sm">
+        <div>
+          <span>Status:</span> <span className="text-emerald-400">Active</span>
+        </div>
+        <div>
+          <span>Access expires:</span>{' '}
+          <span className="text-foreground">{formatBillingDate(earlybird.expiresAt)}</span>
+        </div>
+        <div>
+          <span>Days remaining:</span>{' '}
+          <span className="text-foreground">{earlybird.daysRemaining}</span>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

### Problem
Early bird users who purchased KiloClaw hosting see "No active subscription" with a "Subscribe Now" button on the `/claw#subscription` tab. The `SubscriptionTab` only checks `billing.subscription` (populated for paid subscriptions), but earlybird users only have a `kiloclaw_earlybird_purchases` record — no `kiloclaw_subscriptions` row.

### Solution
- New `EarlybirdCard` component displays early bird access status, expiry date, and days remaining.
- Two visual states: emerald (active, >30 days remaining) and amber (ending soon, ≤30 days). The amber state includes a warning banner with a "View Plans" CTA.
- `SubscriptionTab` renders `EarlybirdCard` when `billing.earlybird` is present with `daysRemaining > 0` and no paid subscription exists. Expired earlybird (`daysRemaining <= 0`) falls through to the existing empty state, consistent with `deriveLockReason` handling expiry via the lock dialog.

### Why this approach
Backfilling `kiloclaw_subscriptions` rows for earlybird users was considered but rejected. The earlybird purchase is a one-time payment with a fixed expiry — not a subscription. It has no plan switching, renewal, cancellation, or payment source. Shoehorning it into the subscription table would require schema changes and extensive conditional logic in `SubscriptionCard` to hide inapplicable actions (Switch Plan, Cancel, Manage Payment).

## Verification

- [x] `pnpm typecheck` — pass
- [x] Six-agent code review (security, logic, types, data, resources, style) — all findings fixed
- [ ] Manual UI verification requires a running KiloClaw worker (`KILOCLAW_API_URL`); the claw dashboard status query blocks rendering without one

## Visual Changes

**EarlybirdCard (active, >30 days remaining):**
Emerald-bordered card with 🦀 icon, "KiloClaw Hosting" title, violet "Early Bird" badge, status/expiry/days-remaining fields.

**EarlybirdCard (ending soon, ≤30 days):**
Same card in amber with an additional warning banner: "Your early bird access is ending soon. Subscribe to a hosting plan to keep your instance running after [date]." plus a "View Plans" button that opens `PlanSelectionDialog`.

## Reviewer Notes

- The `daysRemaining > 0` guard in `SubscriptionTab` prevents rendering the earlybird card for expired access. The `EarlybirdCard` also has defense-in-depth: `isEndingSoon` requires `daysRemaining > 0 && daysRemaining <= 30`.
- When an earlybird user eventually subscribes, `billing.subscription` becomes non-null and the normal `SubscriptionCard` takes over — no special transition logic needed.
- Verify the earlybird expiry date constant at `src/lib/kiloclaw/constants.ts` (`2026-09-26`).