### PR TITLE
feat(coding-plans): add coding plan subscriptions backend

### DIFF
--- a/.specs/coding-plans.md
+++ b/.specs/coding-plans.md
@@ -1,0 +1,39 @@
+# Coding Plans
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC 2119] [RFC 8174] when, and only when, they appear in capitalized form.
+
+---
+
+## 1. Plan Catalog
+
+1.1. The system **MUST** present a catalog of coding plans from multiple upstream providers (e.g., Z.AI, GLM, BytePlus, ByteLabs) within app.kilo.ai.
+
+1.2. Each coding plan **MUST** display its associated cost in Kilo Credits.
+
+## 2. Purchase and Billing
+
+2.1. Users **MUST** be able to purchase coding plans using Kilo Credits through the Kilo backend.
+
+2.2. The system **MUST NOT** redirect users to an external provider site to complete a purchase.
+
+## 3. Customer Relationship
+
+3.1. Kilo **MUST** own the customer relationship. The end user's account, credentials, and billing **MUST** be managed entirely within Kilo.
+
+3.2. User identity **MUST** be obfuscated when interacting with upstream providers. Personally identifiable information such as email addresses and passwords **MUST NOT** be forwarded to the provider.
+
+## 4. Provisioning
+
+4.1. Upon purchase, the system **MUST** automatically provision an API key from the upstream provider and associate it with the purchasing user.
+
+4.2. Provisioned API keys **MUST** be stored securely within the Kilo backend.
+
+4.3. The provisioning lifecycle (creation, rotation, revocation) **SHOULD** be managed via direct API integration with each upstream provider.
+
+## 5. Traffic Routing
+
+5.1. All coding plan API traffic **MUST** route through the Kilo gateway (Vercel).
+
+5.2. Coding plan traffic **MUST NOT** route through the OpenRouter path.
+
+5.3. Implementers **MUST** treat the Kilo gateway path and the OpenRouter BYOK path as distinct and independent traffic flows.

--- a/.specs/coding-plans.md
+++ b/.specs/coding-plans.md
@@ -4,36 +4,72 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ---
 
+## Definitions
+
+**Coding Plan** — A recurring subscription product that grants a user an API key for an upstream provider's API. Subscriptions are billed periodically in Kilo Credits. A coding plan remains active until it is cancelled or the user's credit balance is insufficient to renew. The API key belongs to the subscribing user, who may use it both through the Kilo gateway and independently outside of Kilo.
+
+**Kilo Credits** — The unit of account within Kilo used for billing. The conversion between Kilo Credits and the internal microdollar accounting system is managed by the pricing layer; specs and user-facing surfaces refer only to Kilo Credits.
+
+**Upstream Provider** — An external API vendor (e.g., Z.AI, GLM, BytePlus, ByteLabs) whose coding services are resold through Kilo as coding plans.
+
+**Pre-Purchased Key** — An API key that Kilo has acquired from an upstream provider in advance and stored in its database, ready to be assigned to a user upon subscription creation.
+
+**Kilo Gateway** — The Kilo-operated API reverse proxy. Traffic routed through the gateway uses the user's assigned coding plan key on their behalf.
+
+**BYOK (Bring Your Own Key) Path** — The separate traffic flow and user-facing key management surface for API keys that users supply themselves, independent of coding plans.
+
+**Obfuscated Identity** — An irreversible, per-provider cryptographic hash of the user's internal identifier, used to represent the user to upstream providers without exposing personally identifiable information.
+
+---
+
 ## 1. Plan Catalog
 
 1.1. The system **MUST** present a catalog of coding plans from multiple upstream providers (e.g., Z.AI, GLM, BytePlus, ByteLabs) within app.kilo.ai.
 
-1.2. Each coding plan **MUST** display its associated cost in Kilo Credits.
+1.2. Each coding plan **MUST** display its associated recurring cost in Kilo Credits and its billing period.
 
-## 2. Purchase and Billing
+## 2. Subscription and Billing
 
-2.1. Users **MUST** be able to purchase coding plans using Kilo Credits through the Kilo backend.
+2.1. Users **MUST** be able to subscribe to coding plans using Kilo Credits through the Kilo backend.
 
-2.2. The system **MUST NOT** redirect users to an external provider site to complete a purchase.
+2.2. The system **MUST NOT** redirect users to an external provider site to complete a subscription.
+
+2.3. The system **MUST** reject a subscription if the user's available Kilo Credits balance is less than the plan's cost. Credit deduction and subscription activation **MUST** be atomic — either both succeed or neither takes effect.
+
+2.4. The system **MUST** ensure that concurrent subscription requests from the same user for the same plan are handled idempotently — at most one subscription is fulfilled per plan per user.
+
+2.5. If a user already holds an active subscription to the same upstream provider, a new purchase **MUST** extend the existing subscription rather than creating a duplicate.
 
 ## 3. Customer Relationship
 
-3.1. Kilo **MUST** own the customer relationship. The end user's account, credentials, and billing **MUST** be managed entirely within Kilo.
+3.1. The end user's account, credentials, and billing **MUST** be managed entirely within Kilo. No upstream provider **MAY** have direct contact with or visibility into the end user.
 
-3.2. User identity **MUST** be obfuscated when interacting with upstream providers. Personally identifiable information such as email addresses and passwords **MUST NOT** be forwarded to the provider.
+3.2. The system **MUST** identify users to upstream providers using only obfuscated identities (irreversible, per-provider cryptographic hashes). Personally identifiable information such as email addresses, names, and passwords **MUST NOT** be forwarded to any upstream provider.
 
 ## 4. Provisioning
 
-4.1. Upon purchase, the system **MUST** automatically provision an API key from the upstream provider and associate it with the purchasing user.
+4.1. Kilo **MUST** pre-purchase API keys from upstream providers and store them in the database before they are needed. When a subscription is created, the Kilo backend **MUST** assign a pre-purchased key to the subscribing user and configure it in the user's BYOK section. The key **MUST** be available to the user before the subscription is confirmed as active.
 
-4.2. Provisioned API keys **MUST** be stored securely within the Kilo backend.
+4.2. The Kilo backend **MUST** store all unassigned (pre-purchased) API keys encrypted at rest. Unassigned keys **MUST NOT** appear in application logs, error messages, or API responses.
 
-4.3. The provisioning lifecycle (creation, rotation, revocation) **SHOULD** be managed via direct API integration with each upstream provider.
+4.2.1. Once a key is assigned to a user, the user **MUST** be able to view and copy their API key through the Kilo UI. The key belongs to the user and they **MAY** use it outside of Kilo.
 
-## 5. Traffic Routing
+4.3. If no pre-purchased key is available for the requested upstream provider at the time of subscription, the system **MUST** reject the subscription, refund any deducted credits, and surface an error to the user. The system **MUST NOT** debit credits for a plan whose key assignment has failed.
 
-5.1. All coding plan API traffic **MUST** route through the Kilo gateway (Vercel).
+4.4. The provisioning lifecycle (creation, rotation, revocation) **SHOULD** be managed via direct API integration with each upstream provider in a future version. For v1, Kilo operators **MAY** pre-purchase and upload keys manually.
 
-5.2. Coding plan traffic **MUST NOT** route through the OpenRouter path.
+## 5. Subscription Lifecycle
 
-5.3. Implementers **MUST** treat the Kilo gateway path and the OpenRouter BYOK path as distinct and independent traffic flows.
+5.1. When a subscription expires, is cancelled, or the user's account is deleted, the system **MUST** immediately remove the associated API key from the user's BYOK configuration within Kilo. The system **MUST NOT** revoke the key with the upstream provider, because the key belongs to the user and they may continue to use it independently outside of Kilo.
+
+5.2. Revocation of keys on account deletion **MUST** be included in the GDPR soft-delete flow.
+
+## 6. Traffic Routing
+
+6.1. When a user sends API traffic through Kilo, coding plan keys **MUST** route through the Kilo-operated API gateway. Users **MAY** also use their assigned API key directly with the upstream provider, outside of Kilo.
+
+6.2. Within Kilo, coding plan traffic **MUST NOT** share routing infrastructure with traffic that uses user-supplied (BYOK) API keys. These two traffic classes **MUST** be treated as distinct and independent flows.
+
+## 7. Purchase Processing Order
+
+7.1. The system **MUST** process a new subscription in this order: (1) verify sufficient credit balance, (2) atomically deduct credits and record the subscription, (3) assign a pre-purchased API key to the user's BYOK configuration, (4) confirm the subscription as active to the user.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,364 @@
+# Coding Plans — Backend Implementation Plan
+
+## Overview
+
+Implement the backend for Coding Plans: a recurring subscription product that grants users a pre-purchased API key for an upstream provider, billed periodically in Kilo Credits. This plan covers **backend only** — no UI work.
+
+### What Already Exists
+
+| Component                                   | Status      | Location                                           |
+| ------------------------------------------- | ----------- | -------------------------------------------------- |
+| Provider definitions (BytePlus, Kimi, Z.AI) | ✅ Complete | `src/lib/providers/coding-plans/`                  |
+| Traffic routing (separate from BYOK)        | ✅ Complete | `src/lib/providers/index.ts`                       |
+| BYOK key storage + AES-256-GCM encryption   | ✅ Complete | `src/lib/byok/`, `byok_api_keys` table             |
+| Credit transaction system + idempotency     | ✅ Complete | `credit_transactions` table, `enrollWithCredits()` |
+| Obfuscated identity generation              | ✅ Complete | `src/lib/providerHash.ts`                          |
+| GDPR soft-delete (deletes BYOK keys)        | ✅ Partial  | `src/lib/user.ts:softDeleteUser`                   |
+
+### What Needs to Be Built
+
+1. Two new database tables (subscription + key inventory)
+2. Subscription purchase flow (atomic credit deduction + key assignment)
+3. Pre-purchased key inventory management (admin upload, assignment)
+4. Billing lifecycle cron (renewal + cancellation)
+5. tRPC router (subscribe, cancel, list, admin endpoints)
+6. GDPR soft-delete updates
+7. Tests
+
+### Key Decisions
+
+| Decision                  | Choice                                                                                 |
+| ------------------------- | -------------------------------------------------------------------------------------- |
+| Pricing                   | Env-configurable per provider via env vars (e.g., `CODING_PLAN_PRICE_BYTEPLUS_CODING`) |
+| Billing period            | 30 days for all providers                                                              |
+| Past-due grace period     | None — cancel immediately on failed renewal                                            |
+| Extension behavior (§2.5) | Stack new period onto existing end date                                                |
+| Auto-top-up               | Yes — trigger auto-top-up before canceling on failed renewal                           |
+| Admin key upload          | Admin tRPC endpoint only                                                               |
+
+---
+
+## Step 1: Database Schema
+
+### 1a. `coding_plan_subscriptions` table
+
+New table in `packages/db/src/schema.ts`. Modeled after `kiloclaw_subscriptions` but scoped per-user-per-provider (not per-instance).
+
+```
+coding_plan_subscriptions
+├── id                         uuid PK (gen_random_uuid)
+├── user_id                    text NOT NULL FK→kilocode_users.id ON DELETE CASCADE
+├── provider_id                text NOT NULL  (e.g. 'byteplus-coding', 'zai-coding', 'kimi-coding')
+├── byok_key_id                uuid FK→byok_api_keys.id ON DELETE SET NULL
+├── status                     text NOT NULL  ('active' | 'canceled')
+├── cost_microdollars          bigint NOT NULL  (price per period in microdollars)
+├── billing_period_days        integer NOT NULL  (30)
+├── current_period_start       timestamptz
+├── current_period_end         timestamptz
+├── credit_renewal_at          timestamptz  (next renewal timestamp)
+├── cancel_at_period_end       boolean NOT NULL DEFAULT false
+├── canceled_at                timestamptz
+├── auto_top_up_triggered_for_period  timestamptz
+├── created_at                 timestamptz NOT NULL DEFAULT now()
+├── updated_at                 timestamptz NOT NULL DEFAULT now()  ($onUpdateFn)
+```
+
+**Constraints:**
+
+- `uniqueIndex('UQ_coding_plan_sub_user_provider').on(user_id, provider_id)` — enforces spec §2.4 (one subscription per provider per user). This constraint applies to ALL rows, including canceled ones. When re-subscribing after cancellation, we UPDATE the existing row back to `active` rather than inserting a new one.
+- `enumCheck` on `status` for `['active', 'canceled']`
+
+**Design notes:**
+
+- No `past_due` status — if renewal fails (even after auto-top-up attempt), subscription cancels immediately.
+- `byok_key_id` FK to `byok_api_keys` with `ON DELETE SET NULL` — if the BYOK row is deleted (e.g., during GDPR cleanup), the subscription record survives for billing history but the key link goes null.
+- `cost_microdollars` and `billing_period_days` are stored per-subscription (snapshot at purchase time) so plan pricing can change without affecting existing subscribers.
+
+### 1b. `coding_plan_key_inventory` table
+
+New table for pre-purchased keys awaiting assignment (spec §4.1, §4.2).
+
+```
+coding_plan_key_inventory
+├── id                         uuid PK (gen_random_uuid)
+├── provider_id                text NOT NULL  (e.g. 'byteplus-coding')
+├── encrypted_api_key          jsonb NOT NULL  (EncryptedData — same encryption as BYOK)
+├── assigned_to_user_id        text FK→kilocode_users.id ON DELETE SET NULL
+├── assigned_at                timestamptz
+├── created_at                 timestamptz NOT NULL DEFAULT now()
+```
+
+**Constraints:**
+
+- `index('IDX_coding_plan_key_inv_provider').on(provider_id)` — for fast lookups of available keys
+- `index('IDX_coding_plan_key_inv_unassigned').on(provider_id).where(assigned_to_user_id IS NULL)` — partial index for fast "find next available key"
+
+**Design notes:**
+
+- Unassigned keys (`assigned_to_user_id IS NULL`) are the pool of available keys.
+- Once assigned, `assigned_to_user_id` + `assigned_at` record provenance.
+- Encryption reuses the existing `encryptApiKey()`/`decryptApiKey()` from `src/lib/byok/encryption.ts` (same `BYOK_ENCRYPTION_KEY` env var).
+- Keys are never deleted from this table — they serve as an audit trail. The user-facing key is in `byok_api_keys`.
+
+### 1c. Migration
+
+Generate via `pnpm drizzle generate` after adding both tables to the schema. A single migration file for both tables.
+
+---
+
+## Step 2: Plan Catalog & Pricing
+
+New file: `src/lib/coding-plans/pricing.ts`
+
+Pricing is loaded from environment variables, with each provider having its own env var. The billing period is fixed at 30 days.
+
+```typescript
+import { getEnvVariable } from '@/lib/dotenvx';
+import type { DirectUserByokInferenceProviderId } from '@/lib/providers/openrouter/inference-provider-id';
+
+type CodingPlanCatalogEntry = {
+  costMicrodollars: number;
+  billingPeriodDays: number;
+  name: string;
+};
+
+const CODING_PLAN_PROVIDER_IDS = ['byteplus-coding', 'kimi-coding', 'zai-coding'] as const;
+type CodingPlanProviderId = (typeof CODING_PLAN_PROVIDER_IDS)[number];
+
+// Env var names: CODING_PLAN_PRICE_BYTEPLUS_CODING, CODING_PLAN_PRICE_KIMI_CODING, CODING_PLAN_PRICE_ZAI_CODING
+// Values are in microdollars (integer). E.g., 4990000 = $4.99
+function envVarName(providerId: CodingPlanProviderId): string {
+  return 'CODING_PLAN_PRICE_' + providerId.toUpperCase().replace(/-/g, '_');
+}
+
+const PROVIDER_NAMES: Record<CodingPlanProviderId, string> = {
+  'byteplus-coding': 'BytePlus Coding Plan',
+  'kimi-coding': 'Kimi Code',
+  'zai-coding': 'Z.AI Coding Plan',
+};
+
+export function getCodingPlanCatalog(): Record<CodingPlanProviderId, CodingPlanCatalogEntry> {
+  // Build catalog from env vars; omit providers without a configured price
+  const catalog = {} as Record<string, CodingPlanCatalogEntry>;
+  for (const providerId of CODING_PLAN_PROVIDER_IDS) {
+    const raw = getEnvVariable(envVarName(providerId));
+    if (!raw) continue;
+    const costMicrodollars = parseInt(raw, 10);
+    if (Number.isNaN(costMicrodollars) || costMicrodollars < 0) continue;
+    catalog[providerId] = {
+      costMicrodollars,
+      billingPeriodDays: 30,
+      name: PROVIDER_NAMES[providerId],
+    };
+  }
+  return catalog;
+}
+
+export function getCodingPlanPrice(providerId: string): CodingPlanCatalogEntry | null {
+  const catalog = getCodingPlanCatalog();
+  return catalog[providerId] ?? null;
+}
+```
+
+**Design notes:**
+
+- If an env var is missing or invalid, that provider is simply absent from the catalog — it won't be offered for purchase.
+- Setting a price to `0` allows free subscriptions (key assignment only, no credit deduction).
+- The catalog is computed at call time from env vars, so prices update on next deployment without code changes.
+
+---
+
+## Step 3: Core Business Logic
+
+New file: `src/lib/coding-plans/index.ts`
+
+### 3a. `subscribeToCodingPlan(userId, providerId)`
+
+The main purchase flow. Implements spec §7.1 processing order:
+
+1. **Validate catalog**: Call `getCodingPlanPrice(providerId)`. If null (provider not in catalog or price not configured), throw `PROVIDER_NOT_AVAILABLE`.
+2. **Check existing subscription**: Query `coding_plan_subscriptions` for this user+provider.
+   - If `status = 'active'`: handle extension (spec §2.5) — see §3d below.
+   - If `status = 'canceled'`: will reactivate (update existing row).
+3. **Verify credit balance**: Read user's `total_microdollars_acquired - microdollars_used`. If less than `costMicrodollars` and cost > 0, reject with `INSUFFICIENT_BALANCE` (spec §2.3).
+4. **Atomic transaction** (single DB transaction):
+   a. **Deduct credits** (if cost > 0): Insert into `credit_transactions` with `credit_category: 'coding-plan:{providerId}:{subscriptionId}:{yearMonth}'` and `check_category_uniqueness: true`. Use `onConflictDoNothing()` for idempotency. If `rowCount === 0`, the deduction was already processed — return existing subscription.
+   b. **Increment `microdollars_used`** on the user row.
+   c. **Assign a pre-purchased key**: `UPDATE coding_plan_key_inventory SET assigned_to_user_id = $userId, assigned_at = now() WHERE id = (SELECT id FROM coding_plan_key_inventory WHERE provider_id = $providerId AND assigned_to_user_id IS NULL LIMIT 1 FOR UPDATE SKIP LOCKED) RETURNING *`. If no key available, **roll back the entire transaction** (spec §4.3 — credits are never deducted if key assignment fails).
+   d. **Decrypt the assigned key** and **insert into `byok_api_keys`** (re-encrypted under `kilo_user_id`). This makes it available in the user's BYOK configuration per spec §4.1.
+   e. **Upsert subscription row**: Insert new `coding_plan_subscriptions` row with status `'active'`, linking the new `byok_key_id`, setting `current_period_start = now()`, `current_period_end = now() + 30 days`, `credit_renewal_at = now() + 30 days`. If re-subscribing after cancellation, UPDATE the existing row instead.
+5. **Post-transaction**: Evaluate Kilo Pass bonus (following `enrollWithCredits` pattern).
+6. **Return** the subscription record.
+
+**Idempotency**: The `credit_category` unique index ensures duplicate requests are detected. The `FOR UPDATE SKIP LOCKED` on key assignment prevents concurrent assignment of the same key.
+
+### 3b. `cancelCodingPlanSubscription(userId, providerId)`
+
+User-facing cancellation (cancel at period end):
+
+1. Find the active subscription for this user+provider.
+2. Set `cancel_at_period_end = true`. The subscription remains active until `current_period_end`.
+3. When the billing cron processes it at renewal time, it transitions to `'canceled'` and removes the BYOK key.
+
+### 3c. `cancelCodingPlanImmediately(userId, providerId)`
+
+For admin/GDPR use. Within a transaction:
+
+1. Set status to `'canceled'`, `canceled_at = now()`, `byok_key_id = null`.
+2. Delete the associated `byok_api_keys` row (spec §5.1 — remove from Kilo, do NOT revoke with upstream).
+
+### 3d. `extendSubscription(existingSubscription, userId)` (internal)
+
+Called when a user tries to subscribe to a provider they already have an active subscription for (spec §2.5). Within the same transaction as the purchase:
+
+1. New credit deduction for the next period (same idempotency pattern, different `yearMonth` in category).
+2. Extend `current_period_end` by `billing_period_days` (stacking onto existing end date).
+3. Advance `credit_renewal_at` to the new `current_period_end`.
+4. No new key assignment — user keeps the same key.
+
+---
+
+## Step 4: Billing Lifecycle Cron
+
+New file: `src/lib/coding-plans/billing-lifecycle-cron.ts`
+
+A cron job following the same pattern as `src/lib/kiloclaw/billing-lifecycle-cron.ts`. Triggered on a schedule (e.g., every 5 minutes via Vercel cron or equivalent).
+
+### Sweeps:
+
+**Sweep 1: Cancel at period end**
+
+- Select subscriptions where `status = 'active'` AND `cancel_at_period_end = true` AND `current_period_end <= now()`.
+- For each: transition to `'canceled'`, delete BYOK key (spec §5.1), set `canceled_at = now()`, `byok_key_id = null`.
+
+**Sweep 2: Renewals**
+
+- Select subscriptions where `status = 'active'` AND `credit_renewal_at <= now()` AND `cancel_at_period_end = false`.
+- For each subscription:
+  1. Read the current cost from the subscription row (`cost_microdollars`).
+  2. Check user balance. If insufficient AND user has auto-top-up enabled:
+     - Trigger auto-top-up (follow `fire-and-skip` pattern from KiloClaw — trigger the Stripe charge, then skip this subscription for now; on next cron run, the balance should be replenished).
+     - Set `auto_top_up_triggered_for_period` to prevent duplicate triggers.
+     - Skip to next subscription.
+  3. If sufficient balance:
+     - Atomic transaction: deduct credits (idempotent via `credit_category: 'coding-plan:{providerId}:{subscriptionId}:{yearMonth}'`), advance `current_period_start/end` and `credit_renewal_at` by `billing_period_days`.
+  4. If insufficient balance AND (auto-top-up not enabled OR already triggered):
+     - Cancel immediately: set `status = 'canceled'`, delete BYOK key, set `canceled_at = now()`, `byok_key_id = null`.
+
+### Cron endpoint
+
+New API route: `src/app/api/cron/coding-plans-billing/route.ts`
+
+- Vercel cron config in `vercel.json` (or equivalent).
+- Secured with cron secret header validation (same pattern as KiloClaw cron).
+
+---
+
+## Step 5: tRPC Router
+
+New file: `src/routers/coding-plans-router.ts`
+
+Register in `src/routers/root-router.ts` as `codingPlans: codingPlansRouter`.
+
+### User endpoints:
+
+| Method   | Name                | Input                    | Description                                                                                                                                       |
+| -------- | ------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| query    | `catalog`           | none                     | Returns the plan catalog with pricing (spec §1.1, §1.2). Calls `getCodingPlanCatalog()`. Converts microdollars to Kilo Credits via pricing layer. |
+| query    | `listSubscriptions` | none                     | Returns all coding plan subscriptions for the authenticated user (active + canceled).                                                             |
+| mutation | `subscribe`         | `{ providerId: string }` | Calls `subscribeToCodingPlan()`. Returns subscription record.                                                                                     |
+| mutation | `cancel`            | `{ providerId: string }` | Calls `cancelCodingPlanSubscription()`. Sets cancel-at-period-end.                                                                                |
+
+### Admin endpoints (nested under admin router or `codingPlans` router with `adminProcedure`):
+
+| Method   | Name                     | Input                                    | Description                                                               |
+| -------- | ------------------------ | ---------------------------------------- | ------------------------------------------------------------------------- |
+| query    | `keyInventory`           | `{ providerId?: string }`                | Lists key inventory counts (available/assigned per provider).             |
+| mutation | `uploadKeys`             | `{ providerId: string, keys: string[] }` | Encrypts and inserts pre-purchased keys into `coding_plan_key_inventory`. |
+| mutation | `cancelUserSubscription` | `{ userId: string, providerId: string }` | Admin immediate cancel. Calls `cancelCodingPlanImmediately()`.            |
+
+---
+
+## Step 6: GDPR Soft-Delete Updates
+
+In `src/lib/user.ts:softDeleteUser`:
+
+**Existing behavior**: BYOK keys are already deleted on line 604 (`await tx.delete(byok_api_keys).where(eq(byok_api_keys.kilo_user_id, userId))`). This handles spec §5.2.
+
+**New additions** (within the existing transaction, BEFORE the `byok_api_keys` deletion):
+
+1. Cancel all coding plan subscriptions:
+
+   ```typescript
+   await tx
+     .update(coding_plan_subscriptions)
+     .set({ status: 'canceled', canceled_at: sql`now()`, byok_key_id: null })
+     .where(eq(coding_plan_subscriptions.user_id, userId));
+   ```
+
+2. Auto-cancel without blocking — user is deleting their account, so just cancel everything. No precondition check that blocks deletion (unlike Kilo Pass/KiloClaw which require the user to cancel first).
+
+**New test** in `src/lib/user.test.ts`: Verify that coding plan subscriptions are canceled and BYOK keys are removed when a user is soft-deleted.
+
+---
+
+## Step 7: Model Visibility Integration
+
+No new work needed. The existing `getCodingPlanModelsForUser(userId)` in `src/lib/providers/coding-plans/index.ts` already checks for BYOK keys to determine which coding plan models to show. Since the purchase flow creates a BYOK entry, model visibility is automatically gated by subscription status. When a subscription is canceled and the BYOK key is removed, the models automatically stop appearing for the user.
+
+---
+
+## Step 8: Tests
+
+### Unit tests: `src/lib/coding-plans/index.test.ts`
+
+1. **Happy path**: Subscribe → credits deducted, key assigned, BYOK entry created, subscription active.
+2. **Insufficient balance**: Subscribe with low balance → rejected, no side effects.
+3. **No keys available**: Subscribe when inventory is empty → rejected, no credits deducted (transaction rolled back).
+4. **Idempotency**: Duplicate subscribe request → only one subscription created, only one credit deduction.
+5. **Extension (spec §2.5)**: Subscribe when already subscribed to same provider → period extended (stacked), no new key assigned.
+6. **Cancel at period end**: Cancel → status still active, cancel flag set. Cron sweep → canceled, BYOK key removed.
+7. **Immediate cancel**: Admin immediate cancel → canceled immediately, BYOK key removed.
+8. **Renewal success**: Cron deducts credits, advances period.
+9. **Renewal failure — no auto-top-up**: Insufficient balance, no auto-top-up → canceled immediately, BYOK key removed.
+10. **Renewal failure — auto-top-up triggered**: Insufficient balance, auto-top-up enabled → top-up triggered, subscription skipped (not canceled yet).
+11. **Re-subscribe after cancellation**: Subscribe to previously canceled provider → existing row reactivated, new key assigned.
+12. **Concurrent requests**: Two simultaneous subscribes → at most one succeeds (spec §2.4).
+13. **Free plan (cost = 0)**: Subscribe with cost 0 → no credit deduction, key assigned, subscription active.
+
+### GDPR test addition: `src/lib/user.test.ts`
+
+14. **Soft-delete with coding plan**: User with active coding plan → soft-delete → subscription canceled, BYOK key removed.
+
+### Admin tests: `src/routers/coding-plans-router.test.ts`
+
+15. **Upload keys**: Admin uploads keys → encrypted in inventory, correct count.
+16. **Key inventory query**: Returns correct available/assigned counts per provider.
+17. **Catalog query**: Returns plan info with env-configured pricing. Missing env var → provider excluded.
+
+---
+
+## Implementation Order
+
+| Phase | Work                                                   | Files                                                                                                   |
+| ----- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| 1     | Schema + migration                                     | `packages/db/src/schema.ts`, `packages/db/src/migrations/`                                              |
+| 2     | Pricing catalog (env-driven)                           | `src/lib/coding-plans/pricing.ts`                                                                       |
+| 3     | Core business logic (subscribe, cancel, extend)        | `src/lib/coding-plans/index.ts`                                                                         |
+| 4     | tRPC router + root registration                        | `src/routers/coding-plans-router.ts`, `src/routers/root-router.ts`                                      |
+| 5     | Billing lifecycle cron                                 | `src/lib/coding-plans/billing-lifecycle-cron.ts`, `src/app/api/cron/coding-plans-billing/route.ts`      |
+| 6     | Admin endpoints (upload keys, inventory, admin cancel) | Nested in `src/routers/coding-plans-router.ts` with `adminProcedure`                                    |
+| 7     | GDPR soft-delete updates                               | `src/lib/user.ts`                                                                                       |
+| 8     | Tests                                                  | `src/lib/coding-plans/index.test.ts`, `src/lib/user.test.ts`, `src/routers/coding-plans-router.test.ts` |
+
+---
+
+## New Environment Variables
+
+| Variable                            | Example   | Description                                                      |
+| ----------------------------------- | --------- | ---------------------------------------------------------------- |
+| `CODING_PLAN_PRICE_BYTEPLUS_CODING` | `4990000` | Price in microdollars for BytePlus Coding Plan per 30-day period |
+| `CODING_PLAN_PRICE_KIMI_CODING`     | `4990000` | Price in microdollars for Kimi Code per 30-day period            |
+| `CODING_PLAN_PRICE_ZAI_CODING`      | `4990000` | Price in microdollars for Z.AI Coding Plan per 30-day period     |
+
+Omitting a variable disables that provider from the catalog. Setting to `0` makes it free.

--- a/packages/db/src/migrations/0071_majestic_pestilence.sql
+++ b/packages/db/src/migrations/0071_majestic_pestilence.sql
@@ -1,0 +1,36 @@
+CREATE TABLE "coding_plan_key_inventory" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"provider_id" text NOT NULL,
+	"encrypted_api_key" jsonb NOT NULL,
+	"assigned_to_user_id" text,
+	"assigned_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "coding_plan_subscriptions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"provider_id" text NOT NULL,
+	"byok_key_id" uuid,
+	"status" text NOT NULL,
+	"cost_microdollars" bigint NOT NULL,
+	"billing_period_days" integer NOT NULL,
+	"current_period_start" timestamp with time zone,
+	"current_period_end" timestamp with time zone,
+	"credit_renewal_at" timestamp with time zone,
+	"cancel_at_period_end" boolean DEFAULT false NOT NULL,
+	"canceled_at" timestamp with time zone,
+	"auto_top_up_triggered_for_period" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "coding_plan_subscriptions_status_check" CHECK ("coding_plan_subscriptions"."status" IN ('active', 'canceled'))
+);
+--> statement-breakpoint
+ALTER TABLE "coding_plan_key_inventory" ADD CONSTRAINT "coding_plan_key_inventory_assigned_to_user_id_kilocode_users_id_fk" FOREIGN KEY ("assigned_to_user_id") REFERENCES "public"."kilocode_users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coding_plan_subscriptions" ADD CONSTRAINT "coding_plan_subscriptions_user_id_kilocode_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."kilocode_users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coding_plan_subscriptions" ADD CONSTRAINT "coding_plan_subscriptions_byok_key_id_byok_api_keys_id_fk" FOREIGN KEY ("byok_key_id") REFERENCES "public"."byok_api_keys"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "IDX_coding_plan_key_inv_provider" ON "coding_plan_key_inventory" USING btree ("provider_id");--> statement-breakpoint
+CREATE INDEX "IDX_coding_plan_key_inv_unassigned" ON "coding_plan_key_inventory" USING btree ("provider_id") WHERE "coding_plan_key_inventory"."assigned_to_user_id" is null;--> statement-breakpoint
+CREATE UNIQUE INDEX "UQ_coding_plan_sub_user_provider" ON "coding_plan_subscriptions" USING btree ("user_id","provider_id");--> statement-breakpoint
+CREATE INDEX "IDX_coding_plan_sub_status" ON "coding_plan_subscriptions" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "IDX_coding_plan_sub_renewal" ON "coding_plan_subscriptions" USING btree ("credit_renewal_at");

--- a/packages/db/src/migrations/meta/0071_snapshot.json
+++ b/packages/db/src/migrations/meta/0071_snapshot.json
@@ -1,0 +1,15221 @@
+{
+  "id": "bc33518e-52c0-4cb2-85dd-6d7d30a38d5a",
+  "prevId": "191ad37c-9c1b-4c5e-95c4-d191a8aaabc4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_configs": {
+      "name": "agent_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_type": {
+          "name": "agent_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_agent_configs_org_id": {
+          "name": "IDX_agent_configs_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_agent_configs_owned_by_user_id": {
+          "name": "IDX_agent_configs_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_agent_configs_agent_type": {
+          "name": "IDX_agent_configs_agent_type",
+          "columns": [
+            {
+              "expression": "agent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_agent_configs_platform": {
+          "name": "IDX_agent_configs_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_configs_owned_by_organization_id_organizations_id_fk": {
+          "name": "agent_configs_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "agent_configs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_configs_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "agent_configs_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "agent_configs",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_agent_configs_org_agent_platform": {
+          "name": "UQ_agent_configs_org_agent_platform",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owned_by_organization_id",
+            "agent_type",
+            "platform"
+          ]
+        },
+        "UQ_agent_configs_user_agent_platform": {
+          "name": "UQ_agent_configs_user_agent_platform",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owned_by_user_id",
+            "agent_type",
+            "platform"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_configs_owner_check": {
+          "name": "agent_configs_owner_check",
+          "value": "(\n        (\"agent_configs\".\"owned_by_user_id\" IS NOT NULL AND \"agent_configs\".\"owned_by_organization_id\" IS NULL) OR\n        (\"agent_configs\".\"owned_by_user_id\" IS NULL AND \"agent_configs\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "agent_configs_agent_type_check": {
+          "name": "agent_configs_agent_type_check",
+          "value": "\"agent_configs\".\"agent_type\" IN ('code_review', 'auto_triage', 'auto_fix', 'security_scan')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_environment_profile_commands": {
+      "name": "agent_environment_profile_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_agent_env_profile_commands_profile_id": {
+          "name": "IDX_agent_env_profile_commands_profile_id",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_environment_profile_commands_profile_id_agent_environment_profiles_id_fk": {
+          "name": "agent_environment_profile_commands_profile_id_agent_environment_profiles_id_fk",
+          "tableFrom": "agent_environment_profile_commands",
+          "tableTo": "agent_environment_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_agent_env_profile_commands_profile_sequence": {
+          "name": "UQ_agent_env_profile_commands_profile_sequence",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id",
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_environment_profile_vars": {
+      "name": "agent_environment_profile_vars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_agent_env_profile_vars_profile_id": {
+          "name": "IDX_agent_env_profile_vars_profile_id",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_environment_profile_vars_profile_id_agent_environment_profiles_id_fk": {
+          "name": "agent_environment_profile_vars_profile_id_agent_environment_profiles_id_fk",
+          "tableFrom": "agent_environment_profile_vars",
+          "tableTo": "agent_environment_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_agent_env_profile_vars_profile_key": {
+          "name": "UQ_agent_env_profile_vars_profile_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_environment_profiles": {
+      "name": "agent_environment_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_agent_env_profiles_org_name": {
+          "name": "UQ_agent_env_profiles_org_name",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_environment_profiles\".\"owned_by_organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_agent_env_profiles_user_name": {
+          "name": "UQ_agent_env_profiles_user_name",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_environment_profiles\".\"owned_by_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_agent_env_profiles_org_default": {
+          "name": "UQ_agent_env_profiles_org_default",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_environment_profiles\".\"is_default\" = true AND \"agent_environment_profiles\".\"owned_by_organization_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_agent_env_profiles_user_default": {
+          "name": "UQ_agent_env_profiles_user_default",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_environment_profiles\".\"is_default\" = true AND \"agent_environment_profiles\".\"owned_by_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_agent_env_profiles_org_id": {
+          "name": "IDX_agent_env_profiles_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_agent_env_profiles_user_id": {
+          "name": "IDX_agent_env_profiles_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_environment_profiles_owned_by_organization_id_organizations_id_fk": {
+          "name": "agent_environment_profiles_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "agent_environment_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_environment_profiles_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "agent_environment_profiles_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "agent_environment_profiles",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_env_profiles_owner_check": {
+          "name": "agent_env_profiles_owner_check",
+          "value": "(\n        (\"agent_environment_profiles\".\"owned_by_user_id\" IS NOT NULL AND \"agent_environment_profiles\".\"owned_by_organization_id\" IS NULL) OR\n        (\"agent_environment_profiles\".\"owned_by_user_id\" IS NULL AND \"agent_environment_profiles\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_kind": {
+      "name": "api_kind",
+      "schema": "",
+      "columns": {
+        "api_kind_id": {
+          "name": "api_kind_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_kind": {
+          "name": "api_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_api_kind": {
+          "name": "UQ_api_kind",
+          "columns": [
+            {
+              "expression": "api_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_request_log": {
+      "name": "api_request_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_request_log_created_at": {
+          "name": "idx_api_request_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_builder_feedback": {
+      "name": "app_builder_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_status": {
+          "name": "preview_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streaming": {
+          "name": "is_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_text": {
+          "name": "feedback_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recent_messages": {
+          "name": "recent_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_app_builder_feedback_created_at": {
+          "name": "IDX_app_builder_feedback_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_feedback_kilo_user_id": {
+          "name": "IDX_app_builder_feedback_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_feedback_project_id": {
+          "name": "IDX_app_builder_feedback_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_builder_feedback_kilo_user_id_kilocode_users_id_fk": {
+          "name": "app_builder_feedback_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "app_builder_feedback",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "app_builder_feedback_project_id_app_builder_projects_id_fk": {
+          "name": "app_builder_feedback_project_id_app_builder_projects_id_fk",
+          "tableFrom": "app_builder_feedback",
+          "tableTo": "app_builder_projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_builder_project_sessions": {
+      "name": "app_builder_project_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_version": {
+          "name": "worker_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        }
+      },
+      "indexes": {
+        "IDX_app_builder_project_sessions_project_id": {
+          "name": "IDX_app_builder_project_sessions_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_builder_project_sessions_project_id_app_builder_projects_id_fk": {
+          "name": "app_builder_project_sessions_project_id_app_builder_projects_id_fk",
+          "tableFrom": "app_builder_project_sessions",
+          "tableTo": "app_builder_projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_app_builder_project_sessions_cloud_agent_session_id": {
+          "name": "UQ_app_builder_project_sessions_cloud_agent_session_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cloud_agent_session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_builder_projects": {
+      "name": "app_builder_projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_repo_full_name": {
+          "name": "git_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_platform_integration_id": {
+          "name": "git_platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "migrated_at": {
+          "name": "migrated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_app_builder_projects_created_by_user_id": {
+          "name": "IDX_app_builder_projects_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_projects_owned_by_user_id": {
+          "name": "IDX_app_builder_projects_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_projects_owned_by_organization_id": {
+          "name": "IDX_app_builder_projects_owned_by_organization_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_projects_created_at": {
+          "name": "IDX_app_builder_projects_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_projects_last_message_at": {
+          "name": "IDX_app_builder_projects_last_message_at",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_builder_projects_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "app_builder_projects_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "app_builder_projects",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_builder_projects_owned_by_organization_id_organizations_id_fk": {
+          "name": "app_builder_projects_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "app_builder_projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_builder_projects_deployment_id_deployments_id_fk": {
+          "name": "app_builder_projects_deployment_id_deployments_id_fk",
+          "tableFrom": "app_builder_projects",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_builder_projects_git_platform_integration_id_platform_integrations_id_fk": {
+          "name": "app_builder_projects_git_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "app_builder_projects",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "git_platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_builder_projects_owner_check": {
+          "name": "app_builder_projects_owner_check",
+          "value": "(\n        (\"app_builder_projects\".\"owned_by_user_id\" IS NOT NULL AND \"app_builder_projects\".\"owned_by_organization_id\" IS NULL) OR\n        (\"app_builder_projects\".\"owned_by_user_id\" IS NULL AND \"app_builder_projects\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_min_versions": {
+      "name": "app_min_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "ios_min_version": {
+          "name": "ios_min_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "android_min_version": {
+          "name": "android_min_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_reported_messages": {
+      "name": "app_reported_messages",
+      "schema": "",
+      "columns": {
+        "report_id": {
+          "name": "report_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cli_session_id": {
+          "name": "cli_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_reported_messages_cli_session_id_cli_sessions_session_id_fk": {
+          "name": "app_reported_messages_cli_session_id_cli_sessions_session_id_fk",
+          "tableFrom": "app_reported_messages",
+          "tableTo": "cli_sessions",
+          "columnsFrom": [
+            "cli_session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_fix_tickets": {
+      "name": "auto_fix_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triage_ticket_id": {
+          "name": "triage_ticket_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_url": {
+          "name": "issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_title": {
+          "name": "issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_body": {
+          "name": "issue_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_author": {
+          "name": "issue_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_labels": {
+          "name": "issue_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'label'"
+        },
+        "review_comment_id": {
+          "name": "review_comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_comment_body": {
+          "name": "review_comment_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diff_hunk": {
+          "name": "diff_hunk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_head_ref": {
+          "name": "pr_head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_summary": {
+          "name": "intent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_files": {
+          "name": "related_files",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_session_id": {
+          "name": "cli_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_branch": {
+          "name": "pr_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_auto_fix_tickets_repo_issue": {
+          "name": "UQ_auto_fix_tickets_repo_issue",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auto_fix_tickets\".\"trigger_source\" = 'label'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_auto_fix_tickets_repo_review_comment": {
+          "name": "UQ_auto_fix_tickets_repo_review_comment",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auto_fix_tickets\".\"review_comment_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_owned_by_org": {
+          "name": "IDX_auto_fix_tickets_owned_by_org",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_owned_by_user": {
+          "name": "IDX_auto_fix_tickets_owned_by_user",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_status": {
+          "name": "IDX_auto_fix_tickets_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_created_at": {
+          "name": "IDX_auto_fix_tickets_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_triage_ticket_id": {
+          "name": "IDX_auto_fix_tickets_triage_ticket_id",
+          "columns": [
+            {
+              "expression": "triage_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_session_id": {
+          "name": "IDX_auto_fix_tickets_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auto_fix_tickets_owned_by_organization_id_organizations_id_fk": {
+          "name": "auto_fix_tickets_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "auto_fix_tickets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_fix_tickets_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "auto_fix_tickets_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "auto_fix_tickets",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_fix_tickets_platform_integration_id_platform_integrations_id_fk": {
+          "name": "auto_fix_tickets_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "auto_fix_tickets",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auto_fix_tickets_triage_ticket_id_auto_triage_tickets_id_fk": {
+          "name": "auto_fix_tickets_triage_ticket_id_auto_triage_tickets_id_fk",
+          "tableFrom": "auto_fix_tickets",
+          "tableTo": "auto_triage_tickets",
+          "columnsFrom": [
+            "triage_ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auto_fix_tickets_cli_session_id_cli_sessions_session_id_fk": {
+          "name": "auto_fix_tickets_cli_session_id_cli_sessions_session_id_fk",
+          "tableFrom": "auto_fix_tickets",
+          "tableTo": "cli_sessions",
+          "columnsFrom": [
+            "cli_session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auto_fix_tickets_owner_check": {
+          "name": "auto_fix_tickets_owner_check",
+          "value": "(\n        (\"auto_fix_tickets\".\"owned_by_user_id\" IS NOT NULL AND \"auto_fix_tickets\".\"owned_by_organization_id\" IS NULL) OR\n        (\"auto_fix_tickets\".\"owned_by_user_id\" IS NULL AND \"auto_fix_tickets\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "auto_fix_tickets_status_check": {
+          "name": "auto_fix_tickets_status_check",
+          "value": "\"auto_fix_tickets\".\"status\" IN ('pending', 'running', 'completed', 'failed', 'cancelled')"
+        },
+        "auto_fix_tickets_classification_check": {
+          "name": "auto_fix_tickets_classification_check",
+          "value": "\"auto_fix_tickets\".\"classification\" IN ('bug', 'feature', 'question', 'unclear')"
+        },
+        "auto_fix_tickets_confidence_check": {
+          "name": "auto_fix_tickets_confidence_check",
+          "value": "\"auto_fix_tickets\".\"confidence\" >= 0 AND \"auto_fix_tickets\".\"confidence\" <= 1"
+        },
+        "auto_fix_tickets_trigger_source_check": {
+          "name": "auto_fix_tickets_trigger_source_check",
+          "value": "\"auto_fix_tickets\".\"trigger_source\" IN ('label', 'review_comment')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auto_model": {
+      "name": "auto_model",
+      "schema": "",
+      "columns": {
+        "auto_model_id": {
+          "name": "auto_model_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auto_model": {
+          "name": "auto_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_auto_model": {
+          "name": "UQ_auto_model",
+          "columns": [
+            {
+              "expression": "auto_model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_top_up_configs": {
+      "name": "auto_top_up_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_method_id": {
+          "name": "stripe_payment_method_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5000
+        },
+        "last_auto_top_up_at": {
+          "name": "last_auto_top_up_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_started_at": {
+          "name": "attempt_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_auto_top_up_configs_owned_by_user_id": {
+          "name": "UQ_auto_top_up_configs_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auto_top_up_configs\".\"owned_by_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_auto_top_up_configs_owned_by_organization_id": {
+          "name": "UQ_auto_top_up_configs_owned_by_organization_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auto_top_up_configs\".\"owned_by_organization_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auto_top_up_configs_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "auto_top_up_configs_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "auto_top_up_configs",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "auto_top_up_configs_owned_by_organization_id_organizations_id_fk": {
+          "name": "auto_top_up_configs_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "auto_top_up_configs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auto_top_up_configs_exactly_one_owner": {
+          "name": "auto_top_up_configs_exactly_one_owner",
+          "value": "(\"auto_top_up_configs\".\"owned_by_user_id\" IS NOT NULL AND \"auto_top_up_configs\".\"owned_by_organization_id\" IS NULL) OR (\"auto_top_up_configs\".\"owned_by_user_id\" IS NULL AND \"auto_top_up_configs\".\"owned_by_organization_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auto_triage_tickets": {
+      "name": "auto_triage_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_url": {
+          "name": "issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_title": {
+          "name": "issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_body": {
+          "name": "issue_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_author": {
+          "name": "issue_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_labels": {
+          "name": "issue_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_summary": {
+          "name": "intent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_files": {
+          "name": "related_files",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_duplicate": {
+          "name": "is_duplicate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "duplicate_of_ticket_id": {
+          "name": "duplicate_of_ticket_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "similarity_score": {
+          "name": "similarity_score",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qdrant_point_id": {
+          "name": "qdrant_point_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "should_auto_fix": {
+          "name": "should_auto_fix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_metadata": {
+          "name": "action_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_auto_triage_tickets_repo_issue": {
+          "name": "UQ_auto_triage_tickets_repo_issue",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_owned_by_org": {
+          "name": "IDX_auto_triage_tickets_owned_by_org",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_owned_by_user": {
+          "name": "IDX_auto_triage_tickets_owned_by_user",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_status": {
+          "name": "IDX_auto_triage_tickets_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_created_at": {
+          "name": "IDX_auto_triage_tickets_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_qdrant_point_id": {
+          "name": "IDX_auto_triage_tickets_qdrant_point_id",
+          "columns": [
+            {
+              "expression": "qdrant_point_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_owner_status_created": {
+          "name": "IDX_auto_triage_tickets_owner_status_created",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_user_status_created": {
+          "name": "IDX_auto_triage_tickets_user_status_created",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_repo_classification": {
+          "name": "IDX_auto_triage_tickets_repo_classification",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auto_triage_tickets_owned_by_organization_id_organizations_id_fk": {
+          "name": "auto_triage_tickets_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "auto_triage_tickets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_triage_tickets_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "auto_triage_tickets_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "auto_triage_tickets",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_triage_tickets_platform_integration_id_platform_integrations_id_fk": {
+          "name": "auto_triage_tickets_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "auto_triage_tickets",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auto_triage_tickets_duplicate_of_ticket_id_auto_triage_tickets_id_fk": {
+          "name": "auto_triage_tickets_duplicate_of_ticket_id_auto_triage_tickets_id_fk",
+          "tableFrom": "auto_triage_tickets",
+          "tableTo": "auto_triage_tickets",
+          "columnsFrom": [
+            "duplicate_of_ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auto_triage_tickets_owner_check": {
+          "name": "auto_triage_tickets_owner_check",
+          "value": "(\n        (\"auto_triage_tickets\".\"owned_by_user_id\" IS NOT NULL AND \"auto_triage_tickets\".\"owned_by_organization_id\" IS NULL) OR\n        (\"auto_triage_tickets\".\"owned_by_user_id\" IS NULL AND \"auto_triage_tickets\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "auto_triage_tickets_issue_type_check": {
+          "name": "auto_triage_tickets_issue_type_check",
+          "value": "\"auto_triage_tickets\".\"issue_type\" IN ('issue', 'pull_request')"
+        },
+        "auto_triage_tickets_classification_check": {
+          "name": "auto_triage_tickets_classification_check",
+          "value": "\"auto_triage_tickets\".\"classification\" IN ('bug', 'feature', 'question', 'duplicate', 'unclear')"
+        },
+        "auto_triage_tickets_confidence_check": {
+          "name": "auto_triage_tickets_confidence_check",
+          "value": "\"auto_triage_tickets\".\"confidence\" >= 0 AND \"auto_triage_tickets\".\"confidence\" <= 1"
+        },
+        "auto_triage_tickets_similarity_score_check": {
+          "name": "auto_triage_tickets_similarity_score_check",
+          "value": "\"auto_triage_tickets\".\"similarity_score\" >= 0 AND \"auto_triage_tickets\".\"similarity_score\" <= 1"
+        },
+        "auto_triage_tickets_status_check": {
+          "name": "auto_triage_tickets_status_check",
+          "value": "\"auto_triage_tickets\".\"status\" IN ('pending', 'analyzing', 'actioned', 'failed', 'skipped')"
+        },
+        "auto_triage_tickets_action_taken_check": {
+          "name": "auto_triage_tickets_action_taken_check",
+          "value": "\"auto_triage_tickets\".\"action_taken\" IN ('pr_created', 'comment_posted', 'closed_duplicate', 'needs_clarification')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bot_requests": {
+      "name": "bot_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_thread_id": {
+          "name": "platform_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_message": {
+          "name": "user_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_used": {
+          "name": "model_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_bot_requests_created_at": {
+          "name": "IDX_bot_requests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_bot_requests_created_by": {
+          "name": "IDX_bot_requests_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_bot_requests_organization_id": {
+          "name": "IDX_bot_requests_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_bot_requests_platform_integration_id": {
+          "name": "IDX_bot_requests_platform_integration_id",
+          "columns": [
+            {
+              "expression": "platform_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_bot_requests_status": {
+          "name": "IDX_bot_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_requests_created_by_kilocode_users_id_fk": {
+          "name": "bot_requests_created_by_kilocode_users_id_fk",
+          "tableFrom": "bot_requests",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bot_requests_organization_id_organizations_id_fk": {
+          "name": "bot_requests_organization_id_organizations_id_fk",
+          "tableFrom": "bot_requests",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bot_requests_platform_integration_id_platform_integrations_id_fk": {
+          "name": "bot_requests_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "bot_requests",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.byok_api_keys": {
+      "name": "byok_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_byok_api_keys_organization_id": {
+          "name": "IDX_byok_api_keys_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_byok_api_keys_kilo_user_id": {
+          "name": "IDX_byok_api_keys_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_byok_api_keys_provider_id": {
+          "name": "IDX_byok_api_keys_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "byok_api_keys_organization_id_organizations_id_fk": {
+          "name": "byok_api_keys_organization_id_organizations_id_fk",
+          "tableFrom": "byok_api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "byok_api_keys_kilo_user_id_kilocode_users_id_fk": {
+          "name": "byok_api_keys_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "byok_api_keys",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_byok_api_keys_org_provider": {
+          "name": "UQ_byok_api_keys_org_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "provider_id"
+          ]
+        },
+        "UQ_byok_api_keys_user_provider": {
+          "name": "UQ_byok_api_keys_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "kilo_user_id",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "byok_api_keys_owner_check": {
+          "name": "byok_api_keys_owner_check",
+          "value": "(\n        (\"byok_api_keys\".\"kilo_user_id\" IS NOT NULL AND \"byok_api_keys\".\"organization_id\" IS NULL) OR\n        (\"byok_api_keys\".\"kilo_user_id\" IS NULL AND \"byok_api_keys\".\"organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cli_sessions": {
+      "name": "cli_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_on_platform": {
+          "name": "created_on_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "api_conversation_history_blob_url": {
+          "name": "api_conversation_history_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_metadata_blob_url": {
+          "name": "task_metadata_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ui_messages_blob_url": {
+          "name": "ui_messages_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_state_blob_url": {
+          "name": "git_state_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_mode": {
+          "name": "last_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_model": {
+          "name": "last_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_cli_sessions_kilo_user_id": {
+          "name": "IDX_cli_sessions_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_created_at": {
+          "name": "IDX_cli_sessions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_updated_at": {
+          "name": "IDX_cli_sessions_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_organization_id": {
+          "name": "IDX_cli_sessions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_user_updated": {
+          "name": "IDX_cli_sessions_user_updated",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_sessions_kilo_user_id_kilocode_users_id_fk": {
+          "name": "cli_sessions_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_forked_from_cli_sessions_session_id_fk": {
+          "name": "cli_sessions_forked_from_cli_sessions_session_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "cli_sessions",
+          "columnsFrom": [
+            "forked_from"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_parent_session_id_cli_sessions_session_id_fk": {
+          "name": "cli_sessions_parent_session_id_cli_sessions_session_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "cli_sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_organization_id_organizations_id_fk": {
+          "name": "cli_sessions_organization_id_organizations_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_sessions_cloud_agent_session_id_unique": {
+          "name": "cli_sessions_cloud_agent_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cloud_agent_session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_sessions_v2": {
+      "name": "cli_sessions_v2",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_on_platform": {
+          "name": "created_on_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_cli_sessions_v2_parent_session_id_kilo_user_id": {
+          "name": "IDX_cli_sessions_v2_parent_session_id_kilo_user_id",
+          "columns": [
+            {
+              "expression": "parent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_cli_sessions_v2_public_id": {
+          "name": "UQ_cli_sessions_v2_public_id",
+          "columns": [
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cli_sessions_v2\".\"public_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_cli_sessions_v2_cloud_agent_session_id": {
+          "name": "UQ_cli_sessions_v2_cloud_agent_session_id",
+          "columns": [
+            {
+              "expression": "cloud_agent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cli_sessions_v2\".\"cloud_agent_session_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_v2_organization_id": {
+          "name": "IDX_cli_sessions_v2_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_v2_kilo_user_id": {
+          "name": "IDX_cli_sessions_v2_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_v2_created_at": {
+          "name": "IDX_cli_sessions_v2_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_v2_user_updated": {
+          "name": "IDX_cli_sessions_v2_user_updated",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_sessions_v2_kilo_user_id_kilocode_users_id_fk": {
+          "name": "cli_sessions_v2_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "cli_sessions_v2",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_v2_organization_id_organizations_id_fk": {
+          "name": "cli_sessions_v2_organization_id_organizations_id_fk",
+          "tableFrom": "cli_sessions_v2",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_v2_parent_session_id_kilo_user_id_fk": {
+          "name": "cli_sessions_v2_parent_session_id_kilo_user_id_fk",
+          "tableFrom": "cli_sessions_v2",
+          "tableTo": "cli_sessions_v2",
+          "columnsFrom": [
+            "parent_session_id",
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "session_id",
+            "kilo_user_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "cli_sessions_v2_session_id_kilo_user_id_pk": {
+          "name": "cli_sessions_v2_session_id_kilo_user_id_pk",
+          "columns": [
+            "session_id",
+            "kilo_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_agent_code_reviews": {
+      "name": "cloud_agent_code_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_author": {
+          "name": "pr_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_author_github_id": {
+          "name": "pr_author_github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_ref": {
+          "name": "head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "platform_project_id": {
+          "name": "platform_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_session_id": {
+          "name": "cli_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_reason": {
+          "name": "terminal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'v1'"
+        },
+        "check_run_id": {
+          "name": "check_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens_in": {
+          "name": "total_tokens_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens_out": {
+          "name": "total_tokens_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cost_musd": {
+          "name": "total_cost_musd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_cloud_agent_code_reviews_repo_pr_sha": {
+          "name": "UQ_cloud_agent_code_reviews_repo_pr_sha",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_owned_by_org_id": {
+          "name": "idx_cloud_agent_code_reviews_owned_by_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_owned_by_user_id": {
+          "name": "idx_cloud_agent_code_reviews_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_session_id": {
+          "name": "idx_cloud_agent_code_reviews_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_cli_session_id": {
+          "name": "idx_cloud_agent_code_reviews_cli_session_id",
+          "columns": [
+            {
+              "expression": "cli_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_status": {
+          "name": "idx_cloud_agent_code_reviews_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_repo": {
+          "name": "idx_cloud_agent_code_reviews_repo",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_pr_number": {
+          "name": "idx_cloud_agent_code_reviews_pr_number",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_created_at": {
+          "name": "idx_cloud_agent_code_reviews_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_pr_author_github_id": {
+          "name": "idx_cloud_agent_code_reviews_pr_author_github_id",
+          "columns": [
+            {
+              "expression": "pr_author_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_agent_code_reviews_owned_by_organization_id_organizations_id_fk": {
+          "name": "cloud_agent_code_reviews_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "cloud_agent_code_reviews",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_agent_code_reviews_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "cloud_agent_code_reviews_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "cloud_agent_code_reviews",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_agent_code_reviews_platform_integration_id_platform_integrations_id_fk": {
+          "name": "cloud_agent_code_reviews_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "cloud_agent_code_reviews",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cloud_agent_code_reviews_owner_check": {
+          "name": "cloud_agent_code_reviews_owner_check",
+          "value": "(\n        (\"cloud_agent_code_reviews\".\"owned_by_user_id\" IS NOT NULL AND \"cloud_agent_code_reviews\".\"owned_by_organization_id\" IS NULL) OR\n        (\"cloud_agent_code_reviews\".\"owned_by_user_id\" IS NULL AND \"cloud_agent_code_reviews\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cloud_agent_feedback": {
+      "name": "cloud_agent_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streaming": {
+          "name": "is_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_text": {
+          "name": "feedback_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recent_messages": {
+          "name": "recent_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_cloud_agent_feedback_created_at": {
+          "name": "IDX_cloud_agent_feedback_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_feedback_kilo_user_id": {
+          "name": "IDX_cloud_agent_feedback_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_feedback_cloud_agent_session_id": {
+          "name": "IDX_cloud_agent_feedback_cloud_agent_session_id",
+          "columns": [
+            {
+              "expression": "cloud_agent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_agent_feedback_kilo_user_id_kilocode_users_id_fk": {
+          "name": "cloud_agent_feedback_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "cloud_agent_feedback",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "cloud_agent_feedback_organization_id_organizations_id_fk": {
+          "name": "cloud_agent_feedback_organization_id_organizations_id_fk",
+          "tableFrom": "cloud_agent_feedback",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_agent_webhook_triggers": {
+      "name": "cloud_agent_webhook_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloud_agent'"
+        },
+        "kiloclaw_instance_id": {
+          "name": "kiloclaw_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_cloud_agent_webhook_triggers_user_trigger": {
+          "name": "UQ_cloud_agent_webhook_triggers_user_trigger",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cloud_agent_webhook_triggers\".\"user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_cloud_agent_webhook_triggers_org_trigger": {
+          "name": "UQ_cloud_agent_webhook_triggers_org_trigger",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cloud_agent_webhook_triggers\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_webhook_triggers_user": {
+          "name": "IDX_cloud_agent_webhook_triggers_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_webhook_triggers_org": {
+          "name": "IDX_cloud_agent_webhook_triggers_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_webhook_triggers_active": {
+          "name": "IDX_cloud_agent_webhook_triggers_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_webhook_triggers_profile": {
+          "name": "IDX_cloud_agent_webhook_triggers_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_agent_webhook_triggers_user_id_kilocode_users_id_fk": {
+          "name": "cloud_agent_webhook_triggers_user_id_kilocode_users_id_fk",
+          "tableFrom": "cloud_agent_webhook_triggers",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_agent_webhook_triggers_organization_id_organizations_id_fk": {
+          "name": "cloud_agent_webhook_triggers_organization_id_organizations_id_fk",
+          "tableFrom": "cloud_agent_webhook_triggers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_agent_webhook_triggers_kiloclaw_instance_id_kiloclaw_instances_id_fk": {
+          "name": "cloud_agent_webhook_triggers_kiloclaw_instance_id_kiloclaw_instances_id_fk",
+          "tableFrom": "cloud_agent_webhook_triggers",
+          "tableTo": "kiloclaw_instances",
+          "columnsFrom": [
+            "kiloclaw_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cloud_agent_webhook_triggers_profile_id_agent_environment_profiles_id_fk": {
+          "name": "cloud_agent_webhook_triggers_profile_id_agent_environment_profiles_id_fk",
+          "tableFrom": "cloud_agent_webhook_triggers",
+          "tableTo": "agent_environment_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "CHK_cloud_agent_webhook_triggers_owner": {
+          "name": "CHK_cloud_agent_webhook_triggers_owner",
+          "value": "(\n        (\"cloud_agent_webhook_triggers\".\"user_id\" IS NOT NULL AND \"cloud_agent_webhook_triggers\".\"organization_id\" IS NULL) OR\n        (\"cloud_agent_webhook_triggers\".\"user_id\" IS NULL AND \"cloud_agent_webhook_triggers\".\"organization_id\" IS NOT NULL)\n      )"
+        },
+        "CHK_cloud_agent_webhook_triggers_cloud_agent_fields": {
+          "name": "CHK_cloud_agent_webhook_triggers_cloud_agent_fields",
+          "value": "(\n        \"cloud_agent_webhook_triggers\".\"target_type\" != 'cloud_agent' OR\n        (\"cloud_agent_webhook_triggers\".\"github_repo\" IS NOT NULL AND \"cloud_agent_webhook_triggers\".\"profile_id\" IS NOT NULL)\n      )"
+        },
+        "CHK_cloud_agent_webhook_triggers_kiloclaw_fields": {
+          "name": "CHK_cloud_agent_webhook_triggers_kiloclaw_fields",
+          "value": "(\n        \"cloud_agent_webhook_triggers\".\"target_type\" != 'kiloclaw_chat' OR\n        \"cloud_agent_webhook_triggers\".\"kiloclaw_instance_id\" IS NOT NULL\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.code_indexing_manifest": {
+      "name": "code_indexing_manifest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_count": {
+          "name": "chunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_lines": {
+          "name": "total_lines",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_ai_lines": {
+          "name": "total_ai_lines",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_code_indexing_manifest_organization_id": {
+          "name": "IDX_code_indexing_manifest_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_manifest_kilo_user_id": {
+          "name": "IDX_code_indexing_manifest_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_manifest_project_id": {
+          "name": "IDX_code_indexing_manifest_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_manifest_file_hash": {
+          "name": "IDX_code_indexing_manifest_file_hash",
+          "columns": [
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_manifest_git_branch": {
+          "name": "IDX_code_indexing_manifest_git_branch",
+          "columns": [
+            {
+              "expression": "git_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_manifest_created_at": {
+          "name": "IDX_code_indexing_manifest_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "code_indexing_manifest_kilo_user_id_kilocode_users_id_fk": {
+          "name": "code_indexing_manifest_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "code_indexing_manifest",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_code_indexing_manifest_org_user_project_hash_branch": {
+          "name": "UQ_code_indexing_manifest_org_user_project_hash_branch",
+          "nullsNotDistinct": true,
+          "columns": [
+            "organization_id",
+            "kilo_user_id",
+            "project_id",
+            "file_path",
+            "git_branch"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.code_indexing_search": {
+      "name": "code_indexing_search",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_code_indexing_search_organization_id": {
+          "name": "IDX_code_indexing_search_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_search_kilo_user_id": {
+          "name": "IDX_code_indexing_search_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_search_project_id": {
+          "name": "IDX_code_indexing_search_project_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_search_created_at": {
+          "name": "IDX_code_indexing_search_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "code_indexing_search_kilo_user_id_kilocode_users_id_fk": {
+          "name": "code_indexing_search_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "code_indexing_search",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coding_plan_key_inventory": {
+      "name": "coding_plan_key_inventory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to_user_id": {
+          "name": "assigned_to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_coding_plan_key_inv_provider": {
+          "name": "IDX_coding_plan_key_inv_provider",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_coding_plan_key_inv_unassigned": {
+          "name": "IDX_coding_plan_key_inv_unassigned",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"coding_plan_key_inventory\".\"assigned_to_user_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "coding_plan_key_inventory_assigned_to_user_id_kilocode_users_id_fk": {
+          "name": "coding_plan_key_inventory_assigned_to_user_id_kilocode_users_id_fk",
+          "tableFrom": "coding_plan_key_inventory",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "assigned_to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coding_plan_subscriptions": {
+      "name": "coding_plan_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byok_key_id": {
+          "name": "byok_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_microdollars": {
+          "name": "cost_microdollars",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_period_days": {
+          "name": "billing_period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_renewal_at": {
+          "name": "credit_renewal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_top_up_triggered_for_period": {
+          "name": "auto_top_up_triggered_for_period",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_coding_plan_sub_user_provider": {
+          "name": "UQ_coding_plan_sub_user_provider",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_coding_plan_sub_status": {
+          "name": "IDX_coding_plan_sub_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_coding_plan_sub_renewal": {
+          "name": "IDX_coding_plan_sub_renewal",
+          "columns": [
+            {
+              "expression": "credit_renewal_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "coding_plan_subscriptions_user_id_kilocode_users_id_fk": {
+          "name": "coding_plan_subscriptions_user_id_kilocode_users_id_fk",
+          "tableFrom": "coding_plan_subscriptions",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coding_plan_subscriptions_byok_key_id_byok_api_keys_id_fk": {
+          "name": "coding_plan_subscriptions_byok_key_id_byok_api_keys_id_fk",
+          "tableFrom": "coding_plan_subscriptions",
+          "tableTo": "byok_api_keys",
+          "columnsFrom": [
+            "byok_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "coding_plan_subscriptions_status_check": {
+          "name": "coding_plan_subscriptions_status_check",
+          "value": "\"coding_plan_subscriptions\".\"status\" IN ('active', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credit_transactions": {
+      "name": "credit_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_microdollars": {
+          "name": "amount_microdollars",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration_baseline_microdollars_used": {
+          "name": "expiration_baseline_microdollars_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_baseline_microdollars_used": {
+          "name": "original_baseline_microdollars_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_free": {
+          "name": "is_free",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_transaction_id": {
+          "name": "original_transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coinbase_credit_block_id": {
+          "name": "coinbase_credit_block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_category": {
+          "name": "credit_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_category_uniqueness": {
+          "name": "check_category_uniqueness",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "IDX_credit_transactions_created_at": {
+          "name": "IDX_credit_transactions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_is_free": {
+          "name": "IDX_credit_transactions_is_free",
+          "columns": [
+            {
+              "expression": "is_free",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_kilo_user_id": {
+          "name": "IDX_credit_transactions_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_credit_category": {
+          "name": "IDX_credit_transactions_credit_category",
+          "columns": [
+            {
+              "expression": "credit_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_stripe_payment_id": {
+          "name": "IDX_credit_transactions_stripe_payment_id",
+          "columns": [
+            {
+              "expression": "stripe_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_original_transaction_id": {
+          "name": "IDX_credit_transactions_original_transaction_id",
+          "columns": [
+            {
+              "expression": "original_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_coinbase_credit_block_id": {
+          "name": "IDX_credit_transactions_coinbase_credit_block_id",
+          "columns": [
+            {
+              "expression": "coinbase_credit_block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_organization_id": {
+          "name": "IDX_credit_transactions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_unique_category": {
+          "name": "IDX_credit_transactions_unique_category",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "credit_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_transactions\".\"check_category_uniqueness\" = TRUE",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_llm": {
+      "name": "custom_llm",
+      "schema": "",
+      "columns": {
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_completion_tokens": {
+          "name": "max_completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_ids": {
+          "name": "organization_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supports_image_input": {
+          "name": "supports_image_input",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "force_reasoning": {
+          "name": "force_reasoning",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opencode_settings": {
+          "name": "opencode_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_headers": {
+          "name": "extra_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interleaved_format": {
+          "name": "interleaved_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_llm2": {
+      "name": "custom_llm2",
+      "schema": "",
+      "columns": {
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_builds": {
+      "name": "deployment_builds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deployment_builds_deployment_id": {
+          "name": "idx_deployment_builds_deployment_id",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployment_builds_status": {
+          "name": "idx_deployment_builds_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_builds_deployment_id_deployments_id_fk": {
+          "name": "deployment_builds_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_builds",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_env_vars": {
+      "name": "deployment_env_vars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deployment_env_vars_deployment_id": {
+          "name": "idx_deployment_env_vars_deployment_id",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_env_vars_deployment_id_deployments_id_fk": {
+          "name": "deployment_env_vars_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_env_vars",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_deployment_env_vars_deployment_key": {
+          "name": "UQ_deployment_env_vars_deployment_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deployment_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_events": {
+      "name": "deployment_events",
+      "schema": "",
+      "columns": {
+        "build_id": {
+          "name": "build_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'log'"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_deployment_events_build_id": {
+          "name": "idx_deployment_events_build_id",
+          "columns": [
+            {
+              "expression": "build_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployment_events_timestamp": {
+          "name": "idx_deployment_events_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployment_events_type": {
+          "name": "idx_deployment_events_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_events_build_id_deployment_builds_id_fk": {
+          "name": "deployment_events_build_id_deployment_builds_id_fk",
+          "tableFrom": "deployment_events",
+          "tableTo": "deployment_builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "deployment_events_build_id_event_id_pk": {
+          "name": "deployment_events_build_id_event_id_pk",
+          "columns": [
+            "build_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_threat_detections": {
+      "name": "deployment_threat_detections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threat_type": {
+          "name": "threat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deployment_threat_detections_deployment_id": {
+          "name": "idx_deployment_threat_detections_deployment_id",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployment_threat_detections_created_at": {
+          "name": "idx_deployment_threat_detections_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_threat_detections_deployment_id_deployments_id_fk": {
+          "name": "deployment_threat_detections_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_threat_detections",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deployment_threat_detections_build_id_deployment_builds_id_fk": {
+          "name": "deployment_threat_detections_build_id_deployment_builds_id_fk",
+          "tableFrom": "deployment_threat_detections",
+          "tableTo": "deployment_builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployments": {
+      "name": "deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_slug": {
+          "name": "deployment_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_worker_name": {
+          "name": "internal_worker_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_source": {
+          "name": "repository_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_url": {
+          "name": "deployment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "git_auth_token": {
+          "name": "git_auth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_deployed_at": {
+          "name": "last_deployed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_build_id": {
+          "name": "last_build_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threat_status": {
+          "name": "threat_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from": {
+          "name": "created_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_deployments_owned_by_user_id": {
+          "name": "idx_deployments_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployments_owned_by_organization_id": {
+          "name": "idx_deployments_owned_by_organization_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployments_platform_integration_id": {
+          "name": "idx_deployments_platform_integration_id",
+          "columns": [
+            {
+              "expression": "platform_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployments_repository_source_branch": {
+          "name": "idx_deployments_repository_source_branch",
+          "columns": [
+            {
+              "expression": "repository_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployments_threat_status_pending": {
+          "name": "idx_deployments_threat_status_pending",
+          "columns": [
+            {
+              "expression": "threat_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"deployments\".\"threat_status\" = 'pending_scan'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployments_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "deployments_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployments_owned_by_organization_id_organizations_id_fk": {
+          "name": "deployments_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_deployments_deployment_slug": {
+          "name": "UQ_deployments_deployment_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deployment_slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "deployments_owner_check": {
+          "name": "deployments_owner_check",
+          "value": "(\n        (\"deployments\".\"owned_by_user_id\" IS NOT NULL AND \"deployments\".\"owned_by_organization_id\" IS NULL) OR\n        (\"deployments\".\"owned_by_user_id\" IS NULL AND \"deployments\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "deployments_source_type_check": {
+          "name": "deployments_source_type_check",
+          "value": "\"deployments\".\"source_type\" IN ('github', 'git', 'app-builder')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_auth_requests": {
+      "name": "device_auth_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_device_auth_requests_code": {
+          "name": "UQ_device_auth_requests_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_device_auth_requests_status": {
+          "name": "IDX_device_auth_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_device_auth_requests_expires_at": {
+          "name": "IDX_device_auth_requests_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_device_auth_requests_kilo_user_id": {
+          "name": "IDX_device_auth_requests_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_auth_requests_kilo_user_id_kilocode_users_id_fk": {
+          "name": "device_auth_requests_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "device_auth_requests",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_gateway_listener": {
+      "name": "discord_gateway_listener",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "listener_id": {
+          "name": "listener_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.editor_name": {
+      "name": "editor_name",
+      "schema": "",
+      "columns": {
+        "editor_name_id": {
+          "name": "editor_name_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "editor_name": {
+          "name": "editor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_editor_name": {
+          "name": "UQ_editor_name",
+          "columns": [
+            {
+              "expression": "editor_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichment_data": {
+      "name": "enrichment_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_enrichment_data": {
+          "name": "github_enrichment_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_enrichment_data": {
+          "name": "linkedin_enrichment_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clay_enrichment_data": {
+          "name": "clay_enrichment_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_enrichment_data_user_id": {
+          "name": "IDX_enrichment_data_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrichment_data_user_id_kilocode_users_id_fk": {
+          "name": "enrichment_data_user_id_kilocode_users_id_fk",
+          "tableFrom": "enrichment_data",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_enrichment_data_user_id": {
+          "name": "UQ_enrichment_data_user_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature": {
+      "name": "feature",
+      "schema": "",
+      "columns": {
+        "feature_id": {
+          "name": "feature_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_feature": {
+          "name": "UQ_feature",
+          "columns": [
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finish_reason": {
+      "name": "finish_reason",
+      "schema": "",
+      "columns": {
+        "finish_reason_id": {
+          "name": "finish_reason_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_finish_reason": {
+          "name": "UQ_finish_reason",
+          "columns": [
+            {
+              "expression": "finish_reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.free_model_usage": {
+      "name": "free_model_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_free_model_usage_ip_created_at": {
+          "name": "idx_free_model_usage_ip_created_at",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_free_model_usage_created_at": {
+          "name": "idx_free_model_usage_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_free_model_usage_user_created_at": {
+          "name": "idx_free_model_usage_user_created_at",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"free_model_usage\".\"kilo_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.http_ip": {
+      "name": "http_ip",
+      "schema": "",
+      "columns": {
+        "http_ip_id": {
+          "name": "http_ip_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "http_ip": {
+          "name": "http_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_http_ip": {
+          "name": "UQ_http_ip",
+          "columns": [
+            {
+              "expression": "http_ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.http_user_agent": {
+      "name": "http_user_agent",
+      "schema": "",
+      "columns": {
+        "http_user_agent_id": {
+          "name": "http_user_agent_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "http_user_agent": {
+          "name": "http_user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_http_user_agent": {
+          "name": "UQ_http_user_agent",
+          "columns": [
+            {
+              "expression": "http_user_agent",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ja4_digest": {
+      "name": "ja4_digest",
+      "schema": "",
+      "columns": {
+        "ja4_digest_id": {
+          "name": "ja4_digest_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ja4_digest": {
+          "name": "ja4_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_ja4_digest": {
+          "name": "UQ_ja4_digest",
+          "columns": [
+            {
+              "expression": "ja4_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_audit_log": {
+      "name": "kilo_pass_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilo_pass_subscription_id": {
+          "name": "kilo_pass_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_credit_transaction_id": {
+          "name": "related_credit_transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_monthly_issuance_id": {
+          "name": "related_monthly_issuance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "IDX_kilo_pass_audit_log_created_at": {
+          "name": "IDX_kilo_pass_audit_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_kilo_user_id": {
+          "name": "IDX_kilo_pass_audit_log_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_kilo_pass_subscription_id": {
+          "name": "IDX_kilo_pass_audit_log_kilo_pass_subscription_id",
+          "columns": [
+            {
+              "expression": "kilo_pass_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_action": {
+          "name": "IDX_kilo_pass_audit_log_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_result": {
+          "name": "IDX_kilo_pass_audit_log_result",
+          "columns": [
+            {
+              "expression": "result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_idempotency_key": {
+          "name": "IDX_kilo_pass_audit_log_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_stripe_event_id": {
+          "name": "IDX_kilo_pass_audit_log_stripe_event_id",
+          "columns": [
+            {
+              "expression": "stripe_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_stripe_invoice_id": {
+          "name": "IDX_kilo_pass_audit_log_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_stripe_subscription_id": {
+          "name": "IDX_kilo_pass_audit_log_stripe_subscription_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_related_credit_transaction_id": {
+          "name": "IDX_kilo_pass_audit_log_related_credit_transaction_id",
+          "columns": [
+            {
+              "expression": "related_credit_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_related_monthly_issuance_id": {
+          "name": "IDX_kilo_pass_audit_log_related_monthly_issuance_id",
+          "columns": [
+            {
+              "expression": "related_monthly_issuance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_audit_log_kilo_user_id_kilocode_users_id_fk": {
+          "name": "kilo_pass_audit_log_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "kilo_pass_audit_log",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "kilo_pass_audit_log_kilo_pass_subscription_id_kilo_pass_subscriptions_id_fk": {
+          "name": "kilo_pass_audit_log_kilo_pass_subscription_id_kilo_pass_subscriptions_id_fk",
+          "tableFrom": "kilo_pass_audit_log",
+          "tableTo": "kilo_pass_subscriptions",
+          "columnsFrom": [
+            "kilo_pass_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "kilo_pass_audit_log_related_credit_transaction_id_credit_transactions_id_fk": {
+          "name": "kilo_pass_audit_log_related_credit_transaction_id_credit_transactions_id_fk",
+          "tableFrom": "kilo_pass_audit_log",
+          "tableTo": "credit_transactions",
+          "columnsFrom": [
+            "related_credit_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "kilo_pass_audit_log_related_monthly_issuance_id_kilo_pass_issuances_id_fk": {
+          "name": "kilo_pass_audit_log_related_monthly_issuance_id_kilo_pass_issuances_id_fk",
+          "tableFrom": "kilo_pass_audit_log",
+          "tableTo": "kilo_pass_issuances",
+          "columnsFrom": [
+            "related_monthly_issuance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_audit_log_action_check": {
+          "name": "kilo_pass_audit_log_action_check",
+          "value": "\"kilo_pass_audit_log\".\"action\" IN ('stripe_webhook_received', 'kilo_pass_invoice_paid_handled', 'base_credits_issued', 'bonus_credits_issued', 'bonus_credits_skipped_idempotent', 'first_month_50pct_promo_issued', 'yearly_monthly_base_cron_started', 'yearly_monthly_base_cron_completed', 'issue_yearly_remaining_credits', 'yearly_monthly_bonus_cron_started', 'yearly_monthly_bonus_cron_completed')"
+        },
+        "kilo_pass_audit_log_result_check": {
+          "name": "kilo_pass_audit_log_result_check",
+          "value": "\"kilo_pass_audit_log\".\"result\" IN ('success', 'skipped_idempotent', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_issuance_items": {
+      "name": "kilo_pass_issuance_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_pass_issuance_id": {
+          "name": "kilo_pass_issuance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_transaction_id": {
+          "name": "credit_transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bonus_percent_applied": {
+          "name": "bonus_percent_applied",
+          "type": "numeric(6, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kilo_pass_issuance_items_issuance_id": {
+          "name": "IDX_kilo_pass_issuance_items_issuance_id",
+          "columns": [
+            {
+              "expression": "kilo_pass_issuance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_issuance_items_credit_transaction_id": {
+          "name": "IDX_kilo_pass_issuance_items_credit_transaction_id",
+          "columns": [
+            {
+              "expression": "credit_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_issuance_items_kilo_pass_issuance_id_kilo_pass_issuances_id_fk": {
+          "name": "kilo_pass_issuance_items_kilo_pass_issuance_id_kilo_pass_issuances_id_fk",
+          "tableFrom": "kilo_pass_issuance_items",
+          "tableTo": "kilo_pass_issuances",
+          "columnsFrom": [
+            "kilo_pass_issuance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "kilo_pass_issuance_items_credit_transaction_id_credit_transactions_id_fk": {
+          "name": "kilo_pass_issuance_items_credit_transaction_id_credit_transactions_id_fk",
+          "tableFrom": "kilo_pass_issuance_items",
+          "tableTo": "credit_transactions",
+          "columnsFrom": [
+            "credit_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kilo_pass_issuance_items_credit_transaction_id_unique": {
+          "name": "kilo_pass_issuance_items_credit_transaction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credit_transaction_id"
+          ]
+        },
+        "UQ_kilo_pass_issuance_items_issuance_kind": {
+          "name": "UQ_kilo_pass_issuance_items_issuance_kind",
+          "nullsNotDistinct": false,
+          "columns": [
+            "kilo_pass_issuance_id",
+            "kind"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_issuance_items_bonus_percent_applied_range_check": {
+          "name": "kilo_pass_issuance_items_bonus_percent_applied_range_check",
+          "value": "\"kilo_pass_issuance_items\".\"bonus_percent_applied\" IS NULL OR (\"kilo_pass_issuance_items\".\"bonus_percent_applied\" >= 0 AND \"kilo_pass_issuance_items\".\"bonus_percent_applied\" <= 1)"
+        },
+        "kilo_pass_issuance_items_amount_usd_non_negative_check": {
+          "name": "kilo_pass_issuance_items_amount_usd_non_negative_check",
+          "value": "\"kilo_pass_issuance_items\".\"amount_usd\" >= 0"
+        },
+        "kilo_pass_issuance_items_kind_check": {
+          "name": "kilo_pass_issuance_items_kind_check",
+          "value": "\"kilo_pass_issuance_items\".\"kind\" IN ('base', 'bonus', 'promo_first_month_50pct')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_issuances": {
+      "name": "kilo_pass_issuances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_pass_subscription_id": {
+          "name": "kilo_pass_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_month": {
+          "name": "issue_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_kilo_pass_issuances_stripe_invoice_id": {
+          "name": "UQ_kilo_pass_issuances_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kilo_pass_issuances\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_issuances_subscription_id": {
+          "name": "IDX_kilo_pass_issuances_subscription_id",
+          "columns": [
+            {
+              "expression": "kilo_pass_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_issuances_issue_month": {
+          "name": "IDX_kilo_pass_issuances_issue_month",
+          "columns": [
+            {
+              "expression": "issue_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_issuances_kilo_pass_subscription_id_kilo_pass_subscriptions_id_fk": {
+          "name": "kilo_pass_issuances_kilo_pass_subscription_id_kilo_pass_subscriptions_id_fk",
+          "tableFrom": "kilo_pass_issuances",
+          "tableTo": "kilo_pass_subscriptions",
+          "columnsFrom": [
+            "kilo_pass_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_kilo_pass_issuances_subscription_issue_month": {
+          "name": "UQ_kilo_pass_issuances_subscription_issue_month",
+          "nullsNotDistinct": false,
+          "columns": [
+            "kilo_pass_subscription_id",
+            "issue_month"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_issuances_issue_month_day_one_check": {
+          "name": "kilo_pass_issuances_issue_month_day_one_check",
+          "value": "EXTRACT(DAY FROM \"kilo_pass_issuances\".\"issue_month\") = 1"
+        },
+        "kilo_pass_issuances_source_check": {
+          "name": "kilo_pass_issuances_source_check",
+          "value": "\"kilo_pass_issuances\".\"source\" IN ('stripe_invoice', 'cron')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_scheduled_changes": {
+      "name": "kilo_pass_scheduled_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_tier": {
+          "name": "from_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_cadence": {
+          "name": "from_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_tier": {
+          "name": "to_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_cadence": {
+          "name": "to_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kilo_pass_scheduled_changes_kilo_user_id": {
+          "name": "IDX_kilo_pass_scheduled_changes_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_scheduled_changes_status": {
+          "name": "IDX_kilo_pass_scheduled_changes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_scheduled_changes_stripe_subscription_id": {
+          "name": "IDX_kilo_pass_scheduled_changes_stripe_subscription_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_kilo_pass_scheduled_changes_active_stripe_subscription_id": {
+          "name": "UQ_kilo_pass_scheduled_changes_active_stripe_subscription_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kilo_pass_scheduled_changes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_scheduled_changes_effective_at": {
+          "name": "IDX_kilo_pass_scheduled_changes_effective_at",
+          "columns": [
+            {
+              "expression": "effective_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_scheduled_changes_deleted_at": {
+          "name": "IDX_kilo_pass_scheduled_changes_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_scheduled_changes_kilo_user_id_kilocode_users_id_fk": {
+          "name": "kilo_pass_scheduled_changes_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "kilo_pass_scheduled_changes",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "kilo_pass_scheduled_changes_stripe_subscription_id_kilo_pass_subscriptions_stripe_subscription_id_fk": {
+          "name": "kilo_pass_scheduled_changes_stripe_subscription_id_kilo_pass_subscriptions_stripe_subscription_id_fk",
+          "tableFrom": "kilo_pass_scheduled_changes",
+          "tableTo": "kilo_pass_subscriptions",
+          "columnsFrom": [
+            "stripe_subscription_id"
+          ],
+          "columnsTo": [
+            "stripe_subscription_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_scheduled_changes_from_tier_check": {
+          "name": "kilo_pass_scheduled_changes_from_tier_check",
+          "value": "\"kilo_pass_scheduled_changes\".\"from_tier\" IN ('tier_19', 'tier_49', 'tier_199')"
+        },
+        "kilo_pass_scheduled_changes_from_cadence_check": {
+          "name": "kilo_pass_scheduled_changes_from_cadence_check",
+          "value": "\"kilo_pass_scheduled_changes\".\"from_cadence\" IN ('monthly', 'yearly')"
+        },
+        "kilo_pass_scheduled_changes_to_tier_check": {
+          "name": "kilo_pass_scheduled_changes_to_tier_check",
+          "value": "\"kilo_pass_scheduled_changes\".\"to_tier\" IN ('tier_19', 'tier_49', 'tier_199')"
+        },
+        "kilo_pass_scheduled_changes_to_cadence_check": {
+          "name": "kilo_pass_scheduled_changes_to_cadence_check",
+          "value": "\"kilo_pass_scheduled_changes\".\"to_cadence\" IN ('monthly', 'yearly')"
+        },
+        "kilo_pass_scheduled_changes_status_check": {
+          "name": "kilo_pass_scheduled_changes_status_check",
+          "value": "\"kilo_pass_scheduled_changes\".\"status\" IN ('not_started', 'active', 'completed', 'released', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_subscriptions": {
+      "name": "kilo_pass_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cadence": {
+          "name": "cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_streak_months": {
+          "name": "current_streak_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_yearly_issue_at": {
+          "name": "next_yearly_issue_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kilo_pass_subscriptions_kilo_user_id": {
+          "name": "IDX_kilo_pass_subscriptions_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_subscriptions_status": {
+          "name": "IDX_kilo_pass_subscriptions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_subscriptions_cadence": {
+          "name": "IDX_kilo_pass_subscriptions_cadence",
+          "columns": [
+            {
+              "expression": "cadence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_subscriptions_kilo_user_id_kilocode_users_id_fk": {
+          "name": "kilo_pass_subscriptions_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "kilo_pass_subscriptions",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kilo_pass_subscriptions_stripe_subscription_id_unique": {
+          "name": "kilo_pass_subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_subscriptions_current_streak_months_non_negative_check": {
+          "name": "kilo_pass_subscriptions_current_streak_months_non_negative_check",
+          "value": "\"kilo_pass_subscriptions\".\"current_streak_months\" >= 0"
+        },
+        "kilo_pass_subscriptions_tier_check": {
+          "name": "kilo_pass_subscriptions_tier_check",
+          "value": "\"kilo_pass_subscriptions\".\"tier\" IN ('tier_19', 'tier_49', 'tier_199')"
+        },
+        "kilo_pass_subscriptions_cadence_check": {
+          "name": "kilo_pass_subscriptions_cadence_check",
+          "value": "\"kilo_pass_subscriptions\".\"cadence\" IN ('monthly', 'yearly')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_access_codes": {
+      "name": "kiloclaw_access_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_kiloclaw_access_codes_code": {
+          "name": "UQ_kiloclaw_access_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_access_codes_user_status": {
+          "name": "IDX_kiloclaw_access_codes_user_status",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_kiloclaw_access_codes_one_active_per_user": {
+          "name": "UQ_kiloclaw_access_codes_one_active_per_user",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kiloclaw_access_codes_kilo_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_access_codes_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_access_codes",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_admin_audit_logs": {
+      "name": "kiloclaw_admin_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kiloclaw_admin_audit_logs_target_user_id": {
+          "name": "IDX_kiloclaw_admin_audit_logs_target_user_id",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_admin_audit_logs_action": {
+          "name": "IDX_kiloclaw_admin_audit_logs_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_admin_audit_logs_created_at": {
+          "name": "IDX_kiloclaw_admin_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_cli_runs": {
+      "name": "kiloclaw_cli_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_kiloclaw_cli_runs_user_id": {
+          "name": "IDX_kiloclaw_cli_runs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_cli_runs_started_at": {
+          "name": "IDX_kiloclaw_cli_runs_started_at",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_cli_runs_instance_id": {
+          "name": "IDX_kiloclaw_cli_runs_instance_id",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kiloclaw_cli_runs_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_cli_runs_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_cli_runs",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kiloclaw_cli_runs_instance_id_kiloclaw_instances_id_fk": {
+          "name": "kiloclaw_cli_runs_instance_id_kiloclaw_instances_id_fk",
+          "tableFrom": "kiloclaw_cli_runs",
+          "tableTo": "kiloclaw_instances",
+          "columnsFrom": [
+            "instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_earlybird_purchases": {
+      "name": "kiloclaw_earlybird_purchases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_payment_id": {
+          "name": "manual_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kiloclaw_earlybird_purchases_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_earlybird_purchases_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_earlybird_purchases",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kiloclaw_earlybird_purchases_user_id_unique": {
+          "name": "kiloclaw_earlybird_purchases_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "kiloclaw_earlybird_purchases_stripe_charge_id_unique": {
+          "name": "kiloclaw_earlybird_purchases_stripe_charge_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_charge_id"
+          ]
+        },
+        "kiloclaw_earlybird_purchases_manual_payment_id_unique": {
+          "name": "kiloclaw_earlybird_purchases_manual_payment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "manual_payment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_email_log": {
+      "name": "kiloclaw_email_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_kiloclaw_email_log_user_type": {
+          "name": "UQ_kiloclaw_email_log_user_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kiloclaw_email_log_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_email_log_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_email_log",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_image_catalog": {
+      "name": "kiloclaw_image_catalog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "openclaw_version": {
+          "name": "openclaw_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "image_tag": {
+          "name": "image_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_digest": {
+          "name": "image_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kiloclaw_image_catalog_status": {
+          "name": "IDX_kiloclaw_image_catalog_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_image_catalog_variant": {
+          "name": "IDX_kiloclaw_image_catalog_variant",
+          "columns": [
+            {
+              "expression": "variant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kiloclaw_image_catalog_image_tag_unique": {
+          "name": "kiloclaw_image_catalog_image_tag_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "image_tag"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_instances": {
+      "name": "kiloclaw_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "destroyed_at": {
+          "name": "destroyed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "UQ_kiloclaw_instances_active": {
+          "name": "UQ_kiloclaw_instances_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kiloclaw_instances\".\"destroyed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kiloclaw_instances_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_instances_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_instances",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kiloclaw_instances_organization_id_organizations_id_fk": {
+          "name": "kiloclaw_instances_organization_id_organizations_id_fk",
+          "tableFrom": "kiloclaw_instances",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_subscriptions": {
+      "name": "kiloclaw_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_source": {
+          "name": "payment_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_plan": {
+          "name": "scheduled_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_by": {
+          "name": "scheduled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pending_conversion": {
+          "name": "pending_conversion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trial_started_at": {
+          "name": "trial_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_renewal_at": {
+          "name": "credit_renewal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_ends_at": {
+          "name": "commit_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_due_since": {
+          "name": "past_due_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destruction_deadline": {
+          "name": "destruction_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_top_up_triggered_for_period": {
+          "name": "auto_top_up_triggered_for_period",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kiloclaw_subscriptions_status": {
+          "name": "IDX_kiloclaw_subscriptions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_subscriptions_stripe_schedule_id": {
+          "name": "IDX_kiloclaw_subscriptions_stripe_schedule_id",
+          "columns": [
+            {
+              "expression": "stripe_schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_kiloclaw_subscriptions_instance": {
+          "name": "UQ_kiloclaw_subscriptions_instance",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kiloclaw_subscriptions\".\"instance_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kiloclaw_subscriptions_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_subscriptions_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_subscriptions",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kiloclaw_subscriptions_instance_id_kiloclaw_instances_id_fk": {
+          "name": "kiloclaw_subscriptions_instance_id_kiloclaw_instances_id_fk",
+          "tableFrom": "kiloclaw_subscriptions",
+          "tableTo": "kiloclaw_instances",
+          "columnsFrom": [
+            "instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kiloclaw_subscriptions_stripe_subscription_id_unique": {
+          "name": "kiloclaw_subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "kiloclaw_subscriptions_plan_check": {
+          "name": "kiloclaw_subscriptions_plan_check",
+          "value": "\"kiloclaw_subscriptions\".\"plan\" IN ('trial', 'commit', 'standard')"
+        },
+        "kiloclaw_subscriptions_scheduled_plan_check": {
+          "name": "kiloclaw_subscriptions_scheduled_plan_check",
+          "value": "\"kiloclaw_subscriptions\".\"scheduled_plan\" IN ('commit', 'standard')"
+        },
+        "kiloclaw_subscriptions_scheduled_by_check": {
+          "name": "kiloclaw_subscriptions_scheduled_by_check",
+          "value": "\"kiloclaw_subscriptions\".\"scheduled_by\" IN ('auto', 'user')"
+        },
+        "kiloclaw_subscriptions_status_check": {
+          "name": "kiloclaw_subscriptions_status_check",
+          "value": "\"kiloclaw_subscriptions\".\"status\" IN ('trialing', 'active', 'past_due', 'canceled', 'unpaid')"
+        },
+        "kiloclaw_subscriptions_payment_source_check": {
+          "name": "kiloclaw_subscriptions_payment_source_check",
+          "value": "\"kiloclaw_subscriptions\".\"payment_source\" IN ('stripe', 'credits')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_version_pins": {
+      "name": "kiloclaw_version_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_tag": {
+          "name": "image_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_by": {
+          "name": "pinned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kiloclaw_version_pins_instance_id_kiloclaw_instances_id_fk": {
+          "name": "kiloclaw_version_pins_instance_id_kiloclaw_instances_id_fk",
+          "tableFrom": "kiloclaw_version_pins",
+          "tableTo": "kiloclaw_instances",
+          "columnsFrom": [
+            "instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kiloclaw_version_pins_image_tag_kiloclaw_image_catalog_image_tag_fk": {
+          "name": "kiloclaw_version_pins_image_tag_kiloclaw_image_catalog_image_tag_fk",
+          "tableFrom": "kiloclaw_version_pins",
+          "tableTo": "kiloclaw_image_catalog",
+          "columnsFrom": [
+            "image_tag"
+          ],
+          "columnsTo": [
+            "image_tag"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "kiloclaw_version_pins_pinned_by_kilocode_users_id_fk": {
+          "name": "kiloclaw_version_pins_pinned_by_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_version_pins",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "pinned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kiloclaw_version_pins_instance_id_unique": {
+          "name": "kiloclaw_version_pins_instance_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instance_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilocode_users": {
+      "name": "kilocode_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_user_email": {
+          "name": "google_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_user_name": {
+          "name": "google_user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_user_image_url": {
+          "name": "google_user_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hosted_domain": {
+          "name": "hosted_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microdollars_used": {
+          "name": "microdollars_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "kilo_pass_threshold": {
+          "name": "kilo_pass_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_microdollars_acquired": {
+          "name": "total_microdollars_acquired",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "next_credit_expiration_at": {
+          "name": "next_credit_expiration_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_validation_stytch": {
+          "name": "has_validation_stytch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_validation_novel_card_with_hold": {
+          "name": "has_validation_novel_card_with_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_token_pepper": {
+          "name": "api_token_pepper",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cohorts": {
+          "name": "cohorts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "completed_welcome_form": {
+          "name": "completed_welcome_form",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "linkedin_url": {
+          "name": "linkedin_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_server_membership_verified_at": {
+          "name": "discord_server_membership_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openrouter_upstream_safety_identifier": {
+          "name": "openrouter_upstream_safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_downstream_safety_identifier": {
+          "name": "vercel_downstream_safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_source": {
+          "name": "customer_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "UQ_kilocode_users_openrouter_upstream_safety_identifier": {
+          "name": "UQ_kilocode_users_openrouter_upstream_safety_identifier",
+          "columns": [
+            {
+              "expression": "openrouter_upstream_safety_identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kilocode_users\".\"openrouter_upstream_safety_identifier\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_kilocode_users_vercel_downstream_safety_identifier": {
+          "name": "UQ_kilocode_users_vercel_downstream_safety_identifier",
+          "columns": [
+            {
+              "expression": "vercel_downstream_safety_identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kilocode_users\".\"vercel_downstream_safety_identifier\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_b1afacbcf43f2c7c4cb9f7e7faa": {
+          "name": "UQ_b1afacbcf43f2c7c4cb9f7e7faa",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_user_email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "blocked_reason_not_empty": {
+          "name": "blocked_reason_not_empty",
+          "value": "length(blocked_reason) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.magic_link_tokens": {
+      "name": "magic_link_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_magic_link_tokens_email": {
+          "name": "idx_magic_link_tokens_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_magic_link_tokens_expires_at": {
+          "name": "idx_magic_link_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_expires_at_future": {
+          "name": "check_expires_at_future",
+          "value": "\"magic_link_tokens\".\"expires_at\" > \"magic_link_tokens\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.microdollar_usage": {
+      "name": "microdollar_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_hit_tokens": {
+          "name": "cache_hit_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_model": {
+          "name": "requested_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_discount": {
+          "name": "cache_discount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_error": {
+          "name": "has_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "abuse_classification": {
+          "name": "abuse_classification",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inference_provider": {
+          "name": "inference_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_created_at": {
+          "name": "idx_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_abuse_classification": {
+          "name": "idx_abuse_classification",
+          "columns": [
+            {
+              "expression": "abuse_classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kilo_user_id_created_at2": {
+          "name": "idx_kilo_user_id_created_at2",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_microdollar_usage_organization_id": {
+          "name": "idx_microdollar_usage_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"microdollar_usage\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.microdollar_usage_metadata": {
+      "name": "microdollar_usage_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_user_agent_id": {
+          "name": "http_user_agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_ip_id": {
+          "name": "http_ip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_ip_city_id": {
+          "name": "vercel_ip_city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_ip_country_id": {
+          "name": "vercel_ip_country_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_ip_latitude": {
+          "name": "vercel_ip_latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_ip_longitude": {
+          "name": "vercel_ip_longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ja4_digest_id": {
+          "name": "ja4_digest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_prompt_prefix": {
+          "name": "user_prompt_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_prefix_id": {
+          "name": "system_prompt_prefix_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_length": {
+          "name": "system_prompt_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_middle_out_transform": {
+          "name": "has_middle_out_transform",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_id": {
+          "name": "upstream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason_id": {
+          "name": "finish_reason_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency": {
+          "name": "latency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_latency": {
+          "name": "moderation_latency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_time": {
+          "name": "generation_time",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_byok": {
+          "name": "is_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_user_byok": {
+          "name": "is_user_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamed": {
+          "name": "streamed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_name_id": {
+          "name": "editor_name_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_kind_id": {
+          "name": "api_kind_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_tools": {
+          "name": "has_tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode_id": {
+          "name": "mode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_model_id": {
+          "name": "auto_model_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "market_cost": {
+          "name": "market_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_microdollar_usage_metadata_created_at": {
+          "name": "idx_microdollar_usage_metadata_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "microdollar_usage_metadata_http_user_agent_id_http_user_agent_http_user_agent_id_fk": {
+          "name": "microdollar_usage_metadata_http_user_agent_id_http_user_agent_http_user_agent_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "http_user_agent",
+          "columnsFrom": [
+            "http_user_agent_id"
+          ],
+          "columnsTo": [
+            "http_user_agent_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "microdollar_usage_metadata_http_ip_id_http_ip_http_ip_id_fk": {
+          "name": "microdollar_usage_metadata_http_ip_id_http_ip_http_ip_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "http_ip",
+          "columnsFrom": [
+            "http_ip_id"
+          ],
+          "columnsTo": [
+            "http_ip_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "microdollar_usage_metadata_vercel_ip_city_id_vercel_ip_city_vercel_ip_city_id_fk": {
+          "name": "microdollar_usage_metadata_vercel_ip_city_id_vercel_ip_city_vercel_ip_city_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "vercel_ip_city",
+          "columnsFrom": [
+            "vercel_ip_city_id"
+          ],
+          "columnsTo": [
+            "vercel_ip_city_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "microdollar_usage_metadata_vercel_ip_country_id_vercel_ip_country_vercel_ip_country_id_fk": {
+          "name": "microdollar_usage_metadata_vercel_ip_country_id_vercel_ip_country_vercel_ip_country_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "vercel_ip_country",
+          "columnsFrom": [
+            "vercel_ip_country_id"
+          ],
+          "columnsTo": [
+            "vercel_ip_country_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "microdollar_usage_metadata_ja4_digest_id_ja4_digest_ja4_digest_id_fk": {
+          "name": "microdollar_usage_metadata_ja4_digest_id_ja4_digest_ja4_digest_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "ja4_digest",
+          "columnsFrom": [
+            "ja4_digest_id"
+          ],
+          "columnsTo": [
+            "ja4_digest_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "microdollar_usage_metadata_system_prompt_prefix_id_system_prompt_prefix_system_prompt_prefix_id_fk": {
+          "name": "microdollar_usage_metadata_system_prompt_prefix_id_system_prompt_prefix_system_prompt_prefix_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "system_prompt_prefix",
+          "columnsFrom": [
+            "system_prompt_prefix_id"
+          ],
+          "columnsTo": [
+            "system_prompt_prefix_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mode": {
+      "name": "mode",
+      "schema": "",
+      "columns": {
+        "mode_id": {
+          "name": "mode_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_mode": {
+          "name": "UQ_mode",
+          "columns": [
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_stats": {
+      "name": "model_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_stealth": {
+          "name": "is_stealth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_recommended": {
+          "name": "is_recommended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "openrouter_id": {
+          "name": "openrouter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aa_slug": {
+          "name": "aa_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_creator": {
+          "name": "model_creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_slug": {
+          "name": "creator_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_input": {
+          "name": "price_input",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_output": {
+          "name": "price_output",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coding_index": {
+          "name": "coding_index",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_tokens_per_sec": {
+          "name": "speed_tokens_per_sec",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openrouter_data": {
+          "name": "openrouter_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmarks": {
+          "name": "benchmarks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chart_data": {
+          "name": "chart_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_model_stats_openrouter_id": {
+          "name": "IDX_model_stats_openrouter_id",
+          "columns": [
+            {
+              "expression": "openrouter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_slug": {
+          "name": "IDX_model_stats_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_is_active": {
+          "name": "IDX_model_stats_is_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_creator_slug": {
+          "name": "IDX_model_stats_creator_slug",
+          "columns": [
+            {
+              "expression": "creator_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_price_input": {
+          "name": "IDX_model_stats_price_input",
+          "columns": [
+            {
+              "expression": "price_input",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_coding_index": {
+          "name": "IDX_model_stats_coding_index",
+          "columns": [
+            {
+              "expression": "coding_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_context_length": {
+          "name": "IDX_model_stats_context_length",
+          "columns": [
+            {
+              "expression": "context_length",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_stats_openrouter_id_unique": {
+          "name": "model_stats_openrouter_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "openrouter_id"
+          ]
+        },
+        "model_stats_slug_unique": {
+          "name": "model_stats_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.models_by_provider": {
+      "name": "models_by_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openrouter": {
+          "name": "openrouter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel": {
+          "name": "vercel",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_audit_logs": {
+      "name": "organization_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_organization_audit_logs_organization_id": {
+          "name": "IDX_organization_audit_logs_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_audit_logs_action": {
+          "name": "IDX_organization_audit_logs_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_audit_logs_actor_id": {
+          "name": "IDX_organization_audit_logs_actor_id",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_audit_logs_created_at": {
+          "name": "IDX_organization_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_invitations": {
+      "name": "organization_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_organization_invitations_token": {
+          "name": "UQ_organization_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_invitations_org_id": {
+          "name": "IDX_organization_invitations_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_invitations_email": {
+          "name": "IDX_organization_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_invitations_expires_at": {
+          "name": "IDX_organization_invitations_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_membership_removals": {
+      "name": "organization_membership_removals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_role": {
+          "name": "previous_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_org_membership_removals_org_id": {
+          "name": "IDX_org_membership_removals_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_org_membership_removals_user_id": {
+          "name": "IDX_org_membership_removals_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_org_membership_removals_org_user": {
+          "name": "UQ_org_membership_removals_org_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "kilo_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_organization_memberships_org_id": {
+          "name": "IDX_organization_memberships_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_memberships_user_id": {
+          "name": "IDX_organization_memberships_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_organization_memberships_org_user": {
+          "name": "UQ_organization_memberships_org_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "kilo_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_seats_purchases": {
+      "name": "organization_seats_purchases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_stripe_id": {
+          "name": "subscription_stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_count": {
+          "name": "seat_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        }
+      },
+      "indexes": {
+        "IDX_organization_seats_org_id": {
+          "name": "IDX_organization_seats_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_seats_expires_at": {
+          "name": "IDX_organization_seats_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_seats_created_at": {
+          "name": "IDX_organization_seats_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_seats_updated_at": {
+          "name": "IDX_organization_seats_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_seats_starts_at": {
+          "name": "IDX_organization_seats_starts_at",
+          "columns": [
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_organization_seats_idempotency_key": {
+          "name": "UQ_organization_seats_idempotency_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_user_limits": {
+      "name": "organization_user_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microdollar_limit": {
+          "name": "microdollar_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_organization_user_limits_org_id": {
+          "name": "IDX_organization_user_limits_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_user_limits_user_id": {
+          "name": "IDX_organization_user_limits_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_organization_user_limits_org_user": {
+          "name": "UQ_organization_user_limits_org_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "kilo_user_id",
+            "limit_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_user_usage": {
+      "name": "organization_user_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_date": {
+          "name": "usage_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microdollar_usage": {
+          "name": "microdollar_usage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_organization_user_daily_usage_org_id": {
+          "name": "IDX_organization_user_daily_usage_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_user_daily_usage_user_id": {
+          "name": "IDX_organization_user_daily_usage_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_organization_user_daily_usage_org_user_date": {
+          "name": "UQ_organization_user_daily_usage_org_user_date",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "kilo_user_id",
+            "limit_type",
+            "usage_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "microdollars_used": {
+          "name": "microdollars_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "microdollars_balance": {
+          "name": "microdollars_balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_microdollars_acquired": {
+          "name": "total_microdollars_acquired",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "next_credit_expiration_at": {
+          "name": "next_credit_expiration_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "seat_count": {
+          "name": "seat_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "require_seats": {
+          "name": "require_seats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_kilo_user_id": {
+          "name": "created_by_kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_domain": {
+          "name": "sso_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'teams'"
+        },
+        "free_trial_end_at": {
+          "name": "free_trial_end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_domain": {
+          "name": "company_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_organizations_sso_domain": {
+          "name": "IDX_organizations_sso_domain",
+          "columns": [
+            {
+              "expression": "sso_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organizations_name_not_empty_check": {
+          "name": "organizations_name_not_empty_check",
+          "value": "length(trim(\"organizations\".\"name\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_modes": {
+      "name": "organization_modes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "IDX_organization_modes_organization_id": {
+          "name": "IDX_organization_modes_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_organization_modes_org_id_slug": {
+          "name": "UQ_organization_modes_org_id_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "stripe_fingerprint": {
+          "name": "stripe_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last4": {
+          "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line2": {
+          "name": "address_line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_zip": {
+          "name": "address_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_country": {
+          "name": "address_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "three_d_secure_supported": {
+          "name": "three_d_secure_supported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "funding": {
+          "name": "funding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regulated_status": {
+          "name": "regulated_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line1_check_status": {
+          "name": "address_line1_check_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code_check_status": {
+          "name": "postal_code_check_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_forwarded_for": {
+          "name": "http_x_forwarded_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_city": {
+          "name": "http_x_vercel_ip_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_country": {
+          "name": "http_x_vercel_ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_latitude": {
+          "name": "http_x_vercel_ip_latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_longitude": {
+          "name": "http_x_vercel_ip_longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ja4_digest": {
+          "name": "http_x_vercel_ja4_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligible_for_free_credits": {
+          "name": "eligible_for_free_credits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_data": {
+          "name": "stripe_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_d7d7fb15569674aaadcfbc0428": {
+          "name": "IDX_d7d7fb15569674aaadcfbc0428",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_e1feb919d0ab8a36381d5d5138": {
+          "name": "IDX_e1feb919d0ab8a36381d5d5138",
+          "columns": [
+            {
+              "expression": "stripe_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_payment_methods_organization_id": {
+          "name": "IDX_payment_methods_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_29df1b0403df5792c96bbbfdbe6": {
+          "name": "UQ_29df1b0403df5792c96bbbfdbe6",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_integrations": {
+      "name": "platform_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_type": {
+          "name": "integration_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_installation_id": {
+          "name": "platform_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_account_id": {
+          "name": "platform_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_account_login": {
+          "name": "platform_account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_access": {
+          "name": "repository_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repositories": {
+          "name": "repositories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repositories_synced_at": {
+          "name": "repositories_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilo_requester_user_id": {
+          "name": "kilo_requester_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_requester_account_id": {
+          "name": "platform_requester_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integration_status": {
+          "name": "integration_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_by": {
+          "name": "suspended_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_app_type": {
+          "name": "github_app_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'standard'"
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_platform_integrations_owned_by_org_platform_inst": {
+          "name": "UQ_platform_integrations_owned_by_org_platform_inst",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"platform_integrations\".\"owned_by_organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_platform_integrations_owned_by_user_platform_inst": {
+          "name": "UQ_platform_integrations_owned_by_user_platform_inst",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"platform_integrations\".\"owned_by_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_owned_by_org_id": {
+          "name": "IDX_platform_integrations_owned_by_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_owned_by_user_id": {
+          "name": "IDX_platform_integrations_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_platform_inst_id": {
+          "name": "IDX_platform_integrations_platform_inst_id",
+          "columns": [
+            {
+              "expression": "platform_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_platform": {
+          "name": "IDX_platform_integrations_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_owned_by_org_platform": {
+          "name": "IDX_platform_integrations_owned_by_org_platform",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_owned_by_user_platform": {
+          "name": "IDX_platform_integrations_owned_by_user_platform",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_integration_status": {
+          "name": "IDX_platform_integrations_integration_status",
+          "columns": [
+            {
+              "expression": "integration_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_kilo_requester": {
+          "name": "IDX_platform_integrations_kilo_requester",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kilo_requester_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_platform_requester": {
+          "name": "IDX_platform_integrations_platform_requester",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_requester_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "platform_integrations_owned_by_organization_id_organizations_id_fk": {
+          "name": "platform_integrations_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "platform_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "platform_integrations_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "platform_integrations_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "platform_integrations",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_integrations_owner_check": {
+          "name": "platform_integrations_owner_check",
+          "value": "(\n        (\"platform_integrations\".\"owned_by_user_id\" IS NOT NULL AND \"platform_integrations\".\"owned_by_organization_id\" IS NULL) OR\n        (\"platform_integrations\".\"owned_by_user_id\" IS NULL AND \"platform_integrations\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.referral_code_usages": {
+      "name": "referral_code_usages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "referring_kilo_user_id": {
+          "name": "referring_kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeeming_kilo_user_id": {
+          "name": "redeeming_kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_referral_code_usages_redeeming_kilo_user_id": {
+          "name": "IDX_referral_code_usages_redeeming_kilo_user_id",
+          "columns": [
+            {
+              "expression": "redeeming_kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_referral_code_usages_redeeming_user_id_code": {
+          "name": "UQ_referral_code_usages_redeeming_user_id_code",
+          "nullsNotDistinct": false,
+          "columns": [
+            "redeeming_kilo_user_id",
+            "referring_kilo_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referral_codes": {
+      "name": "referral_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_redemptions": {
+          "name": "max_redemptions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_referral_codes_kilo_user_id": {
+          "name": "UQ_referral_codes_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_referral_codes_code": {
+          "name": "IDX_referral_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.security_analysis_owner_state": {
+      "name": "security_analysis_owner_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_analysis_enabled_at": {
+          "name": "auto_analysis_enabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_until": {
+          "name": "blocked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_reason": {
+          "name": "block_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_actor_resolution_failures": {
+          "name": "consecutive_actor_resolution_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_actor_resolution_failure_at": {
+          "name": "last_actor_resolution_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_security_analysis_owner_state_org_owner": {
+          "name": "UQ_security_analysis_owner_state_org_owner",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"security_analysis_owner_state\".\"owned_by_organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_security_analysis_owner_state_user_owner": {
+          "name": "UQ_security_analysis_owner_state_user_owner",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"security_analysis_owner_state\".\"owned_by_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_analysis_owner_state_owned_by_organization_id_organizations_id_fk": {
+          "name": "security_analysis_owner_state_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "security_analysis_owner_state",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_analysis_owner_state_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "security_analysis_owner_state_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "security_analysis_owner_state",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "security_analysis_owner_state_owner_check": {
+          "name": "security_analysis_owner_state_owner_check",
+          "value": "(\n        (\"security_analysis_owner_state\".\"owned_by_user_id\" IS NOT NULL AND \"security_analysis_owner_state\".\"owned_by_organization_id\" IS NULL) OR\n        (\"security_analysis_owner_state\".\"owned_by_user_id\" IS NULL AND \"security_analysis_owner_state\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "security_analysis_owner_state_block_reason_check": {
+          "name": "security_analysis_owner_state_block_reason_check",
+          "value": "\"security_analysis_owner_state\".\"block_reason\" IS NULL OR \"security_analysis_owner_state\".\"block_reason\" IN ('INSUFFICIENT_CREDITS', 'ACTOR_RESOLUTION_FAILED', 'OPERATOR_PAUSE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.security_analysis_queue": {
+      "name": "security_analysis_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "finding_id": {
+          "name": "finding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queue_status": {
+          "name": "queue_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity_rank": {
+          "name": "severity_rank",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_job_id": {
+          "name": "claimed_by_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reopen_requeue_count": {
+          "name": "reopen_requeue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_redacted": {
+          "name": "last_error_redacted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_security_analysis_queue_finding_id": {
+          "name": "UQ_security_analysis_queue_finding_id",
+          "columns": [
+            {
+              "expression": "finding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_claim_path_org": {
+          "name": "idx_security_analysis_queue_claim_path_org",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"next_retry_at\", '-infinity'::timestamptz)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "severity_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_claim_path_user": {
+          "name": "idx_security_analysis_queue_claim_path_user",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"next_retry_at\", '-infinity'::timestamptz)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "severity_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_in_flight_org": {
+          "name": "idx_security_analysis_queue_in_flight_org",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queue_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_in_flight_user": {
+          "name": "idx_security_analysis_queue_in_flight_user",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queue_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_lag_dashboards": {
+          "name": "idx_security_analysis_queue_lag_dashboards",
+          "columns": [
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_pending_reconciliation": {
+          "name": "idx_security_analysis_queue_pending_reconciliation",
+          "columns": [
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_running_reconciliation": {
+          "name": "idx_security_analysis_queue_running_reconciliation",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_failure_trend": {
+          "name": "idx_security_analysis_queue_failure_trend",
+          "columns": [
+            {
+              "expression": "failure_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"failure_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_analysis_queue_finding_id_security_findings_id_fk": {
+          "name": "security_analysis_queue_finding_id_security_findings_id_fk",
+          "tableFrom": "security_analysis_queue",
+          "tableTo": "security_findings",
+          "columnsFrom": [
+            "finding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_analysis_queue_owned_by_organization_id_organizations_id_fk": {
+          "name": "security_analysis_queue_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "security_analysis_queue",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_analysis_queue_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "security_analysis_queue_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "security_analysis_queue",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "security_analysis_queue_owner_check": {
+          "name": "security_analysis_queue_owner_check",
+          "value": "(\n        (\"security_analysis_queue\".\"owned_by_user_id\" IS NOT NULL AND \"security_analysis_queue\".\"owned_by_organization_id\" IS NULL) OR\n        (\"security_analysis_queue\".\"owned_by_user_id\" IS NULL AND \"security_analysis_queue\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "security_analysis_queue_status_check": {
+          "name": "security_analysis_queue_status_check",
+          "value": "\"security_analysis_queue\".\"queue_status\" IN ('queued', 'pending', 'running', 'failed', 'completed')"
+        },
+        "security_analysis_queue_claim_token_required_check": {
+          "name": "security_analysis_queue_claim_token_required_check",
+          "value": "\"security_analysis_queue\".\"queue_status\" NOT IN ('pending', 'running') OR \"security_analysis_queue\".\"claim_token\" IS NOT NULL"
+        },
+        "security_analysis_queue_attempt_count_non_negative_check": {
+          "name": "security_analysis_queue_attempt_count_non_negative_check",
+          "value": "\"security_analysis_queue\".\"attempt_count\" >= 0"
+        },
+        "security_analysis_queue_reopen_requeue_count_non_negative_check": {
+          "name": "security_analysis_queue_reopen_requeue_count_non_negative_check",
+          "value": "\"security_analysis_queue\".\"reopen_requeue_count\" >= 0"
+        },
+        "security_analysis_queue_severity_rank_check": {
+          "name": "security_analysis_queue_severity_rank_check",
+          "value": "\"security_analysis_queue\".\"severity_rank\" IN (0, 1, 2, 3)"
+        },
+        "security_analysis_queue_failure_code_check": {
+          "name": "security_analysis_queue_failure_code_check",
+          "value": "\"security_analysis_queue\".\"failure_code\" IS NULL OR \"security_analysis_queue\".\"failure_code\" IN (\n        'NETWORK_TIMEOUT',\n        'UPSTREAM_5XX',\n        'TEMP_TOKEN_FAILURE',\n        'START_CALL_AMBIGUOUS',\n        'REQUEUE_TEMPORARY_PRECONDITION',\n        'ACTOR_RESOLUTION_FAILED',\n        'GITHUB_TOKEN_UNAVAILABLE',\n        'INVALID_CONFIG',\n        'MISSING_OWNERSHIP',\n        'PERMISSION_DENIED_PERMANENT',\n        'UNSUPPORTED_SEVERITY',\n        'INSUFFICIENT_CREDITS',\n        'STATE_GUARD_REJECTED',\n        'SKIPPED_ALREADY_IN_PROGRESS',\n        'SKIPPED_NO_LONGER_ELIGIBLE',\n        'REOPEN_LOOP_GUARD',\n        'RUN_LOST'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_state": {
+          "name": "before_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_state": {
+          "name": "after_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_security_audit_log_org_created": {
+          "name": "IDX_security_audit_log_org_created",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_security_audit_log_user_created": {
+          "name": "IDX_security_audit_log_user_created",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_security_audit_log_resource": {
+          "name": "IDX_security_audit_log_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_security_audit_log_actor": {
+          "name": "IDX_security_audit_log_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_security_audit_log_action": {
+          "name": "IDX_security_audit_log_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_audit_log_owned_by_organization_id_organizations_id_fk": {
+          "name": "security_audit_log_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_audit_log_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "security_audit_log_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "security_audit_log_owner_check": {
+          "name": "security_audit_log_owner_check",
+          "value": "(\"security_audit_log\".\"owned_by_user_id\" IS NOT NULL AND \"security_audit_log\".\"owned_by_organization_id\" IS NULL) OR (\"security_audit_log\".\"owned_by_user_id\" IS NULL AND \"security_audit_log\".\"owned_by_organization_id\" IS NOT NULL)"
+        },
+        "security_audit_log_action_check": {
+          "name": "security_audit_log_action_check",
+          "value": "\"security_audit_log\".\"action\" IN ('security.finding.created', 'security.finding.status_change', 'security.finding.dismissed', 'security.finding.auto_dismissed', 'security.finding.analysis_started', 'security.finding.analysis_completed', 'security.finding.deleted', 'security.config.enabled', 'security.config.disabled', 'security.config.updated', 'security.sync.triggered', 'security.sync.completed', 'security.audit_log.exported')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.security_findings": {
+      "name": "security_findings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ghsa_id": {
+          "name": "ghsa_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cve_id": {
+          "name": "cve_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_ecosystem": {
+          "name": "package_ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vulnerable_version_range": {
+          "name": "vulnerable_version_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patched_version": {
+          "name": "patched_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_path": {
+          "name": "manifest_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "ignored_reason": {
+          "name": "ignored_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ignored_by": {
+          "name": "ignored_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fixed_at": {
+          "name": "fixed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sla_due_at": {
+          "name": "sla_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependabot_html_url": {
+          "name": "dependabot_html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cwe_ids": {
+          "name": "cwe_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cvss_score": {
+          "name": "cvss_score",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependency_scope": {
+          "name": "dependency_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_session_id": {
+          "name": "cli_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_status": {
+          "name": "analysis_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_started_at": {
+          "name": "analysis_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_completed_at": {
+          "name": "analysis_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_error": {
+          "name": "analysis_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_detected_at": {
+          "name": "first_detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_security_findings_org_id": {
+          "name": "idx_security_findings_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_user_id": {
+          "name": "idx_security_findings_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_repo": {
+          "name": "idx_security_findings_repo",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_severity": {
+          "name": "idx_security_findings_severity",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_status": {
+          "name": "idx_security_findings_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_package": {
+          "name": "idx_security_findings_package",
+          "columns": [
+            {
+              "expression": "package_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_sla_due_at": {
+          "name": "idx_security_findings_sla_due_at",
+          "columns": [
+            {
+              "expression": "sla_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_session_id": {
+          "name": "idx_security_findings_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_cli_session_id": {
+          "name": "idx_security_findings_cli_session_id",
+          "columns": [
+            {
+              "expression": "cli_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_analysis_status": {
+          "name": "idx_security_findings_analysis_status",
+          "columns": [
+            {
+              "expression": "analysis_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_org_analysis_in_flight": {
+          "name": "idx_security_findings_org_analysis_in_flight",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "analysis_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_findings\".\"analysis_status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_user_analysis_in_flight": {
+          "name": "idx_security_findings_user_analysis_in_flight",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "analysis_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_findings\".\"analysis_status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_findings_owned_by_organization_id_organizations_id_fk": {
+          "name": "security_findings_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "security_findings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_findings_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "security_findings_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "security_findings",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_findings_platform_integration_id_platform_integrations_id_fk": {
+          "name": "security_findings_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "security_findings",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_security_findings_source": {
+          "name": "uq_security_findings_source",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repo_full_name",
+            "source",
+            "source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "security_findings_owner_check": {
+          "name": "security_findings_owner_check",
+          "value": "(\n        (\"security_findings\".\"owned_by_user_id\" IS NOT NULL AND \"security_findings\".\"owned_by_organization_id\" IS NULL) OR\n        (\"security_findings\".\"owned_by_user_id\" IS NULL AND \"security_findings\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shared_cli_sessions": {
+      "name": "shared_cli_sessions",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_state": {
+          "name": "shared_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "api_conversation_history_blob_url": {
+          "name": "api_conversation_history_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_metadata_blob_url": {
+          "name": "task_metadata_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ui_messages_blob_url": {
+          "name": "ui_messages_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_state_blob_url": {
+          "name": "git_state_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_shared_cli_sessions_session_id": {
+          "name": "IDX_shared_cli_sessions_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_shared_cli_sessions_created_at": {
+          "name": "IDX_shared_cli_sessions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shared_cli_sessions_session_id_cli_sessions_session_id_fk": {
+          "name": "shared_cli_sessions_session_id_cli_sessions_session_id_fk",
+          "tableFrom": "shared_cli_sessions",
+          "tableTo": "cli_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "shared_cli_sessions_kilo_user_id_kilocode_users_id_fk": {
+          "name": "shared_cli_sessions_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "shared_cli_sessions",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shared_cli_sessions_shared_state_check": {
+          "name": "shared_cli_sessions_shared_state_check",
+          "value": "\"shared_cli_sessions\".\"shared_state\" IN ('public', 'organization')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_bot_requests": {
+      "name": "slack_bot_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_name": {
+          "name": "slack_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_message": {
+          "name": "user_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_message_truncated": {
+          "name": "user_message_truncated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_used": {
+          "name": "model_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls_made": {
+          "name": "tool_calls_made",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_bot_requests_created_at": {
+          "name": "idx_slack_bot_requests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_slack_team_id": {
+          "name": "idx_slack_bot_requests_slack_team_id",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_owned_by_org_id": {
+          "name": "idx_slack_bot_requests_owned_by_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_owned_by_user_id": {
+          "name": "idx_slack_bot_requests_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_status": {
+          "name": "idx_slack_bot_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_event_type": {
+          "name": "idx_slack_bot_requests_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_team_created": {
+          "name": "idx_slack_bot_requests_team_created",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_bot_requests_owned_by_organization_id_organizations_id_fk": {
+          "name": "slack_bot_requests_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "slack_bot_requests",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_bot_requests_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "slack_bot_requests_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "slack_bot_requests",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_bot_requests_platform_integration_id_platform_integrations_id_fk": {
+          "name": "slack_bot_requests_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "slack_bot_requests",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "slack_bot_requests_owner_check": {
+          "name": "slack_bot_requests_owner_check",
+          "value": "(\n        (\"slack_bot_requests\".\"owned_by_user_id\" IS NOT NULL AND \"slack_bot_requests\".\"owned_by_organization_id\" IS NULL) OR\n        (\"slack_bot_requests\".\"owned_by_user_id\" IS NULL AND \"slack_bot_requests\".\"owned_by_organization_id\" IS NOT NULL) OR\n        (\"slack_bot_requests\".\"owned_by_user_id\" IS NULL AND \"slack_bot_requests\".\"owned_by_organization_id\" IS NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.source_embeddings": {
+      "name": "source_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_line": {
+          "name": "start_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_line": {
+          "name": "end_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "is_base_branch": {
+          "name": "is_base_branch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_source_embeddings_organization_id": {
+          "name": "IDX_source_embeddings_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_kilo_user_id": {
+          "name": "IDX_source_embeddings_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_project_id": {
+          "name": "IDX_source_embeddings_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_created_at": {
+          "name": "IDX_source_embeddings_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_updated_at": {
+          "name": "IDX_source_embeddings_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_file_path_lower": {
+          "name": "IDX_source_embeddings_file_path_lower",
+          "columns": [
+            {
+              "expression": "LOWER(\"file_path\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_git_branch": {
+          "name": "IDX_source_embeddings_git_branch",
+          "columns": [
+            {
+              "expression": "git_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_org_project_branch": {
+          "name": "IDX_source_embeddings_org_project_branch",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "git_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_embeddings_organization_id_organizations_id_fk": {
+          "name": "source_embeddings_organization_id_organizations_id_fk",
+          "tableFrom": "source_embeddings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_embeddings_kilo_user_id_kilocode_users_id_fk": {
+          "name": "source_embeddings_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "source_embeddings",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_source_embeddings_org_project_branch_file_lines": {
+          "name": "UQ_source_embeddings_org_project_branch_file_lines",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "project_id",
+            "git_branch",
+            "file_path",
+            "start_line",
+            "end_line"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stytch_fingerprints": {
+      "name": "stytch_fingerprints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_fingerprint": {
+          "name": "visitor_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_fingerprint": {
+          "name": "browser_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_id": {
+          "name": "browser_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardware_fingerprint": {
+          "name": "hardware_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_fingerprint": {
+          "name": "network_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_action": {
+          "name": "verdict_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_device_type": {
+          "name": "detected_device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_authentic_device": {
+          "name": "is_authentic_device",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"\"}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint_data": {
+          "name": "fingerprint_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_free_tier_allowed": {
+          "name": "kilo_free_tier_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "http_x_forwarded_for": {
+          "name": "http_x_forwarded_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_city": {
+          "name": "http_x_vercel_ip_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_country": {
+          "name": "http_x_vercel_ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_latitude": {
+          "name": "http_x_vercel_ip_latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_longitude": {
+          "name": "http_x_vercel_ip_longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ja4_digest": {
+          "name": "http_x_vercel_ja4_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_user_agent": {
+          "name": "http_user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_fingerprint_data": {
+          "name": "idx_fingerprint_data",
+          "columns": [
+            {
+              "expression": "fingerprint_data",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hardware_fingerprint": {
+          "name": "idx_hardware_fingerprint",
+          "columns": [
+            {
+              "expression": "hardware_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kilo_user_id": {
+          "name": "idx_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reasons": {
+          "name": "idx_reasons",
+          "columns": [
+            {
+              "expression": "reasons",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_verdict_action": {
+          "name": "idx_verdict_action",
+          "columns": [
+            {
+              "expression": "verdict_action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_visitor_fingerprint": {
+          "name": "idx_visitor_fingerprint",
+          "columns": [
+            {
+              "expression": "visitor_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_prompt_prefix": {
+      "name": "system_prompt_prefix",
+      "schema": "",
+      "columns": {
+        "system_prompt_prefix_id": {
+          "name": "system_prompt_prefix_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "system_prompt_prefix": {
+          "name": "system_prompt_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_system_prompt_prefix": {
+          "name": "UQ_system_prompt_prefix",
+          "columns": [
+            {
+              "expression": "system_prompt_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_admin_notes": {
+      "name": "user_admin_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_content": {
+          "name": "note_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_kilo_user_id": {
+          "name": "admin_kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_34517df0b385234babc38fe81b": {
+          "name": "IDX_34517df0b385234babc38fe81b",
+          "columns": [
+            {
+              "expression": "admin_kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_ccbde98c4c14046daa5682ec4f": {
+          "name": "IDX_ccbde98c4c14046daa5682ec4f",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_d0270eb24ef6442d65a0b7853c": {
+          "name": "IDX_d0270eb24ef6442d65a0b7853c",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_auth_provider": {
+      "name": "user_auth_provider",
+      "schema": "",
+      "columns": {
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hosted_domain": {
+          "name": "hosted_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_user_auth_provider_kilo_user_id": {
+          "name": "IDX_user_auth_provider_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_auth_provider_hosted_domain": {
+          "name": "IDX_user_auth_provider_hosted_domain",
+          "columns": [
+            {
+              "expression": "hosted_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_auth_provider_provider_provider_account_id_pk": {
+          "name": "user_auth_provider_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feedback": {
+      "name": "user_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_text": {
+          "name": "feedback_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback_for": {
+          "name": "feedback_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "feedback_batch": {
+          "name": "feedback_batch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "context_json": {
+          "name": "context_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_user_feedback_created_at": {
+          "name": "IDX_user_feedback_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_feedback_kilo_user_id": {
+          "name": "IDX_user_feedback_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_feedback_feedback_for": {
+          "name": "IDX_user_feedback_feedback_for",
+          "columns": [
+            {
+              "expression": "feedback_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_feedback_feedback_batch": {
+          "name": "IDX_user_feedback_feedback_batch",
+          "columns": [
+            {
+              "expression": "feedback_batch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_feedback_source": {
+          "name": "IDX_user_feedback_source",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_feedback_kilo_user_id_kilocode_users_id_fk": {
+          "name": "user_feedback_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "user_feedback",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_period_cache": {
+      "name": "user_period_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_type": {
+          "name": "cache_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "shared_url_token": {
+          "name": "shared_url_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_at": {
+          "name": "shared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_user_period_cache_kilo_user_id": {
+          "name": "IDX_user_period_cache_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_user_period_cache": {
+          "name": "UQ_user_period_cache",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cache_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_period_cache_lookup": {
+          "name": "IDX_user_period_cache_lookup",
+          "columns": [
+            {
+              "expression": "cache_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_user_period_cache_share_token": {
+          "name": "UQ_user_period_cache_share_token",
+          "columns": [
+            {
+              "expression": "shared_url_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_period_cache\".\"shared_url_token\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_period_cache_kilo_user_id_kilocode_users_id_fk": {
+          "name": "user_period_cache_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "user_period_cache",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_period_cache_period_type_check": {
+          "name": "user_period_cache_period_type_check",
+          "value": "\"user_period_cache\".\"period_type\" IN ('year', 'quarter', 'month', 'week', 'custom')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vercel_ip_city": {
+      "name": "vercel_ip_city",
+      "schema": "",
+      "columns": {
+        "vercel_ip_city_id": {
+          "name": "vercel_ip_city_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vercel_ip_city": {
+          "name": "vercel_ip_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_vercel_ip_city": {
+          "name": "UQ_vercel_ip_city",
+          "columns": [
+            {
+              "expression": "vercel_ip_city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_ip_country": {
+      "name": "vercel_ip_country",
+      "schema": "",
+      "columns": {
+        "vercel_ip_country_id": {
+          "name": "vercel_ip_country_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vercel_ip_country": {
+          "name": "vercel_ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_vercel_ip_country": {
+          "name": "UQ_vercel_ip_country",
+          "columns": [
+            {
+              "expression": "vercel_ip_country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed": {
+          "name": "processed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handlers_triggered": {
+          "name": "handlers_triggered",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "errors": {
+          "name": "errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_signature": {
+          "name": "event_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_webhook_events_owned_by_org_id": {
+          "name": "IDX_webhook_events_owned_by_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_webhook_events_owned_by_user_id": {
+          "name": "IDX_webhook_events_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_webhook_events_platform": {
+          "name": "IDX_webhook_events_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_webhook_events_event_type": {
+          "name": "IDX_webhook_events_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_webhook_events_created_at": {
+          "name": "IDX_webhook_events_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_events_owned_by_organization_id_organizations_id_fk": {
+          "name": "webhook_events_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "webhook_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_events_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "webhook_events_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "webhook_events",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_webhook_events_signature": {
+          "name": "UQ_webhook_events_signature",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_signature"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webhook_events_owner_check": {
+          "name": "webhook_events_owner_check",
+          "value": "(\n        (\"webhook_events\".\"owned_by_user_id\" IS NOT NULL AND \"webhook_events\".\"owned_by_organization_id\" IS NULL) OR\n        (\"webhook_events\".\"owned_by_user_id\" IS NULL AND \"webhook_events\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.microdollar_usage_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_hit_tokens": {
+          "name": "cache_hit_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_x_forwarded_for": {
+          "name": "http_x_forwarded_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_city": {
+          "name": "http_x_vercel_ip_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_country": {
+          "name": "http_x_vercel_ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_latitude": {
+          "name": "http_x_vercel_ip_latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_longitude": {
+          "name": "http_x_vercel_ip_longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ja4_digest": {
+          "name": "http_x_vercel_ja4_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_model": {
+          "name": "requested_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_prompt_prefix": {
+          "name": "user_prompt_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_prefix": {
+          "name": "system_prompt_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_length": {
+          "name": "system_prompt_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_user_agent": {
+          "name": "http_user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_discount": {
+          "name": "cache_discount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_middle_out_transform": {
+          "name": "has_middle_out_transform",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_error": {
+          "name": "has_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abuse_classification": {
+          "name": "abuse_classification",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inference_provider": {
+          "name": "inference_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_id": {
+          "name": "upstream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency": {
+          "name": "latency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_latency": {
+          "name": "moderation_latency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_time": {
+          "name": "generation_time",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_byok": {
+          "name": "is_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_user_byok": {
+          "name": "is_user_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamed": {
+          "name": "streamed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_name": {
+          "name": "editor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_kind": {
+          "name": "api_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_tools": {
+          "name": "has_tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_model": {
+          "name": "auto_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "market_cost": {
+          "name": "market_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "\n  SELECT\n    mu.id,\n    mu.kilo_user_id,\n    meta.message_id,\n    mu.cost,\n    mu.input_tokens,\n    mu.output_tokens,\n    mu.cache_write_tokens,\n    mu.cache_hit_tokens,\n    mu.created_at,\n    ip.http_ip AS http_x_forwarded_for,\n    city.vercel_ip_city AS http_x_vercel_ip_city,\n    country.vercel_ip_country AS http_x_vercel_ip_country,\n    meta.vercel_ip_latitude AS http_x_vercel_ip_latitude,\n    meta.vercel_ip_longitude AS http_x_vercel_ip_longitude,\n    ja4.ja4_digest AS http_x_vercel_ja4_digest,\n    mu.provider,\n    mu.model,\n    mu.requested_model,\n    meta.user_prompt_prefix,\n    spp.system_prompt_prefix,\n    meta.system_prompt_length,\n    ua.http_user_agent,\n    mu.cache_discount,\n    meta.max_tokens,\n    meta.has_middle_out_transform,\n    mu.has_error,\n    mu.abuse_classification,\n    mu.organization_id,\n    mu.inference_provider,\n    mu.project_id,\n    meta.status_code,\n    meta.upstream_id,\n    frfr.finish_reason,\n    meta.latency,\n    meta.moderation_latency,\n    meta.generation_time,\n    meta.is_byok,\n    meta.is_user_byok,\n    meta.streamed,\n    meta.cancelled,\n    edit.editor_name,\n    ak.api_kind,\n    meta.has_tools,\n    meta.machine_id,\n    feat.feature,\n    meta.session_id,\n    md.mode,\n    am.auto_model,\n    meta.market_cost\n  FROM \"microdollar_usage\" mu\n  LEFT JOIN \"microdollar_usage_metadata\" meta ON mu.id = meta.id\n  LEFT JOIN \"http_ip\" ip ON meta.http_ip_id = ip.http_ip_id\n  LEFT JOIN \"vercel_ip_city\" city ON meta.vercel_ip_city_id = city.vercel_ip_city_id\n  LEFT JOIN \"vercel_ip_country\" country ON meta.vercel_ip_country_id = country.vercel_ip_country_id\n  LEFT JOIN \"ja4_digest\" ja4 ON meta.ja4_digest_id = ja4.ja4_digest_id\n  LEFT JOIN \"system_prompt_prefix\" spp ON meta.system_prompt_prefix_id = spp.system_prompt_prefix_id\n  LEFT JOIN \"http_user_agent\" ua ON meta.http_user_agent_id = ua.http_user_agent_id\n  LEFT JOIN \"finish_reason\" frfr ON meta.finish_reason_id = frfr.finish_reason_id\n  LEFT JOIN \"editor_name\" edit ON meta.editor_name_id = edit.editor_name_id\n  LEFT JOIN \"api_kind\" ak ON meta.api_kind_id = ak.api_kind_id\n  LEFT JOIN \"feature\" feat ON meta.feature_id = feat.feature_id\n  LEFT JOIN \"mode\" md ON meta.mode_id = md.mode_id\n  LEFT JOIN \"auto_model\" am ON meta.auto_model_id = am.auto_model_id\n",
+      "name": "microdollar_usage_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -498,6 +498,13 @@
       "when": 1775058751690,
       "tag": "0070_powerful_whizzer",
       "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1775106451684,
+      "tag": "0071_majestic_pestilence",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -156,6 +156,16 @@ export const KiloClawPaymentSource = {
 export type KiloClawPaymentSource =
   (typeof KiloClawPaymentSource)[keyof typeof KiloClawPaymentSource];
 
+// --- Coding Plan enums ---
+
+export const CodingPlanSubscriptionStatus = {
+  Active: 'active',
+  Canceled: 'canceled',
+} as const;
+
+export type CodingPlanSubscriptionStatus =
+  (typeof CodingPlanSubscriptionStatus)[keyof typeof CodingPlanSubscriptionStatus];
+
 // NOTE: Do not change these action names. Use present tense for consistency.
 export const KiloClawAdminAuditAction = z.enum([
   'kiloclaw.volume.reassociate',

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -42,6 +42,7 @@ import {
   KiloClawScheduledBy,
   KiloClawSubscriptionStatus,
   KiloClawPaymentSource,
+  CodingPlanSubscriptionStatus,
 } from './schema-types';
 import type { CustomLlmDefinition, KiloClawAdminAuditAction } from './schema-types';
 import type {
@@ -113,6 +114,7 @@ export const SCHEMA_CHECK_ENUMS = {
   KiloClawScheduledPlan,
   KiloClawScheduledBy,
   KiloClawSubscriptionStatus,
+  CodingPlanSubscriptionStatus,
 } as const;
 
 export const credit_transactions = pgTable(
@@ -207,7 +209,10 @@ export const kilocode_users = pgTable(
     completed_welcome_form: boolean().default(false).notNull(),
     linkedin_url: text(),
     github_url: text(),
-    discord_server_membership_verified_at: timestamp({ withTimezone: true, mode: 'string' }),
+    discord_server_membership_verified_at: timestamp({
+      withTimezone: true,
+      mode: 'string',
+    }),
     openrouter_upstream_safety_identifier: text(),
     vercel_downstream_safety_identifier: text(),
     customer_source: text(),
@@ -235,7 +240,10 @@ export const kilo_pass_subscriptions = pgTable(
       .primaryKey(),
     kilo_user_id: text()
       .notNull()
-      .references(() => kilocode_users.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
+      .references(() => kilocode_users.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      }),
     stripe_subscription_id: text().notNull().unique(),
     tier: text().notNull().$type<KiloPassTier>(),
     cadence: text().notNull().$type<KiloPassCadence>(),
@@ -286,7 +294,10 @@ export const kilo_pass_issuances = pgTable(
       .notNull(),
     kilo_pass_subscription_id: uuid()
       .notNull()
-      .references(() => kilo_pass_subscriptions.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
+      .references(() => kilo_pass_subscriptions.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      }),
     issue_month: date().notNull(),
     source: text().notNull().$type<KiloPassIssuanceSource>(),
     stripe_invoice_id: text(),
@@ -326,12 +337,18 @@ export const kilo_pass_issuance_items = pgTable(
       .notNull(),
     kilo_pass_issuance_id: uuid()
       .notNull()
-      .references(() => kilo_pass_issuances.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
+      .references(() => kilo_pass_issuances.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      }),
     kind: text().notNull().$type<KiloPassIssuanceItemKind>(),
     credit_transaction_id: uuid()
       .notNull()
       .unique()
-      .references(() => credit_transactions.id, { onDelete: 'restrict', onUpdate: 'cascade' }),
+      .references(() => credit_transactions.id, {
+        onDelete: 'restrict',
+        onUpdate: 'cascade',
+      }),
     amount_usd: decimal({ precision: 12, scale: 2, mode: 'number' }).notNull(),
     bonus_percent_applied: decimal({ precision: 6, scale: 4, mode: 'number' }),
     created_at: timestamp({ withTimezone: true, mode: 'string' }).defaultNow().notNull(),
@@ -420,7 +437,10 @@ export const kilo_pass_scheduled_changes = pgTable(
       .primaryKey(),
     kilo_user_id: text()
       .notNull()
-      .references(() => kilocode_users.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
+      .references(() => kilocode_users.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      }),
     stripe_subscription_id: text()
       .notNull()
       .references(() => kilo_pass_subscriptions.stripe_subscription_id, {
@@ -1113,7 +1133,10 @@ export const organizations = pgTable(
     total_microdollars_acquired: bigint({ mode: 'number' })
       .default(sql`'0'`)
       .notNull(),
-    next_credit_expiration_at: timestamp({ withTimezone: true, mode: 'string' }),
+    next_credit_expiration_at: timestamp({
+      withTimezone: true,
+      mode: 'string',
+    }),
     stripe_customer_id: text(),
     auto_top_up_enabled: boolean().default(false).notNull(),
     settings: jsonb().default({}).$type<OrganizationSettings>().notNull(),
@@ -1442,8 +1465,12 @@ export const platform_integrations = pgTable(
   'platform_integrations',
   {
     id: idPrimaryKeyColumn,
-    owned_by_organization_id: uuid().references(() => organizations.id, { onDelete: 'cascade' }),
-    owned_by_user_id: text().references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    owned_by_organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
+    owned_by_user_id: text().references(() => kilocode_users.id, {
+      onDelete: 'cascade',
+    }),
     created_by_user_id: text(),
 
     // Platform (examples: 'github', 'gitlab', 'bitbucket', 'azure_devops')
@@ -1666,7 +1693,9 @@ export const deployment_threat_detections = pgTable(
     deployment_id: uuid()
       .notNull()
       .references(() => deployments.id, { onDelete: 'cascade' }),
-    build_id: uuid().references(() => deployment_builds.id, { onDelete: 'set null' }),
+    build_id: uuid().references(() => deployment_builds.id, {
+      onDelete: 'set null',
+    }),
     threat_type: text().notNull(), // 'MALWARE' | 'SOCIAL_ENGINEERING' | 'UNWANTED_SOFTWARE' or comma-separated
     created_at: timestamp({ withTimezone: true, mode: 'string' }).defaultNow().notNull(),
   },
@@ -1750,8 +1779,12 @@ export const agent_configs = pgTable(
   {
     id: idPrimaryKeyColumn,
     // Ownership: exactly one must be set (org OR user)
-    owned_by_organization_id: uuid().references(() => organizations.id, { onDelete: 'cascade' }),
-    owned_by_user_id: text().references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    owned_by_organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
+    owned_by_user_id: text().references(() => kilocode_users.id, {
+      onDelete: 'cascade',
+    }),
 
     // Agent type (examples: 'code_review', 'security_scan')
     agent_type: text().notNull(),
@@ -1820,8 +1853,12 @@ export const webhook_events = pgTable(
   'webhook_events',
   {
     id: idPrimaryKeyColumn,
-    owned_by_organization_id: uuid().references(() => organizations.id, { onDelete: 'cascade' }),
-    owned_by_user_id: text().references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    owned_by_organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
+    owned_by_user_id: text().references(() => kilocode_users.id, {
+      onDelete: 'cascade',
+    }),
 
     // Platform (examples: 'github', 'gitlab', 'bitbucket')
     platform: text().notNull(),
@@ -1874,7 +1911,9 @@ export const cloud_agent_webhook_triggers = pgTable(
   {
     id: uuid('id').primaryKey().defaultRandom(),
     trigger_id: text('trigger_id').notNull(),
-    user_id: text('user_id').references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    user_id: text('user_id').references(() => kilocode_users.id, {
+      onDelete: 'cascade',
+    }),
     organization_id: uuid('organization_id').references(() => organizations.id, {
       onDelete: 'cascade',
     }),
@@ -2039,7 +2078,10 @@ export const modelStats = pgTable(
 
     // Performance (from Artificial Analysis)
     codingIndex: decimal('coding_index', { precision: 5, scale: 2 }),
-    speedTokensPerSec: decimal('speed_tokens_per_sec', { precision: 8, scale: 2 }),
+    speedTokensPerSec: decimal('speed_tokens_per_sec', {
+      precision: 8,
+      scale: 2,
+    }),
 
     // Technical specs (from OpenRouter)
     contextLength: integer('context_length'),
@@ -2093,8 +2135,12 @@ export const cloud_agent_code_reviews = pgTable(
   {
     id: idPrimaryKeyColumn,
     // Ownership: exactly one must be set (org OR user)
-    owned_by_organization_id: uuid().references(() => organizations.id, { onDelete: 'cascade' }),
-    owned_by_user_id: text().references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    owned_by_organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
+    owned_by_user_id: text().references(() => kilocode_users.id, {
+      onDelete: 'cascade',
+    }),
 
     // Platform integration (optional - for linking to integration)
     platform_integration_id: uuid().references(() => platform_integrations.id, {
@@ -2207,7 +2253,9 @@ export const cliSessions = pgTable(
       onDelete: 'set null',
     }),
     cloud_agent_session_id: text().unique(),
-    organization_id: uuid().references(() => organizations.id, { onDelete: 'set null' }),
+    organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'set null',
+    }),
     last_mode: text(),
     last_model: text(),
     version: integer().notNull().default(0),
@@ -2235,7 +2283,9 @@ export const sharedCliSessions = pgTable(
       .default(sql`pg_catalog.gen_random_uuid()`)
       .primaryKey()
       .notNull(),
-    session_id: uuid().references(() => cliSessions.session_id, { onDelete: 'set null' }),
+    session_id: uuid().references(() => cliSessions.session_id, {
+      onDelete: 'set null',
+    }),
     kilo_user_id: text()
       .notNull()
       .references(() => kilocode_users.id, { onDelete: 'restrict' }),
@@ -2270,7 +2320,9 @@ export const cli_sessions_v2 = pgTable(
     title: text(),
     public_id: uuid(),
     parent_session_id: text(),
-    organization_id: uuid().references(() => organizations.id, { onDelete: 'set null' }),
+    organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'set null',
+    }),
     cloud_agent_session_id: text(),
     created_on_platform: text().notNull().default('unknown'),
     git_url: text(),
@@ -2316,7 +2368,9 @@ export const device_auth_requests = pgTable(
       .primaryKey()
       .notNull(),
     code: text().notNull(),
-    kilo_user_id: text().references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    kilo_user_id: text().references(() => kilocode_users.id, {
+      onDelete: 'cascade',
+    }),
     status: text()
       .$type<'pending' | 'approved' | 'denied' | 'expired'>()
       .notNull()
@@ -2356,7 +2410,9 @@ export const app_builder_projects = pgTable(
     title: text().notNull(),
     model_id: text().notNull(),
     template: text(), // nullable - null means default template (nextjs-starter)
-    deployment_id: uuid().references(() => deployments.id, { onDelete: 'set null' }),
+    deployment_id: uuid().references(() => deployments.id, {
+      onDelete: 'set null',
+    }),
     last_message_at: timestamp({ withTimezone: true, mode: 'string' }),
     // Git platform migration fields (GitHub, GitLab, etc.)
     git_repo_full_name: text(), // "owner/repo" after migration
@@ -2430,7 +2486,9 @@ export const app_reported_messages = pgTable('app_reported_messages', {
   signature: jsonb().$type<Record<string, unknown>>().notNull(),
   message: jsonb().$type<Record<string, unknown>>().notNull(),
   created_at: timestamp({ withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-  cli_session_id: uuid().references(() => cliSessions.session_id, { onDelete: 'set null' }),
+  cli_session_id: uuid().references(() => cliSessions.session_id, {
+    onDelete: 'set null',
+  }),
   mode: text(),
   model: text(),
 });
@@ -2441,8 +2499,12 @@ export const byok_api_keys = pgTable(
   'byok_api_keys',
   {
     id: idPrimaryKeyColumn,
-    organization_id: uuid().references(() => organizations.id, { onDelete: 'cascade' }),
-    kilo_user_id: text().references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
+    kilo_user_id: text().references(() => kilocode_users.id, {
+      onDelete: 'cascade',
+    }),
     provider_id: text().notNull(),
     encrypted_api_key: jsonb().$type<EncryptedData>().notNull(),
     is_enabled: boolean().default(true).notNull(),
@@ -2481,8 +2543,12 @@ export const security_findings = pgTable(
     id: idPrimaryKeyColumn,
 
     // Ownership (same pattern as cloud_agent_code_reviews)
-    owned_by_organization_id: uuid().references(() => organizations.id, { onDelete: 'cascade' }),
-    owned_by_user_id: text().references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    owned_by_organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
+    owned_by_user_id: text().references(() => kilocode_users.id, {
+      onDelete: 'cascade',
+    }),
 
     // Platform integration reference
     platform_integration_id: uuid().references(() => platform_integrations.id, {
@@ -2596,8 +2662,12 @@ export const security_analysis_queue = pgTable(
     finding_id: uuid()
       .notNull()
       .references(() => security_findings.id, { onDelete: 'cascade' }),
-    owned_by_organization_id: uuid().references(() => organizations.id, { onDelete: 'cascade' }),
-    owned_by_user_id: text().references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    owned_by_organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
+    owned_by_user_id: text().references(() => kilocode_users.id, {
+      onDelete: 'cascade',
+    }),
     queue_status: text().notNull(),
     severity_rank: smallint().notNull(),
     queued_at: timestamp({ withTimezone: true, mode: 'string' }).notNull(),
@@ -2712,13 +2782,20 @@ export const security_analysis_owner_state = pgTable(
   'security_analysis_owner_state',
   {
     id: idPrimaryKeyColumn,
-    owned_by_organization_id: uuid().references(() => organizations.id, { onDelete: 'cascade' }),
-    owned_by_user_id: text().references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    owned_by_organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
+    owned_by_user_id: text().references(() => kilocode_users.id, {
+      onDelete: 'cascade',
+    }),
     auto_analysis_enabled_at: timestamp({ withTimezone: true, mode: 'string' }),
     blocked_until: timestamp({ withTimezone: true, mode: 'string' }),
     block_reason: text(),
     consecutive_actor_resolution_failures: integer().notNull().default(0),
-    last_actor_resolution_failure_at: timestamp({ withTimezone: true, mode: 'string' }),
+    last_actor_resolution_failure_at: timestamp({
+      withTimezone: true,
+      mode: 'string',
+    }),
     created_at: timestamp({ withTimezone: true, mode: 'string' }).defaultNow().notNull(),
     updated_at: timestamp({ withTimezone: true, mode: 'string' })
       .defaultNow()
@@ -2754,8 +2831,12 @@ export const security_audit_log = pgTable(
   {
     id: idPrimaryKeyColumn,
     // XOR ownership: exactly one of owned_by_organization_id or owned_by_user_id must be set.
-    owned_by_organization_id: uuid().references(() => organizations.id, { onDelete: 'cascade' }),
-    owned_by_user_id: text().references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    owned_by_organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
+    owned_by_user_id: text().references(() => kilocode_users.id, {
+      onDelete: 'cascade',
+    }),
     // actor_id is text to match kilocode_users.id; nullable for system-initiated actions
     actor_id: text(),
     actor_email: text(),
@@ -2797,8 +2878,12 @@ export const slack_bot_requests = pgTable(
     id: idPrimaryKeyColumn,
 
     // Ownership (from the platform_integration)
-    owned_by_organization_id: uuid().references(() => organizations.id, { onDelete: 'cascade' }),
-    owned_by_user_id: text().references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    owned_by_organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
+    owned_by_user_id: text().references(() => kilocode_users.id, {
+      onDelete: 'cascade',
+    }),
 
     // Platform integration reference
     platform_integration_id: uuid().references(() => platform_integrations.id, {
@@ -2866,8 +2951,12 @@ export const auto_triage_tickets = pgTable(
     id: idPrimaryKeyColumn,
 
     // Ownership (exactly one must be set)
-    owned_by_organization_id: uuid().references(() => organizations.id, { onDelete: 'cascade' }),
-    owned_by_user_id: text().references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    owned_by_organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
+    owned_by_user_id: text().references(() => kilocode_users.id, {
+      onDelete: 'cascade',
+    }),
 
     // Platform integration
     platform_integration_id: uuid().references(() => platform_integrations.id, {
@@ -2996,8 +3085,12 @@ export const auto_fix_tickets = pgTable(
     id: idPrimaryKeyColumn,
 
     // Ownership (exactly one must be set)
-    owned_by_organization_id: uuid().references(() => organizations.id, { onDelete: 'cascade' }),
-    owned_by_user_id: text().references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    owned_by_organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
+    owned_by_user_id: text().references(() => kilocode_users.id, {
+      onDelete: 'cascade',
+    }),
 
     // Platform integration
     platform_integration_id: uuid().references(() => platform_integrations.id, {
@@ -3005,7 +3098,9 @@ export const auto_fix_tickets = pgTable(
     }),
 
     // Link to triage ticket (optional)
-    triage_ticket_id: uuid().references(() => auto_triage_tickets.id, { onDelete: 'set null' }),
+    triage_ticket_id: uuid().references(() => auto_triage_tickets.id, {
+      onDelete: 'set null',
+    }),
 
     // GitHub metadata
     platform: text().notNull().default('github'),
@@ -3038,7 +3133,9 @@ export const auto_fix_tickets = pgTable(
 
     // Cloud Agent session
     session_id: text(), // Cloud agent session ID (agent_xxx)
-    cli_session_id: uuid().references(() => cliSessions.session_id, { onDelete: 'set null' }),
+    cli_session_id: uuid().references(() => cliSessions.session_id, {
+      onDelete: 'set null',
+    }),
 
     // PR information
     pr_number: integer(),
@@ -3196,8 +3293,12 @@ export const agent_environment_profiles = pgTable(
       .primaryKey()
       .notNull(),
     // Ownership: exactly one must be set (org OR user) - matches platform_integrations pattern
-    owned_by_organization_id: uuid().references(() => organizations.id, { onDelete: 'cascade' }),
-    owned_by_user_id: text().references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    owned_by_organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
+    owned_by_user_id: text().references(() => kilocode_users.id, {
+      onDelete: 'cascade',
+    }),
 
     name: text().notNull(),
     description: text(),
@@ -3503,7 +3604,9 @@ export const kiloclaw_version_pins = pgTable('kiloclaw_version_pins', {
     .unique(),
   image_tag: text()
     .notNull()
-    .references(() => kiloclaw_image_catalog.image_tag, { onDelete: 'restrict' }),
+    .references(() => kiloclaw_image_catalog.image_tag, {
+      onDelete: 'restrict',
+    }),
   pinned_by: text()
     .notNull()
     .references(() => kilocode_users.id),
@@ -3563,7 +3666,10 @@ export const kiloclaw_subscriptions = pgTable(
     past_due_since: timestamp({ withTimezone: true, mode: 'string' }),
     suspended_at: timestamp({ withTimezone: true, mode: 'string' }),
     destruction_deadline: timestamp({ withTimezone: true, mode: 'string' }),
-    auto_top_up_triggered_for_period: timestamp({ withTimezone: true, mode: 'string' }),
+    auto_top_up_triggered_for_period: timestamp({
+      withTimezone: true,
+      mode: 'string',
+    }),
     created_at: timestamp({ withTimezone: true, mode: 'string' }).defaultNow().notNull(),
     updated_at: timestamp({ withTimezone: true, mode: 'string' })
       .defaultNow()
@@ -3633,7 +3739,9 @@ export const bot_requests = pgTable(
     created_by: text()
       .notNull()
       .references(() => kilocode_users.id, { onDelete: 'cascade' }),
-    organization_id: uuid().references(() => organizations.id, { onDelete: 'cascade' }),
+    organization_id: uuid().references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
 
     platform_integration_id: uuid().references(() => platform_integrations.id, {
       onDelete: 'set null',
@@ -3715,3 +3823,75 @@ export const kiloclaw_cli_runs = pgTable(
 
 export type KiloClawCliRun = typeof kiloclaw_cli_runs.$inferSelect;
 export type NewKiloClawCliRun = typeof kiloclaw_cli_runs.$inferInsert;
+
+// =============================================================================
+// Coding Plans
+// =============================================================================
+
+export const coding_plan_key_inventory = pgTable(
+  'coding_plan_key_inventory',
+  {
+    id: uuid()
+      .default(sql`gen_random_uuid()`)
+      .primaryKey()
+      .notNull(),
+    provider_id: text().notNull(),
+    encrypted_api_key: jsonb().$type<EncryptedData>().notNull(),
+    assigned_to_user_id: text().references(() => kilocode_users.id, {
+      onDelete: 'set null',
+    }),
+    assigned_at: timestamp({ withTimezone: true, mode: 'string' }),
+    created_at: timestamp({ withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+  },
+  table => [
+    index('IDX_coding_plan_key_inv_provider').on(table.provider_id),
+    index('IDX_coding_plan_key_inv_unassigned')
+      .on(table.provider_id)
+      .where(isNull(table.assigned_to_user_id)),
+  ]
+);
+
+export type CodingPlanKeyInventory = typeof coding_plan_key_inventory.$inferSelect;
+
+export const coding_plan_subscriptions = pgTable(
+  'coding_plan_subscriptions',
+  {
+    id: uuid()
+      .default(sql`gen_random_uuid()`)
+      .primaryKey()
+      .notNull(),
+    user_id: text()
+      .notNull()
+      .references(() => kilocode_users.id, { onDelete: 'cascade' }),
+    provider_id: text().notNull(),
+    byok_key_id: uuid().references(() => byok_api_keys.id, {
+      onDelete: 'set null',
+    }),
+    status: text().notNull().$type<CodingPlanSubscriptionStatus>(),
+    cost_microdollars: bigint({ mode: 'number' }).notNull(),
+    billing_period_days: integer().notNull(),
+    current_period_start: timestamp({ withTimezone: true, mode: 'string' }),
+    current_period_end: timestamp({ withTimezone: true, mode: 'string' }),
+    credit_renewal_at: timestamp({ withTimezone: true, mode: 'string' }),
+    cancel_at_period_end: boolean().notNull().default(false),
+    canceled_at: timestamp({ withTimezone: true, mode: 'string' }),
+    auto_top_up_triggered_for_period: timestamp({
+      withTimezone: true,
+      mode: 'string',
+    }),
+    created_at: timestamp({ withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+    updated_at: timestamp({ withTimezone: true, mode: 'string' })
+      .defaultNow()
+      .notNull()
+      .$onUpdateFn(() => sql`now()`),
+  },
+  table => [
+    uniqueIndex('UQ_coding_plan_sub_user_provider').on(table.user_id, table.provider_id),
+    index('IDX_coding_plan_sub_status').on(table.status),
+    index('IDX_coding_plan_sub_renewal').on(table.credit_renewal_at),
+    enumCheck('coding_plan_subscriptions_status_check', table.status, CodingPlanSubscriptionStatus),
+  ]
+);
+
+export type CodingPlanSubscription = typeof coding_plan_subscriptions.$inferSelect;
+export type NewCodingPlanSubscription = typeof coding_plan_subscriptions.$inferInsert;

--- a/src/app/api/cron/coding-plans-billing/route.ts
+++ b/src/app/api/cron/coding-plans-billing/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+
+import { db } from '@/lib/drizzle';
+import { CRON_SECRET } from '@/lib/config.server';
+import { sentryLogger } from '@/lib/utils.server';
+import { runCodingPlanBillingLifecycleCron } from '@/lib/coding-plans/billing-lifecycle-cron';
+
+if (!CRON_SECRET) {
+  throw new Error('CRON_SECRET is not configured in environment variables');
+}
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('authorization');
+  const expectedAuth = `Bearer ${CRON_SECRET}`;
+  if (authHeader !== expectedAuth) {
+    sentryLogger(
+      'cron',
+      'warning'
+    )(
+      'SECURITY: Invalid coding-plans-billing CRON authorization attempt: ' +
+        (authHeader ? 'Invalid authorization header' : 'Missing authorization header')
+    );
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const summary = await runCodingPlanBillingLifecycleCron(db);
+
+  return NextResponse.json(
+    {
+      success: true,
+      summary,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 }
+  );
+}

--- a/src/lib/coding-plans/billing-lifecycle-cron.ts
+++ b/src/lib/coding-plans/billing-lifecycle-cron.ts
@@ -1,0 +1,356 @@
+import 'server-only';
+
+import { and, eq, isNull, lte, sql } from 'drizzle-orm';
+import { addDays, format } from 'date-fns';
+
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type * as schema from '@kilocode/db/schema';
+import {
+  byok_api_keys,
+  coding_plan_subscriptions,
+  credit_transactions,
+  kilocode_users,
+} from '@kilocode/db/schema';
+import { maybeIssueKiloPassBonusFromUsageThreshold } from '@/lib/kilo-pass/usage-triggered-bonus';
+import { maybePerformAutoTopUp } from '@/lib/autoTopUp';
+import { sentryLogger } from '@/lib/utils.server';
+
+const logInfo = sentryLogger('coding-plans-billing-cron', 'info');
+const logError = sentryLogger('coding-plans-billing-cron', 'error');
+
+export type CodingPlanCronSummary = {
+  renewals: number;
+  renewals_skipped_duplicate: number;
+  canceled_at_period_end: number;
+  canceled_insufficient_balance: number;
+  auto_top_up_triggered: number;
+  errors: number;
+};
+
+function emptySummary(): CodingPlanCronSummary {
+  return {
+    renewals: 0,
+    renewals_skipped_duplicate: 0,
+    canceled_at_period_end: 0,
+    canceled_insufficient_balance: 0,
+    auto_top_up_triggered: 0,
+    errors: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main cron entry point
+// ---------------------------------------------------------------------------
+
+export async function runCodingPlanBillingLifecycleCron(
+  database: PostgresJsDatabase<typeof schema>
+): Promise<CodingPlanCronSummary> {
+  const summary = emptySummary();
+  const nowIso = new Date().toISOString();
+
+  // Sweep 1: Cancel-at-period-end subscriptions whose period has elapsed
+  try {
+    await sweepCancelAtPeriodEnd(database, nowIso, summary);
+  } catch (error) {
+    summary.errors++;
+    logError('Sweep 1 (cancel-at-period-end) failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  // Sweep 2: Renew active subscriptions whose credit_renewal_at has passed
+  try {
+    await sweepRenewals(database, nowIso, summary);
+  } catch (error) {
+    summary.errors++;
+    logError('Sweep 2 (renewals) failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  logInfo('Coding plan billing cron completed', summary);
+  return summary;
+}
+
+// ---------------------------------------------------------------------------
+// Sweep 1: Cancel at period end
+// ---------------------------------------------------------------------------
+
+async function sweepCancelAtPeriodEnd(
+  database: PostgresJsDatabase<typeof schema>,
+  nowIso: string,
+  summary: CodingPlanCronSummary
+): Promise<void> {
+  const rows = await database
+    .select({
+      id: coding_plan_subscriptions.id,
+      user_id: coding_plan_subscriptions.user_id,
+      provider_id: coding_plan_subscriptions.provider_id,
+      byok_key_id: coding_plan_subscriptions.byok_key_id,
+    })
+    .from(coding_plan_subscriptions)
+    .where(
+      and(
+        eq(coding_plan_subscriptions.status, 'active'),
+        eq(coding_plan_subscriptions.cancel_at_period_end, true),
+        lte(coding_plan_subscriptions.current_period_end, nowIso)
+      )
+    );
+
+  for (const row of rows) {
+    try {
+      await database.transaction(async tx => {
+        await tx
+          .update(coding_plan_subscriptions)
+          .set({
+            status: 'canceled',
+            canceled_at: sql`now()`,
+            cancel_at_period_end: false,
+            byok_key_id: null,
+          })
+          .where(eq(coding_plan_subscriptions.id, row.id));
+
+        // Spec §5.1: Remove BYOK key from Kilo, do NOT revoke with upstream
+        if (row.byok_key_id) {
+          await tx.delete(byok_api_keys).where(eq(byok_api_keys.id, row.byok_key_id));
+        }
+      });
+
+      summary.canceled_at_period_end++;
+      logInfo('Coding plan canceled at period end', {
+        user_id: row.user_id,
+        providerId: row.provider_id,
+      });
+    } catch (error) {
+      summary.errors++;
+      logError('Failed to cancel coding plan at period end', {
+        subscriptionId: row.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sweep 2: Renewals
+// ---------------------------------------------------------------------------
+
+async function sweepRenewals(
+  database: PostgresJsDatabase<typeof schema>,
+  nowIso: string,
+  summary: CodingPlanCronSummary
+): Promise<void> {
+  // Select active subscriptions due for renewal (not pending cancellation)
+  const rows = await database
+    .select({
+      id: coding_plan_subscriptions.id,
+      user_id: coding_plan_subscriptions.user_id,
+      provider_id: coding_plan_subscriptions.provider_id,
+      byok_key_id: coding_plan_subscriptions.byok_key_id,
+      cost_microdollars: coding_plan_subscriptions.cost_microdollars,
+      billing_period_days: coding_plan_subscriptions.billing_period_days,
+      credit_renewal_at: coding_plan_subscriptions.credit_renewal_at,
+      auto_top_up_triggered_for_period: coding_plan_subscriptions.auto_top_up_triggered_for_period,
+      // User balance fields
+      total_microdollars_acquired: kilocode_users.total_microdollars_acquired,
+      microdollars_used: kilocode_users.microdollars_used,
+      auto_top_up_enabled: kilocode_users.auto_top_up_enabled,
+      next_credit_expiration_at: kilocode_users.next_credit_expiration_at,
+      user_updated_at: kilocode_users.updated_at,
+    })
+    .from(coding_plan_subscriptions)
+    .innerJoin(kilocode_users, eq(coding_plan_subscriptions.user_id, kilocode_users.id))
+    .where(
+      and(
+        eq(coding_plan_subscriptions.status, 'active'),
+        eq(coding_plan_subscriptions.cancel_at_period_end, false),
+        lte(coding_plan_subscriptions.credit_renewal_at, nowIso)
+      )
+    );
+
+  for (const row of rows) {
+    try {
+      await processRenewal(database, row, summary);
+    } catch (error) {
+      summary.errors++;
+      logError('Failed to process coding plan renewal', {
+        subscriptionId: row.id,
+        user_id: row.user_id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+type RenewalRow = {
+  id: string;
+  user_id: string;
+  provider_id: string;
+  byok_key_id: string | null;
+  cost_microdollars: number;
+  billing_period_days: number;
+  credit_renewal_at: string | null;
+  auto_top_up_triggered_for_period: string | null;
+  total_microdollars_acquired: number;
+  microdollars_used: number;
+  auto_top_up_enabled: boolean;
+  next_credit_expiration_at: string | null;
+  user_updated_at: string;
+};
+
+async function processRenewal(
+  database: PostgresJsDatabase<typeof schema>,
+  row: RenewalRow,
+  summary: CodingPlanCronSummary
+): Promise<void> {
+  const {
+    user_id: userId,
+    credit_renewal_at: renewalAt,
+    cost_microdollars: costMicrodollars,
+  } = row;
+  if (!renewalAt) return;
+
+  const balance = row.total_microdollars_acquired - row.microdollars_used;
+
+  if (balance >= costMicrodollars) {
+    // Sufficient balance: deduct and advance
+    const periodKey = format(new Date(renewalAt), 'yyyy-MM');
+    const deductionCategory = `coding-plan:${row.provider_id}:${row.id}:${periodKey}`;
+    const newPeriodEnd = addDays(new Date(renewalAt), row.billing_period_days).toISOString();
+    let deductionIsNew = false;
+
+    await database.transaction(async tx => {
+      const deductionResult = await tx
+        .insert(credit_transactions)
+        .values({
+          id: crypto.randomUUID(),
+          kilo_user_id: userId,
+          amount_microdollars: -costMicrodollars,
+          is_free: false,
+          description: `Coding plan renewal: ${row.provider_id}`,
+          credit_category: deductionCategory,
+          check_category_uniqueness: true,
+          original_baseline_microdollars_used: row.microdollars_used,
+        })
+        .onConflictDoNothing();
+
+      deductionIsNew = (deductionResult.rowCount ?? 0) > 0;
+      if (!deductionIsNew) return;
+
+      await tx
+        .update(kilocode_users)
+        .set({
+          microdollars_used: sql`${kilocode_users.microdollars_used} + ${costMicrodollars}`,
+        })
+        .where(eq(kilocode_users.id, userId));
+
+      await tx
+        .update(coding_plan_subscriptions)
+        .set({
+          current_period_start: renewalAt,
+          current_period_end: newPeriodEnd,
+          credit_renewal_at: newPeriodEnd,
+          auto_top_up_triggered_for_period: null,
+        })
+        .where(eq(coding_plan_subscriptions.id, row.id));
+    });
+
+    if (!deductionIsNew) {
+      summary.renewals_skipped_duplicate++;
+      logInfo('Coding plan renewal: skipped duplicate', {
+        user_id: userId,
+        deductionCategory,
+      });
+      return;
+    }
+
+    // Post-transaction bonus evaluation
+    try {
+      await maybeIssueKiloPassBonusFromUsageThreshold({
+        kiloUserId: userId,
+        nowIso: new Date().toISOString(),
+      });
+    } catch (error) {
+      logError('Kilo Pass bonus evaluation failed after coding plan renewal', {
+        user_id: userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    summary.renewals++;
+    logInfo('Coding plan renewal succeeded', {
+      user_id: userId,
+      providerId: row.provider_id,
+      costMicrodollars,
+      newPeriodEnd,
+    });
+  } else {
+    // Insufficient balance
+
+    // Try auto-top-up if enabled and not already triggered for this period
+    if (row.auto_top_up_enabled && !row.auto_top_up_triggered_for_period) {
+      // Compare-and-set: only set marker if still NULL (prevents concurrent triggers)
+      const markerResult = await database
+        .update(coding_plan_subscriptions)
+        .set({ auto_top_up_triggered_for_period: renewalAt })
+        .where(
+          and(
+            eq(coding_plan_subscriptions.id, row.id),
+            isNull(coding_plan_subscriptions.auto_top_up_triggered_for_period)
+          )
+        );
+
+      if ((markerResult.rowCount ?? 0) === 0) {
+        // Another cron worker already set the marker — skip
+        return;
+      }
+
+      try {
+        await maybePerformAutoTopUp({
+          id: userId,
+          total_microdollars_acquired: row.total_microdollars_acquired,
+          microdollars_used: row.microdollars_used,
+          auto_top_up_enabled: row.auto_top_up_enabled,
+          next_credit_expiration_at: row.next_credit_expiration_at,
+          updated_at: row.user_updated_at,
+        });
+      } catch (error) {
+        logError('Auto top-up trigger failed during coding plan renewal', {
+          user_id: userId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      summary.auto_top_up_triggered++;
+      logInfo('Coding plan renewal: auto top-up triggered, skipping', {
+        user_id: userId,
+      });
+      return;
+    }
+
+    // No grace period: cancel immediately and remove BYOK key
+    await database.transaction(async tx => {
+      await tx
+        .update(coding_plan_subscriptions)
+        .set({
+          status: 'canceled',
+          canceled_at: sql`now()`,
+          byok_key_id: null,
+          auto_top_up_triggered_for_period: null,
+        })
+        .where(eq(coding_plan_subscriptions.id, row.id));
+
+      if (row.byok_key_id) {
+        await tx.delete(byok_api_keys).where(eq(byok_api_keys.id, row.byok_key_id));
+      }
+    });
+
+    summary.canceled_insufficient_balance++;
+    logInfo('Coding plan canceled: insufficient balance', {
+      user_id: userId,
+      providerId: row.provider_id,
+      balance,
+      costMicrodollars,
+    });
+  }
+}

--- a/src/lib/coding-plans/index.test.ts
+++ b/src/lib/coding-plans/index.test.ts
@@ -1,0 +1,337 @@
+/* eslint-disable drizzle/enforce-delete-with-where */
+import { db } from '@/lib/drizzle';
+import {
+  byok_api_keys,
+  coding_plan_key_inventory,
+  coding_plan_subscriptions,
+  credit_transactions,
+  kilocode_users,
+} from '@kilocode/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { encryptApiKey } from '@/lib/byok/encryption';
+import { BYOK_ENCRYPTION_KEY } from '@/lib/config.server';
+import {
+  subscribeToCodingPlan,
+  cancelCodingPlanSubscription,
+  cancelCodingPlanImmediately,
+  uploadKeysToInventory,
+  getKeyInventoryCounts,
+} from '@/lib/coding-plans';
+
+// Use a test provider ID that exists in the coding plan definitions
+const TEST_PROVIDER_ID = 'byteplus-coding';
+const TEST_COST_MICRODOLLARS = 4_990_000;
+const TEST_ENV_VAR = 'CODING_PLAN_PRICE_BYTEPLUS_CODING';
+
+beforeAll(() => {
+  // Set the env var so the provider appears in the catalog
+  process.env[TEST_ENV_VAR] = String(TEST_COST_MICRODOLLARS);
+});
+
+afterAll(() => {
+  delete process.env[TEST_ENV_VAR];
+});
+
+afterEach(async () => {
+  await db.delete(coding_plan_subscriptions);
+  await db.delete(byok_api_keys);
+  await db.delete(coding_plan_key_inventory);
+  await db.delete(credit_transactions);
+  await db.delete(kilocode_users);
+});
+
+async function seedInventoryKey(providerId: string, plaintext = 'test-api-key-' + Math.random()) {
+  const encrypted = encryptApiKey(plaintext, BYOK_ENCRYPTION_KEY);
+  const [row] = await db
+    .insert(coding_plan_key_inventory)
+    .values({ provider_id: providerId, encrypted_api_key: encrypted })
+    .returning();
+  return { row, plaintext };
+}
+
+async function createUserWithBalance(microdollars: number) {
+  return insertTestUser({
+    total_microdollars_acquired: microdollars,
+    microdollars_used: 0,
+  });
+}
+
+describe('coding-plans', () => {
+  describe('subscribeToCodingPlan', () => {
+    it('happy path: subscribe, deduct credits, assign key, create BYOK', async () => {
+      const user = await createUserWithBalance(TEST_COST_MICRODOLLARS);
+      await seedInventoryKey(TEST_PROVIDER_ID);
+
+      const result = await subscribeToCodingPlan(user.id, TEST_PROVIDER_ID);
+
+      // Subscription created
+      const [sub] = await db
+        .select()
+        .from(coding_plan_subscriptions)
+        .where(eq(coding_plan_subscriptions.id, result.subscriptionId));
+      expect(sub.status).toBe('active');
+      expect(sub.provider_id).toBe(TEST_PROVIDER_ID);
+      expect(sub.cost_microdollars).toBe(TEST_COST_MICRODOLLARS);
+      expect(sub.byok_key_id).not.toBeNull();
+      expect(sub.cancel_at_period_end).toBe(false);
+
+      // Credits deducted
+      const [updatedUser] = await db
+        .select()
+        .from(kilocode_users)
+        .where(eq(kilocode_users.id, user.id));
+      expect(updatedUser.microdollars_used).toBe(TEST_COST_MICRODOLLARS);
+
+      // BYOK entry created
+      const [byok] = await db
+        .select()
+        .from(byok_api_keys)
+        .where(
+          and(
+            eq(byok_api_keys.kilo_user_id, user.id),
+            eq(byok_api_keys.provider_id, TEST_PROVIDER_ID)
+          )
+        );
+      expect(byok).toBeDefined();
+      expect(byok.is_enabled).toBe(true);
+
+      // Inventory key assigned
+      const [invKey] = await db
+        .select()
+        .from(coding_plan_key_inventory)
+        .where(eq(coding_plan_key_inventory.assigned_to_user_id, user.id));
+      expect(invKey).toBeDefined();
+      expect(invKey.assigned_at).not.toBeNull();
+    });
+
+    it('rejects when balance is insufficient', async () => {
+      const user = await createUserWithBalance(100); // not enough
+      await seedInventoryKey(TEST_PROVIDER_ID);
+
+      await expect(subscribeToCodingPlan(user.id, TEST_PROVIDER_ID)).rejects.toThrow(
+        'Insufficient credit balance'
+      );
+
+      // No subscription created
+      const subs = await db
+        .select()
+        .from(coding_plan_subscriptions)
+        .where(eq(coding_plan_subscriptions.user_id, user.id));
+      expect(subs).toHaveLength(0);
+
+      // No credits deducted
+      const [updatedUser] = await db
+        .select()
+        .from(kilocode_users)
+        .where(eq(kilocode_users.id, user.id));
+      expect(updatedUser.microdollars_used).toBe(0);
+    });
+
+    it('rejects and rolls back when no inventory key is available', async () => {
+      const user = await createUserWithBalance(TEST_COST_MICRODOLLARS);
+      // No keys seeded!
+
+      await expect(subscribeToCodingPlan(user.id, TEST_PROVIDER_ID)).rejects.toThrow(
+        'No pre-purchased API key available'
+      );
+
+      // Credits NOT deducted (transaction rolled back)
+      const [updatedUser] = await db
+        .select()
+        .from(kilocode_users)
+        .where(eq(kilocode_users.id, user.id));
+      expect(updatedUser.microdollars_used).toBe(0);
+    });
+
+    it('rejects unknown provider', async () => {
+      const user = await createUserWithBalance(TEST_COST_MICRODOLLARS);
+      await expect(subscribeToCodingPlan(user.id, 'nonexistent-provider')).rejects.toThrow(
+        'not available as a coding plan'
+      );
+    });
+
+    it('extends an existing active subscription (spec §2.5)', async () => {
+      const user = await createUserWithBalance(TEST_COST_MICRODOLLARS * 2);
+      await seedInventoryKey(TEST_PROVIDER_ID);
+
+      // First subscription
+      const result1 = await subscribeToCodingPlan(user.id, TEST_PROVIDER_ID);
+
+      const [sub1] = await db
+        .select()
+        .from(coding_plan_subscriptions)
+        .where(eq(coding_plan_subscriptions.id, result1.subscriptionId));
+      const originalEnd = sub1.current_period_end;
+
+      // Second subscription = extension
+      await subscribeToCodingPlan(user.id, TEST_PROVIDER_ID);
+
+      const [sub2] = await db
+        .select()
+        .from(coding_plan_subscriptions)
+        .where(eq(coding_plan_subscriptions.id, result1.subscriptionId));
+
+      // Period end should be extended (stacked)
+      expect(new Date(sub2.current_period_end!).getTime()).toBeGreaterThan(
+        new Date(originalEnd!).getTime()
+      );
+
+      // Two credit transactions (one for initial, one for extension)
+      const txns = await db
+        .select()
+        .from(credit_transactions)
+        .where(eq(credit_transactions.kilo_user_id, user.id));
+      expect(txns).toHaveLength(2);
+
+      // Only one BYOK key (no duplicate)
+      const byokKeys = await db
+        .select()
+        .from(byok_api_keys)
+        .where(eq(byok_api_keys.kilo_user_id, user.id));
+      expect(byokKeys).toHaveLength(1);
+    });
+
+    it('re-subscribes after cancellation', async () => {
+      const user = await createUserWithBalance(TEST_COST_MICRODOLLARS * 2);
+      await seedInventoryKey(TEST_PROVIDER_ID);
+      await seedInventoryKey(TEST_PROVIDER_ID); // need a second key
+
+      // Subscribe
+      const result1 = await subscribeToCodingPlan(user.id, TEST_PROVIDER_ID);
+
+      // Immediately cancel
+      await cancelCodingPlanImmediately(user.id, TEST_PROVIDER_ID);
+
+      // Re-subscribe
+      const result2 = await subscribeToCodingPlan(user.id, TEST_PROVIDER_ID);
+
+      // Should reuse the same subscription row
+      expect(result2.subscriptionId).toBe(result1.subscriptionId);
+
+      const [sub] = await db
+        .select()
+        .from(coding_plan_subscriptions)
+        .where(eq(coding_plan_subscriptions.id, result2.subscriptionId));
+      expect(sub.status).toBe('active');
+      expect(sub.byok_key_id).not.toBeNull();
+      // canceled_at should be preserved for audit history
+      expect(sub.canceled_at).not.toBeNull();
+    });
+
+    it('works with free plan (cost = 0)', async () => {
+      const freeProvider = 'zai-coding';
+      process.env['CODING_PLAN_PRICE_ZAI_CODING'] = '0';
+
+      try {
+        const user = await createUserWithBalance(0); // zero balance is fine for free
+        await seedInventoryKey(freeProvider);
+
+        const result = await subscribeToCodingPlan(user.id, freeProvider);
+
+        const [sub] = await db
+          .select()
+          .from(coding_plan_subscriptions)
+          .where(eq(coding_plan_subscriptions.id, result.subscriptionId));
+        expect(sub.status).toBe('active');
+        expect(sub.cost_microdollars).toBe(0);
+
+        // No credit transactions for free plan
+        const txns = await db
+          .select()
+          .from(credit_transactions)
+          .where(eq(credit_transactions.kilo_user_id, user.id));
+        expect(txns).toHaveLength(0);
+      } finally {
+        delete process.env['CODING_PLAN_PRICE_ZAI_CODING'];
+      }
+    });
+  });
+
+  describe('cancelCodingPlanSubscription', () => {
+    it('sets cancel_at_period_end flag', async () => {
+      const user = await createUserWithBalance(TEST_COST_MICRODOLLARS);
+      await seedInventoryKey(TEST_PROVIDER_ID);
+
+      const result = await subscribeToCodingPlan(user.id, TEST_PROVIDER_ID);
+      await cancelCodingPlanSubscription(user.id, TEST_PROVIDER_ID);
+
+      const [sub] = await db
+        .select()
+        .from(coding_plan_subscriptions)
+        .where(eq(coding_plan_subscriptions.id, result.subscriptionId));
+      expect(sub.status).toBe('active'); // still active until period end
+      expect(sub.cancel_at_period_end).toBe(true);
+    });
+
+    it('throws when no active subscription exists', async () => {
+      const user = await createUserWithBalance(0);
+      await expect(cancelCodingPlanSubscription(user.id, TEST_PROVIDER_ID)).rejects.toThrow(
+        'No active subscription'
+      );
+    });
+  });
+
+  describe('cancelCodingPlanImmediately', () => {
+    it('cancels immediately and removes BYOK key', async () => {
+      const user = await createUserWithBalance(TEST_COST_MICRODOLLARS);
+      await seedInventoryKey(TEST_PROVIDER_ID);
+
+      const result = await subscribeToCodingPlan(user.id, TEST_PROVIDER_ID);
+      await cancelCodingPlanImmediately(user.id, TEST_PROVIDER_ID);
+
+      const [sub] = await db
+        .select()
+        .from(coding_plan_subscriptions)
+        .where(eq(coding_plan_subscriptions.id, result.subscriptionId));
+      expect(sub.status).toBe('canceled');
+      expect(sub.canceled_at).not.toBeNull();
+      expect(sub.byok_key_id).toBeNull();
+
+      // BYOK key removed
+      const byokKeys = await db
+        .select()
+        .from(byok_api_keys)
+        .where(eq(byok_api_keys.kilo_user_id, user.id));
+      expect(byokKeys).toHaveLength(0);
+    });
+  });
+
+  describe('uploadKeysToInventory', () => {
+    it('encrypts and inserts keys', async () => {
+      const result = await uploadKeysToInventory(TEST_PROVIDER_ID, ['key-1', 'key-2', 'key-3']);
+      expect(result.inserted).toBe(3);
+
+      const counts = await getKeyInventoryCounts(TEST_PROVIDER_ID);
+      expect(counts).toHaveLength(1);
+      expect(counts[0].available).toBe(3);
+      expect(counts[0].assigned).toBe(0);
+    });
+  });
+
+  describe('getKeyInventoryCounts', () => {
+    it('returns counts per provider', async () => {
+      await uploadKeysToInventory(TEST_PROVIDER_ID, ['key-1', 'key-2']);
+      await uploadKeysToInventory('zai-coding', ['key-3']);
+
+      const counts = await getKeyInventoryCounts();
+      expect(counts.length).toBeGreaterThanOrEqual(2);
+
+      const bytePlusCounts = counts.find(c => c.providerId === TEST_PROVIDER_ID);
+      expect(bytePlusCounts?.available).toBe(2);
+      expect(bytePlusCounts?.assigned).toBe(0);
+
+      const zaiCounts = counts.find(c => c.providerId === 'zai-coding');
+      expect(zaiCounts?.available).toBe(1);
+    });
+
+    it('filters by providerId when specified', async () => {
+      await uploadKeysToInventory(TEST_PROVIDER_ID, ['key-1']);
+      await uploadKeysToInventory('zai-coding', ['key-2']);
+
+      const counts = await getKeyInventoryCounts(TEST_PROVIDER_ID);
+      expect(counts).toHaveLength(1);
+      expect(counts[0].providerId).toBe(TEST_PROVIDER_ID);
+    });
+  });
+});

--- a/src/lib/coding-plans/index.ts
+++ b/src/lib/coding-plans/index.ts
@@ -246,7 +246,9 @@ export async function subscribeToCodingPlan(
       .limit(1);
 
     if (!currentSub) {
-      throw new Error('Coding plan activation was already processed, but no subscription was found.');
+      throw new Error(
+        'Coding plan activation was already processed, but no subscription was found.'
+      );
     }
 
     return { subscriptionId: currentSub.id };

--- a/src/lib/coding-plans/index.ts
+++ b/src/lib/coding-plans/index.ts
@@ -81,11 +81,13 @@ export async function subscribeToCodingPlan(
   // 4. Atomic transaction
   const now = new Date();
   const periodEnd = addDays(now, billingPeriodDays);
-  const periodKey = format(now, 'yyyy-MM');
   const subscriptionId = existingSub?.id ?? crypto.randomUUID();
-  const deductionCategory = `coding-plan:${providerId}:${subscriptionId}:${periodKey}`;
+  const activationKey =
+    existingSub?.status === 'canceled' ? (existingSub.canceled_at ?? existingSub.id) : 'initial';
+  const deductionCategory = `coding-plan-activate:${providerId}:${userId}:${activationKey}`;
 
   let assignedKeyId: string | null = null;
+  let skippedDuplicateActivation = false;
 
   await db.transaction(async tx => {
     // 4a. Deduct credits (idempotent)
@@ -106,6 +108,7 @@ export async function subscribeToCodingPlan(
 
       if ((deductionResult.rowCount ?? 0) === 0) {
         // Already processed — idempotent duplicate
+        skippedDuplicateActivation = true;
         logInfo('Duplicate subscription attempt', {
           user_id: userId,
           providerId,
@@ -229,6 +232,25 @@ export async function subscribeToCodingPlan(
       });
     }
   });
+
+  if (skippedDuplicateActivation) {
+    const [currentSub] = await db
+      .select({ id: coding_plan_subscriptions.id })
+      .from(coding_plan_subscriptions)
+      .where(
+        and(
+          eq(coding_plan_subscriptions.user_id, userId),
+          eq(coding_plan_subscriptions.provider_id, providerId)
+        )
+      )
+      .limit(1);
+
+    if (!currentSub) {
+      throw new Error('Coding plan activation was already processed, but no subscription was found.');
+    }
+
+    return { subscriptionId: currentSub.id };
+  }
 
   // 5. Post-transaction: evaluate Kilo Pass bonus (best-effort)
   if (costMicrodollars > 0) {

--- a/src/lib/coding-plans/index.ts
+++ b/src/lib/coding-plans/index.ts
@@ -1,0 +1,492 @@
+import 'server-only';
+
+import { and, eq, sql } from 'drizzle-orm';
+import { addDays, format } from 'date-fns';
+
+import { db } from '@/lib/drizzle';
+import {
+  byok_api_keys,
+  coding_plan_key_inventory,
+  coding_plan_subscriptions,
+  credit_transactions,
+  kilocode_users,
+} from '@kilocode/db/schema';
+import { BYOK_ENCRYPTION_KEY } from '@/lib/config.server';
+import { encryptApiKey, decryptApiKey } from '@/lib/byok/encryption';
+import { getCodingPlanPrice } from '@/lib/coding-plans/pricing';
+import { maybeIssueKiloPassBonusFromUsageThreshold } from '@/lib/kilo-pass/usage-triggered-bonus';
+import { sentryLogger } from '@/lib/utils.server';
+
+const logInfo = sentryLogger('coding-plans', 'info');
+const logError = sentryLogger('coding-plans', 'error');
+
+// ---------------------------------------------------------------------------
+// subscribeToCodingPlan — spec §7.1 processing order
+// ---------------------------------------------------------------------------
+
+export async function subscribeToCodingPlan(
+  userId: string,
+  providerId: string
+): Promise<{ subscriptionId: string }> {
+  // 1. Validate catalog
+  const plan = getCodingPlanPrice(providerId);
+  if (!plan) {
+    throw new Error(`Provider "${providerId}" is not available as a coding plan.`);
+  }
+
+  if (!BYOK_ENCRYPTION_KEY) {
+    throw new Error('BYOK encryption is not configured');
+  }
+
+  const { costMicrodollars, billingPeriodDays } = plan;
+
+  // 2. Check existing subscription
+  const [existingSub] = await db
+    .select()
+    .from(coding_plan_subscriptions)
+    .where(
+      and(
+        eq(coding_plan_subscriptions.user_id, userId),
+        eq(coding_plan_subscriptions.provider_id, providerId)
+      )
+    )
+    .limit(1);
+
+  // Spec §2.5: If user already has an active subscription, extend it
+  if (existingSub?.status === 'active') {
+    return extendSubscription(existingSub, userId, costMicrodollars, billingPeriodDays);
+  }
+
+  // 3. Verify credit balance (spec §2.3)
+  const [user] = await db
+    .select({
+      total_microdollars_acquired: kilocode_users.total_microdollars_acquired,
+      microdollars_used: kilocode_users.microdollars_used,
+    })
+    .from(kilocode_users)
+    .where(eq(kilocode_users.id, userId))
+    .limit(1);
+
+  if (!user) {
+    throw new Error('User not found');
+  }
+
+  const balance = user.total_microdollars_acquired - user.microdollars_used;
+  if (costMicrodollars > 0 && balance < costMicrodollars) {
+    throw new Error(
+      `Insufficient credit balance. You need ${costMicrodollars - balance} more microdollars.`
+    );
+  }
+
+  // 4. Atomic transaction
+  const now = new Date();
+  const periodEnd = addDays(now, billingPeriodDays);
+  const periodKey = format(now, 'yyyy-MM');
+  const subscriptionId = existingSub?.id ?? crypto.randomUUID();
+  const deductionCategory = `coding-plan:${providerId}:${subscriptionId}:${periodKey}`;
+
+  let assignedKeyId: string | null = null;
+
+  await db.transaction(async tx => {
+    // 4a. Deduct credits (idempotent)
+    if (costMicrodollars > 0) {
+      const deductionResult = await tx
+        .insert(credit_transactions)
+        .values({
+          id: crypto.randomUUID(),
+          kilo_user_id: userId,
+          amount_microdollars: -costMicrodollars,
+          is_free: false,
+          description: `Coding plan: ${plan.name}`,
+          credit_category: deductionCategory,
+          check_category_uniqueness: true,
+          original_baseline_microdollars_used: user.microdollars_used,
+        })
+        .onConflictDoNothing();
+
+      if ((deductionResult.rowCount ?? 0) === 0) {
+        // Already processed — idempotent duplicate
+        logInfo('Duplicate subscription attempt', {
+          user_id: userId,
+          providerId,
+        });
+        return;
+      }
+
+      // 4b. Increment microdollars_used
+      await tx
+        .update(kilocode_users)
+        .set({
+          microdollars_used: sql`${kilocode_users.microdollars_used} + ${costMicrodollars}`,
+        })
+        .where(eq(kilocode_users.id, userId));
+    }
+
+    // 4c. Assign a pre-purchased key (spec §4.3)
+    // FOR UPDATE SKIP LOCKED prevents concurrent assignment of the same key.
+    const { rows: inventoryRows } = await tx.execute<{
+      id: string;
+      encrypted_api_key: { iv: string; data: string; authTag: string };
+    }>(sql`
+      UPDATE coding_plan_key_inventory
+      SET assigned_to_user_id = ${userId},
+          assigned_at = now()
+      WHERE id = (
+        SELECT id FROM coding_plan_key_inventory
+        WHERE provider_id = ${providerId}
+          AND assigned_to_user_id IS NULL
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED
+      )
+      RETURNING id, encrypted_api_key
+    `);
+
+    const inventoryKey = inventoryRows[0];
+    if (!inventoryKey) {
+      // No key available — the whole transaction rolls back (spec §4.3)
+      throw new Error(
+        `No pre-purchased API key available for provider "${providerId}". Subscription rejected.`
+      );
+    }
+
+    // 4d. Decrypt inventory key and insert into byok_api_keys
+    const plaintext = decryptApiKey(inventoryKey.encrypted_api_key, BYOK_ENCRYPTION_KEY);
+    const reEncrypted = encryptApiKey(plaintext, BYOK_ENCRYPTION_KEY);
+
+    // Guard against overwriting a user-managed BYOK key for the same provider.
+    // Only allow upsert when re-subscribing (existing canceled subscription owns the key).
+    const [existingByok] = await tx
+      .select({ id: byok_api_keys.id })
+      .from(byok_api_keys)
+      .where(and(eq(byok_api_keys.kilo_user_id, userId), eq(byok_api_keys.provider_id, providerId)))
+      .limit(1);
+
+    if (existingByok && !existingSub) {
+      throw new Error(
+        `You already have a BYOK key configured for provider "${providerId}". Remove it before subscribing to a coding plan.`
+      );
+    }
+
+    let byokId: string;
+    if (existingByok) {
+      // Re-subscribing: update the existing BYOK row in place
+      await tx
+        .update(byok_api_keys)
+        .set({ encrypted_api_key: reEncrypted, is_enabled: true })
+        .where(eq(byok_api_keys.id, existingByok.id));
+      byokId = existingByok.id;
+    } else {
+      const [byokRow] = await tx
+        .insert(byok_api_keys)
+        .values({
+          kilo_user_id: userId,
+          organization_id: null,
+          provider_id: providerId,
+          encrypted_api_key: reEncrypted,
+          created_by: userId,
+        })
+        .returning({ id: byok_api_keys.id });
+      byokId = byokRow.id;
+    }
+
+    assignedKeyId = byokId;
+
+    // 4e. Upsert subscription row
+    const nowIso = now.toISOString();
+    const periodEndIso = periodEnd.toISOString();
+
+    if (existingSub) {
+      // Re-subscribing after cancellation — update existing row.
+      // Preserve canceled_at for audit history; the new period timestamps
+      // and status='active' indicate the subscription is reactivated.
+      await tx
+        .update(coding_plan_subscriptions)
+        .set({
+          status: 'active',
+          byok_key_id: assignedKeyId,
+          cost_microdollars: costMicrodollars,
+          billing_period_days: billingPeriodDays,
+          current_period_start: nowIso,
+          current_period_end: periodEndIso,
+          credit_renewal_at: periodEndIso,
+          cancel_at_period_end: false,
+          auto_top_up_triggered_for_period: null,
+        })
+        .where(eq(coding_plan_subscriptions.id, existingSub.id));
+    } else {
+      await tx.insert(coding_plan_subscriptions).values({
+        id: subscriptionId,
+        user_id: userId,
+        provider_id: providerId,
+        byok_key_id: assignedKeyId,
+        status: 'active',
+        cost_microdollars: costMicrodollars,
+        billing_period_days: billingPeriodDays,
+        current_period_start: nowIso,
+        current_period_end: periodEndIso,
+        credit_renewal_at: periodEndIso,
+        cancel_at_period_end: false,
+      });
+    }
+  });
+
+  // 5. Post-transaction: evaluate Kilo Pass bonus (best-effort)
+  if (costMicrodollars > 0) {
+    try {
+      await maybeIssueKiloPassBonusFromUsageThreshold({
+        kiloUserId: userId,
+        nowIso: new Date().toISOString(),
+      });
+    } catch (error) {
+      logError('Kilo Pass bonus evaluation failed after coding plan subscription', {
+        user_id: userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  logInfo('Coding plan subscription created', {
+    user_id: userId,
+    providerId,
+    subscriptionId,
+    costMicrodollars,
+  });
+
+  return { subscriptionId: existingSub?.id ?? subscriptionId };
+}
+
+// ---------------------------------------------------------------------------
+// extendSubscription — spec §2.5: stack new period onto existing end date
+// ---------------------------------------------------------------------------
+
+async function extendSubscription(
+  existingSub: typeof coding_plan_subscriptions.$inferSelect,
+  userId: string,
+  costMicrodollars: number,
+  billingPeriodDays: number
+): Promise<{ subscriptionId: string }> {
+  // Read current user balance
+  const [user] = await db
+    .select({
+      microdollars_used: kilocode_users.microdollars_used,
+      total_microdollars_acquired: kilocode_users.total_microdollars_acquired,
+    })
+    .from(kilocode_users)
+    .where(eq(kilocode_users.id, userId))
+    .limit(1);
+
+  if (!user) throw new Error('User not found');
+
+  const balance = user.total_microdollars_acquired - user.microdollars_used;
+  if (costMicrodollars > 0 && balance < costMicrodollars) {
+    throw new Error(
+      `Insufficient credit balance. You need ${costMicrodollars - balance} more microdollars.`
+    );
+  }
+
+  // Stack onto existing end date
+  const currentEnd = existingSub.current_period_end
+    ? new Date(existingSub.current_period_end)
+    : new Date();
+  const newEnd = addDays(currentEnd, billingPeriodDays);
+  // Key off the period boundary being extended, not wall clock, for stable idempotency
+  const periodKey = format(currentEnd, 'yyyy-MM-dd');
+  const deductionCategory = `coding-plan-extend:${existingSub.provider_id}:${existingSub.id}:${periodKey}`;
+
+  await db.transaction(async tx => {
+    if (costMicrodollars > 0) {
+      const deductionResult = await tx
+        .insert(credit_transactions)
+        .values({
+          id: crypto.randomUUID(),
+          kilo_user_id: userId,
+          amount_microdollars: -costMicrodollars,
+          is_free: false,
+          description: `Coding plan extension: ${existingSub.provider_id}`,
+          credit_category: deductionCategory,
+          check_category_uniqueness: true,
+          original_baseline_microdollars_used: user.microdollars_used,
+        })
+        .onConflictDoNothing();
+
+      if ((deductionResult.rowCount ?? 0) === 0) {
+        logInfo('Duplicate extension attempt', {
+          user_id: userId,
+          providerId: existingSub.provider_id,
+        });
+        return;
+      }
+
+      await tx
+        .update(kilocode_users)
+        .set({
+          microdollars_used: sql`${kilocode_users.microdollars_used} + ${costMicrodollars}`,
+        })
+        .where(eq(kilocode_users.id, userId));
+    }
+
+    await tx
+      .update(coding_plan_subscriptions)
+      .set({
+        current_period_end: newEnd.toISOString(),
+        credit_renewal_at: newEnd.toISOString(),
+        cancel_at_period_end: false,
+      })
+      .where(eq(coding_plan_subscriptions.id, existingSub.id));
+  });
+
+  // Post-transaction bonus evaluation
+  if (costMicrodollars > 0) {
+    try {
+      await maybeIssueKiloPassBonusFromUsageThreshold({
+        kiloUserId: userId,
+        nowIso: new Date().toISOString(),
+      });
+    } catch (error) {
+      logError('Kilo Pass bonus evaluation failed after coding plan extension', {
+        user_id: userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  logInfo('Coding plan subscription extended', {
+    user_id: userId,
+    providerId: existingSub.provider_id,
+    newEndDate: newEnd.toISOString(),
+  });
+
+  return { subscriptionId: existingSub.id };
+}
+
+// ---------------------------------------------------------------------------
+// cancelCodingPlanSubscription — user-facing cancel at period end
+// ---------------------------------------------------------------------------
+
+export async function cancelCodingPlanSubscription(
+  userId: string,
+  providerId: string
+): Promise<void> {
+  const result = await db
+    .update(coding_plan_subscriptions)
+    .set({ cancel_at_period_end: true })
+    .where(
+      and(
+        eq(coding_plan_subscriptions.user_id, userId),
+        eq(coding_plan_subscriptions.provider_id, providerId),
+        eq(coding_plan_subscriptions.status, 'active')
+      )
+    );
+
+  if ((result.rowCount ?? 0) === 0) {
+    throw new Error('No active subscription found for this provider.');
+  }
+
+  logInfo('Coding plan cancellation scheduled', {
+    user_id: userId,
+    providerId,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// cancelCodingPlanImmediately — admin/GDPR immediate cancellation
+// ---------------------------------------------------------------------------
+
+export async function cancelCodingPlanImmediately(
+  userId: string,
+  providerId: string
+): Promise<void> {
+  const [sub] = await db
+    .select({
+      id: coding_plan_subscriptions.id,
+      byok_key_id: coding_plan_subscriptions.byok_key_id,
+    })
+    .from(coding_plan_subscriptions)
+    .where(
+      and(
+        eq(coding_plan_subscriptions.user_id, userId),
+        eq(coding_plan_subscriptions.provider_id, providerId),
+        eq(coding_plan_subscriptions.status, 'active')
+      )
+    )
+    .limit(1);
+
+  if (!sub) {
+    throw new Error('No active subscription found for this provider.');
+  }
+
+  await db.transaction(async tx => {
+    await tx
+      .update(coding_plan_subscriptions)
+      .set({
+        status: 'canceled',
+        canceled_at: sql`now()`,
+        byok_key_id: null,
+        cancel_at_period_end: false,
+      })
+      .where(eq(coding_plan_subscriptions.id, sub.id));
+
+    // Spec §5.1: Remove from BYOK config, do NOT revoke with upstream
+    if (sub.byok_key_id) {
+      await tx.delete(byok_api_keys).where(eq(byok_api_keys.id, sub.byok_key_id));
+    }
+  });
+
+  logInfo('Coding plan immediately canceled', { user_id: userId, providerId });
+}
+
+// ---------------------------------------------------------------------------
+// Admin: upload pre-purchased keys to inventory
+// ---------------------------------------------------------------------------
+
+export async function uploadKeysToInventory(
+  providerId: string,
+  plaintextKeys: string[]
+): Promise<{ inserted: number }> {
+  if (!BYOK_ENCRYPTION_KEY) {
+    throw new Error('BYOK encryption is not configured');
+  }
+
+  const values = plaintextKeys.map(key => ({
+    provider_id: providerId,
+    encrypted_api_key: encryptApiKey(key, BYOK_ENCRYPTION_KEY),
+  }));
+
+  const result = await db.insert(coding_plan_key_inventory).values(values);
+
+  logInfo('Pre-purchased keys uploaded to inventory', {
+    providerId,
+    count: result.rowCount ?? 0,
+  });
+
+  return { inserted: result.rowCount ?? 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Admin: get key inventory counts
+// ---------------------------------------------------------------------------
+
+export async function getKeyInventoryCounts(
+  providerId?: string
+): Promise<Array<{ providerId: string; available: number; assigned: number }>> {
+  const { rows } = await db.execute<{
+    provider_id: string;
+    available: string;
+    assigned: string;
+  }>(sql`
+    SELECT
+      provider_id,
+      COUNT(*) FILTER (WHERE assigned_to_user_id IS NULL) AS available,
+      COUNT(*) FILTER (WHERE assigned_to_user_id IS NOT NULL) AS assigned
+    FROM coding_plan_key_inventory
+    ${providerId ? sql`WHERE provider_id = ${providerId}` : sql``}
+    GROUP BY provider_id
+    ORDER BY provider_id
+  `);
+
+  return rows.map(r => ({
+    providerId: r.provider_id,
+    available: parseInt(r.available, 10),
+    assigned: parseInt(r.assigned, 10),
+  }));
+}

--- a/src/lib/coding-plans/pricing.ts
+++ b/src/lib/coding-plans/pricing.ts
@@ -1,0 +1,55 @@
+import CODING_PLANS from '@/lib/providers/coding-plans/coding-plan-definitions';
+import type { DirectUserByokInferenceProviderId } from '@/lib/providers/openrouter/inference-provider-id';
+
+export type CodingPlanProviderId = (typeof CODING_PLAN_PROVIDER_IDS)[number];
+
+export type CodingPlanCatalogEntry = {
+  providerId: CodingPlanProviderId;
+  costMicrodollars: number;
+  billingPeriodDays: number;
+  name: string;
+};
+
+/** Provider IDs that are coding plans (derived from the definitions file). */
+export const CODING_PLAN_PROVIDER_IDS = CODING_PLANS.map(p => p.id);
+
+const BILLING_PERIOD_DAYS = 30;
+
+/**
+ * Env var naming convention: CODING_PLAN_PRICE_BYTEPLUS_CODING, etc.
+ * Values are in microdollars (integer). E.g., 4990000 = $4.99.
+ * Omit the var or set to empty string to disable a provider.
+ * Set to "0" for a free plan (key assignment only, no credit deduction).
+ */
+function envVarName(providerId: DirectUserByokInferenceProviderId): string {
+  return 'CODING_PLAN_PRICE_' + providerId.toUpperCase().replace(/-/g, '_');
+}
+
+const PROVIDER_NAMES: Record<string, string> = Object.fromEntries(
+  CODING_PLANS.map(p => [p.id, p.name])
+);
+
+export function getCodingPlanCatalog(): CodingPlanCatalogEntry[] {
+  const entries: CodingPlanCatalogEntry[] = [];
+  for (const provider of CODING_PLANS) {
+    const raw = process.env[envVarName(provider.id)];
+    if (!raw) continue;
+    const costMicrodollars = parseInt(raw, 10);
+    if (Number.isNaN(costMicrodollars) || costMicrodollars < 0) continue;
+    entries.push({
+      providerId: provider.id,
+      costMicrodollars,
+      billingPeriodDays: BILLING_PERIOD_DAYS,
+      name: PROVIDER_NAMES[provider.id] ?? provider.id,
+    });
+  }
+  return entries;
+}
+
+export function getCodingPlanPrice(providerId: string): CodingPlanCatalogEntry | null {
+  return getCodingPlanCatalog().find(e => e.providerId === providerId) ?? null;
+}
+
+export function isCodingPlanProvider(providerId: string): providerId is CodingPlanProviderId {
+  return CODING_PLAN_PROVIDER_IDS.some(id => id === providerId);
+}

--- a/src/lib/user.test.ts
+++ b/src/lib/user.test.ts
@@ -35,6 +35,9 @@ import {
   kiloclaw_cli_runs,
   bot_requests,
   kiloclaw_admin_audit_logs,
+  coding_plan_subscriptions,
+  coding_plan_key_inventory,
+  byok_api_keys,
 } from '@kilocode/db/schema';
 import { eq, count } from 'drizzle-orm';
 import { softDeleteUser, SoftDeletePreconditionError, findUserById, findUsersByIds } from './user';
@@ -78,6 +81,9 @@ describe('User', () => {
     await db.delete(user_admin_notes);
     await db.delete(magic_link_tokens);
     await db.delete(bot_requests);
+    await db.delete(coding_plan_subscriptions);
+    await db.delete(coding_plan_key_inventory);
+    await db.delete(byok_api_keys);
     await db.delete(stytch_fingerprints);
     await db.delete(organizations);
     await db.delete(kilocode_users);
@@ -294,7 +300,9 @@ describe('User', () => {
     });
 
     it('should delete organization invitations sent by and addressed to the user', async () => {
-      const user1 = await insertTestUser({ google_user_email: 'invitee@example.com' });
+      const user1 = await insertTestUser({
+        google_user_email: 'invitee@example.com',
+      });
       const user2 = await insertTestUser();
 
       const orgId = randomUUID();
@@ -840,7 +848,9 @@ describe('User', () => {
     });
 
     it('should delete magic_link_tokens by original email', async () => {
-      const user = await insertTestUser({ google_user_email: 'magic@example.com' });
+      const user = await insertTestUser({
+        google_user_email: 'magic@example.com',
+      });
 
       const futureDate = new Date(Date.now() + 1000 * 60 * 60).toISOString();
       await db.insert(magic_link_tokens).values({
@@ -1000,6 +1010,56 @@ describe('User', () => {
       await expect(softDeleteUser(user.id)).rejects.toThrow(SoftDeletePreconditionError);
       const userAfter = await findUserById(user.id);
       expect(userAfter!.google_user_email).toBe(user.google_user_email);
+    });
+
+    it('should cancel coding plan subscriptions and remove BYOK keys on soft delete', async () => {
+      const { encryptApiKey } = await import('@/lib/byok/encryption');
+      const { BYOK_ENCRYPTION_KEY } = await import('@/lib/config.server');
+
+      const user = await insertTestUser();
+
+      // Create a BYOK key for a coding plan provider
+      const encrypted = encryptApiKey('test-key-for-gdpr', BYOK_ENCRYPTION_KEY);
+      const [byokKey] = await db
+        .insert(byok_api_keys)
+        .values({
+          kilo_user_id: user.id,
+          provider_id: 'byteplus-coding',
+          encrypted_api_key: encrypted,
+          created_by: user.id,
+        })
+        .returning();
+
+      // Create an active coding plan subscription
+      await db.insert(coding_plan_subscriptions).values({
+        user_id: user.id,
+        provider_id: 'byteplus-coding',
+        byok_key_id: byokKey.id,
+        status: 'active',
+        cost_microdollars: 4_990_000,
+        billing_period_days: 30,
+        current_period_start: new Date().toISOString(),
+        current_period_end: new Date(Date.now() + 30 * 86_400_000).toISOString(),
+        credit_renewal_at: new Date(Date.now() + 30 * 86_400_000).toISOString(),
+      });
+
+      await softDeleteUser(user.id);
+
+      // Subscription should be canceled
+      const [sub] = await db
+        .select()
+        .from(coding_plan_subscriptions)
+        .where(eq(coding_plan_subscriptions.user_id, user.id));
+      expect(sub.status).toBe('canceled');
+      expect(sub.canceled_at).not.toBeNull();
+      expect(sub.byok_key_id).toBeNull();
+
+      // BYOK key should be deleted
+      const byokKeys = await db
+        .select()
+        .from(byok_api_keys)
+        .where(eq(byok_api_keys.kilo_user_id, user.id));
+      expect(byokKeys).toHaveLength(0);
     });
   });
 

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -55,6 +55,7 @@ import {
   kiloclaw_email_log,
   kiloclaw_admin_audit_logs,
   kiloclaw_cli_runs,
+  coding_plan_subscriptions,
 } from '@kilocode/db/schema';
 import { eq, and, inArray, isNotNull, sql } from 'drizzle-orm';
 import { allow_fake_login } from './constants';
@@ -365,7 +366,10 @@ export async function createOrUpdateUser(
   });
 
   // Set up user identification via user ID
-  posthogClient.alias({ distinctId: savedUser.google_user_email, alias: savedUser.id });
+  posthogClient.alias({
+    distinctId: savedUser.google_user_email,
+    alias: savedUser.id,
+  });
 
   await tryVerifyDiscordGuildMembership(args.provider, args.provider_account_id, savedUser.id);
 
@@ -513,7 +517,10 @@ export async function softDeleteUser(userId: string) {
     // trialing — the user may have a running Fly instance, and deleting the
     // row without destroying the instance would orphan it.
     const liveClawSubscriptions = await tx
-      .select({ id: kiloclaw_subscriptions.id, status: kiloclaw_subscriptions.status })
+      .select({
+        id: kiloclaw_subscriptions.id,
+        status: kiloclaw_subscriptions.status,
+      })
       .from(kiloclaw_subscriptions)
       .where(
         and(
@@ -601,6 +608,11 @@ export async function softDeleteUser(userId: string) {
     await tx
       .delete(platform_integrations)
       .where(eq(platform_integrations.owned_by_user_id, userId));
+    // Cancel all coding plan subscriptions before deleting BYOK keys (spec §5.2)
+    await tx
+      .update(coding_plan_subscriptions)
+      .set({ status: 'canceled', canceled_at: sql`now()`, byok_key_id: null })
+      .where(eq(coding_plan_subscriptions.user_id, userId));
     await tx.delete(byok_api_keys).where(eq(byok_api_keys.kilo_user_id, userId));
     await tx.delete(agent_configs).where(eq(agent_configs.owned_by_user_id, userId));
     await tx.delete(webhook_events).where(eq(webhook_events.owned_by_user_id, userId));
@@ -814,7 +826,9 @@ export async function getAllUserProviders(email: string): Promise<{
  * @returns The WorkOS organization, or null if not found
  */
 export async function getWorkOSOrganization(domain: string) {
-  const orgResult = await workos.organizations.listOrganizations({ domains: [domain] });
+  const orgResult = await workos.organizations.listOrganizations({
+    domains: [domain],
+  });
 
   if (orgResult.data.length === 1) {
     return orgResult.data[0];
@@ -881,7 +895,9 @@ async function tryVerifyDiscordGuildMembership(
     if (isMember) {
       await db
         .update(kilocode_users)
-        .set({ discord_server_membership_verified_at: new Date().toISOString() })
+        .set({
+          discord_server_membership_verified_at: new Date().toISOString(),
+        })
         .where(eq(kilocode_users.id, kiloUserId));
     }
   } catch (error) {

--- a/src/routers/coding-plans-router.ts
+++ b/src/routers/coding-plans-router.ts
@@ -1,0 +1,127 @@
+import { createTRPCRouter, baseProcedure, adminProcedure } from '@/lib/trpc/init';
+import { TRPCError } from '@trpc/server';
+import * as z from 'zod';
+import { eq } from 'drizzle-orm';
+
+import { db } from '@/lib/drizzle';
+import { coding_plan_subscriptions } from '@kilocode/db/schema';
+import { getCodingPlanCatalog } from '@/lib/coding-plans/pricing';
+import {
+  subscribeToCodingPlan,
+  cancelCodingPlanSubscription,
+  cancelCodingPlanImmediately,
+  uploadKeysToInventory,
+  getKeyInventoryCounts,
+} from '@/lib/coding-plans';
+
+export const codingPlansRouter = createTRPCRouter({
+  // -----------------------------------------------------------------------
+  // User endpoints
+  // -----------------------------------------------------------------------
+
+  /** Returns the plan catalog with pricing (spec §1.1, §1.2). */
+  catalog: baseProcedure.query(() => {
+    return getCodingPlanCatalog();
+  }),
+
+  /** Returns all coding plan subscriptions for the authenticated user. */
+  listSubscriptions: baseProcedure.query(async ({ ctx }) => {
+    return db
+      .select({
+        id: coding_plan_subscriptions.id,
+        provider_id: coding_plan_subscriptions.provider_id,
+        status: coding_plan_subscriptions.status,
+        cost_microdollars: coding_plan_subscriptions.cost_microdollars,
+        billing_period_days: coding_plan_subscriptions.billing_period_days,
+        current_period_start: coding_plan_subscriptions.current_period_start,
+        current_period_end: coding_plan_subscriptions.current_period_end,
+        cancel_at_period_end: coding_plan_subscriptions.cancel_at_period_end,
+        canceled_at: coding_plan_subscriptions.canceled_at,
+        created_at: coding_plan_subscriptions.created_at,
+      })
+      .from(coding_plan_subscriptions)
+      .where(eq(coding_plan_subscriptions.user_id, ctx.user.id));
+  }),
+
+  /** Subscribe to a coding plan. */
+  subscribe: baseProcedure
+    .input(z.object({ providerId: z.string() }))
+    .mutation(async ({ input, ctx }) => {
+      try {
+        return await subscribeToCodingPlan(ctx.user.id, input.providerId);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+
+        if (message.includes('Insufficient credit balance')) {
+          throw new TRPCError({ code: 'PRECONDITION_FAILED', message });
+        }
+        if (message.includes('not available as a coding plan')) {
+          throw new TRPCError({ code: 'NOT_FOUND', message });
+        }
+        if (message.includes('No pre-purchased API key available')) {
+          throw new TRPCError({ code: 'PRECONDITION_FAILED', message });
+        }
+        if (message.includes('already processed')) {
+          throw new TRPCError({ code: 'CONFLICT', message });
+        }
+        if (message.includes('already have a BYOK key')) {
+          throw new TRPCError({ code: 'CONFLICT', message });
+        }
+
+        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message });
+      }
+    }),
+
+  /** Cancel subscription at period end. */
+  cancel: baseProcedure
+    .input(z.object({ providerId: z.string() }))
+    .mutation(async ({ input, ctx }) => {
+      try {
+        await cancelCodingPlanSubscription(ctx.user.id, input.providerId);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (message.includes('No active subscription')) {
+          throw new TRPCError({ code: 'NOT_FOUND', message });
+        }
+        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message });
+      }
+    }),
+
+  // -----------------------------------------------------------------------
+  // Admin endpoints
+  // -----------------------------------------------------------------------
+
+  /** Admin: Get key inventory counts per provider. */
+  adminKeyInventory: adminProcedure
+    .input(z.object({ providerId: z.string().optional() }))
+    .query(async ({ input }) => {
+      return getKeyInventoryCounts(input.providerId);
+    }),
+
+  /** Admin: Upload pre-purchased keys to inventory. */
+  adminUploadKeys: adminProcedure
+    .input(
+      z.object({
+        providerId: z.string(),
+        keys: z.array(z.string().min(1)).min(1).max(1000),
+      })
+    )
+    .mutation(async ({ input }) => {
+      return uploadKeysToInventory(input.providerId, input.keys);
+    }),
+
+  /** Admin: Immediately cancel a user's coding plan subscription. */
+  adminCancelSubscription: adminProcedure
+    .input(z.object({ userId: z.string(), providerId: z.string() }))
+    .mutation(async ({ input }) => {
+      try {
+        await cancelCodingPlanImmediately(input.userId, input.providerId);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (message.includes('No active subscription')) {
+          throw new TRPCError({ code: 'NOT_FOUND', message });
+        }
+        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message });
+      }
+    }),
+});

--- a/src/routers/root-router.ts
+++ b/src/routers/root-router.ts
@@ -33,6 +33,7 @@ import { userFeedbackRouter } from '@/routers/user-feedback-router';
 import { appBuilderFeedbackRouter } from '@/routers/app-builder-feedback-router';
 import { cloudAgentNextFeedbackRouter } from '@/routers/cloud-agent-next-feedback-router';
 import { kiloclawRouter } from '@/routers/kiloclaw-router';
+import { codingPlansRouter } from '@/routers/coding-plans-router';
 import { unifiedSessionsRouter } from '@/routers/unified-sessions-router';
 import { activeSessionsRouter } from '@/routers/active-sessions-router';
 export const rootRouter = createTRPCRouter({
@@ -69,6 +70,7 @@ export const rootRouter = createTRPCRouter({
   appBuilderFeedback: appBuilderFeedbackRouter,
   cloudAgentNextFeedback: cloudAgentNextFeedbackRouter,
   kiloclaw: kiloclawRouter,
+  codingPlans: codingPlansRouter,
   unifiedSessions: unifiedSessionsRouter,
   activeSessions: activeSessionsRouter,
 });

--- a/vercel.json
+++ b/vercel.json
@@ -41,6 +41,10 @@
       "schedule": "0 * * * *"
     },
     {
+      "path": "/api/cron/coding-plans-billing",
+      "schedule": "0 * * * *"
+    },
+    {
       "path": "/api/cron/db-pool-metrics",
       "schedule": "* * * * *"
     }


### PR DESCRIPTION
## Summary

- Add the Coding Plans backend, including the requirements/spec docs, Drizzle schema + migration for subscriptions and pre-purchased key inventory, pricing helpers, and the tRPC endpoints for catalog/list/subscribe/cancel plus admin inventory management.
- Add the billing lifecycle cron and secured `/api/cron/coding-plans-billing` route to renew subscriptions from credits, trigger auto-top-up once per period, cancel subscriptions on insufficient balance, and remove BYOK keys when access ends.
- Extend GDPR soft-delete handling for coding plans and fix same-month reactivation so a canceled subscription can be purchased again without reusing the previous activation idempotency key.

## Verification

- [x] `pnpm test -- src/lib/coding-plans/index.test.ts src/lib/user.test.ts`
- [x] `pnpm lint`
- [x] `pnpm typecheck`

## Visual Changes

N/A

## Reviewer Notes

- The main behavioral risk area is `src/lib/coding-plans/index.ts`: initial activation/reactivation and active-plan extension intentionally use different credit transaction idempotency keys.
- `packages/db/src/migrations/0071_majestic_pestilence.sql` and the snapshot are generated migration artifacts for the new coding plan tables and indexes.
- This branch is backend-only; there are no UI changes in scope.
