### PR TITLE
fix(kiloclaw): add default baseUrl when setting org header on kilocode provider

### DIFF
--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -251,6 +251,8 @@ describe('generateBaseConfig', () => {
     expect(config.models.providers.kilocode.headers['X-KiloCode-OrganizationId']).toBe(
       'org_abc123'
     );
+    // Explicit provider entries require a baseUrl per OpenClaw's strict schema
+    expect(config.models.providers.kilocode.baseUrl).toBe('https://api.kilo.ai/api/gateway/');
     expect(config.models.providers.kilocode.models).toEqual([]);
   });
 

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -187,6 +187,11 @@ export function generateBaseConfig(
     config.models = config.models ?? {};
     config.models.providers = config.models.providers ?? {};
     config.models.providers.kilocode = config.models.providers.kilocode ?? {};
+    // Explicit provider entries require a baseUrl per OpenClaw's strict schema.
+    // When KILOCODE_API_BASE_URL already set the URL above, preserve it;
+    // otherwise default to the production gateway URL.
+    config.models.providers.kilocode.baseUrl =
+      config.models.providers.kilocode.baseUrl ?? 'https://api.kilo.ai/api/gateway/';
     config.models.providers.kilocode.headers = config.models.providers.kilocode.headers ?? {};
     config.models.providers.kilocode.headers['X-KiloCode-OrganizationId'] =
       env.KILOCODE_ORGANIZATION_ID;


### PR DESCRIPTION
## Summary

When `KILOCODE_ORGANIZATION_ID` is set without `KILOCODE_API_BASE_URL`, `generateBaseConfig` creates a kilocode provider entry with `headers` and `models` but no `baseUrl`. OpenClaw's strict zod schema requires `baseUrl` on explicit provider entries, so the gateway crashes on startup during config validation.

https://github.com/openclaw/openclaw/blame/main/src/config/zod-schema.core.ts#L252

This adds a default `baseUrl` of `https://api.kilo.ai/api/gateway/` (the production gateway URL) when creating the provider entry for org headers. Uses `??` to preserve any existing `baseUrl` set by the `KILOCODE_API_BASE_URL` block above.

## Verification

- [x] `pnpm test -- controller/src/config-writer.test.ts` — 71 tests pass
- [x] `pnpm typecheck` — clean

## Visual Changes

N/A

## Reviewer Notes

The stale-config migration (lines 147-166) deletes persisted provider entries whose `baseUrl` matches `https://api.kilo.ai/api/gateway/`. On subsequent boots this means the org-header block will delete-then-recreate the entry each time — a minor no-op round-trip since all config is re-derived from env vars on every boot.