### PR TITLE
fix(kiloclaw): skip stale provider migration for org-scoped instances

### DIFF
--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -191,6 +191,31 @@ describe('generateBaseConfig', () => {
     expect(config.models).toBeUndefined();
   });
 
+  it('skips stale migration when KILOCODE_ORGANIZATION_ID is set', () => {
+    const existing = JSON.stringify({
+      models: {
+        providers: {
+          kilocode: {
+            baseUrl: 'https://api.kilo.ai/api/gateway/',
+            headers: { 'X-Custom': 'user-managed' },
+            models: [{ id: 'kept/model', name: 'Kept' }],
+          },
+        },
+      },
+    });
+    const { deps } = fakeDeps(existing);
+    const env = { ...minimalEnv(), KILOCODE_ORGANIZATION_ID: 'org_abc123' };
+    const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
+
+    // Provider not nuked — user-managed settings preserved
+    expect(config.models.providers.kilocode.headers['X-Custom']).toBe('user-managed');
+    expect(config.models.providers.kilocode.headers['X-KiloCode-OrganizationId']).toBe(
+      'org_abc123'
+    );
+    expect(config.models.providers.kilocode.baseUrl).toBe('https://api.kilo.ai/api/gateway/');
+    expect(config.models.providers.kilocode.models).toEqual([{ id: 'kept/model', name: 'Kept' }]);
+  });
+
   it('preserves non-kilocode providers when removing stale kilocode entry', () => {
     const existing = JSON.stringify({
       models: {

--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -191,7 +191,7 @@ describe('generateBaseConfig', () => {
     expect(config.models).toBeUndefined();
   });
 
-  it('skips stale migration when KILOCODE_ORGANIZATION_ID is set', () => {
+  it('skips gateway-URL stale migration for org-scoped instances', () => {
     const existing = JSON.stringify({
       models: {
         providers: {
@@ -214,6 +214,30 @@ describe('generateBaseConfig', () => {
     );
     expect(config.models.providers.kilocode.baseUrl).toBe('https://api.kilo.ai/api/gateway/');
     expect(config.models.providers.kilocode.models).toEqual([{ id: 'kept/model', name: 'Kept' }]);
+  });
+
+  it('still removes openrouter stale provider for org-scoped instances', () => {
+    const existing = JSON.stringify({
+      models: {
+        providers: {
+          kilocode: {
+            baseUrl: 'https://api.kilo.ai/api/openrouter/',
+            headers: { 'X-Custom': 'stale' },
+            models: [],
+          },
+        },
+      },
+    });
+    const { deps } = fakeDeps(existing);
+    const env = { ...minimalEnv(), KILOCODE_ORGANIZATION_ID: 'org_abc123' };
+    const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
+
+    // openrouter provider nuked, then rebuilt by org-header block
+    expect(config.models.providers.kilocode.headers['X-Custom']).toBeUndefined();
+    expect(config.models.providers.kilocode.headers['X-KiloCode-OrganizationId']).toBe(
+      'org_abc123'
+    );
+    expect(config.models.providers.kilocode.baseUrl).toBe('https://api.kilo.ai/api/gateway/');
   });
 
   it('preserves non-kilocode providers when removing stale kilocode entry', () => {

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -148,16 +148,15 @@ export function generateBaseConfig(
   // OpenClaw 2026.2.24+ has a built-in kilocode provider that activates when
   // KILOCODE_API_KEY is in the environment. Stale config entries with the old
   // /api/openrouter/ URL or the production /api/gateway/ URL conflict with it.
-  // Skip when KILOCODE_ORGANIZATION_ID is set: org-scoped instances need an
-  // explicit provider entry (with the production baseUrl) to carry the org header,
-  // and nuking it here would drop user-managed provider settings before the
-  // org-header block below can rebuild them.
-  if (config.models?.providers?.kilocode && !env.KILOCODE_ORGANIZATION_ID) {
+  // For the production /api/gateway/ URL, skip removal when KILOCODE_ORGANIZATION_ID
+  // is set: org-scoped instances need an explicit provider entry (with the production
+  // baseUrl) to carry the org header. The /api/openrouter/ cleanup always runs since
+  // that URL is unconditionally broken.
+  if (config.models?.providers?.kilocode) {
     const staleBaseUrl: string = config.models.providers.kilocode.baseUrl || '';
-    if (
-      staleBaseUrl.includes('/api/openrouter/') ||
-      staleBaseUrl === 'https://api.kilo.ai/api/gateway/'
-    ) {
+    const isOpenrouterUrl = staleBaseUrl.includes('/api/openrouter/');
+    const isGatewayUrl = staleBaseUrl === 'https://api.kilo.ai/api/gateway/';
+    if (isOpenrouterUrl || (isGatewayUrl && !env.KILOCODE_ORGANIZATION_ID)) {
       delete config.models.providers.kilocode;
       console.log(`Removed stale kilocode provider config (baseUrl: ${staleBaseUrl})`);
       if (Object.keys(config.models.providers).length === 0) {

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -148,7 +148,11 @@ export function generateBaseConfig(
   // OpenClaw 2026.2.24+ has a built-in kilocode provider that activates when
   // KILOCODE_API_KEY is in the environment. Stale config entries with the old
   // /api/openrouter/ URL or the production /api/gateway/ URL conflict with it.
-  if (config.models?.providers?.kilocode) {
+  // Skip when KILOCODE_ORGANIZATION_ID is set: org-scoped instances need an
+  // explicit provider entry (with the production baseUrl) to carry the org header,
+  // and nuking it here would drop user-managed provider settings before the
+  // org-header block below can rebuild them.
+  if (config.models?.providers?.kilocode && !env.KILOCODE_ORGANIZATION_ID) {
     const staleBaseUrl: string = config.models.providers.kilocode.baseUrl || '';
     if (
       staleBaseUrl.includes('/api/openrouter/') ||


### PR DESCRIPTION
## Summary

Follow-up to #1907. The stale-provider migration deletes kilocode provider entries whose `baseUrl` matches the production gateway URL (`https://api.kilo.ai/api/gateway/`). Since #1907 persists that exact URL for org-scoped instances, the migration was nuking the provider on every boot — dropping user-managed settings (custom headers, models) before the org-header block could rebuild them.

This skips the stale migration when `KILOCODE_ORGANIZATION_ID` is set, since those instances need the explicit provider entry to carry the org header.

## Verification

- [x] `pnpm test` (kiloclaw) — 1157 tests pass, including new test for the skip behavior
- [x] Pre-push hooks pass (typecheck, lint, format)

## Visual Changes

N/A

## Reviewer Notes

Non-org instances are unaffected — the migration still runs for personal instances without `KILOCODE_ORGANIZATION_ID`. The `/api/openrouter/` cleanup path is also skipped for org instances, but that's harmless since the org-header block overwrites `baseUrl` anyway.