### PR TITLE
fix(bot): register Chat singleton in callback continuation path

### DIFF
--- a/src/app/api/internal/bot-session-callback/[botRequestId]/route.ts
+++ b/src/app/api/internal/bot-session-callback/[botRequestId]/route.ts
@@ -207,6 +207,7 @@ async function continueBotAgentAfterCallback(params: {
   }
 
   await bot.initialize();
+  await bot.registerSingleton();
   const slackAdapter = bot.getAdapter('slack');
   const botToken = await getSlackBotToken(params.requestRow.platform_integration_id);
   if (!botToken) {


### PR DESCRIPTION
## Summary

PR #1916 moved `bot.registerSingleton()` from `agent-runner.ts` into the `onNewMention` handler in `bot.ts` to break a circular dependency. However, the callback continuation path (`continueBotAgentAfterCallback` → `runBotAgent`) never passes through `onNewMention`, so the Chat singleton was never registered. This caused `conversation-context.ts` to throw `"No Chat singleton registered. Call chat.registerSingleton() first."` when building the system prompt for callback-driven continuations.

The fix adds `await bot.registerSingleton()` in `continueBotAgentAfterCallback()` right after the existing `bot.initialize()` call, ensuring the singleton is available before `runBotAgent()` accesses chat adapters through threads.

Fixes KILOCODE-WEB-1PNV

## Verification

- [x] `pnpm typecheck` — passes
- [x] Pre-push hooks (format, lint, typecheck) — all pass

## Visual Changes

N/A

## Reviewer Notes

The `registerSingleton()` call is idempotent, so calling it in both the `onNewMention` path and the callback path is safe. The callback route already calls `bot.initialize()` at the same location, so this is the natural place to also ensure the singleton is registered.