### PR TITLE
feat(kiloclaw): add org-scoped support to chat-credentials and status REST routes

### DIFF
--- a/src/app/api/kiloclaw/chat-credentials/route.ts
+++ b/src/app/api/kiloclaw/chat-credentials/route.ts
@@ -5,25 +5,47 @@ import { KiloClawUserClient } from '@/lib/kiloclaw/kiloclaw-user-client';
 import { KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
 import { requireKiloClawAccess } from '@/lib/kiloclaw/access-gate';
-import { getActiveInstance, workerInstanceId } from '@/lib/kiloclaw/instance-registry';
+import {
+  getActiveInstance,
+  getActiveOrgInstance,
+  workerInstanceId,
+} from '@/lib/kiloclaw/instance-registry';
 
 export async function GET() {
-  const { user, authFailedResponse } = await getUserFromAuth({
+  const { user, authFailedResponse, organizationId } = await getUserFromAuth({
     adminOnly: false,
   });
   if (authFailedResponse) return authFailedResponse;
 
-  try {
-    await requireKiloClawAccess(user.id);
-  } catch (err) {
-    if (err instanceof TRPCError && err.code === 'FORBIDDEN') {
-      return NextResponse.json({ error: err.message }, { status: 403 });
+  // Personal-only billing gate — org access is gated at org membership level
+  // (validated by getUserFromAuth). Matches tRPC org router's
+  // getStreamChatCredentials which uses organizationMemberProcedure (no billing gate).
+  if (!organizationId) {
+    try {
+      await requireKiloClawAccess(user.id);
+    } catch (err) {
+      if (err instanceof TRPCError && err.code === 'FORBIDDEN') {
+        return NextResponse.json({ error: err.message }, { status: 403 });
+      }
+      throw err;
     }
-    throw err;
   }
 
   try {
-    const instance = await getActiveInstance(user.id);
+    const instance = organizationId
+      ? await getActiveOrgInstance(user.id, organizationId)
+      : await getActiveInstance(user.id);
+
+    // No org instance → 404. Without this guard workerInstanceId(null)
+    // → undefined → the worker queries the personal DO, leaking personal
+    // credentials into the org context.
+    if (organizationId && !instance) {
+      return NextResponse.json(
+        { error: 'No active instance for this organization' },
+        { status: 404 }
+      );
+    }
+
     const token = generateApiToken(user, undefined, {
       expiresIn: TOKEN_EXPIRY.fiveMinutes,
     });

--- a/src/app/api/kiloclaw/status/route.ts
+++ b/src/app/api/kiloclaw/status/route.ts
@@ -3,16 +3,33 @@ import { getUserFromAuth } from '@/lib/user.server';
 import { KiloClawUserClient } from '@/lib/kiloclaw/kiloclaw-user-client';
 import { KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
-import { getActiveInstance, workerInstanceId } from '@/lib/kiloclaw/instance-registry';
+import {
+  getActiveInstance,
+  getActiveOrgInstance,
+  workerInstanceId,
+} from '@/lib/kiloclaw/instance-registry';
 
 export async function GET() {
-  const { user, authFailedResponse } = await getUserFromAuth({
+  const { user, authFailedResponse, organizationId } = await getUserFromAuth({
     adminOnly: false,
   });
   if (authFailedResponse) return authFailedResponse;
 
   try {
-    const instance = await getActiveInstance(user.id);
+    const instance = organizationId
+      ? await getActiveOrgInstance(user.id, organizationId)
+      : await getActiveInstance(user.id);
+
+    // No org instance → 404 so the frontend renders CreateInstanceCard.
+    // Without this guard workerInstanceId(null) → undefined → the worker
+    // queries the personal DO, leaking personal status into the org context.
+    if (organizationId && !instance) {
+      return NextResponse.json(
+        { error: 'No active instance for this organization' },
+        { status: 404 }
+      );
+    }
+
     const token = generateApiToken(user, undefined, {
       expiresIn: TOKEN_EXPIRY.fiveMinutes,
     });


### PR DESCRIPTION
## Summary

- Add organization-scoped instance lookups to the `/api/kiloclaw/chat-credentials` and `/api/kiloclaw/status` REST routes. When `organizationId` is present (from the `x-kilocode-organizationid` header, validated by `getUserFromAuth`), requests are routed through `getActiveOrgInstance` instead of `getActiveInstance`.
- Skip the personal billing gate (`requireKiloClawAccess`) for org-scoped requests in `chat-credentials`, matching the tRPC org router's `getStreamChatCredentials` which uses `organizationMemberProcedure` without a billing gate. Org access is gated at membership level by `getUserFromAuth`.
- Guard against `getActiveOrgInstance` returning `null` in both routes — return 404 instead of silently falling back to the personal DO (which would leak personal instance data into an org-scoped response).

## Verification

- [x] `pnpm format:check` — passes (oxfmt)
- [x] Pre-push hooks pass (format, typecheck, lint)
- [x] Code review: confirmed authorization model is consistent with tRPC org router (`organizationMemberProcedure` for org routes, `clawAccessProcedure` for personal `chat-credentials`, `baseProcedure` for personal `status`)
- [x] Verified null-instance guard matches the pattern in the tRPC org `getStatus` route (`organization-kiloclaw-router.ts:247`)

## Visual Changes

N/A

## Reviewer Notes

- The billing gate asymmetry between `chat-credentials` (has personal billing gate) and `status` (no billing gate) is intentional and matches the existing tRPC router structure where `getStatus` uses `baseProcedure` and `getStreamChatCredentials` uses `clawAccessProcedure`.
- `getActiveOrgInstance` is a pure data-access function with no authorization logic — org membership validation is handled upstream by `getUserFromAuth` → `validateUserAuthorization` → `isOrganizationMember`.
- The null-instance guard prevents `workerInstanceId(null) → undefined` from causing the worker to fall back to the personal DO, which would leak personal data into an org context. The tRPC `getStatus` org route already has this guard (`organization-kiloclaw-router.ts:247`); the tRPC `getStreamChatCredentials` does not (pre-existing issue outside this PR's scope).