### PR TITLE
fix(cloud-agent): use LAN IP for KILO_SESSION_INGEST_URL in local dev

### DIFF
--- a/cloud-agent-next/.dev.vars.example
+++ b/cloud-agent-next/.dev.vars.example
@@ -72,6 +72,11 @@ R2_ENDPOINT=""
 R2_ATTACHMENTS_READONLY_ACCESS_KEY_ID=""
 R2_ATTACHMENTS_READONLY_SECRET_ACCESS_KEY=""
 
+# Session ingest URL used by the wrapper to post session data.
+# Use a host-reachable IP (not localhost) so sandbox containers can connect back.
+# @url cloudflare-session-ingest
+KILO_SESSION_INGEST_URL=http://192.168.x.x:8800
+
 # Local dev worker origins allowed to connect to /stream
 # @url nextjs,cloud-agent-next
 WS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8794

--- a/cloud-agent-next/wrangler.jsonc
+++ b/cloud-agent-next/wrangler.jsonc
@@ -259,7 +259,7 @@
         "PENDING_START_TIMEOUT_MS": "300000",
         "R2_ATTACHMENTS_BUCKET": "cloud-agent-attachments-dev",
         "WS_ALLOWED_ORIGINS": "http://localhost:3000,http://192.168.200.174:3000",
-        "KILO_SESSION_INGEST_URL": "http://localhost:8787",
+        "KILO_SESSION_INGEST_URL": "http://localhost:8800",
         "PER_SESSION_SANDBOX_ORG_IDS": "*",
       },
       "services": [


### PR DESCRIPTION
## Summary

`KILO_SESSION_INGEST_URL` was hardcoded in `wrangler.jsonc` as `http://localhost:8787`, which has two problems:
- Wrong port (8787 instead of 8800 where `cloudflare-session-ingest` actually runs)
- Uses `localhost`, which is unreachable from sandbox containers

This adds a `@url cloudflare-session-ingest` annotation in `.dev.vars.example` so that `pnpm dev:env` resolves the URL with the detected LAN IP and correct port (e.g. `http://192.168.1.164:8800`). The `wrangler.jsonc` fallback is also corrected to port 8800.

## Verification

- [x] Verified `cloudflare-session-ingest` runs on port 8800 via its `wrangler.jsonc`
- [x] Confirmed `cloud-agent-next` has `useLanIp: true` in service definitions, so `@url` annotations resolve to LAN IP
- [x] Pre-push hooks passed (typecheck, lint, format)

## Visual Changes

N/A

## Reviewer Notes

The `.dev.vars` value (generated by env-sync) overrides `wrangler.jsonc` vars at runtime, so the `wrangler.jsonc` change is just a fallback correction.