### PR TITLE
feat(kiloclaw): add standalone settings page and KiloClaw sidebar section

### DIFF
--- a/src/app/(app)/claw/components/ClawDashboard.tsx
+++ b/src/app/(app)/claw/components/ClawDashboard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { toast } from 'sonner';
 import dynamic from 'next/dynamic';
 import { Check, MessageSquare, Sparkles, TriangleAlert, X, Zap } from 'lucide-react';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
@@ -19,7 +18,6 @@ import { CreateInstanceCard } from './CreateInstanceCard';
 import { InstanceControls } from './InstanceControls';
 import { InstanceTab } from './InstanceTab';
 import { OpenClawButton } from './OpenClawButton';
-import { SettingsTab } from './SettingsTab';
 import { ChangelogTab } from './ChangelogTab';
 import { SubscriptionTab } from './SubscriptionTab';
 import { ChannelPairingStep } from './ChannelPairingStep';
@@ -127,7 +125,7 @@ function ClawDashboardInner({
     Date.now() - instanceStatus.provisionedAt < SEVEN_DAYS_MS;
   const configServiceNudgeVisible = !instanceStatus || instanceYoung;
 
-  const VALID_TABS = ['instance', 'chat', 'settings', 'subscription', 'changelog'] as const;
+  const VALID_TABS = ['instance', 'chat', 'subscription', 'changelog'] as const;
   type TabValue = (typeof VALID_TABS)[number];
 
   function tabFromHash(): TabValue {
@@ -173,45 +171,11 @@ function ClawDashboardInner({
     prevIsNewSetup.current = isNewSetup;
   }, [isNewSetup]);
 
-  const [dirtySecrets, setDirtySecrets] = useState<Set<string>>(new Set());
-
-  const onSecretsChanged = useCallback((entryId: string) => {
-    setDirtySecrets(prev => new Set([...prev, entryId]));
-  }, []);
   const [upgradeRequested, setUpgradeRequested] = useState(false);
-  const onRequestUpgrade = useCallback(() => setUpgradeRequested(true), []);
   const onUpgradeHandled = useCallback(() => setUpgradeRequested(false), []);
 
-  const onRedeploySuccess = useCallback(() => {
-    setDirtySecrets(new Set());
-  }, []);
-
-  const onRedeploy = useCallback(() => {
-    mutations.restartMachine.mutate(undefined, {
-      onSuccess: () => {
-        toast.success('Redeploying');
-        onRedeploySuccess();
-      },
-      onError: err => {
-        toast.error(err.message, { duration: 10000 });
-      },
-    });
-  }, [mutations.restartMachine, onRedeploySuccess]);
-
-  const onUpgrade = useCallback(() => {
-    mutations.restartMachine.mutate(
-      { imageTag: 'latest' },
-      {
-        onSuccess: () => {
-          toast.success('Upgrading to latest image');
-          onRedeploySuccess();
-        },
-        onError: err => {
-          toast.error(err.message, { duration: 10000 });
-        },
-      }
-    );
-  }, [mutations.restartMachine, onRedeploySuccess]);
+  // Called by InstanceControls after a successful redeploy/upgrade action.
+  const onRedeploySuccess = useCallback(() => {}, []);
 
   // Billing gating (welcome page for new users, loading spinner) is handled
   // by page.tsx before this component mounts. ClawDashboard always renders
@@ -400,9 +364,6 @@ function ClawDashboardInner({
                     <MessageSquare className="mr-1.5 inline h-3.5 w-3.5" />
                     Chat
                   </TabsTrigger>
-                  <TabsTrigger value="settings" className={tabTriggerClass}>
-                    Settings
-                  </TabsTrigger>
                   {!organizationId && (
                     <TabsTrigger value="subscription" className={tabTriggerClass}>
                       Subscription
@@ -425,17 +386,7 @@ function ClawDashboardInner({
                 <TabsContent value="chat" className="mt-0">
                   <ChatTab enabled={activeTab === 'chat' && isRunning} />
                 </TabsContent>
-                <TabsContent value="settings" className="mt-0">
-                  <SettingsTab
-                    status={instanceStatus}
-                    mutations={mutations}
-                    onSecretsChanged={onSecretsChanged}
-                    dirtySecrets={dirtySecrets}
-                    onRedeploy={onRedeploy}
-                    onUpgrade={onUpgrade}
-                    onRequestUpgrade={onRequestUpgrade}
-                  />
-                </TabsContent>
+
                 <TabsContent value="subscription" className="mt-0">
                   <SubscriptionTab />
                 </TabsContent>

--- a/src/app/(app)/claw/components/ClawSettingsPage.tsx
+++ b/src/app/(app)/claw/components/ClawSettingsPage.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { Settings } from 'lucide-react';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { useKiloClawStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { useOrgKiloClawStatus, useOrgKiloClawMutations } from '@/hooks/useOrgKiloClaw';
@@ -82,13 +82,23 @@ function ClawSettingsInner({ status }: { status: KiloClawDashboardStatus }) {
  * before rendering the settings content.
  */
 function ClawSettingsWithStatus({ organizationId }: { organizationId?: string }) {
+  const router = useRouter();
   const personalStatus = useKiloClawStatus();
   const orgStatus = useOrgKiloClawStatus(organizationId ?? '');
   const { data: status, isLoading, error } = organizationId ? orgStatus : personalStatus;
 
   const clawUrl = organizationId ? `/organizations/${organizationId}/claw` : '/claw';
 
-  if (isLoading) {
+  // Redirect to main KiloClaw page when there is no instance — it has the
+  // onboarding/provisioning flow that guides the user through setup.
+  const shouldRedirect = !isLoading && !error && (!status || status.status === null);
+  useEffect(() => {
+    if (shouldRedirect) {
+      router.replace(clawUrl);
+    }
+  }, [shouldRedirect, clawUrl, router]);
+
+  if (isLoading || shouldRedirect) {
     return (
       <Card>
         <CardContent className="py-12 text-center">
@@ -110,22 +120,8 @@ function ClawSettingsWithStatus({ organizationId }: { organizationId?: string })
     );
   }
 
-  if (!status || status.status === null) {
-    return (
-      <Card>
-        <CardContent className="py-12 text-center">
-          <p className="text-muted-foreground">
-            No KiloClaw instance found.{' '}
-            <Link href={clawUrl} className="underline">
-              Go to KiloClaw
-            </Link>{' '}
-            to provision one.
-          </p>
-        </CardContent>
-      </Card>
-    );
-  }
-
+  // status is guaranteed non-null with a non-null .status after the checks above
+  if (!status || status.status === null) return null;
   const settingsContent = <ClawSettingsInner status={status} />;
 
   // Personal context uses BillingWrapper for access-lock dialogs/banners.

--- a/src/app/(app)/claw/components/ClawSettingsPage.tsx
+++ b/src/app/(app)/claw/components/ClawSettingsPage.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+import { Settings } from 'lucide-react';
+import Link from 'next/link';
+import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
+import { useKiloClawStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
+import { useOrgKiloClawStatus, useOrgKiloClawMutations } from '@/hooks/useOrgKiloClaw';
+import { ClawContextProvider, useClawContext } from './ClawContext';
+import { SettingsTab } from './SettingsTab';
+import { BillingWrapper } from './billing/BillingWrapper';
+import { SetPageTitle } from '@/components/SetPageTitle';
+import { Card, CardContent } from '@/components/ui/card';
+
+/**
+ * Standalone settings page content. Sets up the mutation hooks, dirty-secret
+ * tracking, and redeploy/upgrade callbacks that SettingsTab needs.
+ */
+function ClawSettingsInner({ status }: { status: KiloClawDashboardStatus }) {
+  const { organizationId } = useClawContext();
+
+  const personalMutations = useKiloClawMutations();
+  const orgMutations = useOrgKiloClawMutations(organizationId ?? '');
+  const mutations = organizationId ? orgMutations : personalMutations;
+
+  const [dirtySecrets, setDirtySecrets] = useState<Set<string>>(new Set());
+  const onSecretsChanged = useCallback((entryId: string) => {
+    setDirtySecrets(prev => new Set([...prev, entryId]));
+  }, []);
+
+  const onRedeploySuccess = useCallback(() => {
+    setDirtySecrets(new Set());
+  }, []);
+
+  const onRedeploy = useCallback(() => {
+    mutations.restartMachine.mutate(undefined, {
+      onSuccess: () => {
+        toast.success('Redeploying');
+        onRedeploySuccess();
+      },
+      onError: err => {
+        toast.error(err.message, { duration: 10000 });
+      },
+    });
+  }, [mutations.restartMachine, onRedeploySuccess]);
+
+  const onUpgrade = useCallback(() => {
+    mutations.restartMachine.mutate(
+      { imageTag: 'latest' },
+      {
+        onSuccess: () => {
+          toast.success('Upgrading to latest image');
+          onRedeploySuccess();
+        },
+        onError: err => {
+          toast.error(err.message, { duration: 10000 });
+        },
+      }
+    );
+  }, [mutations.restartMachine, onRedeploySuccess]);
+
+  const onRequestUpgrade = useCallback(() => {
+    onUpgrade();
+  }, [onUpgrade]);
+
+  return (
+    <SettingsTab
+      status={status}
+      mutations={mutations}
+      onSecretsChanged={onSecretsChanged}
+      dirtySecrets={dirtySecrets}
+      onRedeploy={onRedeploy}
+      onUpgrade={onUpgrade}
+      onRequestUpgrade={onRequestUpgrade}
+    />
+  );
+}
+
+/**
+ * Wrapper that polls status and handles loading/error/no-instance states
+ * before rendering the settings content.
+ */
+function ClawSettingsWithStatus({ organizationId }: { organizationId?: string }) {
+  const personalStatus = useKiloClawStatus();
+  const orgStatus = useOrgKiloClawStatus(organizationId ?? '');
+  const { data: status, isLoading, error } = organizationId ? orgStatus : personalStatus;
+
+  const clawUrl = organizationId ? `/organizations/${organizationId}/claw` : '/claw';
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <p className="text-muted-foreground">Loading…</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <p className="text-destructive text-sm">
+            Failed to load status: {error instanceof Error ? error.message : 'Unknown error'}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!status || status.status === null) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <p className="text-muted-foreground">
+            No KiloClaw instance found.{' '}
+            <Link href={clawUrl} className="underline">
+              Go to KiloClaw
+            </Link>{' '}
+            to provision one.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const settingsContent = <ClawSettingsInner status={status} />;
+
+  // Personal context uses BillingWrapper for access-lock dialogs/banners.
+  if (!organizationId) {
+    return <BillingWrapper>{settingsContent}</BillingWrapper>;
+  }
+
+  return settingsContent;
+}
+
+export function ClawSettingsPage({ organizationId }: { organizationId?: string }) {
+  return (
+    <ClawContextProvider organizationId={organizationId}>
+      <div className="container m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
+        <SetPageTitle
+          title="Settings"
+          icon={<Settings className="text-muted-foreground h-4 w-4" />}
+        />
+        <ClawSettingsWithStatus organizationId={organizationId} />
+      </div>
+    </ClawContextProvider>
+  );
+}

--- a/src/app/(app)/claw/components/index.ts
+++ b/src/app/(app)/claw/components/index.ts
@@ -1,6 +1,7 @@
 export { OpenClawButton } from './OpenClawButton';
 export { ClawDashboard } from './ClawDashboard';
 export { ClawHeader } from './ClawHeader';
+export { ClawSettingsPage } from './ClawSettingsPage';
 export { CreateInstanceCard } from './CreateInstanceCard';
 export { DetailTile } from './DetailTile';
 export { InstanceTab } from './InstanceTab';

--- a/src/app/(app)/claw/settings/page.tsx
+++ b/src/app/(app)/claw/settings/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ClawSettingsPage } from '../components/ClawSettingsPage';
+
+export default function PersonalClawSettingsPage() {
+  return <ClawSettingsPage />;
+}

--- a/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -23,6 +23,7 @@ import {
   ListChecks,
   Wrench,
   Webhook,
+  Settings,
 } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import { useEffect, useMemo } from 'react';
@@ -121,8 +122,8 @@ export default function OrganizationAppSidebar({
     },
   ];
 
-  // Cloud group
-  const cloudItems: Array<{
+  // KiloClaw group
+  const kiloClawItems: Array<{
     title: string;
     icon: React.ElementType;
     url: string;
@@ -133,6 +134,20 @@ export default function OrganizationAppSidebar({
       icon: KiloCrabIcon,
       url: `/organizations/${organizationId}/claw`,
     },
+    {
+      title: 'Settings',
+      icon: Settings,
+      url: `/organizations/${organizationId}/claw/settings`,
+    },
+  ];
+
+  // Cloud group
+  const cloudItems: Array<{
+    title: string;
+    icon: React.ElementType;
+    url: string;
+    className?: string;
+  }> = [
     {
       title: 'App Builder',
       icon: Plus,
@@ -263,8 +278,8 @@ export default function OrganizationAppSidebar({
   ];
 
   const allUrls = useMemo(
-    () => [...dashboardItems, ...cloudItems, ...accountItems].map(i => i.url),
-    [dashboardItems, cloudItems, accountItems]
+    () => [...dashboardItems, ...kiloClawItems, ...cloudItems, ...accountItems].map(i => i.url),
+    [dashboardItems, kiloClawItems, cloudItems, accountItems]
   );
 
   // Determine if we should show the OrganizationSwitcher
@@ -288,6 +303,7 @@ export default function OrganizationAppSidebar({
 
       <SidebarContent>
         <SidebarMenuList label="Dashboard" items={dashboardItems} allUrls={allUrls} />
+        <SidebarMenuList label="KiloClaw" items={kiloClawItems} allUrls={allUrls} />
         {cloudItems.length > 0 && (
           <SidebarMenuList label="Cloud" items={cloudItems} allUrls={allUrls} />
         )}

--- a/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -24,6 +24,7 @@ import {
   Wrench,
   Webhook,
   Factory,
+  Settings,
 } from 'lucide-react';
 import { useMemo } from 'react';
 import HeaderLogo from '@/components/HeaderLogo';
@@ -67,8 +68,8 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
     },
   ];
 
-  // Cloud group
-  const cloudItems: Array<{
+  // KiloClaw group
+  const kiloClawItems: Array<{
     title: string;
     icon: React.ElementType;
     url: string;
@@ -79,6 +80,20 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
       icon: KiloCrabIcon,
       url: '/claw',
     },
+    {
+      title: 'Settings',
+      icon: Settings,
+      url: '/claw/settings',
+    },
+  ];
+
+  // Cloud group
+  const cloudItems: Array<{
+    title: string;
+    icon: React.ElementType;
+    url: string;
+    className?: string;
+  }> = [
     {
       title: 'App Builder',
       icon: Plus,
@@ -204,8 +219,11 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
   ];
 
   const allUrls = useMemo(
-    () => [...dashboardItems, ...cloudItems, ...accountItems, ...startItems].map(i => i.url),
-    [dashboardItems, cloudItems, accountItems, startItems]
+    () =>
+      [...dashboardItems, ...kiloClawItems, ...cloudItems, ...accountItems, ...startItems].map(
+        i => i.url
+      ),
+    [dashboardItems, kiloClawItems, cloudItems, accountItems, startItems]
   );
 
   return (
@@ -223,6 +241,7 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
 
       <SidebarContent>
         <SidebarMenuList label="Dashboard" items={dashboardItems} allUrls={allUrls} />
+        <SidebarMenuList label="KiloClaw" items={kiloClawItems} allUrls={allUrls} />
         {cloudItems.length > 0 && (
           <SidebarMenuList label="Cloud" items={cloudItems} allUrls={allUrls} />
         )}

--- a/src/app/(app)/organizations/[id]/claw/settings/OrgClawSettingsClient.tsx
+++ b/src/app/(app)/organizations/[id]/claw/settings/OrgClawSettingsClient.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ClawSettingsPage } from '@/app/(app)/claw/components/ClawSettingsPage';
+
+export function OrgClawSettingsClient({ organizationId }: { organizationId: string }) {
+  return <ClawSettingsPage organizationId={organizationId} />;
+}

--- a/src/app/(app)/organizations/[id]/claw/settings/page.tsx
+++ b/src/app/(app)/organizations/[id]/claw/settings/page.tsx
@@ -1,0 +1,15 @@
+import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import { OrgClawSettingsClient } from './OrgClawSettingsClient';
+
+type OrgClawSettingsPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function OrgClawSettingsPage({ params }: OrgClawSettingsPageProps) {
+  return (
+    <OrganizationByPageLayout
+      params={params}
+      render={org => <OrgClawSettingsClient organizationId={org.organization.id} />}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- Moves KiloClaw out of the "Cloud" sidebar group into its own **KiloClaw** section with two sub-items: the main dashboard and a new **Settings** page.
- Adds `/claw/settings` and `/organizations/[id]/claw/settings` routes that render `SettingsTab` as a standalone page (with status polling, mutations, billing gating).
- This is the first step in migrating the topbar tabs (Gateway Process, Chat, Settings, What's New) to individual sidebar pages. Only Settings is extracted in this PR; the existing tab inside `ClawDashboard` remains functional.

## Verification

- [x] `pnpm typecheck` — passes (exit code 0)
- [x] `pnpm format:check` — passes (pre-push hook)

## Visual Changes

<img width="4388" height="2708" alt="CleanShot 2026-04-02 at 17 39 27@2x" src="https://github.com/user-attachments/assets/124e436c-0cd6-4c8e-bdbd-d380bd72d57a" />

## Reviewer Notes

- The `ClawSettingsPage` component duplicates the mutation/dirty-secret/redeploy state setup from `ClawDashboardInner`. Once more tabs are migrated, this shared state should be extracted into a common hook or context to avoid repetition.
- The existing Settings tab in the dashboard topbar is intentionally kept — both entry points work in parallel during the transition period. A follow-up PR can remove the tab once the sidebar approach is validated.
- A future improvement could make the sidebar server-rendered (pass `hasClawInstance` from the layout) to conditionally show expanded KiloClaw sub-items only when the user has a provisioned instance.