### PR TITLE
feat(sidebar): add KiloClaw section with chat and settings navigation

### DIFF
--- a/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -23,6 +23,7 @@ import {
   ListChecks,
   Wrench,
   Webhook,
+  MessagesSquare,
 } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import { useEffect, useMemo } from 'react';
@@ -121,6 +122,25 @@ export default function OrganizationAppSidebar({
     },
   ];
 
+  // KiloClaw group
+  const kiloClawItems: Array<{
+    title: string;
+    icon: React.ElementType;
+    url: string;
+    className?: string;
+  }> = [
+    {
+      title: 'KiloClaw Chat',
+      icon: MessagesSquare,
+      url: `/organizations/${organizationId}/claw#chat`,
+    },
+    {
+      title: 'KiloClaw Settings',
+      icon: KiloCrabIcon,
+      url: `/organizations/${organizationId}/claw`,
+    },
+  ];
+
   // Cloud group
   const cloudItems: Array<{
     title: string;
@@ -128,11 +148,6 @@ export default function OrganizationAppSidebar({
     url: string;
     className?: string;
   }> = [
-    {
-      title: 'KiloClaw',
-      icon: KiloCrabIcon,
-      url: `/organizations/${organizationId}/claw`,
-    },
     {
       title: 'App Builder',
       icon: Plus,
@@ -263,8 +278,8 @@ export default function OrganizationAppSidebar({
   ];
 
   const allUrls = useMemo(
-    () => [...dashboardItems, ...cloudItems, ...accountItems].map(i => i.url),
-    [dashboardItems, cloudItems, accountItems]
+    () => [...dashboardItems, ...kiloClawItems, ...cloudItems, ...accountItems].map(i => i.url),
+    [dashboardItems, kiloClawItems, cloudItems, accountItems]
   );
 
   // Determine if we should show the OrganizationSwitcher
@@ -288,6 +303,7 @@ export default function OrganizationAppSidebar({
 
       <SidebarContent>
         <SidebarMenuList label="Dashboard" items={dashboardItems} allUrls={allUrls} />
+        <SidebarMenuList label="KiloClaw" items={kiloClawItems} allUrls={allUrls} />
         {cloudItems.length > 0 && (
           <SidebarMenuList label="Cloud" items={cloudItems} allUrls={allUrls} />
         )}

--- a/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -24,6 +24,7 @@ import {
   Wrench,
   Webhook,
   Factory,
+  MessagesSquare,
 } from 'lucide-react';
 import { useMemo } from 'react';
 import HeaderLogo from '@/components/HeaderLogo';
@@ -67,6 +68,25 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
     },
   ];
 
+  // KiloClaw group
+  const kiloClawItems: Array<{
+    title: string;
+    icon: React.ElementType;
+    url: string;
+    className?: string;
+  }> = [
+    {
+      title: 'KiloClaw Chat',
+      icon: MessagesSquare,
+      url: '/claw#chat',
+    },
+    {
+      title: 'KiloClaw Settings',
+      icon: KiloCrabIcon,
+      url: '/claw',
+    },
+  ];
+
   // Cloud group
   const cloudItems: Array<{
     title: string;
@@ -74,11 +94,6 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
     url: string;
     className?: string;
   }> = [
-    {
-      title: 'KiloClaw',
-      icon: KiloCrabIcon,
-      url: '/claw',
-    },
     {
       title: 'App Builder',
       icon: Plus,
@@ -204,8 +219,11 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
   ];
 
   const allUrls = useMemo(
-    () => [...dashboardItems, ...cloudItems, ...accountItems, ...startItems].map(i => i.url),
-    [dashboardItems, cloudItems, accountItems, startItems]
+    () =>
+      [...dashboardItems, ...kiloClawItems, ...cloudItems, ...accountItems, ...startItems].map(
+        i => i.url
+      ),
+    [dashboardItems, kiloClawItems, cloudItems, accountItems, startItems]
   );
 
   return (
@@ -223,6 +241,7 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
 
       <SidebarContent>
         <SidebarMenuList label="Dashboard" items={dashboardItems} allUrls={allUrls} />
+        <SidebarMenuList label="KiloClaw" items={kiloClawItems} allUrls={allUrls} />
         {cloudItems.length > 0 && (
           <SidebarMenuList label="Cloud" items={cloudItems} allUrls={allUrls} />
         )}


### PR DESCRIPTION
## Summary

Add a dedicated "KiloClaw" section to both personal and organization sidebars, positioned above the existing "Cloud" section. This change improves navigation by creating a focused KiloClaw section with two distinct navigation items, using appropriate icons to differentiate between chat and settings functionality.

### Changes Made

**Sidebar Structure Updates:**
- Added new "KiloClaw" section above "Cloud" section in both PersonalAppSidebar and OrganizationAppSidebar  
- Split KiloClaw functionality into two distinct navigation items:
  - **KiloClaw Chat** (MessagesSquare icon) → /claw#chat (personal) / /organizations/{id}/claw#chat (org)
  - **KiloClaw Settings** (KiloCrabIcon) → /claw (personal) / /organizations/{id}/claw (org)

**Icon Updates:**
- Imported MessagesSquare from lucide-react for chat functionality
- Used MessagesSquare (multiple chat bubbles) for KiloClaw Chat - this icon is not used elsewhere in sidebars
- Retained KiloCrabIcon for KiloClaw Settings to maintain brand consistency

**Code Structure:**
- Created new kiloClawItems arrays in both sidebar components
- Updated allUrls memoization to include new navigation items  
- Added proper TypeScript typing for new navigation structure

<img width="256" height="121" alt="image" src="https://github.com/user-attachments/assets/92e3c220-19fd-4fb1-9e70-f2a838b37923" />


## Verification

- Verified both personal and organization sidebars render correctly with new KiloClaw section
- Confirmed MessagesSquare icon is unique to chat functionality in sidebar navigation
- Validated URL structure matches existing patterns for personal vs organization contexts
- Checked that existing Cloud section items remain unchanged
- Ran formatting checks and resolved any issues

## Visual Changes

The sidebar now shows:
1. Dashboard (unchanged)
2. **KiloClaw** (new section)
   - KiloClaw Chat (MessagesSquare icon) 
   - KiloClaw Settings (KiloCrabIcon)
3. Cloud (existing section, KiloClaw item removed)
4. Account (unchanged)
5. Start (unchanged, personal only)

## Reviewer Notes

- The MessagesSquare icon was specifically chosen as it's not currently used elsewhere in the sidebar navigation
- URL structure maintains consistency with existing personal vs organization routing patterns  
- This change improves UX by clearly separating chat functionality from general KiloClaw settings
- All existing navigation remains functional and unchanged except for KiloClaw item removal from Cloud section