### PR TITLE
Sanitize path name for dev script

### DIFF
--- a/dev/local/tmux.ts
+++ b/dev/local/tmux.ts
@@ -29,7 +29,7 @@ function getWorktreeRoot(): string {
 
 function getSessionName(): string {
   const root = getWorktreeRoot();
-  const slug = path.basename(root).replace(/\./g, '_');
+  const slug = path.basename(root).replace(/[^A-Za-z0-9_-]/g, '_');
   return `kilo-dev-${slug}`;
 }
 

--- a/dev/local/tmux.ts
+++ b/dev/local/tmux.ts
@@ -29,7 +29,7 @@ function getWorktreeRoot(): string {
 
 function getSessionName(): string {
   const root = getWorktreeRoot();
-  const slug = path.basename(root);
+  const slug = path.basename(root).replace(/\./g, '_');
   return `kilo-dev-${slug}`;
 }
 


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

Replaces unsafe-for-shell chars with `_` in tmux session names