### PR TITLE
fix(kilo-app): resolve Android manifest merger conflict

### DIFF
--- a/kilo-app/app.config.js
+++ b/kilo-app/app.config.js
@@ -98,6 +98,7 @@ const config = {
       },
     ],
     ['react-native-appsflyer', {}],
+    './plugins/withAndroidManifestFix',
   ],
   experiments: {
     typedRoutes: true,

--- a/kilo-app/plugins/withAndroidManifestFix.js
+++ b/kilo-app/plugins/withAndroidManifestFix.js
@@ -1,0 +1,23 @@
+const { withAndroidManifest } = require('expo/config-plugins');
+
+/**
+ * Resolves manifest merger conflict between expo-secure-store and AppsFlyer SDK,
+ * which both declare dataExtractionRules and fullBackupContent on <application>.
+ */
+const withAndroidManifestFix = (config) => {
+  return withAndroidManifest(config, (config) => {
+    const application = config.modResults.manifest.application?.[0];
+    if (!application) return config;
+
+    // Ensure tools namespace is declared
+    config.modResults.manifest.$['xmlns:tools'] = 'http://schemas.android.com/tools';
+
+    // Add tools:replace to resolve the conflicting attributes
+    application.$['tools:replace'] =
+      'android:dataExtractionRules,android:fullBackupContent';
+
+    return config;
+  });
+};
+
+module.exports = withAndroidManifestFix;

--- a/kilo-app/plugins/withAndroidManifestFix.js
+++ b/kilo-app/plugins/withAndroidManifestFix.js
@@ -4,8 +4,8 @@ const { withAndroidManifest } = require('expo/config-plugins');
  * Resolves manifest merger conflict between expo-secure-store and AppsFlyer SDK,
  * which both declare dataExtractionRules and fullBackupContent on <application>.
  */
-const withAndroidManifestFix = (config) => {
-  return withAndroidManifest(config, (config) => {
+const withAndroidManifestFix = config => {
+  return withAndroidManifest(config, config => {
     const application = config.modResults.manifest.application?.[0];
     if (!application) return config;
 
@@ -13,8 +13,7 @@ const withAndroidManifestFix = (config) => {
     config.modResults.manifest.$['xmlns:tools'] = 'http://schemas.android.com/tools';
 
     // Add tools:replace to resolve the conflicting attributes
-    application.$['tools:replace'] =
-      'android:dataExtractionRules,android:fullBackupContent';
+    application.$['tools:replace'] = 'android:dataExtractionRules,android:fullBackupContent';
 
     return config;
   });


### PR DESCRIPTION
## Summary
- Both `expo-secure-store` and AppsFlyer's `af-android-sdk` declare `android:dataExtractionRules` and `android:fullBackupContent` on `<application>`, causing the Android manifest merger to fail during build.
- Adds a config plugin (`plugins/withAndroidManifestFix.js`) that sets `tools:replace` on the application element to resolve the conflict.

## Test plan
- [ ] Verify Android EAS build succeeds