### PR TITLE
Fix/kiloclaw streamchat config

### DIFF
--- a/.github/workflows/deploy-kiloclaw.yml
+++ b/.github/workflows/deploy-kiloclaw.yml
@@ -135,7 +135,6 @@ jobs:
             registry.fly.io/kiloclaw-machines:latest
           build-args: |
             CONTROLLER_COMMIT=${{ github.sha }}
-            STREAM_CHAT_CACHE_BUSTER=2
 
       # ── Resolve image digest ────────────────────────────────────
       # Gets the Docker digest from whichever source is available:

--- a/.github/workflows/deploy-kiloclaw.yml
+++ b/.github/workflows/deploy-kiloclaw.yml
@@ -135,6 +135,7 @@ jobs:
             registry.fly.io/kiloclaw-machines:latest
           build-args: |
             CONTROLLER_COMMIT=${{ github.sha }}
+            STREAM_CHAT_CACHE_BUSTER=2
 
       # ── Resolve image digest ────────────────────────────────────
       # Gets the Docker digest from whichever source is available:

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -52,6 +52,7 @@ RUN npm install -g clawhub
 RUN npm install -g mcporter@0.7.3
 
 # Install Stream Chat channel plugin for OpenClaw (installed from GitHub, not npm)
+ARG STREAM_CHAT_CACHE_BUSTER=1
 RUN npm install -g github:Kilo-Org/openclaw-channel-streamchat#fix/plugin-name-resolution
 
 # Install summarize (web page summarization CLI)

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -52,7 +52,8 @@ RUN npm install -g clawhub
 RUN npm install -g mcporter@0.7.3
 
 # Install Stream Chat channel plugin for OpenClaw (installed from GitHub, not npm)
-RUN npm install -g github:Kilo-Org/openclaw-channel-streamchat#catrielmuller/attach-support
+ARG CACHE_BUSTER=1
+RUN npm install -g github:Kilo-Org/openclaw-channel-streamchat#fix/plugin-name-resolution
 
 # Install summarize (web page summarization CLI)
 RUN npm install -g @steipete/summarize@0.12.0

--- a/kiloclaw/Dockerfile
+++ b/kiloclaw/Dockerfile
@@ -52,7 +52,6 @@ RUN npm install -g clawhub
 RUN npm install -g mcporter@0.7.3
 
 # Install Stream Chat channel plugin for OpenClaw (installed from GitHub, not npm)
-ARG CACHE_BUSTER=1
 RUN npm install -g github:Kilo-Org/openclaw-channel-streamchat#fix/plugin-name-resolution
 
 # Install summarize (web page summarization CLI)

--- a/kiloclaw/Dockerfile.local
+++ b/kiloclaw/Dockerfile.local
@@ -53,7 +53,7 @@ RUN npm install -g clawhub
 RUN npm install -g mcporter@0.7.3
 
 # Install Stream Chat channel plugin for OpenClaw (installed from GitHub, not npm)
-RUN npm install -g github:Kilo-Org/openclaw-channel-streamchat#catrielmuller/attach-support
+RUN npm install -g github:Kilo-Org/openclaw-channel-streamchat#fix/plugin-name-resolution
 
 # Install summarize (web page summarization CLI)
 RUN npm install -g @steipete/summarize@0.12.0

--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -578,6 +578,7 @@ describe('generateBaseConfig', () => {
     expect(config.channels.streamchat.botUserName).toBe('KiloClaw');
     expect(config.channels.streamchat.enabled).toBe(true);
     expect(config.plugins.entries['openclaw-channel-streamchat'].enabled).toBe(true);
+    expect(config.plugins.allow).toContain('openclaw-channel-streamchat');
     expect(config.plugins.load.paths).toContain(
       '/usr/local/lib/node_modules/@wunderchat/openclaw-channel-streamchat'
     );
@@ -605,6 +606,7 @@ describe('generateBaseConfig', () => {
         load: {
           paths: ['/usr/local/lib/node_modules/@wunderchat/openclaw-channel-streamchat'],
         },
+        allow: ['openclaw-channel-streamchat'],
         entries: { 'openclaw-channel-streamchat': { enabled: true } },
       },
     });
@@ -620,6 +622,8 @@ describe('generateBaseConfig', () => {
     const pluginPath = '/usr/local/lib/node_modules/@wunderchat/openclaw-channel-streamchat';
     const paths = config.plugins.load.paths as string[];
     expect(paths.filter(p => p === pluginPath)).toHaveLength(1);
+    const allow = config.plugins.allow as string[];
+    expect(allow.filter((a: string) => a === 'openclaw-channel-streamchat')).toHaveLength(1);
   });
 
   it('does not set gateway auth when OPENCLAW_GATEWAY_TOKEN is missing', () => {

--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -579,7 +579,7 @@ describe('generateBaseConfig', () => {
     expect(config.channels.streamchat.enabled).toBe(true);
     expect(config.plugins.entries.streamchat.enabled).toBe(true);
     expect(config.plugins.load.paths).toContain(
-      '/usr/local/lib/node_modules/@wunderchat/openclaw-channel-streamchat'
+      '/usr/local/lib/node_modules/streamchat'
     );
   });
 
@@ -603,7 +603,7 @@ describe('generateBaseConfig', () => {
       channels: { streamchat: { apiKey: 'old-key', enabled: true } },
       plugins: {
         load: {
-          paths: ['/usr/local/lib/node_modules/@wunderchat/openclaw-channel-streamchat'],
+          paths: ['/usr/local/lib/node_modules/streamchat'],
         },
         entries: { streamchat: { enabled: true } },
       },
@@ -617,7 +617,7 @@ describe('generateBaseConfig', () => {
     };
     const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
 
-    const pluginPath = '/usr/local/lib/node_modules/@wunderchat/openclaw-channel-streamchat';
+    const pluginPath = '/usr/local/lib/node_modules/streamchat';
     const paths = config.plugins.load.paths as string[];
     expect(paths.filter(p => p === pluginPath)).toHaveLength(1);
   });

--- a/kiloclaw/controller/src/config-writer.test.ts
+++ b/kiloclaw/controller/src/config-writer.test.ts
@@ -577,9 +577,9 @@ describe('generateBaseConfig', () => {
     expect(config.channels.streamchat.botUserToken).toBe('sc-bot-token');
     expect(config.channels.streamchat.botUserName).toBe('KiloClaw');
     expect(config.channels.streamchat.enabled).toBe(true);
-    expect(config.plugins.entries.streamchat.enabled).toBe(true);
+    expect(config.plugins.entries['openclaw-channel-streamchat'].enabled).toBe(true);
     expect(config.plugins.load.paths).toContain(
-      '/usr/local/lib/node_modules/streamchat'
+      '/usr/local/lib/node_modules/@wunderchat/openclaw-channel-streamchat'
     );
   });
 
@@ -603,9 +603,9 @@ describe('generateBaseConfig', () => {
       channels: { streamchat: { apiKey: 'old-key', enabled: true } },
       plugins: {
         load: {
-          paths: ['/usr/local/lib/node_modules/streamchat'],
+          paths: ['/usr/local/lib/node_modules/@wunderchat/openclaw-channel-streamchat'],
         },
-        entries: { streamchat: { enabled: true } },
+        entries: { 'openclaw-channel-streamchat': { enabled: true } },
       },
     });
     const { deps } = fakeDeps(existing);
@@ -617,7 +617,7 @@ describe('generateBaseConfig', () => {
     };
     const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
 
-    const pluginPath = '/usr/local/lib/node_modules/streamchat';
+    const pluginPath = '/usr/local/lib/node_modules/@wunderchat/openclaw-channel-streamchat';
     const paths = config.plugins.load.paths as string[];
     expect(paths.filter(p => p === pluginPath)).toHaveLength(1);
   });

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -319,7 +319,7 @@ export function generateBaseConfig(
     config.plugins.load.paths = Array.isArray(config.plugins.load.paths)
       ? config.plugins.load.paths
       : [];
-    const pluginPath = '/usr/local/lib/node_modules/@wunderchat/openclaw-channel-streamchat';
+    const pluginPath = '/usr/local/lib/node_modules/streamchat';
     if (!(config.plugins.load.paths as string[]).includes(pluginPath)) {
       (config.plugins.load.paths as string[]).push(pluginPath);
     }

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -324,11 +324,18 @@ export function generateBaseConfig(
       (config.plugins.load.paths as string[]).push(pluginPath);
     }
 
+    // Explicitly allow the non-bundled streamchat plugin so OpenClaw doesn't
+    // warn about auto-loading untrusted plugins when plugins.allow is empty.
+    config.plugins.allow = Array.isArray(config.plugins.allow) ? config.plugins.allow : [];
+    const scEntry = 'openclaw-channel-streamchat';
+    if (!(config.plugins.allow as string[]).includes(scEntry)) {
+      (config.plugins.allow as string[]).push(scEntry);
+    }
+
     config.plugins.entries = config.plugins.entries ?? {};
     // Entry key must match the plugin's manifest id (openclaw.plugin.json).
     // The fork's manifest declares id "openclaw-channel-streamchat" to align
     // with the idHint that OpenClaw derives from the package name.
-    const scEntry = 'openclaw-channel-streamchat';
     config.plugins.entries[scEntry] = config.plugins.entries[scEntry] ?? {};
     config.plugins.entries[scEntry].enabled = true;
   }

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -327,7 +327,7 @@ export function generateBaseConfig(
     config.plugins.entries = config.plugins.entries ?? {};
     // Entry key must match the plugin's manifest id (openclaw.plugin.json).
     // The fork's manifest declares id "openclaw-channel-streamchat" to align
-    // with the idHint that OpenClaw 3.24 derives from the package name.
+    // with the idHint that OpenClaw derives from the package name.
     const scEntry = 'openclaw-channel-streamchat';
     config.plugins.entries[scEntry] = config.plugins.entries[scEntry] ?? {};
     config.plugins.entries[scEntry].enabled = true;

--- a/kiloclaw/controller/src/config-writer.ts
+++ b/kiloclaw/controller/src/config-writer.ts
@@ -319,14 +319,18 @@ export function generateBaseConfig(
     config.plugins.load.paths = Array.isArray(config.plugins.load.paths)
       ? config.plugins.load.paths
       : [];
-    const pluginPath = '/usr/local/lib/node_modules/streamchat';
+    const pluginPath = '/usr/local/lib/node_modules/@wunderchat/openclaw-channel-streamchat';
     if (!(config.plugins.load.paths as string[]).includes(pluginPath)) {
       (config.plugins.load.paths as string[]).push(pluginPath);
     }
 
     config.plugins.entries = config.plugins.entries ?? {};
-    config.plugins.entries.streamchat = config.plugins.entries.streamchat ?? {};
-    config.plugins.entries.streamchat.enabled = true;
+    // Entry key must match the plugin's manifest id (openclaw.plugin.json).
+    // The fork's manifest declares id "openclaw-channel-streamchat" to align
+    // with the idHint that OpenClaw 3.24 derives from the package name.
+    const scEntry = 'openclaw-channel-streamchat';
+    config.plugins.entries[scEntry] = config.plugins.entries[scEntry] ?? {};
+    config.plugins.entries[scEntry].enabled = true;
   }
 
   // Webhook hooks configuration (required for Gmail push notifications via gog).


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

Many instances are throwing warnings after upgrading to 3.24. This is actually an issue with the plugin itself — in short, the plugin name must match its install path.

The changes on this PR correspond to the fixed configuration of the plugin.

Corresponding changes on https://github.com/Kilo-Org/openclaw-channel-streamchat/pull/1 (will not merge). 

## Verification

- Locally tested E2E
- Paired with @catrielmuller to verify

## Reviewer Notes
