### PR TITLE
refactor(impact): remove RE_SUBSCRIPTION event, use SALE for all paid invoices

### DIFF
--- a/.specs/impact-affiliate-tracking.md
+++ b/.specs/impact-affiliate-tracking.md
@@ -80,14 +80,13 @@ This integration applies only to KiloClaw subscriptions.
 
 8. The system MUST report the following conversion events to Impact.com, in order of the customer lifecycle:
 
-   | Event           | ActionTrackerId | Impact.com Type | Trigger                                       |
-   | --------------- | --------------- | --------------- | --------------------------------------------- |
-   | VISIT           | 71668           | Lead            | Visitor lands on `kilo.ai` with `im_ref`      |
-   | SIGNUP          | 71655           | Lead            | New user creation (with attribution)          |
-   | TRIAL_START     | 71656           | Sale            | KiloClaw trial subscription becomes active    |
-   | TRIAL_END       | 71658           | Sale            | KiloClaw trial subscription ends (any reason) |
-   | SALE            | 71659           | Sale            | First paid KiloClaw invoice settles           |
-   | RE_SUBSCRIPTION | 71660           | Sale            | Subsequent paid KiloClaw invoice settles      |
+   | Event       | ActionTrackerId | Impact.com Type | Trigger                                       |
+   | ----------- | --------------- | --------------- | --------------------------------------------- |
+   | VISIT       | 71668           | Lead            | Visitor lands on `kilo.ai` with `im_ref`      |
+   | SIGNUP      | 71655           | Lead            | New user creation (with attribution)          |
+   | TRIAL_START | 71656           | Sale            | KiloClaw trial subscription becomes active    |
+   | TRIAL_END   | 71658           | Sale            | KiloClaw trial subscription ends (any reason) |
+   | SALE        | 71659           | Sale            | Paid KiloClaw invoice settles                 |
 
 9. Each conversion event sent to Impact.com MUST include:
    - An event timestamp
@@ -112,22 +111,16 @@ This integration applies only to KiloClaw subscriptions.
 
 14. VISIT events MUST NOT include `CustomerId` because the user does not yet exist.
 
-15. SALE and RE_SUBSCRIPTION events MUST include the invoice amount and currency.
+15. SALE events MUST include the invoice amount and currency.
 
-16. SALE and RE_SUBSCRIPTION events MUST include the subscription plan identifier (e.g. `kiloclaw-standard`,
+16. SALE events MUST include the subscription plan identifier (e.g. `kiloclaw-standard`,
     `kiloclaw-commit`) as the item category.
 
-17. RE_SUBSCRIPTION events MUST include the subscription month number in `Numeric1`. The month number MUST be
-    1-indexed from the subscription lifecycle anchor chosen by the implementation, and MUST be used to support
-    Impact.com's 12-month commission cutoff rules.
+17. SALE events MUST be reported for every paid KiloClaw invoice on a subscription (both initial and renewal).
 
-18. SALE events MUST be reported only for the first paid KiloClaw invoice on a subscription.
+18. Conversion events SHOULD include a promo code when one was applied to the transaction.
 
-19. RE_SUBSCRIPTION events MUST be reported for every subsequent paid KiloClaw invoice on the same subscription.
-
-20. Conversion events SHOULD include a promo code when one was applied to the transaction.
-
-21. The SIGNUP event MUST only be sent for new user creation, not for returning users who sign in.
+19. The SIGNUP event MUST only be sent for new user creation, not for returning users who sign in.
 
 ### Client-Side Tracking (UTT)
 
@@ -171,7 +164,7 @@ This integration applies only to KiloClaw subscriptions.
 33. The implementation MUST treat the following program identifiers as configuration constants for this integration:
     - CampaignId: `50754`
     - UTT UUID: `A7138521-9724-4b8f-95f4-1db2fbae81141`
-    - ActionTrackerIds: `71655`, `71656`, `71658`, `71659`, `71660`, `71668`
+    - ActionTrackerIds: `71655`, `71656`, `71658`, `71659`, `71668`
 
 ## Error Handling
 
@@ -201,3 +194,9 @@ Added the VISIT and RE_SUBSCRIPTION events, switched API terminology to `ActionT
 bodies, clarified `IR_AN_64_TS` order ID usage, required `ClickId` fallback on early events, added `Numeric1` month
 tracking for renewals, and recorded the concrete Campaign/UTT/ActionTracker identifiers from the latest implementation
 guide.
+
+### 2026-04-02 -- Remove RE_SUBSCRIPTION event, use SALE for all paid invoices
+
+The RE_SUBSCRIPTION action tracker (71660) no longer exists in Impact.com. Removed the RE_SUBSCRIPTION event and
+consolidated all paid KiloClaw invoice tracking under the SALE event (71659). The `Numeric1` month number field is no
+longer sent. Both initial and renewal invoices now fire the same SALE conversion.

--- a/src/lib/impact-affiliate-utils.test.ts
+++ b/src/lib/impact-affiliate-utils.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from '@jest/globals';
 
 import {
   IMPACT_SIGNUP_FALLBACK_MAX_ACCOUNT_AGE_MS,
-  shouldTrackImpactReSubscription,
   shouldTrackImpactSignupFallback,
 } from '@/lib/impact-affiliate-utils';
 
@@ -46,32 +45,6 @@ describe('impact affiliate utils', () => {
           hasValidationStytch: false,
           userCreatedAt: '2026-04-02T12:00:00.000Z',
           now: new Date('2026-04-02T12:10:00.000Z'),
-        })
-      ).toBe(false);
-    });
-  });
-
-  describe('shouldTrackImpactReSubscription', () => {
-    it('treats settled hybrid subscription cycles as re-subscriptions', () => {
-      expect(
-        shouldTrackImpactReSubscription({
-          billingReason: 'subscription_cycle',
-          subscriptionRow: {
-            paymentSource: 'credits',
-            stripeSubscriptionId: 'sub_123',
-          },
-        })
-      ).toBe(true);
-    });
-
-    it('treats first delayed-billing invoices as sales before hybrid conversion', () => {
-      expect(
-        shouldTrackImpactReSubscription({
-          billingReason: 'subscription_cycle',
-          subscriptionRow: {
-            paymentSource: 'stripe',
-            stripeSubscriptionId: 'sub_123',
-          },
         })
       ).toBe(false);
     });

--- a/src/lib/impact-affiliate-utils.ts
+++ b/src/lib/impact-affiliate-utils.ts
@@ -1,5 +1,3 @@
-import type { KiloClawPaymentSource } from '@kilocode/db/schema-types';
-
 export const IMPACT_SIGNUP_FALLBACK_MAX_ACCOUNT_AGE_MS = 30 * 60 * 1000;
 
 export function shouldTrackImpactSignupFallback(params: {
@@ -16,21 +14,4 @@ export function shouldTrackImpactSignupFallback(params: {
 
   const ageMs = (params.now ?? new Date()).getTime() - createdAtMs;
   return ageMs >= 0 && ageMs <= IMPACT_SIGNUP_FALLBACK_MAX_ACCOUNT_AGE_MS;
-}
-
-export function shouldTrackImpactReSubscription(params: {
-  billingReason: string | null | undefined;
-  subscriptionRow:
-    | {
-        paymentSource: KiloClawPaymentSource | null;
-        stripeSubscriptionId: string | null;
-      }
-    | null
-    | undefined;
-}) {
-  return (
-    params.billingReason === 'subscription_cycle' &&
-    params.subscriptionRow?.paymentSource === 'credits' &&
-    params.subscriptionRow.stripeSubscriptionId !== null
-  );
 }

--- a/src/lib/impact.test.ts
+++ b/src/lib/impact.test.ts
@@ -40,38 +40,6 @@ describe('impact', () => {
     });
   });
 
-  it('builds a re-subscription payload with Numeric1 and sale details', async () => {
-    const { buildReSubscriptionPayload, hashEmailForImpact } = await import('@/lib/impact');
-    const payload = buildReSubscriptionPayload({
-      clickId: 'impact-click-123',
-      customerId: 'user_123',
-      customerEmail: 'user@example.com',
-      orderId: 'in_123',
-      amount: 9,
-      currencyCode: 'usd',
-      eventDate: new Date('2026-04-02T12:00:00.000Z'),
-      itemCategory: 'kiloclaw-standard',
-      itemName: 'KiloClaw Standard Plan',
-      monthNumber: 2,
-    });
-
-    expect(payload).toEqual({
-      CampaignId: '50754',
-      ActionTrackerId: 71660,
-      EventDate: '2026-04-02T12:00:00.000Z',
-      ClickId: 'impact-click-123',
-      CustomerId: 'user_123',
-      CustomerEmail: hashEmailForImpact('user@example.com'),
-      OrderId: 'in_123',
-      ItemSubTotal1: '9.00',
-      CurrencyCode: 'USD',
-      ItemCategory1: 'kiloclaw-standard',
-      ItemName1: 'KiloClaw Standard Plan',
-      ItemQuantity1: 1,
-      Numeric1: 2,
-    });
-  });
-
   it('sends JSON conversions with basic auth and retries once on 5xx', async () => {
     jest.useFakeTimers();
     const fetchMock = jest

--- a/src/lib/impact.ts
+++ b/src/lib/impact.ts
@@ -21,7 +21,6 @@ export const IMPACT_ACTION_TRACKER_IDS = {
   trialStart: 71656,
   trialEnd: 71658,
   sale: 71659,
-  reSubscription: 71660,
   visit: 71668,
 } as const;
 
@@ -197,21 +196,6 @@ export function buildSalePayload(
   };
 }
 
-export function buildReSubscriptionPayload(
-  params: ImpactSaleFields & {
-    eventDate: Date;
-    monthNumber: number;
-  }
-): ImpactConversionPayload {
-  return {
-    CampaignId: IMPACT_CAMPAIGN_ID,
-    ActionTrackerId: IMPACT_ACTION_TRACKER_IDS.reSubscription,
-    EventDate: toEventDate(params.eventDate),
-    Numeric1: params.monthNumber,
-    ...buildSaleFields(params),
-  };
-}
-
 async function sleep(ms: number): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -312,13 +296,4 @@ export async function trackTrialEnd(params: {
 
 export async function trackSale(params: ImpactSaleFields & { eventDate: Date }): Promise<void> {
   await sendImpactConversion(buildSalePayload(params), 'sale');
-}
-
-export async function trackReSubscription(
-  params: ImpactSaleFields & {
-    eventDate: Date;
-    monthNumber: number;
-  }
-): Promise<void> {
-  await sendImpactConversion(buildReSubscriptionPayload(params), 're_subscription');
 }

--- a/src/lib/kiloclaw/stripe-handlers.ts
+++ b/src/lib/kiloclaw/stripe-handlers.ts
@@ -2,7 +2,7 @@ import 'server-only';
 
 import type Stripe from 'stripe';
 import { eq, and, isNotNull, isNull, sql } from 'drizzle-orm';
-import { addMonths, differenceInMonths } from 'date-fns';
+import { addMonths } from 'date-fns';
 
 import { db } from '@/lib/drizzle';
 import { kiloclaw_subscriptions, kiloclaw_instances, kilocode_users } from '@kilocode/db/schema';
@@ -21,8 +21,7 @@ import { after } from 'next/server';
 import { IS_IN_AUTOMATED_TEST } from '@/lib/config.server';
 import { client as stripe } from '@/lib/stripe-client';
 import { getAffiliateAttribution } from '@/lib/affiliate-attribution';
-import { shouldTrackImpactReSubscription } from '@/lib/impact-affiliate-utils';
-import { trackReSubscription, trackSale, trackTrialEnd } from '@/lib/impact';
+import { trackSale, trackTrialEnd } from '@/lib/impact';
 
 const logInfo = sentryLogger('kiloclaw-stripe', 'info');
 const logWarning = sentryLogger('kiloclaw-stripe', 'warning');
@@ -74,13 +73,6 @@ function getImpactItemCategory(plan: 'commit' | 'standard') {
 
 function getImpactItemName(plan: 'commit' | 'standard') {
   return plan === 'commit' ? 'KiloClaw Commit Plan' : 'KiloClaw Standard Plan';
-}
-
-function getReSubscriptionMonthNumber(params: { anchorDate: string; periodStart: string }) {
-  return Math.max(
-    2,
-    differenceInMonths(new Date(params.periodStart), new Date(params.anchorDate)) + 1
-  );
 }
 
 async function runAfterResponse(work: () => Promise<void>) {
@@ -1078,22 +1070,6 @@ export async function handleKiloClawInvoicePaid(params: {
     return;
   }
 
-  const [subscriptionRow] = await db
-    .select({
-      created_at: kiloclaw_subscriptions.created_at,
-      payment_source: kiloclaw_subscriptions.payment_source,
-      stripe_subscription_id: kiloclaw_subscriptions.stripe_subscription_id,
-      trial_started_at: kiloclaw_subscriptions.trial_started_at,
-    })
-    .from(kiloclaw_subscriptions)
-    .where(
-      and(
-        eq(kiloclaw_subscriptions.user_id, metadata.kiloUserId),
-        eq(kiloclaw_subscriptions.stripe_subscription_id, stripeSubscriptionId)
-      )
-    )
-    .limit(1);
-
   const periodStart = new Date(periodStartUnix * 1000).toISOString();
   const periodEnd = new Date(periodEndUnix * 1000).toISOString();
   const amountMicrodollars = invoice.amount_paid * 10_000;
@@ -1141,29 +1117,6 @@ export async function handleKiloClawInvoicePaid(params: {
       itemCategory: getImpactItemCategory(plan),
       itemName: getImpactItemName(plan),
     };
-
-    if (
-      shouldTrackImpactReSubscription({
-        billingReason: invoice.billing_reason,
-        subscriptionRow: subscriptionRow
-          ? {
-              paymentSource: subscriptionRow.payment_source ?? null,
-              stripeSubscriptionId: subscriptionRow.stripe_subscription_id ?? null,
-            }
-          : null,
-      })
-    ) {
-      const anchorDate =
-        subscriptionRow?.trial_started_at ?? subscriptionRow?.created_at ?? periodStart;
-      await trackReSubscription({
-        ...basePayload,
-        monthNumber: getReSubscriptionMonthNumber({
-          anchorDate,
-          periodStart,
-        }),
-      });
-      return;
-    }
 
     await trackSale(basePayload);
   });


### PR DESCRIPTION
## Summary

- Remove the `RE_SUBSCRIPTION` Impact tracking event (ActionTrackerId `71660`) which no longer exists in Impact.com
- All paid KiloClaw invoices — both initial and renewal — now fire the `SALE` event (ActionTrackerId `71659`)
- Removed dead code: `buildReSubscriptionPayload`, `trackReSubscription`, `shouldTrackImpactReSubscription`, `getReSubscriptionMonthNumber`, the unused `subscriptionRow` query in `handleKiloClawInvoicePaid`, and the `reSubscription` constant
- Updated the affiliate tracking spec to reflect the consolidated event model and added a changelog entry

## Verification

- [x] `pnpm typecheck` — passed
- [x] `pnpm jest src/lib/impact.test.ts src/lib/impact-affiliate-utils.test.ts` — 7 tests passed (2 removed tests for deleted functions)
- [x] Automated review (security, logic, types, data, resources, style) — 0 issues across all six reviewers

## Visual Changes

N/A

## Reviewer Notes

- This is a pure deletion/simplification — no new logic was added
- The `Numeric1` month number field is no longer sent to Impact.com since the RE_SUBSCRIPTION event type that consumed it no longer exists
- The `subscriptionRow` DB query in `handleKiloClawInvoicePaid` was also removed since its sole purpose was feeding the re-subscription branching logic
- Net change: -172 lines, +21 lines across 6 files