### PR TITLE
test(gastown): add helper builders for overview component props

### DIFF
--- a/src/tests/helpers/gastown-testing.helper.ts
+++ b/src/tests/helpers/gastown-testing.helper.ts
@@ -1,0 +1,63 @@
+export interface TownCardProps {
+  town: {
+    id: string;
+    name: string;
+    last_activity_at: string | null;
+  };
+  stats: {
+    bead_counts: {
+      total: number;
+      in_progress: number;
+    };
+    active_agent_count: number;
+    sparkline_data: number[];
+  };
+  onClick: () => void;
+}
+
+export interface AggregateStatsSidebarProps {
+  stats: {
+    total_towns: number;
+    active_agents: number;
+    total_beads: number;
+  };
+}
+
+export function createMockTownCardProps(
+  overrides?: Partial<TownCardProps>
+): TownCardProps {
+  return {
+    town: {
+      id: 'mock-town-id',
+      name: 'Mock Town',
+      last_activity_at: new Date().toISOString(),
+      ...(overrides?.town ?? {}),
+    },
+    stats: {
+      bead_counts: {
+        total: 10,
+        in_progress: 5,
+        ...(overrides?.stats?.bead_counts ?? {}),
+      },
+      active_agent_count: 2,
+      sparkline_data: [1, 2, 3, 4, 5],
+      ...(overrides?.stats ?? {}),
+    },
+    onClick: () => {},
+    ...overrides,
+  };
+}
+
+export function createMockAggregateStatsSidebarProps(
+  overrides?: Partial<AggregateStatsSidebarProps>
+): AggregateStatsSidebarProps {
+  return {
+    stats: {
+      total_towns: 5,
+      active_agents: 10,
+      total_beads: 50,
+      ...(overrides?.stats ?? {}),
+    },
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

- Add `src/tests/helpers/gastown-testing.helper.ts` with reusable mock prop builders for overview testing targets.
- Provide typed default fixtures for `TownCard` and `AggregateStatsSidebar` test inputs, with nested override support to keep future tests concise and deterministic.

## Verification

- `git diff --stat main...HEAD` (pass)
- `git diff main...HEAD` (pass)
- `git log --oneline --decorate --no-merges main..HEAD` (pass)
- Automated tests were not run in this refinery review pass.

## Visual Changes

N/A

## Reviewer Notes

- Change scope is test-helper-only and adds no runtime application behavior.