### PR TITLE
feat(gastown): add aggregate stats tRPC endpoint and tests

### DIFF
--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -35,6 +35,7 @@ import {
   RpcAlarmStatusOutput,
   RpcOrgTownOutput,
   RpcMergeQueueDataOutput,
+  RpcAggregateStatsOutput,
 } from './schemas';
 import type { TRPCContext } from './init';
 
@@ -326,6 +327,39 @@ async function mintKilocodeToken(env: Env, user: { id: string; api_token_pepper:
   return generateKiloApiToken(user, secret);
 }
 
+async function fetchAggregateStats(connectionString: string): Promise<{
+  totalCost: number;
+  totalTokens: number;
+}> {
+  const [{ getWorkerDb }, { microdollar_usage_view }, { and, eq, gte, sql }] = await Promise.all([
+    import('@kilocode/db/client'),
+    import('@kilocode/db/schema'),
+    import('drizzle-orm'),
+  ]);
+
+  const db = getWorkerDb(connectionString, { statement_timeout: 5_000 });
+  const sevenDaysAgoIso = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const result = await db
+    .select({
+      totalCost: sql<number>`COALESCE(SUM(${microdollar_usage_view.cost}), 0)`,
+      totalTokens: sql<number>`COALESCE(SUM(${microdollar_usage_view.input_tokens} + ${microdollar_usage_view.output_tokens}), 0)`,
+    })
+    .from(microdollar_usage_view)
+    .where(
+      and(
+        eq(microdollar_usage_view.feature, 'gastown'),
+        gte(microdollar_usage_view.created_at, sevenDaysAgoIso)
+      )
+    );
+
+  const totals = result[0];
+  return {
+    totalCost: Number(totals?.totalCost ?? 0),
+    totalTokens: Number(totals?.totalTokens ?? 0),
+  };
+}
+
 // ── Router ─────────────────────────────────────────────────────────────
 
 export const gastownRouter = router({
@@ -355,6 +389,26 @@ export const gastownRouter = router({
     const userStub = getGastownUserStub(ctx.env, ctx.userId);
     return userStub.listTowns();
   }),
+
+  getAggregateStats: gastownProcedure
+    .output(RpcAggregateStatsOutput)
+    .query(async ({ ctx }) => {
+      if (!ctx.env.HYPERDRIVE) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'HYPERDRIVE binding not configured',
+        });
+      }
+      try {
+        return await fetchAggregateStats(ctx.env.HYPERDRIVE.connectionString);
+      } catch (error) {
+        console.error('[gastown-trpc] getAggregateStats failed', error);
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to load aggregate stats',
+        });
+      }
+    }),
 
   getTown: gastownProcedure
     .input(z.object({ townId: z.string().uuid() }))

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -390,25 +390,23 @@ export const gastownRouter = router({
     return userStub.listTowns();
   }),
 
-  getAggregateStats: gastownProcedure
-    .output(RpcAggregateStatsOutput)
-    .query(async ({ ctx }) => {
-      if (!ctx.env.HYPERDRIVE) {
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'HYPERDRIVE binding not configured',
-        });
-      }
-      try {
-        return await fetchAggregateStats(ctx.env.HYPERDRIVE.connectionString);
-      } catch (error) {
-        console.error('[gastown-trpc] getAggregateStats failed', error);
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'Failed to load aggregate stats',
-        });
-      }
-    }),
+  getAggregateStats: gastownProcedure.output(RpcAggregateStatsOutput).query(async ({ ctx }) => {
+    if (!ctx.env.HYPERDRIVE) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'HYPERDRIVE binding not configured',
+      });
+    }
+    try {
+      return await fetchAggregateStats(ctx.env.HYPERDRIVE.connectionString);
+    } catch (error) {
+      console.error('[gastown-trpc] getAggregateStats failed', error);
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to load aggregate stats',
+      });
+    }
+  }),
 
   getTown: gastownProcedure
     .input(z.object({ townId: z.string().uuid() }))

--- a/cloudflare-gastown/src/trpc/schemas.ts
+++ b/cloudflare-gastown/src/trpc/schemas.ts
@@ -188,6 +188,13 @@ export const RpcConvoyOutput = rpcSafe(ConvoyOutput);
 export const RpcConvoyDetailOutput = rpcSafe(ConvoyDetailOutput);
 export const RpcSlingResultOutput = rpcSafe(SlingResultOutput);
 
+// Aggregate stats (overview page)
+const AggregateStatsOutput = z.object({
+  totalCost: z.number(),
+  totalTokens: z.number().int().nonnegative(),
+});
+export const RpcAggregateStatsOutput = rpcSafe(AggregateStatsOutput);
+
 // Alarm status
 const AlarmStatusOutput = z.object({
   alarm: z.object({

--- a/cloudflare-gastown/test/integration/trpc-get-aggregate-stats.integration.test.ts
+++ b/cloudflare-gastown/test/integration/trpc-get-aggregate-stats.integration.test.ts
@@ -1,0 +1,59 @@
+import { SELF } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+import { signKiloToken } from '@kilocode/worker-utils';
+
+const NEXTAUTH_SECRET = 'test-nextauth-secret-at-least-32-chars';
+
+function api(path: string): string {
+  return `http://localhost${path}`;
+}
+
+async function authHeader(): Promise<Record<string, string>> {
+  const { token } = await signKiloToken({
+    userId: `user-${crypto.randomUUID()}`,
+    pepper: null,
+    secret: NEXTAUTH_SECRET,
+    expiresInSeconds: 300,
+    env: 'development',
+    extra: {
+      gastownAccess: true,
+    },
+  });
+
+  return {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+describe('tRPC getAggregateStats integration', () => {
+  it('rejects unauthenticated requests', async () => {
+    const res = await SELF.fetch(
+      api(`/trpc/gastown.getAggregateStats?input=${encodeURIComponent(JSON.stringify({}))}`),
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns internal error when HYPERDRIVE is unavailable', async () => {
+    const res = await SELF.fetch(
+      api(`/trpc/gastown.getAggregateStats?input=${encodeURIComponent(JSON.stringify({}))}`),
+      {
+        method: 'GET',
+        headers: await authHeader(),
+      }
+    );
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { data: { code: string }; message: string } };
+
+    expect(body.error.data.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(body.error.message).toContain('HYPERDRIVE binding not configured');
+  });
+});

--- a/cloudflare-gastown/test/unit/trpc-get-aggregate-stats.test.ts
+++ b/cloudflare-gastown/test/unit/trpc-get-aggregate-stats.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TRPCContext } from '../../src/trpc/init';
+
+const getWorkerDb = vi.fn();
+
+vi.mock('@kilocode/db/client', () => ({
+  getWorkerDb,
+}));
+
+vi.mock('../../src/dos/Town.do', () => ({
+  getTownDOStub: vi.fn(),
+}));
+
+vi.mock('../../src/dos/TownContainer.do', () => ({
+  getTownContainerStub: vi.fn(),
+}));
+
+vi.mock('../../src/dos/GastownUser.do', () => ({
+  getGastownUserStub: vi.fn(),
+}));
+
+vi.mock('../../src/dos/GastownOrg.do', () => ({
+  getGastownOrgStub: vi.fn(),
+}));
+
+function createCtx(overrides: Partial<TRPCContext> = {}): TRPCContext {
+  return {
+    env: {
+      HYPERDRIVE: {
+        connectionString: 'postgres://test-host/db',
+      },
+    } as Env,
+    userId: 'user-1',
+    isAdmin: false,
+    apiTokenPepper: null,
+    gastownAccess: true,
+    orgMemberships: [],
+    ...overrides,
+  };
+}
+
+describe('trpc gastown.getAggregateStats', () => {
+  beforeEach(() => {
+    getWorkerDb.mockReset();
+  });
+
+  it('returns aggregated stats with numeric formatting', async () => {
+    const where = vi.fn().mockResolvedValue([{ totalCost: '12345.67', totalTokens: '890' }]);
+    const from = vi.fn().mockReturnValue({ where });
+    const select = vi.fn().mockReturnValue({ from });
+    getWorkerDb.mockReturnValue({ select });
+
+    const { wrappedGastownRouter } = await import('../../src/trpc/router');
+    const caller = wrappedGastownRouter.createCaller(createCtx());
+    const result = await caller.gastown.getAggregateStats();
+
+    expect(result).toEqual({ totalCost: 12345.67, totalTokens: 890 });
+    expect(getWorkerDb).toHaveBeenCalledWith('postgres://test-host/db', {
+      statement_timeout: 5_000,
+    });
+  });
+
+  it('returns zero defaults when aggregate query returns nulls', async () => {
+    const where = vi.fn().mockResolvedValue([{ totalCost: null, totalTokens: null }]);
+    const from = vi.fn().mockReturnValue({ where });
+    const select = vi.fn().mockReturnValue({ from });
+    getWorkerDb.mockReturnValue({ select });
+
+    const { wrappedGastownRouter } = await import('../../src/trpc/router');
+    const caller = wrappedGastownRouter.createCaller(createCtx());
+    const result = await caller.gastown.getAggregateStats();
+
+    expect(result).toEqual({ totalCost: 0, totalTokens: 0 });
+  });
+
+  it('throws INTERNAL_SERVER_ERROR when aggregation query fails', async () => {
+    const where = vi.fn().mockRejectedValue(new Error('db timeout'));
+    const from = vi.fn().mockReturnValue({ where });
+    const select = vi.fn().mockReturnValue({ from });
+    getWorkerDb.mockReturnValue({ select });
+
+    const { wrappedGastownRouter } = await import('../../src/trpc/router');
+    const caller = wrappedGastownRouter.createCaller(createCtx());
+
+    await expect(caller.gastown.getAggregateStats()).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Failed to load aggregate stats',
+    });
+  });
+
+  it('throws INTERNAL_SERVER_ERROR when HYPERDRIVE is missing', async () => {
+    const { wrappedGastownRouter } = await import('../../src/trpc/router');
+    const caller = wrappedGastownRouter.createCaller(
+      createCtx({
+        env: {} as Env,
+      })
+    );
+
+    await expect(caller.gastown.getAggregateStats()).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'HYPERDRIVE binding not configured',
+    });
+  });
+});

--- a/cloudflare-gastown/wrangler.test.jsonc
+++ b/cloudflare-gastown/wrangler.test.jsonc
@@ -27,6 +27,7 @@
   // Test secrets — plain text vars used in place of secrets_store_secrets
   "vars": {
     "GASTOWN_JWT_SECRET": "test-jwt-secret-must-be-at-least-32-chars-long",
+    "NEXTAUTH_SECRET": "test-nextauth-secret-at-least-32-chars",
     "ENVIRONMENT": "development",
     "CF_ACCESS_TEAM": "engineering-e11",
     "CF_ACCESS_AUD": "f30e3fd893df52fa3ffc50fbdb5ee6a4f111625ae92234233429684e1429d809",


### PR DESCRIPTION
## Summary

- Add `gastown.getAggregateStats` to the Cloudflare Gastown tRPC router to return 7-day totals for gastown usage from `microdollar_usage_view`.
- Add `RpcAggregateStatsOutput` schema and normalize aggregate results to numeric output with zero fallbacks.
- Add unit tests for success/null/error/missing-HYPERDRIVE paths and worker integration tests for unauthenticated access and missing-HYPERDRIVE behavior; include `NEXTAUTH_SECRET` in `wrangler.test.jsonc` to support authenticated integration test setup.

## Verification

- `pnpm vitest cloudflare-gastown/test/unit/trpc-get-aggregate-stats.test.ts cloudflare-gastown/test/integration/trpc-get-aggregate-stats.integration.test.ts` **failed** (`Command \"vitest\" not found` at repo root)
- `pnpm --filter cloudflare-gastown exec vitest run test/unit/trpc-get-aggregate-stats.test.ts` **failed** (`Command \"vitest\" not found`)
- `pnpm test -- test/unit/trpc-get-aggregate-stats.test.ts` (in `cloudflare-gastown/`) **failed** (`vitest: not found`; workspace indicates missing `node_modules`)
- `pnpm test:integration -- test/integration/trpc-get-aggregate-stats.integration.test.ts` (in `cloudflare-gastown/`) **failed** (`vitest: not found`; workspace indicates missing `node_modules`)

## Visual Changes

N/A

## Reviewer Notes

- `fetchAggregateStats` uses dynamic imports for `@kilocode/db/client`, `@kilocode/db/schema`, and `drizzle-orm` inside the query helper; this keeps startup lean but is a notable implementation detail.
- Error handling currently logs failures with `console.error('[gastown-trpc] getAggregateStats failed', error)` and maps query failures to `INTERNAL_SERVER_ERROR`.