### PR TITLE
fix(admin): invalidate controllerVersion on machineRedeploy and machineUpgrade success

### DIFF
--- a/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1221,6 +1221,13 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         toast.success('Redeploy requested');
         invalidateMachineQueries();
         invalidateGatewayQueries();
+        if (data?.user_id) {
+          void queryClient.invalidateQueries({
+            queryKey: trpc.admin.kiloclawInstances.controllerVersion.queryKey({
+              userId: data.user_id,
+            }),
+          });
+        }
         setAwaitingRestartCompletion(true);
       },
       onError: err => {
@@ -1235,6 +1242,13 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         toast.success('Upgrade to latest requested');
         invalidateMachineQueries();
         invalidateGatewayQueries();
+        if (data?.user_id) {
+          void queryClient.invalidateQueries({
+            queryKey: trpc.admin.kiloclawInstances.controllerVersion.queryKey({
+              userId: data.user_id,
+            }),
+          });
+        }
         setAwaitingRestartCompletion(true);
       },
       onError: err => {


### PR DESCRIPTION
## Summary

Adds immediate `controllerVersion` query invalidation to the `onSuccess` callbacks of both `machineRedeploy` and `machineUpgrade` mutations in `KiloclawInstanceDetail.tsx`.

Previously, these mutations invalidated the machine and gateway queries but did not invalidate `controllerVersion`. Because `controllerVersion` has a 5-minute `staleTime`, `supportsConfigRestore` could reflect a stale value immediately after a redeploy or upgrade. This fix eagerly invalidates the query in `onSuccess` (guarded by `data?.user_id`) so the UI fetches a fresh value right away, complementing the existing post-restart polling re-invalidation.

## Verification

- Code review: diff is 14 lines, no logic changes beyond adding `invalidateQueries` calls consistent with the existing polling handler pattern.
- No quality gates configured for this rig.

## Visual Changes

N/A

## Reviewer Notes

The change mirrors the exact same `controllerVersion` invalidation already present in the `useEffect` polling handler (lines ~1133–1141). The only difference is this fires immediately on mutation success rather than waiting for the machine to return to `running` — both invalidations are desirable (eager + confirmed).