### PR TITLE
fix(gastown): gate refreshContainerToken on hasActiveWork to stop waking idle containers

### DIFF
--- a/cloudflare-gastown/docs/local-debug-testing.md
+++ b/cloudflare-gastown/docs/local-debug-testing.md
@@ -249,6 +249,7 @@ grep "container\|startAgent\|eviction" /tmp/gastown-wrangler.log | tail -20
 ### Drain Flag Clearing
 
 The TownDO's `_draining` flag is cleared by whichever happens first:
+
 - **Heartbeat instance ID change** (~30s): each container has a UUID. When a new container's heartbeat arrives with a different ID, the drain clears.
 - **Nonce handshake**: the new container calls `/container-ready` with the drain nonce.
 - **Hard timeout** (7 min): safety net if no heartbeat or handshake arrives.
@@ -276,6 +277,7 @@ docker kill $(docker ps -q) 2>/dev/null
 ### Drain Stuck "Waiting for N agents"
 
 Agents show as `running` but aren't doing work. Common causes:
+
 - **`fetchPendingNudges` hanging**: should be skipped during drain (check `_draining` flag)
 - **`server.heartbeat` clearing idle timer**: these events should be in `IDLE_TIMER_IGNORE_EVENTS`
 - **Agent in `starting` status**: `session.prompt()` blocking. Status is set to `running` before the prompt now.
@@ -283,6 +285,7 @@ Agents show as `running` but aren't doing work. Common causes:
 ### Drain Flag Persists After Restart
 
 The drain banner stays visible after the container restarted. Causes:
+
 - **No heartbeats arriving**: container failed to start, no agents registered
 - **`_containerInstanceId` not persisted**: should be in `ctx.storage`
 - Fallback: wait for the 7-minute hard timeout
@@ -290,14 +293,17 @@ The drain banner stays visible after the container restarted. Causes:
 ### Git Credential Errors
 
 Container starts but agents fail at `git clone`:
+
 ```
 Error checking if container is ready: Invalid username
 ```
+
 This means the git token is stale/expired. Refresh credentials in the town settings.
 
 ### Accumulating Escalation Beads
 
 Triage/escalation beads pile up with `rig_id=NULL`. These are by design:
+
 - `type=escalation` beads surface for human attention (merge conflicts, rework)
 - `type=issue` triage beads are handled by `maybeDispatchTriageAgent`
 - GUPP force-stop beads are created by the patrol system for stuck agents

--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -3320,9 +3320,9 @@ export class TownDO extends DurableObject<Env> {
       // Refresh the container-scoped JWT before any work that might
       // trigger API calls. Throttled to once per hour (tokens have 8h
       // expiry, so hourly refresh provides ample safety margin).
-      // Gated on hasRigs (not hasActiveWork) because the container may
-      // still be running with an idle mayor accepting user messages,
-      // even when there are no active beads or agents.
+      // Skips idle towns (no active work) — the container is sleeping
+      // and the token will be refreshed at dispatch time via
+      // ensureContainerToken() in startAgentInContainer().
       try {
         await this.refreshContainerToken();
       } catch (err) {
@@ -3647,6 +3647,12 @@ export class TownDO extends DurableObject<Env> {
    * requests that reset the container's sleepAfter timer (#1409).
    */
   private async refreshContainerToken(): Promise<void> {
+    // Skip if no active work — the container is sleeping and doesn't need
+    // a fresh token. The token will be refreshed when work is next
+    // dispatched (ensureContainerToken is called in startAgentInContainer
+    // at container-dispatch.ts:329).
+    if (!this.hasActiveWork()) return;
+
     const TOKEN_REFRESH_INTERVAL_MS = 60 * 60_000; // 1 hour
     const now = Date.now();
     const lastRefresh = (await this.ctx.storage.get<number>('container:lastTokenRefreshAt')) ?? 0;


### PR DESCRIPTION
## Summary

- Added `hasActiveWork()` early-return guard in `refreshContainerToken()` to prevent the hourly alarm from sending token-refresh requests to sleeping containers on idle towns. This avoids resetting the container's `sleepAfter` timer when no work is active (#1409).
- Updated the call-site comment to reflect the new behavior and document that tokens are refreshed at dispatch time via `ensureContainerToken()` in `startAgentInContainer()`.
- Fixed markdown formatting in `local-debug-testing.md` (blank lines before list items for proper rendering).

## Verification

- Polecat reports typecheck, lint, and formatting all pass.
- Code review confirmed the `hasActiveWork()` guard semantics match the existing idle-detection pattern used elsewhere in the alarm loop.
- Verified the `ensureContainerToken` reference at `container-dispatch.ts:329` is accurate.

## Visual Changes

N/A

## Reviewer Notes

- The early return means idle towns will let their container token expire naturally (8h). When work is next dispatched, `ensureContainerToken` in `startAgentInContainer` mints a fresh token before starting the agent, so there's no coverage gap.
- The markdown changes are purely cosmetic formatting fixes (blank lines before list items).