### PR TITLE
feat(container): expand apt-get block with build tools, ripgrep, and dev libraries

### DIFF
--- a/cloudflare-gastown/container/Dockerfile
+++ b/cloudflare-gastown/container/Dockerfile
@@ -1,18 +1,61 @@
 FROM oven/bun:1-slim
 
-# Install git, gh CLI, and Node.js (required by @kilocode/cli which uses #!/usr/bin/env node)
+# Install dev toolchain, search tools, build deps, gh CLI, and Node.js
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git git-lfs curl ca-certificates && \
-    curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
-    apt-get install -y --no-install-recommends nodejs && \
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-      > /etc/apt/sources.list.d/github-cli.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends gh && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends \
+      # Version control
+      git \
+      git-lfs \
+      # Network / download
+      curl \
+      wget \
+      ca-certificates \
+      gnupg \
+      unzip \
+      # Build toolchain
+      build-essential \
+      autoconf \
+      # Search tools
+      ripgrep \
+      jq \
+      # Compression
+      bzip2 \
+      zstd \
+      # SSL / crypto
+      libssl-dev \
+      libffi-dev \
+      # Database client libs
+      libdb-dev \
+      libgdbm-dev \
+      libgdbm6 \
+      # Python build deps (for repos with Python)
+      libbz2-dev \
+      liblzma-dev \
+      libncurses5-dev \
+      libreadline-dev \
+      zlib1g-dev \
+      # Ruby build deps (for repos with Ruby)
+      libyaml-dev \
+      # Image processing (for repos with image pipelines)
+      libvips-dev \
+      # Browser/rendering (for repos with Puppeteer, Playwright)
+      libgbm1 \
+      # C++ stdlib (for native addons)
+      libc++1 \
+      # Math (for native crypto/ML deps)
+      libgmp-dev \
+      # Timezone data (for TZ-aware test suites)
+      tzdata \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+         -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+         > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN git lfs install --system
 

--- a/cloudflare-gastown/container/Dockerfile
+++ b/cloudflare-gastown/container/Dockerfile
@@ -1,50 +1,51 @@
 FROM oven/bun:1-slim
 
 # Install dev toolchain, search tools, build deps, gh CLI, and Node.js
+# Package categories:
+#   version control: git, git-lfs
+#   network/download: curl, wget, ca-certificates, gnupg, unzip
+#   build toolchain: build-essential, autoconf
+#   search tools: ripgrep, jq
+#   compression: bzip2, zstd
+#   SSL/crypto: libssl-dev, libffi-dev
+#   database client libs: libdb-dev, libgdbm-dev, libgdbm6
+#   Python build deps: libbz2-dev, liblzma-dev, libncurses5-dev, libreadline-dev, zlib1g-dev
+#   Ruby build deps: libyaml-dev
+#   image processing: libvips-dev
+#   browser/rendering: libgbm1
+#   C++ stdlib: libc++1
+#   math: libgmp-dev
+#   timezone data: tzdata
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      # Version control
       git \
       git-lfs \
-      # Network / download
       curl \
       wget \
       ca-certificates \
       gnupg \
       unzip \
-      # Build toolchain
       build-essential \
       autoconf \
-      # Search tools
       ripgrep \
       jq \
-      # Compression
       bzip2 \
       zstd \
-      # SSL / crypto
       libssl-dev \
       libffi-dev \
-      # Database client libs
       libdb-dev \
       libgdbm-dev \
       libgdbm6 \
-      # Python build deps (for repos with Python)
       libbz2-dev \
       liblzma-dev \
       libncurses5-dev \
       libreadline-dev \
       zlib1g-dev \
-      # Ruby build deps (for repos with Ruby)
       libyaml-dev \
-      # Image processing (for repos with image pipelines)
       libvips-dev \
-      # Browser/rendering (for repos with Puppeteer, Playwright)
       libgbm1 \
-      # C++ stdlib (for native addons)
       libc++1 \
-      # Math (for native crypto/ML deps)
       libgmp-dev \
-      # Timezone data (for TZ-aware test suites)
       tzdata \
     && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \

--- a/cloudflare-gastown/container/Dockerfile.dev
+++ b/cloudflare-gastown/container/Dockerfile.dev
@@ -1,50 +1,51 @@
 FROM --platform=linux/arm64 oven/bun:1-slim
 
 # Install dev toolchain, search tools, build deps, gh CLI, and Node.js
+# Package categories:
+#   version control: git, git-lfs
+#   network/download: curl, wget, ca-certificates, gnupg, unzip
+#   build toolchain: build-essential, autoconf
+#   search tools: ripgrep, jq
+#   compression: bzip2, zstd
+#   SSL/crypto: libssl-dev, libffi-dev
+#   database client libs: libdb-dev, libgdbm-dev, libgdbm6
+#   Python build deps: libbz2-dev, liblzma-dev, libncurses5-dev, libreadline-dev, zlib1g-dev
+#   Ruby build deps: libyaml-dev
+#   image processing: libvips-dev
+#   browser/rendering: libgbm1
+#   C++ stdlib: libc++1
+#   math: libgmp-dev
+#   timezone data: tzdata
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      # Version control
       git \
       git-lfs \
-      # Network / download
       curl \
       wget \
       ca-certificates \
       gnupg \
       unzip \
-      # Build toolchain
       build-essential \
       autoconf \
-      # Search tools
       ripgrep \
       jq \
-      # Compression
       bzip2 \
       zstd \
-      # SSL / crypto
       libssl-dev \
       libffi-dev \
-      # Database client libs
       libdb-dev \
       libgdbm-dev \
       libgdbm6 \
-      # Python build deps (for repos with Python)
       libbz2-dev \
       liblzma-dev \
       libncurses5-dev \
       libreadline-dev \
       zlib1g-dev \
-      # Ruby build deps (for repos with Ruby)
       libyaml-dev \
-      # Image processing (for repos with image pipelines)
       libvips-dev \
-      # Browser/rendering (for repos with Puppeteer, Playwright)
       libgbm1 \
-      # C++ stdlib (for native addons)
       libc++1 \
-      # Math (for native crypto/ML deps)
       libgmp-dev \
-      # Timezone data (for TZ-aware test suites)
       tzdata \
     && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \

--- a/cloudflare-gastown/container/Dockerfile.dev
+++ b/cloudflare-gastown/container/Dockerfile.dev
@@ -1,18 +1,61 @@
 FROM --platform=linux/arm64 oven/bun:1-slim
 
-# Install git, gh CLI, and Node.js (required by @kilocode/cli which uses #!/usr/bin/env node)
+# Install dev toolchain, search tools, build deps, gh CLI, and Node.js
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git git-lfs curl ca-certificates && \
-    curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
-    apt-get install -y --no-install-recommends nodejs && \
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-      > /etc/apt/sources.list.d/github-cli.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends gh && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends \
+      # Version control
+      git \
+      git-lfs \
+      # Network / download
+      curl \
+      wget \
+      ca-certificates \
+      gnupg \
+      unzip \
+      # Build toolchain
+      build-essential \
+      autoconf \
+      # Search tools
+      ripgrep \
+      jq \
+      # Compression
+      bzip2 \
+      zstd \
+      # SSL / crypto
+      libssl-dev \
+      libffi-dev \
+      # Database client libs
+      libdb-dev \
+      libgdbm-dev \
+      libgdbm6 \
+      # Python build deps (for repos with Python)
+      libbz2-dev \
+      liblzma-dev \
+      libncurses5-dev \
+      libreadline-dev \
+      zlib1g-dev \
+      # Ruby build deps (for repos with Ruby)
+      libyaml-dev \
+      # Image processing (for repos with image pipelines)
+      libvips-dev \
+      # Browser/rendering (for repos with Puppeteer, Playwright)
+      libgbm1 \
+      # C++ stdlib (for native addons)
+      libc++1 \
+      # Math (for native crypto/ML deps)
+      libgmp-dev \
+      # Timezone data (for TZ-aware test suites)
+      tzdata \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+         -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+         > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN git lfs install --system
 


### PR DESCRIPTION
## Summary

Expands the `apt-get install` block in both `cloudflare-gastown/container/Dockerfile` and `Dockerfile.dev` with a comprehensive set of build tools, search utilities, and dev libraries needed by agent workloads. Both files now install: build-essential, autoconf, ripgrep, jq, wget, gnupg, unzip, bzip2, zstd, libssl-dev, libffi-dev, libdb-dev, libgdbm-dev, libgdbm6, libbz2-dev, liblzma-dev, libncurses5-dev, libreadline-dev, zlib1g-dev, libyaml-dev, libvips-dev, libgbm1, libc++1, libgmp-dev, and tzdata. Package lists are kept identical between the two files; only the FROM platform flag, CLI architecture packages, and plugin/git config blocks differ.

## Verification

- Reviewed full diff of both Dockerfiles
- Confirmed package lists are identical between Dockerfile and Dockerfile.dev
- Verified no unrelated files were changed (only 2 files touched)
- Checked that `apt-get clean` and `rm -rf /var/lib/apt/lists/*` are preserved
- No quality gates configured for this review

## Visual Changes

N/A

## Reviewer Notes

- This increases the container image size due to additional packages. All packages use `--no-install-recommends` to minimize bloat.
- The inline comments categorizing packages (Version control, Build toolchain, Search tools, etc.) improve readability and maintainability.