### PR TITLE
feat(gastown): skip review queue for gt:pr-fixup beads

### DIFF
--- a/cloudflare-gastown/docs/local-debug-testing.md
+++ b/cloudflare-gastown/docs/local-debug-testing.md
@@ -249,6 +249,7 @@ grep "container\|startAgent\|eviction" /tmp/gastown-wrangler.log | tail -20
 ### Drain Flag Clearing
 
 The TownDO's `_draining` flag is cleared by whichever happens first:
+
 - **Heartbeat instance ID change** (~30s): each container has a UUID. When a new container's heartbeat arrives with a different ID, the drain clears.
 - **Nonce handshake**: the new container calls `/container-ready` with the drain nonce.
 - **Hard timeout** (7 min): safety net if no heartbeat or handshake arrives.
@@ -276,6 +277,7 @@ docker kill $(docker ps -q) 2>/dev/null
 ### Drain Stuck "Waiting for N agents"
 
 Agents show as `running` but aren't doing work. Common causes:
+
 - **`fetchPendingNudges` hanging**: should be skipped during drain (check `_draining` flag)
 - **`server.heartbeat` clearing idle timer**: these events should be in `IDLE_TIMER_IGNORE_EVENTS`
 - **Agent in `starting` status**: `session.prompt()` blocking. Status is set to `running` before the prompt now.
@@ -283,6 +285,7 @@ Agents show as `running` but aren't doing work. Common causes:
 ### Drain Flag Persists After Restart
 
 The drain banner stays visible after the container restarted. Causes:
+
 - **No heartbeats arriving**: container failed to start, no agents registered
 - **`_containerInstanceId` not persisted**: should be in `ctx.storage`
 - Fallback: wait for the 7-minute hard timeout
@@ -290,14 +293,17 @@ The drain banner stays visible after the container restarted. Causes:
 ### Git Credential Errors
 
 Container starts but agents fail at `git clone`:
+
 ```
 Error checking if container is ready: Invalid username
 ```
+
 This means the git token is stale/expired. Refresh credentials in the town settings.
 
 ### Accumulating Escalation Beads
 
 Triage/escalation beads pile up with `rig_id=NULL`. These are by design:
+
 - `type=escalation` beads surface for human attention (merge conflicts, rework)
 - `type=issue` triage beads are handled by `maybeDispatchTriageAgent`
 - GUPP force-stop beads are created by the patrol system for stuck agents

--- a/cloudflare-gastown/src/dos/town/review-queue.ts
+++ b/cloudflare-gastown/src/dos/town/review-queue.ts
@@ -577,6 +577,17 @@ export function agentDone(sql: SqlStorage, agentId: string, input: AgentDoneInpu
     return;
   }
 
+  // PR-fixup beads skip the review queue. The polecat pushed fixup commits
+  // to an existing PR branch — no separate review is needed.
+  if (hookedBead?.labels.includes('gt:pr-fixup')) {
+    console.log(
+      `[review-queue] agentDone: pr-fixup bead ${agent.current_hook_bead_id} — closing directly (skip review)`
+    );
+    closeBead(sql, agent.current_hook_bead_id, agentId);
+    unhookBead(sql, agentId);
+    return;
+  }
+
   if (agent.role === 'refinery') {
     // The refinery handles merging (direct strategy) or PR creation (pr strategy)
     // itself. When it calls gt_done:


### PR DESCRIPTION
## Summary

Add `gt:pr-fixup` label handling to `agentDone()` in `review-queue.ts`, mirroring the existing `gt:rework` skip pattern. Beads with the `gt:pr-fixup` label are closed directly and unhook the agent without creating a merge-request bead, since the polecat already pushed fixup commits to an existing PR branch.

Also fixes minor markdown formatting in `local-debug-testing.md` (missing blank lines before list items per CommonMark spec).

## Verification

- [x] TypeScript compiles cleanly (`tsgo --noEmit` — 0 errors, ran via pre-push hook)
- [x] Formatter passes (`oxfmt --list-different .` — 0 warnings, 0 errors)
- [x] Linter passes (0 warnings, 0 errors via pre-push hook)
- [x] Code review: change mirrors existing `gt:rework` pattern exactly

## Visual Changes

N/A

## Reviewer Notes

The new block (lines 580-589 of `review-queue.ts`) is structurally identical to the `gt:rework` block immediately above it (lines 567-578). Both call `closeBead` + `unhookBead` and return early, skipping the review queue. The only differences are the label string and the log message.