### PR TITLE
feat(gastown): add PR-fixup workflow to polecat and mayor system prompts

### DIFF
--- a/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
@@ -284,6 +284,26 @@ For large convoys (>5 beads) where the decomposition is non-obvious, consider
 using staged=true by default to give the user a chance to review before agents
 start spending compute.
 
+## PR Fixup Dispatch
+
+When you need to dispatch a polecat to fix PR review comments or CI failures on an existing PR:
+
+1. Use \`gt_sling\` with the \`labels\` parameter set to \`["gt:pr-fixup"]\`
+2. Include the PR URL, branch name, and target branch in the bead metadata:
+   \`\`\`
+   metadata: JSON.stringify({
+     pr_url: "https://github.com/org/repo/pull/123",
+     branch: "gt/toast/abc123",
+     target_branch: "main"
+   })
+   \`\`\`
+3. In the bead body, include:
+   - The PR URL
+   - What needs fixing (specific review comments, CI failures, etc.)
+   - The branch to work on
+
+The \`gt:pr-fixup\` label causes the bead to skip the review queue when the polecat calls gt_done — the work goes directly to the existing PR branch without creating a separate review cycle.
+
 ## Bug Reporting
 
 If a user reports a bug or you encounter a repeating error, you can file a bug report

--- a/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/mayor-system.prompt.ts
@@ -291,11 +291,11 @@ When you need to dispatch a polecat to fix PR review comments or CI failures on 
 1. Use \`gt_sling\` with the \`labels\` parameter set to \`["gt:pr-fixup"]\`
 2. Include the PR URL, branch name, and target branch in the bead metadata:
    \`\`\`
-   metadata: JSON.stringify({
+   metadata: {
      pr_url: "https://github.com/org/repo/pull/123",
      branch: "gt/toast/abc123",
      target_branch: "main"
-   })
+   }
    \`\`\`
 3. In the bead body, include:
    - The PR URL

--- a/cloudflare-gastown/src/prompts/polecat-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/polecat-system.prompt.ts
@@ -58,6 +58,20 @@ You have these tools available. Use them to coordinate with the Gastown orchestr
 4. **Checkpoint**: After significant milestones, call gt_checkpoint with a summary of progress.
 5. **Done**: When the bead is complete, push your branch and call gt_done with the branch name. The bead transitions to \`in_review\` and the refinery picks it up for merge. If the review fails (rework), you will be re-dispatched with the bead back in \`in_progress\`.
 ${gatesSection}
+## PR Fixup Workflow
+
+When your hooked bead has the \`gt:pr-fixup\` label, you are fixing an existing PR rather than creating new work:
+
+1. Check out the PR branch specified in your bead metadata.
+2. Look at ALL comments on the PR using \`gh pr view <number> --comments\` and the GitHub API.
+3. For each review comment thread:
+   - If the comment is actionable: fix the issue, push the fix, reply explaining how you fixed it, and resolve the thread.
+   - If the comment is not relevant or is incorrect: reply explaining why, and resolve the thread.
+4. **Important**: Resolve the entire thread, not just the individual comment. Use \`gh api\` to resolve review threads.
+5. After addressing all comments, push your changes and call gt_done.
+
+Do NOT create a new PR. Push to the existing branch.
+
 ## Commit & Push Hygiene
 
 - Commit after every meaningful unit of work (new function, passing test, config change).

--- a/cloudflare-gastown/src/prompts/polecat-system.prompt.ts
+++ b/cloudflare-gastown/src/prompts/polecat-system.prompt.ts
@@ -60,9 +60,9 @@ You have these tools available. Use them to coordinate with the Gastown orchestr
 ${gatesSection}
 ## PR Fixup Workflow
 
-When your hooked bead has the \`gt:pr-fixup\` label, you are fixing an existing PR rather than creating new work:
+When your hooked bead has the \`gt:pr-fixup\` label, you are fixing an existing PR rather than creating new work. **This is the ONE exception to the "do not switch branches" rule.** You MUST check out the PR branch from your bead metadata instead of using the default worktree branch.
 
-1. Check out the PR branch specified in your bead metadata.
+1. Check out the PR branch specified in your bead metadata (e.g. \`git fetch origin <branch> && git checkout <branch>\`). This overrides the default worktree branch for this bead.
 2. Look at ALL comments on the PR using \`gh pr view <number> --comments\` and the GitHub API.
 3. For each review comment thread:
    - If the comment is actionable: fix the issue, push the fix, reply explaining how you fixed it, and resolve the thread.
@@ -77,7 +77,7 @@ Do NOT create a new PR. Push to the existing branch.
 - Commit after every meaningful unit of work (new function, passing test, config change).
 - Push after every commit. Do not batch pushes.
 - Use descriptive commit messages referencing the bead if applicable.
-- Branch naming: your branch is pre-configured in your worktree. Do not switch branches.
+- Branch naming: your branch is pre-configured in your worktree. Do not switch branches — **unless** your bead has the \`gt:pr-fixup\` label (see PR Fixup Workflow above).
 
 ## Escalation
 


### PR DESCRIPTION
## Summary

Add system prompt instructions for the `gt:pr-fixup` workflow to both polecat and mayor agents, complementing the backend feature added in #1985 that skips the review queue for PR-fixup beads.

- **polecat-system.prompt.ts**: New "PR Fixup Workflow" section instructs polecats how to handle `gt:pr-fixup` beads — check out the PR branch, review all comments via `gh pr view` and GitHub API, fix actionable comments, resolve threads, and push to the existing branch.
- **mayor-system.prompt.ts**: New "PR Fixup Dispatch" section instructs the mayor how to dispatch PR fixup beads using `gt_sling` with `labels: ["gt:pr-fixup"]` and the required metadata (`pr_url`, `branch`, `target_branch`).

## Verification

- No quality gates configured for this review
- Verified prompt metadata fields (`pr_url`, `branch`, `target_branch`) match the backend `pr_fixup_context` in `agents.ts:496-505`
- Verified `gt:pr-fixup` label usage matches the skip-review-queue logic in `review-queue.ts:582-588`
- Verified `gt_sling` tool schema in `mayor-tools.ts` accepts the `labels` parameter as described

## Visual Changes

N/A

## Reviewer Notes

The branch contains an empty WIP commit (`e3e0b1e2 WIP: container eviction save`) with no file changes — it's harmless but should be dropped if the branch is rebased.