### PR TITLE
fix(gastown): load ClipboardAddon so Mayor OSC 52 clipboard writes work

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@vercel/functions": "^3.4.3",
     "@vercel/otel": "^2.1.1",
     "@workos-inc/node": "catalog:",
+    "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       '@workos-inc/node':
         specifier: 'catalog:'
         version: 8.9.0
+      '@xterm/addon-clipboard':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
@@ -7854,6 +7857,9 @@ packages:
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
     deprecated: this version has critical issues, please update to the latest version
+
+  '@xterm/addon-clipboard@0.2.0':
+    resolution: {integrity: sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg==}
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
@@ -22046,6 +22052,8 @@ snapshots:
   '@workos-inc/node@8.9.0': {}
 
   '@xmldom/xmldom@0.8.11': {}
+
+  '@xterm/addon-clipboard@0.2.0': {}
 
   '@xterm/addon-fit@0.11.0': {}
 

--- a/src/components/gastown/useXtermPty.ts
+++ b/src/components/gastown/useXtermPty.ts
@@ -292,11 +292,14 @@ export function useXtermPty({
       if (!container) return;
 
       // Lazy-load xterm.js to avoid SSR issues and minimize bundle impact
-      const [{ Terminal }, { FitAddon }, { WebLinksAddon }] = await Promise.all([
-        import('@xterm/xterm'),
-        import('@xterm/addon-fit'),
-        import('@xterm/addon-web-links'),
-      ]);
+      const [{ Terminal }, { FitAddon }, { WebLinksAddon }, { ClipboardAddon }] = await Promise.all(
+        [
+          import('@xterm/xterm'),
+          import('@xterm/addon-fit'),
+          import('@xterm/addon-web-links'),
+          import('@xterm/addon-clipboard'),
+        ]
+      );
 
       if (disposed) return;
 
@@ -305,6 +308,7 @@ export function useXtermPty({
 
       const fitAddon = new FitAddon();
       const webLinksAddon = new WebLinksAddon();
+      const clipboardAddon = new ClipboardAddon();
 
       const term = new Terminal({
         cursorBlink: true,
@@ -323,6 +327,7 @@ export function useXtermPty({
 
       term.loadAddon(fitAddon);
       term.loadAddon(webLinksAddon);
+      term.loadAddon(clipboardAddon);
       term.open(container);
       attachKittyEnterHandler(term, wsRef);
       fitAddon.fit();


### PR DESCRIPTION
## Summary

The xterm.js terminal in the Gastown component was missing the `@xterm/addon-clipboard` addon, which is required to handle [OSC 52](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands) escape sequences for clipboard writes. Applications running inside the terminal (such as Mayor) use OSC 52 to write text to the system clipboard. Without this addon, those clipboard write requests were silently dropped.

This fix:
- Adds `@xterm/addon-clipboard` as a dependency
- Lazily imports and instantiates `ClipboardAddon` alongside the existing xterm addons
- Loads the addon into the terminal so OSC 52 clipboard operations are handled correctly

No architectural changes; purely additive.

## Verification

- [ ] Manually tested: copied text in the Mayor terminal and confirmed it reached the system clipboard
- [ ] TypeScript compiled without errors (`pnpm typecheck`)
- [ ] No regressions in existing terminal behaviour

## Visual Changes

N/A

## Reviewer Notes

The `ClipboardAddon` is loaded lazily in the same `Promise.all` block as the other addons, keeping the SSR-safe lazy-loading pattern intact. The addon has no configuration options; default behaviour is to read/write the system clipboard via the Clipboard API, falling back gracefully when permissions are denied.