### PR TITLE
fix(reconciler): parameterize circuit breaker SQL query

### DIFF
--- a/cloudflare-gastown/src/dos/town/reconciler.ts
+++ b/cloudflare-gastown/src/dos/town/reconciler.ts
@@ -52,6 +52,7 @@ const CIRCUIT_BREAKER_WINDOW_MINUTES = 30;
  * beads that eventually succeeded (status = 'closed').
  */
 function checkDispatchCircuitBreaker(sql: SqlStorage): Action[] {
+  const cutoff = new Date(Date.now() - CIRCUIT_BREAKER_WINDOW_MINUTES * 60_000).toISOString();
   const rows = z
     .object({ failure_count: z.number() })
     .array()
@@ -61,11 +62,11 @@ function checkDispatchCircuitBreaker(sql: SqlStorage): Action[] {
         /* sql */ `
           SELECT count(*) as failure_count
           FROM ${beads}
-          WHERE ${beads.last_dispatch_attempt_at} > strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-${CIRCUIT_BREAKER_WINDOW_MINUTES} minutes')
+          WHERE ${beads.last_dispatch_attempt_at} > ?
             AND ${beads.dispatch_attempts} > 0
             AND ${beads.status} != 'closed'
         `,
-        []
+        [cutoff]
       ),
     ]);
 


### PR DESCRIPTION
## Summary

Replaced template literal interpolation in the circuit breaker SQL query (`strftime('...', 'now', '-${CIRCUIT_BREAKER_WINDOW_MINUTES} minutes')`) with a JS-computed ISO 8601 cutoff timestamp passed as a bound SQL parameter. This eliminates string interpolation inside the SQL string while preserving the same 30-minute window behavior. No functional change.

## Verification

- Typecheck passes (reported by polecat)
- All 15 reconciler integration tests pass (1 pre-existing failure in Rule 6 test is unrelated)

## Visual Changes

N/A

## Reviewer Notes

- The branch includes an empty `WIP: container eviction save` commit with no file changes — can be squashed on merge.
- The change aligns with the codebase convention of using `?` bound parameters with the `query()` helper instead of interpolating values into SQL strings.