### PR TITLE
fix(gastown): rollback agent to idle on dispatch container start failure

### DIFF
--- a/cloudflare-gastown/src/dos/town/actions.ts
+++ b/cloudflare-gastown/src/dos/town/actions.ts
@@ -558,15 +558,15 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
 
       const capturedAgentId = agentId;
       return async () => {
-        // Best-effort dispatch. If it fails, the agent stays 'working'
-        // and the bead stays 'in_progress'. The reconciler detects the
-        // mismatch on the next tick (idle agent hooked to in_progress
-        // bead) and retries dispatch.
+        // Best-effort dispatch. If the container start fails, roll the
+        // agent back to 'idle' so the reconciler can retry on the next
+        // tick. The bead stays 'in_progress' — no transition needed.
         await ctx.dispatchAgent(capturedAgentId, beadId, rigId).catch(err => {
           console.warn(
-            `${LOG} dispatch_agent: container start failed for agent=${capturedAgentId} bead=${beadId}`,
+            `${LOG} dispatch_agent: container start failed for agent=${capturedAgentId} bead=${beadId}, rolling back to idle`,
             err
           );
+          agentOps.updateAgentStatus(sql, capturedAgentId, 'idle');
         });
       };
     }


### PR DESCRIPTION
## Summary

When `dispatch_agent`'s async side effect fails (container start fails), the agent was left in `working` status with no container running, creating a 90-second dead zone until heartbeat timeout detection kicked in.

Now the `.catch()` handler in the `dispatch_agent` action rolls the agent back to `idle` via `agentOps.updateAgentStatus()` so the reconciler can retry dispatch on the next tick, per spec §5.4. The bead stays `in_progress` — no transition needed.

- Updated comment to document the rollback behavior
- Added `rolling back to idle` to the warning log message for observability

## Verification

- Typecheck passes
- Reconciler-related tests pass (2 pre-existing failures in unrelated client.test.ts)
- Manual review confirms the SQL write in `.catch()` is safe — it's part of the promise chain awaited by `Promise.allSettled` in Phase 2 of the alarm loop

## Visual Changes

N/A

## Reviewer Notes

- The idle agent remains hooked to the `in_progress` bead. The reconciler handles this state: `reconcileBeads` will see an unassigned `in_progress` bead with an idle agent and re-dispatch.
- There is an empty "WIP: container eviction save" commit (no file changes) — harmless artifact from the polecat's workflow.