### PR TITLE
fix(reconciler): parameterize circuit breaker SQL query

### DIFF
--- a/cloudflare-gastown/src/dos/town/reconciler.ts
+++ b/cloudflare-gastown/src/dos/town/reconciler.ts
@@ -52,6 +52,7 @@ const CIRCUIT_BREAKER_WINDOW_MINUTES = 30;
  * beads that eventually succeeded (status = 'closed').
  */
 function checkDispatchCircuitBreaker(sql: SqlStorage): Action[] {
+  const cutoff = new Date(Date.now() - CIRCUIT_BREAKER_WINDOW_MINUTES * 60_000).toISOString();
   const rows = z
     .object({ failure_count: z.number() })
     .array()
@@ -61,11 +62,11 @@ function checkDispatchCircuitBreaker(sql: SqlStorage): Action[] {
         /* sql */ `
           SELECT count(*) as failure_count
           FROM ${beads}
-          WHERE ${beads.last_dispatch_attempt_at} > strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-${CIRCUIT_BREAKER_WINDOW_MINUTES} minutes')
+          WHERE ${beads.last_dispatch_attempt_at} > ?
             AND ${beads.dispatch_attempts} > 0
             AND ${beads.status} != 'closed'
         `,
-        []
+        [cutoff]
       ),
     ]);
 


### PR DESCRIPTION
## Summary

Replace `strftime()` template literal interpolation in the circuit breaker SQL query with a JS-computed cutoff timestamp passed as a bound SQL parameter. The `CIRCUIT_BREAKER_WINDOW_MINUTES` constant is now used to compute the ISO 8601 cutoff in JS (`new Date(Date.now() - N * 60_000).toISOString()`), then passed via `?` binding instead of being interpolated into the query string. Same 30-minute window, no behavioral change.

## Verification

- Reviewed the diff for correctness: `toISOString()` produces the same ISO 8601 format that `strftime('%Y-%m-%dT%H:%M:%fZ', ...)` would, and string comparison with `>` works identically.
- Confirmed single-file, 3-line change with no unrelated modifications.
- Polecat reports typecheck, lint, and format checks all pass.

## Visual Changes

N/A

## Reviewer Notes

- This is a pure SQL hygiene improvement — moving from template literal interpolation to bound parameters. Although the interpolated value was a constant (not user input), bound parameters are the standard pattern per the project's SQL conventions in `AGENTS.md`.
- The `Date.now()` call happens at function invocation time, so the cutoff is computed once per reconciler tick, which matches the previous behavior of SQLite's `now` being evaluated at query execution time.