### PR TITLE
fix(admin-omnibox): point Admin Panel link to users

### DIFF
--- a/src/components/admin-omnibox/action-registry.ts
+++ b/src/components/admin-omnibox/action-registry.ts
@@ -78,7 +78,7 @@ export const createRoleTestingGroup = (
 export const createAdminLinks = (): OmniboxAdminLink[] => [
   {
     label: 'Admin Panel',
-    href: '/admin/organizations',
+    href: '/admin/users',
     icon: Building2,
   },
   {


### PR DESCRIPTION
## Summary

- Point the admin omnibox Admin Panel shortcut at `/admin/users` so it lands on the main admin destination instead of the organizations page.

## Verification

- [ ] Not run (review-only change)

## Visual Changes

N/A

## Reviewer Notes

- Single-line navigation fix in `src/components/admin-omnibox/action-registry.ts`.