### PR TITLE
fix(ci): run vercel CLI from repo root for monorepo deployment

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,15 +35,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Setup Vercel ENV
+      # Setup Vercel ENV — link from repo root; Vercel rootDirectory (apps/web) is set on the dashboard
       - run: pnpm install --global vercel@latest
       - run: vercel link --project=kilocode-app --token=${{ secrets.VERCEL_TOKEN }} --yes
-        working-directory: apps/web
       - run: vercel env pull .env.local --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-        working-directory: apps/web
-
-      # packages/db/drizzle.config.ts reads ../../.env.local (repo root) — copy it there
-      - run: cp apps/web/.env.local .env.local
 
       - name: Run Drizzle migrations
         run: NODE_ENV=production pnpm run drizzle migrate
@@ -90,21 +85,17 @@ jobs:
         run: pnpm install --global vercel@latest
 
       - run: vercel link --project=kilocode-app --token=${{ secrets.VERCEL_TOKEN }} --yes
-        working-directory: apps/web
 
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-        working-directory: apps/web
 
       - name: Build Project Artifacts
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-        working-directory: apps/web
 
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
-        working-directory: apps/web
 
   deploy-global-app:
     runs-on: ${{ vars.RUNNER_LARGE_LABEL || 'ubuntu-24.04-8core' }}
@@ -148,21 +139,17 @@ jobs:
         run: pnpm install --global vercel@latest
 
       - run: vercel link --project=kilocode-global-app --token=${{ secrets.VERCEL_TOKEN }} --yes
-        working-directory: apps/web
 
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-        working-directory: apps/web
 
       - name: Build Project Artifacts
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-        working-directory: apps/web
 
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
-        working-directory: apps/web
 
   check-kiloclaw-changes:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+public-hoist-pattern[]=@types/*
 public-hoist-pattern[]=*import-in-the-middle*
 public-hoist-pattern[]=*require-in-the-middle*
 minimum-release-age-exclude[]=@sentry/*

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -22,6 +22,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
+    "typeRoots": ["./node_modules/@types"],
     "plugins": [
       {
         "name": "next"

--- a/packages/trpc/rollup.config.mjs
+++ b/packages/trpc/rollup.config.mjs
@@ -16,7 +16,7 @@ function resolveDts(base) {
 }
 
 export default {
-  external: ['pg'],
+  external: ['pg', '@tanstack/react-query', '@trpc/client', 'next/server'],
   input: './dist/tsc/packages/trpc/src/index.d.ts',
   output: {
     file: './dist/index.d.ts',


### PR DESCRIPTION
## Summary

Production deploys have failed on every push since the monorepo restructure (#1315) — 4 consecutive failures. Three issues fixed:

1. **Doubled Vercel path:** The restructure added `working-directory: apps/web` to all Vercel CLI commands, but `vercel build` post-processing then appended the project-relative path again, resolving to `apps/web/apps/web/.next/routes-manifest.json`. Fix: run all Vercel CLI commands from the repo root, following Vercel's documented monorepo pattern where the dashboard Root Directory setting (`apps/web`) tells the CLI where to find the app.

2. **Broken `@types/*` hoisting:** The `.npmrc` overrides `public-hoist-pattern` with custom Sentry patterns, which silently dropped pnpm's default `@types/*` hoisting. This meant `@types/react` was only in `apps/web/node_modules/` — not at the repo root — so TypeScript couldn't resolve `ScriptHTMLAttributes` from `react` when type-checking `next/dist/client/script.d.ts` deep in the `.pnpm` store. Fix: restore `public-hoist-pattern[]=@types/*` in `.npmrc`.

3. **`@types/bun` polluting global `fetch`:** Restoring `@types/*` hoisting also hoisted `@types/bun` (a devDependency of `cloud-agent` workspaces) to root. TypeScript auto-includes all `@types/*` from root `node_modules/`, so `bun-types` globals added `preconnect` to the `fetch` type, breaking `next build`. Fix: add `typeRoots: ["./node_modules/@types"]` to `apps/web/tsconfig.json`, restricting auto-inclusion to only the web app's own `@types`.

This also simplifies the migration job — `vercel env pull` now writes `.env.local` directly to the repo root where `drizzle.config.ts` expects it, eliminating the `cp apps/web/.env.local .env.local` workaround.

## Verification

- [x] Verified the doubled-path error in [failed run logs](https://github.com/Kilo-Org/cloud/actions/runs/24022162000/job/70053187144)
- [x] Confirmed `drizzle.config.ts` reads `../../.env.local` relative to `packages/db/` (resolves to repo root — matches new `vercel env pull` location)
- [x] Confirmed CI workflow (`ci.yml`) is unaffected — it uses `pnpm run build`, not `vercel build`
- [x] `@types/react` now hoisted to root `node_modules/` after `.npmrc` fix
- [x] `pnpm typecheck` passes (was failing on `StytchClient.tsx` before the `.npmrc` fix)
- [x] `vercel build --prod` from repo root completes successfully — TypeScript passes, static pages generated, `routes-manifest.json` at correct path, build output in `.vercel/output`
- [ ] Post-merge: validate production deploy succeeds after dashboard Root Directory update

## Visual Changes

N/A

## Reviewer Notes

- **Both changes must land together with a dashboard update:** merge this PR and update Vercel dashboard Root Directory to `apps/web` on both projects (`kilocode-app`, `kilocode-global-app`). Either change alone will still fail.
- The last successful production deploy was `41f3ab325` (Apr 4). All 4 deploys since the monorepo restructure have failed with the same doubled-path error.
- The `@types/bun` issue was a chain reaction: restoring `@types/*` hoisting (needed for `@types/react`) also hoisted `@types/bun` from other workspaces, which added `preconnect` to global `fetch` via `bun-types`. The `typeRoots` restriction in tsconfig scopes auto-inclusion to the web app's own dependencies.