### PR TITLE
fix(gastown): deduplicate checkPRFeedback call and hoist circuit breaker evaluation

### DIFF
--- a/cloudflare-gastown/src/dos/town/actions.ts
+++ b/cloudflare-gastown/src/dos/town/actions.ts
@@ -632,9 +632,17 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
             const refineryConfig = townConfig.refinery;
             if (!refineryConfig) return;
 
+            // Fetch PR feedback once and reuse for both auto-resolve and
+            // auto-merge checks, avoiding a duplicate GitHub API call.
+            const needsFeedback =
+              refineryConfig.auto_resolve_pr_feedback ||
+              (refineryConfig.auto_merge !== false &&
+                refineryConfig.auto_merge_delay_minutes !== null &&
+                refineryConfig.auto_merge_delay_minutes !== undefined);
+            const feedback = needsFeedback ? await ctx.checkPRFeedback(action.pr_url) : null;
+
             // Auto-resolve PR feedback: detect unresolved comments and failing CI
             if (refineryConfig.auto_resolve_pr_feedback) {
-              const feedback = await ctx.checkPRFeedback(action.pr_url);
               if (
                 feedback &&
                 (feedback.hasUnresolvedComments ||
@@ -694,7 +702,6 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
               refineryConfig.auto_merge_delay_minutes !== null &&
               refineryConfig.auto_merge_delay_minutes !== undefined
             ) {
-              const feedback = await ctx.checkPRFeedback(action.pr_url);
               if (!feedback) return;
 
               const allGreen =

--- a/cloudflare-gastown/src/dos/town/reconciler.ts
+++ b/cloudflare-gastown/src/dos/town/reconciler.ts
@@ -465,10 +465,20 @@ export function reconcile(
 ): Action[] {
   const draining = opts?.draining ?? false;
   const actions: Action[] = [];
+
+  // Evaluate the dispatch circuit breaker once per reconcile tick and pass
+  // the result to sub-functions that need it, avoiding duplicate COUNT queries.
+  const circuitBreakerActions = checkDispatchCircuitBreaker(sql);
+  const circuitBreakerOpen = circuitBreakerActions.length > 0;
+
   actions.push(...reconcileAgents(sql, { draining }));
-  actions.push(...reconcileBeads(sql, { draining }));
+  actions.push(...reconcileBeads(sql, { draining, circuitBreakerOpen, circuitBreakerActions }));
   actions.push(
-    ...reconcileReviewQueue(sql, { draining, refineryCodeReview: opts?.refineryCodeReview })
+    ...reconcileReviewQueue(sql, {
+      draining,
+      refineryCodeReview: opts?.refineryCodeReview,
+      circuitBreakerOpen,
+    })
   );
   actions.push(...reconcileConvoys(sql));
   actions.push(...reconcileGUPP(sql, { draining }));
@@ -621,14 +631,21 @@ export function reconcileAgents(sql: SqlStorage, opts?: { draining?: boolean }):
 // reconcileBeads — handle unassigned beads, lost agents, stale reviews
 // ════════════════════════════════════════════════════════════════════
 
-export function reconcileBeads(sql: SqlStorage, opts?: { draining?: boolean }): Action[] {
+export function reconcileBeads(
+  sql: SqlStorage,
+  opts?: {
+    draining?: boolean;
+    circuitBreakerOpen?: boolean;
+    circuitBreakerActions?: Action[];
+  }
+): Action[] {
   const draining = opts?.draining ?? false;
   const actions: Action[] = [];
 
-  // Town-level circuit breaker: if too many dispatch failures in the
-  // window, skip all dispatch_agent actions and escalate to mayor.
-  const circuitBreakerActions = checkDispatchCircuitBreaker(sql);
-  const circuitBreakerOpen = circuitBreakerActions.length > 0;
+  // Circuit breaker state is hoisted to reconcile() and passed in to
+  // avoid duplicate COUNT queries per tick.
+  const circuitBreakerActions = opts?.circuitBreakerActions ?? checkDispatchCircuitBreaker(sql);
+  const circuitBreakerOpen = opts?.circuitBreakerOpen ?? circuitBreakerActions.length > 0;
 
   // Rule 1: Open issue beads with no assignee, no blockers, not staged, not triage
   const unassigned = BeadRow.array().parse([
@@ -1031,14 +1048,16 @@ export function reconcileBeads(sql: SqlStorage, opts?: { draining?: boolean }): 
 
 export function reconcileReviewQueue(
   sql: SqlStorage,
-  opts?: { draining?: boolean; refineryCodeReview?: boolean }
+  opts?: { draining?: boolean; refineryCodeReview?: boolean; circuitBreakerOpen?: boolean }
 ): Action[] {
   const draining = opts?.draining ?? false;
   const refineryCodeReview = opts?.refineryCodeReview ?? true;
   const actions: Action[] = [];
 
-  // Town-level circuit breaker
-  const circuitBreakerOpen = checkDispatchCircuitBreaker(sql).length > 0;
+  // Circuit breaker state is hoisted to reconcile() and passed in to
+  // avoid duplicate COUNT queries per tick.
+  const circuitBreakerOpen =
+    opts?.circuitBreakerOpen ?? checkDispatchCircuitBreaker(sql).length > 0;
 
   // Get all MR beads that need attention
   const mrBeads = MrBeadRow.array().parse([


### PR DESCRIPTION
## Summary

- **B4**: Caches the `checkPRFeedback` result in `poll_pr` so both `auto_resolve` and `auto_merge` blocks reuse a single GitHub API call instead of making two identical requests per reconciler tick.
- **B5**: Hoists `checkDispatchCircuitBreaker` from `reconcileBeads` and `reconcileReviewQueue` into the top-level `reconcile()` function, passing the boolean result down as parameters. Eliminates one redundant SQL `COUNT` query per tick.

## Verification

- Verified cherry-pick applied cleanly with identical diff to original commit 630d4f9b
- Confirmed toast branch is exactly 1 commit ahead of head branch
- Confirmed head branch matches gastown-staging at d36364dd1

## Visual Changes

N/A

## Reviewer Notes

This is a rework of the original B4+B5 fix (commit 630d4f9b) to correct a workflow issue where the commit was pushed directly to the convoy head branch instead of the toast branch. The code changes are identical — only the branch structure was fixed to allow proper PR review.