### PR TITLE
fix(gastown): add from-state guard, parameterize circuit breaker, fix Rule 4 staleness

### DIFF
--- a/cloudflare-gastown/src/dos/town/actions.ts
+++ b/cloudflare-gastown/src/dos/town/actions.ts
@@ -317,6 +317,19 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
     // ── Bead mutations ──────────────────────────────────────────
 
     case 'transition_bead': {
+      // When `from` is specified, verify the bead is in the expected state
+      // before applying the transition. This prevents concurrent rule firings
+      // from producing unexpected state changes.
+      if (action.from !== null) {
+        const currentBead = beadOps.getBead(sql, action.bead_id);
+        if (currentBead && currentBead.status !== action.from) {
+          console.warn(
+            `${LOG} transition_bead: expected from=${action.from} but bead is ${currentBead.status}, skipping (bead=${action.bead_id})`
+          );
+          return null;
+        }
+      }
+
       try {
         const failureReason =
           action.to === 'failed'

--- a/cloudflare-gastown/src/dos/town/reconciler.ts
+++ b/cloudflare-gastown/src/dos/town/reconciler.ts
@@ -1140,12 +1140,18 @@ export function reconcileReviewQueue(
     // Rule 4: PR-strategy MR beads orphaned (refinery dispatched then died, stale >30min)
     // Only in_progress — open beads are just waiting for the refinery to pop them.
     // Skip when refinery code review is disabled: poll_pr keeps the bead alive via
-    // updated_at touches, and no refinery is expected to be working on it.
+    // last_poll_at touches, and no refinery is expected to be working on it.
+    // Use last_poll_at (set by poll_pr each tick) to determine staleness; fall back
+    // to updated_at for old beads that predate the last_poll_at field.
     if (
       refineryCodeReview &&
       mr.status === 'in_progress' &&
       mr.pr_url &&
-      staleMs(mr.updated_at, ORPHANED_PR_REVIEW_TIMEOUT_MS)
+      staleMs(
+        (typeof mr.metadata?.last_poll_at === 'string' ? mr.metadata.last_poll_at : null) ??
+          mr.updated_at,
+        ORPHANED_PR_REVIEW_TIMEOUT_MS
+      )
     ) {
       const workingAgent = hasWorkingAgentHooked(sql, mr.bead_id);
       if (!workingAgent) {

--- a/cloudflare-gastown/src/dos/town/reconciler.ts
+++ b/cloudflare-gastown/src/dos/town/reconciler.ts
@@ -52,6 +52,7 @@ const CIRCUIT_BREAKER_WINDOW_MINUTES = 30;
  * beads that eventually succeeded (status = 'closed').
  */
 function checkDispatchCircuitBreaker(sql: SqlStorage): Action[] {
+  const cutoff = new Date(Date.now() - CIRCUIT_BREAKER_WINDOW_MINUTES * 60_000).toISOString();
   const rows = z
     .object({ failure_count: z.number() })
     .array()
@@ -61,11 +62,11 @@ function checkDispatchCircuitBreaker(sql: SqlStorage): Action[] {
         /* sql */ `
           SELECT count(*) as failure_count
           FROM ${beads}
-          WHERE ${beads.last_dispatch_attempt_at} > strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-${CIRCUIT_BREAKER_WINDOW_MINUTES} minutes')
+          WHERE ${beads.last_dispatch_attempt_at} > ?
             AND ${beads.dispatch_attempts} > 0
             AND ${beads.status} != 'closed'
         `,
-        []
+        [cutoff]
       ),
     ]);
 
@@ -1049,8 +1050,7 @@ export function reconcileReviewQueue(
                b.${beads.columns.rig_id}, b.${beads.columns.updated_at},
                b.${beads.columns.metadata},
                rm.${review_metadata.columns.pr_url},
-               b.${beads.columns.assignee_agent_bead_id},
-               b.${beads.columns.metadata}
+               b.${beads.columns.assignee_agent_bead_id}
         FROM ${beads} b
         INNER JOIN ${review_metadata} rm ON rm.${review_metadata.columns.bead_id} = b.${beads.columns.bead_id}
         WHERE b.${beads.columns.type} = 'merge_request'


### PR DESCRIPTION
## Summary

Three targeted bug fixes for the reconciler:

- **From-state guard on `transition_bead`**: When `action.from` is non-null, the handler now verifies the bead's current status matches before applying the transition. Prevents concurrent rule firings from producing unexpected state changes (e.g., double-transitioning a bead).
- **Parameterized circuit breaker query**: Replaces inline `strftime` string interpolation with a parameterized `?` placeholder, improving portability and preventing potential SQL injection. Also removes a duplicate `metadata` column in the MR bead SELECT query.
- **Rule 4 staleness uses `last_poll_at`**: Rule 4 (orphaned PR review detection) now uses `metadata.last_poll_at` (set by `poll_pr` each tick) instead of `updated_at`, which could be touched by unrelated operations. Falls back to `updated_at` for old beads that predate the field.

## Verification

- Code review: all three changes are well-scoped, correct, and consistent with existing patterns
- No build artifacts, secrets, or generated content in the diff
- Only 2 source files changed (`actions.ts`, `reconciler.ts`), both in the expected domain

## Visual Changes

N/A

## Reviewer Notes

- The `TransitionBead` schema already defines `from: z.string().nullable()`, so all existing callers already populate this field
- The `getBead` call in the from-state guard is a single-row SELECT by PK — negligible overhead
- Rule 4's `last_poll_at` access is defensively guarded with `typeof` check and `??` fallback