### PR TITLE
fix(reconciler): emit stop_agent when bead is cancelled with working agent

### DIFF
--- a/cloudflare-gastown/src/dos/Town.do.ts
+++ b/cloudflare-gastown/src/dos/Town.do.ts
@@ -3460,6 +3460,7 @@ export class TownDO extends DurableObject<Env> {
     };
 
     // Phase 0: Drain events and apply state transitions
+    const eventActions: reconciler.Action[] = [];
     try {
       const pending = events.drainEvents(this.sql);
       metrics.eventsDrained = pending.length;
@@ -3468,7 +3469,8 @@ export class TownDO extends DurableObject<Env> {
       }
       for (const event of pending) {
         try {
-          reconciler.applyEvent(this.sql, event);
+          const actions = reconciler.applyEvent(this.sql, event);
+          eventActions.push(...actions);
           events.markProcessed(this.sql, event.event_id);
         } catch (err) {
           logger.error('reconciler: applyEvent failed', {
@@ -3508,13 +3510,32 @@ export class TownDO extends DurableObject<Env> {
 
     // Phase 1: Reconcile — compute desired state vs actual state
     const sideEffects: Array<() => Promise<void>> = [];
+
+    // Process side-effect actions emitted by events (e.g. stop_agent from bead_cancelled)
+    if (eventActions.length > 0) {
+      const ctx = this.applyActionCtx;
+      for (const action of eventActions) {
+        metrics.actionsByType[action.type] = (metrics.actionsByType[action.type] ?? 0) + 1;
+        try {
+          const effect = applyAction(ctx, action);
+          if (effect) sideEffects.push(effect);
+        } catch (err) {
+          logger.error('reconciler: applyAction (from event) failed', {
+            actionType: action.type,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+      metrics.actionsEmitted += eventActions.length;
+    }
+
     try {
       const townConfig = await this.getTownConfig();
       const actions = reconciler.reconcile(this.sql, {
         draining: this._draining,
         refineryCodeReview: townConfig.refinery?.code_review ?? true,
       });
-      metrics.actionsEmitted = actions.length;
+      metrics.actionsEmitted += actions.length;
       for (const a of actions) {
         metrics.actionsByType[a.type] = (metrics.actionsByType[a.type] ?? 0) + 1;
       }
@@ -4743,15 +4764,19 @@ export class TownDO extends DurableObject<Env> {
       ]);
 
       // Apply each event to reconstruct state transitions
+      const replayEventActions: Action[] = [];
       for (const event of rangeEvents) {
-        reconciler.applyEvent(this.sql, event);
+        replayEventActions.push(...reconciler.applyEvent(this.sql, event));
       }
 
       // Run reconciler against the resulting state
       const tc = await this.getTownConfig();
-      const actions = reconciler.reconcile(this.sql, {
-        refineryCodeReview: tc.refinery?.code_review ?? true,
-      });
+      const actions = [
+        ...replayEventActions,
+        ...reconciler.reconcile(this.sql, {
+          refineryCodeReview: tc.refinery?.code_review ?? true,
+        }),
+      ];
 
       // Capture a state snapshot before rollback
       const agentSnapshot = [
@@ -4824,16 +4849,20 @@ export class TownDO extends DurableObject<Env> {
     try {
       // Phase 0: Drain and apply pending events (same as real alarm loop)
       const pending = events.drainEvents(this.sql);
+      const dryRunEventActions: Action[] = [];
       for (const event of pending) {
-        reconciler.applyEvent(this.sql, event);
+        dryRunEventActions.push(...reconciler.applyEvent(this.sql, event));
         events.markProcessed(this.sql, event.event_id);
       }
 
       // Phase 1: Reconcile against now-current state
       const tc2 = await this.getTownConfig();
-      const actions = reconciler.reconcile(this.sql, {
-        refineryCodeReview: tc2.refinery?.code_review ?? true,
-      });
+      const actions = [
+        ...dryRunEventActions,
+        ...reconciler.reconcile(this.sql, {
+          refineryCodeReview: tc2.refinery?.code_review ?? true,
+        }),
+      ];
       const pendingEventCount = events.pendingEventCount(this.sql);
       const actionsByType: Record<string, number> = {};
       for (const a of actions) {

--- a/cloudflare-gastown/src/dos/town/reconciler.ts
+++ b/cloudflare-gastown/src/dos/town/reconciler.ts
@@ -32,6 +32,7 @@ import * as beadOps from './beads';
 import { getRig } from './rigs';
 import { PR_POLL_INTERVAL_MS } from './actions';
 import type { Action } from './actions';
+export type { Action } from './actions';
 import type { TownEventRecord } from '../../db/tables/town-events.table';
 
 const LOG = '[reconciler]';
@@ -199,40 +200,40 @@ type ConvoyRow = z.infer<typeof ConvoyRow>;
  *
  * See reconciliation-spec.md §5.2.
  */
-export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
+export function applyEvent(sql: SqlStorage, event: TownEventRecord): Action[] {
   const payload = event.payload;
 
   switch (event.event_type) {
     case 'agent_done': {
       if (!event.agent_id) {
         console.warn(`${LOG} applyEvent: agent_done missing agent_id`);
-        return;
+        return [];
       }
       const branch = typeof payload.branch === 'string' ? payload.branch : '';
       const pr_url = typeof payload.pr_url === 'string' ? payload.pr_url : undefined;
       const summary = typeof payload.summary === 'string' ? payload.summary : undefined;
 
       reviewQueue.agentDone(sql, event.agent_id, { branch, pr_url, summary });
-      return;
+      return [];
     }
 
     case 'agent_completed': {
       if (!event.agent_id) {
         console.warn(`${LOG} applyEvent: agent_completed missing agent_id`);
-        return;
+        return [];
       }
       const status =
         payload.status === 'completed' || payload.status === 'failed' ? payload.status : 'failed';
       const reason = typeof payload.reason === 'string' ? payload.reason : undefined;
 
       reviewQueue.agentCompleted(sql, event.agent_id, { status, reason });
-      return;
+      return [];
     }
 
     case 'pr_status_changed': {
       if (!event.bead_id) {
         console.warn(`${LOG} applyEvent: pr_status_changed missing bead_id`);
-        return;
+        return [];
       }
       const pr_state = payload.pr_state;
       if (pr_state === 'merged') {
@@ -248,19 +249,19 @@ export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
           message: 'PR closed without merge',
         });
       }
-      return;
+      return [];
     }
 
     case 'bead_created': {
       // No state change needed — bead already exists in DB.
       // Reconciler will pick it up as unassigned on next pass.
-      return;
+      return [];
     }
 
     case 'bead_cancelled': {
       if (!event.bead_id) {
         console.warn(`${LOG} applyEvent: bead_cancelled missing bead_id`);
-        return;
+        return [];
       }
       const cancelStatus =
         payload.cancel_status === 'closed' || payload.cancel_status === 'failed'
@@ -269,32 +270,44 @@ export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
 
       beadOps.updateBeadStatus(sql, event.bead_id, cancelStatus, 'system');
 
-      // Unhook any agent hooked to this bead
+      // Unhook any agent hooked to this bead and collect working agents to stop
       const hookedAgentRows = z
-        .object({ bead_id: z.string() })
+        .object({ bead_id: z.string(), status: z.string() })
         .array()
         .parse([
           ...query(
             sql,
             /* sql */ `
-            SELECT ${agent_metadata.bead_id}
+            SELECT ${agent_metadata.bead_id},
+                   ${agent_metadata.status}
             FROM ${agent_metadata}
             WHERE ${agent_metadata.current_hook_bead_id} = ?
           `,
             [event.bead_id]
           ),
         ]);
+
+      const stopActions: Action[] = [];
       for (const row of hookedAgentRows) {
         agents.unhookBead(sql, row.bead_id);
+        // Stop agents that are actively running — skip those already
+        // in terminal states (stalled, dead) to avoid double-stops.
+        if (row.status === 'working' || row.status === 'waiting') {
+          stopActions.push({
+            type: 'stop_agent',
+            agent_id: row.bead_id,
+            reason: `bead ${event.bead_id} cancelled`,
+          });
+        }
       }
-      return;
+      return stopActions;
     }
 
     case 'convoy_started': {
       const convoyId = typeof payload.convoy_id === 'string' ? payload.convoy_id : null;
       if (!convoyId) {
         console.warn(`${LOG} applyEvent: convoy_started missing convoy_id`);
-        return;
+        return [];
       }
       query(
         sql,
@@ -305,15 +318,15 @@ export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
         `,
         [convoyId]
       );
-      return;
+      return [];
     }
 
     case 'container_status': {
-      if (!event.agent_id) return;
+      if (!event.agent_id) return [];
 
       const containerStatus = payload.status as string;
       const agent = agents.getAgent(sql, event.agent_id);
-      if (!agent) return;
+      if (!agent) return [];
 
       // Only act on working/stalled agents whose container has stopped.
       // For 'not_found': skip if the agent was dispatched recently (#1358).
@@ -324,7 +337,7 @@ export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
       // agents are caught by reconcileAgents after 90s of no heartbeats.
       if (containerStatus === 'not_found' && agent.last_activity_at) {
         const ageSec = (Date.now() - new Date(agent.last_activity_at).getTime()) / 1000;
-        if (ageSec < 180) return; // 3-minute grace for cold starts
+        if (ageSec < 180) return []; // 3-minute grace for cold starts
       }
 
       if (
@@ -354,34 +367,34 @@ export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
           agents.updateAgentStatus(sql, event.agent_id, 'idle');
         }
       }
-      return;
+      return [];
     }
 
     case 'container_eviction': {
       // Draining flag is managed by the TownDO via KV storage.
       // The reconciler reads it from there; no SQL state change needed here.
       // The event is recorded for audit trail.
-      return;
+      return [];
     }
 
     case 'nudge_timeout': {
       // GUPP violations are handled by reconcileGUPP on the next pass.
       // The event just records the fact for audit trail.
-      return;
+      return [];
     }
 
     case 'pr_feedback_detected': {
       const mrBeadId = typeof payload.mr_bead_id === 'string' ? payload.mr_bead_id : null;
       if (!mrBeadId) {
         console.warn(`${LOG} applyEvent: pr_feedback_detected missing mr_bead_id`);
-        return;
+        return [];
       }
 
       const mrBead = beadOps.getBead(sql, mrBeadId);
-      if (!mrBead || mrBead.status === 'closed' || mrBead.status === 'failed') return;
+      if (!mrBead || mrBead.status === 'closed' || mrBead.status === 'failed') return [];
 
       // Check for existing non-terminal feedback bead to prevent duplicates
-      if (hasExistingPrFeedbackBead(sql, mrBeadId)) return;
+      if (hasExistingPrFeedbackBead(sql, mrBeadId)) return [];
 
       const prUrl = typeof payload.pr_url === 'string' ? payload.pr_url : '';
       const prNumber = typeof payload.pr_number === 'number' ? payload.pr_number : 0;
@@ -420,18 +433,18 @@ export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
 
       // Feedback bead blocks the MR bead (same pattern as rework beads)
       beadOps.insertDependency(sql, mrBeadId, feedbackBead.bead_id, 'blocks');
-      return;
+      return [];
     }
 
     case 'pr_auto_merge': {
       const mrBeadId = typeof payload.mr_bead_id === 'string' ? payload.mr_bead_id : null;
       if (!mrBeadId) {
         console.warn(`${LOG} applyEvent: pr_auto_merge missing mr_bead_id`);
-        return;
+        return [];
       }
 
       const mrBead = beadOps.getBead(sql, mrBeadId);
-      if (!mrBead || mrBead.status === 'closed' || mrBead.status === 'failed') return;
+      if (!mrBead || mrBead.status === 'closed' || mrBead.status === 'failed') return [];
 
       // The actual merge is handled by the merge_pr side effect generated by
       // the reconciler on the next tick when it sees this event has been processed.
@@ -446,11 +459,12 @@ export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
         `,
         [new Date().toISOString(), mrBeadId]
       );
-      return;
+      return [];
     }
 
     default: {
       console.warn(`${LOG} applyEvent: unknown event type: ${event.event_type}`);
+      return [];
     }
   }
 }


### PR DESCRIPTION
## Summary

When a bead is cancelled while an agent is in `working` or `waiting` state, the agent container was not stopped immediately — it lingered until the 90-second heartbeat timeout triggered cleanup. This change makes `applyEvent()` return `Action[]` instead of `void`, enabling the `bead_cancelled` handler to emit `stop_agent` actions for agents that were actively running. All three callers in `Town.do.ts` (alarm loop, debug replay, dry-run) are updated to collect and process these event-emitted actions through the existing `applyAction` pipeline.

## Verification

- [x] Typecheck passes (`tsgo --noEmit` — 0 errors)
- [x] Format check passes (`oxfmt --list-different` — 0 warnings, 0 errors)
- [x] Lint passes (0 warnings, 0 errors)
- [x] Code review: return type change is mechanical across all non-`bead_cancelled` branches (all return `[]`), status check correctly uses pre-unhook query snapshot, double-stop is harmless due to try-catch in `stop_agent` handler

## Visual Changes

N/A

## Reviewer Notes

- The `bead_cancelled` handler queries `agent_metadata.status` before calling `unhookBead()` (which sets status to `idle`), so the working/waiting check reflects the agent's actual pre-cancellation state.
- If the reconciler's next `reconcile()` pass also emits a `stop_agent` for the same agent, it is harmless — the `stop_agent` handler in `actions.ts:574` wraps the call in a try-catch.
- Debug replay and dry-run endpoints concatenate event actions into their reported actions array without executing them, which is correct for read-only/rollback contexts.