### PR TITLE
feat(kiloclaw): add bot identity onboarding

### DIFF
--- a/apps/storybook/stories/claw/BotIdentityStep.stories.tsx
+++ b/apps/storybook/stories/claw/BotIdentityStep.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { BotIdentityStep } from '@/app/(app)/claw/components/BotIdentityStep';
+
+const meta: Meta<typeof BotIdentityStep> = {
+  title: 'Claw/BotIdentityStep',
+  component: BotIdentityStep,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div className="mx-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    instanceRunning: true,
+  },
+};
+
+export const WithProvisioningBanner: Story = {
+  args: {
+    instanceRunning: false,
+  },
+};

--- a/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
@@ -4,10 +4,64 @@ import { useState } from 'react';
 import { ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { OnboardingStepView } from './OnboardingStepView';
 import type { BotIdentity } from './claw.types';
-import { DEFAULT_BOT_IDENTITY } from './claw.types';
+import { cn } from '@/lib/utils';
+
+const NAME_SUGGESTIONS = ['Aria', 'Echo', 'Nova', 'Rex', 'Sage', 'Iris', 'Orion', 'Pixel'];
+
+const EMOJI_OPTIONS = [
+  '🤖',
+  '🐱',
+  '🐙',
+  '🦁',
+  '⚡',
+  '🌙',
+  '🍥',
+  '🔥',
+  '🦄',
+  '🧠',
+  '🐉',
+  '✨',
+  '🌊',
+  '🎪',
+  '🦋',
+  '💎',
+];
+
+type NaturePreset = {
+  id: string;
+  emoji: string;
+  label: string;
+  vibe: string;
+};
+
+const NATURE_PRESETS: NaturePreset[] = [
+  {
+    id: 'ai-assistant',
+    emoji: '🤖',
+    label: 'AI assistant',
+    vibe: 'Helpful, capable, professional',
+  },
+  {
+    id: 'digital-creature',
+    emoji: '🐙',
+    label: 'Digital creature',
+    vibe: 'Quirky, alive, a bit unpredictable',
+  },
+  {
+    id: 'virtual-companion',
+    emoji: '🌙',
+    label: 'Virtual companion',
+    vibe: 'Warm, present, genuinely cares',
+  },
+  {
+    id: 'something-weirder',
+    emoji: '🌀',
+    label: 'Something weirder...',
+    vibe: 'Define it yourself',
+  },
+];
 
 export function BotIdentityStep({
   instanceRunning,
@@ -16,80 +70,137 @@ export function BotIdentityStep({
   instanceRunning: boolean;
   onContinue: (identity: BotIdentity) => void;
 }) {
-  const [identity, setIdentity] = useState<BotIdentity>(DEFAULT_BOT_IDENTITY);
+  const [botName, setBotName] = useState('');
+  const [selectedEmoji, setSelectedEmoji] = useState('🤖');
+  const [customEmoji, setCustomEmoji] = useState('');
+  const [selectedNatureId, setSelectedNatureId] = useState('ai-assistant');
 
-  function updateField<K extends keyof BotIdentity>(key: K, value: BotIdentity[K]) {
-    setIdentity(current => ({ ...current, [key]: value }));
+  const activeEmoji = customEmoji || selectedEmoji;
+  const nature = NATURE_PRESETS.find(n => n.id === selectedNatureId) ?? NATURE_PRESETS[0];
+
+  function handleContinue() {
+    onContinue({
+      botName: botName.trim() || 'KiloClaw',
+      botEmoji: activeEmoji,
+      botNature: nature.label,
+      botVibe: nature.vibe,
+    });
   }
 
   return (
     <OnboardingStepView
       currentStep={2}
       totalSteps={5}
-      title="Shape your bot's identity"
-      description="Give your assistant a name and personality so it shows up consistently across channels and in its workspace docs."
+      title="Give your bot an identity"
+      description="Make it yours. You can always change this later."
       showProvisioningBanner={!instanceRunning}
-      contentClassName="gap-5"
+      contentClassName="gap-6"
     >
-      <div className="grid gap-5 md:grid-cols-2">
-        <div className="space-y-2 md:col-span-2">
-          <Label htmlFor="bot-name">Bot name</Label>
-          <Input
-            id="bot-name"
-            value={identity.botName}
-            onChange={event => updateField('botName', event.target.value)}
-            maxLength={80}
-            placeholder="KiloClaw"
-          />
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="bot-nature">Nature</Label>
-          <Input
-            id="bot-nature"
-            value={identity.botNature}
-            onChange={event => updateField('botNature', event.target.value)}
-            maxLength={120}
-            placeholder="AI executive assistant"
-          />
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="bot-emoji">Emoji</Label>
-          <Input
-            id="bot-emoji"
-            value={identity.botEmoji}
-            onChange={event => updateField('botEmoji', event.target.value)}
-            maxLength={16}
-            placeholder="🦾"
-          />
-        </div>
-
-        <div className="space-y-2 md:col-span-2">
-          <Label htmlFor="bot-vibe">Vibe</Label>
-          <Input
-            id="bot-vibe"
-            value={identity.botVibe}
-            onChange={event => updateField('botVibe', event.target.value)}
-            maxLength={120}
-            placeholder="Helpful, calm, and proactive"
-          />
+      {/* Name */}
+      <div className="space-y-3">
+        <h3 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+          What should we call it?
+        </h3>
+        <Input
+          value={botName}
+          onChange={e => setBotName(e.target.value)}
+          maxLength={80}
+          placeholder="e.g. Aria, Sage, Nova..."
+        />
+        <div className="flex flex-wrap gap-2">
+          {NAME_SUGGESTIONS.map(name => (
+            <button
+              key={name}
+              type="button"
+              className={cn(
+                'rounded-full border px-3 py-1 text-sm transition-colors',
+                botName === name
+                  ? 'border-blue-500 bg-blue-500/10 text-blue-400'
+                  : 'border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+              )}
+              onClick={() => setBotName(name)}
+            >
+              {name}
+            </button>
+          ))}
         </div>
       </div>
 
-      <div className="border-border bg-muted/30 rounded-lg border p-4 text-sm">
-        <p className="text-foreground font-medium">
-          {identity.botEmoji || '🤖'} {identity.botName || 'Your bot'}
-        </p>
-        <p className="text-muted-foreground mt-1">
-          {identity.botNature || 'AI assistant'} · {identity.botVibe || 'Ready to help'}
-        </p>
+      {/* Emoji picker */}
+      <div className="space-y-3">
+        <h3 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+          Pick a signature emoji
+        </h3>
+        <div className="grid grid-cols-8 gap-2">
+          {EMOJI_OPTIONS.map(emoji => (
+            <button
+              key={emoji}
+              type="button"
+              className={cn(
+                'flex h-12 items-center justify-center rounded-lg border text-xl transition-colors',
+                selectedEmoji === emoji && !customEmoji
+                  ? 'border-blue-500 bg-blue-500/10'
+                  : 'border-border hover:border-foreground/30 hover:bg-muted/50'
+              )}
+              onClick={() => {
+                setSelectedEmoji(emoji);
+                setCustomEmoji('');
+              }}
+            >
+              {emoji}
+            </button>
+          ))}
+        </div>
+        <Input
+          value={customEmoji}
+          onChange={e => {
+            setCustomEmoji(e.target.value);
+          }}
+          maxLength={16}
+          placeholder="or type your own..."
+        />
+      </div>
+
+      {/* Nature */}
+      <div className="space-y-3">
+        <h3 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+          What kind of creature is it?
+        </h3>
+        <div className="grid gap-3 md:grid-cols-2">
+          {NATURE_PRESETS.map(preset => (
+            <button
+              key={preset.id}
+              type="button"
+              className={cn(
+                'flex items-center gap-3 rounded-lg border p-4 text-left transition-colors',
+                selectedNatureId === preset.id
+                  ? 'border-blue-500 bg-blue-500/10'
+                  : 'border-border hover:border-foreground/30 hover:bg-muted/50'
+              )}
+              onClick={() => setSelectedNatureId(preset.id)}
+            >
+              <span className="text-2xl">{preset.emoji}</span>
+              <div>
+                <p className="text-foreground font-medium">{preset.label}</p>
+                <p className="text-muted-foreground text-sm">{preset.vibe}</p>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Preview */}
+      <div className="border-border bg-muted/30 flex items-center gap-3 rounded-lg border p-4">
+        <span className="text-2xl">{activeEmoji}</span>
+        <div>
+          <p className="text-foreground font-medium">{botName || 'Your bot'}</p>
+          <p className="text-muted-foreground text-sm">{nature.label}</p>
+        </div>
       </div>
 
       <Button
         className="w-full bg-emerald-600 py-6 text-base text-white hover:bg-emerald-700"
-        onClick={() => onContinue(identity)}
-        disabled={Object.values(identity).some(value => value.trim().length === 0)}
+        onClick={handleContinue}
       >
         Continue
         <ChevronRight className="ml-1 h-5 w-5" />

--- a/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { OnboardingStepView } from './OnboardingStepView';
+import type { BotIdentity } from './claw.types';
+import { DEFAULT_BOT_IDENTITY } from './claw.types';
+
+export function BotIdentityStep({
+  instanceRunning,
+  onContinue,
+}: {
+  instanceRunning: boolean;
+  onContinue: (identity: BotIdentity) => void;
+}) {
+  const [identity, setIdentity] = useState<BotIdentity>(DEFAULT_BOT_IDENTITY);
+
+  function updateField<K extends keyof BotIdentity>(key: K, value: BotIdentity[K]) {
+    setIdentity(current => ({ ...current, [key]: value }));
+  }
+
+  return (
+    <OnboardingStepView
+      currentStep={2}
+      totalSteps={5}
+      title="Shape your bot's identity"
+      description="Give your assistant a name and personality so it shows up consistently across channels and in its workspace docs."
+      showProvisioningBanner={!instanceRunning}
+      contentClassName="gap-5"
+    >
+      <div className="grid gap-5 md:grid-cols-2">
+        <div className="space-y-2 md:col-span-2">
+          <Label htmlFor="bot-name">Bot name</Label>
+          <Input
+            id="bot-name"
+            value={identity.botName}
+            onChange={event => updateField('botName', event.target.value)}
+            maxLength={80}
+            placeholder="KiloClaw"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="bot-nature">Nature</Label>
+          <Input
+            id="bot-nature"
+            value={identity.botNature}
+            onChange={event => updateField('botNature', event.target.value)}
+            maxLength={120}
+            placeholder="AI executive assistant"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="bot-emoji">Emoji</Label>
+          <Input
+            id="bot-emoji"
+            value={identity.botEmoji}
+            onChange={event => updateField('botEmoji', event.target.value)}
+            maxLength={16}
+            placeholder="🦾"
+          />
+        </div>
+
+        <div className="space-y-2 md:col-span-2">
+          <Label htmlFor="bot-vibe">Vibe</Label>
+          <Input
+            id="bot-vibe"
+            value={identity.botVibe}
+            onChange={event => updateField('botVibe', event.target.value)}
+            maxLength={120}
+            placeholder="Helpful, calm, and proactive"
+          />
+        </div>
+      </div>
+
+      <div className="border-border bg-muted/30 rounded-lg border p-4 text-sm">
+        <p className="text-foreground font-medium">
+          {identity.botEmoji || '🤖'} {identity.botName || 'Your bot'}
+        </p>
+        <p className="text-muted-foreground mt-1">
+          {identity.botNature || 'AI assistant'} · {identity.botVibe || 'Ready to help'}
+        </p>
+      </div>
+
+      <Button
+        className="w-full bg-emerald-600 py-6 text-base text-white hover:bg-emerald-700"
+        onClick={() => onContinue(identity)}
+        disabled={Object.values(identity).some(value => value.trim().length === 0)}
+      >
+        Continue
+        <ChevronRight className="ml-1 h-5 w-5" />
+      </Button>
+    </OnboardingStepView>
+  );
+}

--- a/apps/web/src/app/(app)/claw/components/ChannelPairingStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/ChannelPairingStep.tsx
@@ -125,8 +125,8 @@ export function ChannelPairingStepView({
   if (matchingRequest) {
     return (
       <OnboardingStepView
-        currentStep={5}
-        totalSteps={5}
+        currentStep={6}
+        totalSteps={6}
         title={`Pair your ${meta.label} bot`}
         description={meta.instruction}
         contentClassName="gap-6"
@@ -186,8 +186,8 @@ export function ChannelPairingStepView({
 
   return (
     <OnboardingStepView
-      currentStep={5}
-      totalSteps={5}
+      currentStep={6}
+      totalSteps={6}
       title={`Pair your ${meta.label} bot`}
       description={meta.instruction}
       contentClassName="gap-8"

--- a/apps/web/src/app/(app)/claw/components/ChannelSelectionStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/ChannelSelectionStep.tsx
@@ -140,8 +140,8 @@ export function ChannelSelectionStepView({
 
   return (
     <OnboardingStepView
-      currentStep={3}
-      totalSteps={4}
+      currentStep={4}
+      totalSteps={5}
       title="Where do you want to chat?"
       description="Pick where you'd like to talk to your KiloClaw bot. You can add more channels any time from settings."
       showProvisioningBanner={instanceRunning === false}

--- a/apps/web/src/app/(app)/claw/components/ClawDashboard.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawDashboard.tsx
@@ -20,10 +20,11 @@ import { OpenClawButton } from './OpenClawButton';
 import { ChangelogTab } from './ChangelogTab';
 import { SubscriptionTab } from './SubscriptionTab';
 import { ChannelPairingStep } from './ChannelPairingStep';
+import { BotIdentityStep } from './BotIdentityStep';
 import { ChannelSelectionStepView } from './ChannelSelectionStep';
 import { PermissionStep } from './PermissionStep';
 import { ProvisioningStep } from './ProvisioningStep';
-import type { ExecPreset } from './claw.types';
+import type { BotIdentity, ExecPreset } from './claw.types';
 import { BillingWrapper } from './billing/BillingWrapper';
 
 function MaybeBillingWrapper({
@@ -140,9 +141,10 @@ function ClawDashboardInner({
   }, []);
 
   const [onboardingStep, setOnboardingStep] = useState<
-    'permissions' | 'channels' | 'provisioning' | 'pairing' | 'done'
-  >('permissions');
+    'identity' | 'permissions' | 'channels' | 'provisioning' | 'pairing' | 'done'
+  >('identity');
   const [selectedPreset, setSelectedPreset] = useState<ExecPreset | null>(null);
+  const [botIdentity, setBotIdentity] = useState<BotIdentity | null>(null);
   const [channelTokens, setChannelTokens] = useState<Record<string, string> | null>(null);
   const [selectedChannelId, setSelectedChannelId] = useState<string | null>(null);
   const hasPairingStep = selectedChannelId === 'telegram' || selectedChannelId === 'discord';
@@ -152,8 +154,9 @@ function ClawDashboardInner({
   const prevIsNewSetup = useRef(isNewSetup);
   useEffect(() => {
     if (isNewSetup && !prevIsNewSetup.current) {
-      setOnboardingStep('permissions');
+      setOnboardingStep('identity');
       setSelectedPreset(null);
+      setBotIdentity(null);
       setChannelTokens(null);
       setSelectedChannelId(null);
     }
@@ -236,6 +239,14 @@ function ClawDashboardInner({
             onProvisionStart={() => onNewSetupChange(true)}
             onProvisionFailed={() => onNewSetupChange(false)}
           />
+        ) : isNewSetup && onboardingStep === 'identity' ? (
+          <BotIdentityStep
+            instanceRunning={isRunning && gatewayStatus?.state === 'running'}
+            onContinue={identity => {
+              setBotIdentity(identity);
+              setOnboardingStep('permissions');
+            }}
+          />
         ) : isNewSetup && onboardingStep === 'permissions' ? (
           <PermissionStep
             instanceRunning={isRunning && gatewayStatus?.state === 'running'}
@@ -262,9 +273,10 @@ function ClawDashboardInner({
           <ProvisioningStep
             preset={selectedPreset}
             channelTokens={channelTokens}
+            botIdentity={botIdentity}
             instanceRunning={isRunning && gatewayStatus?.state === 'running'}
             mutations={mutations}
-            totalSteps={hasPairingStep ? 5 : 4}
+            totalSteps={hasPairingStep ? 6 : 5}
             onComplete={() => setOnboardingStep(hasPairingStep ? 'pairing' : 'done')}
           />
         ) : isNewSetup &&

--- a/apps/web/src/app/(app)/claw/components/PermissionStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/PermissionStep.tsx
@@ -13,8 +13,8 @@ export function PermissionStep({
 }) {
   return (
     <OnboardingStepView
-      currentStep={2}
-      totalSteps={4}
+      currentStep={3}
+      totalSteps={5}
       title="Set Bot Permissions"
       description="Choose how your KiloClaw bot handles actions on your behalf."
       showProvisioningBanner={!instanceRunning}

--- a/apps/web/src/app/(app)/claw/components/ProvisioningStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/ProvisioningStep.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { useClawGatewayReady } from '../hooks/useClawHooks';
 import {
+  type BotIdentity,
   type ExecPreset,
   type ClawMutations,
   execPresetToConfig,
@@ -34,13 +35,15 @@ function playChime() {
 export function ProvisioningStep({
   preset,
   channelTokens,
+  botIdentity,
   instanceRunning,
   mutations,
-  totalSteps = 4,
+  totalSteps = 5,
   onComplete,
 }: {
   preset: ExecPreset;
   channelTokens: Record<string, string> | null;
+  botIdentity: BotIdentity | null;
   instanceRunning: boolean;
   mutations: ClawMutations;
   totalSteps?: number;
@@ -60,8 +63,12 @@ export function ProvisioningStep({
   patchChannelsRef.current = mutations.patchChannels.mutate;
   const patchExecPresetRef = useRef(mutations.patchExecPreset.mutate);
   patchExecPresetRef.current = mutations.patchExecPreset.mutate;
+  const patchBotIdentityRef = useRef(mutations.patchBotIdentity.mutate);
+  patchBotIdentityRef.current = mutations.patchBotIdentity.mutate;
   const channelTokensRef = useRef(channelTokens);
   channelTokensRef.current = channelTokens;
+  const botIdentityRef = useRef(botIdentity);
+  botIdentityRef.current = botIdentity;
 
   useEffect(() => {
     if (!instanceRunning || completedRef.current) return;
@@ -91,6 +98,15 @@ export function ProvisioningStep({
     if (preset !== 'always-ask') {
       const { security, ask } = execPresetToConfig(preset);
       patchExecPresetRef.current({ security, ask });
+    }
+
+    if (botIdentityRef.current) {
+      patchBotIdentityRef.current({
+        botName: botIdentityRef.current.botName,
+        botNature: botIdentityRef.current.botNature,
+        botVibe: botIdentityRef.current.botVibe,
+        botEmoji: botIdentityRef.current.botEmoji,
+      });
     }
 
     if (Object.keys(configPatch).length === 0) {
@@ -195,10 +211,10 @@ const PROVISIONING_PHRASES = [
 ];
 
 /** Error view shown when the gateway returns a 502 during provisioning. */
-export function ProvisioningErrorView({ totalSteps = 4 }: { totalSteps?: number }) {
+export function ProvisioningErrorView({ totalSteps = 5 }: { totalSteps?: number }) {
   return (
     <OnboardingStepView
-      currentStep={4}
+      currentStep={5}
       totalSteps={totalSteps}
       stepLabel="Provisioning failed"
       contentClassName="items-center gap-8"
@@ -230,7 +246,7 @@ export function ProvisioningErrorView({ totalSteps = 4 }: { totalSteps?: number 
 }
 
 /** Pure visual shell — extracted so Storybook can render it without wiring up mutations. */
-export function ProvisioningStepView({ totalSteps = 4 }: { totalSteps?: number }) {
+export function ProvisioningStepView({ totalSteps = 5 }: { totalSteps?: number }) {
   const [phraseIndex, setPhraseIndex] = useState(() =>
     Math.floor(Math.random() * PROVISIONING_PHRASES.length)
   );
@@ -255,7 +271,7 @@ export function ProvisioningStepView({ totalSteps = 4 }: { totalSteps?: number }
   }, []);
   return (
     <OnboardingStepView
-      currentStep={4}
+      currentStep={5}
       totalSteps={totalSteps}
       stepLabel="Almost there..."
       contentClassName="items-center gap-8"

--- a/apps/web/src/app/(app)/claw/components/claw.types.ts
+++ b/apps/web/src/app/(app)/claw/components/claw.types.ts
@@ -5,6 +5,20 @@ export type ClawState = KiloClawDashboardStatus['status'];
 
 export type ExecPreset = 'always-ask' | 'never-ask';
 
+export type BotIdentity = {
+  botName: string;
+  botNature: string;
+  botVibe: string;
+  botEmoji: string;
+};
+
+export const DEFAULT_BOT_IDENTITY: BotIdentity = {
+  botName: 'KiloClaw',
+  botNature: 'AI executive assistant',
+  botVibe: 'Helpful, calm, and proactive',
+  botEmoji: '🦾',
+};
+
 export type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 
 export function execPresetToConfig(preset: ExecPreset): { security: string; ask: string } {

--- a/apps/web/src/app/(app)/claw/components/withStatusQueryBoundary.test.ts
+++ b/apps/web/src/app/(app)/claw/components/withStatusQueryBoundary.test.ts
@@ -28,6 +28,10 @@ const baseStatus: KiloClawDashboardStatus = {
   gmailNotificationsEnabled: false,
   execSecurity: null,
   execAsk: null,
+  botName: null,
+  botNature: null,
+  botVibe: null,
+  botEmoji: null,
   workerUrl: 'https://claw.kilo.ai',
   instanceId: null,
 };

--- a/apps/web/src/hooks/useKiloClaw.ts
+++ b/apps/web/src/hooks/useKiloClaw.ts
@@ -298,6 +298,9 @@ export function useKiloClawMutations() {
     patchExecPreset: useMutation(
       trpc.kiloclaw.patchExecPreset.mutationOptions({ onSuccess: invalidateStatus })
     ),
+    patchBotIdentity: useMutation(
+      trpc.kiloclaw.patchBotIdentity.mutationOptions({ onSuccess: invalidateStatus })
+    ),
     patchOpenclawConfig: useMutation(trpc.kiloclaw.patchOpenclawConfig.mutationOptions()),
     disconnectGoogle: useMutation(
       trpc.kiloclaw.disconnectGoogle.mutationOptions({ onSuccess: invalidateStatus })

--- a/apps/web/src/hooks/useOrgKiloClaw.ts
+++ b/apps/web/src/hooks/useOrgKiloClaw.ts
@@ -361,6 +361,9 @@ export function useOrgKiloClawMutations(organizationId: string) {
   const rawPatchExecPreset = useMutation(
     trpc.organizations.kiloclaw.patchExecPreset.mutationOptions({ onSuccess: invalidateStatus })
   );
+  const rawPatchBotIdentity = useMutation(
+    trpc.organizations.kiloclaw.patchBotIdentity.mutationOptions({ onSuccess: invalidateStatus })
+  );
   const rawPatchOpenclawConfig = useMutation(
     trpc.organizations.kiloclaw.patchOpenclawConfig.mutationOptions()
   );
@@ -409,6 +412,7 @@ export function useOrgKiloClawMutations(organizationId: string) {
     removeMyPin: bindVoid(rawRemoveMyPin),
     writeFile: bind(rawWriteFile),
     patchExecPreset: bind(rawPatchExecPreset),
+    patchBotIdentity: bind(rawPatchBotIdentity),
     patchOpenclawConfig: bind(rawPatchOpenclawConfig),
     disconnectGoogle: bindVoid(rawDisconnectGoogle),
     setGmailNotifications: bind(rawSetGmailNotifications),

--- a/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -9,6 +9,8 @@ import type {
   RegistryEntriesResponse,
   KiloCodeConfigPatchInput,
   KiloCodeConfigResponse,
+  BotIdentityPatchInput,
+  BotIdentityPatchResponse,
   ChannelsPatchInput,
   ChannelsPatchResponse,
   SecretsPatchInput,
@@ -272,6 +274,22 @@ export class KiloClawInternalClient {
     const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
     return this.request(
       `/api/platform/exec-preset${params}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ userId, ...patch }),
+      },
+      { userId }
+    );
+  }
+
+  async patchBotIdentity(
+    userId: string,
+    patch: BotIdentityPatchInput,
+    instanceId?: string
+  ): Promise<BotIdentityPatchResponse> {
+    const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
+    return this.request(
+      `/api/platform/bot-identity${params}`,
       {
         method: 'PATCH',
         body: JSON.stringify({ userId, ...patch }),

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -38,6 +38,20 @@ export type KiloCodeConfigResponse = {
   kilocodeDefaultModel: string | null;
 };
 
+export type BotIdentityPatchInput = {
+  botName?: string | null;
+  botNature?: string | null;
+  botVibe?: string | null;
+  botEmoji?: string | null;
+};
+
+export type BotIdentityPatchResponse = {
+  botName: string | null;
+  botNature: string | null;
+  botVibe: string | null;
+  botEmoji: string | null;
+};
+
 /** Input to PATCH /api/platform/channels */
 export type ChannelsPatchInput = {
   channels: {
@@ -155,6 +169,10 @@ export type PlatformStatusResponse = {
   gmailNotificationsEnabled: boolean;
   execSecurity: string | null;
   execAsk: string | null;
+  botName: string | null;
+  botNature: string | null;
+  botVibe: string | null;
+  botEmoji: string | null;
 };
 
 /** A single registry DO's entries + migration status. */

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -317,6 +317,13 @@ const patchChannelsSchema = z.object({
   slackAppToken: z.string().nullable().optional(),
 });
 
+const patchBotIdentitySchema = z.object({
+  botName: z.string().trim().min(1).max(80).nullable().optional(),
+  botNature: z.string().trim().min(1).max(120).nullable().optional(),
+  botVibe: z.string().trim().min(1).max(120).nullable().optional(),
+  botEmoji: z.string().trim().min(1).max(16).nullable().optional(),
+});
+
 /**
  * Build the worker provision payload from plaintext channel tokens.
  * The worker expects the flat encrypted envelope shape for channels.
@@ -1586,6 +1593,14 @@ export const kiloclawRouter = createTRPCRouter({
       const instance = await getActiveInstance(ctx.user.id);
       const client = new KiloClawInternalClient();
       return client.patchExecPreset(ctx.user.id, input, workerInstanceId(instance));
+    }),
+
+  patchBotIdentity: clawAccessProcedure
+    .input(patchBotIdentitySchema)
+    .mutation(async ({ ctx, input }) => {
+      const instance = await getActiveInstance(ctx.user.id);
+      const client = new KiloClawInternalClient();
+      return client.patchBotIdentity(ctx.user.id, input, workerInstanceId(instance));
     }),
 
   /**

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -156,6 +156,14 @@ const patchChannelsSchema = z.object({
   slackAppToken: z.string().nullable().optional(),
 });
 
+const patchBotIdentitySchema = z.object({
+  organizationId: z.uuid(),
+  botName: z.string().trim().min(1).max(80).nullable().optional(),
+  botNature: z.string().trim().min(1).max(120).nullable().optional(),
+  botVibe: z.string().trim().min(1).max(120).nullable().optional(),
+  botEmoji: z.string().trim().min(1).max(16).nullable().optional(),
+});
+
 // ── Helpers ────────────────────────────────────────────────────────
 
 function buildWorkerChannels(channels: z.infer<typeof updateConfigSchema>['channels']) {
@@ -268,6 +276,10 @@ export const organizationKiloclawRouter = createTRPCRouter({
         gmailNotificationsEnabled: false,
         execSecurity: null,
         execAsk: null,
+        botName: null,
+        botNature: null,
+        botVibe: null,
+        botEmoji: null,
         workerUrl,
         name: null,
         instanceId: null,
@@ -511,6 +523,14 @@ export const organizationKiloclawRouter = createTRPCRouter({
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
       const client = new KiloClawInternalClient();
       return client.patchExecPreset(ctx.user.id, input, workerInstanceId(instance));
+    }),
+
+  patchBotIdentity: organizationMemberMutationProcedure
+    .input(patchBotIdentitySchema)
+    .mutation(async ({ ctx, input }) => {
+      const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
+      const client = new KiloClawInternalClient();
+      return client.patchBotIdentity(ctx.user.id, input, workerInstanceId(instance));
     }),
 
   patchSecrets: organizationMemberMutationProcedure

--- a/services/kiloclaw/.dev.vars.example
+++ b/services/kiloclaw/.dev.vars.example
@@ -45,7 +45,7 @@ BACKEND_API_URL=http://localhost:3000
 
 # Fly.io Machines API
 # Token is auto-created/refreshed by the dev-start script.
-# @exec fly auth token
+# @exec fly tokens create org kilo-dev
 FLY_API_TOKEN=
 # Fly org slug. The dev-start script reads this value for token creation.
 # Use "kilo-dev" for Kilo team members, or "personal" for your own Fly account.

--- a/services/kiloclaw/.dev.vars.example
+++ b/services/kiloclaw/.dev.vars.example
@@ -45,7 +45,7 @@ BACKEND_API_URL=http://localhost:3000
 
 # Fly.io Machines API
 # Token is auto-created/refreshed by the dev-start script.
-# @exec fly tokens create org kilo-dev
+# @exec fly auth token
 FLY_API_TOKEN=
 # Fly org slug. The dev-start script reads this value for token creation.
 # Use "kilo-dev" for Kilo team members, or "personal" for your own Fly account.

--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -8,6 +8,8 @@ import {
   configureGitHub,
   configureLinear,
   runOnboardOrDoctor,
+  formatBotIdentityMarkdown,
+  writeBotIdentityFile,
   updateToolsMdSection,
   GOG_SECTION_CONFIG,
   KILO_CLI_SECTION_CONFIG,
@@ -554,6 +556,39 @@ describe('configureLinear', () => {
   });
 });
 
+// ---- bot identity file ----
+
+describe('formatBotIdentityMarkdown', () => {
+  it('renders the bot identity markdown with defaults', () => {
+    const result = formatBotIdentityMarkdown({});
+
+    expect(result).toContain('# IDENTITY');
+    expect(result).toContain('- Name: KiloClaw');
+    expect(result).toContain('- Nature: AI executive assistant');
+  });
+});
+
+describe('writeBotIdentityFile', () => {
+  it('writes workspace/IDENTITY.md and removes legacy files when present', () => {
+    const harness = fakeDeps();
+    (harness.deps.existsSync as ReturnType<typeof vi.fn>).mockImplementation(
+      (p: string) => p === '/root/.openclaw/workspace/BOOTSTRAP.md'
+    );
+
+    writeBotIdentityFile(
+      { KILOCLAW_BOT_NAME: 'Milo', KILOCLAW_BOT_NATURE: 'Operator' },
+      harness.deps
+    );
+
+    expect(
+      harness.renameCalls.some(call => call.to === '/root/.openclaw/workspace/IDENTITY.md')
+    ).toBe(true);
+    expect((harness.deps.unlinkSync as ReturnType<typeof vi.fn>).mock.calls).toEqual([
+      ['/root/.openclaw/workspace/BOOTSTRAP.md'],
+    ]);
+  });
+});
+
 // ---- runOnboardOrDoctor ----
 
 describe('runOnboardOrDoctor', () => {
@@ -605,6 +640,7 @@ describe('runOnboardOrDoctor', () => {
 
     const toolsCopy = harness.copyCalls.find(c => c.dest.endsWith('TOOLS.md'));
     expect(toolsCopy).toBeDefined();
+    expect(harness.renameCalls.some(call => call.to.endsWith('/workspace/IDENTITY.md'))).toBe(true);
   });
 
   it('runs doctor when config exists', () => {
@@ -633,6 +669,7 @@ describe('runOnboardOrDoctor', () => {
     expect(doctorCall?.args).toContain('--fix');
     expect(doctorCall?.args).toContain('--non-interactive');
     expect(env.KILOCLAW_FRESH_INSTALL).toBe('false');
+    expect(harness.renameCalls.some(call => call.to.endsWith('/workspace/IDENTITY.md'))).toBe(true);
   });
 });
 

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -23,6 +23,8 @@ const WORKSPACE_DIR = '/root/clawd';
 const COMPILE_CACHE_DIR = '/var/tmp/openclaw-compile-cache';
 const TOOLS_MD_SOURCE = '/usr/local/share/kiloclaw/TOOLS.md';
 const TOOLS_MD_DEST = '/root/.openclaw/workspace/TOOLS.md';
+const IDENTITY_MD_DEST = '/root/.openclaw/workspace/IDENTITY.md';
+const LEGACY_BOT_IDENTITY_DESTS = ['/root/.openclaw/workspace/BOOTSTRAP.md'];
 
 const ENC_PREFIX = 'KILOCLAW_ENC_';
 const VALUE_PREFIX = 'enc:v1:';
@@ -261,6 +263,45 @@ export function generateHooksToken(env: EnvLike): void {
   }
 }
 
+export function formatBotIdentityMarkdown(env: EnvLike): string {
+  const lines = [
+    '# IDENTITY',
+    '',
+    `- Name: ${env.KILOCLAW_BOT_NAME ?? 'KiloClaw'}`,
+    `- Nature: ${env.KILOCLAW_BOT_NATURE ?? 'AI executive assistant'}`,
+    `- Vibe: ${env.KILOCLAW_BOT_VIBE ?? 'Helpful, calm, and proactive'}`,
+    `- Emoji: ${env.KILOCLAW_BOT_EMOJI ?? '🦾'}`,
+    '',
+    'Use this file as the canonical identity and tone reference for the bot.',
+    '',
+  ];
+  return lines.join('\n');
+}
+
+export function writeBotIdentityFile(
+  env: EnvLike,
+  deps: Pick<
+    BootstrapDeps,
+    'mkdirSync' | 'writeFileSync' | 'renameSync' | 'unlinkSync' | 'existsSync'
+  > = defaultDeps
+): void {
+  deps.mkdirSync(path.dirname(IDENTITY_MD_DEST), { recursive: true });
+  atomicWrite(IDENTITY_MD_DEST, formatBotIdentityMarkdown(env), {
+    writeFileSync: deps.writeFileSync,
+    renameSync: deps.renameSync,
+    unlinkSync: deps.unlinkSync,
+  });
+
+  for (const legacyPath of LEGACY_BOT_IDENTITY_DESTS) {
+    if (!deps.existsSync(legacyPath)) continue;
+    try {
+      deps.unlinkSync(legacyPath);
+    } catch (error) {
+      console.warn(`[controller] Failed to remove legacy bot identity file ${legacyPath}:`, error);
+    }
+  }
+}
+
 // ---- Step 5: GitHub config ----
 
 /**
@@ -406,6 +447,8 @@ export function runOnboardOrDoctor(env: EnvLike, deps: BootstrapDeps = defaultDe
 
     env.KILOCLAW_FRESH_INSTALL = 'false';
   }
+
+  writeBotIdentityFile(env, deps);
 }
 
 // ---- TOOLS.md bounded-section helper ----

--- a/services/kiloclaw/controller/src/routes/files.test.ts
+++ b/services/kiloclaw/controller/src/routes/files.test.ts
@@ -9,6 +9,8 @@ vi.mock('node:fs', () => ({
     existsSync: vi.fn(),
     lstatSync: vi.fn(),
     statSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    unlinkSync: vi.fn(),
     realpathSync: vi.fn((p: string) => p), // identity by default (no symlinks)
   },
 }));
@@ -61,6 +63,39 @@ describe('file routes', () => {
         headers: { Authorization: 'Bearer wrong-token' },
       });
       expect(res.status).toBe(401);
+    });
+
+    it('protects the bot identity route', async () => {
+      const res = await app.request('/_kilo/bot-identity', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer wrong-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ botName: 'Milo' }),
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /_kilo/bot-identity', () => {
+    it('writes workspace/IDENTITY.md', async () => {
+      vi.mocked(fs.existsSync).mockImplementation(
+        (path: any) => typeof path === 'string' && path.endsWith('BOOTSTRAP.md')
+      );
+
+      const res = await app.request('/_kilo/bot-identity', {
+        method: 'POST',
+        headers: authHeaders(),
+        body: JSON.stringify({ botName: 'Milo', botNature: 'Operator' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(atomicWrite).toHaveBeenCalledWith(
+        `${ROOT}/workspace/IDENTITY.md`,
+        expect.stringContaining('- Name: Milo')
+      );
+
+      const body = (await res.json()) as any;
+      expect(body.path).toBe('workspace/IDENTITY.md');
+      expect(vi.mocked(fs.unlinkSync)).toHaveBeenCalledWith(`${ROOT}/workspace/BOOTSTRAP.md`);
     });
   });
 

--- a/services/kiloclaw/controller/src/routes/files.ts
+++ b/services/kiloclaw/controller/src/routes/files.ts
@@ -8,6 +8,7 @@ import { timingSafeTokenEqual } from '../auth';
 import { resolveSafePath, verifyCanonicalized, SafePathError } from '../safe-path';
 import { atomicWrite } from '../atomic-write';
 import { backupFile } from '../backup-file';
+import { formatBotIdentityMarkdown } from '../bootstrap';
 
 function computeEtag(content: string): string {
   return crypto.createHash('md5').update(content).digest('hex');
@@ -100,6 +101,16 @@ function resolveAndValidateFile(
   return resolved;
 }
 
+const BotIdentityBodySchema = z.object({
+  botName: z.string().trim().min(1).max(80).nullable().optional(),
+  botNature: z.string().trim().min(1).max(120).nullable().optional(),
+  botVibe: z.string().trim().min(1).max(120).nullable().optional(),
+  botEmoji: z.string().trim().min(1).max(16).nullable().optional(),
+});
+
+const BOT_IDENTITY_RELATIVE_PATH = 'workspace/IDENTITY.md';
+const LEGACY_BOT_IDENTITY_RELATIVE_PATHS = ['workspace/BOOTSTRAP.md'];
+
 export function registerFileRoutes(app: Hono, expectedToken: string, rootDir: string): void {
   app.use('/_kilo/files/*', async (c, next) => {
     const token = getBearerToken(c.req.header('authorization'));
@@ -107,6 +118,68 @@ export function registerFileRoutes(app: Hono, expectedToken: string, rootDir: st
       return c.json({ error: 'Unauthorized' }, 401);
     }
     await next();
+  });
+
+  app.use('/_kilo/bot-identity', async (c, next) => {
+    const token = getBearerToken(c.req.header('authorization'));
+    if (!timingSafeTokenEqual(token, expectedToken)) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+    await next();
+  });
+
+  app.post('/_kilo/bot-identity', async c => {
+    let rawBody: unknown;
+    try {
+      rawBody = await c.req.json();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+
+    const parsed = BotIdentityBodySchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return c.json({ error: 'Missing or invalid bot identity fields' }, 400);
+    }
+
+    let targetPath: string;
+    try {
+      targetPath = resolveSafePath(BOT_IDENTITY_RELATIVE_PATH, rootDir);
+    } catch (err) {
+      if (err instanceof SafePathError) {
+        return c.json({ error: err.message }, 400);
+      }
+      throw err;
+    }
+
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+
+    try {
+      atomicWrite(
+        targetPath,
+        formatBotIdentityMarkdown({
+          KILOCLAW_BOT_NAME: parsed.data.botName ?? undefined,
+          KILOCLAW_BOT_NATURE: parsed.data.botNature ?? undefined,
+          KILOCLAW_BOT_VIBE: parsed.data.botVibe ?? undefined,
+          KILOCLAW_BOT_EMOJI: parsed.data.botEmoji ?? undefined,
+        })
+      );
+
+      for (const legacyPath of LEGACY_BOT_IDENTITY_RELATIVE_PATHS) {
+        try {
+          const resolvedLegacyPath = resolveSafePath(legacyPath, rootDir);
+          if (fs.existsSync(resolvedLegacyPath)) {
+            fs.unlinkSync(resolvedLegacyPath);
+          }
+        } catch (error) {
+          console.warn('[files] Failed to remove legacy bot identity file:', legacyPath, error);
+        }
+      }
+
+      return c.json({ ok: true, path: BOT_IDENTITY_RELATIVE_PATH });
+    } catch (err) {
+      console.error('[files] Failed to write bot identity:', err);
+      return c.json({ error: 'Failed to write bot identity' }, 500);
+    }
   });
 
   app.get('/_kilo/files/tree', c => {

--- a/services/kiloclaw/controller/src/safe-path.test.ts
+++ b/services/kiloclaw/controller/src/safe-path.test.ts
@@ -28,6 +28,12 @@ describe('resolveSafePath', () => {
     expect(() => resolveSafePath('workspace/SOUL\0.md', ROOT)).toThrow();
   });
 
+  it('resolves the legacy bootstrap path in workspace', () => {
+    expect(resolveSafePath('workspace/BOOTSTRAP.md', ROOT)).toBe(
+      '/root/.openclaw/workspace/BOOTSTRAP.md'
+    );
+  });
+
   it('allows credentials directory', () => {
     expect(resolveSafePath('credentials/key.json', ROOT)).toBe(
       '/root/.openclaw/credentials/key.json'

--- a/services/kiloclaw/src/durable-objects/gateway-controller-types.ts
+++ b/services/kiloclaw/src/durable-objects/gateway-controller-types.ts
@@ -32,6 +32,11 @@ export const GatewayCommandResponseSchema = z.object({
   ok: z.boolean(),
 });
 
+export const BotIdentityResponseSchema = z.object({
+  ok: z.boolean(),
+  path: z.string(),
+});
+
 export const ConfigRestoreResponseSchema = z.object({
   ok: z.boolean(),
   signaled: z.boolean(),

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -6596,6 +6596,65 @@ describe('updateExecPreset', () => {
   });
 });
 
+describe('updateBotIdentity', () => {
+  it('persists bot identity fields to DO storage', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage);
+
+    const result = await instance.updateBotIdentity({
+      botName: 'Milo',
+      botNature: 'Operations copilot',
+      botVibe: 'Dry wit',
+      botEmoji: '🤖',
+    });
+
+    expect(result).toEqual({
+      botName: 'Milo',
+      botNature: 'Operations copilot',
+      botVibe: 'Dry wit',
+      botEmoji: '🤖',
+    });
+    expect(storage._store.get('botName')).toBe('Milo');
+    expect(storage._store.get('botNature')).toBe('Operations copilot');
+    expect(storage._store.get('botVibe')).toBe('Dry wit');
+    expect(storage._store.get('botEmoji')).toBe('🤖');
+  });
+
+  it('writes IDENTITY.md on running instances', async () => {
+    const env = createFakeEnv();
+    env.FLY_APP_NAME = 'bot-app';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, path: 'workspace/IDENTITY.md' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { instance, storage } = createInstance(undefined, env);
+    await seedProvisioned(storage, {
+      status: 'running',
+      flyMachineId: 'machine-1',
+      sandboxId: 'sandbox-1',
+    });
+
+    await instance.updateBotIdentity({ botName: 'Milo' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://bot-app.fly.dev/_kilo/bot-identity',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          botName: 'Milo',
+          botNature: null,
+          botVibe: null,
+          botEmoji: null,
+        }),
+      })
+    );
+    vi.unstubAllGlobals();
+  });
+});
+
 describe('tryMarkInstanceReady', () => {
   it('returns shouldNotify: true on first call and persists the flag', async () => {
     const { instance, storage } = createInstance();

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
@@ -147,6 +147,10 @@ export async function buildUserEnvVars(
       instanceFeatures: state.instanceFeatures,
       execSecurity: state.execSecurity ?? undefined,
       execAsk: state.execAsk ?? undefined,
+      botName: state.botName ?? undefined,
+      botNature: state.botNature ?? undefined,
+      botVibe: state.botVibe ?? undefined,
+      botEmoji: state.botEmoji ?? undefined,
       orgId: state.orgId,
       customSecretMeta: state.customSecretMeta ?? undefined,
     }

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -5,6 +5,7 @@ import {
   type GatewayProcessStatus,
   GatewayProcessStatusSchema,
   GatewayCommandResponseSchema,
+  BotIdentityResponseSchema,
   ConfigRestoreResponseSchema,
   ControllerVersionResponseSchema,
   GatewayReadyResponseSchema,
@@ -186,6 +187,26 @@ export function restartGatewayProcess(
     '/_kilo/gateway/restart',
     'POST',
     GatewayCommandResponseSchema
+  );
+}
+
+export function writeBotIdentity(
+  state: InstanceMutableState,
+  env: KiloClawEnv,
+  botIdentity: {
+    botName?: string | null;
+    botNature?: string | null;
+    botVibe?: string | null;
+    botEmoji?: string | null;
+  }
+): Promise<{ ok: boolean; path: string }> {
+  return callGatewayController(
+    state,
+    env,
+    '/_kilo/bot-identity',
+    'POST',
+    BotIdentityResponseSchema,
+    botIdentity
   );
 }
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -574,6 +574,59 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     };
   }
 
+  async updateBotIdentity(patch: {
+    botName?: string | null;
+    botNature?: string | null;
+    botVibe?: string | null;
+    botEmoji?: string | null;
+  }): Promise<{
+    botName: string | null;
+    botNature: string | null;
+    botVibe: string | null;
+    botEmoji: string | null;
+  }> {
+    await this.loadState();
+
+    const pending: Partial<PersistedState> = {};
+
+    if (patch.botName !== undefined) {
+      this.s.botName = patch.botName;
+      pending.botName = patch.botName;
+    }
+    if (patch.botNature !== undefined) {
+      this.s.botNature = patch.botNature;
+      pending.botNature = patch.botNature;
+    }
+    if (patch.botVibe !== undefined) {
+      this.s.botVibe = patch.botVibe;
+      pending.botVibe = patch.botVibe;
+    }
+    if (patch.botEmoji !== undefined) {
+      this.s.botEmoji = patch.botEmoji;
+      pending.botEmoji = patch.botEmoji;
+    }
+
+    if (Object.keys(pending).length > 0) {
+      await this.ctx.storage.put(pending);
+    }
+
+    if (this.s.status === 'running' && Object.keys(pending).length > 0) {
+      await gateway.writeBotIdentity(this.s, this.env, {
+        botName: this.s.botName,
+        botNature: this.s.botNature,
+        botVibe: this.s.botVibe,
+        botEmoji: this.s.botEmoji,
+      });
+    }
+
+    return {
+      botName: this.s.botName,
+      botNature: this.s.botNature,
+      botVibe: this.s.botVibe,
+      botEmoji: this.s.botEmoji,
+    };
+  }
+
   async updateChannels(patch: {
     telegramBotToken?: EncryptedEnvelope | null;
     discordBotToken?: EncryptedEnvelope | null;
@@ -1453,6 +1506,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     gmailNotificationsEnabled: boolean;
     execSecurity: string | null;
     execAsk: string | null;
+    botName: string | null;
+    botNature: string | null;
+    botVibe: string | null;
+    botEmoji: string | null;
   }> {
     await this.loadState();
 
@@ -1492,6 +1549,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       gmailNotificationsEnabled: this.s.gmailNotificationsEnabled,
       execSecurity: this.s.execSecurity,
       execAsk: this.s.execAsk,
+      botName: this.s.botName,
+      botNature: this.s.botNature,
+      botVibe: this.s.botVibe,
+      botEmoji: this.s.botEmoji,
     };
   }
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
@@ -79,6 +79,10 @@ export async function loadState(ctx: DurableObjectState, s: InstanceMutableState
     s.gmailPushOidcEmail = d.gmailPushOidcEmail;
     s.execSecurity = d.execSecurity;
     s.execAsk = d.execAsk;
+    s.botName = d.botName;
+    s.botNature = d.botNature;
+    s.botVibe = d.botVibe;
+    s.botEmoji = d.botEmoji;
     s.previousVolumeId = d.previousVolumeId;
     s.restoreStartedAt = d.restoreStartedAt;
     s.preRestoreStatus = d.preRestoreStatus;
@@ -162,6 +166,10 @@ export function resetMutableState(s: InstanceMutableState): void {
   s.gmailPushOidcEmail = null;
   s.execSecurity = null;
   s.execAsk = null;
+  s.botName = null;
+  s.botNature = null;
+  s.botVibe = null;
+  s.botEmoji = null;
   s.previousVolumeId = null;
   s.restoreStartedAt = null;
   s.preRestoreStatus = null;
@@ -236,6 +244,10 @@ export function createMutableState(): InstanceMutableState {
     gmailPushOidcEmail: null,
     execSecurity: null,
     execAsk: null,
+    botName: null,
+    botNature: null,
+    botVibe: null,
+    botEmoji: null,
     previousVolumeId: null,
     restoreStartedAt: null,
     preRestoreStatus: null,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
@@ -95,6 +95,10 @@ export type InstanceMutableState = {
   gmailPushOidcEmail: string | null;
   execSecurity: string | null;
   execAsk: string | null;
+  botName: string | null;
+  botNature: string | null;
+  botVibe: string | null;
+  botEmoji: string | null;
   // Snapshot restore tracking
   previousVolumeId: string | null;
   restoreStartedAt: string | null;

--- a/services/kiloclaw/src/gateway/env.ts
+++ b/services/kiloclaw/src/gateway/env.ts
@@ -30,6 +30,10 @@ export type UserConfig = {
   instanceFeatures?: string[];
   execSecurity?: string | null;
   execAsk?: string | null;
+  botName?: string | null;
+  botNature?: string | null;
+  botVibe?: string | null;
+  botEmoji?: string | null;
   /** Organization ID — injected as KILOCODE_ORGANIZATION_ID for org instances. */
   orgId?: string | null;
   customSecretMeta?: Record<string, { configPath?: string }> | null;
@@ -211,6 +215,11 @@ export async function buildEnvVars(
   // User-selected exec permissions preset (non-sensitive, survives restarts).
   if (userConfig?.execSecurity) plainEnv.KILOCLAW_EXEC_SECURITY = userConfig.execSecurity;
   if (userConfig?.execAsk) plainEnv.KILOCLAW_EXEC_ASK = userConfig.execAsk;
+
+  if (userConfig?.botName) plainEnv.KILOCLAW_BOT_NAME = userConfig.botName;
+  if (userConfig?.botNature) plainEnv.KILOCLAW_BOT_NATURE = userConfig.botNature;
+  if (userConfig?.botVibe) plainEnv.KILOCLAW_BOT_VIBE = userConfig.botVibe;
+  if (userConfig?.botEmoji) plainEnv.KILOCLAW_BOT_EMOJI = userConfig.botEmoji;
 
   // Instance feature flags → env vars (non-sensitive, not user-overridable).
   // Applied after user env vars so users cannot suppress features via envVars config.

--- a/services/kiloclaw/src/routes/controller.test.ts
+++ b/services/kiloclaw/src/routes/controller.test.ts
@@ -42,6 +42,10 @@ function makeEnv(options?: {
   });
   const getStatus = vi.fn().mockResolvedValue({
     userId: 'user-1',
+    botName: 'Milo',
+    botNature: 'Operations copilot',
+    botVibe: 'Dry wit',
+    botEmoji: '🤖',
   });
   const tryMarkInstanceReady =
     options?.tryMarkInstanceReady ??

--- a/services/kiloclaw/src/routes/controller.ts
+++ b/services/kiloclaw/src/routes/controller.ts
@@ -20,10 +20,10 @@ const ProductTelemetrySchema = z.object({
   enabledChannels: z.array(z.string()),
   toolsProfile: z.string().nullable(),
   execSecurity: z.string().nullable(),
-  botName: z.string().nullable(),
-  botNature: z.string().nullable(),
-  botVibe: z.string().nullable(),
-  botEmoji: z.string().nullable(),
+  botName: z.string().nullable().optional(),
+  botNature: z.string().nullable().optional(),
+  botVibe: z.string().nullable().optional(),
+  botEmoji: z.string().nullable().optional(),
   browserEnabled: z.boolean(),
 });
 

--- a/services/kiloclaw/src/routes/controller.ts
+++ b/services/kiloclaw/src/routes/controller.ts
@@ -20,6 +20,10 @@ const ProductTelemetrySchema = z.object({
   enabledChannels: z.array(z.string()),
   toolsProfile: z.string().nullable(),
   execSecurity: z.string().nullable(),
+  botName: z.string().nullable(),
+  botNature: z.string().nullable(),
+  botVibe: z.string().nullable(),
+  botEmoji: z.string().nullable(),
   browserEnabled: z.boolean(),
 });
 

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -505,6 +505,14 @@ const ExecPresetPatchSchema = z.object({
   ask: z.string().optional(),
 });
 
+const BotIdentityPatchSchema = z.object({
+  userId: z.string().min(1),
+  botName: z.string().trim().min(1).max(80).nullable().optional(),
+  botNature: z.string().trim().min(1).max(120).nullable().optional(),
+  botVibe: z.string().trim().min(1).max(120).nullable().optional(),
+  botEmoji: z.string().trim().min(1).max(16).nullable().optional(),
+});
+
 platform.patch('/exec-preset', async c => {
   const result = await parseBody(c, ExecPresetPatchSchema);
   if ('error' in result) return result.error;
@@ -523,6 +531,28 @@ platform.patch('/exec-preset', async c => {
     return c.json(updated, 200);
   } catch (err) {
     const { message, status } = sanitizeError(err, 'exec-preset patch');
+    return jsonError(message, status);
+  }
+});
+
+platform.patch('/bot-identity', async c => {
+  const result = await parseBody(c, BotIdentityPatchSchema);
+  if ('error' in result) return result.error;
+
+  const iidResult = parseInstanceIdQuery(c);
+  if ('error' in iidResult) return iidResult.error;
+
+  const { userId, botName, botNature, botVibe, botEmoji } = result.data;
+
+  try {
+    const updated = await withDORetry(
+      instanceStubFactory(c.env, userId, iidResult.instanceId),
+      stub => stub.updateBotIdentity({ botName, botNature, botVibe, botEmoji }),
+      'updateBotIdentity'
+    );
+    return c.json(updated, 200);
+  } catch (err) {
+    const { message, status } = sanitizeError(err, 'bot-identity patch');
     return jsonError(message, status);
   }
 });

--- a/services/kiloclaw/src/schemas/instance-config.ts
+++ b/services/kiloclaw/src/schemas/instance-config.ts
@@ -239,6 +239,10 @@ export const PersistedStateSchema = z.object({
   // null = use defaults (security: 'allowlist', ask: 'on-miss').
   execSecurity: z.string().nullable().default(null),
   execAsk: z.string().nullable().default(null),
+  botName: z.string().nullable().default(null),
+  botNature: z.string().nullable().default(null),
+  botVibe: z.string().nullable().default(null),
+  botEmoji: z.string().nullable().default(null),
   // Snapshot restore: tracks the volume before the most recent restore for admin revert path.
   previousVolumeId: z.string().nullable().default(null),
   // Snapshot restore: timestamp set at enqueue time. Used by alarm for stuck-restore detection


### PR DESCRIPTION
## Summary

- Add a "bot identity" step to the KiloClaw onboarding flow, allowing users to configure their bot's name, nature, vibe, and emoji before provisioning.
- Identity data is persisted in the Instance DO, transported via env vars to the Fly machine, and written to `IDENTITY.md` (not `SOUL.md`) on disk.
- Adds the full pipeline: frontend form (`BotIdentityStep`), tRPC mutations, platform API route, DO `updateBotIdentity` method, and controller file-write endpoint.

## Verification

- [x] `pnpm typecheck` — all workspace packages pass
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format:check` — clean
- [x] `pnpm --filter kiloclaw test` — 1165 passed, 5 failed (pre-existing `/checkin` PostHog failures, unrelated)
- [x] `pnpm --filter web test -- --testPathPattern 'claw|kiloclaw'` — 228 passed, 0 failed

## Visual Changes

https://github.com/user-attachments/assets/e611ff3d-0237-44df-8d2d-4dce75708935

## Reviewer Notes

- Supersedes #1912, which was blocked by the monorepo restructure.