### PR TITLE
fix(dev): use pnpm --filter for stripe script after monorepo restructure

### DIFF
--- a/dev/local/scripts/start-stripe.ts
+++ b/dev/local/scripts/start-stripe.ts
@@ -34,7 +34,7 @@ console.log('Starting Stripe webhook listener...');
 
 let secretPattern: RegExp | null = /whsec_[a-zA-Z0-9]+/;
 
-const child = spawn('pnpm', ['run', 'stripe'], {
+const child = spawn('pnpm', ['--filter', 'web', 'run', 'stripe'], {
   stdio: ['ignore', 'pipe', 'pipe'],
   cwd: repoRoot,
 });


### PR DESCRIPTION
## Summary

After the monorepo restructure, the `stripe` npm script moved from the repo root to `apps/web`. The `start-stripe.ts` dev script was still running `pnpm run stripe` at the repo root, which no longer works. This changes the spawn call to use `pnpm --filter web run stripe` so pnpm resolves the script from the correct workspace package.

## Verification

- Confirmed `stripe` script is defined in `apps/web/package.json`
- Confirmed no `stripe` script exists in the root `package.json`
- Typecheck: N/A (runtime-only change, no type impact)

## Visual Changes

N/A

## Reviewer Notes

N/A