### PR TITLE
feat(kiloclaw): add standalone Chat page to sidebar

### DIFF
--- a/apps/web/src/app/(app)/claw/chat/page.tsx
+++ b/apps/web/src/app/(app)/claw/chat/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ClawChatPage } from '../components/ClawChatPage';
+
+export default function PersonalClawChatPage() {
+  return <ClawChatPage />;
+}

--- a/apps/web/src/app/(app)/claw/components/ClawChatPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawChatPage.tsx
@@ -5,7 +5,7 @@ import { MessageSquare } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useKiloClawStatus } from '@/hooks/useKiloClaw';
 import { useOrgKiloClawStatus } from '@/hooks/useOrgKiloClaw';
-import { ClawContextProvider, useClawContext } from './ClawContext';
+import { ClawContextProvider } from './ClawContext';
 import { ChatTab } from './ChatTab';
 import { BillingWrapper } from './billing/BillingWrapper';
 import { SetPageTitle } from '@/components/SetPageTitle';

--- a/apps/web/src/app/(app)/claw/components/ClawChatPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawChatPage.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useEffect } from 'react';
+import { MessageSquare } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useKiloClawStatus } from '@/hooks/useKiloClaw';
+import { useOrgKiloClawStatus } from '@/hooks/useOrgKiloClaw';
+import { ClawContextProvider, useClawContext } from './ClawContext';
+import { ChatTab } from './ChatTab';
+import { BillingWrapper } from './billing/BillingWrapper';
+import { SetPageTitle } from '@/components/SetPageTitle';
+import { Card, CardContent } from '@/components/ui/card';
+
+/**
+ * Wrapper that polls status and handles loading/error/no-instance states
+ * before rendering the chat content.
+ */
+function ClawChatWithStatus({ organizationId }: { organizationId?: string }) {
+  const router = useRouter();
+  const personalStatus = useKiloClawStatus();
+  const orgStatus = useOrgKiloClawStatus(organizationId ?? '');
+  const { data: status, isLoading, error } = organizationId ? orgStatus : personalStatus;
+
+  const clawUrl = organizationId ? `/organizations/${organizationId}/claw` : '/claw';
+
+  // Redirect to main KiloClaw page when there is no instance — it has the
+  // onboarding/provisioning flow that guides the user through setup.
+  const shouldRedirect = !isLoading && !error && (!status || status.status === null);
+  useEffect(() => {
+    if (shouldRedirect) {
+      router.replace(clawUrl);
+    }
+  }, [shouldRedirect, clawUrl, router]);
+
+  if (isLoading || shouldRedirect) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <p className="text-muted-foreground">Loading…</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <p className="text-destructive text-sm">
+            Failed to load status: {error instanceof Error ? error.message : 'Unknown error'}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!status || status.status === null) return null;
+
+  const isRunning = status.status === 'running';
+  const chatContent = (
+    <Card>
+      <CardContent className="p-5">
+        <ChatTab enabled={isRunning} />
+      </CardContent>
+    </Card>
+  );
+
+  // Personal context uses BillingWrapper for access-lock dialogs/banners.
+  if (!organizationId) {
+    return <BillingWrapper>{chatContent}</BillingWrapper>;
+  }
+
+  return chatContent;
+}
+
+export function ClawChatPage({ organizationId }: { organizationId?: string }) {
+  return (
+    <ClawContextProvider organizationId={organizationId}>
+      <div className="container m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
+        <SetPageTitle
+          title="Chat"
+          icon={<MessageSquare className="text-muted-foreground h-4 w-4" />}
+        />
+        <ClawChatWithStatus organizationId={organizationId} />
+      </div>
+    </ClawContextProvider>
+  );
+}

--- a/apps/web/src/app/(app)/claw/components/ClawDashboard.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawDashboard.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import dynamic from 'next/dynamic';
-import { Check, MessageSquare, Sparkles, TriangleAlert, X, Zap } from 'lucide-react';
+import { Check, Sparkles, TriangleAlert, X, Zap } from 'lucide-react';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { useKiloClawGatewayStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { useOrgKiloClawGatewayStatus, useOrgKiloClawMutations } from '@/hooks/useOrgKiloClaw';
@@ -39,16 +38,6 @@ function MaybeBillingWrapper({
   if (skip) return <>{children}</>;
   return <BillingWrapper hideBanners={hideBanners}>{children}</BillingWrapper>;
 }
-
-// Lazy-load the Chat tab so the stream-chat-react bundle (~200KB) only loads
-// when the user opens that tab, not on every /claw page visit.
-const ChatTab = dynamic(() => import('./ChatTab').then(m => ({ default: m.ChatTab })), {
-  loading: () => (
-    <div className="flex h-96 items-center justify-center text-sm text-muted-foreground">
-      Loading chat…
-    </div>
-  ),
-});
 
 type PopulatedClawStatus = KiloClawDashboardStatus & {
   status: NonNullable<KiloClawDashboardStatus['status']>;
@@ -125,7 +114,7 @@ function ClawDashboardInner({
     Date.now() - instanceStatus.provisionedAt < SEVEN_DAYS_MS;
   const configServiceNudgeVisible = !instanceStatus || instanceYoung;
 
-  const VALID_TABS = ['instance', 'chat', 'subscription', 'changelog'] as const;
+  const VALID_TABS = ['instance', 'subscription', 'changelog'] as const;
   type TabValue = (typeof VALID_TABS)[number];
 
   function tabFromHash(): TabValue {
@@ -360,10 +349,6 @@ function ClawDashboardInner({
                   <TabsTrigger value="instance" className={tabTriggerClass}>
                     Gateway Process
                   </TabsTrigger>
-                  <TabsTrigger value="chat" className={tabTriggerClass}>
-                    <MessageSquare className="mr-1.5 inline h-3.5 w-3.5" />
-                    Chat
-                  </TabsTrigger>
                   {!organizationId && (
                     <TabsTrigger value="subscription" className={tabTriggerClass}>
                       Subscription
@@ -383,10 +368,6 @@ function ClawDashboardInner({
                     gatewayError={gatewayError}
                   />
                 </TabsContent>
-                <TabsContent value="chat" className="mt-0">
-                  <ChatTab enabled={activeTab === 'chat' && isRunning} />
-                </TabsContent>
-
                 <TabsContent value="subscription" className="mt-0">
                   <SubscriptionTab />
                 </TabsContent>

--- a/apps/web/src/app/(app)/claw/components/index.ts
+++ b/apps/web/src/app/(app)/claw/components/index.ts
@@ -1,6 +1,7 @@
 export { OpenClawButton } from './OpenClawButton';
 export { ClawDashboard } from './ClawDashboard';
 export { ClawHeader } from './ClawHeader';
+export { ClawChatPage } from './ClawChatPage';
 export { ClawSettingsPage } from './ClawSettingsPage';
 export { CreateInstanceCard } from './CreateInstanceCard';
 export { DetailTile } from './DetailTile';

--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -24,6 +24,7 @@ import {
   Wrench,
   Webhook,
   Settings,
+  MessageSquare,
 } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import { useEffect, useMemo } from 'react';
@@ -133,6 +134,11 @@ export default function OrganizationAppSidebar({
       title: 'KiloClaw',
       icon: KiloCrabIcon,
       url: `/organizations/${organizationId}/claw`,
+    },
+    {
+      title: 'Chat',
+      icon: MessageSquare,
+      url: `/organizations/${organizationId}/claw/chat`,
     },
     {
       title: 'Settings',

--- a/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -25,6 +25,7 @@ import {
   Webhook,
   Factory,
   Settings,
+  MessageSquare,
 } from 'lucide-react';
 import { useMemo } from 'react';
 import HeaderLogo from '@/components/HeaderLogo';
@@ -79,6 +80,11 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
       title: 'KiloClaw',
       icon: KiloCrabIcon,
       url: '/claw',
+    },
+    {
+      title: 'Chat',
+      icon: MessageSquare,
+      url: '/claw/chat',
     },
     {
       title: 'Settings',

--- a/apps/web/src/app/(app)/organizations/[id]/claw/chat/OrgClawChatClient.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/claw/chat/OrgClawChatClient.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ClawChatPage } from '@/app/(app)/claw/components/ClawChatPage';
+
+export function OrgClawChatClient({ organizationId }: { organizationId: string }) {
+  return <ClawChatPage organizationId={organizationId} />;
+}

--- a/apps/web/src/app/(app)/organizations/[id]/claw/chat/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/claw/chat/page.tsx
@@ -1,0 +1,15 @@
+import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import { OrgClawChatClient } from './OrgClawChatClient';
+
+type OrgClawChatPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function OrgClawChatPage({ params }: OrgClawChatPageProps) {
+  return (
+    <OrganizationByPageLayout
+      params={params}
+      render={org => <OrgClawChatClient organizationId={org.organization.id} />}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- Adds KiloClaw Chat as a standalone sidebar item (alongside the existing KiloClaw and Settings entries) at `/claw/chat` and `/organizations/[id]/claw/chat`
- Removes the Chat tab from the ClawDashboard tabs — chat now lives on its own page following the same pattern as the Settings page
- The standalone chat page polls instance status, redirects to `/claw` if no instance exists, wraps personal context in `BillingWrapper`, and enables chat when the instance is running

## Verification

- Lint passes (pre-push hook)
- Reviewed that the `ClawChatPage` component follows the same pattern as `ClawSettingsPage` for status polling, redirects, and billing wrapping

## Visual Changes

<img width="4388" height="2708" alt="CleanShot 2026-04-06 at 13 50 41@2x" src="https://github.com/user-attachments/assets/fff7f06f-10d9-41e3-b6a9-e0675fc8758a" />

## Reviewer Notes

- Users visiting old `/claw#chat` bookmarks will now land on the default Gateway Process tab since `'chat'` was removed from `VALID_TABS`
- The `ChatTab` component itself is unchanged — it's simply rendered in a standalone page context now instead of inside the dashboard tabs