### PR TITLE
fix(dev): use pnpm --filter instead of cd for service commands

### DIFF
--- a/dev/local/runner.ts
+++ b/dev/local/runner.ts
@@ -85,8 +85,16 @@ export async function waitForPort(port: number, name: string, maxWaitMs: number)
 
 export function buildStartCommand(serviceName: string): string {
   const svc = getService(serviceName);
-  const parts: string[] = [];
 
+  // Use pnpm --filter instead of cd to avoid cwd issues on restart —
+  // after ctrl-c the shell stays in the service dir, so a relative cd
+  // would try to descend into <dir>/<dir> which doesn't exist.
+  if (svc.dir !== '.' && svc.command[0] === 'pnpm') {
+    const [, ...rest] = svc.command;
+    return `pnpm --filter {./${svc.dir}} ${rest.join(' ')}`;
+  }
+
+  const parts: string[] = [];
   if (svc.dir !== '.') parts.push(`cd ${svc.dir}`);
   parts.push(svc.command.join(' '));
 


### PR DESCRIPTION
## Summary

- Replace `cd <dir> && pnpm run dev` with `pnpm --filter {./<dir>}` in `buildStartCommand` so that restarting a service after ctrl-c works regardless of the shell's current working directory.

## Verification

- Typecheck passes (pre-existing `tsgo` failure unrelated).
- Lint and format checks pass (verified by push hook).

## Visual Changes

N/A

## Reviewer Notes

After ctrl-c in a tmux pane, the shell stays in the service directory. Re-sending the old `cd services/foo && pnpm run dev` command would try to descend into `services/foo/services/foo`, which doesn't exist. `pnpm --filter` always resolves from the repo root.

Non-pnpm commands (tsx scripts, docker compose) are unaffected — they already use `dir: '.'`.