### PR TITLE
fix(dev): clean up tmux session when terminal window is closed

### DIFF
--- a/dev/local/dashboard.tsx
+++ b/dev/local/dashboard.tsx
@@ -756,6 +756,16 @@ if (serviceNames.length === 0) {
   };
 }
 
+// When tmux destroys the session (e.g. terminal window closed with
+// destroy-unattached), it sends SIGHUP to all pane processes. Catch it
+// so we can run docker compose down before exiting.
+for (const signal of ['SIGHUP', 'SIGTERM'] as const) {
+  process.on(signal, () => {
+    doCleanup();
+    process.exit(0);
+  });
+}
+
 // Clear screen so ink starts with a clean canvas
 process.stdout.write('\x1b[2J\x1b[H');
 

--- a/dev/local/tmux.ts
+++ b/dev/local/tmux.ts
@@ -62,8 +62,13 @@ function createSession(sessionName: string): void {
   execSync(`tmux new-session -d -s ${sessionName} -n dashboard -c ${repoRoot}`, {
     stdio: 'ignore',
   });
-  // Destroy the session when no clients are attached (e.g. terminal window closed)
-  execSync(`tmux set-option -t ${sessionName} destroy-unattached on`, { stdio: 'ignore' });
+  // Destroy the session when no clients are attached (e.g. terminal window closed).
+  // The session starts detached (-d) so we must defer the option via a hook;
+  // setting it immediately would destroy the session before any client attaches.
+  execSync(
+    `tmux set-hook -t ${sessionName} client-attached "set-option -t ${sessionName} destroy-unattached on"`,
+    { stdio: 'ignore' }
+  );
   // Enable mouse so clicking the status-bar window tabs works
   execSync(`tmux set-option -t ${sessionName} mouse on`, { stdio: 'ignore' });
   // Enable focus events so tmux detects terminal tab switches (needed for client-focus-in hook)

--- a/dev/local/tmux.ts
+++ b/dev/local/tmux.ts
@@ -62,6 +62,8 @@ function createSession(sessionName: string): void {
   execSync(`tmux new-session -d -s ${sessionName} -n dashboard -c ${repoRoot}`, {
     stdio: 'ignore',
   });
+  // Destroy the session when no clients are attached (e.g. terminal window closed)
+  execSync(`tmux set-option -t ${sessionName} destroy-unattached on`, { stdio: 'ignore' });
   // Enable mouse so clicking the status-bar window tabs works
   execSync(`tmux set-option -t ${sessionName} mouse on`, { stdio: 'ignore' });
   // Enable focus events so tmux detects terminal tab switches (needed for client-focus-in hook)


### PR DESCRIPTION
## Summary

When closing the terminal window that runs `pnpm dev:start`, the tmux session was left running in the background. This adds proper cleanup so the session (and Docker containers) are torn down automatically.

Two changes:
- **`destroy-unattached on`** on the tmux session (`dev/local/tmux.ts`) — tmux destroys the session when the last client disconnects (i.e. terminal window closed)
- **SIGHUP/SIGTERM handlers** in the dashboard (`dev/local/dashboard.tsx`) — when tmux destroys the session it sends SIGHUP to all pane processes; the dashboard catches this and runs `docker compose down` before exiting

## Verification

- `pnpm typecheck` passes
- `pnpm lint` passes (ran via pre-push hook)

## Visual Changes

N/A

## Reviewer Notes

`destroy-unattached` also triggers on intentional `tmux detach` (Ctrl+b d). This is acceptable because `pnpm dev:start` re-creates the session if it doesn't exist, so the workflow is just: close terminal → run `pnpm dev:start` again.