### PR TITLE
fix(gastown): parameterize circuit breaker SQL query (B1+H8)

### DIFF
--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -52,6 +52,9 @@ const CIRCUIT_BREAKER_WINDOW_MINUTES = 30;
  * beads that eventually succeeded (status = 'closed').
  */
 function checkDispatchCircuitBreaker(sql: SqlStorage): Action[] {
+  const cutoffTimestamp = new Date(
+    Date.now() - CIRCUIT_BREAKER_WINDOW_MINUTES * 60_000
+  ).toISOString();
   const rows = z
     .object({ failure_count: z.number() })
     .array()
@@ -61,11 +64,11 @@ function checkDispatchCircuitBreaker(sql: SqlStorage): Action[] {
         /* sql */ `
           SELECT count(*) as failure_count
           FROM ${beads}
-          WHERE ${beads.last_dispatch_attempt_at} > strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-${CIRCUIT_BREAKER_WINDOW_MINUTES} minutes')
+          WHERE ${beads.last_dispatch_attempt_at} > ?
             AND ${beads.dispatch_attempts} > 0
             AND ${beads.status} != 'closed'
         `,
-        []
+        [cutoffTimestamp]
       ),
     ]);
 


### PR DESCRIPTION
## Summary
- Fixed circuit breaker SQL query to use parameterized query instead of template literal interpolation
- Computed cutoff timestamp in JS using `new Date(Date.now() - CIRCUIT_BREAKER_WINDOW_MINUTES * 60_000).toISOString()` and passed as parameterized query argument

## Verification
- [x] Typecheck passes (`pnpm --filter cloudflare-gastown typecheck`)
- [x] Lint passes (`pnpm --filter cloudflare-gastown lint`)

## Visual Changes
N/A

## Reviewer Notes
N/A