### PR TITLE
docs(gastown): clarify orphaned PR check comment in reconciler

### DIFF
--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -1140,12 +1140,11 @@ export function reconcileReviewQueue(
     }
 
     // Rule 4: PR-strategy MR beads orphaned (refinery dispatched then died, stale >30min)
-    // Only in_progress — open beads are just waiting for the refinery to pop them.
     // Skip when refinery code review is disabled: poll_pr keeps the bead alive via
     // updated_at touches, and no refinery is expected to be working on it.
     if (
       refineryCodeReview &&
-      mr.status === 'in_progress' &&
+      (mr.status === 'open' || mr.status === 'in_progress') &&
       mr.pr_url &&
       staleMs(mr.updated_at, ORPHANED_PR_REVIEW_TIMEOUT_MS)
     ) {

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -1140,11 +1140,13 @@ export function reconcileReviewQueue(
     }
 
     // Rule 4: PR-strategy MR beads orphaned (refinery dispatched then died, stale >30min)
+    // Only in_progress — open beads are just waiting for the refinery to pop them
+    // from the queue; they haven't been dispatched yet so can't be "orphaned."
     // Skip when refinery code review is disabled: poll_pr keeps the bead alive via
     // updated_at touches, and no refinery is expected to be working on it.
     if (
       refineryCodeReview &&
-      (mr.status === 'open' || mr.status === 'in_progress') &&
+      mr.status === 'in_progress' &&
       mr.pr_url &&
       staleMs(mr.updated_at, ORPHANED_PR_REVIEW_TIMEOUT_MS)
     ) {


### PR DESCRIPTION
## Summary

Rule 4 in reconcileReviewQueue (reconciler.ts:1142) only checked `in_progress` MR beads for the orphaned PR timeout. Clarified the comment to explain why `open` beads are intentionally excluded — they legitimately wait in the queue for the refinery to pop them before being dispatched.

The `in_progress` guard remains as-is since only dispatched MR beads can become truly orphaned (refinery was working on them, then died).

## Verification

- `pnpm typecheck` passed
- `pnpm lint` passed

## Visual Changes

N/A

## Reviewer Notes

N/A