### PR TITLE
feat(gastown): add cmake and pkg-config to container images

### DIFF
--- a/services/gastown/container/Dockerfile
+++ b/services/gastown/container/Dockerfile
@@ -4,7 +4,7 @@ FROM oven/bun:1-slim
 # Package categories:
 #   version control: git, git-lfs
 #   network/download: curl, wget, ca-certificates, gnupg, unzip
-#   build toolchain: build-essential, autoconf
+#   build toolchain: build-essential, autoconf, cmake, pkg-config
 #   search tools: ripgrep, jq
 #   compression: bzip2, zstd
 #   SSL/crypto: libssl-dev, libffi-dev
@@ -27,6 +27,8 @@ RUN apt-get update && \
       unzip \
       build-essential \
       autoconf \
+      cmake \
+      pkg-config \
       ripgrep \
       jq \
       bzip2 \

--- a/services/gastown/container/Dockerfile.dev
+++ b/services/gastown/container/Dockerfile.dev
@@ -4,7 +4,7 @@ FROM --platform=linux/arm64 oven/bun:1-slim
 # Package categories:
 #   version control: git, git-lfs
 #   network/download: curl, wget, ca-certificates, gnupg, unzip
-#   build toolchain: build-essential, autoconf
+#   build toolchain: build-essential, autoconf, cmake, pkg-config
 #   search tools: ripgrep, jq
 #   compression: bzip2, zstd
 #   SSL/crypto: libssl-dev, libffi-dev
@@ -27,6 +27,8 @@ RUN apt-get update && \
       unzip \
       build-essential \
       autoconf \
+      cmake \
+      pkg-config \
       ripgrep \
       jq \
       bzip2 \


### PR DESCRIPTION
## Summary

Add cmake and pkg-config to both prod and dev Dockerfiles. 

## Verification

- cmake --version inside container
- pkg-config --version inside container
- Confirmed package lists are identical between Dockerfile and Dockerfile.dev
- Verified no unrelated files were changed (only 2 files touched)

## Visual Changes

N/A

## Reviewer Notes

Follows up on the package expansion from #1978 (which closed #1976)
