### PR TITLE
fix(admin): pass instanceId to admin file picker and volume reassociation

### DIFF
--- a/apps/web/src/app/admin/components/KiloclawInstances/AdminFileEditor.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/AdminFileEditor.tsx
@@ -11,11 +11,13 @@ import { validateOpenclawJsonForSave } from '@/app/(app)/claw/components/validat
 
 function AdminFileEditorPaneInner({
   userId,
+  instanceId,
   filePath,
   writeFileMutation,
   onDirtyChange,
 }: {
   userId: string;
+  instanceId: string;
   filePath: string;
   writeFileMutation: ReturnType<typeof useMutation<{ etag: string }, any, any>>; // eslint-disable-line @typescript-eslint/no-explicit-any
   onDirtyChange: (dirty: boolean) => void;
@@ -23,7 +25,7 @@ function AdminFileEditorPaneInner({
   const trpc = useTRPC();
   const { data, isLoading, error, refetch } = useQuery(
     trpc.admin.kiloclawInstances.readFile.queryOptions(
-      { userId, path: filePath },
+      { userId, instanceId, path: filePath },
       { refetchOnWindowFocus: false, refetchOnMount: 'always' }
     )
   );
@@ -37,11 +39,11 @@ function AdminFileEditorPaneInner({
       }
     ) => {
       writeFileMutation.mutate(
-        { userId, path: args.path, content: args.content, etag: args.etag },
+        { userId, instanceId, path: args.path, content: args.content, etag: args.etag },
         callbacks
       );
     },
-    [writeFileMutation, userId]
+    [writeFileMutation, userId, instanceId]
   );
 
   const validateBeforeSave = useCallback(validateOpenclawJsonForSave, []);
@@ -61,7 +63,7 @@ function AdminFileEditorPaneInner({
   );
 }
 
-export function AdminFileEditor({ userId }: { userId: string }) {
+export function AdminFileEditor({ userId, instanceId }: { userId: string; instanceId: string }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const [enabled, setEnabled] = useState(false);
@@ -73,7 +75,7 @@ export function AdminFileEditor({ userId }: { userId: string }) {
     refetch,
   } = useQuery(
     trpc.admin.kiloclawInstances.fileTree.queryOptions(
-      { userId },
+      { userId, instanceId },
       { refetchOnWindowFocus: false, enabled }
     )
   );
@@ -82,10 +84,10 @@ export function AdminFileEditor({ userId }: { userId: string }) {
     trpc.admin.kiloclawInstances.writeFile.mutationOptions({
       onSuccess: async () => {
         await queryClient.invalidateQueries({
-          queryKey: trpc.admin.kiloclawInstances.fileTree.queryKey({ userId }),
+          queryKey: trpc.admin.kiloclawInstances.fileTree.queryKey({ userId, instanceId }),
         });
         await queryClient.invalidateQueries({
-          queryKey: trpc.admin.kiloclawInstances.readFile.queryKey(),
+          queryKey: trpc.admin.kiloclawInstances.readFile.queryKey({ userId, instanceId }),
         });
       },
     })
@@ -111,6 +113,7 @@ export function AdminFileEditor({ userId }: { userId: string }) {
         <AdminFileEditorPaneInner
           key={selectedPath}
           userId={userId}
+          instanceId={instanceId}
           filePath={selectedPath}
           writeFileMutation={writeFileMutation}
           onDirtyChange={onDirtyChange}

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -395,12 +395,14 @@ const PHASE_LABELS: Record<ReassociatePhase, string> = {
 
 function VolumeReassociationCard({
   userId,
+  instanceId,
   currentStatus,
   currentMachineId,
   previousVolumeId,
   onStatusChange,
 }: {
   userId: string;
+  instanceId: string;
   currentStatus: string | null;
   currentMachineId: string | null;
   previousVolumeId: string | null;
@@ -421,7 +423,7 @@ function VolumeReassociationCard({
     error: candidatesError,
     refetch: refetchCandidates,
   } = useQuery({
-    ...trpc.admin.kiloclawInstances.candidateVolumes.queryOptions({ userId }),
+    ...trpc.admin.kiloclawInstances.candidateVolumes.queryOptions({ userId, instanceId }),
     enabled: expanded,
   });
 
@@ -440,7 +442,7 @@ function VolumeReassociationCard({
   // Poll parent status during active phases
   const polling = phase === 'stopping' || phase === 'starting' || phase === 'waiting';
   useQuery({
-    queryKey: ['volume-reassociate-poll', userId, polling],
+    queryKey: ['volume-reassociate-poll', userId, instanceId, polling],
     queryFn: async () => {
       void queryClient.invalidateQueries({
         queryKey: trpc.admin.kiloclawInstances.get.queryKey(),
@@ -481,18 +483,18 @@ function VolumeReassociationCard({
       // Step 1: Stop if not already stopped
       if (!isStopped) {
         setPhase('stopping');
-        await machineStop({ userId });
+        await machineStop({ userId, instanceId });
         // Wait for stopped state
         await new Promise(resolve => setTimeout(resolve, 5000));
       }
 
       // Step 2: Reassociate
       setPhase('reassociating');
-      await reassociate({ userId, newVolumeId: selectedVolumeId, reason });
+      await reassociate({ userId, instanceId, newVolumeId: selectedVolumeId, reason });
 
       // Step 3: Start
       setPhase('starting');
-      await machineStart({ userId });
+      await machineStart({ userId, instanceId });
 
       // Step 4: Wait for running
       setPhase('waiting');
@@ -2440,6 +2442,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         {isActive && data.workerStatus && data.workerStatus.status !== 'recovering' && (
           <VolumeReassociationCard
             userId={data.user_id}
+            instanceId={data.id}
             currentStatus={data.workerStatus.status}
             currentMachineId={data.workerStatus.flyMachineId}
             previousVolumeId={data.workerStatus.previousVolumeId ?? null}
@@ -2639,7 +2642,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <AdminFileEditor userId={data.user_id} />
+              <AdminFileEditor userId={data.user_id} instanceId={data.id} />
             </CardContent>
           </Card>
         )}


### PR DESCRIPTION
## Summary

- **Bug**: When viewing an org KiloClaw instance in the admin UI, the file picker and volume reassociation card were targeting the admin user's **personal** instance instead of the org instance being viewed.
- **Root cause**: Both `AdminFileEditor` and `VolumeReassociationCard` only passed `userId` to tRPC calls. The backend's `resolveInstance()` falls back to `getActiveInstance()` which filters for `organization_id IS NULL` — always returning personal instances.
- **Fix**: Added `instanceId` prop to both components and forwarded it to all tRPC calls (`fileTree`, `readFile`, `writeFile`, `candidateVolumes`, `machineStop`, `machineStart`, `reassociateVolume`). The backend already supports `instanceId` — it was just never being passed.

## Verification

- `pnpm --filter web tsc --noEmit` — no errors in changed files
- `pnpm --filter web lint` — no errors in changed files

## Visual Changes

N/A

## Reviewer Notes

Two components changed in `KiloclawInstanceDetail.tsx` and `AdminFileEditor.tsx`. The tRPC router (`admin-kiloclaw-instances-router.ts`) needed no changes — `resolveInstance()` already handles `instanceId` correctly.