### PR TITLE
feat(gastown): add Java JDK to container images

### DIFF
--- a/services/gastown/container/Dockerfile
+++ b/services/gastown/container/Dockerfile
@@ -16,6 +16,7 @@ FROM oven/bun:1-slim
 #   C++ stdlib: libc++1
 #   math: libgmp-dev
 #   timezone data: tzdata
+#   Java: default-jdk
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git \
@@ -47,6 +48,7 @@ RUN apt-get update && \
       libc++1 \
       libgmp-dev \
       tzdata \
+      default-jdk \
     && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/services/gastown/container/Dockerfile.dev
+++ b/services/gastown/container/Dockerfile.dev
@@ -16,6 +16,7 @@ FROM --platform=linux/arm64 oven/bun:1-slim
 #   C++ stdlib: libc++1
 #   math: libgmp-dev
 #   timezone data: tzdata
+#   Java: default-jdk
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git \
@@ -47,6 +48,7 @@ RUN apt-get update && \
       libc++1 \
       libgmp-dev \
       tzdata \
+      default-jdk \
     && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
## Summary

Install default-jdk (OpenJDK) in both prod and dev Dockerfiles to support Java project builds and runtime.

## Verification

- java --version (inside container)
- Confirmed package lists are identical between Dockerfile and Dockerfile.dev
- Verified no unrelated files were changed (only 2 files touched)

## Visual Changes

N/A

## Reviewer Notes

Follows up on the package expansion from https://github.com/Kilo-Org/cloud/pull/1978 (which closed https://github.com/Kilo-Org/cloud/issues/1976)