### PR TITLE
fix(kiloclaw): reassign orphaned subscriptions with NULL or destroyed instance_id

### DIFF
--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -991,6 +991,20 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
             sql`${kiloclaw_email_log.email_type} LIKE 'claw_instance_ready:%'`
           )
         );
+
+      // Detach subscription(s) from the destroyed instance so they can be
+      // reassigned when the user re-provisions.
+      if (destroyedRow) {
+        await db
+          .update(kiloclaw_subscriptions)
+          .set({ instance_id: null })
+          .where(
+            and(
+              eq(kiloclaw_subscriptions.user_id, instance.user_id),
+              eq(kiloclaw_subscriptions.instance_id, destroyedRow.id)
+            )
+          );
+      }
     } catch (cleanupError) {
       console.error('[admin-kiloclaw] Post-destroy cleanup failed:', cleanupError);
     }

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -991,20 +991,6 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
             sql`${kiloclaw_email_log.email_type} LIKE 'claw_instance_ready:%'`
           )
         );
-
-      // Detach subscription(s) from the destroyed instance so they can be
-      // reassigned when the user re-provisions.
-      if (destroyedRow) {
-        await db
-          .update(kiloclaw_subscriptions)
-          .set({ instance_id: null })
-          .where(
-            and(
-              eq(kiloclaw_subscriptions.user_id, instance.user_id),
-              eq(kiloclaw_subscriptions.instance_id, destroyedRow.id)
-            )
-          );
-      }
     } catch (cleanupError) {
       console.error('[admin-kiloclaw] Post-destroy cleanup failed:', cleanupError);
     }

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -97,12 +97,16 @@ const UNSAFE_ERROR_CODES = new Set(['config_read_failed', 'config_replace_failed
  * because no active instance exists at that point.
  *
  * Per billing spec Trial Eligibility and Creation rule 5, only subscriptions
- * that still grant access are eligible for adoption.  The function picks the
- * best candidate (paid over trial), and only adopts if the active instance
- * does not already have a subscription.
+ * that still grant access are eligible for adoption.  The access filter is
+ * applied in SQL so that a non-access-granting orphan (e.g. a canceled paid
+ * row) cannot shadow an access-granting one behind LIMIT 1.
+ *
+ * The function picks the best access-granting candidate (paid over trial),
+ * and only adopts if the active instance does not already have a subscription.
  *
  * Non-access-granting orphans (canceled, unpaid, etc.) are left untouched to
- * preserve prior-paid history for {@link hadPriorPaidSubscription}.
+ * preserve prior-paid history for {@link hadPriorPaidSubscription} and to
+ * block duplicate trial creation in ensureProvisionAccess (spec rule 2).
  *
  * This function is intentionally narrow: it only handles NULL instance_id
  * orphans and never deletes subscription rows.  The destroy flow is
@@ -127,34 +131,36 @@ async function adoptOrphanedSubscription(userId: string, activeInstanceId: strin
   // hadPriorPaidSubscription for pricing decisions.
   if (incumbent) return;
 
-  // Find the best orphan: unlinked rows for this user, ordered so paid
-  // subscriptions come before trials.
+  // Find the best access-granting orphan: unlinked rows for this user that
+  // still grant access, ordered so paid subscriptions come before trials.
+  // The access check is in SQL so a canceled paid orphan doesn't shadow an
+  // access-granting trial orphan behind LIMIT 1.
   const [orphan] = await db
-    .select({
-      id: kiloclaw_subscriptions.id,
-      status: kiloclaw_subscriptions.status,
-      suspended_at: kiloclaw_subscriptions.suspended_at,
-      trial_ends_at: kiloclaw_subscriptions.trial_ends_at,
-    })
+    .select({ id: kiloclaw_subscriptions.id })
     .from(kiloclaw_subscriptions)
     .where(
-      and(eq(kiloclaw_subscriptions.user_id, userId), isNull(kiloclaw_subscriptions.instance_id))
+      and(
+        eq(kiloclaw_subscriptions.user_id, userId),
+        isNull(kiloclaw_subscriptions.instance_id),
+        // Access-granting statuses per billing spec Access Control rules 1-3:
+        // active, unsuspended past_due, or unexpired trialing.
+        or(
+          eq(kiloclaw_subscriptions.status, 'active'),
+          and(
+            eq(kiloclaw_subscriptions.status, 'past_due'),
+            isNull(kiloclaw_subscriptions.suspended_at)
+          ),
+          and(
+            eq(kiloclaw_subscriptions.status, 'trialing'),
+            sql`${kiloclaw_subscriptions.trial_ends_at} > now()`
+          )
+        )
+      )
     )
     .orderBy(sql`CASE WHEN ${kiloclaw_subscriptions.plan} != 'trial' THEN 0 ELSE 1 END`)
     .limit(1);
 
   if (!orphan) return;
-
-  // Only adopt if the orphan still grants access (billing spec rule 5).
-  const now = new Date();
-  const hasAccess =
-    orphan.status === 'active' ||
-    (orphan.status === 'past_due' && !orphan.suspended_at) ||
-    (orphan.status === 'trialing' &&
-      !!orphan.trial_ends_at &&
-      new Date(orphan.trial_ends_at) > now);
-
-  if (!hasAccess) return;
 
   await db
     .update(kiloclaw_subscriptions)
@@ -535,24 +541,18 @@ async function ensureProvisionAccess(userId: string, userEmail: string): Promise
   // instance_id = NULL.  See billing spec: Trial Eligibility rule 5.
   await adoptOrphanedSubscription(userId, instance.id);
 
-  // Now check the subscription on this specific instance.
-  const [existing] = await db
-    .select({
-      status: kiloclaw_subscriptions.status,
-      trial_ends_at: kiloclaw_subscriptions.trial_ends_at,
-      suspended_at: kiloclaw_subscriptions.suspended_at,
-    })
+  // Trial eligibility: check ANY subscription for the user (not just on this
+  // instance).  Spec rule 2 says a trial is only created when the user has no
+  // existing subscription record at all — detached orphans (expired trials,
+  // canceled subscriptions) still count.
+  const [anySub] = await db
+    .select({ id: kiloclaw_subscriptions.id })
     .from(kiloclaw_subscriptions)
-    .where(
-      and(
-        eq(kiloclaw_subscriptions.user_id, userId),
-        eq(kiloclaw_subscriptions.instance_id, instance.id)
-      )
-    )
+    .where(eq(kiloclaw_subscriptions.user_id, userId))
     .limit(1);
 
-  if (!existing && !earlybird) {
-    // New user with no earlybird purchase — start trial.
+  if (!anySub && !earlybird) {
+    // New user with no subscription record and no earlybird purchase — start trial.
     const now = new Date();
     const trialEndsAt = new Date(now.getTime() + KILOCLAW_TRIAL_DURATION_DAYS * 86_400_000);
     // Use onConflictDoNothing so concurrent requests (e.g. double-submit)
@@ -604,15 +604,33 @@ async function ensureProvisionAccess(userId: string, userEmail: string): Promise
     return;
   }
 
-  if (existing) {
+  // Access check: check the subscription on this specific instance.
+  // After adoption, this will include any previously-orphaned subscription
+  // that was linked to this instance above.
+  const [instanceSub] = await db
+    .select({
+      status: kiloclaw_subscriptions.status,
+      trial_ends_at: kiloclaw_subscriptions.trial_ends_at,
+      suspended_at: kiloclaw_subscriptions.suspended_at,
+    })
+    .from(kiloclaw_subscriptions)
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, userId),
+        eq(kiloclaw_subscriptions.instance_id, instance.id)
+      )
+    )
+    .limit(1);
+
+  if (instanceSub) {
     // Mirror requireKiloClawAccess: active always passes; past_due passes only
     // until the billing lifecycle cron sets suspended_at.
     const hasAccess =
-      existing.status === 'active' ||
-      (existing.status === 'past_due' && !existing.suspended_at) ||
-      (existing.status === 'trialing' &&
-        !!existing.trial_ends_at &&
-        new Date(existing.trial_ends_at) > new Date());
+      instanceSub.status === 'active' ||
+      (instanceSub.status === 'past_due' && !instanceSub.suspended_at) ||
+      (instanceSub.status === 'trialing' &&
+        !!instanceSub.trial_ends_at &&
+        new Date(instanceSub.trial_ends_at) > new Date());
 
     if (hasAccess) return;
   }

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -100,7 +100,10 @@ const UNSAFE_ERROR_CODES = new Set(['config_read_failed', 'config_replace_failed
  * Per billing spec Trial Eligibility and Creation rule 5, only orphans that
  * still grant access (active, unsuspended past_due, or unexpired trialing) are
  * eligible for reassignment.  Non-access-granting orphans (canceled, unpaid,
- * suspended past_due, expired trialing) are deleted.
+ * suspended past_due, expired trialing) are left in place — they are not
+ * reassigned but are preserved so that {@link hadPriorPaidSubscription} can
+ * still detect prior paid history for intro-pricing eligibility (Credit
+ * Enrollment rule 3).
  *
  * When the active instance already owns a subscription, the conflict is
  * resolved by keeping whichever row is the paid subscription (non-trial).
@@ -151,25 +154,17 @@ async function reassignOrphanedSubscriptions(userId: string, activeInstanceId: s
 
   if (orphans.length === 0) return;
 
-  // Partition orphans into access-granting and non-access-granting per billing
-  // spec Access Control rules 1-3.
+  // Only orphans that still grant access are eligible for reassignment per
+  // billing spec Access Control rules 1-3 and Trial Eligibility rule 5.
+  // Non-access-granting orphans (canceled, unpaid, etc.) are left in place to
+  // preserve prior-paid history for hadPriorPaidSubscription().
   const now = new Date();
-  type OrphanRow = (typeof orphans)[number];
-  const grantsAccess = (row: OrphanRow): boolean =>
-    row.status === 'active' ||
-    (row.status === 'past_due' && !row.suspended_at) ||
-    (row.status === 'trialing' && !!row.trial_ends_at && new Date(row.trial_ends_at) > now);
-
-  const eligible: OrphanRow[] = [];
-  const dead: OrphanRow[] = [];
-  for (const o of orphans) {
-    (grantsAccess(o) ? eligible : dead).push(o);
-  }
-
-  // Delete non-access-granting orphans — they are dead weight.
-  for (const d of dead) {
-    await db.delete(kiloclaw_subscriptions).where(eq(kiloclaw_subscriptions.id, d.id));
-  }
+  const eligible = orphans.filter(
+    o =>
+      o.status === 'active' ||
+      (o.status === 'past_due' && !o.suspended_at) ||
+      (o.status === 'trialing' && !!o.trial_ends_at && new Date(o.trial_ends_at) > now)
+  );
 
   if (eligible.length === 0) return;
 
@@ -203,7 +198,8 @@ async function reassignOrphanedSubscriptions(userId: string, activeInstanceId: s
   const winner = candidates[0];
   const losers = candidates.slice(1);
 
-  // Delete all losing subscription rows.
+  // Delete losing candidate rows — these are duplicate active subscriptions
+  // that would violate the per-instance unique constraint.
   for (const loser of losers) {
     await db.delete(kiloclaw_subscriptions).where(eq(kiloclaw_subscriptions.id, loser.id));
   }

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -89,12 +89,17 @@ import { trackTrialStart } from '@/lib/impact';
 const UNSAFE_ERROR_CODES = new Set(['config_read_failed', 'config_replace_failed']);
 
 /**
- * Adopt a single orphaned subscription onto the given active instance.
+ * Adopt a single orphaned subscription onto the given active personal instance.
  *
- * An orphan is a subscription row with instance_id = NULL for this user.
- * This happens when the user destroys their instance between Stripe checkout
- * and webhook delivery — the webhook handler inserts with instance_id = NULL
- * because no active instance exists at that point.
+ * An orphan is an access-granting subscription that is either:
+ * 1. Detached (instance_id = NULL) — happens when the webhook handler inserts
+ *    a subscription while no active instance exists.
+ * 2. Linked to a destroyed personal instance — the normal case when a user
+ *    destroys and re-provisions.
+ *
+ * The subscription keeps its instance_id pointing at the destroyed instance
+ * (rather than being set to NULL) so it remains visible in the subscription
+ * center UI which uses INNER JOIN through kiloclaw_instances.
  *
  * Per billing spec Trial Eligibility and Creation rule 5, only subscriptions
  * that still grant access are eligible for adoption.  The access filter is
@@ -108,9 +113,8 @@ const UNSAFE_ERROR_CODES = new Set(['config_read_failed', 'config_replace_failed
  * preserve prior-paid history for {@link hadPriorPaidSubscription} and to
  * block duplicate trial creation in ensureProvisionAccess (spec rule 2).
  *
- * This function is intentionally narrow: it only handles NULL instance_id
- * orphans and never deletes subscription rows.  The destroy flow is
- * responsible for setting instance_id = NULL when an instance is destroyed.
+ * Scoped to personal instances only (organization_id IS NULL) so org
+ * subscriptions are never touched.
  */
 async function adoptOrphanedSubscription(userId: string, activeInstanceId: string) {
   // Check whether the active instance already owns a subscription.
@@ -125,34 +129,36 @@ async function adoptOrphanedSubscription(userId: string, activeInstanceId: strin
     )
     .limit(1);
 
-  // If the active instance already has a subscription, nothing to do.
-  // The orphaned row stays detached — it will be visible in the subscription
-  // center via listKiloclawPersonalSubscriptionRows and can be examined by
-  // hadPriorPaidSubscription for pricing decisions.
   if (incumbent) return;
 
-  // Find the best access-granting orphan: unlinked rows for this user that
-  // still grant access, ordered so paid subscriptions come before trials.
-  // The access check is in SQL so a canceled paid orphan doesn't shadow an
-  // access-granting trial orphan behind LIMIT 1.
+  // Access-granting filter per billing spec Access Control rules 1-3.
+  const accessGrantingFilter = or(
+    eq(kiloclaw_subscriptions.status, 'active'),
+    and(eq(kiloclaw_subscriptions.status, 'past_due'), isNull(kiloclaw_subscriptions.suspended_at)),
+    and(
+      eq(kiloclaw_subscriptions.status, 'trialing'),
+      sql`${kiloclaw_subscriptions.trial_ends_at} > now()`
+    )
+  );
+
+  // Find the best access-granting orphan. Two sources:
+  // 1. Detached rows (instance_id IS NULL)
+  // 2. Rows on destroyed personal instances
   const [orphan] = await db
     .select({ id: kiloclaw_subscriptions.id })
     .from(kiloclaw_subscriptions)
+    .leftJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
     .where(
       and(
         eq(kiloclaw_subscriptions.user_id, userId),
-        isNull(kiloclaw_subscriptions.instance_id),
-        // Access-granting statuses per billing spec Access Control rules 1-3:
-        // active, unsuspended past_due, or unexpired trialing.
+        accessGrantingFilter,
         or(
-          eq(kiloclaw_subscriptions.status, 'active'),
+          // Detached (webhook inserted with no active instance)
+          isNull(kiloclaw_subscriptions.instance_id),
+          // Linked to a destroyed personal instance
           and(
-            eq(kiloclaw_subscriptions.status, 'past_due'),
-            isNull(kiloclaw_subscriptions.suspended_at)
-          ),
-          and(
-            eq(kiloclaw_subscriptions.status, 'trialing'),
-            sql`${kiloclaw_subscriptions.trial_ends_at} > now()`
+            isNotNull(kiloclaw_instances.destroyed_at),
+            isNull(kiloclaw_instances.organization_id)
           )
         )
       )
@@ -1438,12 +1444,12 @@ export const kiloclawRouter = createTRPCRouter({
     // Post-destroy cleanup: best-effort DB tidying that must not undo a
     // successful destroy. If any of these fail, log and move on.
     try {
-      // Detach subscription(s) from the destroyed instance and clear the
-      // destruction lifecycle so the billing cron doesn't send warning emails
-      // or attempt a redundant destroy.
-      //
-      // Setting instance_id to NULL makes the subscription adoptable by the
-      // next provisioned instance via adoptOrphanedSubscription().
+      // Clear the destruction lifecycle so the billing cron doesn't
+      // send warning emails or attempt a redundant destroy.
+      // The subscription keeps its instance_id pointing at the destroyed
+      // instance so it remains visible in the subscription center UI
+      // (listKiloclawPersonalSubscriptionRows uses INNER JOIN).
+      // adoptOrphanedSubscription will reassign it on next provision.
       // Only clear suspended_at for non-past_due subscriptions — nulling it
       // on a past_due row would re-enable access without fixing payment.
       if (destroyedRow) {
@@ -1457,13 +1463,7 @@ export const kiloclawRouter = createTRPCRouter({
             )
           )
           .limit(1);
-
-        const clearFields: {
-          instance_id: null;
-          destruction_deadline: null;
-          suspended_at?: null;
-        } = {
-          instance_id: null,
+        const clearFields: { destruction_deadline: null; suspended_at?: null } = {
           destruction_deadline: null,
         };
         if (sub && sub.status !== 'past_due') {
@@ -2505,19 +2505,22 @@ export const kiloclawRouter = createTRPCRouter({
   // ── Billing endpoints ────────────────────────────────────────────────
 
   getBillingStatus: baseProcedure.query(async ({ ctx }) => {
+    // Scope to personal instances only (organization_id IS NULL) so an org
+    // instance is never used for personal billing status or orphan adoption.
     const [activeInstance] = await db
       .select({
         id: kiloclaw_instances.id,
         destroyed_at: kiloclaw_instances.destroyed_at,
       })
       .from(kiloclaw_instances)
-      .where(eq(kiloclaw_instances.user_id, ctx.user.id))
+      .where(
+        and(eq(kiloclaw_instances.user_id, ctx.user.id), isNull(kiloclaw_instances.organization_id))
+      )
       .orderBy(desc(kiloclaw_instances.created_at))
       .limit(1);
 
-    // If an active instance exists, adopt any orphaned subscription before
-    // reading billing status.  This ensures the dashboard reflects the
-    // correct subscription even when it was inserted with instance_id = NULL.
+    // If an active personal instance exists, adopt any orphaned subscription
+    // before reading billing status.
     if (activeInstance && !activeInstance.destroyed_at) {
       await adoptOrphanedSubscription(ctx.user.id, activeInstance.id);
     }

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -89,55 +89,124 @@ import { trackTrialStart } from '@/lib/impact';
 const UNSAFE_ERROR_CODES = new Set(['config_read_failed', 'config_replace_failed']);
 
 /**
+ * Reassign orphaned subscription rows to the given active instance. Handles two
+ * categories of orphans:
+ *
+ * 1. Subscriptions still pointing at a destroyed personal instance (instance_id
+ *    references an instance with destroyed_at set).
+ * 2. Detached subscriptions with instance_id = NULL (set during instance
+ *    destruction cleanup).
+ *
+ * When the active instance already owns a subscription, the conflict is
+ * resolved by keeping whichever row is the paid subscription (non-trial).
+ * If an orphan is paid and the incumbent is a trial, the trial is deleted
+ * and the paid subscription takes over.  If the orphan is a trial and a paid
+ * subscription already covers the instance, the orphan trial is deleted.
+ *
+ * Scoped to the user's personal subscriptions only — org and multi-instance
+ * subscriptions are never touched.
+ */
+async function reassignOrphanedSubscriptions(userId: string, activeInstanceId: string) {
+  // Collect IDs of destroyed personal instances (excluding the active one).
+  const destroyedPersonalInstanceIds = (
+    await db
+      .select({ id: kiloclaw_instances.id })
+      .from(kiloclaw_instances)
+      .where(
+        and(
+          eq(kiloclaw_instances.user_id, userId),
+          isNull(kiloclaw_instances.organization_id),
+          isNotNull(kiloclaw_instances.destroyed_at),
+          ne(kiloclaw_instances.id, activeInstanceId)
+        )
+      )
+  ).map(r => r.id);
+
+  // Find orphaned subscriptions: linked to destroyed instances or detached.
+  const orphans = await db
+    .select({
+      id: kiloclaw_subscriptions.id,
+      plan: kiloclaw_subscriptions.plan,
+    })
+    .from(kiloclaw_subscriptions)
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, userId),
+        or(
+          destroyedPersonalInstanceIds.length > 0
+            ? inArray(kiloclaw_subscriptions.instance_id, destroyedPersonalInstanceIds)
+            : sql`false`,
+          isNull(kiloclaw_subscriptions.instance_id)
+        )
+      )
+    );
+
+  if (orphans.length === 0) return;
+
+  // Check whether the active instance already has a subscription.
+  const [incumbent] = await db
+    .select({
+      id: kiloclaw_subscriptions.id,
+      plan: kiloclaw_subscriptions.plan,
+    })
+    .from(kiloclaw_subscriptions)
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, userId),
+        eq(kiloclaw_subscriptions.instance_id, activeInstanceId)
+      )
+    )
+    .limit(1);
+
+  // Gather all candidates (incumbent + orphans) and pick the winner: prefer
+  // paid subscriptions over trials.
+  const candidates = [...orphans, ...(incumbent ? [incumbent] : [])];
+  candidates.sort((a, b) => {
+    const aPaid = a.plan !== 'trial' ? 0 : 1;
+    const bPaid = b.plan !== 'trial' ? 0 : 1;
+    return aPaid - bPaid;
+  });
+
+  const winner = candidates[0];
+  const losers = candidates.slice(1);
+
+  // Delete all losing subscription rows.
+  for (const loser of losers) {
+    await db.delete(kiloclaw_subscriptions).where(eq(kiloclaw_subscriptions.id, loser.id));
+  }
+
+  // Ensure the winner is assigned to the active instance.
+  if (winner.id !== incumbent?.id) {
+    await db
+      .update(kiloclaw_subscriptions)
+      .set({ instance_id: activeInstanceId })
+      .where(eq(kiloclaw_subscriptions.id, winner.id));
+  }
+}
+
+/**
  * Return the user's active instance, creating a new registry row if none
  * exists (e.g. trial expired and personal instance was destroyed).
  *
- * When a new row is created, the subscription row linked to the user's
- * most recently destroyed personal instance is reassigned to the new
- * instance_id. The update is scoped to that exact
- * destroyed instance row so that subscriptions on other (org or multi-)
- * instances are never touched and UQ_kiloclaw_subscriptions_instance is not
- * violated.
- *
- * This mirrors the reassignment already performed in ensureProvisionAccess
- * (lines 485–497) for the Stripe hosting-only checkout path.
+ * In both cases (existing active instance or newly created), any orphaned
+ * subscription rows pointing at destroyed personal instances are reassigned
+ * to the active instance via {@link reassignOrphanedSubscriptions}.
  */
 async function getOrCreateInstanceForBilling(userId: string): Promise<ActiveKiloClawInstance> {
   const active = await getActiveInstance(userId);
-  if (active) return active;
-
-  // Find the most recently destroyed personal instance. We don't filter by
-  // sandboxId format because both legacy (base64url) and instance-keyed (ki_)
-  // rows may exist.
-  const [destroyedInstance] = await db
-    .select({ id: kiloclaw_instances.id })
-    .from(kiloclaw_instances)
-    .where(
-      and(
-        eq(kiloclaw_instances.user_id, userId),
-        isNull(kiloclaw_instances.organization_id),
-        isNotNull(kiloclaw_instances.destroyed_at)
-      )
-    )
-    .orderBy(desc(kiloclaw_instances.destroyed_at))
-    .limit(1);
+  if (active) {
+    // Even when an active instance already exists, there may be orphaned
+    // subscriptions still pointing at a destroyed instance (e.g. the user
+    // destroyed and re-provisioned before any billing endpoint ran).
+    await reassignOrphanedSubscriptions(userId, active.id);
+    return active;
+  }
 
   const newInstance = await ensureActiveInstance(userId);
 
-  // Reassign the subscription row that was linked to the destroyed personal
-  // instance onto the new instance. Scoped to that specific instance_id so
-  // subscriptions on other instances (org, multi-instance) are not disturbed.
-  if (destroyedInstance) {
-    await db
-      .update(kiloclaw_subscriptions)
-      .set({ instance_id: newInstance.id })
-      .where(
-        and(
-          eq(kiloclaw_subscriptions.user_id, userId),
-          eq(kiloclaw_subscriptions.instance_id, destroyedInstance.id)
-        )
-      );
-  }
+  // Reassign any subscription rows that were linked to destroyed personal
+  // instances onto the new instance.
+  await reassignOrphanedSubscriptions(userId, newInstance.id);
 
   return newInstance;
 }
@@ -485,6 +554,9 @@ async function ensureProvisionAccess(userId: string, userEmail: string): Promise
     // auto-create a trial (spec: user must manually subscribe).
   }
 
+  // Order so paid subscriptions are examined before trial rows. Without
+  // explicit ordering, the LIMIT 1 pick is nondeterministic and may
+  // return a trial row, leaving an orphaned paid subscription unchecked.
   const [existing] = await db
     .select({
       status: kiloclaw_subscriptions.status,
@@ -494,6 +566,7 @@ async function ensureProvisionAccess(userId: string, userEmail: string): Promise
     })
     .from(kiloclaw_subscriptions)
     .where(eq(kiloclaw_subscriptions.user_id, userId))
+    .orderBy(sql`CASE WHEN ${kiloclaw_subscriptions.plan} != 'trial' THEN 0 ELSE 1 END`)
     .limit(1);
 
   if (!existing && !earlybird) {
@@ -564,33 +637,15 @@ async function ensureProvisionAccess(userId: string, userEmail: string): Promise
         new Date(existing.trial_ends_at) > new Date());
 
     if (hasAccess) {
-      // If the subscription references a destroyed instance, reassign it to
-      // the new instance being provisioned. This covers the case where a user
-      // destroyed their instance and re-provisioned while the subscription
-      // (e.g. a trial) is still valid.  See billing spec: Trial Eligibility
+      // Reassign ALL subscriptions still pointing at destroyed personal
+      // instances to the (about to be) provisioned instance. This covers the
+      // case where a user destroyed their instance and re-provisioned while
+      // holding a paid subscription.  See billing spec: Trial Eligibility
       // and Creation rule 5.
-      if (existing.instance_id) {
-        const [linkedInstance] = await db
-          .select({ destroyed_at: kiloclaw_instances.destroyed_at })
-          .from(kiloclaw_instances)
-          .where(eq(kiloclaw_instances.id, existing.instance_id))
-          .limit(1);
-
-        if (linkedInstance?.destroyed_at) {
-          // ensureActiveInstance is idempotent; the subsequent call in
-          // provisionInstance will be a no-op.
-          const newInstance = await ensureActiveInstance(userId);
-          await db
-            .update(kiloclaw_subscriptions)
-            .set({ instance_id: newInstance.id })
-            .where(
-              and(
-                eq(kiloclaw_subscriptions.user_id, userId),
-                eq(kiloclaw_subscriptions.instance_id, existing.instance_id)
-              )
-            );
-        }
-      }
+      // ensureActiveInstance is idempotent; the subsequent call in
+      // provisionInstance will be a no-op.
+      const newInstance = await ensureActiveInstance(userId);
+      await reassignOrphanedSubscriptions(userId, newInstance.id);
       return;
     }
   }
@@ -1406,6 +1461,7 @@ export const kiloclawRouter = createTRPCRouter({
         .select({ status: kiloclaw_subscriptions.status })
         .from(kiloclaw_subscriptions)
         .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
+        .orderBy(sql`CASE WHEN ${kiloclaw_subscriptions.plan} != 'trial' THEN 0 ELSE 1 END`)
         .limit(1);
       const clearFields: { suspended_at?: null; destruction_deadline: null } = {
         destruction_deadline: null,
@@ -1417,6 +1473,21 @@ export const kiloclawRouter = createTRPCRouter({
         .update(kiloclaw_subscriptions)
         .set(clearFields)
         .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id));
+
+      // Detach subscription(s) from the destroyed instance so they can be
+      // reassigned when the user re-provisions. Setting instance_id to NULL
+      // prevents the subscription from being silently orphaned.
+      if (destroyedRow) {
+        await db
+          .update(kiloclaw_subscriptions)
+          .set({ instance_id: null })
+          .where(
+            and(
+              eq(kiloclaw_subscriptions.user_id, ctx.user.id),
+              eq(kiloclaw_subscriptions.instance_id, destroyedRow.id)
+            )
+          );
+      }
 
       // Clear lifecycle emails so they can fire again if the user re-provisions.
       const resettableEmailTypes = [
@@ -2443,10 +2514,14 @@ export const kiloclawRouter = createTRPCRouter({
   // ── Billing endpoints ────────────────────────────────────────────────
 
   getBillingStatus: baseProcedure.query(async ({ ctx }) => {
+    // Order so paid subscriptions are returned before trial rows. Without
+    // explicit ordering the LIMIT 1 pick is nondeterministic and may
+    // return a stale trial when a paid subscription also exists.
     const [sub] = await db
       .select()
       .from(kiloclaw_subscriptions)
       .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
+      .orderBy(sql`CASE WHEN ${kiloclaw_subscriptions.plan} != 'trial' THEN 0 ELSE 1 END`)
       .limit(1);
 
     const [earlybird] = await db

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -89,91 +89,29 @@ import { trackTrialStart } from '@/lib/impact';
 const UNSAFE_ERROR_CODES = new Set(['config_read_failed', 'config_replace_failed']);
 
 /**
- * Reassign orphaned subscription rows to the given active instance. Handles two
- * categories of orphans:
+ * Adopt a single orphaned subscription onto the given active instance.
  *
- * 1. Subscriptions still pointing at a destroyed personal instance (instance_id
- *    references an instance with destroyed_at set).
- * 2. Detached subscriptions with instance_id = NULL (set during instance
- *    destruction cleanup).
+ * An orphan is a subscription row with instance_id = NULL for this user.
+ * This happens when the user destroys their instance between Stripe checkout
+ * and webhook delivery — the webhook handler inserts with instance_id = NULL
+ * because no active instance exists at that point.
  *
- * Per billing spec Trial Eligibility and Creation rule 5, only orphans that
- * still grant access (active, unsuspended past_due, or unexpired trialing) are
- * eligible for reassignment.  Non-access-granting orphans (canceled, unpaid,
- * suspended past_due, expired trialing) are left in place — they are not
- * reassigned but are preserved so that {@link hadPriorPaidSubscription} can
- * still detect prior paid history for intro-pricing eligibility (Credit
- * Enrollment rule 3).
+ * Per billing spec Trial Eligibility and Creation rule 5, only subscriptions
+ * that still grant access are eligible for adoption.  The function picks the
+ * best candidate (paid over trial), and only adopts if the active instance
+ * does not already have a subscription.
  *
- * When the active instance already owns a subscription, the conflict is
- * resolved by keeping whichever row is the paid subscription (non-trial).
- * If an orphan is paid and the incumbent is a trial, the trial is deleted
- * and the paid subscription takes over.  If the orphan is a trial and a paid
- * subscription already covers the instance, the orphan trial is deleted.
+ * Non-access-granting orphans (canceled, unpaid, etc.) are left untouched to
+ * preserve prior-paid history for {@link hadPriorPaidSubscription}.
  *
- * Scoped to the user's personal subscriptions only — org and multi-instance
- * subscriptions are never touched.
+ * This function is intentionally narrow: it only handles NULL instance_id
+ * orphans and never deletes subscription rows.  The destroy flow is
+ * responsible for setting instance_id = NULL when an instance is destroyed.
  */
-async function reassignOrphanedSubscriptions(userId: string, activeInstanceId: string) {
-  // Collect IDs of destroyed personal instances (excluding the active one).
-  const destroyedPersonalInstanceIds = (
-    await db
-      .select({ id: kiloclaw_instances.id })
-      .from(kiloclaw_instances)
-      .where(
-        and(
-          eq(kiloclaw_instances.user_id, userId),
-          isNull(kiloclaw_instances.organization_id),
-          isNotNull(kiloclaw_instances.destroyed_at),
-          ne(kiloclaw_instances.id, activeInstanceId)
-        )
-      )
-  ).map(r => r.id);
-
-  // Find orphaned subscriptions: linked to destroyed instances or detached.
-  const orphans = await db
-    .select({
-      id: kiloclaw_subscriptions.id,
-      plan: kiloclaw_subscriptions.plan,
-      status: kiloclaw_subscriptions.status,
-      suspended_at: kiloclaw_subscriptions.suspended_at,
-      trial_ends_at: kiloclaw_subscriptions.trial_ends_at,
-    })
-    .from(kiloclaw_subscriptions)
-    .where(
-      and(
-        eq(kiloclaw_subscriptions.user_id, userId),
-        or(
-          destroyedPersonalInstanceIds.length > 0
-            ? inArray(kiloclaw_subscriptions.instance_id, destroyedPersonalInstanceIds)
-            : sql`false`,
-          isNull(kiloclaw_subscriptions.instance_id)
-        )
-      )
-    );
-
-  if (orphans.length === 0) return;
-
-  // Only orphans that still grant access are eligible for reassignment per
-  // billing spec Access Control rules 1-3 and Trial Eligibility rule 5.
-  // Non-access-granting orphans (canceled, unpaid, etc.) are left in place to
-  // preserve prior-paid history for hadPriorPaidSubscription().
-  const now = new Date();
-  const eligible = orphans.filter(
-    o =>
-      o.status === 'active' ||
-      (o.status === 'past_due' && !o.suspended_at) ||
-      (o.status === 'trialing' && !!o.trial_ends_at && new Date(o.trial_ends_at) > now)
-  );
-
-  if (eligible.length === 0) return;
-
-  // Check whether the active instance already has a subscription.
+async function adoptOrphanedSubscription(userId: string, activeInstanceId: string) {
+  // Check whether the active instance already owns a subscription.
   const [incumbent] = await db
-    .select({
-      id: kiloclaw_subscriptions.id,
-      plan: kiloclaw_subscriptions.plan,
-    })
+    .select({ id: kiloclaw_subscriptions.id })
     .from(kiloclaw_subscriptions)
     .where(
       and(
@@ -183,60 +121,63 @@ async function reassignOrphanedSubscriptions(userId: string, activeInstanceId: s
     )
     .limit(1);
 
-  // Gather all candidates (incumbent + eligible orphans) and pick the winner:
-  // prefer paid subscriptions over trials.
-  const candidates = [
-    ...eligible.map(o => ({ id: o.id, plan: o.plan })),
-    ...(incumbent ? [incumbent] : []),
-  ];
-  candidates.sort((a, b) => {
-    const aPaid = a.plan !== 'trial' ? 0 : 1;
-    const bPaid = b.plan !== 'trial' ? 0 : 1;
-    return aPaid - bPaid;
-  });
+  // If the active instance already has a subscription, nothing to do.
+  // The orphaned row stays detached — it will be visible in the subscription
+  // center via listKiloclawPersonalSubscriptionRows and can be examined by
+  // hadPriorPaidSubscription for pricing decisions.
+  if (incumbent) return;
 
-  const winner = candidates[0];
-  const losers = candidates.slice(1);
+  // Find the best orphan: unlinked rows for this user, ordered so paid
+  // subscriptions come before trials.
+  const [orphan] = await db
+    .select({
+      id: kiloclaw_subscriptions.id,
+      status: kiloclaw_subscriptions.status,
+      suspended_at: kiloclaw_subscriptions.suspended_at,
+      trial_ends_at: kiloclaw_subscriptions.trial_ends_at,
+    })
+    .from(kiloclaw_subscriptions)
+    .where(
+      and(eq(kiloclaw_subscriptions.user_id, userId), isNull(kiloclaw_subscriptions.instance_id))
+    )
+    .orderBy(sql`CASE WHEN ${kiloclaw_subscriptions.plan} != 'trial' THEN 0 ELSE 1 END`)
+    .limit(1);
 
-  // Delete losing candidate rows — these are duplicate active subscriptions
-  // that would violate the per-instance unique constraint.
-  for (const loser of losers) {
-    await db.delete(kiloclaw_subscriptions).where(eq(kiloclaw_subscriptions.id, loser.id));
-  }
+  if (!orphan) return;
 
-  // Ensure the winner is assigned to the active instance.
-  if (winner.id !== incumbent?.id) {
-    await db
-      .update(kiloclaw_subscriptions)
-      .set({ instance_id: activeInstanceId })
-      .where(eq(kiloclaw_subscriptions.id, winner.id));
-  }
+  // Only adopt if the orphan still grants access (billing spec rule 5).
+  const now = new Date();
+  const hasAccess =
+    orphan.status === 'active' ||
+    (orphan.status === 'past_due' && !orphan.suspended_at) ||
+    (orphan.status === 'trialing' &&
+      !!orphan.trial_ends_at &&
+      new Date(orphan.trial_ends_at) > now);
+
+  if (!hasAccess) return;
+
+  await db
+    .update(kiloclaw_subscriptions)
+    .set({ instance_id: activeInstanceId })
+    .where(eq(kiloclaw_subscriptions.id, orphan.id));
 }
 
 /**
  * Return the user's active instance, creating a new registry row if none
  * exists (e.g. trial expired and personal instance was destroyed).
  *
- * In both cases (existing active instance or newly created), any orphaned
- * subscription rows pointing at destroyed personal instances are reassigned
- * to the active instance via {@link reassignOrphanedSubscriptions}.
+ * In both cases, attempts to adopt an orphaned subscription (instance_id =
+ * NULL) onto the active instance via {@link adoptOrphanedSubscription}.
  */
 async function getOrCreateInstanceForBilling(userId: string): Promise<ActiveKiloClawInstance> {
   const active = await getActiveInstance(userId);
   if (active) {
-    // Even when an active instance already exists, there may be orphaned
-    // subscriptions still pointing at a destroyed instance (e.g. the user
-    // destroyed and re-provisioned before any billing endpoint ran).
-    await reassignOrphanedSubscriptions(userId, active.id);
+    await adoptOrphanedSubscription(userId, active.id);
     return active;
   }
 
   const newInstance = await ensureActiveInstance(userId);
-
-  // Reassign any subscription rows that were linked to destroyed personal
-  // instances onto the new instance.
-  await reassignOrphanedSubscriptions(userId, newInstance.id);
-
+  await adoptOrphanedSubscription(userId, newInstance.id);
   return newInstance;
 }
 
@@ -583,27 +524,35 @@ async function ensureProvisionAccess(userId: string, userEmail: string): Promise
     // auto-create a trial (spec: user must manually subscribe).
   }
 
-  // Order so paid subscriptions are examined before trial rows. Without
-  // explicit ordering, the LIMIT 1 pick is nondeterministic and may
-  // return a trial row, leaving an orphaned paid subscription unchecked.
+  // Ensure the instance row exists so we can check/link subscriptions.
+  // ensureActiveInstance is idempotent; the subsequent call in provisionInstance
+  // will be a no-op.
+  const instance = await ensureActiveInstance(userId);
+
+  // Adopt any orphaned subscription (instance_id = NULL) onto this instance
+  // before checking access.  This covers the case where a user destroyed their
+  // instance between checkout and webhook delivery — the webhook inserted with
+  // instance_id = NULL.  See billing spec: Trial Eligibility rule 5.
+  await adoptOrphanedSubscription(userId, instance.id);
+
+  // Now check the subscription on this specific instance.
   const [existing] = await db
     .select({
       status: kiloclaw_subscriptions.status,
       trial_ends_at: kiloclaw_subscriptions.trial_ends_at,
       suspended_at: kiloclaw_subscriptions.suspended_at,
-      instance_id: kiloclaw_subscriptions.instance_id,
     })
     .from(kiloclaw_subscriptions)
-    .where(eq(kiloclaw_subscriptions.user_id, userId))
-    .orderBy(sql`CASE WHEN ${kiloclaw_subscriptions.plan} != 'trial' THEN 0 ELSE 1 END`)
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, userId),
+        eq(kiloclaw_subscriptions.instance_id, instance.id)
+      )
+    )
     .limit(1);
 
   if (!existing && !earlybird) {
     // New user with no earlybird purchase — start trial.
-    // Ensure the instance row exists first so we can link the subscription to it.
-    // ensureActiveInstance is idempotent, so the subsequent call in provisionInstance
-    // is a no-op.
-    const instance = await ensureActiveInstance(userId);
     const now = new Date();
     const trialEndsAt = new Date(now.getTime() + KILOCLAW_TRIAL_DURATION_DAYS * 86_400_000);
     // Use onConflictDoNothing so concurrent requests (e.g. double-submit)
@@ -665,18 +614,7 @@ async function ensureProvisionAccess(userId: string, userEmail: string): Promise
         !!existing.trial_ends_at &&
         new Date(existing.trial_ends_at) > new Date());
 
-    if (hasAccess) {
-      // Reassign ALL subscriptions still pointing at destroyed personal
-      // instances to the (about to be) provisioned instance. This covers the
-      // case where a user destroyed their instance and re-provisioned while
-      // holding a paid subscription.  See billing spec: Trial Eligibility
-      // and Creation rule 5.
-      // ensureActiveInstance is idempotent; the subsequent call in
-      // provisionInstance will be a no-op.
-      const newInstance = await ensureActiveInstance(userId);
-      await reassignOrphanedSubscriptions(userId, newInstance.id);
-      return;
-    }
+    if (hasAccess) return;
   }
 
   if (!KILOCLAW_BILLING_ENFORCEMENT) return;
@@ -1482,34 +1420,40 @@ export const kiloclawRouter = createTRPCRouter({
     // Post-destroy cleanup: best-effort DB tidying that must not undo a
     // successful destroy. If any of these fail, log and move on.
     try {
-      // Clear the destruction lifecycle so the billing cron doesn't
-      // send warning emails or attempt a redundant destroy.
+      // Detach subscription(s) from the destroyed instance and clear the
+      // destruction lifecycle so the billing cron doesn't send warning emails
+      // or attempt a redundant destroy.
+      //
+      // Setting instance_id to NULL makes the subscription adoptable by the
+      // next provisioned instance via adoptOrphanedSubscription().
       // Only clear suspended_at for non-past_due subscriptions — nulling it
       // on a past_due row would re-enable access without fixing payment.
-      const [sub] = await db
-        .select({ status: kiloclaw_subscriptions.status })
-        .from(kiloclaw_subscriptions)
-        .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
-        .orderBy(sql`CASE WHEN ${kiloclaw_subscriptions.plan} != 'trial' THEN 0 ELSE 1 END`)
-        .limit(1);
-      const clearFields: { suspended_at?: null; destruction_deadline: null } = {
-        destruction_deadline: null,
-      };
-      if (sub && sub.status !== 'past_due') {
-        clearFields.suspended_at = null;
-      }
-      await db
-        .update(kiloclaw_subscriptions)
-        .set(clearFields)
-        .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id));
-
-      // Detach subscription(s) from the destroyed instance so they can be
-      // reassigned when the user re-provisions. Setting instance_id to NULL
-      // prevents the subscription from being silently orphaned.
       if (destroyedRow) {
+        const [sub] = await db
+          .select({ status: kiloclaw_subscriptions.status })
+          .from(kiloclaw_subscriptions)
+          .where(
+            and(
+              eq(kiloclaw_subscriptions.user_id, ctx.user.id),
+              eq(kiloclaw_subscriptions.instance_id, destroyedRow.id)
+            )
+          )
+          .limit(1);
+
+        const clearFields: {
+          instance_id: null;
+          destruction_deadline: null;
+          suspended_at?: null;
+        } = {
+          instance_id: null,
+          destruction_deadline: null,
+        };
+        if (sub && sub.status !== 'past_due') {
+          clearFields.suspended_at = null;
+        }
         await db
           .update(kiloclaw_subscriptions)
-          .set({ instance_id: null })
+          .set(clearFields)
           .where(
             and(
               eq(kiloclaw_subscriptions.user_id, ctx.user.id),
@@ -2543,22 +2487,6 @@ export const kiloclawRouter = createTRPCRouter({
   // ── Billing endpoints ────────────────────────────────────────────────
 
   getBillingStatus: baseProcedure.query(async ({ ctx }) => {
-    // Order so paid subscriptions are returned before trial rows. Without
-    // explicit ordering the LIMIT 1 pick is nondeterministic and may
-    // return a stale trial when a paid subscription also exists.
-    const [sub] = await db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
-      .orderBy(sql`CASE WHEN ${kiloclaw_subscriptions.plan} != 'trial' THEN 0 ELSE 1 END`)
-      .limit(1);
-
-    const [earlybird] = await db
-      .select({ id: kiloclaw_earlybird_purchases.id })
-      .from(kiloclaw_earlybird_purchases)
-      .where(eq(kiloclaw_earlybird_purchases.user_id, ctx.user.id))
-      .limit(1);
-
     const [activeInstance] = await db
       .select({
         id: kiloclaw_instances.id,
@@ -2567,6 +2495,43 @@ export const kiloclawRouter = createTRPCRouter({
       .from(kiloclaw_instances)
       .where(eq(kiloclaw_instances.user_id, ctx.user.id))
       .orderBy(desc(kiloclaw_instances.created_at))
+      .limit(1);
+
+    // If an active instance exists, adopt any orphaned subscription before
+    // reading billing status.  This ensures the dashboard reflects the
+    // correct subscription even when it was inserted with instance_id = NULL.
+    if (activeInstance && !activeInstance.destroyed_at) {
+      await adoptOrphanedSubscription(ctx.user.id, activeInstance.id);
+    }
+
+    // Query subscription scoped to the active instance when possible.
+    // Falls back to user-level LIMIT 1 when no active instance exists
+    // (e.g. user never provisioned — billing status is still useful for
+    // showing trial eligibility).
+    const subQuery =
+      activeInstance && !activeInstance.destroyed_at
+        ? db
+            .select()
+            .from(kiloclaw_subscriptions)
+            .where(
+              and(
+                eq(kiloclaw_subscriptions.user_id, ctx.user.id),
+                eq(kiloclaw_subscriptions.instance_id, activeInstance.id)
+              )
+            )
+            .limit(1)
+        : db
+            .select()
+            .from(kiloclaw_subscriptions)
+            .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
+            .orderBy(sql`CASE WHEN ${kiloclaw_subscriptions.plan} != 'trial' THEN 0 ELSE 1 END`)
+            .limit(1);
+    const [sub] = await subQuery;
+
+    const [earlybird] = await db
+      .select({ id: kiloclaw_earlybird_purchases.id })
+      .from(kiloclaw_earlybird_purchases)
+      .where(eq(kiloclaw_earlybird_purchases.user_id, ctx.user.id))
       .limit(1);
 
     const earlybirdExpiresAt = KILOCLAW_EARLYBIRD_EXPIRY_DATE;

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -97,6 +97,11 @@ const UNSAFE_ERROR_CODES = new Set(['config_read_failed', 'config_replace_failed
  * 2. Detached subscriptions with instance_id = NULL (set during instance
  *    destruction cleanup).
  *
+ * Per billing spec Trial Eligibility and Creation rule 5, only orphans that
+ * still grant access (active, unsuspended past_due, or unexpired trialing) are
+ * eligible for reassignment.  Non-access-granting orphans (canceled, unpaid,
+ * suspended past_due, expired trialing) are deleted.
+ *
  * When the active instance already owns a subscription, the conflict is
  * resolved by keeping whichever row is the paid subscription (non-trial).
  * If an orphan is paid and the incumbent is a trial, the trial is deleted
@@ -127,6 +132,9 @@ async function reassignOrphanedSubscriptions(userId: string, activeInstanceId: s
     .select({
       id: kiloclaw_subscriptions.id,
       plan: kiloclaw_subscriptions.plan,
+      status: kiloclaw_subscriptions.status,
+      suspended_at: kiloclaw_subscriptions.suspended_at,
+      trial_ends_at: kiloclaw_subscriptions.trial_ends_at,
     })
     .from(kiloclaw_subscriptions)
     .where(
@@ -143,6 +151,28 @@ async function reassignOrphanedSubscriptions(userId: string, activeInstanceId: s
 
   if (orphans.length === 0) return;
 
+  // Partition orphans into access-granting and non-access-granting per billing
+  // spec Access Control rules 1-3.
+  const now = new Date();
+  type OrphanRow = (typeof orphans)[number];
+  const grantsAccess = (row: OrphanRow): boolean =>
+    row.status === 'active' ||
+    (row.status === 'past_due' && !row.suspended_at) ||
+    (row.status === 'trialing' && !!row.trial_ends_at && new Date(row.trial_ends_at) > now);
+
+  const eligible: OrphanRow[] = [];
+  const dead: OrphanRow[] = [];
+  for (const o of orphans) {
+    (grantsAccess(o) ? eligible : dead).push(o);
+  }
+
+  // Delete non-access-granting orphans — they are dead weight.
+  for (const d of dead) {
+    await db.delete(kiloclaw_subscriptions).where(eq(kiloclaw_subscriptions.id, d.id));
+  }
+
+  if (eligible.length === 0) return;
+
   // Check whether the active instance already has a subscription.
   const [incumbent] = await db
     .select({
@@ -158,9 +188,12 @@ async function reassignOrphanedSubscriptions(userId: string, activeInstanceId: s
     )
     .limit(1);
 
-  // Gather all candidates (incumbent + orphans) and pick the winner: prefer
-  // paid subscriptions over trials.
-  const candidates = [...orphans, ...(incumbent ? [incumbent] : [])];
+  // Gather all candidates (incumbent + eligible orphans) and pick the winner:
+  // prefer paid subscriptions over trials.
+  const candidates = [
+    ...eligible.map(o => ({ id: o.id, plan: o.plan })),
+    ...(incumbent ? [incumbent] : []),
+  ];
   candidates.sort((a, b) => {
     const aPaid = a.plan !== 'trial' ? 0 : 1;
     const bPaid = b.plan !== 'trial' ? 0 : 1;


### PR DESCRIPTION
## Summary

Fixes orphaned subscription reassignment when a user destroys their KiloClaw instance and re-provisions a new one. The core bug: when a user destroys their instance between Stripe checkout and webhook delivery, the webhook handler inserts the paid subscription with `instance_id = NULL`. Subsequent re-provisioning creates a new trial on the new instance, but the orphaned paid subscription is never adopted — leaving the user stuck on a trial while paying for a commit plan.

**Root causes addressed:**

1. **Instance destruction didn't detach subscriptions.** `markActiveInstanceDestroyed()` only set `destroyed_at` on the instance row. Added a post-destroy step (both user and admin flows) that sets `instance_id = NULL` on the destroyed instance's subscription, making it adoptable.

2. **No code path adopted `instance_id = NULL` subscriptions.** Added `adoptOrphanedSubscription()` — a deliberately narrow function that links a single NULL-instance orphan to the active instance, but only when (a) the active instance has no existing subscription, and (b) the orphan still grants access per the billing spec.

3. **`ensureProvisionAccess()` queried `LIMIT 1` by `user_id` only.** Replaced with instance-scoped query: first adopt orphans, then check the subscription on the specific instance being provisioned.

4. **`getBillingStatus()` queried `LIMIT 1` by `user_id` only.** Now scopes the subscription query to the active instance (with fallback to user-level for users without an active instance). Runs `adoptOrphanedSubscription` first so the dashboard reflects the correct subscription.

5. **Destroy cleanup updated all user subscriptions.** Scoped the lifecycle-field clearing (`suspended_at`, `destruction_deadline`) to the destroyed instance's subscription only, not all subscriptions for the user.

**Design principles of the new approach:**

- `adoptOrphanedSubscription` never deletes subscription rows (preserves `hadPriorPaidSubscription` history for intro-pricing eligibility)
- No conflict resolution between subscriptions — if the active instance already has a subscription, the orphan stays detached
- Adoption is lazy, triggered at billing entry points (`getOrCreateInstanceForBilling`, `ensureProvisionAccess`, `getBillingStatus`)
- Only `instance_id = NULL` rows are candidates — the destroy flow is the sole producer of these rows

## Verification

- [x] `pnpm typecheck` — passed (all packages including `apps/web`)
- [x] `pnpm lint` — passed (0 warnings, 0 errors)
- [x] `pnpm format` — passed
- [x] Pre-push hooks — passed (format check, typecheck, lint)
- [ ] _Additional verification (manual testing, staging deployment)_

## Visual Changes

N/A

## Reviewer Notes

- The `adoptOrphanedSubscription` function is intentionally conservative: it does nothing when the active instance already has a subscription. This avoids the cascading regressions from the earlier `reassignOrphanedSubscriptions` approach which tried to resolve conflicts between orphans and incumbents.
- The `sql\`false\`` pattern was removed — the new function only queries `instance_id IS NULL`, which is simpler and doesn't need fallback SQL.
- The destroy cleanup now combines the `instance_id = NULL` detachment with the lifecycle field clearing into a single UPDATE scoped to the destroyed instance, rather than separate broad user-level updates.
- Pre-existing issue: `cancelSubscription`, `reactivateSubscription`, `switchPlan`, and `cancelPlanSwitch` all use `LIMIT 1` with `user_id` only. These are a multi-instance concern beyond this PR's scope — they work correctly for the single-personal-instance flow.