### PR TITLE
fix(admin): fix duplicate instances in KiloClaw admin and add subscription column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ supabase/.temp
 TMP_CI_commit_msg.txt
 *.csv
 run-milvus-test.sh
+.env*.local

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
@@ -45,10 +45,19 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
+import type { KiloClawSubscriptionStatus } from '@kilocode/db/schema-types';
 
 type SortField = 'created_at' | 'destroyed_at';
 type SortOrder = 'asc' | 'desc';
 type StatusFilter = 'all' | 'active' | 'suspended' | 'destroyed';
+
+const subscriptionBadgeClass: Record<KiloClawSubscriptionStatus, string> = {
+  active: 'border-green-500/30 bg-green-500/15 text-green-400',
+  trialing: 'border-blue-500/30 bg-blue-500/15 text-blue-400',
+  past_due: 'border-amber-500/30 bg-amber-500/15 text-amber-400',
+  canceled: 'border-red-500/30 bg-red-500/15 text-red-400',
+  unpaid: 'border-red-500/30 bg-red-500/15 text-red-400',
+};
 
 function toSortedSearchParams(obj: Record<string, unknown>): URLSearchParams {
   const params = new URLSearchParams();
@@ -472,6 +481,7 @@ export function KiloclawInstancesPage() {
               <TableHead>User</TableHead>
               <TableHead>Type</TableHead>
               <TableHead>Sandbox ID</TableHead>
+              <TableHead>Subscription</TableHead>
               <TableHead>Status</TableHead>
               <TableHead
                 className="hover:bg-muted/50 cursor-pointer"
@@ -496,13 +506,13 @@ export function KiloclawInstancesPage() {
           <TableBody>
             {isLoading ? (
               <TableRow>
-                <TableCell colSpan={6} className="h-24 text-center">
+                <TableCell colSpan={7} className="h-24 text-center">
                   Loading instances...
                 </TableCell>
               </TableRow>
             ) : instances.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={6} className="h-24 text-center">
+                <TableCell colSpan={7} className="h-24 text-center">
                   No instances found.
                 </TableCell>
               </TableRow>
@@ -555,6 +565,19 @@ export function KiloclawInstancesPage() {
                     >
                       {instance.sandbox_id}
                     </span>
+                  </TableCell>
+                  <TableCell>
+                    {instance.subscription_status ? (
+                      <Badge
+                        variant="outline"
+                        className={subscriptionBadgeClass[instance.subscription_status]}
+                        title={instance.subscription_id ?? undefined}
+                      >
+                        {instance.subscription_status}
+                      </Badge>
+                    ) : (
+                      <span className="text-muted-foreground text-sm">—</span>
+                    )}
                   </TableCell>
                   <TableCell>
                     {instance.destroyed_at !== null ? (

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -7,6 +7,7 @@ import {
   kiloclaw_cli_runs,
   kilocode_users,
 } from '@kilocode/db/schema';
+import type { KiloClawSubscriptionStatus } from '@kilocode/db/schema-types';
 import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { KiloClawUserClient } from '@/lib/kiloclaw/kiloclaw-user-client';
 import {
@@ -170,6 +171,8 @@ export type AdminKiloclawInstance = {
   destroyed_at: string | null;
   suspended_at: string | null;
   user_email: string | null;
+  subscription_id: string | null;
+  subscription_status: KiloClawSubscriptionStatus | null;
 };
 
 export type AdminKiloclawInstanceDetail = AdminKiloclawInstance & {
@@ -185,12 +188,14 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         instance: kiloclaw_instances,
         user_email: kilocode_users.google_user_email,
         suspended_at: kiloclaw_subscriptions.suspended_at,
+        subscription_id: kiloclaw_subscriptions.id,
+        subscription_status: kiloclaw_subscriptions.status,
       })
       .from(kiloclaw_instances)
       .leftJoin(kilocode_users, eq(kiloclaw_instances.user_id, kilocode_users.id))
       .leftJoin(
         kiloclaw_subscriptions,
-        eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id)
+        eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id)
       )
       .where(eq(kiloclaw_instances.id, input.id))
       .limit(1);
@@ -208,6 +213,8 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       destroyed_at: result.instance.destroyed_at,
       suspended_at: result.suspended_at ?? null,
       user_email: result.user_email,
+      subscription_id: result.subscription_id ?? null,
+      subscription_status: result.subscription_status ?? null,
     };
 
     const derivedFlyAppName = flyAppNameFromUserId(instance.user_id);
@@ -290,12 +297,14 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         instance: kiloclaw_instances,
         user_email: kilocode_users.google_user_email,
         suspended_at: kiloclaw_subscriptions.suspended_at,
+        subscription_id: kiloclaw_subscriptions.id,
+        subscription_status: kiloclaw_subscriptions.status,
       })
       .from(kiloclaw_instances)
       .leftJoin(kilocode_users, eq(kiloclaw_instances.user_id, kilocode_users.id))
       .leftJoin(
         kiloclaw_subscriptions,
-        eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id)
+        eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id)
       )
       .where(whereCondition)
       .orderBy(orderCondition)
@@ -308,7 +317,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       .leftJoin(kilocode_users, eq(kiloclaw_instances.user_id, kilocode_users.id))
       .leftJoin(
         kiloclaw_subscriptions,
-        eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id)
+        eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id)
       )
       .where(whereCondition);
 
@@ -324,6 +333,8 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       destroyed_at: row.instance.destroyed_at,
       suspended_at: row.suspended_at ?? null,
       user_email: row.user_email,
+      subscription_id: row.subscription_id ?? null,
+      subscription_status: row.subscription_status ?? null,
     }));
 
     return {
@@ -352,7 +363,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       .from(kiloclaw_instances)
       .leftJoin(
         kiloclaw_subscriptions,
-        eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id)
+        eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id)
       );
 
     // Time-windowed counts


### PR DESCRIPTION
## Summary

- Fix duplicate rows in the KiloClaw admin instances list caused by joining `kiloclaw_subscriptions` on `user_id` instead of `instance_id`. A user with N subscriptions would see each instance duplicated N times. The fix changes all four JOIN sites (`get`, `list`, count, and stats queries) to join on `kiloclaw_instances.id = kiloclaw_subscriptions.instance_id`, which has a unique index.
- Add a **Subscription** column to the instances table showing the linked subscription's status (`active`, `trialing`, `past_due`, `canceled`, `unpaid`) with color-coded badges. The subscription ID is available on hover.
- The `subscription_status` field is typed as `KiloClawSubscriptionStatus | null` (not `string`) so the API contract is precise and the UI uses an exhaustive `Record<KiloClawSubscriptionStatus, string>` map for badge styling.

## Verification

- [x] `pnpm typecheck` — passes across all 30 workspace packages
- [x] Six-agent code review (security, logic, types, data, resources, style) — all findings addressed
- [ ] Manual verification in browser

## Visual Changes

| Before | After |
| ------ | ----- |
| Instances list shows duplicate rows per user; no subscription info | Each instance appears once; new Subscription column shows status badge |

## Reviewer Notes

- The `.gitignore` addition (`.env*.local`) is a small hygiene fix bundled in.
- The stats query (overview counts) also had the same bad JOIN — active/suspended/destroyed counts were inflated by the cross-product. Now fixed.
- Instances with no linked subscription (`instance_id` is NULL on all subscriptions) correctly show `—` in the Subscription column and still count in stats via the LEFT JOIN.