### PR TITLE
fix(dev): restore tsconfig and fix tsx resolution for dev scripts

### DIFF
--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -270,7 +270,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
     initialViewedService,
     JSON.stringify(enabledGroupIds),
   ];
-  const dashboardCmd = `tsx dev/local/dashboard.tsx ${dashboardArgs.map(a => JSON.stringify(a)).join(' ')}`;
+  const dashboardCmd = `pnpm exec tsx dev/local/dashboard.tsx ${dashboardArgs.map(a => JSON.stringify(a)).join(' ')}`;
   sendKeys(sessionName, 0, dashboardCmd, 0);
 
   // --- Focus sidebar pane and attach ---

--- a/dev/local/services.ts
+++ b/dev/local/services.ts
@@ -278,7 +278,7 @@ function buildServiceDefs(): ServiceDef[] {
         dir: '.',
         port: 0,
         dependsOn: meta.dependsOn,
-        command: ['tsx', 'dev/local/scripts/start-tunnel.ts', String(nextjsPort)],
+        command: ['pnpm', 'exec', 'tsx', 'dev/local/scripts/start-tunnel.ts', String(nextjsPort)],
         group: meta.group,
       });
       continue;
@@ -291,7 +291,7 @@ function buildServiceDefs(): ServiceDef[] {
         dir: '.',
         port: 0,
         dependsOn: meta.dependsOn,
-        command: ['tsx', 'dev/local/scripts/start-stripe.ts'],
+        command: ['pnpm', 'exec', 'tsx', 'dev/local/scripts/start-stripe.ts'],
         group: meta.group,
       });
       continue;
@@ -306,7 +306,13 @@ function buildServiceDefs(): ServiceDef[] {
         dir: '.',
         port: 0,
         dependsOn: meta.dependsOn,
-        command: ['tsx', 'dev/local/scripts/start-app-builder-tunnel.ts', String(appBuilderPort)],
+        command: [
+          'pnpm',
+          'exec',
+          'tsx',
+          'dev/local/scripts/start-app-builder-tunnel.ts',
+          String(appBuilderPort),
+        ],
         group: meta.group,
       });
       continue;

--- a/services/kiloclaw/scripts/dev-start.sh
+++ b/services/kiloclaw/scripts/dev-start.sh
@@ -374,7 +374,7 @@ if ! docker info &>/dev/null; then
   echo "Start Docker Desktop (or 'dockerd') and retry."
   exit 1
 fi
-if ! (cd "$MONOREPO_ROOT" && docker compose -f apps/web/dev/docker-compose.yml up -d --wait); then
+if ! (cd "$MONOREPO_ROOT" && docker compose -f dev/docker-compose.yml up -d --wait); then
   echo ""
   echo "ERROR: 'docker compose up' failed."
   echo "Check 'docker compose -f dev/docker-compose.yml logs' for details."
@@ -384,13 +384,13 @@ fi
 # Extra safety: wait for Postgres to accept connections (handles first-run init)
 echo "==> Waiting for Postgres to accept connections..."
 for i in $(seq 1 30); do
-  if docker exec "$(docker compose -f "$MONOREPO_ROOT/apps/web/dev/docker-compose.yml" ps -q postgres)" \
+  if docker exec "$(docker compose -f "$MONOREPO_ROOT/dev/docker-compose.yml" ps -q postgres)" \
     pg_isready -U postgres -q 2>/dev/null; then
     break
   fi
   if [ "$i" -eq 30 ]; then
     echo "ERROR: Postgres did not become ready within 30 seconds."
-    echo "Check: docker compose -f apps/web/dev/docker-compose.yml logs postgres"
+    echo "Check: docker compose -f dev/docker-compose.yml logs postgres"
     exit 1
   fi
   sleep 1
@@ -402,8 +402,8 @@ if ! (cd "$MONOREPO_ROOT" && pnpm drizzle migrate); then
   echo ""
   echo "ERROR: Database migrations failed."
   echo "The database container may not be ready yet. Check:"
-  echo "  docker compose -f apps/web/dev/docker-compose.yml ps"
-  echo "  docker compose -f apps/web/dev/docker-compose.yml logs"
+  echo "  docker compose -f dev/docker-compose.yml ps"
+  echo "  docker compose -f dev/docker-compose.yml logs"
   exit 1
 fi
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "jsx": "react-jsx",
+    "noEmit": true
+  },
+  "include": ["dev/**/*", "scripts/**/*"]
+}

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.json"
+}


### PR DESCRIPTION
## Summary

After the monorepo restructure (#1315), `pnpm dev:start` fails because `tsx` can't find a tsconfig when running dev scripts from the repo root — the root `tsconfig.json` and `tsconfig.scripts.json` were moved to `apps/web/` without replacements.

This adds a minimal root `tsconfig.json` scoped to `dev/**/*` and `scripts/**/*`, plus a `tsconfig.scripts.json` alias for backward compatibility. It also fixes two related issues:

- **Bare `tsx` unreachable in tmux** — commands sent into tmux panes used bare `tsx`, which isn't on PATH without pnpm's `node_modules/.bin` augmentation. Changed to `pnpm exec tsx`.
- **Stale docker-compose paths in kiloclaw** — `dev-start.sh` still referenced the pre-restructure `apps/web/dev/docker-compose.yml` path instead of `dev/docker-compose.yml`.

## Verification

- [x] `pnpm typecheck` passes
- [x] `pnpm exec tsx dev/local/dashboard.tsx` runs successfully with core and kiloclaw services
- [x] `pnpm dev:start` / `pnpm dev:stop` lifecycle works

## Visual Changes

N/A

## Reviewer Notes

The root `tsconfig.scripts.json` exists because `tsx` caches the tsconfig filename in the `TSX_TSCONFIG_PATH` env var, which can persist across tmux sessions from before the restructure. It's a one-line `extends` — zero maintenance cost.