### PR TITLE
fix(gastown): remove dispatch rollback, handle both promise rejection and false return

### DIFF
--- a/services/gastown/src/dos/town/actions.ts
+++ b/services/gastown/src/dos/town/actions.ts
@@ -557,29 +557,19 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
       beadOps.updateBeadStatus(sql, beadId, 'in_progress', agentId);
 
       const capturedAgentId = agentId;
-      const capturedBeadId = beadId;
       return async () => {
-        // Best-effort dispatch. On failure (rejects or returns false), unhook
-        // the agent and reset the bead to 'open' so scheduling can retry it
-        // on the next tick instead of waiting for stale-bead recovery (~5 min).
-        //
-        // The double-dispatch risk from false returns (timeout race) is
-        // acceptable here: if the container DID start, the original agent
-        // finds no hooked bead and exits cleanly. If it DIDN'T start, we
-        // correctly rollback and retry. Either way we avoid the ~90s+ delay
-        // from the stale-bead recovery path.
-        let started = false;
-        try {
-          started = await ctx.dispatchAgent(capturedAgentId, capturedBeadId, rigId);
-        } catch (err) {
+        const success = await ctx.dispatchAgent(capturedAgentId, beadId, rigId).catch(err => {
           console.warn(
-            `${LOG} dispatch_agent: container start failed for agent=${capturedAgentId} bead=${capturedBeadId}`,
+            `${LOG} dispatch_agent: container start failed for agent=${capturedAgentId} bead=${beadId}`,
             err
           );
-        }
-        if (!started) {
-          agentOps.unhookBead(sql, capturedAgentId);
-          beadOps.updateBeadStatus(sql, capturedBeadId, 'open', null);
+          return false;
+        });
+        if (!success) {
+          console.warn(
+            `${LOG} dispatch_agent: container did not start within timeout for agent=${capturedAgentId} bead=${beadId}. ` +
+              'Leaving bead in current state; stale-bead recovery will handle if container fails to start.'
+          );
         }
       };
     }


### PR DESCRIPTION
## Summary
- Removed dispatch rollback behavior from `dispatch_agent` action
- Now handles both promise rejection (via `.catch()` returning false) and explicit false return (via `if (!success)` check)
- When dispatch fails, logs a warning and leaves bead/agent state unchanged — consistent with timeout race documented in `scheduling.ts:171-177`
- Cooldown protection, heartbeat detection, and stale-bead recovery handle actual failures

This addresses review feedback from PR #2065 which was closed without merging.

Fixes #1986 B2/R1

## Verification
- `pnpm typecheck` passed
- `pnpm lint` passed

## Visual Changes
N/A

## Reviewer Notes
- The rollback to `idle` was removed to avoid the dispatch timeout race where the container may still have started
- The reconciler's heartbeat detection and stale-bead recovery handle actual failures