### PR TITLE
fix(gastown): replace async SQL writes with event emissions

### DIFF
--- a/services/gastown/src/db/tables/town-events.table.ts
+++ b/services/gastown/src/db/tables/town-events.table.ts
@@ -13,6 +13,8 @@ export const TownEventType = z.enum([
   'nudge_timeout',
   'pr_feedback_detected',
   'pr_auto_merge',
+  'auto_merge_cleared',
+  'poll_pr_null',
 ]);
 
 export type TownEventType = z.output<typeof TownEventType>;

--- a/services/gastown/src/dos/town/actions.ts
+++ b/services/gastown/src/dos/town/actions.ts
@@ -828,6 +828,15 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
             console.log(
               `${LOG} merge_pr: fresh feedback check found issues, aborting merge for bead=${action.bead_id}`
             );
+            query(
+              sql,
+              /* sql */ `
+                UPDATE ${review_metadata}
+                SET ${review_metadata.columns.auto_merge_ready_since} = NULL
+                WHERE ${review_metadata.bead_id} = ?
+              `,
+              [action.bead_id]
+            );
             ctx.insertEvent('auto_merge_cleared', {
               bead_id: action.bead_id,
               payload: { reason: 'fresh_feedback' },
@@ -845,6 +854,15 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
             console.warn(
               `${LOG} merge_pr: merge failed, cleared auto_merge_pending for bead=${action.bead_id}`
             );
+            query(
+              sql,
+              /* sql */ `
+                UPDATE ${review_metadata}
+                SET ${review_metadata.columns.auto_merge_ready_since} = NULL
+                WHERE ${review_metadata.bead_id} = ?
+              `,
+              [action.bead_id]
+            );
             ctx.insertEvent('auto_merge_cleared', {
               bead_id: action.bead_id,
               payload: { reason: 'merge_failed' },
@@ -852,6 +870,15 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
           }
         } catch (err) {
           console.warn(`${LOG} merge_pr failed: bead=${action.bead_id} url=${action.pr_url}`, err);
+          query(
+            sql,
+            /* sql */ `
+              UPDATE ${review_metadata}
+              SET ${review_metadata.columns.auto_merge_ready_since} = NULL
+              WHERE ${review_metadata.bead_id} = ?
+            `,
+            [action.bead_id]
+          );
           ctx.insertEvent('auto_merge_cleared', {
             bead_id: action.bead_id,
             payload: { reason: 'error' },

--- a/services/gastown/src/dos/town/actions.ts
+++ b/services/gastown/src/dos/town/actions.ts
@@ -291,9 +291,6 @@ export type ApplyActionContext = {
 
 const LOG = '[actions]';
 
-/** Fail MR bead after this many consecutive null poll results (#1632). */
-const PR_POLL_NULL_THRESHOLD = 10;
-
 /** Minimum interval between PR polls per MR bead (ms) (#1632). */
 export const PR_POLL_INTERVAL_MS = 60_000; // 1 minute
 
@@ -772,58 +769,10 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
               }
             }
           } else {
-            // Null result — GitHub API unreachable (token missing, expired, rate-limited, or 5xx).
-            // Increment consecutive null counter; fail the bead after PR_POLL_NULL_THRESHOLD.
-            query(
-              sql,
-              /* sql */ `
-                UPDATE ${beads}
-                SET ${beads.columns.metadata} = json_set(
-                  COALESCE(${beads.columns.metadata}, '{}'),
-                  '$.poll_null_count',
-                  COALESCE(
-                    json_extract(${beads.columns.metadata}, '$.poll_null_count'),
-                    0
-                  ) + 1
-                )
-                WHERE ${beads.bead_id} = ?
-              `,
-              [action.bead_id]
-            );
-            const rows = [
-              ...query(
-                sql,
-                /* sql */ `
-                  SELECT json_extract(${beads.columns.metadata}, '$.poll_null_count') AS null_count
-                  FROM ${beads}
-                  WHERE ${beads.bead_id} = ?
-                `,
-                [action.bead_id]
-              ),
-            ];
-            const nullCount = Number(rows[0]?.null_count ?? 0);
-            if (nullCount >= PR_POLL_NULL_THRESHOLD) {
-              console.warn(
-                `${LOG} poll_pr: ${nullCount} consecutive null results for bead=${action.bead_id}, failing`
-              );
-              beadOps.updateBeadStatus(sql, action.bead_id, 'failed', 'system');
-              query(
-                sql,
-                /* sql */ `
-                  UPDATE ${beads}
-                  SET ${beads.columns.metadata} = json_set(
-                    COALESCE(${beads.columns.metadata}, '{}'),
-                    '$.failureReason', 'pr_poll_failed',
-                    '$.failureMessage', ?
-                  )
-                  WHERE ${beads.bead_id} = ?
-                `,
-                [
-                  `Cannot poll PR status — GitHub API returned null ${nullCount} consecutive times. Check that a valid GitHub token is configured in town settings and that the GitHub API is reachable.`,
-                  action.bead_id,
-                ]
-              );
-            }
+            ctx.insertEvent('poll_pr_null', {
+              bead_id: action.bead_id,
+              payload: {},
+            });
           }
           // status === 'open' — no action needed, poll again next tick
         } catch (err) {
@@ -879,25 +828,10 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
             console.log(
               `${LOG} merge_pr: fresh feedback check found issues, aborting merge for bead=${action.bead_id}`
             );
-            query(
-              sql,
-              /* sql */ `
-                UPDATE ${beads}
-                SET ${beads.columns.metadata} = json_remove(COALESCE(${beads.metadata}, '{}'), '$.auto_merge_pending'),
-                    ${beads.columns.updated_at} = ?
-                WHERE ${beads.bead_id} = ?
-              `,
-              [now(), action.bead_id]
-            );
-            query(
-              sql,
-              /* sql */ `
-                UPDATE ${review_metadata}
-                SET ${review_metadata.columns.auto_merge_ready_since} = NULL
-                WHERE ${review_metadata.bead_id} = ?
-              `,
-              [action.bead_id]
-            );
+            ctx.insertEvent('auto_merge_cleared', {
+              bead_id: action.bead_id,
+              payload: { reason: 'fresh_feedback' },
+            });
             return;
           }
 
@@ -908,54 +842,20 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
               payload: { pr_url: action.pr_url, pr_state: 'merged' },
             });
           } else {
-            // Merge failed (405/409: branch protection, merge conflict, stale head, etc.)
-            // Clear auto_merge_pending so we resume normal polling on the next tick.
-            // Also reset the auto_merge_ready_since timer so it re-evaluates freshness.
-            query(
-              sql,
-              /* sql */ `
-                UPDATE ${beads}
-                SET ${beads.columns.metadata} = json_remove(COALESCE(${beads.metadata}, '{}'), '$.auto_merge_pending'),
-                    ${beads.columns.updated_at} = ?
-                WHERE ${beads.bead_id} = ?
-              `,
-              [now(), action.bead_id]
-            );
-            query(
-              sql,
-              /* sql */ `
-                UPDATE ${review_metadata}
-                SET ${review_metadata.columns.auto_merge_ready_since} = NULL
-                WHERE ${review_metadata.bead_id} = ?
-              `,
-              [action.bead_id]
-            );
             console.warn(
               `${LOG} merge_pr: merge failed, cleared auto_merge_pending for bead=${action.bead_id}`
             );
+            ctx.insertEvent('auto_merge_cleared', {
+              bead_id: action.bead_id,
+              payload: { reason: 'merge_failed' },
+            });
           }
         } catch (err) {
           console.warn(`${LOG} merge_pr failed: bead=${action.bead_id} url=${action.pr_url}`, err);
-          // Clear pending flag on unexpected errors too
-          query(
-            sql,
-            /* sql */ `
-              UPDATE ${beads}
-              SET ${beads.columns.metadata} = json_remove(COALESCE(${beads.metadata}, '{}'), '$.auto_merge_pending'),
-                  ${beads.columns.updated_at} = ?
-              WHERE ${beads.bead_id} = ?
-            `,
-            [now(), action.bead_id]
-          );
-          query(
-            sql,
-            /* sql */ `
-              UPDATE ${review_metadata}
-              SET ${review_metadata.columns.auto_merge_ready_since} = NULL
-              WHERE ${review_metadata.bead_id} = ?
-            `,
-            [action.bead_id]
-          );
+          ctx.insertEvent('auto_merge_cleared', {
+            bead_id: action.bead_id,
+            payload: { reason: 'error' },
+          });
         }
       };
     }

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -43,6 +43,9 @@ const CIRCUIT_BREAKER_FAILURE_THRESHOLD = 20;
 /** Window in minutes for counting dispatch failures. */
 const CIRCUIT_BREAKER_WINDOW_MINUTES = 30;
 
+/** Fail MR bead after this many consecutive null poll results (#1632). */
+const PR_POLL_NULL_THRESHOLD = 10;
+
 /**
  * Town-level dispatch circuit breaker. Counts beads with at least one
  * dispatch attempt in the recent window that have not yet closed
@@ -449,6 +452,95 @@ export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
         `,
         [new Date().toISOString(), mrBeadId]
       );
+      return;
+    }
+
+    case 'auto_merge_cleared': {
+      const beadId = typeof payload.bead_id === 'string' ? payload.bead_id : event.bead_id;
+      if (!beadId) {
+        console.warn(`${LOG} applyEvent: auto_merge_cleared missing bead_id`);
+        return;
+      }
+
+      query(
+        sql,
+        /* sql */ `
+          UPDATE ${beads}
+          SET ${beads.columns.metadata} = json_remove(COALESCE(${beads.metadata}, '{}'), '$.auto_merge_pending'),
+              ${beads.columns.updated_at} = ?
+          WHERE ${beads.bead_id} = ?
+        `,
+        [new Date().toISOString(), beadId]
+      );
+      query(
+        sql,
+        /* sql */ `
+          UPDATE ${review_metadata}
+          SET ${review_metadata.columns.auto_merge_ready_since} = NULL
+          WHERE ${review_metadata.bead_id} = ?
+        `,
+        [beadId]
+      );
+      return;
+    }
+
+    case 'poll_pr_null': {
+      const beadId = event.bead_id;
+      if (!beadId) {
+        console.warn(`${LOG} applyEvent: poll_pr_null missing bead_id`);
+        return;
+      }
+
+      query(
+        sql,
+        /* sql */ `
+          UPDATE ${beads}
+          SET ${beads.columns.metadata} = json_set(
+            COALESCE(${beads.columns.metadata}, '{}'),
+            '$.poll_null_count',
+            COALESCE(
+              json_extract(${beads.columns.metadata}, '$.poll_null_count'),
+              0
+            ) + 1
+          )
+          WHERE ${beads.bead_id} = ?
+        `,
+        [beadId]
+      );
+      const rows = [
+        ...query(
+          sql,
+          /* sql */ `
+            SELECT json_extract(${beads.columns.metadata}, '$.poll_null_count') AS null_count
+            FROM ${beads}
+            WHERE ${beads.bead_id} = ?
+          `,
+          [beadId]
+        ),
+      ];
+      const nullCount = Number(rows[0]?.null_count ?? 0);
+      if (nullCount >= PR_POLL_NULL_THRESHOLD) {
+        console.warn(
+          `${LOG} poll_pr: ${nullCount} consecutive null results for bead=${beadId}, failing`
+        );
+        beadOps.updateBeadStatus(sql, beadId, 'failed', 'system');
+        query(
+          sql,
+          /* sql */ `
+            UPDATE ${beads}
+            SET ${beads.columns.metadata} = json_set(
+              COALESCE(${beads.columns.metadata}, '{}'),
+              '$.failureReason', 'pr_poll_failed',
+              '$.failureMessage', ?
+            )
+            WHERE ${beads.bead_id} = ?
+          `,
+          [
+            `Cannot poll PR status — GitHub API returned null ${nullCount} consecutive times. Check that a valid GitHub token is configured in town settings and that the GitHub API is reachable.`,
+            beadId,
+          ]
+        );
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
Fixes B3 from issue #1986 — SQL mutations inside async closures in `merge_pr` and `poll_pr` violated phase separation.

Changes:
- Add `auto_merge_cleared` and `poll_pr_null` event types to `TownEventType`
- Replace direct SQL mutations in `merge_pr` async closures with event emissions
- Replace direct SQL mutations in `poll_pr` async closures with event emissions  
- Add `auto_merge_cleared` and `poll_pr_null` handlers in `applyEvent` (reconciler.ts)
- Move `PR_POLL_NULL_THRESHOLD` constant to reconciler.ts

## Verification
- `pnpm typecheck` passes
- `pnpm lint --filter=gastown` passes with 0 warnings and 0 errors

## Visual Changes
N/A

## Reviewer Notes
N/A