### PR TITLE
fix(gastown): remove redundant SQL mutations and fix race condition

### DIFF
--- a/services/gastown/src/db/tables/town-events.table.ts
+++ b/services/gastown/src/db/tables/town-events.table.ts
@@ -13,6 +13,8 @@ export const TownEventType = z.enum([
   'nudge_timeout',
   'pr_feedback_detected',
   'pr_auto_merge',
+  'auto_merge_cleared',
+  'poll_pr_null',
 ]);
 
 export type TownEventType = z.output<typeof TownEventType>;

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -606,6 +606,19 @@ export class TownDO extends DurableObject<Env> {
   private _drainStartedAt: number | null = null;
   /** Instance UUID of the current container, set by the first heartbeat. */
   private _containerInstanceId: string | null = null;
+  private _poisonEventFailureCounts = new Map<string, number>();
+  private async _loadPoisonEventFailureCounts(): Promise<void> {
+    const stored = await this.ctx.storage.get<Record<string, number>>(
+      'town:poisonEventFailureCounts'
+    );
+    if (stored) {
+      this._poisonEventFailureCounts = new Map(Object.entries(stored));
+    }
+  }
+  private async _savePoisonEventFailureCounts(): Promise<void> {
+    const obj = Object.fromEntries(this._poisonEventFailureCounts);
+    await this.ctx.storage.put('town:poisonEventFailureCounts', obj);
+  }
 
   private get townId(): string {
     return this._townId ?? this.ctx.id.name ?? this.ctx.id.toString();
@@ -3472,6 +3485,9 @@ export class TownDO extends DurableObject<Env> {
     };
 
     // Phase 0: Drain events and apply state transitions
+    const poisonEventActions: Action[] = [];
+    const POISON_EVENT_THRESHOLD = 3;
+    await this._loadPoisonEventFailureCounts();
     try {
       const pending = events.drainEvents(this.sql);
       metrics.eventsDrained = pending.length;
@@ -3482,18 +3498,43 @@ export class TownDO extends DurableObject<Env> {
         try {
           reconciler.applyEvent(this.sql, event);
           events.markProcessed(this.sql, event.event_id);
+          this._poisonEventFailureCounts.delete(event.event_id);
         } catch (err) {
           logger.error('reconciler: applyEvent failed', {
             eventId: event.event_id,
             eventType: event.event_type,
             error: err instanceof Error ? err.message : String(err),
           });
-          // Event stays unprocessed — will be retried on the next alarm tick.
-          // Mark it processed anyway after 3 consecutive failures to prevent
-          // a poison event from blocking the entire queue forever.
-          // For now, we skip it and let the next tick retry.
+          const failureCount = (this._poisonEventFailureCounts.get(event.event_id) ?? 0) + 1;
+          this._poisonEventFailureCounts.set(event.event_id, failureCount);
+          if (failureCount >= POISON_EVENT_THRESHOLD) {
+            logger.error('reconciler: poison event threshold exceeded, marking as processed', {
+              eventId: event.event_id,
+              eventType: event.event_type,
+              failureCount,
+            });
+            Sentry.captureMessage(
+              `Poison event detected: ${event.event_type} (${event.event_id}) failed ${failureCount} times. Event marked as processed and escalated.`,
+              {
+                level: 'error',
+                extra: {
+                  eventId: event.event_id,
+                  eventType: event.event_type,
+                  failureCount,
+                  townId,
+                },
+              }
+            );
+            events.markProcessed(this.sql, event.event_id);
+            this._poisonEventFailureCounts.delete(event.event_id);
+            poisonEventActions.push({
+              type: 'notify_mayor',
+              message: `Poison event detected and quarantined: ${event.event_type} event (${event.event_id}) failed ${failureCount} times. Event has been marked as processed.`,
+            });
+          }
         }
       }
+      await this._savePoisonEventFailureCounts();
     } catch (err) {
       logger.error('reconciler: event drain failed', {
         error: err instanceof Error ? err.message : String(err),
@@ -3522,10 +3563,11 @@ export class TownDO extends DurableObject<Env> {
     const sideEffects: Array<() => Promise<void>> = [];
     try {
       const townConfig = await this.getTownConfig();
-      const actions = reconciler.reconcile(this.sql, {
+      const reconcileActions = reconciler.reconcile(this.sql, {
         draining: this._draining,
         refineryCodeReview: townConfig.refinery?.code_review ?? true,
       });
+      const actions = [...reconcileActions, ...poisonEventActions];
       metrics.actionsEmitted = actions.length;
       for (const a of actions) {
         metrics.actionsByType[a.type] = (metrics.actionsByType[a.type] ?? 0) + 1;

--- a/services/gastown/src/dos/town/actions.ts
+++ b/services/gastown/src/dos/town/actions.ts
@@ -557,17 +557,30 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
       beadOps.updateBeadStatus(sql, beadId, 'in_progress', agentId);
 
       const capturedAgentId = agentId;
+      const capturedBeadId = beadId;
       return async () => {
-        // Best-effort dispatch. If it fails, the agent stays 'working'
-        // and the bead stays 'in_progress'. The reconciler detects the
-        // mismatch on the next tick (idle agent hooked to in_progress
-        // bead) and retries dispatch.
-        await ctx.dispatchAgent(capturedAgentId, beadId, rigId).catch(err => {
+        // Best-effort dispatch. On failure (rejects or returns false), unhook
+        // the agent and reset the bead to 'open' so scheduling can retry it
+        // on the next tick instead of waiting for stale-bead recovery (~5 min).
+        //
+        // The double-dispatch risk from false returns (timeout race) is
+        // acceptable here: if the container DID start, the original agent
+        // finds no hooked bead and exits cleanly. If it DIDN'T start, we
+        // correctly rollback and retry. Either way we avoid the ~90s+ delay
+        // from the stale-bead recovery path.
+        let started = false;
+        try {
+          started = await ctx.dispatchAgent(capturedAgentId, capturedBeadId, rigId);
+        } catch (err) {
           console.warn(
-            `${LOG} dispatch_agent: container start failed for agent=${capturedAgentId} bead=${beadId}`,
+            `${LOG} dispatch_agent: container start failed for agent=${capturedAgentId} bead=${capturedBeadId}`,
             err
           );
-        });
+        }
+        if (!started) {
+          agentOps.unhookBead(sql, capturedAgentId);
+          beadOps.updateBeadStatus(sql, capturedBeadId, 'open', null);
+        }
       };
     }
 

--- a/services/gastown/src/dos/town/actions.ts
+++ b/services/gastown/src/dos/town/actions.ts
@@ -747,13 +747,32 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
                 } else {
                   const elapsed = Date.now() - new Date(readySince).getTime();
                   if (elapsed >= (refineryConfig.auto_merge_delay_minutes ?? 0) * 60_000) {
-                    ctx.insertEvent('pr_auto_merge', {
-                      bead_id: action.bead_id,
-                      payload: {
-                        mr_bead_id: action.bead_id,
-                        pr_url: action.pr_url,
-                      },
-                    });
+                    const pendingRows = z
+                      .object({ metadata: z.string().nullable() })
+                      .array()
+                      .parse([
+                        ...query(
+                          sql,
+                          /* sql */ `
+                            SELECT ${beads.columns.metadata}
+                            FROM ${beads}
+                            WHERE ${beads.bead_id} = ?
+                          `,
+                          [action.bead_id]
+                        ),
+                      ]);
+                    const pending = pendingRows[0]?.metadata
+                      ? JSON.parse(pendingRows[0].metadata).auto_merge_pending
+                      : null;
+                    if (!pending) {
+                      ctx.insertEvent('pr_auto_merge', {
+                        bead_id: action.bead_id,
+                        payload: {
+                          mr_bead_id: action.bead_id,
+                          pr_url: action.pr_url,
+                        },
+                      });
+                    }
                   }
                 }
               } else {
@@ -828,15 +847,6 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
             console.log(
               `${LOG} merge_pr: fresh feedback check found issues, aborting merge for bead=${action.bead_id}`
             );
-            query(
-              sql,
-              /* sql */ `
-                UPDATE ${review_metadata}
-                SET ${review_metadata.columns.auto_merge_ready_since} = NULL
-                WHERE ${review_metadata.bead_id} = ?
-              `,
-              [action.bead_id]
-            );
             ctx.insertEvent('auto_merge_cleared', {
               bead_id: action.bead_id,
               payload: { reason: 'fresh_feedback' },
@@ -854,15 +864,6 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
             console.warn(
               `${LOG} merge_pr: merge failed, cleared auto_merge_pending for bead=${action.bead_id}`
             );
-            query(
-              sql,
-              /* sql */ `
-                UPDATE ${review_metadata}
-                SET ${review_metadata.columns.auto_merge_ready_since} = NULL
-                WHERE ${review_metadata.bead_id} = ?
-              `,
-              [action.bead_id]
-            );
             ctx.insertEvent('auto_merge_cleared', {
               bead_id: action.bead_id,
               payload: { reason: 'merge_failed' },
@@ -870,15 +871,6 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
           }
         } catch (err) {
           console.warn(`${LOG} merge_pr failed: bead=${action.bead_id} url=${action.pr_url}`, err);
-          query(
-            sql,
-            /* sql */ `
-              UPDATE ${review_metadata}
-              SET ${review_metadata.columns.auto_merge_ready_since} = NULL
-              WHERE ${review_metadata.bead_id} = ?
-            `,
-            [action.bead_id]
-          );
           ctx.insertEvent('auto_merge_cleared', {
             bead_id: action.bead_id,
             payload: { reason: 'error' },

--- a/services/gastown/src/dos/town/actions.ts
+++ b/services/gastown/src/dos/town/actions.ts
@@ -291,9 +291,6 @@ export type ApplyActionContext = {
 
 const LOG = '[actions]';
 
-/** Fail MR bead after this many consecutive null poll results (#1632). */
-const PR_POLL_NULL_THRESHOLD = 10;
-
 /** Minimum interval between PR polls per MR bead (ms) (#1632). */
 export const PR_POLL_INTERVAL_MS = 60_000; // 1 minute
 
@@ -772,58 +769,10 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
               }
             }
           } else {
-            // Null result — GitHub API unreachable (token missing, expired, rate-limited, or 5xx).
-            // Increment consecutive null counter; fail the bead after PR_POLL_NULL_THRESHOLD.
-            query(
-              sql,
-              /* sql */ `
-                UPDATE ${beads}
-                SET ${beads.columns.metadata} = json_set(
-                  COALESCE(${beads.columns.metadata}, '{}'),
-                  '$.poll_null_count',
-                  COALESCE(
-                    json_extract(${beads.columns.metadata}, '$.poll_null_count'),
-                    0
-                  ) + 1
-                )
-                WHERE ${beads.bead_id} = ?
-              `,
-              [action.bead_id]
-            );
-            const rows = [
-              ...query(
-                sql,
-                /* sql */ `
-                  SELECT json_extract(${beads.columns.metadata}, '$.poll_null_count') AS null_count
-                  FROM ${beads}
-                  WHERE ${beads.bead_id} = ?
-                `,
-                [action.bead_id]
-              ),
-            ];
-            const nullCount = Number(rows[0]?.null_count ?? 0);
-            if (nullCount >= PR_POLL_NULL_THRESHOLD) {
-              console.warn(
-                `${LOG} poll_pr: ${nullCount} consecutive null results for bead=${action.bead_id}, failing`
-              );
-              beadOps.updateBeadStatus(sql, action.bead_id, 'failed', 'system');
-              query(
-                sql,
-                /* sql */ `
-                  UPDATE ${beads}
-                  SET ${beads.columns.metadata} = json_set(
-                    COALESCE(${beads.columns.metadata}, '{}'),
-                    '$.failureReason', 'pr_poll_failed',
-                    '$.failureMessage', ?
-                  )
-                  WHERE ${beads.bead_id} = ?
-                `,
-                [
-                  `Cannot poll PR status — GitHub API returned null ${nullCount} consecutive times. Check that a valid GitHub token is configured in town settings and that the GitHub API is reachable.`,
-                  action.bead_id,
-                ]
-              );
-            }
+            ctx.insertEvent('poll_pr_null', {
+              bead_id: action.bead_id,
+              payload: {},
+            });
           }
           // status === 'open' — no action needed, poll again next tick
         } catch (err) {
@@ -882,22 +831,16 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
             query(
               sql,
               /* sql */ `
-                UPDATE ${beads}
-                SET ${beads.columns.metadata} = json_remove(COALESCE(${beads.metadata}, '{}'), '$.auto_merge_pending'),
-                    ${beads.columns.updated_at} = ?
-                WHERE ${beads.bead_id} = ?
-              `,
-              [now(), action.bead_id]
-            );
-            query(
-              sql,
-              /* sql */ `
                 UPDATE ${review_metadata}
                 SET ${review_metadata.columns.auto_merge_ready_since} = NULL
                 WHERE ${review_metadata.bead_id} = ?
               `,
               [action.bead_id]
             );
+            ctx.insertEvent('auto_merge_cleared', {
+              bead_id: action.bead_id,
+              payload: { reason: 'fresh_feedback' },
+            });
             return;
           }
 
@@ -908,18 +851,8 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
               payload: { pr_url: action.pr_url, pr_state: 'merged' },
             });
           } else {
-            // Merge failed (405/409: branch protection, merge conflict, stale head, etc.)
-            // Clear auto_merge_pending so we resume normal polling on the next tick.
-            // Also reset the auto_merge_ready_since timer so it re-evaluates freshness.
-            query(
-              sql,
-              /* sql */ `
-                UPDATE ${beads}
-                SET ${beads.columns.metadata} = json_remove(COALESCE(${beads.metadata}, '{}'), '$.auto_merge_pending'),
-                    ${beads.columns.updated_at} = ?
-                WHERE ${beads.bead_id} = ?
-              `,
-              [now(), action.bead_id]
+            console.warn(
+              `${LOG} merge_pr: merge failed, cleared auto_merge_pending for bead=${action.bead_id}`
             );
             query(
               sql,
@@ -930,23 +863,13 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
               `,
               [action.bead_id]
             );
-            console.warn(
-              `${LOG} merge_pr: merge failed, cleared auto_merge_pending for bead=${action.bead_id}`
-            );
+            ctx.insertEvent('auto_merge_cleared', {
+              bead_id: action.bead_id,
+              payload: { reason: 'merge_failed' },
+            });
           }
         } catch (err) {
           console.warn(`${LOG} merge_pr failed: bead=${action.bead_id} url=${action.pr_url}`, err);
-          // Clear pending flag on unexpected errors too
-          query(
-            sql,
-            /* sql */ `
-              UPDATE ${beads}
-              SET ${beads.columns.metadata} = json_remove(COALESCE(${beads.metadata}, '{}'), '$.auto_merge_pending'),
-                  ${beads.columns.updated_at} = ?
-              WHERE ${beads.bead_id} = ?
-            `,
-            [now(), action.bead_id]
-          );
           query(
             sql,
             /* sql */ `
@@ -956,6 +879,10 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
             `,
             [action.bead_id]
           );
+          ctx.insertEvent('auto_merge_cleared', {
+            bead_id: action.bead_id,
+            payload: { reason: 'error' },
+          });
         }
       };
     }

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -52,6 +52,9 @@ const CIRCUIT_BREAKER_WINDOW_MINUTES = 30;
  * beads that eventually succeeded (status = 'closed').
  */
 function checkDispatchCircuitBreaker(sql: SqlStorage): Action[] {
+  const cutoffTimestamp = new Date(
+    Date.now() - CIRCUIT_BREAKER_WINDOW_MINUTES * 60_000
+  ).toISOString();
   const rows = z
     .object({ failure_count: z.number() })
     .array()
@@ -61,11 +64,11 @@ function checkDispatchCircuitBreaker(sql: SqlStorage): Action[] {
         /* sql */ `
           SELECT count(*) as failure_count
           FROM ${beads}
-          WHERE ${beads.last_dispatch_attempt_at} > strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-${CIRCUIT_BREAKER_WINDOW_MINUTES} minutes')
+          WHERE ${beads.last_dispatch_attempt_at} > ?
             AND ${beads.dispatch_attempts} > 0
             AND ${beads.status} != 'closed'
         `,
-        []
+        [cutoffTimestamp]
       ),
     ]);
 

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -1140,7 +1140,8 @@ export function reconcileReviewQueue(
     }
 
     // Rule 4: PR-strategy MR beads orphaned (refinery dispatched then died, stale >30min)
-    // Only in_progress — open beads are just waiting for the refinery to pop them.
+    // Only in_progress — open beads are just waiting for the refinery to pop them
+    // from the queue; they haven't been dispatched yet so can't be "orphaned."
     // Skip when refinery code review is disabled: poll_pr keeps the bead alive via
     // updated_at touches, and no refinery is expected to be working on it.
     if (

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -43,6 +43,9 @@ const CIRCUIT_BREAKER_FAILURE_THRESHOLD = 20;
 /** Window in minutes for counting dispatch failures. */
 const CIRCUIT_BREAKER_WINDOW_MINUTES = 30;
 
+/** Fail MR bead after this many consecutive null poll results (#1632). */
+const PR_POLL_NULL_THRESHOLD = 10;
+
 /**
  * Town-level dispatch circuit breaker. Counts beads with at least one
  * dispatch attempt in the recent window that have not yet closed
@@ -449,6 +452,95 @@ export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
         `,
         [new Date().toISOString(), mrBeadId]
       );
+      return;
+    }
+
+    case 'auto_merge_cleared': {
+      const beadId = typeof payload.bead_id === 'string' ? payload.bead_id : event.bead_id;
+      if (!beadId) {
+        console.warn(`${LOG} applyEvent: auto_merge_cleared missing bead_id`);
+        return;
+      }
+
+      query(
+        sql,
+        /* sql */ `
+          UPDATE ${beads}
+          SET ${beads.columns.metadata} = json_remove(COALESCE(${beads.metadata}, '{}'), '$.auto_merge_pending'),
+              ${beads.columns.updated_at} = ?
+          WHERE ${beads.bead_id} = ?
+        `,
+        [new Date().toISOString(), beadId]
+      );
+      query(
+        sql,
+        /* sql */ `
+          UPDATE ${review_metadata}
+          SET ${review_metadata.columns.auto_merge_ready_since} = NULL
+          WHERE ${review_metadata.bead_id} = ?
+        `,
+        [beadId]
+      );
+      return;
+    }
+
+    case 'poll_pr_null': {
+      const beadId = event.bead_id;
+      if (!beadId) {
+        console.warn(`${LOG} applyEvent: poll_pr_null missing bead_id`);
+        return;
+      }
+
+      query(
+        sql,
+        /* sql */ `
+          UPDATE ${beads}
+          SET ${beads.columns.metadata} = json_set(
+            COALESCE(${beads.columns.metadata}, '{}'),
+            '$.poll_null_count',
+            COALESCE(
+              json_extract(${beads.columns.metadata}, '$.poll_null_count'),
+              0
+            ) + 1
+          )
+          WHERE ${beads.bead_id} = ?
+        `,
+        [beadId]
+      );
+      const rows = [
+        ...query(
+          sql,
+          /* sql */ `
+            SELECT json_extract(${beads.columns.metadata}, '$.poll_null_count') AS null_count
+            FROM ${beads}
+            WHERE ${beads.bead_id} = ?
+          `,
+          [beadId]
+        ),
+      ];
+      const nullCount = Number(rows[0]?.null_count ?? 0);
+      if (nullCount >= PR_POLL_NULL_THRESHOLD) {
+        console.warn(
+          `${LOG} poll_pr: ${nullCount} consecutive null results for bead=${beadId}, failing`
+        );
+        beadOps.updateBeadStatus(sql, beadId, 'failed', 'system');
+        query(
+          sql,
+          /* sql */ `
+            UPDATE ${beads}
+            SET ${beads.columns.metadata} = json_set(
+              COALESCE(${beads.columns.metadata}, '{}'),
+              '$.failureReason', 'pr_poll_failed',
+              '$.failureMessage', ?
+            )
+            WHERE ${beads.bead_id} = ?
+          `,
+          [
+            `Cannot poll PR status — GitHub API returned null ${nullCount} consecutive times. Check that a valid GitHub token is configured in town settings and that the GitHub API is reachable.`,
+            beadId,
+          ]
+        );
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- Removed three redundant direct SQL mutations in `merge_pr` async closure that cleared `auto_merge_ready_since` before emitting `auto_merge_cleared` event (fresh feedback, merge failed, error cases). The event handler already clears this column.
- Added check for `auto_merge_pending` in `poll_pr` before emitting `pr_auto_merge` to prevent race condition when `merge_pr` and `poll_pr` run concurrently.

## Verification
- Code review of changes to `services/gastown/src/dos/town/actions.ts`

## Visual Changes
N/A

## Reviewer Notes
N/A