### PR TITLE
Bump to 2026.4.5

### DIFF
--- a/apps/web/src/app/(app)/claw/components/changelog-data.ts
+++ b/apps/web/src/app/(app)/claw/components/changelog-data.ts
@@ -12,8 +12,7 @@ export type ChangelogEntry = {
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
     date: '2026-04-06',
-    description:
-      'Updated OpenClaw to 2026.4.5.',
+    description: 'Updated OpenClaw to 2026.4.5.',
     category: 'feature',
     deployHint: 'redeploy_suggested',
   },

--- a/apps/web/src/app/(app)/claw/components/changelog-data.ts
+++ b/apps/web/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,13 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-04-06',
+    description:
+      'Updated OpenClaw to 2026.4.5.',
+    category: 'feature',
+    deployHint: 'redeploy_suggested',
+  },
+  {
     date: '2026-04-03',
     description: 'Updated OpenClaw to 2026.3.28.',
     category: 'feature',

--- a/services/kiloclaw/.dev.vars.example
+++ b/services/kiloclaw/.dev.vars.example
@@ -68,7 +68,7 @@ FLY_IMAGE_DIGEST=
 # Used by the worker to self-register the version → image tag mapping in KV,
 # enabling per-user version tracking. Without this, version tracking fields
 # will be null and instances fall back to FLY_IMAGE_TAG directly.
-OPENCLAW_VERSION=2026.3.28
+OPENCLAW_VERSION=2026.4.5
 
 # Legacy fallback for existing instances without per-user apps.
 # New instances get per-user apps (acct-{hash}) created automatically.

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -46,7 +46,7 @@ RUN npm install -g pnpm
 
 # Install OpenClaw
 # Pin to specific version for reproducible builds
-RUN npm install -g openclaw@2026.3.28 \
+RUN npm install -g openclaw@2026.4.5 \
     && openclaw --version
 
 # Install ClawHub CLI

--- a/services/kiloclaw/e2e/docker-image-testing.md
+++ b/services/kiloclaw/e2e/docker-image-testing.md
@@ -141,7 +141,7 @@ docker rm kiloclaw-gateway
 ```bash
 # Check versions
 docker run --rm kiloclaw:test node --version        # v24.14.1
-docker run --rm kiloclaw:test openclaw --version    # 2026.3.28
+docker run --rm kiloclaw:test openclaw --version    # 2026.4.5
 
 # Check directories
 docker run --rm kiloclaw:test ls -la /root/.openclaw


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary
Bumps OC to 2026.4.5

## Verification
The following integrations were tested as an initial deployment, as well as on an instance provisioned on 3.28 and upgraded to 4.5:

- Telegram
- Slack
- Discord
- Streamchat
- Web UI
- Linear