### PR TITLE
B4+B5: Cache checkPRFeedback + hoist circuit breaker

### DIFF
--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -560,11 +560,22 @@ export function reconcile(
 ): Action[] {
   const draining = opts?.draining ?? false;
   const actions: Action[] = [];
+
+  const circuitBreakerActions = checkDispatchCircuitBreaker(sql);
+  const circuitBreakerOpen = circuitBreakerActions.length > 0;
+
   actions.push(...reconcileAgents(sql, { draining }));
-  actions.push(...reconcileBeads(sql, { draining }));
+  actions.push(...reconcileBeads(sql, { draining, circuitBreakerOpen }));
   actions.push(
-    ...reconcileReviewQueue(sql, { draining, refineryCodeReview: opts?.refineryCodeReview })
+    ...reconcileReviewQueue(sql, {
+      draining,
+      refineryCodeReview: opts?.refineryCodeReview,
+      circuitBreakerOpen,
+    })
   );
+  if (circuitBreakerOpen) {
+    actions.push(...circuitBreakerActions);
+  }
   actions.push(...reconcileConvoys(sql));
   actions.push(...reconcileGUPP(sql, { draining }));
   actions.push(...reconcileGC(sql));
@@ -716,14 +727,13 @@ export function reconcileAgents(sql: SqlStorage, opts?: { draining?: boolean }):
 // reconcileBeads — handle unassigned beads, lost agents, stale reviews
 // ════════════════════════════════════════════════════════════════════
 
-export function reconcileBeads(sql: SqlStorage, opts?: { draining?: boolean }): Action[] {
+export function reconcileBeads(
+  sql: SqlStorage,
+  opts?: { draining?: boolean; circuitBreakerOpen?: boolean }
+): Action[] {
   const draining = opts?.draining ?? false;
+  const circuitBreakerOpen = opts?.circuitBreakerOpen ?? false;
   const actions: Action[] = [];
-
-  // Town-level circuit breaker: if too many dispatch failures in the
-  // window, skip all dispatch_agent actions and escalate to mayor.
-  const circuitBreakerActions = checkDispatchCircuitBreaker(sql);
-  const circuitBreakerOpen = circuitBreakerActions.length > 0;
 
   // Rule 1: Open issue beads with no assignee, no blockers, not staged, not triage
   const unassigned = BeadRow.array().parse([
@@ -1111,11 +1121,6 @@ export function reconcileBeads(sql: SqlStorage, opts?: { draining?: boolean }): 
     }
   }
 
-  // Emit circuit breaker notification (once per reconcile pass)
-  if (circuitBreakerOpen) {
-    actions.push(...circuitBreakerActions);
-  }
-
   return actions;
 }
 
@@ -1126,14 +1131,12 @@ export function reconcileBeads(sql: SqlStorage, opts?: { draining?: boolean }): 
 
 export function reconcileReviewQueue(
   sql: SqlStorage,
-  opts?: { draining?: boolean; refineryCodeReview?: boolean }
+  opts?: { draining?: boolean; refineryCodeReview?: boolean; circuitBreakerOpen?: boolean }
 ): Action[] {
   const draining = opts?.draining ?? false;
   const refineryCodeReview = opts?.refineryCodeReview ?? true;
+  const circuitBreakerOpen = opts?.circuitBreakerOpen ?? false;
   const actions: Action[] = [];
-
-  // Town-level circuit breaker
-  const circuitBreakerOpen = checkDispatchCircuitBreaker(sql).length > 0;
 
   // Get all MR beads that need attention
   const mrBeads = MrBeadRow.array().parse([


### PR DESCRIPTION
## Summary
- **B4** (actions.ts): `poll_pr` already fetches `checkPRFeedback` once at line 655 and reuses the `feedback` result for both the auto-resolve block (lines 658–707) and auto-merge block (lines 711–769). No change needed.
- **B5** (reconciler.ts): Hoisted `checkDispatchCircuitBreaker(sql)` from `reconcileBeads` and `reconcileReviewQueue` into `reconcile()`. The circuit breaker check now runs once per tick instead of twice, eliminating a redundant COUNT query.

## Verification
- `pnpm format` applied minor formatting fix (line break in `reconcileReviewQueue` call)
- `pnpm lint` passed (0 errors, 0 warnings)
- `pnpm typecheck` passed via local `cd services/gastown && pnpm typecheck`

## Visual Changes
N/A

## Reviewer Notes
N/A