### PR TITLE
fix(kiloclaw): keep recovery APIs available in degraded bootstrap

### DIFF
--- a/.specs/kiloclaw-controller.md
+++ b/.specs/kiloclaw-controller.md
@@ -44,17 +44,12 @@ one succeeding, except where noted.
    reachable from the moment the machine boots, even if bootstrap
    takes seconds or fails entirely.
 
-2. **Bootstrap.** The controller MUST run all bootstrap steps
-   (decryption, directories, feature flags, GitHub config,
-   onboard/doctor with config patching, gateway args) after the HTTP
-   server is listening. Not every internal step corresponds to a
-   distinct health phase — config patching and gateway args
-   construction happen within the onboard/doctor step and at the end
-   of bootstrap respectively, without separate phase transitions.
-   Each major step updates the controller state so `/_kilo/health`
-   reflects progress. If any step fails, the controller MUST enter
-   degraded mode (see Degraded Mode) and MUST NOT proceed to
-   subsequent phases.
+2. **Critical bootstrap.** The controller MUST run the critical
+   bootstrap steps (decryption, directories, feature flags, gateway
+   args) after the HTTP server is listening. Each major step updates
+   the controller state so `/_kilo/health` reflects progress. If any
+   critical step fails, the controller MUST enter degraded mode (see
+   Degraded Mode) and MUST NOT proceed to subsequent phases.
 
 3. **Runtime config load.** The controller MUST read the decrypted
    environment variables produced by bootstrap and construct the
@@ -63,18 +58,26 @@ one succeeding, except where noted.
    happens between `bootstrapping` and `starting` states. If this
    fails, the controller MUST enter degraded mode.
 
-4. **Pre-gateway setup.** The controller SHOULD attempt best-effort
-   setup tasks (Kilo CLI config, gog credentials). Failures in this
-   phase MUST be logged but MUST NOT prevent startup from continuing.
-
-5. **Route registration.** The controller MUST register all Hono
+4. **Route registration.** The controller MUST register all Hono
    routes and activate the Hono app before attempting to start the
    gateway. This ensures that diagnostic and recovery endpoints
    (`/_kilo/version`, `/_kilo/config/*`, `/_kilo/env/*`,
-   `/_kilo/gateway/*`) are available even if the gateway fails to
-   start.
+   `/_kilo/gateway/*`) are available even if a later startup phase or
+   the gateway itself fails.
 
-6. **Gateway start.** The controller MUST start the gateway
+5. **Non-critical bootstrap.** The controller MUST then run the
+   non-critical bootstrap steps (GitHub config, Linear config,
+   onboard/doctor with config patching, TOOLS.md updates, mcporter
+   config). If one of these steps fails, the controller MUST enter
+   degraded mode but MUST keep the Hono app active so authenticated
+   recovery endpoints remain available. The controller MUST NOT
+   proceed to gateway start after a non-critical bootstrap failure.
+
+6. **Pre-gateway setup.** The controller SHOULD attempt best-effort
+   setup tasks (Kilo CLI config, gog credentials). Failures in this
+   phase MUST be logged but MUST NOT prevent startup from continuing.
+
+7. **Gateway start.** The controller MUST start the gateway
    supervisor as the final phase. If the gateway fails to start, the
    controller MUST enter degraded mode but MUST NOT tear down the
    Hono app — all `/_kilo/*` routes MUST remain functional.
@@ -147,9 +150,11 @@ The `phase` field during `bootstrapping` progresses through:
 
 | Phase                          | `/_kilo/health`                 | `/_kilo/*` routes | User traffic (proxy)    | WebSocket               |
 | ------------------------------ | ------------------------------- | ----------------- | ----------------------- | ----------------------- |
-| Bootstrap running              | Inline: `bootstrapping` + phase | 503               | 503                     | 503 reject              |
-| Bootstrap failed               | Inline: `degraded`              | 503               | 503                     | 503 reject              |
+| Critical bootstrap running     | Inline: `bootstrapping` + phase | 503               | 503                     | 503 reject              |
+| Critical bootstrap failed      | Inline: `degraded`              | 503               | 503                     | 503 reject              |
 | Runtime config failed          | Inline: `degraded`              | 503               | 503                     | 503 reject              |
+| Routes registered              | Hono: `bootstrapping` + phase   | Auth-gated        | 503 "Gateway not ready" | 503 reject              |
+| Non-critical bootstrap failed  | Hono: `degraded`                | Auth-gated        | 503 "Gateway not ready" | 503 reject              |
 | Routes registered, gw starting | Hono: `starting`                | Auth-gated        | 503 "Gateway not ready" | Auth-gated              |
 | Gateway start failed           | Hono: `degraded`                | Auth-gated        | 503 "Gateway not ready" | Auth-gated              |
 | Fully operational              | Hono: `ready`                   | Auth-gated        | Proxied to gateway      | Proxied to gateway      |
@@ -217,11 +222,15 @@ gateway supervisor handles crash recovery independently. Use
 2. The controller MUST NOT expose raw error messages on any
    unauthenticated endpoint. All degraded error strings MUST be
    generic stage labels.
-3. When bootstrap or runtime config load fails, only the inline
+3. When critical bootstrap or runtime config load fails, only the inline
    health handler is active. All non-health HTTP requests MUST
    receive 503. WebSocket upgrades MUST receive a 503 response and
    the socket MUST be destroyed.
-4. When the gateway fails to start (after routes are registered), all
+4. When non-critical bootstrap fails after routes are registered, all
+   `/_kilo/*` endpoints required for recovery MUST remain functional.
+   The catch-all proxy MUST return 503 with `"Gateway not ready"` for
+   user traffic.
+5. When the gateway fails to start (after routes are registered), all
    `/_kilo/*` endpoints MUST remain functional. The catch-all proxy
    MUST return 503 with `"Gateway not ready"` for user traffic.
 

--- a/services/kiloclaw/controller/src/bootstrap-phases.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap-phases.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { registerFileRoutes } from './routes/files';
+import { registerKiloCliRunRoutes } from './routes/kilo-cli-run';
+import { registerHealthRoute } from './routes/health';
+import { registerConfigRoutes } from './routes/config';
+import { createSupervisor } from './supervisor';
+import type { ControllerStateRef } from './bootstrap';
+
+const TOKEN = 'test-token';
+
+function authHeaders(): HeadersInit {
+  return { Authorization: `Bearer ${TOKEN}` };
+}
+
+describe('degraded route availability', () => {
+  it('keeps recovery routes available when degraded after route activation', async () => {
+    const app = new Hono();
+    const stateRef: ControllerStateRef = {
+      current: { state: 'degraded', error: 'Startup failed during doctor' },
+    };
+    const supervisor = createSupervisor({ args: ['gateway', '--port', '3001'] });
+
+    registerHealthRoute(app, supervisor, TOKEN, stateRef);
+    registerConfigRoutes(app, supervisor, TOKEN);
+    registerFileRoutes(app, TOKEN, '/root/.openclaw');
+    registerKiloCliRunRoutes(app, TOKEN);
+
+    const [healthResp, configResp, filesResp, cliResp] = await Promise.all([
+      app.request('/_kilo/health'),
+      app.request('/_kilo/config/read', { headers: authHeaders() }),
+      app.request('/_kilo/files/tree', { headers: authHeaders() }),
+      app.request('/_kilo/cli-run/status', { headers: authHeaders() }),
+    ]);
+
+    expect(healthResp.status).toBe(200);
+    expect(configResp.status).not.toBe(503);
+    expect(filesResp.status).not.toBe(503);
+    expect(cliResp.status).toBe(200);
+  });
+});

--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -800,7 +800,11 @@ describe('bootstrapCritical', () => {
     const harness = fakeDeps();
 
     await expect(
-      bootstrapCritical({ KILOCLAW_ENC_FOO: 'enc:v1:bogus' }, phase => phases.push(phase), harness.deps)
+      bootstrapCritical(
+        { KILOCLAW_ENC_FOO: 'enc:v1:bogus' },
+        phase => phases.push(phase),
+        harness.deps
+      )
     ).rejects.toThrow('KILOCLAW_ENV_KEY is not set');
 
     expect(phases).toEqual(['decrypting']);

--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -815,7 +815,7 @@ describe('bootstrapCritical', () => {
 // ---- bootstrapNonCritical ----
 
 describe('bootstrapNonCritical', () => {
-  it('returns github failure and stops subsequent steps', async () => {
+  it('treats github CLI failures as best-effort and continues', async () => {
     const harness = fakeDeps();
     const phases: string[] = [];
     (harness.deps.execFileSync as ReturnType<typeof vi.fn>).mockImplementation((cmd: string) => {
@@ -830,13 +830,43 @@ describe('bootstrapNonCritical', () => {
         GITHUB_TOKEN: 'gh-token',
         KILOCODE_API_KEY: 'api-key',
         OPENCLAW_GATEWAY_TOKEN: 'gw-token',
+        AUTO_APPROVE_DEVICES: 'true',
       },
       phase => phases.push(phase),
       harness.deps
     );
 
-    expect(result).toEqual({ ok: false, phase: 'github', error: 'gh auth failed' });
-    expect(phases).toEqual(['github']);
+    expect(result).toEqual({ ok: true });
+    expect(phases).toEqual(['github', 'linear', 'onboard', 'tools-md', 'mcporter']);
+  });
+
+  it('returns tools-md failure and stops before mcporter', async () => {
+    const harness = fakeDeps();
+    const phases: string[] = [];
+    (harness.deps.existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p.endsWith('openclaw.json')) return false;
+      if (p.endsWith('workspace/TOOLS.md')) return true;
+      return false;
+    });
+    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p.endsWith('workspace/TOOLS.md')) {
+        throw new Error('tools read failed');
+      }
+      return '';
+    });
+
+    const result = await bootstrapNonCritical(
+      {
+        KILOCODE_API_KEY: 'api-key',
+        OPENCLAW_GATEWAY_TOKEN: 'gw-token',
+        AUTO_APPROVE_DEVICES: 'true',
+      },
+      phase => phases.push(phase),
+      harness.deps
+    );
+
+    expect(result).toEqual({ ok: false, phase: 'tools-md', error: 'tools read failed' });
+    expect(phases).toEqual(['github', 'linear', 'onboard', 'tools-md']);
   });
 
   it('returns ok when doctor/onboard succeeds', async () => {

--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -815,6 +815,30 @@ describe('bootstrapCritical', () => {
 // ---- bootstrapNonCritical ----
 
 describe('bootstrapNonCritical', () => {
+  it('returns github failure and stops subsequent steps', async () => {
+    const harness = fakeDeps();
+    const phases: string[] = [];
+    (harness.deps.execFileSync as ReturnType<typeof vi.fn>).mockImplementation((cmd: string) => {
+      if (cmd === 'gh') {
+        throw new Error('gh auth failed');
+      }
+      return '';
+    });
+
+    const result = await bootstrapNonCritical(
+      {
+        GITHUB_TOKEN: 'gh-token',
+        KILOCODE_API_KEY: 'api-key',
+        OPENCLAW_GATEWAY_TOKEN: 'gw-token',
+      },
+      phase => phases.push(phase),
+      harness.deps
+    );
+
+    expect(result).toEqual({ ok: false, phase: 'github', error: 'gh auth failed' });
+    expect(phases).toEqual(['github']);
+  });
+
   it('returns ok when doctor/onboard succeeds', async () => {
     const harness = fakeDeps();
     const phases: string[] = [];

--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -14,6 +14,8 @@ import {
   OP_SECTION_CONFIG,
   LINEAR_SECTION_CONFIG,
   buildGatewayArgs,
+  bootstrapCritical,
+  bootstrapNonCritical,
   bootstrap,
 } from './bootstrap';
 import type { BootstrapDeps, ToolsMdSectionConfig } from './bootstrap';
@@ -773,6 +775,94 @@ describe('buildGatewayArgs', () => {
   });
 });
 
+// ---- bootstrapCritical ----
+
+describe('bootstrapCritical', () => {
+  it('sets critical phases and gateway args', async () => {
+    const key = generateTestKey();
+    const phases: string[] = [];
+    const harness = fakeDeps();
+    const env: Record<string, string | undefined> = {
+      KILOCLAW_ENV_KEY: key,
+      KILOCLAW_ENC_KILOCODE_API_KEY: encryptValue(key, 'api-key'),
+      KILOCLAW_ENC_OPENCLAW_GATEWAY_TOKEN: encryptValue(key, 'gw-token'),
+      AUTO_APPROVE_DEVICES: 'true',
+    };
+
+    await bootstrapCritical(env, phase => phases.push(phase), harness.deps);
+
+    expect(phases).toEqual(['decrypting', 'directories', 'feature-flags']);
+    expect(JSON.parse(env.KILOCLAW_GATEWAY_ARGS ?? '[]')).toContain('gw-token');
+  });
+
+  it('throws before later steps when decryption fails', async () => {
+    const phases: string[] = [];
+    const harness = fakeDeps();
+
+    await expect(
+      bootstrapCritical({ KILOCLAW_ENC_FOO: 'enc:v1:bogus' }, phase => phases.push(phase), harness.deps)
+    ).rejects.toThrow('KILOCLAW_ENV_KEY is not set');
+
+    expect(phases).toEqual(['decrypting']);
+    expect(harness.mkdirCalls).toHaveLength(0);
+  });
+});
+
+// ---- bootstrapNonCritical ----
+
+describe('bootstrapNonCritical', () => {
+  it('returns ok when doctor/onboard succeeds', async () => {
+    const harness = fakeDeps();
+    const phases: string[] = [];
+    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+      JSON.stringify({ gateway: { port: 3001, mode: 'local' } })
+    );
+
+    const result = await bootstrapNonCritical(
+      {
+        KILOCODE_API_KEY: 'api-key',
+        OPENCLAW_GATEWAY_TOKEN: 'gw-token',
+        AUTO_APPROVE_DEVICES: 'true',
+      },
+      phase => phases.push(phase),
+      harness.deps
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(phases).toEqual(['github', 'linear', 'onboard', 'tools-md', 'mcporter']);
+  });
+
+  it('returns a doctor failure instead of throwing', async () => {
+    const harness = fakeDeps();
+    const phases: string[] = [];
+    (harness.deps.existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p.endsWith('openclaw.json')) return true;
+      return false;
+    });
+    (harness.deps.execFileSync as ReturnType<typeof vi.fn>).mockImplementation(
+      (cmd: string, args: string[]) => {
+        if (cmd === 'openclaw' && args.includes('doctor')) {
+          throw new Error('doctor exited 1');
+        }
+        return '';
+      }
+    );
+
+    const result = await bootstrapNonCritical(
+      {
+        KILOCODE_API_KEY: 'api-key',
+        OPENCLAW_GATEWAY_TOKEN: 'gw-token',
+        AUTO_APPROVE_DEVICES: 'true',
+      },
+      phase => phases.push(phase),
+      harness.deps
+    );
+
+    expect(result).toEqual({ ok: false, phase: 'doctor', error: 'doctor exited 1' });
+    expect(phases).toEqual(['github', 'linear', 'doctor']);
+  });
+});
+
 // ---- bootstrap orchestrator ----
 
 describe('bootstrap', () => {
@@ -802,6 +892,8 @@ describe('bootstrap', () => {
       'github',
       'linear',
       'onboard',
+      'tools-md',
+      'mcporter',
     ]);
   });
 

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -580,9 +580,7 @@ export async function bootstrapCritical(
   await yieldToEventLoop();
 }
 
-export type BootstrapNonCriticalResult =
-  | { ok: true }
-  | { ok: false; phase: string; error: string };
+export type BootstrapNonCriticalResult = { ok: true } | { ok: false; phase: string; error: string };
 
 type BootstrapStep = { phase: string; run: () => void | Promise<void> };
 

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -559,7 +559,7 @@ export function buildGatewayArgs(env: EnvLike): string[] {
 /** Yield to the event loop so the HTTP server can process pending requests. */
 const yieldToEventLoop = (): Promise<void> => new Promise(resolve => setImmediate(resolve));
 
-export async function bootstrap(
+export async function bootstrapCritical(
   env: EnvLike,
   setPhase: (phase: string) => void,
   deps: BootstrapDeps = defaultDeps
@@ -576,28 +576,70 @@ export async function bootstrap(
   applyFeatureFlags(env, deps);
 
   generateHooksToken(env);
-  await yieldToEventLoop();
-
-  setPhase('github');
-  configureGitHub(env, deps);
-  await yieldToEventLoop();
-
-  setPhase('linear');
-  configureLinear(env);
-  await yieldToEventLoop();
-
-  const configExists = deps.existsSync(CONFIG_PATH);
-  setPhase(configExists ? 'doctor' : 'onboard');
-  runOnboardOrDoctor(env, deps);
-  await yieldToEventLoop();
-
-  updateToolsMdSection(true, KILO_CLI_SECTION_CONFIG, deps);
-  updateToolsMdSection(!!env.KILOCLAW_GOG_CONFIG_TARBALL, GOG_SECTION_CONFIG, deps);
-  updateToolsMdSection(!!env.OP_SERVICE_ACCOUNT_TOKEN, OP_SECTION_CONFIG, deps);
-  updateToolsMdSection(!!env.LINEAR_API_KEY, LINEAR_SECTION_CONFIG, deps);
-
-  // Write mcporter config for MCP servers (AgentCard, etc.)
-  writeMcporterConfig(env);
-
   env.KILOCLAW_GATEWAY_ARGS = JSON.stringify(buildGatewayArgs(env));
+  await yieldToEventLoop();
+}
+
+export type BootstrapNonCriticalResult =
+  | { ok: true }
+  | { ok: false; phase: string; error: string };
+
+type BootstrapStep = { phase: string; run: () => void | Promise<void> };
+
+export async function bootstrapNonCritical(
+  env: EnvLike,
+  setPhase: (phase: string) => void,
+  deps: BootstrapDeps = defaultDeps
+): Promise<BootstrapNonCriticalResult> {
+  await yieldToEventLoop();
+  const configPhase = deps.existsSync(CONFIG_PATH) ? 'doctor' : 'onboard';
+
+  const steps: BootstrapStep[] = [
+    { phase: 'github', run: () => configureGitHub(env, deps) },
+    { phase: 'linear', run: () => configureLinear(env) },
+    { phase: configPhase, run: () => runOnboardOrDoctor(env, deps) },
+    {
+      phase: 'tools-md',
+      run: () => {
+        updateToolsMdSection(true, KILO_CLI_SECTION_CONFIG, deps);
+        updateToolsMdSection(!!env.KILOCLAW_GOG_CONFIG_TARBALL, GOG_SECTION_CONFIG, deps);
+        updateToolsMdSection(!!env.OP_SERVICE_ACCOUNT_TOKEN, OP_SECTION_CONFIG, deps);
+        updateToolsMdSection(!!env.LINEAR_API_KEY, LINEAR_SECTION_CONFIG, deps);
+      },
+    },
+    {
+      phase: 'mcporter',
+      run: () => {
+        writeMcporterConfig(env);
+      },
+    },
+  ];
+
+  for (const step of steps) {
+    try {
+      setPhase(step.phase);
+      await step.run();
+      await yieldToEventLoop();
+    } catch (error) {
+      return {
+        ok: false,
+        phase: step.phase,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  return { ok: true };
+}
+
+export async function bootstrap(
+  env: EnvLike,
+  setPhase: (phase: string) => void,
+  deps: BootstrapDeps = defaultDeps
+): Promise<void> {
+  await bootstrapCritical(env, setPhase, deps);
+  const result = await bootstrapNonCritical(env, setPhase, deps);
+  if (!result.ok) {
+    throw new Error(result.error);
+  }
 }

--- a/services/kiloclaw/controller/src/index.ts
+++ b/services/kiloclaw/controller/src/index.ts
@@ -24,7 +24,7 @@ import { CONTROLLER_COMMIT, CONTROLLER_VERSION } from './version';
 import { writeKiloCliConfig } from './kilo-cli-config';
 import { writeGogCredentials } from './gog-credentials';
 import { startWatchRenewal, stopWatchRenewal } from './gmail-watch-renewal';
-import { bootstrap } from './bootstrap';
+import { bootstrapCritical, bootstrapNonCritical } from './bootstrap';
 import type { ControllerStateRef, ControllerState } from './bootstrap';
 import { getOpenclawVersion } from './openclaw-version';
 import { startCheckin } from './checkin';
@@ -264,12 +264,12 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
     });
   });
 
-  // ── Phase 2: Bootstrap ──────────────────────────────────────────────
-  // Decrypts env vars, sets up directories, applies feature flags, runs
-  // onboard/doctor, patches config, builds gateway args. Updates
-  // controllerState as it progresses through each phase.
+  // ── Phase 2: Critical bootstrap ─────────────────────────────────────
+  // Decrypts env vars, sets up directories, applies feature flags, and
+  // builds gateway args. Failures here are fatal because route auth and
+  // runtime config depend on the decrypted env.
   try {
-    await bootstrap(env, phase => {
+    await bootstrapCritical(env, phase => {
       controllerState.current = { state: 'bootstrapping', phase };
     });
   } catch (err) {
@@ -290,24 +290,10 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
     return;
   }
 
-  // ── Phase 4: Best-effort pre-gateway setup ──────────────────────────
-  try {
-    writeKiloCliConfig(env as Record<string, string | undefined>);
-  } catch (err) {
-    console.error('[kilo-cli] Failed to write config:', err);
-  }
-
-  try {
-    await writeGogCredentials(env as Record<string, string | undefined>);
-  } catch (err) {
-    console.error('[gog] Failed to write credentials:', err);
-  }
-
-  // ── Phase 5: Create supervisors and register routes ─────────────────
-  // Routes are registered unconditionally so /_kilo/version, /_kilo/config/*,
-  // and /_kilo/env/* are available even if the gateway fails to start.
-  // The catch-all proxy returns 503 "Gateway not ready" when the supervisor
-  // isn't running, which is the correct behavior for degraded mode.
+  // ── Phase 4: Create supervisors and register routes ─────────────────
+  // Routes are registered before the doctor/onboard path runs so the
+  // controller's recovery APIs remain available if non-critical bootstrap
+  // later fails.
   const pc = createPairingCache();
   pairingCache = pc;
 
@@ -374,7 +360,6 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
     })
   );
 
-  // Activate the Hono app and WebSocket handler.
   app = honoApp;
   const wsState = { activeConnections: 0 };
   wsUpgradeRef.handler = (req, socket, head) => {
@@ -389,7 +374,36 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
     });
   };
 
-  // ── Phase 6: Start gateway ──────────────────────────────────────────
+  // ── Phase 5: Non-critical bootstrap ─────────────────────────────────
+  const nonCriticalResult = await bootstrapNonCritical(env, phase => {
+    controllerState.current = { state: 'bootstrapping', phase };
+  });
+  if (!nonCriticalResult.ok) {
+    controllerState.current = {
+      state: 'degraded',
+      error: toPublicDegradedError(nonCriticalResult.phase),
+    };
+    console.error(
+      `[controller] Non-critical bootstrap failed during ${nonCriticalResult.phase}, running in degraded mode:`,
+      nonCriticalResult.error
+    );
+    return;
+  }
+
+  // ── Phase 6: Best-effort pre-gateway setup ──────────────────────────
+  try {
+    writeKiloCliConfig(env as Record<string, string | undefined>);
+  } catch (err) {
+    console.error('[kilo-cli] Failed to write config:', err);
+  }
+
+  try {
+    await writeGogCredentials(env as Record<string, string | undefined>);
+  } catch (err) {
+    console.error('[gog] Failed to write credentials:', err);
+  }
+
+  // ── Phase 7: Start gateway ──────────────────────────────────────────
   controllerState.current = { state: 'starting' };
   console.log('[controller] Bootstrap complete, starting gateway...');
 

--- a/services/kiloclaw/controller/src/start-controller-degraded.test.ts
+++ b/services/kiloclaw/controller/src/start-controller-degraded.test.ts
@@ -21,7 +21,11 @@ class MockServerResponse extends Writable {
     return this;
   }
 
-  _write(chunk: Buffer | string, _encoding: BufferEncoding, callback: (error?: Error | null) => void) {
+  _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void
+  ) {
     this.body += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
     callback();
   }
@@ -40,7 +44,11 @@ function createRequest(pathname: string, headers: Record<string, string> = {}): 
   return req;
 }
 
-async function dispatch(httpState: HttpState, pathname: string, headers: Record<string, string> = {}) {
+async function dispatch(
+  httpState: HttpState,
+  pathname: string,
+  headers: Record<string, string> = {}
+) {
   if (!httpState.requestHandler) {
     throw new Error('request handler was not initialized');
   }
@@ -166,7 +174,7 @@ describe('startController degraded behavior', () => {
   });
 
   it('keeps inline-only health behavior when critical bootstrap fails', async () => {
-    const bootstrapNonCritical = vi.fn(async () => ({ ok: true } as const));
+    const bootstrapNonCritical = vi.fn(async () => ({ ok: true }) as const);
     const { startController, httpState } = await loadStartControllerWithMocks({
       bootstrapCritical: async () => {
         throw new Error('decrypt failed');

--- a/services/kiloclaw/controller/src/start-controller-degraded.test.ts
+++ b/services/kiloclaw/controller/src/start-controller-degraded.test.ts
@@ -1,0 +1,201 @@
+import { Readable, Writable } from 'node:stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type HttpState = {
+  requestHandler: ((req: unknown, res: unknown) => void) | null;
+};
+
+type DispatchResult = {
+  status: number;
+  body: string;
+  headers: Record<string, string | number | readonly string[]>;
+};
+
+class MockServerResponse extends Writable {
+  statusCode = 200;
+  headers: Record<string, string | number | readonly string[]> = {};
+  body = '';
+
+  setHeader(name: string, value: string | number | readonly string[]): this {
+    this.headers[name.toLowerCase()] = value;
+    return this;
+  }
+
+  _write(chunk: Buffer | string, _encoding: BufferEncoding, callback: (error?: Error | null) => void) {
+    this.body += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    callback();
+  }
+}
+
+function createRequest(pathname: string, headers: Record<string, string> = {}): Readable {
+  const req = new Readable({ read() {} }) as Readable & {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+  };
+  req.method = 'GET';
+  req.url = pathname;
+  req.headers = { host: 'localhost:18789', ...headers };
+  req.push(null);
+  return req;
+}
+
+async function dispatch(httpState: HttpState, pathname: string, headers: Record<string, string> = {}) {
+  if (!httpState.requestHandler) {
+    throw new Error('request handler was not initialized');
+  }
+
+  const req = createRequest(pathname, headers);
+  const res = new MockServerResponse();
+
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`request timeout for ${pathname}`)), 2000);
+    res.on('finish', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    httpState.requestHandler?.(req, res);
+  });
+
+  return {
+    status: res.statusCode,
+    body: res.body,
+    headers: res.headers,
+  } satisfies DispatchResult;
+}
+
+async function loadStartControllerWithMocks(options: {
+  bootstrapCritical: () => Promise<void>;
+  bootstrapNonCritical: () => Promise<{ ok: true } | { ok: false; phase: string; error: string }>;
+}) {
+  vi.resetModules();
+
+  const httpState: HttpState = { requestHandler: null };
+
+  vi.doMock('node:http', () => {
+    return {
+      default: {
+        createServer: (handler: (req: unknown, res: unknown) => void) => {
+          httpState.requestHandler = handler;
+          return {
+            on: () => undefined,
+            listen: (_port: number, _host: string, cb: () => void) => cb(),
+            close: (cb: () => void) => cb(),
+          };
+        },
+      },
+    };
+  });
+
+  vi.doMock('./bootstrap', () => ({
+    bootstrapCritical: options.bootstrapCritical,
+    bootstrapNonCritical: options.bootstrapNonCritical,
+  }));
+
+  vi.doMock('./supervisor', () => ({
+    createSupervisor: () => ({
+      getState: () => 'stopped',
+      start: async () => undefined,
+      shutdown: async () => undefined,
+      getStats: () => ({
+        state: 'stopped',
+        restartCount: 0,
+      }),
+      signalUsr1: () => false,
+    }),
+  }));
+
+  vi.doMock('./pairing-cache', () => ({
+    createPairingCache: () => ({
+      onPairingLogLine: () => undefined,
+      start: () => undefined,
+      cleanup: () => undefined,
+    }),
+  }));
+
+  vi.spyOn(process, 'on').mockImplementation(() => process);
+
+  const mod = await import('./index');
+  return { startController: mod.startController, httpState };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe('startController degraded behavior', () => {
+  it('keeps C&C routes available after non-critical bootstrap failure', async () => {
+    const { startController, httpState } = await loadStartControllerWithMocks({
+      bootstrapCritical: async () => undefined,
+      bootstrapNonCritical: async () => ({
+        ok: false,
+        phase: 'doctor',
+        error: 'doctor exited 1',
+      }),
+    });
+
+    const env = {
+      OPENCLAW_GATEWAY_TOKEN: 'test-token',
+      KILOCLAW_GATEWAY_ARGS: '["--port","3001"]',
+    } as unknown as NodeJS.ProcessEnv;
+
+    await startController(env);
+
+    const [health, filesTree, cliRunStatus, proxy] = await Promise.all([
+      dispatch(httpState, '/_kilo/health'),
+      dispatch(httpState, '/_kilo/files/tree', {
+        authorization: 'Bearer test-token',
+      }),
+      dispatch(httpState, '/_kilo/cli-run/status', {
+        authorization: 'Bearer test-token',
+      }),
+      dispatch(httpState, '/'),
+    ]);
+
+    expect(health.status).toBe(200);
+    expect(JSON.parse(health.body)).toEqual({
+      status: 'ok',
+      state: 'degraded',
+      error: 'Startup failed during doctor',
+    });
+    expect(filesTree.status).toBe(200);
+    expect(cliRunStatus.status).toBe(200);
+    expect(proxy.status).toBe(503);
+    expect(JSON.parse(proxy.body)).toEqual({ error: 'Gateway not ready' });
+  });
+
+  it('keeps inline-only health behavior when critical bootstrap fails', async () => {
+    const bootstrapNonCritical = vi.fn(async () => ({ ok: true } as const));
+    const { startController, httpState } = await loadStartControllerWithMocks({
+      bootstrapCritical: async () => {
+        throw new Error('decrypt failed');
+      },
+      bootstrapNonCritical,
+    });
+
+    const env = {
+      OPENCLAW_GATEWAY_TOKEN: 'test-token',
+      KILOCLAW_GATEWAY_ARGS: '["--port","3001"]',
+    } as unknown as NodeJS.ProcessEnv;
+
+    await startController(env);
+
+    const [health, filesTree] = await Promise.all([
+      dispatch(httpState, '/_kilo/health'),
+      dispatch(httpState, '/_kilo/files/tree', {
+        authorization: 'Bearer test-token',
+      }),
+    ]);
+
+    expect(bootstrapNonCritical).not.toHaveBeenCalled();
+    expect(health.status).toBe(200);
+    expect(JSON.parse(health.body)).toEqual({
+      status: 'ok',
+      state: 'degraded',
+      error: 'Startup failed during bootstrap',
+    });
+    expect(filesTree.status).toBe(503);
+    expect(JSON.parse(filesTree.body)).toEqual({ error: 'Service starting', state: 'degraded' });
+  });
+});


### PR DESCRIPTION
## Summary

When users borked their config bad enough, and then restarted the machine - you could get into a situation where the initial `openclaw doctor --fix` invocation would exit with a non-0 exit code. When openclaw doctor failed during this bootstrapping phase - we never brought our command and control api endpoints online. 

That meant things like the file picker or kilo recovery endpoints would not be available. 

This breaks up the bootstrapping phase. Critical things - like a failure to decrypt still prevent C&C endpoints from starting (because if the config is that broken, we have no way to auth). But if its just openclaw doctor that fails, we'll start up the C&C endpoints.


Changes:

- Split controller startup bootstrap into two phases: `bootstrapCritical` (decrypt/directories/feature flags/gateway args) and `bootstrapNonCritical` (GitHub/Linear, onboard-or-doctor, TOOLS.md, mcporter).
- Reordered startup in `startController` so Hono routes and C&C endpoints are registered before non-critical bootstrap runs, which keeps authenticated recovery APIs available when non-critical startup work fails.
- Added degraded-path test coverage for the split bootstrap phases and updated the controller spec to document critical vs non-critical degraded behavior and endpoint availability.

## Verification

- [x] `pnpm typecheck` (pass)
- [x] `pnpm lint` (pass)
- [x] `pnpm test -- controller/src/bootstrap.test.ts controller/src/bootstrap-phases.test.ts --runInBand` from `services/kiloclaw` (pass)
- [x] `pnpm format` (pass)
- [ ] Additional user-provided verification

## Visual Changes

N/A

## Reviewer Notes

- Main behavior change is startup ordering: route activation now happens before non-critical bootstrap, so doctor/onboard failures still expose `/_kilo/*` recovery endpoints while proxy traffic remains `503 Gateway not ready` when the gateway is offline. 
- Critical bootstrap/runtime-config failures remain inline-health-only degraded mode by design because auth/runtime token derivation has not completed.
- Risk area to focus on in review: lifecycle transitions (`bootstrapping -> degraded`) and ensuring gateway start is skipped on non-critical bootstrap failure.