### PR TITLE
feat(gastown): add GitHub OAuth device flow for gh CLI

### DIFF
--- a/cloudflare-gastown/src/handlers/town-config.handler.ts
+++ b/cloudflare-gastown/src/handlers/town-config.handler.ts
@@ -70,6 +70,7 @@ function maskSensitiveValues(config: TownConfig): TownConfig {
   return {
     ...config,
     kilocode_token: maskToken(config.kilocode_token),
+    github_cli_pat: maskToken(config.github_cli_pat),
     env_vars: envVars,
     git_auth: {
       ...config.git_auth,

--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -859,6 +859,190 @@ export const gastownRouter = router({
       await townStub.forceRefreshContainerToken();
     }),
 
+  // ── GitHub OAuth Device Flow ────────────────────────────────────────
+
+  githubOAuthDeviceCode: gastownProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+
+      const clientId = ctx.env.GITHUB_OAUTH_CLIENT_ID;
+      if (!clientId) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'GitHub OAuth is not configured (missing GITHUB_OAUTH_CLIENT_ID)',
+        });
+      }
+
+      const response = await fetch('https://github.com/login/device/code', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          client_id: clientId,
+          scope: 'repo read:user user:email',
+        }),
+      });
+
+      if (!response.ok) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `GitHub device code request failed: ${response.status}`,
+        });
+      }
+
+      const DeviceCodeResponse = z.object({
+        device_code: z.string(),
+        user_code: z.string(),
+        verification_uri: z.string(),
+        expires_in: z.number(),
+        interval: z.number(),
+      });
+      const raw: unknown = await response.json();
+      const data = DeviceCodeResponse.parse(raw);
+
+      return {
+        userCode: data.user_code,
+        verificationUri: data.verification_uri,
+        deviceCode: data.device_code,
+        expiresIn: data.expires_in,
+        interval: data.interval,
+      };
+    }),
+
+  githubOAuthPoll: gastownProcedure
+    .input(z.object({ townId: z.string().uuid(), deviceCode: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+
+      const clientId = ctx.env.GITHUB_OAUTH_CLIENT_ID;
+      if (!clientId) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'GitHub OAuth is not configured (missing GITHUB_OAUTH_CLIENT_ID)',
+        });
+      }
+
+      const response = await fetch('https://github.com/login/oauth/access_token', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          client_id: clientId,
+          device_code: input.deviceCode,
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        }),
+      });
+
+      if (!response.ok) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `GitHub token exchange failed: ${response.status}`,
+        });
+      }
+
+      const TokenResponse = z.object({
+        access_token: z.string().optional(),
+        token_type: z.string().optional(),
+        scope: z.string().optional(),
+        error: z.string().optional(),
+        error_description: z.string().optional(),
+      });
+      const raw: unknown = await response.json();
+      const data = TokenResponse.parse(raw);
+
+      if (data.error === 'authorization_pending' || data.error === 'slow_down') {
+        return { status: 'pending' as const };
+      }
+
+      if (data.error) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: data.error_description ?? data.error,
+        });
+      }
+
+      if (!data.access_token) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'GitHub returned no access token',
+        });
+      }
+
+      // Fetch the authenticated GitHub user
+      const userResponse = await fetch('https://api.github.com/user', {
+        headers: {
+          Authorization: `Bearer ${data.access_token}`,
+          Accept: 'application/json',
+          'User-Agent': 'Kilo-Gastown',
+        },
+      });
+
+      if (!userResponse.ok) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `GitHub user lookup failed: ${userResponse.status}`,
+        });
+      }
+
+      const GitHubUser = z.object({
+        login: z.string(),
+        avatar_url: z.string(),
+      });
+      const userRaw: unknown = await userResponse.json();
+      const user = GitHubUser.parse(userRaw);
+
+      // Store the token and OAuth metadata
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      await townStub.updateTownConfig({
+        github_cli_pat: data.access_token,
+        github_cli_oauth_username: user.login,
+        github_cli_oauth_connected_at: new Date().toISOString(),
+      });
+
+      return {
+        status: 'complete' as const,
+        username: user.login,
+        avatarUrl: user.avatar_url,
+      };
+    }),
+
+  githubOAuthDisconnect: gastownProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      await townStub.updateTownConfig({
+        github_cli_pat: '',
+        github_cli_oauth_username: '',
+        github_cli_oauth_connected_at: '',
+      });
+    }),
+
+  githubOAuthStatus: gastownProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      const config = await townStub.getTownConfig();
+
+      if (config.github_cli_oauth_username && config.github_cli_pat) {
+        return {
+          connected: true as const,
+          username: config.github_cli_oauth_username,
+          connectedAt: config.github_cli_oauth_connected_at,
+        };
+      }
+
+      return { connected: false as const };
+    }),
+
   // ── Events ──────────────────────────────────────────────────────────
 
   getBeadEvents: gastownProcedure

--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -271,6 +271,12 @@ export const TownConfigSchema = z.object({
    *  Git clone/push still uses the integration token from git_auth. */
   github_cli_pat: z.string().optional(),
 
+  /** GitHub username resolved from OAuth Device Flow (display only). */
+  github_cli_oauth_username: z.string().optional(),
+
+  /** ISO timestamp of when GitHub was connected via OAuth. */
+  github_cli_oauth_connected_at: z.string().optional(),
+
   /** Custom git commit author name. When set, the user becomes the primary author
    *  and the AI agent is added as co-author (unless disable_ai_coauthor is true). */
   git_author_name: z.string().optional(),
@@ -327,6 +333,8 @@ export const TownConfigUpdateSchema = z.object({
     .optional(),
   staged_convoys_default: z.boolean().optional(),
   github_cli_pat: z.string().optional(),
+  github_cli_oauth_username: z.string().optional(),
+  github_cli_oauth_connected_at: z.string().optional(),
   git_author_name: z.string().optional(),
   git_author_email: z.string().optional(),
   disable_ai_coauthor: z.boolean().optional(),

--- a/cloudflare-gastown/worker-configuration.d.ts
+++ b/cloudflare-gastown/worker-configuration.d.ts
@@ -60,6 +60,7 @@ declare namespace Cloudflare {
 		CF_VERSION_METADATA?: WorkerVersionMetadata;
 		SENTRY_DSN?: string; // worker secret
 		SENTRY_RELEASE?: string; // deploy-time --var
+		GITHUB_OAUTH_CLIENT_ID?: string;
 	}
 }
 interface Env extends Cloudflare.Env {}

--- a/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { useUser } from '@/hooks/useUser';
@@ -27,12 +27,26 @@ import {
   Container,
   User,
   Key,
+  Github,
+  ChevronDown,
+  Copy,
+  Check,
+  Loader2,
+  X,
 } from 'lucide-react';
 import { motion } from 'motion/react';
 
 type Props = { townId: string; readOnly?: boolean };
 
 type EnvVarEntry = { key: string; value: string; isNew?: boolean };
+
+type DeviceFlowState = {
+  userCode: string;
+  verificationUri: string;
+  deviceCode: string;
+  interval: number;
+  expiresIn: number;
+};
 
 // Section definitions for the scrollspy nav
 const SECTIONS = [
@@ -103,6 +117,7 @@ export function TownSettingsPageClient({ townId, readOnly = false }: Props) {
 
   const townQuery = useQuery(trpc.gastown.getTown.queryOptions({ townId }));
   const configQuery = useQuery(trpc.gastown.getTownConfig.queryOptions({ townId }));
+  const githubOAuthStatus = useQuery(trpc.gastown.githubOAuthStatus.queryOptions({ townId }));
 
   const effectiveReadOnly = readOnly && currentUser?.id !== configQuery.data?.created_by_user_id;
 
@@ -125,6 +140,38 @@ export function TownSettingsPageClient({ townId, readOnly = false }: Props) {
     })
   );
 
+  const githubOAuthDeviceCode = useMutation(
+    trpc.gastown.githubOAuthDeviceCode.mutationOptions({
+      onSuccess: data => {
+        setDeviceFlowState({
+          userCode: data.userCode,
+          verificationUri: data.verificationUri,
+          deviceCode: data.deviceCode,
+          interval: data.interval,
+          expiresIn: data.expiresIn,
+        });
+      },
+      onError: err => toast.error(`Failed to start GitHub connection: ${err.message}`),
+    })
+  );
+
+  const githubOAuthPollMutation = useMutation(trpc.gastown.githubOAuthPoll.mutationOptions({}));
+
+  const githubOAuthDisconnect = useMutation(
+    trpc.gastown.githubOAuthDisconnect.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.gastown.githubOAuthStatus.queryKey({ townId }),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.gastown.getTownConfig.queryKey({ townId }),
+        });
+        toast.success('GitHub account disconnected');
+      },
+      onError: err => toast.error(`Disconnect failed: ${err.message}`),
+    })
+  );
+
   // Local state for form fields
   const [envVars, setEnvVars] = useState<EnvVarEntry[]>([]);
   const [githubToken, setGithubToken] = useState('');
@@ -142,6 +189,9 @@ export function TownSettingsPageClient({ townId, readOnly = false }: Props) {
   const [disableAiCoauthor, setDisableAiCoauthor] = useState(false);
   const [initialized, setInitialized] = useState(false);
   const [showTokens, setShowTokens] = useState(false);
+  const [deviceFlowState, setDeviceFlowState] = useState<DeviceFlowState | null>(null);
+  const [showManualPat, setShowManualPat] = useState(false);
+  const [codeCopied, setCodeCopied] = useState(false);
 
   // Sync config into local state when loaded
   if (configQuery.data && !initialized) {
@@ -166,6 +216,70 @@ export function TownSettingsPageClient({ townId, readOnly = false }: Props) {
   const { activeId: activeSection, scrollTo: scrollToSection } = useScrollSpy(
     SECTIONS.map(s => s.id)
   );
+
+  // GitHub OAuth Device Flow polling
+  const cancelDeviceFlow = useCallback(() => {
+    setDeviceFlowState(null);
+    setCodeCopied(false);
+  }, []);
+
+  // Use a ref for the poll mutate function to avoid re-triggering the effect
+  const pollMutateRef = useRef(githubOAuthPollMutation.mutate);
+  pollMutateRef.current = githubOAuthPollMutation.mutate;
+
+  useEffect(() => {
+    if (!deviceFlowState) return;
+
+    const intervalMs = (deviceFlowState.interval || 5) * 1000;
+    const expiresAt = Date.now() + deviceFlowState.expiresIn * 1000;
+
+    const timer = setInterval(() => {
+      if (Date.now() > expiresAt) {
+        clearInterval(timer);
+        toast.error('Authorization timed out. Please try again.');
+        setDeviceFlowState(null);
+        setCodeCopied(false);
+        return;
+      }
+
+      pollMutateRef.current(
+        { townId, deviceCode: deviceFlowState.deviceCode },
+        {
+          onSuccess: result => {
+            if (result.status === 'complete') {
+              clearInterval(timer);
+              setDeviceFlowState(null);
+              setCodeCopied(false);
+              toast.success(`Connected as @${result.username}`);
+              void queryClient.invalidateQueries({
+                queryKey: trpc.gastown.githubOAuthStatus.queryKey({ townId }),
+              });
+              void queryClient.invalidateQueries({
+                queryKey: trpc.gastown.getTownConfig.queryKey({ townId }),
+              });
+            }
+          },
+          onError: err => {
+            clearInterval(timer);
+            toast.error(`Authorization failed: ${err.message}`);
+            setDeviceFlowState(null);
+            setCodeCopied(false);
+          },
+        }
+      );
+    }, intervalMs);
+
+    return () => clearInterval(timer);
+  }, [deviceFlowState, townId, queryClient, trpc]);
+
+  function copyUserCode() {
+    if (!deviceFlowState) return;
+    void navigator.clipboard.writeText(deviceFlowState.userCode).then(() => {
+      setCodeCopied(true);
+      toast.success('Code copied to clipboard');
+      setTimeout(() => setCodeCopied(false), 2000);
+    });
+  }
 
   function handleSave() {
     const envVarObj: Record<string, string> = {};
@@ -337,24 +451,132 @@ export function TownSettingsPageClient({ townId, readOnly = false }: Props) {
               <SettingsSection
                 id="github-cli"
                 title="GitHub CLI"
-                description="Personal Access Token used exclusively for gh CLI operations (PRs, issues, reviews). Git clone and push still use the integration token above."
+                description="Authenticate gh CLI operations (PRs, issues, reviews). Git clone and push still use the integration token above."
                 icon={Key}
                 index={1}
               >
-                <div className="space-y-4">
-                  <FieldGroup
-                    label="GitHub Personal Access Token"
-                    hint="When set, PRs and issues created by agents will appear under your GitHub identity. Requires repo scope (or fine-grained: contents, pull_requests, issues)."
-                  >
-                    <Input
-                      type={showTokens ? 'text' : 'password'}
-                      value={githubCliPat}
-                      onChange={e => setGithubCliPat(e.target.value)}
-                      placeholder="ghp_xxxxxxxxxxxx or github_pat_xxxxxxxxxxxx"
-                      className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
-                    />
-                  </FieldGroup>
-                </div>
+                {/* Connected state */}
+                {githubOAuthStatus.data?.connected ? (
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between rounded-lg border border-[color:oklch(95%_0.15_108_/_0.15)] bg-[color:oklch(95%_0.15_108_/_0.04)] px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <img
+                          src={`https://github.com/${githubOAuthStatus.data.username}.png?size=64`}
+                          alt={githubOAuthStatus.data.username}
+                          className="size-10 rounded-full ring-1 ring-white/10"
+                        />
+                        <div>
+                          <p className="text-sm font-medium text-white/85">
+                            @{githubOAuthStatus.data.username}
+                          </p>
+                          {githubOAuthStatus.data.connectedAt && (
+                            <p className="text-[11px] text-white/35">
+                              Connected{' '}
+                              {new Date(githubOAuthStatus.data.connectedAt).toLocaleDateString()}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                      <Button
+                        onClick={() => githubOAuthDisconnect.mutate({ townId })}
+                        disabled={githubOAuthDisconnect.isPending}
+                        variant="secondary"
+                        size="sm"
+                        className="gap-1.5 text-red-400 hover:bg-red-500/10 hover:text-red-300"
+                      >
+                        <X className="size-3" />
+                        {githubOAuthDisconnect.isPending ? 'Disconnecting...' : 'Disconnect'}
+                      </Button>
+                    </div>
+                  </div>
+                ) : deviceFlowState ? (
+                  /* Connecting state — device flow in progress */
+                  <div className="space-y-4">
+                    <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed border-white/[0.15] bg-white/[0.02] px-4 py-6">
+                      <p className="text-xs text-white/40">
+                        Enter this code at GitHub to connect your account
+                      </p>
+                      <div className="flex items-center gap-2">
+                        <code className="rounded-lg border border-white/[0.1] bg-white/[0.05] px-5 py-3 font-mono text-2xl font-bold tracking-[0.2em] text-white/90">
+                          {deviceFlowState.userCode}
+                        </code>
+                        <button
+                          onClick={copyUserCode}
+                          className="rounded-md p-2 text-white/40 transition-colors hover:bg-white/[0.06] hover:text-white/70"
+                          title="Copy code"
+                        >
+                          {codeCopied ? (
+                            <Check className="size-4 text-[color:oklch(95%_0.15_108)]" />
+                          ) : (
+                            <Copy className="size-4" />
+                          )}
+                        </button>
+                      </div>
+                      <a
+                        href={deviceFlowState.verificationUri}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs text-[color:oklch(95%_0.15_108_/_0.8)] underline decoration-white/20 underline-offset-2 transition-colors hover:text-[color:oklch(95%_0.15_108)]"
+                      >
+                        Enter this code at github.com/login/device
+                      </a>
+                      <div className="flex items-center gap-2 pt-1 text-xs text-white/35">
+                        <Loader2 className="size-3 animate-spin" />
+                        Waiting for authorization...
+                      </div>
+                    </div>
+                    <div className="flex justify-center">
+                      <button
+                        onClick={cancelDeviceFlow}
+                        className="rounded-md px-3 py-1.5 text-xs text-white/40 transition-colors hover:bg-white/[0.04] hover:text-white/60"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  /* Disconnected state — show Connect button and collapsible manual PAT */
+                  <div className="space-y-4">
+                    <Button
+                      onClick={() => githubOAuthDeviceCode.mutate({ townId })}
+                      disabled={githubOAuthDeviceCode.isPending}
+                      variant="primary"
+                      size="sm"
+                      className="gap-2 bg-[color:oklch(95%_0.15_108_/_0.90)] px-4 py-2.5 text-sm text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+                    >
+                      <Github className="size-4" />
+                      {githubOAuthDeviceCode.isPending ? 'Connecting...' : 'Connect GitHub'}
+                    </Button>
+
+                    <div className="border-t border-white/[0.06] pt-3">
+                      <button
+                        onClick={() => setShowManualPat(prev => !prev)}
+                        className="flex items-center gap-1.5 text-xs text-white/35 transition-colors hover:text-white/55"
+                      >
+                        <ChevronDown
+                          className={`size-3 transition-transform ${showManualPat ? '' : '-rotate-90'}`}
+                        />
+                        Or enter a token manually
+                      </button>
+                      {showManualPat && (
+                        <div className="mt-3">
+                          <FieldGroup
+                            label="GitHub Personal Access Token"
+                            hint="When set, PRs and issues created by agents will appear under your GitHub identity. Requires repo scope (or fine-grained: contents, pull_requests, issues)."
+                          >
+                            <Input
+                              type={showTokens ? 'text' : 'password'}
+                              value={githubCliPat}
+                              onChange={e => setGithubCliPat(e.target.value)}
+                              placeholder="ghp_xxxxxxxxxxxx or github_pat_xxxxxxxxxxxx"
+                              className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
+                            />
+                          </FieldGroup>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
               </SettingsSection>
 
               {/* ── Commit Identity ─────────────────────────────────── */}

--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -454,6 +454,8 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
           | undefined;
         staged_convoys_default: boolean;
         github_cli_pat?: string | undefined;
+        github_cli_oauth_username?: string | undefined;
+        github_cli_oauth_connected_at?: string | undefined;
         git_author_name?: string | undefined;
         git_author_email?: string | undefined;
         disable_ai_coauthor: boolean;
@@ -495,6 +497,8 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
             | undefined;
           staged_convoys_default?: boolean | undefined;
           github_cli_pat?: string | undefined;
+          github_cli_oauth_username?: string | undefined;
+          github_cli_oauth_connected_at?: string | undefined;
           git_author_name?: string | undefined;
           git_author_email?: string | undefined;
           disable_ai_coauthor?: boolean | undefined;
@@ -537,6 +541,43 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
         townId: string;
       };
       output: void;
+      meta: object;
+    }>;
+    githubOAuthDeviceCode: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        userCode: string;
+        verificationUri: string;
+        deviceCode: string;
+        expiresIn: number;
+        interval: number;
+      };
+      meta: object;
+    }>;
+    githubOAuthPoll: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        deviceCode: string;
+      };
+      output: { status: 'pending' } | { status: 'complete'; username: string; avatarUrl: string };
+      meta: object;
+    }>;
+    githubOAuthDisconnect: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    githubOAuthStatus: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output:
+        | { connected: true; username: string; connectedAt: string | undefined }
+        | { connected: false };
       meta: object;
     }>;
     getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
@@ -1660,6 +1701,8 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
               | undefined;
             staged_convoys_default: boolean;
             github_cli_pat?: string | undefined;
+            github_cli_oauth_username?: string | undefined;
+            github_cli_oauth_connected_at?: string | undefined;
             git_author_name?: string | undefined;
             git_author_email?: string | undefined;
             disable_ai_coauthor: boolean;
@@ -1701,6 +1744,8 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
                 | undefined;
               staged_convoys_default?: boolean | undefined;
               github_cli_pat?: string | undefined;
+              github_cli_oauth_username?: string | undefined;
+              github_cli_oauth_connected_at?: string | undefined;
               git_author_name?: string | undefined;
               git_author_email?: string | undefined;
               disable_ai_coauthor?: boolean | undefined;
@@ -1743,6 +1788,45 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             townId: string;
           };
           output: void;
+          meta: object;
+        }>;
+        githubOAuthDeviceCode: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            userCode: string;
+            verificationUri: string;
+            deviceCode: string;
+            expiresIn: number;
+            interval: number;
+          };
+          meta: object;
+        }>;
+        githubOAuthPoll: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            deviceCode: string;
+          };
+          output:
+            | { status: 'pending' }
+            | { status: 'complete'; username: string; avatarUrl: string };
+          meta: object;
+        }>;
+        githubOAuthDisconnect: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        githubOAuthStatus: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output:
+            | { connected: true; username: string; connectedAt: string | undefined }
+            | { connected: false };
           meta: object;
         }>;
         getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{


### PR DESCRIPTION
## Summary
- Add Gastown tRPC endpoints to start, poll, disconnect, and read GitHub OAuth device-flow state for Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
  browse:        Open repositories, issues, pull requests, and more in the browser
  codespace:     Connect to and manage codespaces
  gist:          Manage gists
  issue:         Manage issues
  org:           Manage organizations
  pr:            Manage pull requests
  project:       Work with GitHub Projects.
  release:       Manage releases
  repo:          Manage repositories

GITHUB ACTIONS COMMANDS
  cache:         Manage GitHub Actions caches
  run:           View details about workflow runs
  workflow:      View details about GitHub Actions workflows

ALIAS COMMANDS
  co:            Alias for "pr checkout"

ADDITIONAL COMMANDS
  agent-task:    Work with agent tasks (preview)
  alias:         Create command shortcuts
  api:           Make an authenticated GitHub API request
  attestation:   Work with artifact attestations
  completion:    Generate shell completion scripts
  config:        Manage configuration for gh
  copilot:       Run the GitHub Copilot CLI (preview)
  extension:     Manage gh extensions
  gpg-key:       Manage GPG keys
  label:         Manage labels
  licenses:      View third-party license information
  preview:       Execute previews for gh features
  ruleset:       View info about repo rulesets
  search:        Search for repositories, issues, and pull requests
  secret:        Manage GitHub secrets
  ssh-key:       Manage SSH keys
  status:        Print information about relevant issues, pull requests, and notifications across repositories
  variable:      Manage GitHub Actions variables

HELP TOPICS
  accessibility: Learn about GitHub CLI's accessibility experiences
  actions:       Learn about working with GitHub Actions
  environment:   Environment variables that can be used with gh
  exit-codes:    Exit codes used by gh
  formatting:    Formatting options for JSON data exported from gh
  mintty:        Information about using gh with MinTTY
  reference:     A comprehensive reference of all gh commands

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility` CLI authentication.
- Store and mask the connected GitHub token plus display metadata in town config, and expose the required worker env var.
- Update the town settings GitHub CLI section to support connect/disconnect via device flow while retaining optional manual PAT entry.

## Verification
- No automated checks were configured for this review.
- Code review of diff --git a/cloudflare-gastown/src/handlers/town-config.handler.ts b/cloudflare-gastown/src/handlers/town-config.handler.ts
index de0929aba..4345c4df9 100644
--- a/cloudflare-gastown/src/handlers/town-config.handler.ts
+++ b/cloudflare-gastown/src/handlers/town-config.handler.ts
@@ -70,6 +70,7 @@ function maskSensitiveValues(config: TownConfig): TownConfig {
   return {
     ...config,
     kilocode_token: maskToken(config.kilocode_token),
+    github_cli_pat: maskToken(config.github_cli_pat),
     env_vars: envVars,
     git_auth: {
       ...config.git_auth,
diff --git a/cloudflare-gastown/src/trpc/router.ts b/cloudflare-gastown/src/trpc/router.ts
index c76afd093..3d135574d 100644
--- a/cloudflare-gastown/src/trpc/router.ts
+++ b/cloudflare-gastown/src/trpc/router.ts
@@ -859,6 +859,190 @@ export const gastownRouter = router({
       await townStub.forceRefreshContainerToken();
     }),
 
+  // ── GitHub OAuth Device Flow ────────────────────────────────────────
+
+  githubOAuthDeviceCode: gastownProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+
+      const clientId = ctx.env.GITHUB_OAUTH_CLIENT_ID;
+      if (!clientId) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'GitHub OAuth is not configured (missing GITHUB_OAUTH_CLIENT_ID)',
+        });
+      }
+
+      const response = await fetch('https://github.com/login/device/code', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          client_id: clientId,
+          scope: 'repo read:user user:email',
+        }),
+      });
+
+      if (!response.ok) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `GitHub device code request failed: ${response.status}`,
+        });
+      }
+
+      const DeviceCodeResponse = z.object({
+        device_code: z.string(),
+        user_code: z.string(),
+        verification_uri: z.string(),
+        expires_in: z.number(),
+        interval: z.number(),
+      });
+      const raw: unknown = await response.json();
+      const data = DeviceCodeResponse.parse(raw);
+
+      return {
+        userCode: data.user_code,
+        verificationUri: data.verification_uri,
+        deviceCode: data.device_code,
+        expiresIn: data.expires_in,
+        interval: data.interval,
+      };
+    }),
+
+  githubOAuthPoll: gastownProcedure
+    .input(z.object({ townId: z.string().uuid(), deviceCode: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+
+      const clientId = ctx.env.GITHUB_OAUTH_CLIENT_ID;
+      if (!clientId) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'GitHub OAuth is not configured (missing GITHUB_OAUTH_CLIENT_ID)',
+        });
+      }
+
+      const response = await fetch('https://github.com/login/oauth/access_token', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          client_id: clientId,
+          device_code: input.deviceCode,
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        }),
+      });
+
+      if (!response.ok) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `GitHub token exchange failed: ${response.status}`,
+        });
+      }
+
+      const TokenResponse = z.object({
+        access_token: z.string().optional(),
+        token_type: z.string().optional(),
+        scope: z.string().optional(),
+        error: z.string().optional(),
+        error_description: z.string().optional(),
+      });
+      const raw: unknown = await response.json();
+      const data = TokenResponse.parse(raw);
+
+      if (data.error === 'authorization_pending' || data.error === 'slow_down') {
+        return { status: 'pending' as const };
+      }
+
+      if (data.error) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: data.error_description ?? data.error,
+        });
+      }
+
+      if (!data.access_token) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'GitHub returned no access token',
+        });
+      }
+
+      // Fetch the authenticated GitHub user
+      const userResponse = await fetch('https://api.github.com/user', {
+        headers: {
+          Authorization: `Bearer ${data.access_token}`,
+          Accept: 'application/json',
+          'User-Agent': 'Kilo-Gastown',
+        },
+      });
+
+      if (!userResponse.ok) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `GitHub user lookup failed: ${userResponse.status}`,
+        });
+      }
+
+      const GitHubUser = z.object({
+        login: z.string(),
+        avatar_url: z.string(),
+      });
+      const userRaw: unknown = await userResponse.json();
+      const user = GitHubUser.parse(userRaw);
+
+      // Store the token and OAuth metadata
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      await townStub.updateTownConfig({
+        github_cli_pat: data.access_token,
+        github_cli_oauth_username: user.login,
+        github_cli_oauth_connected_at: new Date().toISOString(),
+      });
+
+      return {
+        status: 'complete' as const,
+        username: user.login,
+        avatarUrl: user.avatar_url,
+      };
+    }),
+
+  githubOAuthDisconnect: gastownProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      await townStub.updateTownConfig({
+        github_cli_pat: '',
+        github_cli_oauth_username: '',
+        github_cli_oauth_connected_at: '',
+      });
+    }),
+
+  githubOAuthStatus: gastownProcedure
+    .input(z.object({ townId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx.userId, input.townId, ctx.orgMemberships);
+
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      const config = await townStub.getTownConfig();
+
+      if (config.github_cli_oauth_username && config.github_cli_pat) {
+        return {
+          connected: true as const,
+          username: config.github_cli_oauth_username,
+          connectedAt: config.github_cli_oauth_connected_at,
+        };
+      }
+
+      return { connected: false as const };
+    }),
+
   // ── Events ──────────────────────────────────────────────────────────
 
   getBeadEvents: gastownProcedure
diff --git a/cloudflare-gastown/src/types.ts b/cloudflare-gastown/src/types.ts
index c9d015849..d5029c8bf 100644
--- a/cloudflare-gastown/src/types.ts
+++ b/cloudflare-gastown/src/types.ts
@@ -271,6 +271,12 @@ export const TownConfigSchema = z.object({
    *  Git clone/push still uses the integration token from git_auth. */
   github_cli_pat: z.string().optional(),
 
+  /** GitHub username resolved from OAuth Device Flow (display only). */
+  github_cli_oauth_username: z.string().optional(),
+
+  /** ISO timestamp of when GitHub was connected via OAuth. */
+  github_cli_oauth_connected_at: z.string().optional(),
+
   /** Custom git commit author name. When set, the user becomes the primary author
    *  and the AI agent is added as co-author (unless disable_ai_coauthor is true). */
   git_author_name: z.string().optional(),
@@ -327,6 +333,8 @@ export const TownConfigUpdateSchema = z.object({
     .optional(),
   staged_convoys_default: z.boolean().optional(),
   github_cli_pat: z.string().optional(),
+  github_cli_oauth_username: z.string().optional(),
+  github_cli_oauth_connected_at: z.string().optional(),
   git_author_name: z.string().optional(),
   git_author_email: z.string().optional(),
   disable_ai_coauthor: z.boolean().optional(),
diff --git a/cloudflare-gastown/worker-configuration.d.ts b/cloudflare-gastown/worker-configuration.d.ts
index 1acac8ca5..aca8b3025 100644
--- a/cloudflare-gastown/worker-configuration.d.ts
+++ b/cloudflare-gastown/worker-configuration.d.ts
@@ -60,6 +60,7 @@ declare namespace Cloudflare {
 		CF_VERSION_METADATA?: WorkerVersionMetadata;
 		SENTRY_DSN?: string; // worker secret
 		SENTRY_RELEASE?: string; // deploy-time --var
+		GITHUB_OAUTH_CLIENT_ID?: string;
 	}
 }
 interface Env extends Cloudflare.Env {}
diff --git a/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx b/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
index 49e48d5f9..4e3abc65f 100644
--- a/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { useUser } from '@/hooks/useUser';
@@ -27,6 +27,12 @@ import {
   Container,
   User,
   Key,
+  Github,
+  ChevronDown,
+  Copy,
+  Check,
+  Loader2,
+  X,
 } from 'lucide-react';
 import { motion } from 'motion/react';
 
@@ -34,6 +40,14 @@ type Props = { townId: string; readOnly?: boolean };
 
 type EnvVarEntry = { key: string; value: string; isNew?: boolean };
 
+type DeviceFlowState = {
+  userCode: string;
+  verificationUri: string;
+  deviceCode: string;
+  interval: number;
+  expiresIn: number;
+};
+
 // Section definitions for the scrollspy nav
 const SECTIONS = [
   { id: 'git-auth', label: 'Git Authentication', icon: GitBranch },
@@ -103,6 +117,7 @@ export function TownSettingsPageClient({ townId, readOnly = false }: Props) {
 
   const townQuery = useQuery(trpc.gastown.getTown.queryOptions({ townId }));
   const configQuery = useQuery(trpc.gastown.getTownConfig.queryOptions({ townId }));
+  const githubOAuthStatus = useQuery(trpc.gastown.githubOAuthStatus.queryOptions({ townId }));
 
   const effectiveReadOnly = readOnly && currentUser?.id !== configQuery.data?.created_by_user_id;
 
@@ -125,6 +140,38 @@ export function TownSettingsPageClient({ townId, readOnly = false }: Props) {
     })
   );
 
+  const githubOAuthDeviceCode = useMutation(
+    trpc.gastown.githubOAuthDeviceCode.mutationOptions({
+      onSuccess: data => {
+        setDeviceFlowState({
+          userCode: data.userCode,
+          verificationUri: data.verificationUri,
+          deviceCode: data.deviceCode,
+          interval: data.interval,
+          expiresIn: data.expiresIn,
+        });
+      },
+      onError: err => toast.error(`Failed to start GitHub connection: ${err.message}`),
+    })
+  );
+
+  const githubOAuthPollMutation = useMutation(trpc.gastown.githubOAuthPoll.mutationOptions({}));
+
+  const githubOAuthDisconnect = useMutation(
+    trpc.gastown.githubOAuthDisconnect.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.gastown.githubOAuthStatus.queryKey({ townId }),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.gastown.getTownConfig.queryKey({ townId }),
+        });
+        toast.success('GitHub account disconnected');
+      },
+      onError: err => toast.error(`Disconnect failed: ${err.message}`),
+    })
+  );
+
   // Local state for form fields
   const [envVars, setEnvVars] = useState<EnvVarEntry[]>([]);
   const [githubToken, setGithubToken] = useState('');
@@ -142,6 +189,9 @@ export function TownSettingsPageClient({ townId, readOnly = false }: Props) {
   const [disableAiCoauthor, setDisableAiCoauthor] = useState(false);
   const [initialized, setInitialized] = useState(false);
   const [showTokens, setShowTokens] = useState(false);
+  const [deviceFlowState, setDeviceFlowState] = useState<DeviceFlowState | null>(null);
+  const [showManualPat, setShowManualPat] = useState(false);
+  const [codeCopied, setCodeCopied] = useState(false);
 
   // Sync config into local state when loaded
   if (configQuery.data && !initialized) {
@@ -167,6 +217,70 @@ export function TownSettingsPageClient({ townId, readOnly = false }: Props) {
     SECTIONS.map(s => s.id)
   );
 
+  // GitHub OAuth Device Flow polling
+  const cancelDeviceFlow = useCallback(() => {
+    setDeviceFlowState(null);
+    setCodeCopied(false);
+  }, []);
+
+  // Use a ref for the poll mutate function to avoid re-triggering the effect
+  const pollMutateRef = useRef(githubOAuthPollMutation.mutate);
+  pollMutateRef.current = githubOAuthPollMutation.mutate;
+
+  useEffect(() => {
+    if (!deviceFlowState) return;
+
+    const intervalMs = (deviceFlowState.interval || 5) * 1000;
+    const expiresAt = Date.now() + deviceFlowState.expiresIn * 1000;
+
+    const timer = setInterval(() => {
+      if (Date.now() > expiresAt) {
+        clearInterval(timer);
+        toast.error('Authorization timed out. Please try again.');
+        setDeviceFlowState(null);
+        setCodeCopied(false);
+        return;
+      }
+
+      pollMutateRef.current(
+        { townId, deviceCode: deviceFlowState.deviceCode },
+        {
+          onSuccess: result => {
+            if (result.status === 'complete') {
+              clearInterval(timer);
+              setDeviceFlowState(null);
+              setCodeCopied(false);
+              toast.success(`Connected as @${result.username}`);
+              void queryClient.invalidateQueries({
+                queryKey: trpc.gastown.githubOAuthStatus.queryKey({ townId }),
+              });
+              void queryClient.invalidateQueries({
+                queryKey: trpc.gastown.getTownConfig.queryKey({ townId }),
+              });
+            }
+          },
+          onError: err => {
+            clearInterval(timer);
+            toast.error(`Authorization failed: ${err.message}`);
+            setDeviceFlowState(null);
+            setCodeCopied(false);
+          },
+        }
+      );
+    }, intervalMs);
+
+    return () => clearInterval(timer);
+  }, [deviceFlowState, townId, queryClient, trpc]);
+
+  function copyUserCode() {
+    if (!deviceFlowState) return;
+    void navigator.clipboard.writeText(deviceFlowState.userCode).then(() => {
+      setCodeCopied(true);
+      toast.success('Code copied to clipboard');
+      setTimeout(() => setCodeCopied(false), 2000);
+    });
+  }
+
   function handleSave() {
     const envVarObj: Record<string, string> = {};
     for (const entry of envVars) {
@@ -337,24 +451,132 @@ export function TownSettingsPageClient({ townId, readOnly = false }: Props) {
               <SettingsSection
                 id="github-cli"
                 title="GitHub CLI"
-                description="Personal Access Token used exclusively for gh CLI operations (PRs, issues, reviews). Git clone and push still use the integration token above."
+                description="Authenticate gh CLI operations (PRs, issues, reviews). Git clone and push still use the integration token above."
                 icon={Key}
                 index={1}
               >
-                <div className="space-y-4">
-                  <FieldGroup
-                    label="GitHub Personal Access Token"
-                    hint="When set, PRs and issues created by agents will appear under your GitHub identity. Requires repo scope (or fine-grained: contents, pull_requests, issues)."
-                  >
-                    <Input
-                      type={showTokens ? 'text' : 'password'}
-                      value={githubCliPat}
-                      onChange={e => setGithubCliPat(e.target.value)}
-                      placeholder="ghp_xxxxxxxxxxxx or github_pat_xxxxxxxxxxxx"
-                      className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
-                    />
-                  </FieldGroup>
-                </div>
+                {/* Connected state */}
+                {githubOAuthStatus.data?.connected ? (
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between rounded-lg border border-[color:oklch(95%_0.15_108_/_0.15)] bg-[color:oklch(95%_0.15_108_/_0.04)] px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <img
+                          src={`https://github.com/${githubOAuthStatus.data.username}.png?size=64`}
+                          alt={githubOAuthStatus.data.username}
+                          className="size-10 rounded-full ring-1 ring-white/10"
+                        />
+                        <div>
+                          <p className="text-sm font-medium text-white/85">
+                            @{githubOAuthStatus.data.username}
+                          </p>
+                          {githubOAuthStatus.data.connectedAt && (
+                            <p className="text-[11px] text-white/35">
+                              Connected{' '}
+                              {new Date(githubOAuthStatus.data.connectedAt).toLocaleDateString()}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                      <Button
+                        onClick={() => githubOAuthDisconnect.mutate({ townId })}
+                        disabled={githubOAuthDisconnect.isPending}
+                        variant="secondary"
+                        size="sm"
+                        className="gap-1.5 text-red-400 hover:bg-red-500/10 hover:text-red-300"
+                      >
+                        <X className="size-3" />
+                        {githubOAuthDisconnect.isPending ? 'Disconnecting...' : 'Disconnect'}
+                      </Button>
+                    </div>
+                  </div>
+                ) : deviceFlowState ? (
+                  /* Connecting state — device flow in progress */
+                  <div className="space-y-4">
+                    <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed border-white/[0.15] bg-white/[0.02] px-4 py-6">
+                      <p className="text-xs text-white/40">
+                        Enter this code at GitHub to connect your account
+                      </p>
+                      <div className="flex items-center gap-2">
+                        <code className="rounded-lg border border-white/[0.1] bg-white/[0.05] px-5 py-3 font-mono text-2xl font-bold tracking-[0.2em] text-white/90">
+                          {deviceFlowState.userCode}
+                        </code>
+                        <button
+                          onClick={copyUserCode}
+                          className="rounded-md p-2 text-white/40 transition-colors hover:bg-white/[0.06] hover:text-white/70"
+                          title="Copy code"
+                        >
+                          {codeCopied ? (
+                            <Check className="size-4 text-[color:oklch(95%_0.15_108)]" />
+                          ) : (
+                            <Copy className="size-4" />
+                          )}
+                        </button>
+                      </div>
+                      <a
+                        href={deviceFlowState.verificationUri}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs text-[color:oklch(95%_0.15_108_/_0.8)] underline decoration-white/20 underline-offset-2 transition-colors hover:text-[color:oklch(95%_0.15_108)]"
+                      >
+                        Enter this code at github.com/login/device
+                      </a>
+                      <div className="flex items-center gap-2 pt-1 text-xs text-white/35">
+                        <Loader2 className="size-3 animate-spin" />
+                        Waiting for authorization...
+                      </div>
+                    </div>
+                    <div className="flex justify-center">
+                      <button
+                        onClick={cancelDeviceFlow}
+                        className="rounded-md px-3 py-1.5 text-xs text-white/40 transition-colors hover:bg-white/[0.04] hover:text-white/60"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  /* Disconnected state — show Connect button and collapsible manual PAT */
+                  <div className="space-y-4">
+                    <Button
+                      onClick={() => githubOAuthDeviceCode.mutate({ townId })}
+                      disabled={githubOAuthDeviceCode.isPending}
+                      variant="primary"
+                      size="sm"
+                      className="gap-2 bg-[color:oklch(95%_0.15_108_/_0.90)] px-4 py-2.5 text-sm text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+                    >
+                      <Github className="size-4" />
+                      {githubOAuthDeviceCode.isPending ? 'Connecting...' : 'Connect GitHub'}
+                    </Button>
+
+                    <div className="border-t border-white/[0.06] pt-3">
+                      <button
+                        onClick={() => setShowManualPat(prev => !prev)}
+                        className="flex items-center gap-1.5 text-xs text-white/35 transition-colors hover:text-white/55"
+                      >
+                        <ChevronDown
+                          className={`size-3 transition-transform ${showManualPat ? '' : '-rotate-90'}`}
+                        />
+                        Or enter a token manually
+                      </button>
+                      {showManualPat && (
+                        <div className="mt-3">
+                          <FieldGroup
+                            label="GitHub Personal Access Token"
+                            hint="When set, PRs and issues created by agents will appear under your GitHub identity. Requires repo scope (or fine-grained: contents, pull_requests, issues)."
+                          >
+                            <Input
+                              type={showTokens ? 'text' : 'password'}
+                              value={githubCliPat}
+                              onChange={e => setGithubCliPat(e.target.value)}
+                              placeholder="ghp_xxxxxxxxxxxx or github_pat_xxxxxxxxxxxx"
+                              className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
+                            />
+                          </FieldGroup>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
               </SettingsSection>
 
               {/* ── Commit Identity ─────────────────────────────────── */}
diff --git a/src/lib/gastown/types/router.d.ts b/src/lib/gastown/types/router.d.ts
index 591ea8bef..5f4be943d 100644
--- a/src/lib/gastown/types/router.d.ts
+++ b/src/lib/gastown/types/router.d.ts
@@ -454,6 +454,8 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
           | undefined;
         staged_convoys_default: boolean;
         github_cli_pat?: string | undefined;
+        github_cli_oauth_username?: string | undefined;
+        github_cli_oauth_connected_at?: string | undefined;
         git_author_name?: string | undefined;
         git_author_email?: string | undefined;
         disable_ai_coauthor: boolean;
@@ -495,6 +497,8 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
             | undefined;
           staged_convoys_default?: boolean | undefined;
           github_cli_pat?: string | undefined;
+          github_cli_oauth_username?: string | undefined;
+          github_cli_oauth_connected_at?: string | undefined;
           git_author_name?: string | undefined;
           git_author_email?: string | undefined;
           disable_ai_coauthor?: boolean | undefined;
@@ -539,6 +543,43 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
       output: void;
       meta: object;
     }>;
+    githubOAuthDeviceCode: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: {
+        userCode: string;
+        verificationUri: string;
+        deviceCode: string;
+        expiresIn: number;
+        interval: number;
+      };
+      meta: object;
+    }>;
+    githubOAuthPoll: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        deviceCode: string;
+      };
+      output: { status: 'pending' } | { status: 'complete'; username: string; avatarUrl: string };
+      meta: object;
+    }>;
+    githubOAuthDisconnect: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+      };
+      output: void;
+      meta: object;
+    }>;
+    githubOAuthStatus: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        townId: string;
+      };
+      output:
+        | { connected: true; username: string; connectedAt: string | undefined }
+        | { connected: false };
+      meta: object;
+    }>;
     getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
       input: {
         rigId: string;
@@ -1660,6 +1701,8 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
               | undefined;
             staged_convoys_default: boolean;
             github_cli_pat?: string | undefined;
+            github_cli_oauth_username?: string | undefined;
+            github_cli_oauth_connected_at?: string | undefined;
             git_author_name?: string | undefined;
             git_author_email?: string | undefined;
             disable_ai_coauthor: boolean;
@@ -1701,6 +1744,8 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
                 | undefined;
               staged_convoys_default?: boolean | undefined;
               github_cli_pat?: string | undefined;
+              github_cli_oauth_username?: string | undefined;
+              github_cli_oauth_connected_at?: string | undefined;
               git_author_name?: string | undefined;
               git_author_email?: string | undefined;
               disable_ai_coauthor?: boolean | undefined;
@@ -1745,6 +1790,45 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
           output: void;
           meta: object;
         }>;
+        githubOAuthDeviceCode: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: {
+            userCode: string;
+            verificationUri: string;
+            deviceCode: string;
+            expiresIn: number;
+            interval: number;
+          };
+          meta: object;
+        }>;
+        githubOAuthPoll: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            deviceCode: string;
+          };
+          output:
+            | { status: 'pending' }
+            | { status: 'complete'; username: string; avatarUrl: string };
+          meta: object;
+        }>;
+        githubOAuthDisconnect: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+          };
+          output: void;
+          meta: object;
+        }>;
+        githubOAuthStatus: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            townId: string;
+          };
+          output:
+            | { connected: true; username: string; connectedAt: string | undefined }
+            | { connected: false };
+          meta: object;
+        }>;
         getBeadEvents: import('@trpc/server').TRPCQueryProcedure<{
           input: {
             rigId: string; completed.

## Visual Changes
- N/A

## Reviewer Notes
- The branch adds a direct  load from ; verify the app's image policy intentionally allows this non-Next image usage in settings.
- The device-flow polling effect treats  the same as , so GitHub's requested backoff is ignored and may cause unnecessary poll failures under rate limiting.