### PR TITLE
ci(kiloclaw): add GitHub workflow for pushing dev controller image

### DIFF
--- a/.github/workflows/push-dev-kiloclaw.yml
+++ b/.github/workflows/push-dev-kiloclaw.yml
@@ -28,12 +28,13 @@ jobs:
           username: x
           password: ${{ secrets.FLY_DEV_API_TOKEN }}
 
-      - name: Generate image tag
+      - name: Generate image tag and cache bust value
         id: tag
         run: |
-          TAG="dev-$(date +%s)"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Tag: ${TAG}"
+          TIMESTAMP=$(date +%s)
+          echo "tag=dev-${TIMESTAMP}" >> "$GITHUB_OUTPUT"
+          echo "cache_bust=${TIMESTAMP}" >> "$GITHUB_OUTPUT"
+          echo "Tag: dev-${TIMESTAMP}"
 
       - name: Compute source content hash
         id: content-hash
@@ -73,7 +74,7 @@ jobs:
             registry.fly.io/kiloclaw-registry-dev:${{ steps.tag.outputs.tag }}
           build-args: |
             CONTROLLER_COMMIT=${{ github.sha }}
-            CONTROLLER_CACHE_BUST=$(date +%s)
+            CONTROLLER_CACHE_BUST=${{ steps.tag.outputs.cache_bust }}
 
       - name: Extract image digest
         id: digest

--- a/.github/workflows/push-dev-kiloclaw.yml
+++ b/.github/workflows/push-dev-kiloclaw.yml
@@ -1,0 +1,129 @@
+name: Push Dev KiloClaw Image
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  push-dev:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    name: Build & Push Dev Image
+
+    steps:
+      - name: Checkout code
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        with:
+          dissociate: true
+
+      - name: Setup Docker Buildx
+        uses: useblacksmith/setup-docker-builder@5241b2e9423e8b1fa37ed6050ecb62d0fb9a4e38 # v1.6.0
+
+      - name: Login to Fly Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: registry.fly.io
+          username: x
+          password: ${{ secrets.FLY_DEV_API_TOKEN }}
+
+      - name: Generate image tag
+        id: tag
+        run: |
+          TAG="dev-$(date +%s)"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Tag: ${TAG}"
+
+      - name: Compute source content hash
+        id: content-hash
+        working-directory: services/kiloclaw
+        run: |
+          for path in Dockerfile controller container skills \
+                      openclaw-pairing-list.js openclaw-device-pairing-list.js; do
+            if [ ! -e "$path" ]; then
+              echo "::error::Required path not found: $path"
+              exit 1
+            fi
+          done
+
+          CONTENT_HASH=$(
+            find Dockerfile controller/ container/ skills/ \
+              openclaw-pairing-list.js openclaw-device-pairing-list.js \
+              -type f \
+              | sort \
+              | xargs sha256sum \
+              | sha256sum \
+              | cut -d' ' -f1 \
+              | cut -c1-12
+          )
+
+          echo "hash=${CONTENT_HASH}" >> "$GITHUB_OUTPUT"
+          echo "Source content hash: ${CONTENT_HASH}"
+
+      - name: Build and push Docker image
+        id: docker-build
+        uses: useblacksmith/build-push-action@cbd1f60d194a98cb3be5523b15134501eaf0fbf3 # v2.1.0
+        with:
+          context: services/kiloclaw
+          file: services/kiloclaw/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            registry.fly.io/kiloclaw-registry-dev:${{ steps.tag.outputs.tag }}
+          build-args: |
+            CONTROLLER_COMMIT=${{ github.sha }}
+            CONTROLLER_CACHE_BUST=$(date +%s)
+
+      - name: Extract image digest
+        id: digest
+        env:
+          BUILD_DIGEST: ${{ steps.docker-build.outputs.digest }}
+        run: |
+          echo "digest=${BUILD_DIGEST:-}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract OpenClaw version
+        id: openclaw-version
+        run: |
+          VERSION=$(sed -n 's/.*openclaw@\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' services/kiloclaw/Dockerfile | head -1)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Failed to extract OpenClaw version from Dockerfile"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Write .dev.vars summary
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          DIGEST="${{ steps.digest.outputs.digest }}"
+          OPENCLAW="${{ steps.openclaw-version.outputs.version }}"
+          CONTENT="${{ steps.content-hash.outputs.hash }}"
+
+          {
+            echo ""
+            echo "## .dev.vars entries for KiloClaw worker"
+            echo ""
+            echo "Add or update these in \`services/kiloclaw/.dev.vars\`, then restart wrangler dev:"
+            echo ""
+            echo '```'
+            echo "FLY_IMAGE_TAG=${TAG}"
+            if [ -n "$DIGEST" ]; then
+              echo "FLY_IMAGE_DIGEST=${DIGEST}"
+            fi
+            echo "OPENCLAW_VERSION=${OPENCLAW}"
+            echo "FLY_IMAGE_CONTENT_HASH=${CONTENT}"
+            echo '```'
+            echo ""
+            echo "**Image pushed to:** \`registry.fly.io/kiloclaw-registry-dev:${TAG}\`"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo ""
+          echo "=== .dev.vars entries ==="
+          echo "FLY_IMAGE_TAG=${TAG}"
+          if [ -n "$DIGEST" ]; then
+            echo "FLY_IMAGE_DIGEST=${DIGEST}"
+          fi
+          echo "OPENCLAW_VERSION=${OPENCLAW}"
+          echo "FLY_IMAGE_CONTENT_HASH=${CONTENT}"
+          echo "=========================="


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g. feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

Adds a manually-triggered GitHub Actions workflow (`workflow_dispatch`) for building and pushing the KiloClaw controller Docker image to the dev Fly registry.

Developers push up a feature branch and trigger the workflow on-demand from the GitHub Actions UI. After the build completes, the workflow prints the four `.dev.vars` entries (`FLY_IMAGE_TAG`, `FLY_IMAGE_DIGEST`, `OPENCLAW_VERSION`, `FLY_IMAGE_CONTENT_HASH`) to both the job log and the GitHub Summary tab for easy copy-paste into `services/kiloclaw/.dev.vars`.

Key design decisions (matching existing conventions):
- Pushes to `registry.fly.io/kiloclaw-registry-dev` (separate from production `kiloclaw-machines`)
- Uses `dev-{timestamp}` tags (always builds, matching `push-dev.sh`)
- Uses a separate `FLY_DEV_API_TOKEN` secret scoped to the dev Fly org
- Content hash computation mirrors the `find | sort | xargs sha256sum` approach from `deploy-kiloclaw.yml` so the `FLY_IMAGE_CONTENT_HASH` value is consistent across local and CI builds
- No worker deploy, no Slack notification — purely an image-push + vars-output tool

## Verification

<!-- List the checks you ran and what passed. Add command output notes when useful. -->

- [ ] `pnpm format` — formatted the new workflow file (oxfmt)
- [ ] YAML structure reviewed against existing `deploy-kiloclaw.yml` patterns (same actions, same runner label, same Docker setup)
- [x] `FLY_DEV_API_TOKEN` secret must be added to the repo before first run


## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If no visual/UI changes are likely, replace the table with: N/A -->

N/A

## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->

- The `FLY_DEV_API_TOKEN` secret must be added to the repo's GitHub Actions secrets before this workflow can run. The workflow will fail at the `Login to Fly Registry` step without it.
- The workflow reuses the same pinned action versions as `deploy-kiloclaw.yml` for consistency.
- No changes to any application code, schema, or runtime behavior.