### PR TITLE
feat(gastown): isolate agent SQLite DB via KILO_TEST_HOME

### DIFF
--- a/services/gastown/container/src/agent-runner.ts
+++ b/services/gastown/container/src/agent-runner.ts
@@ -98,6 +98,7 @@ function buildAgentEnv(request: StartAgentRequest): Record<string, string> {
     GASTOWN_TOWN_ID: request.townId,
     GASTOWN_AGENT_ROLE: request.role,
     KILOCODE_FEATURE: 'gastown',
+    KILO_TEST_HOME: `/tmp/agent-home-${request.agentId}`,
 
     GIT_AUTHOR_NAME: authorName,
     GIT_AUTHOR_EMAIL: authorEmail,


### PR DESCRIPTION
## Summary

- Added `KILO_TEST_HOME` env var in `buildAgentEnv()` (`services/gastown/container/src/agent-runner.ts`) set to `/tmp/agent-home-${request.agentId}`
- This ensures `@kilocode/sdk` isolates the `kilo.db` SQLite file per agent instead of sharing the container's default path

## Verification

- [x] TypeScript compiles without errors

## Visual Changes

N/A

## Reviewer Notes

N/A