### PR TITLE
feat(gastown): add AGENT_DB_SNAPSHOTS_KV binding for agent DB snapshots

### DIFF
--- a/services/gastown/worker-configuration.d.ts
+++ b/services/gastown/worker-configuration.d.ts
@@ -40,6 +40,7 @@ declare namespace Cloudflare {
 		AGENT: DurableObjectNamespace<import("./src/gastown.worker").AgentDO>;
 		GIT_TOKEN_SERVICE: GitTokenService;
 		AI: Ai;
+		AGENT_DB_SNAPSHOTS_KV: KVNamespace;
 	}
 	interface Env {
 		GASTOWN_AE: AnalyticsEngineDataset;
@@ -58,6 +59,7 @@ declare namespace Cloudflare {
 		AGENT: DurableObjectNamespace<import("./src/gastown.worker").AgentDO>;
 		GIT_TOKEN_SERVICE: GitTokenService;
 		AI: Ai;
+		AGENT_DB_SNAPSHOTS_KV: KVNamespace;
 		HYPERDRIVE?: Hyperdrive;
 		CF_VERSION_METADATA?: WorkerVersionMetadata;
 		SENTRY_DSN?: string; // worker secret

--- a/services/gastown/wrangler.jsonc
+++ b/services/gastown/wrangler.jsonc
@@ -85,7 +85,7 @@
   "ai": { "binding": "AI" },
 
   "kv_namespaces": [
-    { "binding": "AGENT_DB_SNAPSHOTS_KV", "id": "<your-kv-namespace-id>" },
+    { "binding": "AGENT_DB_SNAPSHOTS_KV", "id": "" },
   ],
 
   "analytics_engine_datasets": [{ "binding": "GASTOWN_AE", "dataset": "gastown_events" }],

--- a/services/gastown/wrangler.jsonc
+++ b/services/gastown/wrangler.jsonc
@@ -84,6 +84,10 @@
 
   "ai": { "binding": "AI" },
 
+  "kv_namespaces": [
+    { "binding": "AGENT_DB_SNAPSHOTS_KV", "id": "<your-kv-namespace-id>" },
+  ],
+
   "analytics_engine_datasets": [{ "binding": "GASTOWN_AE", "dataset": "gastown_events" }],
 
   "services": [


### PR DESCRIPTION
## Summary
- Add KV namespace binding to wrangler.jsonc for storing agent SQLite database snapshots
- Add AGENT_DB_SNAPSHOTS_KV: KVNamespace to the Env interface in worker-configuration.d.ts

## Verification
- TypeScript compilation verified
- Changes committed and pushed

## Visual Changes
N/A

## Reviewer Notes
- The KV namespace ID is a placeholder - replace with actual namespace ID after creating it