### PR TITLE
feat(gastown): add process registry RPC to TownContainerDO

### DIFF
--- a/services/gastown/src/dos/TownContainer.do.ts
+++ b/services/gastown/src/dos/TownContainer.do.ts
@@ -67,6 +67,16 @@ export class TownContainerDO extends Container<Env> {
     console.log(`${TC_LOG} deleteEnvVar: ${key} removed`);
   }
 
+  async updateRegistry(registry: unknown): Promise<void> {
+    await this.ctx.storage.put('container:registry', registry);
+    console.log(`${TC_LOG} updateRegistry: updated (${Array.isArray(registry) ? registry.length : '?'} entries)`);
+  }
+
+  async getRegistry(): Promise<unknown> {
+    const registry = await this.ctx.storage.get<unknown>('container:registry');
+    return registry ?? [];
+  }
+
   override onStart(): void {
     console.log(`${TC_LOG} container started for DO id=${this.ctx.id.toString()}`);
   }


### PR DESCRIPTION
## Summary

Adds two RPC methods to `TownContainerDO` for persisting the container's process registry:
- `updateRegistry(registry)` - saves registry via Durable Object storage
- `getRegistry()` - retrieves registry or returns `[]` if not found

## Verification

- [x] Code reviewed and matches bead requirements

## Visual Changes

N/A

## Reviewer Notes

N/A