### PR TITLE
feat(gastown): pass GASTOWN_TOWN_ID to container on provision

### DIFF
--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -96,6 +96,7 @@ export async function ensureContainerToken(
   // Store for next boot
   try {
     await container.setEnvVar('GASTOWN_CONTAINER_TOKEN', token);
+    await container.setEnvVar('GASTOWN_TOWN_ID', townId);
   } catch (err) {
     console.warn(
       `${TOWN_LOG} ensureContainerToken: setEnvVar failed (container may not be running):`,
@@ -161,6 +162,7 @@ export async function forceRefreshContainerToken(
   // Store for next boot (best-effort — the critical step is the live push below)
   try {
     await container.setEnvVar('GASTOWN_CONTAINER_TOKEN', token);
+    await container.setEnvVar('GASTOWN_TOWN_ID', townId);
   } catch (err) {
     console.warn(
       `${TOWN_LOG} forceRefreshContainerToken: setEnvVar failed:`,


### PR DESCRIPTION
## Summary
- Add `GASTOWN_TOWN_ID` env var to container on provision in both `ensureContainerToken()` and `forceRefreshContainerToken()`.
- This ensures the container can read `process.env.GASTOWN_TOWN_ID` on cold boot to know its town identity.

## Verification
- Read both functions in `services/gastown/src/dos/town/container-dispatch.ts`.
- Confirmed `await container.setEnvVar('GASTOWN_TOWN_ID', townId)` added after each `setEnvVar('GASTOWN_CONTAINER_TOKEN', token)` call.

## Visual Changes
N/A

## Reviewer Notes
N/A