### PR TITLE
fix(gastown): abort in-flight startup on agent restart

### DIFF
--- a/cloudflare-gastown/container/src/process-manager.ts
+++ b/cloudflare-gastown/container/src/process-manager.ts
@@ -546,6 +546,16 @@ export async function startAgent(
     console.log(
       `${MANAGER_LOG} startAgent: stopping existing session for ${request.agentId} (status=${existing.status})`
     );
+
+    // If the agent is still starting, abort the in-flight startup to prevent
+    // an orphaned session from being created after stopAgent returns.
+    if (existing.status === 'starting' && existing.startupAbortController) {
+      console.log(
+        `${MANAGER_LOG} startAgent: aborting in-flight startup for ${request.agentId}`
+      );
+      existing.startupAbortController.abort();
+    }
+
     await stopAgent(request.agentId).catch(err => {
       console.warn(
         `${MANAGER_LOG} startAgent: failed to stop existing session for ${request.agentId}`,
@@ -555,6 +565,7 @@ export async function startAgent(
   }
 
   const now = new Date().toISOString();
+  const startupAbortController = new AbortController();
   const agent: ManagedAgent = {
     agentId: request.agentId,
     rigId: request.rigId,
@@ -579,14 +590,21 @@ export async function startAgent(
     completionCallbackUrl: request.envVars?.GASTOWN_COMPLETION_CALLBACK_URL ?? null,
     model: request.model ?? null,
     startupEnv: env,
+    startupAbortController,
   };
   agents.set(request.agentId, agent);
 
+  const { signal } = startupAbortController;
   let sessionCounted = false;
   try {
     // 1. Ensure SDK server is running for this workdir
     const { client, port } = await ensureSDKServer(workdir, env);
     agent.serverPort = port;
+
+    // Check if startup was cancelled while waiting for the SDK server
+    if (signal.aborted) {
+      throw new StartupAbortedError(request.agentId);
+    }
 
     // Track session count on the SDK instance
     const instance = sdkInstances.get(workdir);
@@ -597,6 +615,13 @@ export async function startAgent(
 
     // 2. Create a session
     const sessionResult = await client.session.create({ body: {} });
+
+    // Check if startup was cancelled while creating the session — this is
+    // the critical window where an orphaned session would leak.
+    if (signal.aborted) {
+      throw new StartupAbortedError(request.agentId);
+    }
+
     const rawSession: unknown = sessionResult.data ?? sessionResult;
     const parsed = SessionResponse.safeParse(rawSession);
     if (!parsed.success) {
@@ -622,6 +647,11 @@ export async function startAgent(
       modelParam = { providerID: 'kilo', modelID: request.model };
     }
 
+    // Final abort check before sending the prompt
+    if (signal.aborted) {
+      throw new StartupAbortedError(request.agentId);
+    }
+
     await client.session.prompt({
       path: { id: sessionId },
       body: {
@@ -634,6 +664,7 @@ export async function startAgent(
     if (agent.status === 'starting') {
       agent.status = 'running';
     }
+    agent.startupAbortController = null;
     agent.messageCount = 1;
 
     log.info('agent.start', {
@@ -646,7 +677,28 @@ export async function startAgent(
 
     return agent;
   } catch (err) {
+    // On abort, clean up silently — the new startAgent invocation will
+    // proceed with a fresh entry.
+    if (err instanceof StartupAbortedError) {
+      console.log(
+        `${MANAGER_LOG} startAgent: startup aborted for ${request.agentId}, cleaning up`
+      );
+      if (sessionCounted) {
+        const instance = sdkInstances.get(workdir);
+        if (instance) {
+          instance.sessionCount--;
+          if (instance.sessionCount <= 0) {
+            instance.server.close();
+            sdkInstances.delete(workdir);
+          }
+        }
+      }
+      agents.delete(request.agentId);
+      throw err;
+    }
+
     agent.status = 'failed';
+    agent.startupAbortController = null;
     agent.exitReason = err instanceof Error ? err.message : String(err);
     if (sessionCounted) {
       const instance = sdkInstances.get(workdir);
@@ -657,12 +709,31 @@ export async function startAgent(
 }
 
 /**
+ * Thrown when a startup sequence is cancelled via AbortController.
+ * Distinct from other errors so the catch block can clean up without
+ * marking the agent as failed (a new startup is taking over).
+ */
+class StartupAbortedError extends Error {
+  constructor(agentId: string) {
+    super(`Startup aborted for agent ${agentId}`);
+    this.name = 'StartupAbortedError';
+  }
+}
+
+/**
  * Stop an agent by aborting its session.
  */
 export async function stopAgent(agentId: string): Promise<void> {
   const agent = agents.get(agentId);
   if (!agent) throw new Error(`Agent ${agentId} not found`);
   if (agent.status !== 'running' && agent.status !== 'starting') return;
+
+  // If still starting, abort the in-flight startup so session.create()
+  // doesn't produce an orphaned session after we return.
+  if (agent.startupAbortController) {
+    agent.startupAbortController.abort();
+    agent.startupAbortController = null;
+  }
 
   agent.status = 'stopping';
 

--- a/cloudflare-gastown/container/src/types.ts
+++ b/cloudflare-gastown/container/src/types.ts
@@ -133,6 +133,10 @@ export type ManagedAgent = {
   model: string | null;
   /** Full env dict from buildAgentEnv, stored so model hot-swap can replay it. */
   startupEnv: Record<string, string>;
+  /** AbortController for the in-flight startup sequence. Aborted when a
+   *  restart is requested while the agent is still in 'starting' status,
+   *  preventing orphaned sessions from leaking. */
+  startupAbortController: AbortController | null;
 };
 
 export type AgentStatusResponse = {


### PR DESCRIPTION
## Summary
- thread an AbortController through the container `startAgent()` startup path so restarting a still-starting agent aborts the in-flight startup before `stopAgent()` runs
- add abort checks and a dedicated `StartupAbortedError` cleanup path to prevent orphaned SDK sessions and avoid marking aborted startups as failed
- abort pending startup work from `stopAgent()` and store the controller on `ManagedAgent` so restarts and explicit stops share the same leak-prevention logic

## Verification
- No quality gates configured for this review bead
- Reviewed `git diff main...HEAD`
- Author reported `pnpm typecheck` passes

## Visual Changes
- N/A

## Reviewer Notes
- Focused change in `services/gastown/container/src/process-manager.ts` and `services/gastown/container/src/types.ts`
- I manually checked the session-count cleanup paths to ensure aborted startups remove the transient agent entry and release SDK server state without double-decrementing on the normal event-stream path