### PR TITLE
feat(gastown): KV-backed agent session persistence

### DIFF
--- a/services/gastown/container/src/agent-runner.ts
+++ b/services/gastown/container/src/agent-runner.ts
@@ -98,6 +98,7 @@ function buildAgentEnv(request: StartAgentRequest): Record<string, string> {
     GASTOWN_TOWN_ID: request.townId,
     GASTOWN_AGENT_ROLE: request.role,
     KILOCODE_FEATURE: 'gastown',
+    KILO_TEST_HOME: `/tmp/agent-home-${request.agentId}`,
 
     GIT_AUTHOR_NAME: authorName,
     GIT_AUTHOR_EMAIL: authorEmail,

--- a/services/gastown/container/src/main.ts
+++ b/services/gastown/container/src/main.ts
@@ -1,5 +1,6 @@
 import { startControlServer } from './control-server';
 import { log } from './logger';
+import { bootHydration } from './process-manager';
 
 log.info('container.cold_start', { uptime: 0, ts: new Date().toISOString() });
 
@@ -13,3 +14,7 @@ process.on('SIGTERM', () => {
 });
 
 startControlServer();
+
+void (async () => {
+  await bootHydration();
+})();

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -8,6 +8,7 @@
 
 import { createKilo, type KiloClient } from '@kilocode/sdk';
 import { z } from 'zod';
+import * as fs from 'node:fs/promises';
 import type { ManagedAgent, StartAgentRequest } from './types';
 import { reportAgentCompleted, reportMayorWaiting } from './completion-reporter';
 import { buildKiloConfigContent } from './agent-runner';
@@ -64,6 +65,80 @@ let sdkServerLock: Promise<void> = Promise.resolve();
 
 export function getUptime(): number {
   return Date.now() - startTime;
+}
+
+async function hydrateDbFromSnapshot(
+  agentId: string,
+  apiUrl: string,
+  token: string,
+  rigId: string,
+  townId: string
+): Promise<void> {
+  const MANAGER_LOG = '[process-manager]';
+  try {
+    const resp = await fetch(
+      `${apiUrl}/api/towns/${townId}/rigs/${rigId}/agents/${agentId}/db-snapshot`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
+    if (!resp.ok) {
+      if (resp.status === 404) {
+        console.log(`${MANAGER_LOG} No DB snapshot found for agent ${agentId}, starting fresh`);
+        return;
+      }
+      console.warn(`${MANAGER_LOG} Failed to fetch DB snapshot for ${agentId}: ${resp.status}`);
+      return;
+    }
+    const buffer = await resp.arrayBuffer();
+    if (buffer.byteLength === 0) {
+      console.log(`${MANAGER_LOG} DB snapshot for ${agentId} is empty, skipping hydration`);
+      return;
+    }
+    const dir = `/tmp/agent-home-${agentId}/.local/share/kilo`;
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(`${dir}/kilo.db`, Buffer.from(buffer));
+    console.log(`${MANAGER_LOG} Hydrated DB snapshot for agent ${agentId} (${buffer.byteLength} bytes)`);
+  } catch (err) {
+    console.warn(`${MANAGER_LOG} DB hydration failed for agent ${agentId}:`, err);
+  }
+}
+
+async function saveDbSnapshot(
+  agentId: string,
+  apiUrl: string,
+  token: string,
+  rigId: string,
+  townId: string
+): Promise<void> {
+  const MANAGER_LOG = '[process-manager]';
+  try {
+    const dbPath = `/tmp/agent-home-${agentId}/.local/share/kilo/kilo.db`;
+    await fs.access(dbPath);
+    const buffer = await fs.readFile(dbPath);
+    const resp = await fetch(
+      `${apiUrl}/api/towns/${townId}/rigs/${rigId}/agents/${agentId}/db-snapshot`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/octet-stream',
+        },
+        body: buffer,
+      }
+    );
+    if (!resp.ok) {
+      console.warn(`${MANAGER_LOG} Failed to save DB snapshot for ${agentId}: ${resp.status}`);
+      return;
+    }
+    console.log(`${MANAGER_LOG} Saved DB snapshot for agent ${agentId} (${buffer.byteLength} bytes)`);
+  } catch (err) {
+    if ((err as { code?: string }).code === 'ENOENT') {
+      console.log(`${MANAGER_LOG} No kilo.db found for agent ${agentId}, skipping snapshot save`);
+      return;
+    }
+    console.warn(`${MANAGER_LOG} DB snapshot save failed for agent ${agentId}:`, err);
+  }
 }
 
 export function registerEventSink(
@@ -503,6 +578,14 @@ async function subscribeToEvents(
         sdkInstances.delete(agent.workdir);
       }
     }
+
+    // Save DB snapshot before completing exit
+    const apiUrl = agent.gastownApiUrl;
+    const token = agent.gastownContainerToken ?? process.env.GASTOWN_CONTAINER_TOKEN ?? null;
+    if (apiUrl && token) {
+      void saveDbSnapshot(agent.agentId, apiUrl, token, agent.rigId, agent.townId);
+    }
+
     controller.abort();
   };
 
@@ -669,6 +752,13 @@ export async function startAgent(
   const { signal } = startupAbortController;
   let sessionCounted = false;
   try {
+    // 0. Hydrate agent DB from KV snapshot before starting the SDK server
+    const apiUrl = agent.gastownApiUrl;
+    const token = agent.gastownContainerToken ?? process.env.GASTOWN_CONTAINER_TOKEN ?? null;
+    if (apiUrl && token) {
+      await hydrateDbFromSnapshot(request.agentId, apiUrl, token, request.rigId, request.townId);
+    }
+
     // 1. Ensure SDK server is running for this workdir
     const { client, port } = await ensureSDKServer(workdir, env);
     agent.serverPort = port;
@@ -868,6 +958,13 @@ export async function stopAgent(agentId: string): Promise<void> {
   agent.exitReason = 'stopped';
   log.info('agent.exit', { agentId, reason: 'stopped', exitReason: 'stopped' });
   broadcastEvent(agentId, 'agent.exited', { reason: 'stopped' });
+
+  // Save DB snapshot before completing stop
+  const apiUrl = agent.gastownApiUrl;
+  const token = agent.gastownContainerToken ?? process.env.GASTOWN_CONTAINER_TOKEN ?? null;
+  if (apiUrl && token) {
+    void saveDbSnapshot(agentId, apiUrl, token, agent.rigId, agent.townId);
+  }
 }
 
 /**
@@ -1375,7 +1472,14 @@ export async function drainAll(): Promise<void> {
         });
       }
 
-      // 4d: Report the agent as completed so the TownDO can unhook it
+      // 4d: Save DB snapshot
+      const apiUrl = agent.gastownApiUrl;
+      const token = agent.gastownContainerToken ?? process.env.GASTOWN_CONTAINER_TOKEN ?? null;
+      if (apiUrl && token) {
+        await saveDbSnapshot(agent.agentId, apiUrl, token, agent.rigId, agent.townId);
+      }
+
+      // 4e: Report the agent as completed so the TownDO can unhook it
       // and transition the bead. Without this, the bead stays in_progress
       // and the agent stays working until stale-bead recovery kicks in.
       if (agent.role !== 'mayor' && agent.role !== 'triage') {
@@ -1402,7 +1506,7 @@ export async function stopAll(): Promise<void> {
   }
   eventAbortControllers.clear();
 
-  // Abort all running sessions
+  // Abort all running sessions and save DB snapshots
   for (const agent of agents.values()) {
     if (agent.status === 'running' || agent.status === 'starting') {
       try {
@@ -1417,6 +1521,13 @@ export async function stopAll(): Promise<void> {
       }
       agent.status = 'exited';
       agent.exitReason = 'container shutdown';
+
+      // Save DB snapshot before completing shutdown
+      const apiUrl = agent.gastownApiUrl;
+      const token = agent.gastownContainerToken ?? process.env.GASTOWN_CONTAINER_TOKEN ?? null;
+      if (apiUrl && token) {
+        void saveDbSnapshot(agent.agentId, apiUrl, token, agent.rigId, agent.townId);
+      }
     }
   }
 
@@ -1425,4 +1536,67 @@ export async function stopAll(): Promise<void> {
     instance.server.close();
   }
   sdkInstances.clear();
+}
+
+/**
+ * Boot-time agent hydration — fetches the container registry from the
+ * Gastown worker and resumes all registered agents.
+ *
+ * Called from main.ts when GASTOWN_TOWN_ID and GASTOWN_API_URL are set.
+ */
+export async function bootHydration(): Promise<void> {
+  const LOG = '[boot-hydration]';
+  const apiUrl = process.env.GASTOWN_API_URL;
+  const townId = process.env.GASTOWN_TOWN_ID;
+  const token = process.env.GASTOWN_CONTAINER_TOKEN;
+
+  if (!apiUrl || !townId || !token) {
+    console.log(`${LOG} Missing GASTOWN_API_URL, GASTOWN_TOWN_ID, or GASTOWN_CONTAINER_TOKEN — skipping boot hydration`);
+    return;
+  }
+
+  console.log(`${LOG} Fetching container registry for town=${townId}`);
+  let registry: unknown;
+  try {
+    const resp = await fetch(`${apiUrl}/api/towns/${townId}/container-registry`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!resp.ok) {
+      console.warn(`${LOG} Failed to fetch registry: ${resp.status}`);
+      return;
+    }
+    const json = (await resp.json()) as { data: unknown };
+    registry = json.data;
+  } catch (err) {
+    console.warn(`${LOG} Registry fetch failed:`, err);
+    return;
+  }
+
+  if (!Array.isArray(registry) || registry.length === 0) {
+    console.log(`${LOG} No agents in registry — nothing to hydrate`);
+    return;
+  }
+
+  console.log(`${LOG} Resuming ${registry.length} agent(s) from registry`);
+
+  for (const entry of registry as Record<string, unknown>[]) {
+    const agentId = entry.agentId as string | undefined;
+    const agentRequest = entry.request as StartAgentRequest | undefined;
+    const workdir = entry.workdir as string | undefined;
+    const env = entry.env as Record<string, string> | undefined;
+
+    if (!agentId || !agentRequest || !workdir || !env) {
+      console.warn(`${LOG} Skipping malformed registry entry:`, entry);
+      continue;
+    }
+
+    console.log(`${LOG} Resuming agent ${agentId} in ${workdir}`);
+    try {
+      await startAgent(agentRequest, workdir, env);
+      console.log(`${LOG} Agent ${agentId} resumed`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`${LOG} Failed to resume agent ${agentId}:`, msg);
+    }
+  }
 }

--- a/services/gastown/src/dos/TownContainer.do.ts
+++ b/services/gastown/src/dos/TownContainer.do.ts
@@ -67,6 +67,16 @@ export class TownContainerDO extends Container<Env> {
     console.log(`${TC_LOG} deleteEnvVar: ${key} removed`);
   }
 
+  async updateRegistry(registry: unknown): Promise<void> {
+    await this.ctx.storage.put('container:registry', registry);
+    console.log(`${TC_LOG} updateRegistry: updated (${Array.isArray(registry) ? registry.length : '?'} entries)`);
+  }
+
+  async getRegistry(): Promise<unknown> {
+    const registry = await this.ctx.storage.get<unknown>('container:registry');
+    return registry ?? [];
+  }
+
   override onStart(): void {
     console.log(`${TC_LOG} container started for DO id=${this.ctx.id.toString()}`);
   }

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -96,6 +96,7 @@ export async function ensureContainerToken(
   // Store for next boot
   try {
     await container.setEnvVar('GASTOWN_CONTAINER_TOKEN', token);
+    await container.setEnvVar('GASTOWN_TOWN_ID', townId);
   } catch (err) {
     console.warn(
       `${TOWN_LOG} ensureContainerToken: setEnvVar failed (container may not be running):`,
@@ -161,6 +162,7 @@ export async function forceRefreshContainerToken(
   // Store for next boot (best-effort — the critical step is the live push below)
   try {
     await container.setEnvVar('GASTOWN_CONTAINER_TOKEN', token);
+    await container.setEnvVar('GASTOWN_TOWN_ID', townId);
   } catch (err) {
     console.warn(
       `${TOWN_LOG} forceRefreshContainerToken: setEnvVar failed:`,

--- a/services/gastown/src/gastown.worker.ts
+++ b/services/gastown/src/gastown.worker.ts
@@ -642,13 +642,18 @@ app.use('/api/users/*', async (c: Context<GastownEnv, string>, next) =>
   kiloAuthMiddleware(c, next)
 );
 // Town routes: kilo auth + admin audit + town ownership check (supports both personal and org-owned towns).
-app.use('/api/towns/:townId/*', async (c: Context<GastownEnv, string>, next) =>
-  kiloAuthMiddleware(c, async () => {
+// Skip for container-registry routes which use authMiddleware with container JWT support.
+app.use('/api/towns/:townId/*', async (c: Context<GastownEnv, string>, next) => {
+  const path = c.req.path;
+  if (path.includes('/container-registry')) {
+    return next();
+  }
+  await kiloAuthMiddleware(c, async () => {
     await adminAuditMiddleware(c, async () => {
       await townAuthMiddleware(c, next);
     });
-  })
-);
+  });
+});
 
 // ── Org Auth ────────────────────────────────────────────────────────────
 // Kilo user auth + org membership check for all org routes.

--- a/services/gastown/src/gastown.worker.ts
+++ b/services/gastown/src/gastown.worker.ts
@@ -748,6 +748,45 @@ app.get('/api/users/:userId/towns/:townId/events', c =>
   )
 );
 
+// ── Container Registry ─────────────────────────────────────────────────
+// Simple pass-through to TownContainerDO registry.
+
+app.get('/api/towns/:townId/container-registry', async c => {
+  const townId = c.req.param('townId');
+  const tc = getTownContainerStub(c.env, townId);
+  // eslint-disable-next-line @typescript-eslint/await-thenable -- DO RPC returns promise at runtime
+  const registry = await tc.getRegistry();
+  return c.json({ success: true, data: registry });
+});
+
+app.post('/api/towns/:townId/container-registry', async c => {
+  const townId = c.req.param('townId');
+  const body = await c.req.json();
+  const tc = getTownContainerStub(c.env, townId);
+  // eslint-disable-next-line @typescript-eslint/await-thenable -- DO RPC returns promise at runtime
+  await tc.updateRegistry(body);
+  return c.json({ success: true });
+});
+
+// ── Agent DB Snapshot ───────────────────────────────────────────────────
+// Stored in the AGENT_DB_SNAPSHOTS_KV namespace keyed by agentId.
+
+app.get('/api/towns/:townId/rigs/:rigId/agents/:agentId/db-snapshot', async c => {
+  const { agentId } = c.req.param();
+  const snapshot = await c.env.AGENT_DB_SNAPSHOTS_KV.get(agentId, 'arrayBuffer');
+  if (!snapshot) return c.json({ success: false, error: 'Snapshot not found' }, 404);
+  return new Response(snapshot, {
+    headers: { 'Content-Type': 'application/octet-stream' },
+  });
+});
+
+app.post('/api/towns/:townId/rigs/:rigId/agents/:agentId/db-snapshot', async c => {
+  const { agentId } = c.req.param();
+  const body = await c.req.arrayBuffer();
+  await c.env.AGENT_DB_SNAPSHOTS_KV.put(agentId, body);
+  return c.json({ success: true });
+});
+
 // ── Town Container ──────────────────────────────────────────────────────
 // These routes proxy commands to the container's control server via DO.fetch().
 // Protected by Cloudflare Access at the perimeter; no additional auth required.

--- a/services/gastown/src/gastown.worker.ts
+++ b/services/gastown/src/gastown.worker.ts
@@ -585,6 +585,54 @@ app.get('/api/towns/:townId/drain-status', c =>
   instrumented(c, 'GET /api/towns/:townId/drain-status', () => handleDrainStatus(c, c.req.param()))
 );
 
+// ── Container Registry ─────────────────────────────────────────────────
+// Simple pass-through to TownContainerDO registry.
+// Protected by authMiddleware (accepts container JWTs), not kiloAuthMiddleware.
+
+app.use(
+  '/api/towns/:townId/container-registry',
+  async (c: Context<GastownEnv, string>, next) =>
+    c.env.ENVIRONMENT === 'development' ? next() : authMiddleware(c, next)
+);
+
+app.get('/api/towns/:townId/container-registry', async c => {
+  const townId = c.req.param('townId');
+  const tc = getTownContainerStub(c.env, townId);
+  // eslint-disable-next-line @typescript-eslint/await-thenable -- DO RPC returns promise at runtime
+  const registry = await tc.getRegistry();
+  return c.json({ success: true, data: registry });
+});
+
+app.post('/api/towns/:townId/container-registry', async c => {
+  const townId = c.req.param('townId');
+  const body = await c.req.json();
+  const tc = getTownContainerStub(c.env, townId);
+  // eslint-disable-next-line @typescript-eslint/await-thenable -- DO RPC returns promise at runtime
+  await tc.updateRegistry(body);
+  return c.json({ success: true });
+});
+
+// ── Agent DB Snapshot ───────────────────────────────────────────────────
+// Stored in the AGENT_DB_SNAPSHOTS_KV namespace keyed by agentId.
+// Protected by authMiddleware (accepts container JWTs), not kiloAuthMiddleware.
+// Registered after authMiddleware but before kiloAuthMiddleware wildcard.
+
+app.get('/api/towns/:townId/rigs/:rigId/agents/:agentId/db-snapshot', async c => {
+  const { agentId } = c.req.param();
+  const snapshot = await c.env.AGENT_DB_SNAPSHOTS_KV.get(agentId, 'arrayBuffer');
+  if (!snapshot) return c.json({ success: false, error: 'Snapshot not found' }, 404);
+  return new Response(snapshot, {
+    headers: { 'Content-Type': 'application/octet-stream' },
+  });
+});
+
+app.post('/api/towns/:townId/rigs/:rigId/agents/:agentId/db-snapshot', async c => {
+  const { agentId } = c.req.param();
+  const body = await c.req.arrayBuffer();
+  await c.env.AGENT_DB_SNAPSHOTS_KV.put(agentId, body);
+  return c.json({ success: true });
+});
+
 // ── Kilo User Auth ──────────────────────────────────────────────────────
 // Validate Kilo user JWT (signed with NEXTAUTH_SECRET) for dashboard/user
 // routes. Container→worker routes use the agent JWT middleware instead
@@ -748,44 +796,7 @@ app.get('/api/users/:userId/towns/:townId/events', c =>
   )
 );
 
-// ── Container Registry ─────────────────────────────────────────────────
-// Simple pass-through to TownContainerDO registry.
 
-app.get('/api/towns/:townId/container-registry', async c => {
-  const townId = c.req.param('townId');
-  const tc = getTownContainerStub(c.env, townId);
-  // eslint-disable-next-line @typescript-eslint/await-thenable -- DO RPC returns promise at runtime
-  const registry = await tc.getRegistry();
-  return c.json({ success: true, data: registry });
-});
-
-app.post('/api/towns/:townId/container-registry', async c => {
-  const townId = c.req.param('townId');
-  const body = await c.req.json();
-  const tc = getTownContainerStub(c.env, townId);
-  // eslint-disable-next-line @typescript-eslint/await-thenable -- DO RPC returns promise at runtime
-  await tc.updateRegistry(body);
-  return c.json({ success: true });
-});
-
-// ── Agent DB Snapshot ───────────────────────────────────────────────────
-// Stored in the AGENT_DB_SNAPSHOTS_KV namespace keyed by agentId.
-
-app.get('/api/towns/:townId/rigs/:rigId/agents/:agentId/db-snapshot', async c => {
-  const { agentId } = c.req.param();
-  const snapshot = await c.env.AGENT_DB_SNAPSHOTS_KV.get(agentId, 'arrayBuffer');
-  if (!snapshot) return c.json({ success: false, error: 'Snapshot not found' }, 404);
-  return new Response(snapshot, {
-    headers: { 'Content-Type': 'application/octet-stream' },
-  });
-});
-
-app.post('/api/towns/:townId/rigs/:rigId/agents/:agentId/db-snapshot', async c => {
-  const { agentId } = c.req.param();
-  const body = await c.req.arrayBuffer();
-  await c.env.AGENT_DB_SNAPSHOTS_KV.put(agentId, body);
-  return c.json({ success: true });
-});
 
 // ── Town Container ──────────────────────────────────────────────────────
 // These routes proxy commands to the container's control server via DO.fetch().

--- a/services/gastown/worker-configuration.d.ts
+++ b/services/gastown/worker-configuration.d.ts
@@ -40,6 +40,7 @@ declare namespace Cloudflare {
 		AGENT: DurableObjectNamespace<import("./src/gastown.worker").AgentDO>;
 		GIT_TOKEN_SERVICE: GitTokenService;
 		AI: Ai;
+		AGENT_DB_SNAPSHOTS_KV: KVNamespace;
 	}
 	interface Env {
 		GASTOWN_AE: AnalyticsEngineDataset;
@@ -58,6 +59,7 @@ declare namespace Cloudflare {
 		AGENT: DurableObjectNamespace<import("./src/gastown.worker").AgentDO>;
 		GIT_TOKEN_SERVICE: GitTokenService;
 		AI: Ai;
+		AGENT_DB_SNAPSHOTS_KV: KVNamespace;
 		HYPERDRIVE?: Hyperdrive;
 		CF_VERSION_METADATA?: WorkerVersionMetadata;
 		SENTRY_DSN?: string; // worker secret

--- a/services/gastown/wrangler.jsonc
+++ b/services/gastown/wrangler.jsonc
@@ -85,7 +85,7 @@
   "ai": { "binding": "AI" },
 
   "kv_namespaces": [
-    { "binding": "AGENT_DB_SNAPSHOTS_KV", "id": "" },
+    { "binding": "AGENT_DB_SNAPSHOTS_KV", "id": "placeholder" },
   ],
 
   "analytics_engine_datasets": [{ "binding": "GASTOWN_AE", "dataset": "gastown_events" }],

--- a/services/gastown/wrangler.jsonc
+++ b/services/gastown/wrangler.jsonc
@@ -84,6 +84,10 @@
 
   "ai": { "binding": "AI" },
 
+  "kv_namespaces": [
+    { "binding": "AGENT_DB_SNAPSHOTS_KV", "id": "" },
+  ],
+
   "analytics_engine_datasets": [{ "binding": "GASTOWN_AE", "dataset": "gastown_events" }],
 
   "services": [


### PR DESCRIPTION
## Summary
- Pass GASTOWN_TOWN_ID to container on provision.
- Add container-registry and db-snapshot worker endpoints.
- Add process registry RPC to TownContainerDO.
- Add AGENT_DB_SNAPSHOTS_KV binding for agent DB snapshots.
- Isolate agent SQLite DB via KILO_TEST_HOME.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
N/A
