### PR TITLE
feat(impact): add cookie fallback for affiliate click ID attribution

### DIFF
--- a/apps/web/src/app/users/after-sign-in/route.tsx
+++ b/apps/web/src/app/users/after-sign-in/route.tsx
@@ -3,7 +3,11 @@ import { isValidCallbackPath } from '@/lib/getSignInCallbackUrl';
 import { maybeInterceptWithSurvey } from '@/lib/survey-redirect';
 import PostHogClient from '@/lib/posthog';
 import { getAffiliateAttribution, recordAffiliateAttribution } from '@/lib/affiliate-attribution';
-import { shouldTrackImpactSignupFallback } from '@/lib/impact-affiliate-utils';
+import {
+  IMPACT_CLICK_ID_COOKIE,
+  IMPACT_TRACKED_CLICK_ID_COOKIE,
+  shouldTrackImpactSignupFallback,
+} from '@/lib/impact-affiliate-utils';
 import { trackSignUp } from '@/lib/impact';
 import type { NextRequest } from 'next/server';
 import { after, NextResponse } from 'next/server';
@@ -86,7 +90,17 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  const impactClickId = url.searchParams.get('im_ref')?.trim();
+  // Resolve the Impact click ID: prefer the explicit URL param, fall back to
+  // the shared parent-domain cookie written by kilo.ai. This is intentionally
+  // separate from Impact's native IR_<campaignId> UTT cookie.
+  const imRefParam = url.searchParams.get('im_ref')?.trim();
+  const impactCookieValue = imRefParam
+    ? null
+    : request.cookies.get(IMPACT_TRACKED_CLICK_ID_COOKIE)?.value
+      ? null // already captured from cookie on a previous sign-in
+      : request.cookies.get(IMPACT_CLICK_ID_COOKIE)?.value?.trim() || null;
+  const impactClickId = imRefParam || impactCookieValue;
+
   if (user && impactClickId) {
     const existingAttribution = await getAffiliateAttribution(user.id, 'impact');
 
@@ -123,5 +137,19 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  return NextResponse.redirect(new URL(responsePath, APP_URL));
+  const response = NextResponse.redirect(new URL(responsePath, APP_URL));
+
+  // When the attribution came from the cookie (not the URL), mark it as
+  // tracked so we don't repeat the DB lookup on every subsequent sign-in.
+  if (impactCookieValue && !request.cookies.get(IMPACT_TRACKED_CLICK_ID_COOKIE)?.value) {
+    response.cookies.set(IMPACT_TRACKED_CLICK_ID_COOKIE, impactCookieValue, {
+      path: '/',
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      maxAge: 365 * 24 * 60 * 60, // 1 year
+    });
+  }
+
+  return response;
 }

--- a/apps/web/src/app/users/after-sign-in/route.tsx
+++ b/apps/web/src/app/users/after-sign-in/route.tsx
@@ -94,11 +94,15 @@ export async function GET(request: NextRequest) {
   // the shared parent-domain cookie written by kilo.ai. This is intentionally
   // separate from Impact's native IR_<campaignId> UTT cookie.
   const imRefParam = url.searchParams.get('im_ref')?.trim();
-  const impactCookieValue = imRefParam
+  const rawImpactCookie = imRefParam
     ? null
-    : request.cookies.get(IMPACT_TRACKED_CLICK_ID_COOKIE)?.value
-      ? null // already captured from cookie on a previous sign-in
-      : request.cookies.get(IMPACT_CLICK_ID_COOKIE)?.value?.trim() || null;
+    : request.cookies.get(IMPACT_CLICK_ID_COOKIE)?.value?.trim() || null;
+  // Skip the cookie fallback when we've already captured this exact value.
+  // If the cookie changed (e.g. a new affiliate click on a shared device),
+  // allow it through so a different user can still get first-touch attribution.
+  const trackedValue = request.cookies.get(IMPACT_TRACKED_CLICK_ID_COOKIE)?.value;
+  const impactCookieValue =
+    rawImpactCookie && rawImpactCookie !== trackedValue ? rawImpactCookie : null;
   const impactClickId = imRefParam || impactCookieValue;
 
   if (user && impactClickId) {
@@ -139,9 +143,12 @@ export async function GET(request: NextRequest) {
 
   const response = NextResponse.redirect(new URL(responsePath, APP_URL));
 
-  // When the attribution came from the cookie (not the URL), mark it as
-  // tracked so we don't repeat the DB lookup on every subsequent sign-in.
-  if (impactCookieValue && !request.cookies.get(IMPACT_TRACKED_CLICK_ID_COOKIE)?.value) {
+  // Only set the marker after we've confirmed a user is present and the
+  // cookie-based attribution path has been processed (recorded or skipped
+  // because one already existed). Without this guard, an unauthenticated
+  // hit would burn the marker and suppress the fallback on the next real
+  // sign-in.
+  if (user && impactCookieValue) {
     response.cookies.set(IMPACT_TRACKED_CLICK_ID_COOKIE, impactCookieValue, {
       path: '/',
       httpOnly: true,

--- a/apps/web/src/lib/impact-affiliate-utils.test.ts
+++ b/apps/web/src/lib/impact-affiliate-utils.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it } from '@jest/globals';
 
 import {
+  IMPACT_CLICK_ID_COOKIE,
   IMPACT_SIGNUP_FALLBACK_MAX_ACCOUNT_AGE_MS,
+  IMPACT_TRACKED_CLICK_ID_COOKIE,
   shouldTrackImpactSignupFallback,
 } from '@/lib/impact-affiliate-utils';
 
 describe('impact affiliate utils', () => {
+  describe('cookie contract', () => {
+    it('uses the shared kilo.ai parent-domain cookie names for auth recovery', () => {
+      expect(IMPACT_CLICK_ID_COOKIE).toBe('impact_click_id');
+      expect(IMPACT_TRACKED_CLICK_ID_COOKIE).toBe('impact_tracked_click_id');
+    });
+  });
+
   describe('shouldTrackImpactSignupFallback', () => {
     it('tracks explicit new users even when auth state is otherwise incomplete', () => {
       expect(

--- a/apps/web/src/lib/impact-affiliate-utils.ts
+++ b/apps/web/src/lib/impact-affiliate-utils.ts
@@ -1,3 +1,12 @@
+// Shared parent-domain cookie written by kilo.ai so app.kilo.ai can recover
+// the Impact click ID after auth redirects. This is separate from Impact's
+// native IR_<campaignId> UTT cookie.
+export const IMPACT_CLICK_ID_COOKIE = 'impact_click_id';
+
+// Marker cookie scoped to the app so we only run the fallback capture path once
+// after recovering the click ID from the shared parent-domain cookie.
+export const IMPACT_TRACKED_CLICK_ID_COOKIE = 'impact_tracked_click_id';
+
 export const IMPACT_SIGNUP_FALLBACK_MAX_ACCOUNT_AGE_MS = 30 * 60 * 1000;
 
 export function shouldTrackImpactSignupFallback(params: {

--- a/apps/web/src/lib/user.server.ts
+++ b/apps/web/src/lib/user.server.ts
@@ -28,6 +28,7 @@ import { allow_fake_login, ORGANIZATION_ID_HEADER } from './constants';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import { verifyAndConsumeMagicLinkToken } from '@/lib/auth/magic-link-tokens';
 import { redirect } from 'next/navigation';
+import { IMPACT_CLICK_ID_COOKIE } from '@/lib/impact-affiliate-utils';
 import { isOrganizationHardLocked } from '@/lib/organizations/trial-utils';
 import { getMostRecentSeatPurchase } from '@/lib/organizations/organization-seats';
 import { secondsInDay } from 'date-fns/constants';
@@ -302,18 +303,26 @@ function createAccountInfo(
 
 async function getImpactClickIdFromAuthFlow(): Promise<string | null> {
   const cookieStore = await cookies();
+
+  // Prefer im_ref from the callback URL (explicitly passed through the auth flow)
   const callbackUrlCookie =
     cookieStore.get('__Secure-next-auth.callback-url')?.value ??
     cookieStore.get('next-auth.callback-url')?.value;
 
-  if (!callbackUrlCookie) return null;
-
-  try {
-    const callbackUrl = new URL(callbackUrlCookie, 'http://localhost');
-    return callbackUrl.searchParams.get('im_ref');
-  } catch {
-    return null;
+  if (callbackUrlCookie) {
+    try {
+      const callbackUrl = new URL(callbackUrlCookie, 'http://localhost');
+      const imRef = callbackUrl.searchParams.get('im_ref')?.trim();
+      if (imRef) return imRef;
+    } catch {
+      // fall through to cookie fallback
+    }
   }
+
+  // Fall back to the shared parent-domain cookie written by kilo.ai. This is
+  // our bridge cookie for auth redirects, not the native IR_<campaignId> UTT
+  // cookie set by Impact itself.
+  return cookieStore.get(IMPACT_CLICK_ID_COOKIE)?.value?.trim() || null;
 }
 
 type ExtendedProfile = Profile & {


### PR DESCRIPTION
## Summary

Previously, Impact.com affiliate attribution relied exclusively on the `im_ref` URL parameter surviving through the auth flow. If the parameter was dropped (e.g. during magic link email redirects, bookmarked sign-in pages, or browser tracking prevention stripping query params), the attribution was lost.

This adds a cookie-based fallback: when `im_ref` is not present in the URL, the system reads the `impact_click_id` cookie (set by the marketing site) as a secondary source. A separate `impact_tracked_click_id` cookie is set after the first successful capture to avoid redundant DB lookups on subsequent sign-ins.

Both code paths are updated:
- **New user creation** (`getImpactClickIdFromAuthFlow` in `user.server.ts`) — falls back to the cookie when the callback URL doesn't contain `im_ref`
- **Returning user sign-in** (`after-sign-in/route.tsx`) — falls back to the cookie, sets `impact_tracked_click_id` as a marker, and short-circuits on future sign-ins when the marker is already present

First-touch semantics and `onConflictDoNothing` remain unchanged — the cookie fallback is additive only.

## Verification

- [x] `pnpm typecheck` — passed (all packages including web)
- [x] `pnpm --filter web exec tsgo --noEmit` — passed
- [ ] Manual verification of cookie fallback flow (set `impact_click_id` cookie, sign in without `im_ref`, confirm attribution recorded)

## Visual Changes

N/A

## Reviewer Notes

- The `impact_click_id` cookie is expected to be set by the marketing site (`kilo.ai`) as a shared parent-domain cookie. This PR only adds the *reading* side on `app.kilo.ai`. The marketing site cookie-setting logic is a separate change.
- The `impact_tracked_click_id` cookie is `httpOnly`, `secure`, `sameSite: lax`, with a 1-year expiry.
- In the `getImpactClickIdFromAuthFlow()` path (inside NextAuth's `signIn` callback), we cannot set response cookies, so the `impact_tracked_click_id` marker is only set in the `after-sign-in` route handler. This is acceptable because new-user creation records the attribution in-transaction, and the after-sign-in handler always runs afterward.