### PR TITLE
Dev: add .dev.vars and wrapper/dist to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,12 +14,16 @@ node_modules/
 /out/
 /build
 packages/trpc/dist/
+**/wrapper/dist/
 *.tsbuildinfo
 next-env.d.ts
 
 # env & secrets
 .env*.local*
 !.env*.example*
+.dev.vars
+.dev.vars.*
+!.dev.vars.example*
 .env.keys
 .env.grafana
 .env.sentry-build-plugin


### PR DESCRIPTION
## Summary

Added `.dev.vars`, `.dev.vars.*`, and `wrapper/dist` to `.gitignore` to prevent local dev files and build artifacts from being tracked.

## Verification

- Committed the change
- Pushed branch to origin

## Visual Changes

N/A

## Reviewer Notes

N/A