### PR TITLE
fix(kiloclaw): restore Open button on gateway page

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawGatewayPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawGatewayPage.tsx
@@ -17,7 +17,9 @@ import {
 import { ClawContextProvider, useClawContext } from './ClawContext';
 import { InstanceControls } from './InstanceControls';
 import { InstanceTab } from './InstanceTab';
+import { OpenClawButton } from './OpenClawButton';
 import { BillingWrapper } from './billing/BillingWrapper';
+import { useGatewayUrl } from '../hooks/useGatewayUrl';
 import { SetPageTitle } from '@/components/SetPageTitle';
 import { Card, CardContent } from '@/components/ui/card';
 
@@ -30,6 +32,7 @@ function ClawGatewayInner({ status }: { status: KiloClawDashboardStatus }) {
   const mutations = organizationId ? orgMutations : personalMutations;
 
   const isRunning = status.status === 'running';
+  const gatewayUrl = useGatewayUrl(status);
 
   const personalGateway = useKiloClawGatewayStatus(!organizationId && isRunning);
   const orgGateway = useOrgKiloClawGatewayStatus(
@@ -46,26 +49,33 @@ function ClawGatewayInner({ status }: { status: KiloClawDashboardStatus }) {
 
   const onRedeploySuccess = useCallback(() => {}, []);
 
+  const gatewayReady = gatewayStatus?.state === 'running';
+
   const gatewayContent = (
-    <Card>
-      <CardContent className="border-b p-5">
-        <InstanceControls
-          status={status}
-          mutations={mutations}
-          onRedeploySuccess={onRedeploySuccess}
-          upgradeRequested={upgradeRequested}
-          onUpgradeHandled={onUpgradeHandled}
-        />
-      </CardContent>
-      <CardContent className="p-5">
-        <InstanceTab
-          status={status}
-          gatewayStatus={gatewayStatus}
-          gatewayLoading={gatewayLoading}
-          gatewayError={gatewayError}
-        />
-      </CardContent>
-    </Card>
+    <>
+      <div className="flex justify-end">
+        <OpenClawButton canShow={isRunning && !!gatewayReady} gatewayUrl={gatewayUrl} />
+      </div>
+      <Card>
+        <CardContent className="border-b p-5">
+          <InstanceControls
+            status={status}
+            mutations={mutations}
+            onRedeploySuccess={onRedeploySuccess}
+            upgradeRequested={upgradeRequested}
+            onUpgradeHandled={onUpgradeHandled}
+          />
+        </CardContent>
+        <CardContent className="p-5">
+          <InstanceTab
+            status={status}
+            gatewayStatus={gatewayStatus}
+            gatewayLoading={gatewayLoading}
+            gatewayError={gatewayError}
+          />
+        </CardContent>
+      </Card>
+    </>
   );
 
   if (!organizationId) {


### PR DESCRIPTION
## Summary

- Restores the "Open" button that was lost when `ClawDashboard` was split into standalone sidebar pages in #2054
- The button opens the OpenClaw control UI in a new tab with auto-authentication
- Appears right-aligned above the gateway card on both `/claw/gateway` (personal) and `/organizations/[id]/claw/gateway` (org scope), matching the previous `ClawHeader` behavior

## Verification

- `pnpm typecheck` passes
- `pnpm format` passes

## Visual Changes

The yellow "Open" button reappears at the top of the gateway page when the instance is running and the gateway is ready.

## Reviewer Notes

N/A