### PR TITLE
feat(web): add Exa search API proxy endpoint

### DIFF
--- a/apps/web/src/app/api/exa/[...path]/route.test.ts
+++ b/apps/web/src/app/api/exa/[...path]/route.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { NextResponse } from 'next/server';
+import { getUserFromAuth } from '@/lib/user.server';
+import { failureResult } from '@/lib/maybe-result';
+import type { User } from '@kilocode/db/schema';
+
+// Capture promises scheduled via next/server `after` so tests can await them.
+let afterCallbacks: (() => Promise<void>)[] = [];
+
+jest.mock('next/server', () => {
+  return {
+    ...(jest.requireActual('next/server') as Record<string, unknown>),
+    after: (fn: () => Promise<void>) => {
+      afterCallbacks.push(fn);
+    },
+  };
+});
+
+async function flushAfterCallbacks() {
+  for (const fn of afterCallbacks) {
+    await fn();
+  }
+  afterCallbacks = [];
+}
+
+jest.mock('@/lib/config.server', () => ({
+  EXA_API_KEY: 'test-exa-key',
+}));
+
+jest.mock('@/lib/user.server');
+
+const mockedGetUserFromAuth = jest.mocked(getUserFromAuth);
+const mockedFetch = jest.fn() as jest.MockedFunction<typeof globalThis.fetch>;
+const originalFetch = globalThis.fetch;
+
+function makeRequest(path: string, body: unknown = { query: 'test' }) {
+  return new Request(`http://localhost:3000/api/exa${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function setUserAuth(id = 'user-123') {
+  mockedGetUserFromAuth.mockResolvedValue({
+    user: { id } as User,
+    authFailedResponse: null,
+  });
+}
+
+function makeUpstreamResponse(body: unknown, headers?: Record<string, string>, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+}
+
+describe('POST /api/exa/[...path]', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    afterCallbacks = [];
+    globalThis.fetch = mockedFetch;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('authentication', () => {
+    it('returns auth failure response when not authenticated', async () => {
+      const authFailedResponse = NextResponse.json(failureResult('Unauthorized'), { status: 401 });
+      mockedGetUserFromAuth.mockResolvedValue({
+        user: null,
+        authFailedResponse,
+      });
+
+      const { POST } = await import('./route');
+      const response = await POST(makeRequest('/search') as never);
+
+      expect(response).toBe(authFailedResponse);
+      expect(mockedFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('path validation', () => {
+    it.each(['/search', '/contents', '/findSimilar', '/answer', '/context'])(
+      'allows %s',
+      async path => {
+        setUserAuth();
+        mockedFetch.mockResolvedValue(makeUpstreamResponse({ results: [] }));
+
+        const { POST } = await import('./route');
+        const response = await POST(makeRequest(path) as never);
+
+        expect(response.status).toBe(200);
+        expect(mockedFetch).toHaveBeenCalledWith(`https://api.exa.ai${path}`, expect.any(Object));
+      }
+    );
+
+    it('rejects disallowed paths with 400', async () => {
+      setUserAuth();
+
+      const { POST } = await import('./route');
+      const response = await POST(makeRequest('/badpath') as never);
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.error).toContain('Invalid path');
+      expect(mockedFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('request signal propagation', () => {
+    it('passes request.signal to upstream fetch', async () => {
+      setUserAuth();
+      mockedFetch.mockResolvedValue(makeUpstreamResponse({ results: [] }));
+
+      const { POST } = await import('./route');
+      const request = makeRequest('/search');
+      await POST(request as never);
+
+      expect(mockedFetch).toHaveBeenCalledWith(
+        'https://api.exa.ai/search',
+        expect.objectContaining({
+          signal: request.signal,
+        })
+      );
+    });
+
+    it('aborts upstream fetch when request signal is already aborted', async () => {
+      setUserAuth();
+      mockedFetch.mockImplementation((_url, init) => {
+        if (init?.signal?.aborted) {
+          throw new DOMException('The operation was aborted.', 'AbortError');
+        }
+        return Promise.resolve(makeUpstreamResponse({ results: [] }));
+      });
+
+      const controller = new AbortController();
+      controller.abort();
+
+      const request = new Request('http://localhost:3000/api/exa/search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: 'test' }),
+        signal: controller.signal,
+      });
+
+      const { POST } = await import('./route');
+      await expect(POST(request as never)).rejects.toThrow('aborted');
+    });
+  });
+
+  describe('response headers', () => {
+    it('sets Content-Encoding: identity to prevent Vercel compression issues', async () => {
+      setUserAuth();
+      mockedFetch.mockResolvedValue(makeUpstreamResponse({ results: [] }));
+
+      const { POST } = await import('./route');
+      const response = await POST(makeRequest('/search') as never);
+
+      expect(response.headers.get('Content-Encoding')).toBe('identity');
+    });
+
+    it('forwards content-type from upstream response', async () => {
+      setUserAuth();
+      mockedFetch.mockResolvedValue(
+        makeUpstreamResponse({ results: [] }, { 'content-type': 'application/json; charset=utf-8' })
+      );
+
+      const { POST } = await import('./route');
+      const response = await POST(makeRequest('/search') as never);
+
+      expect(response.headers.get('content-type')).toBe('application/json; charset=utf-8');
+    });
+
+    it('does not leak upstream headers beyond the safe set', async () => {
+      setUserAuth();
+      const upstream = new Response(JSON.stringify({ results: [] }), {
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'should-not-leak',
+          'x-ratelimit-remaining': '99',
+          server: 'exa-internal',
+        },
+      });
+      mockedFetch.mockResolvedValue(upstream);
+
+      const { POST } = await import('./route');
+      const response = await POST(makeRequest('/search') as never);
+
+      expect(response.headers.get('x-api-key')).toBeNull();
+      expect(response.headers.get('x-ratelimit-remaining')).toBeNull();
+      expect(response.headers.get('server')).toBeNull();
+    });
+  });
+
+  describe('upstream request', () => {
+    it('sends correct headers including API key', async () => {
+      setUserAuth();
+      mockedFetch.mockResolvedValue(makeUpstreamResponse({ results: [] }));
+
+      const { POST } = await import('./route');
+      await POST(makeRequest('/search') as never);
+
+      expect(mockedFetch).toHaveBeenCalledWith(
+        'https://api.exa.ai/search',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': 'test-exa-key',
+          },
+        })
+      );
+    });
+
+    it('forwards request body to upstream', async () => {
+      setUserAuth();
+      mockedFetch.mockResolvedValue(makeUpstreamResponse({ results: [] }));
+
+      const body = { query: 'test query', numResults: 5 };
+      const { POST } = await import('./route');
+      await POST(makeRequest('/search', body) as never);
+
+      expect(mockedFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: JSON.stringify(body),
+        })
+      );
+    });
+
+    it('preserves upstream status code in response', async () => {
+      setUserAuth();
+      mockedFetch.mockResolvedValue(
+        new Response(JSON.stringify({ error: 'rate limited' }), {
+          status: 429,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+
+      const { POST } = await import('./route');
+      const response = await POST(makeRequest('/search') as never);
+
+      expect(response.status).toBe(429);
+    });
+  });
+
+  describe('cost logging', () => {
+    it('logs cost from non-streaming response via after callback', async () => {
+      setUserAuth();
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      mockedFetch.mockResolvedValue(
+        makeUpstreamResponse({ results: [], costDollars: { total: 0.007 } })
+      );
+
+      const { POST } = await import('./route');
+      await POST(makeRequest('/search') as never);
+      await flushAfterCallbacks();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[exa] user=user-123 path=/search cost=$0.007')
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('does not schedule after callback for streaming responses', async () => {
+      setUserAuth();
+      const streamResponse = new Response('data: {}\n\n', {
+        headers: { 'content-type': 'text/event-stream' },
+      });
+      mockedFetch.mockResolvedValue(streamResponse);
+
+      const { POST } = await import('./route');
+      await POST(makeRequest('/answer') as never);
+
+      expect(afterCallbacks).toHaveLength(0);
+    });
+  });
+});

--- a/apps/web/src/app/api/exa/[...path]/route.ts
+++ b/apps/web/src/app/api/exa/[...path]/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse, type NextResponse as NextResponseType } from 'next/server';
+import { type NextRequest } from 'next/server';
+import { getUserFromAuth } from '@/lib/user.server';
+import { EXA_API_KEY } from '@/lib/config.server';
+import { after } from 'next/server';
+
+const EXA_BASE_URL = 'https://api.exa.ai';
+
+const ALLOWED_PATHS = new Set(['/search', '/contents', '/findSimilar', '/answer', '/context']);
+
+function extractExaPath(url: URL): string | null {
+  const prefix = '/api/exa';
+  if (!url.pathname.startsWith(prefix)) return null;
+  const path = url.pathname.slice(prefix.length);
+  return ALLOWED_PATHS.has(path) ? path : null;
+}
+
+function logExaCost(userId: string, path: string, responseBody: unknown) {
+  const body = responseBody as { costDollars?: { total?: number } } | null;
+  const cost = body?.costDollars?.total;
+  if (cost !== undefined) {
+    console.log(`[exa] user=${userId} path=${path} cost=$${cost}`);
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponseType<unknown>> {
+  const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
+  if (authFailedResponse) return authFailedResponse;
+
+  const url = new URL(request.url);
+  const exaPath = extractExaPath(url);
+  if (!exaPath) {
+    return NextResponse.json(
+      { error: `Invalid path. Allowed: ${[...ALLOWED_PATHS].join(', ')}` },
+      { status: 400 }
+    );
+  }
+
+  if (!EXA_API_KEY) {
+    console.error('[exa] EXA_API_KEY is not configured');
+    return NextResponse.json({ error: 'Exa search is not configured' }, { status: 503 });
+  }
+
+  const requestBody = await request.text();
+
+  const response = await fetch(`${EXA_BASE_URL}${exaPath}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': EXA_API_KEY,
+    },
+    body: requestBody,
+  });
+
+  if (response.status >= 400) {
+    console.error(
+      `[exa] upstream error: status=${response.status} user=${user.id} path=${exaPath}`
+    );
+  }
+
+  // For non-streaming responses, extract cost info asynchronously
+  const isStreaming = response.headers.get('content-type')?.includes('text/event-stream');
+  if (!isStreaming) {
+    const cloned = response.clone();
+    after(async () => {
+      try {
+        const body: unknown = await cloned.json();
+        logExaCost(user.id, exaPath, body);
+      } catch {
+        // Response wasn't JSON — nothing to log
+      }
+    });
+  }
+
+  return new NextResponse(response.body, {
+    status: response.status,
+    headers: {
+      'Content-Type': response.headers.get('Content-Type') ?? 'application/json',
+    },
+  });
+}

--- a/apps/web/src/app/api/exa/[...path]/route.ts
+++ b/apps/web/src/app/api/exa/[...path]/route.ts
@@ -1,8 +1,9 @@
-import { NextResponse, type NextResponse as NextResponseType } from 'next/server';
+import { NextResponse } from 'next/server';
 import { type NextRequest } from 'next/server';
 import { getUserFromAuth } from '@/lib/user.server';
 import { EXA_API_KEY } from '@/lib/config.server';
 import { after } from 'next/server';
+import { wrapInSafeNextResponse } from '@/lib/llm-proxy-helpers';
 
 const EXA_BASE_URL = 'https://api.exa.ai';
 
@@ -23,7 +24,7 @@ function logExaCost(userId: string, path: string, responseBody: unknown) {
   }
 }
 
-export async function POST(request: NextRequest): Promise<NextResponseType<unknown>> {
+export async function POST(request: NextRequest) {
   const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
   if (authFailedResponse) return authFailedResponse;
 
@@ -50,6 +51,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       'x-api-key': EXA_API_KEY,
     },
     body: requestBody,
+    signal: request.signal,
   });
 
   if (response.status >= 400) {
@@ -72,10 +74,5 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     });
   }
 
-  return new NextResponse(response.body, {
-    status: response.status,
-    headers: {
-      'Content-Type': response.headers.get('Content-Type') ?? 'application/json',
-    },
-  });
+  return wrapInSafeNextResponse(response);
 }

--- a/apps/web/src/lib/config.server.ts
+++ b/apps/web/src/lib/config.server.ts
@@ -25,6 +25,7 @@ export const OPENROUTER_API_KEY = getEnvVariable('OPENROUTER_API_KEY');
 export const MISTRAL_API_KEY = getEnvVariable('MISTRAL_API_KEY');
 export const OPENAI_API_KEY = getEnvVariable('OPENAI_API_KEY');
 export const INCEPTION_API_KEY = getEnvVariable('INCEPTION_API_KEY');
+export const EXA_API_KEY = getEnvVariable('EXA_API_KEY');
 export const INTERNAL_API_SECRET = getEnvVariable('INTERNAL_API_SECRET');
 export const CODE_REVIEW_WORKER_AUTH_TOKEN = getEnvVariable('CODE_REVIEW_WORKER_AUTH_TOKEN');
 export const IMPACT_ACCOUNT_SID = getEnvVariable('IMPACT_ACCOUNT_SID') || '';


### PR DESCRIPTION
## Summary

Adds a new API proxy at `/api/exa/[...path]` that forwards authenticated requests to [Exa's search API](https://exa.ai). This is the first step toward giving users web search capabilities.

- **Auth**: Requires sign-in via `getUserFromAuth`; unauthenticated requests get 401.
- **Allow-listed endpoints**: `/search`, `/contents`, `/findSimilar`, `/answer`, `/context`. All others return 400.
- **Cost logging**: For non-streaming responses, asynchronously extracts `costDollars.total` from the Exa response and logs it as `[exa] user=<id> path=<path> cost=$<amount>`. This gives us visibility into usage costs before building a quota system.
- **Env**: Requires `EXA_API_KEY` to be set; returns 503 if missing.

## Verification

- [x] `pnpm typecheck` — passes
- [x] `pnpm format` — passes (pre-push hook confirmed)
- [x] Manual test: authenticated search request → 200 with 3 results and `costDollars.total: $0.007`
- [x] Manual test: invalid path `/api/exa/badpath` → 400 with allow-list error message
- [x] Manual test: unauthenticated request (`credentials: 'omit'`) → 401 Unauthorized

## Visual Changes

N/A

## Reviewer Notes

- `EXA_API_KEY` needs to be added to Vercel environment variables before deploying. Get one from https://dashboard.exa.ai/api-keys.
- Cost logging is console-only for now. Once we decide on a quota model, this should be replaced with proper usage tracking (similar to `accountForMicrodollarUsage` for the LLM proxy).
- Streaming responses (`text/event-stream`) are passed through without cost extraction since Exa doesn't include `costDollars` in SSE chunks.