### PR TITLE
fix(gastown): filter closed beads from re-escalation query

### DIFF
--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -4530,7 +4530,7 @@ Respond with ONLY a JSON object (no markdown, no explanation): { "blocking": tru
     const candidates = [
       ...query(
         this.sql,
-        /* sql */ `${ESCALATION_JOIN} WHERE ${escalation_metadata.acknowledged} = 0 AND ${escalation_metadata.re_escalation_count} < ?`,
+        /* sql */ `${ESCALATION_JOIN} WHERE ${beads.status} != 'closed' AND ${escalation_metadata.acknowledged} = 0 AND ${escalation_metadata.re_escalation_count} < ?`,
         [MAX_RE_ESCALATIONS]
       ),
     ].map(r => toEscalation(EscalationBeadRecord.parse(r)));

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -4530,7 +4530,7 @@ Respond with ONLY a JSON object (no markdown, no explanation): { "blocking": tru
     const candidates = [
       ...query(
         this.sql,
-        /* sql */ `${ESCALATION_JOIN} WHERE ${beads.status} != 'closed' AND ${escalation_metadata.acknowledged} = 0 AND ${escalation_metadata.re_escalation_count} < ?`,
+        /* sql */ `${ESCALATION_JOIN} WHERE ${beads.status} NOT IN ('closed', 'failed') AND ${escalation_metadata.acknowledged} = 0 AND ${escalation_metadata.re_escalation_count} < ?`,
         [MAX_RE_ESCALATIONS]
       ),
     ].map(r => toEscalation(EscalationBeadRecord.parse(r)));


### PR DESCRIPTION
Fixed issue #2123: Added `status != 'closed'` filter to the re-escalation query in Town.do.ts line 4533 to prevent phantom Re-Escalation messages for already-closed escalation beads.