### PR TITLE
fix: Apple Sign In cookie fixes and remove feature flag

### DIFF
--- a/apps/web/src/app/api/auth/verify-turnstile/route.ts
+++ b/apps/web/src/app/api/auth/verify-turnstile/route.ts
@@ -57,8 +57,8 @@ export async function POST(request: NextRequest) {
   const res = NextResponse.json({ success: true });
   res.cookies.set('turnstile_jwt', verificationJWT, {
     httpOnly: true,
-    secure: process.env.NODE_ENV !== 'development',
-    sameSite: 'lax',
+    sameSite: 'none',
+    secure: true,
     path: '/',
     maxAge: 60 * 60,
   });

--- a/apps/web/src/app/api/auth/verify-turnstile/route.ts
+++ b/apps/web/src/app/api/auth/verify-turnstile/route.ts
@@ -1,4 +1,4 @@
-import { NEXTAUTH_SECRET, TURNSTILE_SECRET_KEY } from '@/lib/config.server';
+import { NEXTAUTH_SECRET, NEXTAUTH_URL, TURNSTILE_SECRET_KEY } from '@/lib/config.server';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import jwt from 'jsonwebtoken';
@@ -55,10 +55,11 @@ export async function POST(request: NextRequest) {
   });
 
   const res = NextResponse.json({ success: true });
+  const useSecureCookies = NEXTAUTH_URL?.startsWith('https://') ?? false;
   res.cookies.set('turnstile_jwt', verificationJWT, {
     httpOnly: true,
-    sameSite: 'none',
-    secure: true,
+    sameSite: useSecureCookies ? 'none' : 'lax',
+    secure: useSecureCookies,
     path: '/',
     maxAge: 60 * 60,
   });

--- a/apps/web/src/app/get-started/slack/page.tsx
+++ b/apps/web/src/app/get-started/slack/page.tsx
@@ -4,7 +4,6 @@ import { getAuthPageProps } from '@/lib/auth/auth-page-wrapper';
 import { AuthPageLayout } from '@/components/auth/AuthPageLayout';
 import { SignInForm } from '@/components/auth/SignInForm';
 import { allow_fake_login } from '@/lib/constants';
-import { isAppleSignInEnabled } from '@/lib/auth/apple-feature-flag';
 import { SlackGetStartedFlow } from './_components/SlackGetStartedFlow';
 
 export default async function GetStartedSlackPage({
@@ -16,10 +15,7 @@ export default async function GetStartedSlackPage({
 
   // If user is not authenticated, show sign-up form
   if (!user) {
-    const [{ params, error }, appleSignInEnabled] = await Promise.all([
-      getAuthPageProps(searchParams),
-      isAppleSignInEnabled(),
-    ]);
+    const { params, error } = await getAuthPageProps(searchParams);
     return (
       <AuthPageLayout>
         <div className="mt-4 flex flex-col items-center">
@@ -30,7 +26,6 @@ export default async function GetStartedSlackPage({
             allowFakeLogin={allow_fake_login}
             title="Get Started with Kilo for Slack"
             subtitle="Sign up to connect Kilo to your Slack workspace and start chatting with AI directly from Slack."
-            appleSignInEnabled={appleSignInEnabled}
           />
         </div>
       </AuthPageLayout>

--- a/apps/web/src/app/get-started/teams/page.tsx
+++ b/apps/web/src/app/get-started/teams/page.tsx
@@ -1,16 +1,12 @@
 import { GetStartedPage } from '@/components/auth/GetStartedPage';
 import { getAuthPageProps } from '@/lib/auth/auth-page-wrapper';
-import { isAppleSignInEnabled } from '@/lib/auth/apple-feature-flag';
 
 type GetStartedPageProps = {
   searchParams: Promise<Record<string, string>>;
 };
 
 export default async function TeamsGetStartedPage({ searchParams }: GetStartedPageProps) {
-  const [{ params, error }, appleSignInEnabled] = await Promise.all([
-    getAuthPageProps(searchParams, '/organizations/new'),
-    isAppleSignInEnabled(),
-  ]);
+  const { params, error } = await getAuthPageProps(searchParams, '/organizations/new');
 
   return (
     <>
@@ -20,7 +16,6 @@ export default async function TeamsGetStartedPage({ searchParams }: GetStartedPa
         searchParams={params}
         error={error}
         signUpText="Try out Kilo Teams with a 14-day free trial, no credit card required. After you sign up, you can directly onboard all your team members."
-        appleSignInEnabled={appleSignInEnabled}
       />
     </>
   );

--- a/apps/web/src/app/users/sign_in/page.tsx
+++ b/apps/web/src/app/users/sign_in/page.tsx
@@ -2,17 +2,13 @@ import { allow_fake_login } from '@/lib/constants';
 import { getAuthPageProps } from '@/lib/auth/auth-page-wrapper';
 import { AuthPageLayout } from '@/components/auth/AuthPageLayout';
 import { SignInForm } from '@/components/auth/SignInForm';
-import { isAppleSignInEnabled } from '@/lib/auth/apple-feature-flag';
 
 export default async function SignInPage({
   searchParams,
 }: {
   searchParams: Promise<Record<string, string>>;
 }) {
-  const [{ params, error }, appleSignInEnabled] = await Promise.all([
-    getAuthPageProps(searchParams),
-    isAppleSignInEnabled(),
-  ]);
+  const { params, error } = await getAuthPageProps(searchParams);
   const ssoMode = params['sso'] === 'true' || !!params['domain'];
 
   return (
@@ -31,7 +27,6 @@ export default async function SignInPage({
           }
           ssoMode={ssoMode}
           emailOnly={ssoMode}
-          appleSignInEnabled={appleSignInEnabled}
         />
       </div>
     </AuthPageLayout>

--- a/apps/web/src/components/auth/GetStartedPage.tsx
+++ b/apps/web/src/components/auth/GetStartedPage.tsx
@@ -9,7 +9,6 @@ type GetStartedPageProps = {
   searchParams: Record<string, string>;
   error?: string;
   signUpText?: string;
-  appleSignInEnabled?: boolean;
 };
 
 export function GetStartedPage({
@@ -18,7 +17,6 @@ export function GetStartedPage({
   searchParams,
   error,
   signUpText,
-  appleSignInEnabled,
 }: GetStartedPageProps) {
   const searchParamsWithCallback = useMemo(
     () => ({ ...searchParams, callbackPath }),
@@ -34,7 +32,6 @@ export function GetStartedPage({
           isSignUp={true}
           allowFakeLogin={allow_fake_login}
           title={title}
-          appleSignInEnabled={appleSignInEnabled}
           subtitle={
             signUpText ??
             `After you sign up, you can directly get started with free models, or top up, and get

--- a/apps/web/src/components/auth/SignInForm.tsx
+++ b/apps/web/src/components/auth/SignInForm.tsx
@@ -13,7 +13,6 @@ import Link from 'next/link';
 import { Mail, SquareUserRound } from 'lucide-react';
 import type { SignInFormInitialState } from '@/hooks/useSignInFlow';
 import { OAuthProviderIds, ProdNonSSOAuthProviders } from '@/lib/auth/provider-metadata';
-import { useMemo } from 'react';
 
 type SignInFormProps = {
   searchParams: Record<string, string>;
@@ -25,7 +24,6 @@ type SignInFormProps = {
   emailOnly?: boolean; // If true, only show email input (for SSO page)
   ssoMode?: boolean; // If true, triggers SSO-specific messaging and email input view
   storybookInitialState?: SignInFormInitialState;
-  appleSignInEnabled?: boolean;
 };
 
 export function SignInForm({
@@ -38,7 +36,6 @@ export function SignInForm({
   emailOnly = false,
   ssoMode = false,
   storybookInitialState,
-  appleSignInEnabled = true,
 }: SignInFormProps) {
   const flow = useSignInFlow({
     searchParams,
@@ -47,18 +44,6 @@ export function SignInForm({
     isSignUp,
     storybookInitialState,
   });
-
-  const oauthProviders = useMemo(
-    () => (appleSignInEnabled ? OAuthProviderIds : OAuthProviderIds.filter(p => p !== 'apple')),
-    [appleSignInEnabled]
-  );
-  const nonSSOProviders = useMemo(
-    () =>
-      appleSignInEnabled
-        ? ProdNonSSOAuthProviders
-        : ProdNonSSOAuthProviders.filter(p => p !== 'apple'),
-    [appleSignInEnabled]
-  );
 
   // Show minimal loading state while checking localStorage for returning user hint
   // This prevents flash of "new user" UI before switching to "returning user" UI
@@ -206,7 +191,7 @@ export function SignInForm({
                     {/* Expandable other methods section */}
                     {flow.showOtherMethods ? (
                       <AuthProviderButtons
-                        providers={nonSSOProviders.filter(p => p !== lastAuthMethod)}
+                        providers={ProdNonSSOAuthProviders.filter(p => p !== lastAuthMethod)}
                         onProviderClick={flow.handleOAuthClick}
                       />
                     ) : (
@@ -311,7 +296,7 @@ export function SignInForm({
                   <div className="mx-auto max-w-md space-y-4">
                     {/* OAuth provider buttons - Google first */}
                     <AuthProviderButtons
-                      providers={oauthProviders}
+                      providers={OAuthProviderIds}
                       onProviderClick={flow.handleOAuthClick}
                     />
                     <SignInButton onClick={flow.handleShowEmailInput}>

--- a/apps/web/src/lib/auth/apple-feature-flag.ts
+++ b/apps/web/src/lib/auth/apple-feature-flag.ts
@@ -1,8 +1,0 @@
-import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
-
-const APPLE_SIGN_IN_FLAG = 'apple-sign-in';
-
-export async function isAppleSignInEnabled(): Promise<boolean> {
-  if (process.env.NODE_ENV !== 'production') return true;
-  return isFeatureFlagEnabled(APPLE_SIGN_IN_FLAG);
-}

--- a/apps/web/src/lib/user.server.ts
+++ b/apps/web/src/lib/user.server.ts
@@ -61,6 +61,7 @@ import {
   WORKOS_API_KEY,
   WORKOS_CLIENT_ID,
   NEXTAUTH_SECRET,
+  NEXTAUTH_URL,
   GITLAB_CLIENT_ID,
   GITLAB_CLIENT_SECRET,
   DISCORD_OAUTH_CLIENT_ID,
@@ -384,8 +385,25 @@ const logger: LoggerInstance = {
   error: sentryLogger('NEXTAUTH', 'error'),
 };
 
+const useSecureCookies = NEXTAUTH_URL?.startsWith('https://') ?? false;
+const cookiePrefix = useSecureCookies ? '__Secure-' : '';
+
 const authOptions: NextAuthOptions = {
   secret: NEXTAUTH_SECRET,
+  cookies: {
+    // Apple Sign In uses response_mode=form_post, which is a cross-site POST
+    // from appleid.apple.com. SameSite=Lax (the default) cookies are not sent
+    // on cross-site POSTs, so the PKCE code_verifier cookie gets dropped.
+    pkceCodeVerifier: {
+      name: `${cookiePrefix}next-auth.pkce.code_verifier`,
+      options: {
+        httpOnly: true,
+        sameSite: 'none',
+        path: '/',
+        secure: true,
+      },
+    },
+  },
   providers: [
     GoogleProvider({
       clientId: GOOGLE_CLIENT_ID,


### PR DESCRIPTION
## Summary
- Set `SameSite=None; Secure` on the PKCE code_verifier and turnstile_jwt cookies so they survive Apple's cross-site `form_post` callback from `appleid.apple.com`
- Remove the PostHog feature flag gate for Apple Sign In — now enabled for all users

## Test plan
- [x] Sign in with Apple on web completes successfully
- [ ] Other OAuth providers (Google, GitHub, etc.) still work
- [ ] Turnstile verification passes before OAuth redirect