### PR TITLE
fix(auth): authorization fixes for listWastelands and deleteCredential

### DIFF
--- a/cloudflare-wasteland/src/trpc/router.ts
+++ b/cloudflare-wasteland/src/trpc/router.ts
@@ -149,16 +149,16 @@ export const wastelandRouter = router({
     )
     .output(z.array(RpcWastelandOutput))
     .query(async ({ ctx, input }) => {
+      // Verify org access before any data fetching
+      if (input.organizationId) {
+        verifyOrgAccess(ctx, input.organizationId);
+      }
+
       const registryStub = getWastelandRegistryStub(ctx.env);
 
       const entries = input.organizationId
         ? await registryStub.listByOrg(input.organizationId)
         : await registryStub.listByUser(ctx.userId);
-
-      // If listing org wastelands, verify the user has org membership
-      if (input.organizationId) {
-        verifyOrgAccess(ctx, input.organizationId);
-      }
 
       // Resolve each wasteland's full config from its DO
       const results = await Promise.all(
@@ -484,8 +484,7 @@ export const wastelandRouter = router({
     .input(z.object({ wastelandId: z.string().uuid() }))
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
-      // Users can only delete their own credentials — no ownership
-      // check needed beyond auth (userId comes from the JWT).
+      await resolveWastelandOwnership(ctx.env, ctx, input.wastelandId);
       const stub = getWastelandDOStub(ctx.env, input.wastelandId);
       await stub.deleteCredential(ctx.userId);
 


### PR DESCRIPTION
## Summary
- Move verifyOrgAccess before registry query in listWastelands to prevent unauthorized DO fan-out
- Add missing resolveWastelandOwnership to deleteCredential for symmetric authz with storeCredential and getCredentialStatus

## Verification
- Code changes reviewed and committed

## Visual Changes
N/A

## Reviewer Notes
- Issue 1: listWastelands authz check now runs before the registry query, preventing resource consumption attacks
- Issue 2: deleteCredential now verifies ownership before allowing deletion