### PR TITLE
fix(kiloclaw): reapply --instance-id flag in Google setup command

### DIFF
--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2080,7 +2080,7 @@ export const kiloclawRouter = createTRPCRouter({
     return client.restoreConfig(ctx.user.id, undefined, workerInstanceId(instance));
   }),
 
-  getGoogleSetupCommand: clawAccessProcedure.query(({ ctx }) => {
+  getGoogleSetupCommand: clawAccessProcedure.query(async ({ ctx }) => {
     // Short-lived token — the user should run the setup command promptly.
     // Regenerated on each page load, so 1 hour is sufficient.
     const token = generateApiToken(ctx.user, undefined, {
@@ -2092,9 +2092,12 @@ export const kiloclawRouter = createTRPCRouter({
       ? ` --worker-url=${process.env.KILOCLAW_API_URL ?? 'http://localhost:8795'}`
       : '';
     const gmailPushFlag = isDev ? ' --gmail-push-worker-url=${GMAIL_PUSH_WORKER_URL}' : '';
+    const instance = await getActiveInstance(ctx.user.id);
+    const iid = workerInstanceId(instance);
+    const instanceFlag = iid ? ` --instance-id=${iid}` : '';
     const imageUrl = `ghcr.io/kilo-org/google-setup${imageTag}`;
     return {
-      command: `docker pull ${imageUrl} ; docker run -it --network host ${imageUrl} --token="${token}"${workerFlag}${gmailPushFlag}`,
+      command: `docker pull ${imageUrl} ; docker run -it --network host ${imageUrl} --token="${token}"${instanceFlag}${workerFlag}${gmailPushFlag}`,
     };
   }),
 


### PR DESCRIPTION
  ## Summary                                                                  

The monorepo restructure (#1315, 3ede682dc, Apr 5) silently reverted the fix from ed64feadd (Apr 1) that passes `--instance-id` to the Google setup Docker container. Without this flag, the setup container POSTs credentials to the userId-keyed Durable Object, while the dashboard reads status from the instanceId-keyed DO — causing Google to always show "Not connected" for all multi-instance (`ki_`-prefixed) users.                                 

The `setup.mjs` side of the original fix survived the restructure, but the command generation in `kiloclaw-router.ts` was reverted to the pre-fix version.                                                                    

**Also pushed updated `ghcr.io/kilo-org/google-setup` Docker images (`:dev` and `:latest`)** to bake in the `setup.mjs` that forwards `--instance-id` as    `?instanceId=` on API calls. The image had never been rebuilt since the original fix landed.                                            

**NOTE: Affected users will most likely need to reconnect Google. This only affects users who setup Google between the dates of April 1 and April 7**


## Verification                                                            

- [x] `pnpm run typecheck` — passes                                         
- [x] `pnpm run format:check` — our file passes (pre-existing failures in   `proposals/` unrelated)                                                     
- [x] Generated command includes `--instance-id=<uuid>` in local dev
- [x] Full end-to-end test: ran Google setup via Docker against local kiloclaw worker, confirmed `POST /api/admin/google-credentials?instanceId=<uuid>` and dashboard shows "Connected"                                                                 

## Visual Changes                                                           

  N/A                                                                         

## Reviewer Notes                      

- The change re-applies the exact same patch from ed64feadd to the new monorepo file path
- Makes `getGoogleSetupCommand` async (needed for `getActiveInstance()` call)                                                                       
- Legacy instances (non-`ki_` sandboxId) are unaffected —   `workerInstanceId()` returns `undefined`, so `instanceFlag` is empty        
- Affected users who set up Google after Apr 5 will need to re-run the setup    flow after this deploys  
