### PR TITLE
feat(dev): auto-create secrets store secrets and improve env-sync output

### DIFF
--- a/dev/local/env-sync/output.ts
+++ b/dev/local/env-sync/output.ts
@@ -1,6 +1,7 @@
+import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type { EnvSyncPlan } from './types';
+import type { EnvSyncPlan, SecretStoreAutoCreate } from './types';
 import { formatValue } from './parse';
 
 // ---------------------------------------------------------------------------
@@ -18,14 +19,11 @@ const CYAN = '\x1b[36m';
 // Plan display
 // ---------------------------------------------------------------------------
 
-function truncateValue(value: string, maxLen = 50): string {
-  if (value.length <= maxLen) return value;
-  return value.slice(0, maxLen - 1) + '…';
-}
-
 function planHasChanges(plan: EnvSyncPlan): boolean {
   const hasDevVarsDrift = plan.devVarsChanges.some(c => c.isNew || c.keyChanges.length > 0);
-  return hasDevVarsDrift || plan.envDevLocalChanges.length > 0;
+  return (
+    hasDevVarsDrift || plan.envDevLocalChanges.length > 0 || plan.secretStoreAutoCreates.length > 0
+  );
 }
 
 function displayPlan(plan: EnvSyncPlan): void {
@@ -34,70 +32,97 @@ function displayPlan(plan: EnvSyncPlan): void {
     return;
   }
 
-  if (plan.lanIp) {
-    console.log(`${DIM}LAN IP: ${plan.lanIp}${RESET}`);
-    console.log();
-  }
-
   let hasOutput = false;
 
-  // .dev.vars changes
-  if (plan.devVarsChanges.length > 0) {
-    for (const change of plan.devVarsChanges) {
-      if (change.isNew) {
-        console.log(`${GREEN}+ ${change.workerDir}/.dev.vars${RESET} ${DIM}(new)${RESET}`);
-      } else {
-        console.log(`${CYAN}✎ ${change.workerDir}/.dev.vars${RESET}`);
-        for (const kc of change.keyChanges) {
-          if (kc.oldValue === undefined) {
-            console.log(`    ${GREEN}+ ${kc.key}${RESET} = ${truncateValue(kc.newValue)}`);
-          } else {
-            console.log(
-              `    ${YELLOW}~ ${kc.key}${RESET}: ${truncateValue(kc.oldValue)} → ${truncateValue(kc.newValue)}`
-            );
-          }
+  // ── Group per-service items by workerDir ──────────────────────────────
+
+  type ServiceGroup = {
+    devVars: DevVarsFileChange | undefined;
+    autoCreates: SecretStoreAutoCreate[];
+    warning: SecretStoreWarning | undefined;
+  };
+
+  const serviceMap = new Map<string, ServiceGroup>();
+
+  const getGroup = (dir: string): ServiceGroup => {
+    let g = serviceMap.get(dir);
+    if (!g) {
+      g = { devVars: undefined, autoCreates: [], warning: undefined };
+      serviceMap.set(dir, g);
+    }
+    return g;
+  };
+
+  for (const c of plan.devVarsChanges) getGroup(c.workerDir).devVars = c;
+  for (const c of plan.secretStoreAutoCreates) getGroup(c.workerDir).autoCreates.push(c);
+  for (const w of plan.secretStoreWarnings) getGroup(w.workerDir).warning = w;
+
+  // ── Render each service ───────────────────────────────────────────────
+
+  for (const [workerDir, group] of serviceMap) {
+    const dv = group.devVars;
+    const hasDevVars = dv && (dv.isNew || dv.keyChanges.length > 0 || dv.missingValues.length > 0);
+    if (!hasDevVars && group.autoCreates.length === 0 && !group.warning) continue;
+
+    if (hasOutput) console.log();
+    console.log(`${CYAN}${workerDir}${RESET}`);
+
+    // .dev.vars (skip keys already shown as ⊕ auto-creates)
+    if (dv) {
+      const autoCreateKeys = new Set(group.autoCreates.map(c => c.binding.secret_name));
+      if (dv.isNew) {
+        console.log(`  ${GREEN}+ .dev.vars${RESET} ${DIM}(new)${RESET}`);
+      }
+      for (const kc of dv.keyChanges) {
+        if (autoCreateKeys.has(kc.key)) continue;
+        if (kc.oldValue === undefined) {
+          console.log(`    ${GREEN}+ ${kc.key}${RESET}`);
+        } else {
+          console.log(`    ${YELLOW}~ ${kc.key}${RESET}`);
         }
       }
-      for (const missing of change.missingValues) {
+      for (const missing of dv.missingValues) {
         console.log(`    ${RED}⚠ ${missing}${RESET} — no value found`);
       }
     }
+
+    // Secrets store auto-creates
+    for (const create of group.autoCreates) {
+      console.log(
+        `    ${GREEN}⊕${RESET} secret: ${create.binding.secret_name} ${DIM}@from ${create.envLocalKey}${RESET}`
+      );
+    }
+
+    // Secrets store warnings
+    if (group.warning) {
+      console.log(`    ${YELLOW}⚠${RESET} secrets_store — missing local secrets:`);
+      for (const binding of group.warning.bindings) {
+        console.log(
+          `      ${binding.binding}: wrangler secrets-store secret create ${binding.store_id} --name ${binding.secret_name} --scopes workers`
+        );
+      }
+    }
+
     hasOutput = true;
   }
 
-  // .env.development.local changes
+  // ── .env.development.local (not per-service) ─────────────────────────
+
   if (plan.envDevLocalChanges.length > 0) {
     if (hasOutput) console.log();
     console.log(`${CYAN}✎ .env.development.local${RESET}`);
     for (const change of plan.envDevLocalChanges) {
       if (change.oldValue === undefined) {
-        console.log(`    ${GREEN}+ ${change.key}${RESET} = ${change.newValue}`);
+        console.log(`    ${GREEN}+ ${change.key}${RESET}`);
       } else {
-        console.log(
-          `    ${YELLOW}~ ${change.key}${RESET}: ${truncateValue(change.oldValue)} → ${change.newValue}`
-        );
+        console.log(`    ${YELLOW}~ ${change.key}${RESET}`);
       }
     }
     hasOutput = true;
   }
 
-  // Secrets store warnings
-  if (plan.secretStoreWarnings.length > 0) {
-    if (hasOutput) console.log();
-    for (const warning of plan.secretStoreWarnings) {
-      console.log(
-        `${YELLOW}⚠ ${warning.workerDir}${RESET} uses secrets_store — missing local secrets:`
-      );
-      for (const binding of warning.bindings) {
-        console.log(
-          `    ${binding.binding}: wrangler secrets-store secret create ${binding.store_id} --name ${binding.secret_name} --scopes workers`
-        );
-      }
-    }
-    hasOutput = true;
-  }
+  // ── Consistency warnings (cross-service) ──────────────────────────────
 
-  // Consistency warnings
   if (plan.consistencyWarnings.length > 0) {
     if (hasOutput) console.log();
     for (const warning of plan.consistencyWarnings) {
@@ -107,7 +132,7 @@ function displayPlan(plan: EnvSyncPlan): void {
           entry.workerKey !== warning.sourceKey
             ? `${entry.workerDir} (${entry.workerKey})`
             : entry.workerDir;
-        console.log(`    ${keyLabel}: ${truncateValue(entry.value)}`);
+        console.log(`    ${keyLabel}`);
       }
     }
     hasOutput = true;
@@ -115,7 +140,15 @@ function displayPlan(plan: EnvSyncPlan): void {
 
   if (!hasOutput) {
     console.log(`${GREEN}✓ All env vars are up to date${RESET}`);
+    return;
   }
+
+  // ── Legend ─────────────────────────────────────────────────────────────
+
+  console.log();
+  console.log(
+    `${DIM}${GREEN}+${RESET}${DIM} new  ${YELLOW}~${RESET}${DIM} changed  ${GREEN}⊕${RESET}${DIM} create secret  ${RED}⚠${RESET}${DIM} missing  ${RED}✗${RESET}${DIM} mismatch${RESET}`
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -126,7 +159,64 @@ function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+// ---------------------------------------------------------------------------
+// Secrets store creation
+// ---------------------------------------------------------------------------
+
+function createSecretsStoreSecret(
+  repoRoot: string,
+  workerDir: string,
+  storeId: string,
+  secretName: string,
+  value: string
+): boolean {
+  const result = spawnSync(
+    'pnpm',
+    [
+      'wrangler',
+      'secrets-store',
+      'secret',
+      'create',
+      storeId,
+      '--name',
+      secretName,
+      '--scopes',
+      'workers',
+    ],
+    {
+      cwd: path.join(repoRoot, workerDir),
+      encoding: 'utf-8',
+      input: value, // Pass value via stdin for security
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }
+  );
+  return result.status === 0;
+}
+
+function applySecretsStoreAutoCreates(creates: SecretStoreAutoCreate[], repoRoot: string): void {
+  if (creates.length === 0) return;
+
+  console.log('\nCreating secrets store secrets...');
+  for (const create of creates) {
+    const success = createSecretsStoreSecret(
+      repoRoot,
+      create.workerDir,
+      create.binding.store_id,
+      create.binding.secret_name,
+      create.value
+    );
+    if (success) {
+      console.log(`  ✓ ${create.binding.secret_name}`);
+    } else {
+      console.error(`  ✗ ${create.binding.secret_name} (failed)`);
+    }
+  }
+}
+
 function applyPlan(plan: EnvSyncPlan, repoRoot: string): void {
+  // Create secrets store secrets first
+  applySecretsStoreAutoCreates(plan.secretStoreAutoCreates, repoRoot);
+
   for (const change of plan.devVarsChanges) {
     const devVarsPath = path.join(repoRoot, change.workerDir, '.dev.vars');
 
@@ -154,7 +244,7 @@ function applyPlan(plan: EnvSyncPlan, repoRoot: string): void {
   }
 
   if (plan.envDevLocalChanges.length > 0) {
-    const envDevLocalPath = path.join(repoRoot, '.env.development.local');
+    const envDevLocalPath = path.join(repoRoot, 'apps/web/.env.development.local');
 
     let existingContent = '';
     try {

--- a/dev/local/env-sync/output.ts
+++ b/dev/local/env-sync/output.ts
@@ -1,7 +1,12 @@
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type { EnvSyncPlan, SecretStoreAutoCreate } from './types';
+import type {
+  DevVarsFileChange,
+  EnvSyncPlan,
+  SecretStoreAutoCreate,
+  SecretStoreWarning,
+} from './types';
 import { formatValue } from './parse';
 
 // ---------------------------------------------------------------------------

--- a/dev/local/env-sync/plan.ts
+++ b/dev/local/env-sync/plan.ts
@@ -154,9 +154,9 @@ function extractSecretsStoreBindings(repoRoot: string, workerDir: string): Secre
 // Local secrets store check (via wrangler CLI)
 // ---------------------------------------------------------------------------
 
-function listLocalStoreSecrets(repoRoot: string, storeId: string): string {
+function listLocalStoreSecrets(repoRoot: string, workerDir: string, storeId: string): string {
   const result = spawnSync('pnpm', ['wrangler', 'secrets-store', 'secret', 'list', storeId], {
-    cwd: repoRoot,
+    cwd: path.join(repoRoot, workerDir),
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
   });
@@ -175,6 +175,7 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
       devVarsChanges: [],
       envDevLocalChanges: [],
       secretStoreWarnings: [],
+      secretStoreAutoCreates: [],
       consistencyWarnings: [],
       missingEnvLocal: true,
     };
@@ -281,9 +282,9 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
   const envDevLocalChanges: EnvDevLocalChange[] = [];
   const processEnvDevLocal = !serviceFilter || serviceFilter.has('nextjs');
 
-  const envDevLocalExamplePath = path.join(repoRoot, '.env.development.local.example');
+  const envDevLocalExamplePath = path.join(repoRoot, 'apps/web/.env.development.local.example');
   if (processEnvDevLocal && fs.existsSync(envDevLocalExamplePath)) {
-    const envDevLocalPath = path.join(repoRoot, '.env.development.local');
+    const envDevLocalPath = path.join(repoRoot, 'apps/web/.env.development.local');
     const envDevLocal = readEnvFile(envDevLocalPath);
     const exampleContent = fs.readFileSync(envDevLocalExamplePath, 'utf-8');
     const entries = parseExampleFile(exampleContent);
@@ -301,11 +302,13 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
 
       // Effective value: .env.development.local overrides .env.local
       const effectiveValue = envDevLocal.get(entry.key) ?? envLocal.get(entry.key);
+      const isMissing = !envDevLocal.has(entry.key);
 
-      if (effectiveValue !== expectedValue) {
+      // Add change if: (1) key is missing from file, or (2) value differs from expected
+      if (isMissing || effectiveValue !== expectedValue) {
         envDevLocalChanges.push({
           key: entry.key,
-          oldValue: effectiveValue,
+          oldValue: isMissing ? undefined : effectiveValue,
           newValue: expectedValue,
         });
       }
@@ -314,6 +317,8 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
 
   // --- Secrets store warnings ---
   const secretStoreWarnings: SecretStoreWarning[] = [];
+  const secretStoreAutoCreates: SecretStoreAutoCreate[] = [];
+  // Cache keyed by workerDir+storeId — wrangler scopes secret visibility per worker locally
   const storeOutputCache = new Map<string, string>();
 
   for (const [name, svc] of services) {
@@ -322,14 +327,38 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
     const bindings = extractSecretsStoreBindings(repoRoot, svc.dir);
     if (bindings.length === 0) continue;
 
-    const missingBindings = bindings.filter(b => {
-      let output = storeOutputCache.get(b.store_id);
+    const missingBindings: SecretStoreBinding[] = [];
+
+    for (const b of bindings) {
+      const cacheKey = `${svc.dir}:${b.store_id}`;
+      let output = storeOutputCache.get(cacheKey);
       if (output === undefined) {
-        output = listLocalStoreSecrets(repoRoot, b.store_id);
-        storeOutputCache.set(b.store_id, output);
+        output = listLocalStoreSecrets(repoRoot, svc.dir, b.store_id);
+        storeOutputCache.set(cacheKey, output);
       }
-      return !output.includes(b.secret_name);
-    });
+
+      if (output.includes(b.secret_name)) {
+        continue; // Secret exists, nothing to do
+      }
+
+      // Try to map secret name to .env.local key via naming convention
+      // Strip _PROD or _DEV suffix to get base key
+      const envLocalKey = b.secret_name.replace(/_(PROD|DEV)$/, '');
+      const value = envLocal.get(envLocalKey);
+
+      if (value) {
+        // Can auto-create from .env.local
+        secretStoreAutoCreates.push({
+          workerDir: svc.dir,
+          binding: b,
+          envLocalKey,
+          value,
+        });
+      } else {
+        // Missing and no source value - warn
+        missingBindings.push(b);
+      }
+    }
 
     if (missingBindings.length > 0) {
       secretStoreWarnings.push({ workerDir: svc.dir, bindings: missingBindings });
@@ -368,6 +397,7 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
     devVarsChanges,
     envDevLocalChanges,
     secretStoreWarnings,
+    secretStoreAutoCreates,
     consistencyWarnings,
     missingEnvLocal: false,
   };

--- a/dev/local/env-sync/types.ts
+++ b/dev/local/env-sync/types.ts
@@ -39,11 +39,19 @@ type ConsistencyWarning = {
   entries: { workerDir: string; workerKey: string; value: string }[];
 };
 
+type SecretStoreAutoCreate = {
+  workerDir: string;
+  binding: SecretStoreBinding;
+  envLocalKey: string;
+  value: string;
+};
+
 type EnvSyncPlan = {
   lanIp: string | undefined;
   devVarsChanges: DevVarsFileChange[];
   envDevLocalChanges: EnvDevLocalChange[];
   secretStoreWarnings: SecretStoreWarning[];
+  secretStoreAutoCreates: SecretStoreAutoCreate[];
   consistencyWarnings: ConsistencyWarning[];
   missingEnvLocal: boolean;
 };
@@ -87,6 +95,7 @@ export type {
   EnvDevLocalChange,
   SecretStoreBinding,
   SecretStoreWarning,
+  SecretStoreAutoCreate,
   ConsistencyWarning,
   EnvSyncPlan,
   Annotation,

--- a/services/app-builder/.dev.vars.example
+++ b/services/app-builder/.dev.vars.example
@@ -28,6 +28,9 @@ GIT_JWT_SECRET=your-secret-key-at-least-32-bytes-long
 # In dev mode previews are accessed using regular app builder url
 DEV_MODE=true
 
+# Git token expiry time in seconds (default: 300 = 5 minutes)
+GIT_TOKEN_EXPIRY_SECONDS=300
+
 # URL of the DB proxy worker for database provisioning
 # @url cloudflare-db-proxy
 DB_PROXY_URL=http://localhost:8798

--- a/services/auto-fix-infra/.dev.vars.example
+++ b/services/auto-fix-infra/.dev.vars.example
@@ -3,6 +3,7 @@
 API_URL=http://localhost:3000
 
 # Internal API secret for authentication (shared with backend)
+# @from INTERNAL_API_SECRET
 INTERNAL_API_SECRET=your-secret-here
 
 # Backend auth token for authenticating incoming requests from backend
@@ -14,3 +15,12 @@ BACKEND_AUTH_TOKEN=your-backend-auth-token
 # For production: use https://cloud-agent-next.kilosessions.ai
 # @url cloud-agent-next
 CLOUD_AGENT_URL=http://localhost:8794
+
+# Sentry DSN for error tracking (optional)
+SENTRY_DSN=
+
+# Cloudflare version metadata (optional, set by deployment)
+CF_VERSION_METADATA=
+
+# Environment name
+ENVIRONMENT=development

--- a/services/auto-triage-infra/.dev.vars.example
+++ b/services/auto-triage-infra/.dev.vars.example
@@ -3,6 +3,7 @@
 API_URL=http://localhost:3000
 
 # Internal API secret for authentication (shared with backend)
+# @from INTERNAL_API_SECRET
 INTERNAL_API_SECRET=your-secret-here
 
 # Backend auth token for authenticating incoming requests from backend
@@ -12,3 +13,6 @@ BACKEND_AUTH_TOKEN=your-backend-auth-token
 # Cloud agent URL for triage execution
 # @url cloud-agent-next
 CLOUD_AGENT_URL=http://localhost:8794
+
+# Environment configuration
+ENVIRONMENT=development

--- a/services/cloud-agent-next/.dev.vars.example
+++ b/services/cloud-agent-next/.dev.vars.example
@@ -81,7 +81,7 @@ AGENT_ENV_VARS_PRIVATE_KEY=""
 R2_ENDPOINT=""
 R2_ATTACHMENTS_BUCKET=""
 R2_ATTACHMENTS_READONLY_ACCESS_KEY_ID=""
-R2_ATTACHMENTS_READONLY_SECRET_ACCESS_KEY="
+R2_ATTACHMENTS_READONLY_SECRET_ACCESS_KEY=""
 
 # Session ingest URL used by the wrapper to post session data.
 # Use a host-reachable IP (not localhost) so sandbox containers can connect back.

--- a/services/cloud-agent-next/.dev.vars.example
+++ b/services/cloud-agent-next/.dev.vars.example
@@ -1,7 +1,9 @@
 # Shared secret for JWT token validation (same as NextAuth.js secret)
+# @from NEXTAUTH_SECRET
 NEXTAUTH_SECRET=your-nextauth-secret-here
 
 # Shared secret for internal API calls, same as .env.development.
+# @from INTERNAL_API_SECRET
 INTERNAL_API_SECRET=your-internal-api-secret-here
 
 # Optional: Override Kilocode credentials in session environment variables used during kilocode invocation
@@ -35,6 +37,10 @@ REAPER_INTERVAL_MS=300000
 STALE_THRESHOLD_MS=600000
 PENDING_START_TIMEOUT_MS=300000
 
+# Per-session sandbox org IDs (optional)
+# Comma-separated list of org IDs that use per-session sandboxes, or `*` for all orgs
+PER_SESSION_SANDBOX_ORG_IDS=
+
 # GitHub App credentials for git commit attribution
 # These identify commits as coming from the Kilo Code GitHub App
 # Format for git config:
@@ -58,6 +64,10 @@ GITHUB_LITE_APP_ID=
 # @pkcs8
 GITHUB_LITE_APP_PRIVATE_KEY=
 
+# GitHub Lite App slug and bot user ID for git commit attribution (optional)
+GITHUB_LITE_APP_SLUG=
+GITHUB_LITE_APP_BOT_USER_ID=
+
 # Agent Environment Profile Secrets Decryption
 # Used to decrypt encrypted secrets from agent environment profiles at session execution time.
 # This is a RSA private key that pairs with AGENT_ENV_VARS_PUBLIC_KEY in the backend.
@@ -69,8 +79,9 @@ AGENT_ENV_VARS_PRIVATE_KEY=""
 # R2 Attachments Bucket Readonly Access
 # 1pass (Cloudflare - R2 Cloud Agents Attachments Read Only)
 R2_ENDPOINT=""
+R2_ATTACHMENTS_BUCKET=""
 R2_ATTACHMENTS_READONLY_ACCESS_KEY_ID=""
-R2_ATTACHMENTS_READONLY_SECRET_ACCESS_KEY=""
+R2_ATTACHMENTS_READONLY_SECRET_ACCESS_KEY="
 
 # Session ingest URL used by the wrapper to post session data.
 # Use a host-reachable IP (not localhost) so sandbox containers can connect back.

--- a/services/cloud-agent/.dev.vars.example
+++ b/services/cloud-agent/.dev.vars.example
@@ -1,7 +1,9 @@
 # Shared secret for JWT token validation (same as NextAuth.js secret)
+# @from NEXTAUTH_SECRET
 NEXTAUTH_SECRET=your-nextauth-secret-here
 
 # Shared secret for internal API calls, same as .env.development.
+# @from INTERNAL_API_SECRET
 INTERNAL_API_SECRET=your-internal-api-secret-here
 
 # Optional: Override Kilocode credentials in session environment variables used during kilocode invocation
@@ -9,8 +11,8 @@ INTERNAL_API_SECRET=your-internal-api-secret-here
 # Use these to inject test/dev credentials while maintaining proper authentication with credentials sent
 # Affects:
 #   - Session environment variables (KILOCODE_TOKEN and KILOCODE_ORG_ID)
-# 
-# Note: With the introduction of server-backed sessions, these should probably not be used any more, 
+#
+# Note: With the introduction of server-backed sessions, these should probably not be used any more,
 # you should set KILOCODE_BACKEND_BASE_URL instead and use local dev only.
 #KILOCODE_TOKEN_OVERRIDE=your-override-token-here
 #KILOCODE_ORG_ID_OVERRIDE=your-override-org-id-here
@@ -58,6 +60,8 @@ GITHUB_APP_PRIVATE_KEY=
 GITHUB_LITE_APP_ID=
 # @pkcs8
 GITHUB_LITE_APP_PRIVATE_KEY=
+GITHUB_LITE_APP_SLUG=
+GITHUB_LITE_APP_BOT_USER_ID=
 
 # Agent Environment Profile Secrets Decryption
 # Used to decrypt encrypted secrets from agent environment profiles at session execution time.

--- a/services/code-review-infra/.dev.vars.example
+++ b/services/code-review-infra/.dev.vars.example
@@ -3,6 +3,7 @@
 API_URL=http://localhost:3000
 
 # Internal API secret for authentication (shared with backend)
+# @from INTERNAL_API_SECRET
 INTERNAL_API_SECRET=your-secret-here
 
 # Backend auth token for authenticating incoming requests from backend
@@ -16,3 +17,9 @@ CLOUD_AGENT_URL=http://localhost:8794
 # Cloud agent (next) URL for v2 code review execution
 # @url cloud-agent-next
 CLOUD_AGENT_NEXT_URL=http://localhost:8794
+
+# Environment setting
+ENVIRONMENT=development
+
+# Sentry DSN for error tracking (optional)
+# SENTRY_DSN=

--- a/services/deploy-infra/dispatcher/.dev.vars.example
+++ b/services/deploy-infra/dispatcher/.dev.vars.example
@@ -5,7 +5,8 @@
 # Generate with: openssl rand -base64 32
 JWT_SECRET=your-secret-key-at-least-32-bytes-long
 
-# Session duration in seconds for JWT tokens (optional, configured in wrangler.jsonc)
+# Session duration in seconds for JWT tokens
+# Optional: already configured in wrangler.jsonc
 SESSION_DURATION_SECONDS=604800
 
 # Backend authentication token for Management API endpoints (required)

--- a/services/git-token-service/.dev.vars.example
+++ b/services/git-token-service/.dev.vars.example
@@ -14,3 +14,9 @@ GITHUB_LITE_APP_PRIVATE_KEY=
 # GitLab App credentials (optional, used as fallback when metadata lacks client credentials)
 GITLAB_CLIENT_ID=
 GITLAB_CLIENT_SECRET=
+
+# Hyperdrive binding for database connectivity
+HYPERDRIVE=
+
+# KV namespace binding for token caching
+TOKEN_CACHE=

--- a/services/git-token-service/.dev.vars.example
+++ b/services/git-token-service/.dev.vars.example
@@ -14,9 +14,3 @@ GITHUB_LITE_APP_PRIVATE_KEY=
 # GitLab App credentials (optional, used as fallback when metadata lacks client credentials)
 GITLAB_CLIENT_ID=
 GITLAB_CLIENT_SECRET=
-
-# Hyperdrive binding for database connectivity
-HYPERDRIVE=
-
-# KV namespace binding for token caching
-TOKEN_CACHE=

--- a/services/images-mcp/.dev.vars.example
+++ b/services/images-mcp/.dev.vars.example
@@ -4,3 +4,11 @@
 R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=
 R2_ENDPOINT=
+
+# Secrets Store binding for JWT validation (used to validate tokens from web app)
+# @from NEXTAUTH_SECRET
+NEXTAUTH_SECRET=
+
+# JSON object mapping bucket names to their public CDN URLs
+# Example: {"cloud-agent-attachments": "https://attachments.example.com", "app-builder-assets": "https://assets.example.com"}
+BUCKET_PUBLIC_URLS=

--- a/services/kiloclaw/.dev.vars.example
+++ b/services/kiloclaw/.dev.vars.example
@@ -13,10 +13,15 @@
 #                                          or ask a team member for values)
 
 # Auth (synced automatically from Vercel by the dev-start script)
+# JWT verification secret (shared with Next.js for token signing/verification)
+# @from NEXTAUTH_SECRET
 NEXTAUTH_SECRET=dev-secret-change-me
+# Platform API authentication key (for internal service-to-service calls)
+# @from INTERNAL_API_SECRET
 INTERNAL_API_SECRET=dev-internal-secret
 
 # Auth (static defaults — these work as-is for local dev)
+# HMAC secret for deriving per-sandbox gateway tokens (machine authentication)
 GATEWAY_TOKEN_SECRET=dev-gateway-secret-kiloclaw
 # Override WORKER_ENV to "development" for local development.
 # Production default is set in wrangler.jsonc. This selects the development
@@ -50,6 +55,9 @@ FLY_REGION=us,eu
 # Docker image tag on registry.fly.io/{FLY_REGISTRY_APP}:{tag}.
 # Set automatically by scripts/push-dev.sh, or use "latest" to start.
 FLY_IMAGE_TAG=latest
+# Docker image digest (sha256:...) for immutable image references.
+# Set automatically by scripts/push-dev.sh when pushing images.
+FLY_IMAGE_DIGEST=
 # OpenClaw version (must match the openclaw@x.x.x version in the Dockerfile).
 # Used by the worker to self-register the version → image tag mapping in KV,
 # enabling per-user version tracking. Without this, version tracking fields

--- a/services/webhook-agent-ingest/.dev.vars.example
+++ b/services/webhook-agent-ingest/.dev.vars.example
@@ -1,5 +1,7 @@
 # Shared secrets (required for local dev — secrets store not available in wrangler dev)
+# @from NEXTAUTH_SECRET
 NEXTAUTH_SECRET=
+# @from INTERNAL_API_SECRET
 INTERNAL_API_SECRET=
 
 # Worker environment


### PR DESCRIPTION
## Summary

Enhance the local env-sync tooling to automatically create secrets store secrets from `.env.local` values, eliminating manual `wrangler secrets-store secret create` commands during local dev setup.

Key changes:
- **Auto-create secrets store secrets**: When a secret is missing from the local store but the corresponding key exists in `.env.local` (matched by stripping `_PROD`/`_DEV` suffixes), env-sync now creates it automatically via `wrangler` CLI.
- **Grouped output by service**: Plan display now groups `.dev.vars` changes, auto-creates, and warnings under each service directory instead of listing them in separate sections.
- **Redact values from output**: Plan display no longer prints secret values — only key names and change types are shown.
- **Fix `.env.development.local` path**: Corrected from repo root to `apps/web/.env.development.local` to match actual Next.js location.
- **`@from` annotations**: Added `@from` comments to `.dev.vars.example` files so env-sync can resolve values from `.env.local` automatically.
- **New env vars**: Added missing variables across 12 service `.dev.vars.example` files (e.g., `PER_SESSION_SANDBOX_ORG_IDS`, `FLY_IMAGE_DIGEST`, `R2_ATTACHMENTS_BUCKET`, `BUCKET_PUBLIC_URLS`).

## Verification

<img width="648" height="410" alt="Screenshot 2026-04-07 at 22 29 33" src="https://github.com/user-attachments/assets/cfc06af1-11ba-41af-b815-64b38f1e30b5" />


## Reviewer Notes

- The `listLocalStoreSecrets` function now takes `workerDir` as an argument because wrangler scopes secret visibility per worker directory locally. The cache key was updated accordingly.
- Auto-create uses `spawnSync` with stdin piping to avoid passing secret values on the command line.