### PR TITLE
perf(kiloclaw): defer kilo CLI background upgrade to avoid startup contention

### DIFF
--- a/services/kiloclaw/controller/src/index.ts
+++ b/services/kiloclaw/controller/src/index.ts
@@ -436,21 +436,34 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
     // The Docker image bakes in a pinned version; this upgrades to the
     // latest release in the background so the instance always has the
     // newest CLI without requiring an image rebuild.
+    //
+    // The upgrade is deferred so it doesn't compete with the gateway for
+    // CPU during startup. On shared-cpu-2x (~6% of 2 cores), npm's
+    // dependency resolution and decompression would otherwise starve the
+    // gateway's lazy initialization, adding ~30-100s to the user's first
+    // request. Once the gateway is warm and CPU has settled, the upgrade
+    // runs safely in the background.
+    //
+    // TODO: Replace this timeout with a warm-up callback that fires after
+    // the gateway is confirmed ready (see gateway-warmup.ts).
     if (env.KILOCLAW_KILO_CLI === 'true') {
-      // Strip NPM_CONFIG_PREFIX so the install overwrites the system-wide
-      // binary in /usr/local/bin instead of writing to the per-user prefix.
-      const upgradeEnv = { ...process.env };
-      delete upgradeEnv.NPM_CONFIG_PREFIX;
-      execFile('npm', ['install', '-g', '@kilocode/cli@latest'], { env: upgradeEnv }, err => {
-        if (err) {
-          console.warn(
-            '[kilo-cli] Background upgrade failed (using baked-in version):',
-            err.message
-          );
-        } else {
-          console.log('[kilo-cli] Upgraded to latest version');
-        }
-      });
+      const KILO_CLI_UPGRADE_DELAY_MS = 5 * 60 * 1000; // 5 minutes
+      setTimeout(() => {
+        // Strip NPM_CONFIG_PREFIX so the install overwrites the system-wide
+        // binary in /usr/local/bin instead of writing to the per-user prefix.
+        const upgradeEnv = { ...process.env };
+        delete upgradeEnv.NPM_CONFIG_PREFIX;
+        execFile('npm', ['install', '-g', '@kilocode/cli@latest'], { env: upgradeEnv }, err => {
+          if (err) {
+            console.warn(
+              '[kilo-cli] Background upgrade failed (using baked-in version):',
+              err.message
+            );
+          } else {
+            console.log('[kilo-cli] Upgraded to latest version');
+          }
+        });
+      }, KILO_CLI_UPGRADE_DELAY_MS);
     }
   } catch (err) {
     const fullError = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary                                                                                                     
                                                                                                                 
  The `npm install -g @kilocode/cli@latest` was firing immediately after the controller reported "ready",        
  competing with the openclaw gateway's lazy initialization for CPU on Fly's shared-cpu-2x (~6% of 2 physical    
  cores). This caused the gateway's first-request latency to balloon — `chat.history` and `models.list` took 39+ 
  seconds on a cold gateway.                                                                                     
                                                                                                                 
  Wraps the existing fire-and-forget `execFile` in a 5-minute `setTimeout` so the gateway can initialize without 
  CPU contention. The Docker image already bakes in a pinned kilo CLI version that covers immediate use; the     
  background upgrade just pulls the latest.                                                                      
                                                                                                                 
  ## Verification                                                                                             
                                                                                                                 
  - [x] `vitest run` — 52 test files, 1186 tests passed                                                          
  - [x] Workspace `typecheck` — clean                                                                            
  - [x] `oxfmt --list-different` on changed file — clean                                                         
  - [x] Dev image deployed to `dev-inst-8a4d4e0a262a27346b8a` (dfw, shared-cpu-2x, fresh volume)                 
  - [x] Baseline comparison: `chat.history` first request dropped from **39,205ms → 10ms**, `models.list` from   
  **39,197ms → 4ms**, first agent run from **36,719ms → 6,364ms**                                                
                                                                                                                 
  ## Visual Changes                                                                                              
                                                                                                                 
  N/A                                                                                                            
                                                                                                                 
  ## Reviewer Notes                                                                                              
                                                                                                                 
  - The only code change is wrapping the existing `execFile('npm', ...)` call in a `setTimeout` with a 5-minute  
  delay — no new logic, no new dependencies                                                                      
  - There's a TODO comment for replacing the timeout with a gateway warm-up callback (future PR)                 
  - No existing test coverage for the npm upgrade path (fire-and-forget, no assertions before or after)          
  - The 5-minute delay is conservative; in practice the gateway initializes in ~30-60s on throttled CPU, so even 
  a shorter delay would work. 5 minutes gives plenty of headroom      
