### PR TITLE
Perf/kiloclaw shrink docker image

### DIFF
--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -95,14 +95,13 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/b
 # ── Builder stage: compile the controller with Bun ────────────────────
 # Bun is only needed to bundle the controller TypeScript into a single JS
 # file. By building in a separate stage, Bun (~100MB) stays out of the
-# final image. (Bun was also installed to /root/.bun/ which gets shadowed
-# by the Fly Volume mount at /root, so it was unreachable at runtime anyway.)
+# final image. Bun installed to /root/.bun/ which gets shadowed by the
+# Fly Volume mount at /root, so it was unreachable at runtime anyway.
 FROM debian:bookworm-slim AS controller-builder
 
-ARG BUN_VERSION=1.2.4
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl unzip \
-    && curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \
+    && curl -fsSL https://bun.sh/install | bash -s "bun-v1.2.4" \
     && rm -rf /var/lib/apt/lists/*
 ENV PATH="/root/.bun/bin:$PATH"
 

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -1,4 +1,8 @@
-FROM debian:bookworm-slim
+# Global build args — declared before any FROM so they're available to all stages.
+ARG CONTROLLER_COMMIT=unknown
+ARG CONTROLLER_CACHE_BUST=1
+
+FROM debian:bookworm-slim AS runtime
 
 # Install Node.js 24 (required by OpenClaw)
 ENV NODE_VERSION=24.14.1
@@ -88,15 +92,23 @@ RUN GOBIN=/usr/local/bin go install github.com/steipete/gogcli/cmd/gog@v0.12.0 \
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
     && uv --version
 
-# Install pinned Bun (build-time only) and compile the controller bundle.
+# ── Builder stage: compile the controller with Bun ────────────────────
+# Bun is only needed to bundle the controller TypeScript into a single JS
+# file. By building in a separate stage, Bun (~100MB) stays out of the
+# final image. (Bun was also installed to /root/.bun/ which gets shadowed
+# by the Fly Volume mount at /root, so it was unreachable at runtime anyway.)
+FROM debian:bookworm-slim AS controller-builder
+
 ARG BUN_VERSION=1.2.4
-RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl unzip \
+    && curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \
+    && rm -rf /var/lib/apt/lists/*
 ENV PATH="/root/.bun/bin:$PATH"
 
-ARG CONTROLLER_COMMIT=unknown
-# Changing this ARG value invalidates the COPY + RUN layers below it,
-# forcing a controller rebuild even when Docker thinks the source is unchanged.
-ARG CONTROLLER_CACHE_BUST=1
+# Re-declare global ARGs to make them available in this stage
+ARG CONTROLLER_COMMIT
+ARG CONTROLLER_CACHE_BUST
 COPY controller/ /tmp/controller-build/
 RUN cd /tmp/controller-build \
     && bun install --frozen-lockfile \
@@ -105,6 +117,12 @@ RUN cd /tmp/controller-build \
        --define "KILOCLAW_CONTROLLER_VERSION=\"${CONTROLLER_VERSION}\"" \
        --define "KILOCLAW_CONTROLLER_COMMIT=\"${CONTROLLER_COMMIT}\"" \
     && rm -rf /tmp/controller-build
+
+# ── Final stage: runtime image ────────────────────────────────────────
+FROM runtime AS final
+
+# Copy the compiled controller from the builder stage
+COPY --from=controller-builder /usr/local/bin/kiloclaw-controller.js /usr/local/bin/kiloclaw-controller.js
 
 # Create OpenClaw directories
 # When a Fly Volume is mounted at /root, these dirs persist across restarts.


### PR DESCRIPTION
## Summary                                                             

Introduces a multi stage Docker build to keep Bun and its dependencies (~330MB) out of the final runtime image. 

Bun is only needed at build time to compile the controller TypeScript into a single JS file — and  **was already unreachable at runtime since it installed to `/root/.bun/`   which gets shadowed by the Fly Volume mount at `/root`**.

The Dockerfile now has three stages:                                   
- **`runtime`** — all runtime dependencies (Node, Go, Chromium, apt   packages, npm globals)                                                 
- **`controller-builder`** — lightweight Debian + Bun, compiles   controller to a single JS file                                         
- **`final`** — inherits `runtime`, copies the compiled controller       artifact from the builder                                              

Image size: 2.32GB → 1.99GB (-14%)                                     

## Verification                                                        

- [x] Local Docker build succeeds (`docker buildx build --target final`)                                                               
- [x] Image size confirmed: 1.99GB (was 2.32GB)                        
- [x] Dev image deployed and tested on `dev-inst-xxxxxxxx` iad, fresh volume, uncached host)                                     
- [x] Image pull on uncached host: **1m36s** (was 2m31s on previous prod image — ~36% faster)                                              
- [x] Controller boots and reports correct version/commit 
- [x] Gateway starts, StreamChat connects, agent runs complete successfully                                                           
- [x] First agent run: 6,255ms (StreamChat), 5,055ms (webchat) —  consistent with pre-change performance                                 
- [x] `openclaw onboard` completes normally on fresh volume
- [x] Workspace typecheck passes                                       

## Visual Changes                                                      

  N/A                                    

## Reviewer Notes

- Global `ARG`s (`CONTROLLER_COMMIT`, `CONTROLLER_CACHE_BUST`) are declared before any `FROM` and re-declared in the builder stage — this   is required by Docker for cross-stage ARG visibility                   
- The `controller-builder` stage uses `debian:bookworm-slim` (same base    as runtime) to match architecture                                     
- Bun version is inlined (`bun-v1.2.4`) rather than using an ARG since   it's never overridden at build time                                    
- The CI workflow (`push-dev-kiloclaw.yml`) passes `CONTROLLER_COMMIT`   and `CONTROLLER_CACHE_BUST` as build-args — these correctly reach the     builder stage via the global ARG declarations                         
- No runtime behavior changes — the compiled `kiloclaw-controller.js` output is identical 
