### PR TITLE
feat(kilo-ops): implement auth proxy worker with CF Access + Kilo JWT verification

### DIFF
--- a/services/kilo-ops/src/cf-access.ts
+++ b/services/kilo-ops/src/cf-access.ts
@@ -1,0 +1,174 @@
+import { z } from 'zod';
+
+const SECONDS_PER_DAY = 86400;
+
+const accessJWTRegex = /^[a-z0-9_-]+\.[a-z0-9_-]+\.[a-z0-9_-]+$/i;
+
+const AccessJWT = z.string().regex(accessJWTRegex);
+const AccessTeam = z.string().regex(/^[a-z0-9-]+$/);
+const AccessTeamDomain = z.string().regex(/^https:\/\/[a-z0-9-]+\.cloudflareaccess\.com$/);
+const AccessKid = z.string().regex(/^[a-f0-9]{64}$/);
+const AccessAudience = z.string().regex(/^[a-f0-9]{64}$/);
+const AccessAlgorithm = z.literal('RS256');
+
+const AccessHeader = z.object({
+  kid: AccessKid,
+  alg: AccessAlgorithm,
+  typ: z.literal('JWT').optional(),
+});
+
+const AccessKey = z.object({
+  kid: AccessKid,
+  kty: z.literal('RSA'),
+  alg: AccessAlgorithm,
+  use: z.string().min(1),
+  e: z.string().min(1),
+  n: z.string().min(1),
+});
+
+const PublicCERT = z.object({
+  kid: AccessKid,
+  cert: z
+    .string()
+    .min(1)
+    .refine(
+      c => c.includes('-----BEGIN CERTIFICATE-----') && c.includes('-----END CERTIFICATE-----'),
+      { message: 'invalid cert format - missing or invalid header/footer' }
+    ),
+});
+
+const AccessCertsResponse = z.object({
+  keys: z.array(AccessKey).min(1, { message: 'Could not fetch signing keys.' }),
+  public_cert: PublicCERT,
+  public_certs: z.array(PublicCERT).min(1, { message: 'Could not fetch public certs.' }),
+});
+
+const AccessPayloadCommon = z.object({
+  type: z.enum(['app', 'org']),
+  exp: z.number().min(1),
+  iat: z.number().min(1),
+  iss: AccessTeamDomain,
+});
+
+const ServiceAuthAccessPayload = AccessPayloadCommon.extend({
+  aud: AccessAudience,
+  common_name: z.string().regex(/^[a-f0-9]{32}\.access$/),
+  sub: z.literal(''),
+  identity_nonce: z.undefined(),
+});
+
+const UserAccessPayload = AccessPayloadCommon.extend({
+  aud: z.array(AccessAudience),
+  nbf: z.number().min(1),
+  email: z
+    .string()
+    .min(1)
+    .refine(e => e.includes('@')),
+  identity_nonce: z.string().min(1),
+  sub: z.string().uuid(),
+  country: z.string().length(2),
+});
+
+const AccessPayload = z.union([UserAccessPayload, ServiceAuthAccessPayload]);
+
+type UserAccessPayload = z.infer<typeof UserAccessPayload>;
+
+function base64URLDecode(s: string): ArrayBuffer {
+  s = s.replace(/-/g, '+').replace(/_/g, '/').replace(/\s/g, '');
+  return new Uint8Array(Array.from(atob(s)).map((c: string) => c.charCodeAt(0))).buffer;
+}
+
+function asciiToUint8Array(s: string): ArrayBuffer {
+  const chars: number[] = [];
+  for (let i = 0; i < s.length; ++i) chars.push(s.charCodeAt(i));
+  return new Uint8Array(chars).buffer;
+}
+
+function includesAud(payload: z.infer<typeof AccessPayload>, aud: string): boolean {
+  if (typeof payload.aud === 'string') return payload.aud === aud;
+  return payload.aud.includes(aud);
+}
+
+function extractJWTFromRequest(req: Request): string {
+  return AccessJWT.parse(req.headers.get('Cf-Access-Jwt-Assertion'));
+}
+
+async function validateAccessJWT(
+  request: Request,
+  accessTeamDomain: string,
+  accessAud: string
+): Promise<{ payload: z.infer<typeof AccessPayload> }> {
+  const jwt = extractJWTFromRequest(request);
+  const parts = jwt.split('.');
+  if (parts.length !== 3) throw new Error('JWT does not have three parts.');
+  const [header, payload, signature] = parts;
+
+  const textDecoder = new TextDecoder('utf-8');
+  const { kid } = AccessHeader.parse(JSON.parse(textDecoder.decode(base64URLDecode(header))));
+
+  const certsURL = new URL('/cdn-cgi/access/certs', accessTeamDomain);
+  const certsResponse = await fetch(certsURL.toString(), {
+    cf: { cacheEverything: true, cacheTtl: SECONDS_PER_DAY },
+  });
+  const { keys } = AccessCertsResponse.parse(await certsResponse.json());
+  const jwk = keys.find(key => key.kid === kid);
+  if (!jwk) throw new Error('Could not find matching signing key.');
+
+  const key = await crypto.subtle.importKey(
+    'jwk',
+    jwk,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['verify']
+  );
+
+  const unroundedSecondsSinceEpoch = Date.now() / 1000;
+  const payloadObj = AccessPayload.parse(JSON.parse(textDecoder.decode(base64URLDecode(payload))));
+
+  if (payloadObj.iss !== certsURL.origin) throw new Error('JWT issuer is incorrect.');
+  if (!includesAud(payloadObj, accessAud)) throw new Error('JWT audience is incorrect.');
+  if (Math.floor(unroundedSecondsSinceEpoch) >= payloadObj.exp) throw new Error('JWT has expired.');
+  if (payloadObj.identity_nonce && Math.ceil(unroundedSecondsSinceEpoch) < payloadObj.nbf) {
+    throw new Error('JWT is not yet valid.');
+  }
+
+  const verified = await crypto.subtle.verify(
+    'RSASSA-PKCS1-v1_5',
+    key,
+    base64URLDecode(signature),
+    asciiToUint8Array(`${header}.${payload}`)
+  );
+  if (!verified) throw new Error('Could not verify JWT.');
+
+  return { payload: payloadObj };
+}
+
+export async function verifyCfAccess(
+  request: Request,
+  team: string,
+  audience: string
+): Promise<string | null> {
+  try {
+    AccessTeam.parse(team);
+    AccessAudience.parse(audience);
+  } catch {
+    return null;
+  }
+
+  const assertionHeader = request.headers.get('Cf-Access-Jwt-Assertion');
+  if (!assertionHeader) return null;
+
+  const accessTeamDomain = AccessTeamDomain.parse(`https://${team}.cloudflareaccess.com`);
+  const accessAud = AccessAudience.parse(audience);
+
+  try {
+    const { payload } = await validateAccessJWT(request, accessTeamDomain, accessAud);
+    if ('email' in payload) {
+      const userPayload = payload as UserAccessPayload;
+      return userPayload.email;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/services/kilo-ops/src/worker.ts
+++ b/services/kilo-ops/src/worker.ts
@@ -47,10 +47,14 @@ app.all('/*', async c => {
   const url = new URL(c.req.url);
   const container = getGrafanaContainerStub(c.env);
 
+  const STRIPPED_HEADERS = new Set([
+    'x-webauth-user',
+    'authorization',
+    'cf-access-jwt-assertion',
+  ]);
   const headers = new Headers();
   for (const [key, value] of c.req.raw.headers.entries()) {
-    const lower = key.toLowerCase();
-    if (lower === 'x-webauth-user') continue;
+    if (STRIPPED_HEADERS.has(key.toLowerCase())) continue;
     headers.set(key, value);
   }
   headers.set('X-WEBAUTH-USER', userIdentity);
@@ -69,6 +73,8 @@ app.all('/*', async c => {
 
   const containerUrl = `http://container${url.pathname}${url.search}`;
   const response = await container.fetch(containerUrl, init);
+
+  if (response.status === 101) return response;
 
   return new Response(response.body, {
     status: response.status,

--- a/services/kilo-ops/src/worker.ts
+++ b/services/kilo-ops/src/worker.ts
@@ -1,18 +1,103 @@
 import { Container } from '@cloudflare/containers';
 import { Hono } from 'hono';
+import { extractBearerToken, verifyKiloToken } from '@kilocode/worker-utils';
+import { verifyCfAccess } from './cf-access';
 
 export type KiloOpsEnv = {
   Bindings: Env;
-  Variables: Record<string, never>;
+  Variables: {
+    userIdentity: string;
+  };
 };
+
+const GRAFANA_DO_ID = 'grafana';
 
 export class GrafanaContainer extends Container<Env> {
   defaultPort = 3000;
   sleepAfter = '5m';
 }
 
+function getGrafanaContainerStub(env: Env) {
+  return env.GRAFANA_CONTAINER.get(env.GRAFANA_CONTAINER.idFromName(GRAFANA_DO_ID));
+}
+
+async function resolveSecret(binding: SecretsStoreSecret | string): Promise<string | null> {
+  if (typeof binding === 'string') return binding;
+  try {
+    return await binding.get();
+  } catch (err) {
+    console.error(
+      '[resolveSecret] Secrets Store fetch failed:',
+      err instanceof Error ? err.message : err
+    );
+    return null;
+  }
+}
+
 const app = new Hono<KiloOpsEnv>();
 
 app.get('/healthz', c => c.json({ ok: true }));
+
+app.all('/*', async c => {
+  const userIdentity = await authenticate(c.req.raw, c.env);
+  if (!userIdentity) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const url = new URL(c.req.url);
+  const container = getGrafanaContainerStub(c.env);
+
+  const headers = new Headers();
+  for (const [key, value] of c.req.raw.headers.entries()) {
+    const lower = key.toLowerCase();
+    if (lower === 'x-webauth-user') continue;
+    headers.set(key, value);
+  }
+  headers.set('X-WEBAUTH-USER', userIdentity);
+
+  const init: RequestInit = {
+    method: c.req.method,
+    headers,
+  };
+
+  if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
+    const body = await c.req.raw.arrayBuffer();
+    if (body.byteLength > 0) {
+      init.body = body;
+    }
+  }
+
+  const containerUrl = `http://container${url.pathname}${url.search}`;
+  const response = await container.fetch(containerUrl, init);
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+});
+
+async function authenticate(request: Request, env: Env): Promise<string | null> {
+  const bearerToken = extractBearerToken(request.headers.get('Authorization'));
+  if (bearerToken) {
+    const identity = await verifyKiloJwt(bearerToken, env);
+    if (identity) return identity;
+  }
+
+  return verifyCfAccess(request, env.CF_ACCESS_TEAM, env.CF_ACCESS_AUD);
+}
+
+async function verifyKiloJwt(token: string, env: Env): Promise<string | null> {
+  const secret = await resolveSecret(env.NEXTAUTH_SECRET);
+  if (!secret) return null;
+
+  try {
+    const payload = await verifyKiloToken(token, secret);
+    if (payload.isAdmin !== true) return null;
+    return payload.kiloUserId;
+  } catch {
+    return null;
+  }
+}
 
 export default app;


### PR DESCRIPTION
## Summary

Implement the full auth proxy worker at `services/kilo-ops/src/worker.ts` that sits in front of the Grafana container and handles authentication + request proxying.

- **Auth strategy**: Two methods tried in order — (1) Kilo JWT via `Authorization: Bearer` header using `verifyKiloToken` from `@kilocode/worker-utils`, checking `payload.isAdmin === true`; (2) Cloudflare Access JWT via `Cf-Access-Jwt-Assertion` header with full RSA signature verification and audience validation
- **Proxy logic**: Strips any client-provided `X-WEBAUTH-USER` header (security-critical spoofing prevention), injects `X-WEBAUTH-USER` with the authenticated user identity, and forwards the full request to the Grafana container DO
- **Container binding**: Uses `GRAFANA_CONTAINER` DO namespace with a stable ID (`idFromName('grafana')`) for a single Grafana instance
- **CF Access validation**: Adapted from gastown's `cf-access.middleware.ts` into a standalone `cf-access.ts` module (no gastown dependency), with cert caching via CF cache API
- **Routes**: `GET /healthz` (no auth, returns `{ ok: true }`), `ALL /*` (auth + proxy to container)
- **`GrafanaContainer` DO**: Extends `Container<Env>` with `defaultPort = 3000`, `sleepAfter = '5m'`

## Verification

- `tsc --noEmit --project services/kilo-ops/tsconfig.json` passes with zero errors

## Visual Changes

N/A

## Reviewer Notes

- The `resolveSecret` helper handles `SecretsStoreSecret` (production) vs plain string (test) for `NEXTAUTH_SECRET`
- CF Access cert fetching uses `cf: { cacheEverything: true, cacheTtl: 86400 }` for 1-day caching (same as gastown)
- Request body is forwarded as `ArrayBuffer` for binary-safe passthrough (Grafana may serve images, etc.)