### PR TITLE
feat(kilo-ops): wire up wrangler.jsonc with container env vars, secrets, and DO bindings

### DIFF
--- a/services/kilo-ops/src/worker.ts
+++ b/services/kilo-ops/src/worker.ts
@@ -15,6 +15,27 @@ const GRAFANA_DO_ID = 'grafana';
 export class GrafanaContainer extends Container<Env> {
   defaultPort = 3000;
   sleepAfter = '5m';
+
+  override async fetch(request: Request): Promise<Response> {
+    const state = await this.getState();
+    const needsStart =
+      state.status !== 'running' &&
+      state.status !== 'healthy' &&
+      state.status !== 'stopping';
+
+    if (needsStart) {
+      const analyticsApiKey = await resolveSecret(this.env.CF_ANALYTICS_API_KEY);
+      const gfSecretKey = await resolveSecret(this.env.GF_SECRET_KEY);
+      this.envVars = {
+        CF_CLICKHOUSE_URL: this.env.CF_CLICKHOUSE_URL,
+        CF_ACCOUNT_ID: this.env.CF_ACCOUNT_ID,
+        CF_ANALYTICS_API_KEY: analyticsApiKey ?? '',
+        GF_SECRET_KEY: gfSecretKey ?? '',
+      };
+    }
+
+    return super.fetch(request);
+  }
 }
 
 function getGrafanaContainerStub(env: Env) {

--- a/services/kilo-ops/src/worker.ts
+++ b/services/kilo-ops/src/worker.ts
@@ -26,11 +26,16 @@ export class GrafanaContainer extends Container<Env> {
     if (needsStart) {
       const analyticsApiKey = await resolveSecret(this.env.CF_ANALYTICS_API_KEY);
       const gfSecretKey = await resolveSecret(this.env.GF_SECRET_KEY);
+      if (!analyticsApiKey || !gfSecretKey) {
+        return new Response('Grafana secrets unavailable; cannot start container', {
+          status: 503,
+        });
+      }
       this.envVars = {
         CF_CLICKHOUSE_URL: this.env.CF_CLICKHOUSE_URL,
         CF_ACCOUNT_ID: this.env.CF_ACCOUNT_ID,
-        CF_ANALYTICS_API_KEY: analyticsApiKey ?? '',
-        GF_SECRET_KEY: gfSecretKey ?? '',
+        CF_ANALYTICS_API_KEY: analyticsApiKey,
+        GF_SECRET_KEY: gfSecretKey,
       };
     }
 

--- a/services/kilo-ops/worker-configuration.d.ts
+++ b/services/kilo-ops/worker-configuration.d.ts
@@ -5,9 +5,13 @@ declare namespace Cloudflare {
 	}
 	interface Env {
 		NEXTAUTH_SECRET: SecretsStoreSecret;
+		CF_ANALYTICS_API_KEY: SecretsStoreSecret;
+		GF_SECRET_KEY: SecretsStoreSecret;
 		ENVIRONMENT: 'production' | 'development';
 		CF_ACCESS_TEAM: 'engineering-e11';
 		CF_ACCESS_AUD: '7f6eda4c0714f6ea2afb74a3f055db65659b67571a913eab42468636a9b8c8be';
+		CF_CLICKHOUSE_URL: string;
+		CF_ACCOUNT_ID: string;
 		GRAFANA_CONTAINER: DurableObjectNamespace<import('./src/worker').GrafanaContainer>;
 	}
 }

--- a/services/kilo-ops/wrangler.jsonc
+++ b/services/kilo-ops/wrangler.jsonc
@@ -53,6 +53,8 @@
     "ENVIRONMENT": "production",
     "CF_ACCESS_TEAM": "engineering-e11",
     "CF_ACCESS_AUD": "7f6eda4c0714f6ea2afb74a3f055db65659b67571a913eab42468636a9b8c8be",
+    "CF_CLICKHOUSE_URL": "https://api.cloudflare.com/client/v4/accounts/e115e769bcdd4c3d66af59d3332cb394/analytics_engine/sql",
+    "CF_ACCOUNT_ID": "e115e769bcdd4c3d66af59d3332cb394",
   },
 
   "secrets_store_secrets": [
@@ -60,6 +62,16 @@
       "binding": "NEXTAUTH_SECRET",
       "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
       "secret_name": "NEXTAUTH_SECRET",
+    },
+    {
+      "binding": "CF_ANALYTICS_API_KEY",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+      "secret_name": "O11Y_CF_AE_API_TOKEN",
+    },
+    {
+      "binding": "GF_SECRET_KEY",
+      "store_id": "342a86d9e3a94da698e82d0c6e2a36f0",
+      "secret_name": "GF_SECRET_KEY",
     },
   ],
 

--- a/services/kilo-ops/wrangler.jsonc
+++ b/services/kilo-ops/wrangler.jsonc
@@ -79,6 +79,8 @@
     "dev": {
       "vars": {
         "ENVIRONMENT": "development",
+        "CF_CLICKHOUSE_URL": "https://api.cloudflare.com/client/v4/accounts/e115e769bcdd4c3d66af59d3332cb394/analytics_engine/sql",
+        "CF_ACCOUNT_ID": "e115e769bcdd4c3d66af59d3332cb394",
       },
       "workers_dev": true,
       "dev": { "port": 8805 },


### PR DESCRIPTION
## Summary

Finalize `services/kilo-ops/wrangler.jsonc` to wire the worker, container, DO bindings, and environment variables together:

- Add `CF_CLICKHOUSE_URL` (CF Analytics Engine SQL API endpoint) and `CF_ACCOUNT_ID` as plain `vars`
- Add `CF_ANALYTICS_API_KEY` (maps to `O11Y_CF_AE_API_TOKEN` in shared secrets store) and `GF_SECRET_KEY` as `secrets_store_secrets` bindings
- Override `GrafanaContainer.fetch()` to resolve secrets from the store and set `envVars` before the container starts, ensuring Grafana receives `CF_CLICKHOUSE_URL`, `CF_ACCOUNT_ID`, `CF_ANALYTICS_API_KEY`, and `GF_SECRET_KEY` as environment variables for datasource provisioning and config substitution
- Update `worker-configuration.d.ts` with the new binding types

All existing configuration (containers, durable_objects, migrations, sleepAfter, placement, upload_source_maps) was already correct and verified consistent.

## Verification

- Reviewed `services/gastown/wrangler.jsonc` and `services/o11y/wrangler.jsonc` for conventions (secrets store IDs, account ID, AE API token naming)
- Verified `GrafanaContainer` class name is consistent across wrangler.jsonc containers, durable_objects, migrations, and worker.ts export
- Verified container env vars match what `container/provisioning/datasources/clickhouse.yaml` and `container/grafana.ini` reference via `${VAR}` substitution

## Visual Changes

N/A

## Reviewer Notes

- `CF_ANALYTICS_API_KEY` reuses the same secret as `O11Y_CF_AE_API_TOKEN` from the o11y service (same store, same token) — the binding name differs but the underlying secret is the same
- The `GrafanaContainer.fetch()` override checks container state before resolving secrets to avoid unnecessary async calls on every request
- `GF_SECRET_KEY` secret needs to exist in the shared secrets store (store `342a86d9e3a94da698e82d0c6e2a36f0`) before deployment