### PR TITLE
CI - Add missing account_id to wrangler configs

### DIFF
--- a/services/auto-fix-infra/wrangler.jsonc
+++ b/services/auto-fix-infra/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
+  "account_id": "e115e769bcdd4c3d66af59d3332cb394",
   "name": "kilo-auto-fix-worker",
   "main": "src/index.ts",
   "compatibility_date": "2025-01-20",

--- a/services/auto-triage-infra/wrangler.jsonc
+++ b/services/auto-triage-infra/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
+  "account_id": "e115e769bcdd4c3d66af59d3332cb394",
   "name": "kilo-auto-triage-worker",
   "main": "src/index.ts",
   "compatibility_date": "2025-01-20",

--- a/services/code-review-infra/wrangler.jsonc
+++ b/services/code-review-infra/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
+  "account_id": "e115e769bcdd4c3d66af59d3332cb394",
   "name": "kilo-code-review-worker",
   "main": "src/index.ts",
   "compatibility_date": "2025-01-20",

--- a/services/gastown/wrangler.jsonc
+++ b/services/gastown/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
+  "account_id": "e115e769bcdd4c3d66af59d3332cb394",
   "name": "gastown",
   "main": "src/gastown.worker.ts",
   "compatibility_date": "2026-02-24",

--- a/services/gmail-push/wrangler.jsonc
+++ b/services/gmail-push/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
+  "account_id": "e115e769bcdd4c3d66af59d3332cb394",
   "name": "cloudflare-gmail-push",
   "main": "src/index.ts",
   "compatibility_date": "2025-03-10",

--- a/services/images-mcp/wrangler.jsonc
+++ b/services/images-mcp/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
+  "account_id": "e115e769bcdd4c3d66af59d3332cb394",
   "name": "images-mcp",
   "main": "src/index.ts",
   "compatibility_date": "2025-09-01",


### PR DESCRIPTION
## Summary

Six Cloudflare Worker services were missing `account_id` in their `wrangler.jsonc` configs. Without it, wrangler falls back to calling the `/memberships` API to discover the account, which requires a broader token scope than what the CI token has — causing auth failures (code 9106) on deploy.

Added `account_id: e115e769bcdd4c3d66af59d3332cb394` to:
- `services/auto-triage-infra`
- `services/code-review-infra`
- `services/images-mcp`
- `services/auto-fix-infra`
- `services/gastown`
- `services/gmail-push`

## Verification

Checked that all other services in `services/*/wrangler.jsonc` already have `account_id` set.

## Visual Changes

<img width="640" height="455" alt="Screenshot 2026-04-08 at 09 41 15" src="https://github.com/user-attachments/assets/815e96ab-45b8-46eb-89fa-23cc4cdcd7d3" />


## Reviewer Notes

N/A