### PR TITLE
feat(kiloclaw): tag dev Fly machines with developer identity for cleanup

### DIFF
--- a/dev/local/env-sync/output.ts
+++ b/dev/local/env-sync/output.ts
@@ -147,8 +147,9 @@ function displayPlan(plan: EnvSyncPlan): void {
   if (plan.execWarnings.length > 0) {
     if (hasOutput) console.log();
     for (const warning of plan.execWarnings) {
+      const cmd = [warning.command, ...warning.args].join(' ');
       console.log(
-        `${YELLOW}⚠ ${warning.workerDir}${RESET}: ${RED}${warning.key}${RESET} — \`${warning.commandLine}\` failed`
+        `${YELLOW}⚠ ${warning.workerDir}${RESET}: ${RED}${warning.key}${RESET} — \`${cmd}\` failed`
       );
       console.log(`    Run the command manually to diagnose.`);
     }

--- a/dev/local/env-sync/output.ts
+++ b/dev/local/env-sync/output.ts
@@ -143,6 +143,18 @@ function displayPlan(plan: EnvSyncPlan): void {
     hasOutput = true;
   }
 
+  // @exec annotation failures (always shown, even if existing value is preserved)
+  if (plan.execWarnings.length > 0) {
+    if (hasOutput) console.log();
+    for (const warning of plan.execWarnings) {
+      console.log(
+        `${YELLOW}⚠ ${warning.workerDir}${RESET}: ${RED}${warning.key}${RESET} — \`${warning.commandLine}\` failed`
+      );
+      console.log(`    Run the command manually to diagnose.`);
+    }
+    hasOutput = true;
+  }
+
   if (!hasOutput) {
     console.log(`${GREEN}✓ All env vars are up to date${RESET}`);
     return;

--- a/dev/local/env-sync/parse.ts
+++ b/dev/local/env-sync/parse.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import { services } from '../services';
@@ -96,7 +97,7 @@ function readEnvFile(filePath: string): Map<string, string> {
 // Annotation parser
 // ---------------------------------------------------------------------------
 
-const KNOWN_DIRECTIVES = new Set(['url', 'from', 'pkcs8']);
+const KNOWN_DIRECTIVES = new Set(['url', 'from', 'pkcs8', 'exec']);
 
 function parseAnnotation(directive: string, args: string): Annotation | undefined {
   switch (directive) {
@@ -113,6 +114,11 @@ function parseAnnotation(directive: string, args: string): Annotation | undefine
       return { type: 'from', envLocalKey: args.trim() };
     case 'pkcs8':
       return { type: 'pkcs8' };
+    case 'exec': {
+      const commandLine = args.trim();
+      if (!commandLine) return undefined;
+      return { type: 'exec', commandLine };
+    }
     default:
       return undefined;
   }
@@ -245,6 +251,20 @@ function resolveAnnotatedValue(
     case 'pkcs8': {
       const val = envLocal.get(key);
       if (val !== undefined) return { value: toPkcs8IfNeeded(val), resolved: true };
+      if (entry.defaultValue) return { value: entry.defaultValue, resolved: true };
+      return { value: '', resolved: false };
+    }
+
+    case 'exec': {
+      const result = spawnSync(entry.annotation.commandLine, {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        shell: true,
+        timeout: 5000,
+      });
+      if (result.status === 0 && result.stdout.trim()) {
+        return { value: result.stdout.trim(), resolved: true };
+      }
       if (entry.defaultValue) return { value: entry.defaultValue, resolved: true };
       return { value: '', resolved: false };
     }

--- a/dev/local/env-sync/parse.ts
+++ b/dev/local/env-sync/parse.ts
@@ -115,9 +115,9 @@ function parseAnnotation(directive: string, args: string): Annotation | undefine
     case 'pkcs8':
       return { type: 'pkcs8' };
     case 'exec': {
-      const commandLine = args.trim();
-      if (!commandLine) return undefined;
-      return { type: 'exec', commandLine };
+      const parts = args.trim().split(/\s+/);
+      if (parts.length === 0 || !parts[0]) return undefined;
+      return { type: 'exec', command: parts[0], args: parts.slice(1) };
     }
     default:
       return undefined;
@@ -256,10 +256,9 @@ function resolveAnnotatedValue(
     }
 
     case 'exec': {
-      const result = spawnSync(entry.annotation.commandLine, {
+      const result = spawnSync(entry.annotation.command, entry.annotation.args, {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
-        shell: true,
         timeout: 5000,
       });
       if (result.status === 0 && result.stdout.trim()) {

--- a/dev/local/env-sync/plan.ts
+++ b/dev/local/env-sync/plan.ts
@@ -240,7 +240,8 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
           execWarnings.push({
             workerDir,
             key: entry.key,
-            commandLine: entry.annotation.commandLine,
+            command: entry.annotation.command,
+            args: entry.annotation.args,
           });
         }
       }

--- a/dev/local/env-sync/plan.ts
+++ b/dev/local/env-sync/plan.ts
@@ -9,6 +9,7 @@ import type {
   EnvDevLocalChange,
   EnvSyncPlan,
   ExampleEntry,
+  ExecWarning,
   KeyChange,
   SecretStoreBinding,
   SecretStoreWarning,
@@ -177,6 +178,7 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
       secretStoreWarnings: [],
       secretStoreAutoCreates: [],
       consistencyWarnings: [],
+      execWarnings: [],
       missingEnvLocal: true,
     };
   }
@@ -208,6 +210,7 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
 
   // --- .dev.vars changes ---
   const devVarsChanges: DevVarsFileChange[] = [];
+  const execWarnings: ExecWarning[] = [];
   const allResolvedEntries = new Map<
     string,
     { vars: Map<string, string>; entries: ExampleEntry[] }
@@ -231,7 +234,16 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
         serviceUsesLanIp
       );
       resolvedVars.set(entry.key, value);
-      if (!resolved) unresolvedKeys.push(entry.key);
+      if (!resolved) {
+        unresolvedKeys.push(entry.key);
+        if (entry.annotation.type === 'exec') {
+          execWarnings.push({
+            workerDir,
+            key: entry.key,
+            commandLine: entry.annotation.commandLine,
+          });
+        }
+      }
     }
 
     allResolvedEntries.set(workerDir, { vars: resolvedVars, entries });
@@ -399,6 +411,7 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
     secretStoreWarnings,
     secretStoreAutoCreates,
     consistencyWarnings,
+    execWarnings,
     missingEnvLocal: false,
   };
 }

--- a/dev/local/env-sync/types.ts
+++ b/dev/local/env-sync/types.ts
@@ -49,7 +49,8 @@ type SecretStoreAutoCreate = {
 type ExecWarning = {
   workerDir: string;
   key: string;
-  commandLine: string;
+  command: string;
+  args: string[];
 };
 type EnvSyncPlan = {
   lanIp: string | undefined;
@@ -71,7 +72,7 @@ type Annotation =
   | { type: 'from'; envLocalKey: string }
   | { type: 'url'; services: { name: string; path?: string }[] }
   | { type: 'pkcs8' }
-  | { type: 'exec'; commandLine: string };
+  | { type: 'exec'; command: string; args: string[] };
 
 type ExampleEntry = {
   key: string;

--- a/dev/local/env-sync/types.ts
+++ b/dev/local/env-sync/types.ts
@@ -46,6 +46,11 @@ type SecretStoreAutoCreate = {
   value: string;
 };
 
+type ExecWarning = {
+  workerDir: string;
+  key: string;
+  commandLine: string;
+};
 type EnvSyncPlan = {
   lanIp: string | undefined;
   devVarsChanges: DevVarsFileChange[];
@@ -53,6 +58,7 @@ type EnvSyncPlan = {
   secretStoreWarnings: SecretStoreWarning[];
   secretStoreAutoCreates: SecretStoreAutoCreate[];
   consistencyWarnings: ConsistencyWarning[];
+  execWarnings: ExecWarning[];
   missingEnvLocal: boolean;
 };
 
@@ -64,7 +70,8 @@ type Annotation =
   | { type: 'passthrough' }
   | { type: 'from'; envLocalKey: string }
   | { type: 'url'; services: { name: string; path?: string }[] }
-  | { type: 'pkcs8' };
+  | { type: 'pkcs8' }
+  | { type: 'exec'; commandLine: string };
 
 type ExampleEntry = {
   key: string;
@@ -97,6 +104,7 @@ export type {
   SecretStoreWarning,
   SecretStoreAutoCreate,
   ConsistencyWarning,
+  ExecWarning,
   EnvSyncPlan,
   Annotation,
   ExampleEntry,

--- a/services/kiloclaw/.dev.vars.example
+++ b/services/kiloclaw/.dev.vars.example
@@ -45,7 +45,7 @@ BACKEND_API_URL=http://localhost:3000
 
 # Fly.io Machines API
 # Token is auto-created/refreshed by the dev-start script.
-# @exec fly auth token --json | jq -r .token
+# @exec fly auth token
 FLY_API_TOKEN=
 # Fly org slug. The dev-start script reads this value for token creation.
 # Use "kilo-dev" for Kilo team members, or "personal" for your own Fly account.

--- a/services/kiloclaw/.dev.vars.example
+++ b/services/kiloclaw/.dev.vars.example
@@ -28,6 +28,11 @@ GATEWAY_TOKEN_SECRET=dev-gateway-secret-kiloclaw
 # Fly app naming prefix ("dev-") for per-user app creation.
 WORKER_ENV=development
 
+# Auto-populated by dev-start from `fly auth whoami`.
+# Tags Fly machines with developer identity for cleanup.
+# @exec fly auth whoami
+DEV_CREATOR=
+
 # Backend app origin for internal API calls (e.g. instance-ready email).
 # In dev, point this at your local Next.js server.
 BACKEND_API_URL=http://localhost:3000
@@ -40,7 +45,8 @@ BACKEND_API_URL=http://localhost:3000
 
 # Fly.io Machines API
 # Token is auto-created/refreshed by the dev-start script.
-FLY_API_TOKEN=fo1_...
+# @exec fly auth token --json | jq -r .token
+FLY_API_TOKEN=
 # Fly org slug. The dev-start script reads this value for token creation.
 # Use "kilo-dev" for Kilo team members, or "personal" for your own Fly account.
 FLY_ORG_SLUG=kilo-dev

--- a/services/kiloclaw/scripts/dev-start.sh
+++ b/services/kiloclaw/scripts/dev-start.sh
@@ -355,6 +355,38 @@ fi
 
 echo "    Fly API token is valid."
 
+# ---------- Resolve developer identity for machine tagging ----------
+
+echo "==> Resolving developer identity..."
+if ! command -v fly &>/dev/null; then
+  echo ""
+  echo "WARNING: 'fly' CLI not found — cannot determine developer identity."
+  echo "  Dev Fly machines will not be tagged with your identity for cleanup."
+  echo "  Install the Fly CLI: https://fly.io/docs/flyctl/install/"
+  echo ""
+  DEV_CREATOR=""
+elif ! DEV_CREATOR="$(fly auth whoami 2>/dev/null)" || [ -z "$DEV_CREATOR" ]; then
+  echo ""
+  echo "WARNING: Could not determine your Fly identity."
+  echo "  'fly auth whoami' failed — are you logged in?"
+  echo "  Run 'fly auth login' to authenticate, then restart dev-start."
+  echo ""
+  echo "  Dev Fly machines will not be tagged with your identity."
+  echo "  This means cleanup scripts won't be able to find your machines."
+  echo ""
+  DEV_CREATOR=""
+else
+  echo "    Developer identity: $DEV_CREATOR"
+fi
+
+if grep -q '^DEV_CREATOR=' "$KILOCLAW_DIR/.dev.vars"; then
+  sed "s|^DEV_CREATOR=.*|DEV_CREATOR=$DEV_CREATOR|" \
+    "$KILOCLAW_DIR/.dev.vars" > "$KILOCLAW_DIR/.dev.vars.tmp"
+  mv "$KILOCLAW_DIR/.dev.vars.tmp" "$KILOCLAW_DIR/.dev.vars"
+else
+  echo "DEV_CREATOR=$DEV_CREATOR" >> "$KILOCLAW_DIR/.dev.vars"
+fi
+
 # ---------- Install dependencies ----------
 
 echo "==> Installing dependencies..."

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -1063,6 +1063,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       orgId: this.s.orgId,
       openclawVersion: this.s.openclawVersion,
       imageVariant: this.s.imageVariant,
+      devCreator: this.env.WORKER_ENV === 'development' ? (this.env.DEV_CREATOR ?? null) : null,
     };
     const machineConfig = buildMachineConfig(
       getRegistryApp(this.env),
@@ -2237,6 +2238,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         orgId: this.s.orgId,
         openclawVersion: this.s.openclawVersion,
         imageVariant: this.s.imageVariant,
+        devCreator: this.env.WORKER_ENV === 'development' ? (this.env.DEV_CREATOR ?? null) : null,
       };
       const machineConfig = buildMachineConfig(
         getRegistryApp(this.env),

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
@@ -389,6 +389,7 @@ export async function runUnexpectedStopRecoveryInBackground(
       orgId: state.orgId,
       openclawVersion: state.openclawVersion,
       imageVariant: state.imageVariant,
+      devCreator: env.WORKER_ENV === 'development' ? (env.DEV_CREATOR ?? null) : null,
     };
     const machineConfig = buildMachineConfig(
       getRegistryApp(env),

--- a/services/kiloclaw/src/durable-objects/machine-config.ts
+++ b/services/kiloclaw/src/durable-objects/machine-config.ts
@@ -12,6 +12,7 @@ export const METADATA_KEY_SANDBOX_ID = 'kiloclaw_sandbox_id';
 export const METADATA_KEY_ORG_ID = 'kiloclaw_org_id';
 export const METADATA_KEY_OPENCLAW_VERSION = 'kiloclaw_openclaw_version';
 export const METADATA_KEY_IMAGE_VARIANT = 'kiloclaw_image_variant';
+export const METADATA_KEY_DEV_CREATOR = 'kiloclaw_dev_creator';
 
 // ============================================================================
 // Machine config builder
@@ -23,6 +24,7 @@ export type MachineIdentity = {
   orgId: string | null;
   openclawVersion: string | null;
   imageVariant: string | null;
+  devCreator: string | null;
 };
 
 export function buildMachineConfig(
@@ -66,6 +68,7 @@ export function buildMachineConfig(
         [METADATA_KEY_OPENCLAW_VERSION]: identity.openclawVersion,
       }),
       ...(identity.imageVariant && { [METADATA_KEY_IMAGE_VARIANT]: identity.imageVariant }),
+      ...(identity.devCreator && { [METADATA_KEY_DEV_CREATOR]: identity.devCreator }),
     },
   };
 }

--- a/services/kiloclaw/src/types.ts
+++ b/services/kiloclaw/src/types.ts
@@ -46,6 +46,9 @@ export type KiloClawEnv = {
   FLY_IMAGE_DIGEST?: string;
   OPENCLAW_VERSION?: string;
 
+  // Developer identity (development only, auto-populated by dev-start from `fly auth whoami`)
+  DEV_CREATOR?: string;
+
   // Stream Chat (default channel for new instances)
   STREAM_CHAT_API_KEY?: string;
   STREAM_CHAT_API_SECRET?: string;


### PR DESCRIPTION
## Summary

Dev KiloClaw machines on Fly.io had no way to identify which developer created them, making per-developer cleanup impossible. This adds automatic developer identity tagging via `fly auth whoami` and a new `@exec` annotation type for the env-sync system.

- **Fly machine metadata**: New `kiloclaw_dev_creator` metadata key set on every dev machine (production is unaffected)
- **Auto-detection**: `DEV_CREATOR` is auto-populated by `dev-start.sh` and the env-sync `@exec` annotation — no manual configuration needed
- **`@exec` annotation**: New env-sync directive that runs shell commands (with pipe support via `shell: true`) to resolve `.dev.vars` values
- **Clear warnings**: When `fly auth whoami` fails (CLI missing or not logged in), both `dev-start.sh` and `pnpm dev:env` show actionable diagnostics

## Verification

- [x] `pnpm typecheck` — passes across all 31 workspace packages
- [x] `pnpm --filter kiloclaw test` — all 1187 tests pass (52 files)
- [x] `pnpm dev:env kiloclaw` — verified `@exec` resolves `fly auth whoami` and `fly auth token --json | jq -r .token` correctly
- [x] `pnpm dev:env kiloclaw` with expired Fly auth — verified exec warning is shown
- [x] `pnpm format` — passes

## Visual Changes

<img width="1352" height="464" alt="CleanShot 2026-04-08 at 10 00 23@2x" src="https://github.com/user-attachments/assets/8407c5f9-bd68-41df-83eb-5008aedf89ca" />

## Reviewer Notes

- The `@exec` annotation runs commands through a shell (`shell: true` in `spawnSync`), which is necessary for pipe support (e.g., `fly auth token --json | jq -r .token`). This is safe since the command strings come from `.dev.vars.example` (committed, reviewed code), not user input.
- `execWarnings` in the env-sync plan are always shown, even when `.dev.vars` already has a stale value for the key. This is intentional — unlike `missingValues` (which are suppressed when an existing value exists), exec failures indicate a broken tool that should be fixed.
- The `FLY_API_TOKEN` annotation change (`@exec fly auth token --json | jq -r .token`) was added to make sure that the `.dev.vars` file is correct after running `pnpm dev:env`