### PR TITLE
fix(admin): fix FK violation in softDeleteUser and surface errors

### DIFF
--- a/apps/web/src/app/admin/api/users/gdpr-removal/route.ts
+++ b/apps/web/src/app/admin/api/users/gdpr-removal/route.ts
@@ -51,16 +51,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<GdprRemov
     );
   }
 
-  const warnings: string[] = [];
-  try {
-    await softDeleteUserExternalServices(user);
-  } catch (error) {
-    captureException(error, {
-      tags: { source: 'gdpr-removal-external' },
-      extra: { userId },
-    });
-    warnings.push('External service cleanup failed — check Sentry for details');
-  }
+  const warnings = await softDeleteUserExternalServices(user);
 
   return NextResponse.json({
     success: true,

--- a/apps/web/src/app/admin/api/users/gdpr-removal/route.ts
+++ b/apps/web/src/app/admin/api/users/gdpr-removal/route.ts
@@ -3,16 +3,29 @@ import { NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user.server';
 import { softDeleteUserExternalServices } from '@/lib/external-services';
 import { softDeleteUser, SoftDeletePreconditionError, findUserById } from '@/lib/user';
+import { captureException } from '@sentry/nextjs';
 
-export async function POST(
-  request: NextRequest
-): Promise<NextResponse<{ error: string } | { success: boolean; message: string }>> {
+type GdprRemovalResponse =
+  | { error: string }
+  | { success: boolean; message: string; warnings?: string[] };
+
+export async function POST(request: NextRequest): Promise<NextResponse<GdprRemovalResponse>> {
   const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
   if (authFailedResponse) return authFailedResponse;
 
-  const { userId } = await request.json();
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON in request body' }, { status: 400 });
+  }
 
-  if (!userId) {
+  const userId =
+    typeof body === 'object' && body !== null && 'userId' in body
+      ? (body as Record<string, unknown>).userId
+      : undefined;
+
+  if (!userId || typeof userId !== 'string') {
     return NextResponse.json({ error: 'User ID is required' }, { status: 400 });
   }
 
@@ -24,16 +37,34 @@ export async function POST(
 
   try {
     await softDeleteUser(userId);
-    await softDeleteUserExternalServices(user);
   } catch (error) {
     if (error instanceof SoftDeletePreconditionError) {
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
-    throw error;
+    captureException(error, {
+      tags: { source: 'gdpr-removal' },
+      extra: { userId },
+    });
+    return NextResponse.json(
+      { error: 'Database deletion failed — check Sentry for details' },
+      { status: 500 }
+    );
+  }
+
+  const warnings: string[] = [];
+  try {
+    await softDeleteUserExternalServices(user);
+  } catch (error) {
+    captureException(error, {
+      tags: { source: 'gdpr-removal-external' },
+      extra: { userId },
+    });
+    warnings.push('External service cleanup failed — check Sentry for details');
   }
 
   return NextResponse.json({
     success: true,
     message: `Account for user ${userId} has been soft-deleted and PII removed`,
+    ...(warnings.length > 0 ? { warnings } : {}),
   });
 }

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminGdprRemoval.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminGdprRemoval.tsx
@@ -14,7 +14,12 @@ import { AlertTriangle, ExternalLink } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { Label } from '@/components/ui/label';
+import { toast } from 'sonner';
 import type { UserDetailProps } from '@/types/admin';
+
+type GdprRemovalResult =
+  | { error: string }
+  | { success: boolean; message: string; warnings?: string[] };
 
 export function UserAdminGdprRemoval(user: UserDetailProps) {
   const router = useRouter();
@@ -30,25 +35,43 @@ export function UserAdminGdprRemoval(user: UserDetailProps) {
     setShowGdprConfirmDialog(false);
     setIsProcessingGdprRequest(true);
 
-    const response = await fetch('/admin/api/users/gdpr-removal', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ userId: user.id }),
-    });
+    try {
+      const response = await fetch('/admin/api/users/gdpr-removal', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ userId: user.id }),
+      });
 
-    const result = await response.json();
+      const result: GdprRemovalResult = await response.json();
 
-    if (response.ok) {
-      console.log('GDPR data removal completed:', result.message);
-      // Redirect back to users list since this user no longer exists
-      router.push('/admin/users');
-    } else {
-      console.error('GDPR data removal failed:', result.error);
+      if (response.ok && 'success' in result) {
+        if (result.warnings?.length) {
+          toast.warning('GDPR deletion partially completed', {
+            description: result.warnings.join('\n'),
+            duration: 15_000,
+          });
+        } else {
+          toast.success('GDPR data removal completed');
+        }
+        router.push('/admin/users');
+      } else {
+        const errorMessage =
+          'error' in result ? result.error : `Server responded with ${response.status}`;
+        toast.error('GDPR data removal failed', {
+          description: errorMessage,
+          duration: 15_000,
+        });
+      }
+    } catch (error) {
+      toast.error('GDPR data removal failed', {
+        description: error instanceof Error ? error.message : 'Network error',
+        duration: 15_000,
+      });
+    } finally {
+      setIsProcessingGdprRequest(false);
     }
-
-    setIsProcessingGdprRequest(false);
   };
 
   const handleCancelGdprRequest = () => {

--- a/apps/web/src/lib/external-services.ts
+++ b/apps/web/src/lib/external-services.ts
@@ -15,13 +15,13 @@ import { generateInternalServiceToken } from '@/lib/tokens';
  * Delete user from Customer.io
  * Customer.io API docs: https://customer.io/docs/api/track/#operation/delete
  */
-async function deleteUserFromCustomerIO(email: string): Promise<void> {
+async function deleteUserFromCustomerIO(email: string): Promise<string | null> {
   const siteId = getEnvVariable('CUSTOMERIO_SITE_ID');
   const apiKey = getEnvVariable('CUSTOMERIO_API_KEY');
 
   if (!siteId || !apiKey) {
     warnExceptInTest('Customer.io credentials not configured, skipping deletion');
-    return;
+    return null;
   }
 
   try {
@@ -41,20 +41,22 @@ async function deleteUserFromCustomerIO(email: string): Promise<void> {
     } else {
       logExceptInTest(`Successfully deleted customer ${email} from Customer.io`);
     }
+    return null;
   } catch (error) {
-    const message = `Failed to delete user from Customer.io for email ${email}: ${error instanceof Error ? error.message : String(error)}`;
+    const message = `Failed to delete user from Customer.io: ${error instanceof Error ? error.message : String(error)}`;
     errorExceptInTest(message);
     captureException(error, {
       tags: { source: 'customerio-deletion' },
       extra: { email },
     });
+    return 'Customer.io deletion failed';
   }
 }
 
 /**
  * Delete CLI session blobs from R2 storage
  */
-async function deleteCliSessionBlobs(userId: string): Promise<void> {
+async function deleteCliSessionBlobs(userId: string): Promise<string | null> {
   try {
     // Fetch all CLI sessions owned by the user
     const userCliSessions = await db
@@ -115,6 +117,7 @@ async function deleteCliSessionBlobs(userId: string): Promise<void> {
     logExceptInTest(
       `Successfully deleted CLI session blobs for user: ${userId} (${userCliSessions.length} sessions, ${userSharedSessions.length} shared sessions)`
     );
+    return null;
   } catch (error) {
     const message = `Failed to delete CLI session blobs for user ${userId}: ${error instanceof Error ? error.message : String(error)}`;
     errorExceptInTest(message);
@@ -122,6 +125,7 @@ async function deleteCliSessionBlobs(userId: string): Promise<void> {
       tags: { source: 'cli-sessions-deletion' },
       extra: { userId },
     });
+    return 'CLI session blob deletion failed';
   }
 }
 
@@ -133,10 +137,10 @@ const V2_SESSION_DELETE_CONCURRENCY = 10;
  * This function calls the session ingest worker's delete endpoint for each session,
  * processing sessions in concurrent batches for performance.
  */
-async function deleteCliSessionV2Blobs(userId: string): Promise<void> {
+async function deleteCliSessionV2Blobs(userId: string): Promise<string | null> {
   if (!SESSION_INGEST_WORKER_URL) {
     warnExceptInTest('SESSION_INGEST_WORKER_URL not configured, skipping v2 session blob deletion');
-    return;
+    return null;
   }
 
   try {
@@ -148,7 +152,7 @@ async function deleteCliSessionV2Blobs(userId: string): Promise<void> {
 
     if (userV2Sessions.length === 0) {
       logExceptInTest(`No v2 CLI sessions found for user: ${userId}`);
-      return;
+      return null;
     }
 
     // Generate a token for the user to authenticate with the session ingest worker
@@ -198,6 +202,9 @@ async function deleteCliSessionV2Blobs(userId: string): Promise<void> {
     logExceptInTest(
       `Deleted v2 CLI session blobs for user: ${userId} (${successCount} succeeded, ${failCount} failed out of ${userV2Sessions.length} sessions)`
     );
+    return failCount > 0
+      ? `V2 session blob deletion partially failed (${failCount}/${userV2Sessions.length})`
+      : null;
   } catch (error) {
     const message = `Failed to delete v2 CLI session blobs for user ${userId}: ${error instanceof Error ? error.message : String(error)}`;
     errorExceptInTest(message);
@@ -205,6 +212,7 @@ async function deleteCliSessionV2Blobs(userId: string): Promise<void> {
       tags: { source: 'cli-sessions-v2-deletion' },
       extra: { userId },
     });
+    return 'V2 session blob deletion failed';
   }
 }
 
@@ -221,26 +229,17 @@ async function deleteCliSessionV2Blobs(userId: string): Promise<void> {
  * Each individual service handler is resilient - errors are caught and logged
  * to Sentry but don't prevent other services from being cleaned up.
  */
-export async function softDeleteUserExternalServices(user: User): Promise<void> {
+export async function softDeleteUserExternalServices(user: User): Promise<string[]> {
   logExceptInTest(`Soft-deleting user from external services: ${user.id}`);
 
-  const results = await Promise.allSettled([
+  const results = await Promise.all([
     deleteUserFromCustomerIO(user.google_user_email),
     deleteCliSessionBlobs(user.id),
     deleteCliSessionV2Blobs(user.id),
   ]);
 
-  // Log any unexpected top-level failures (individual handlers already catch their own errors)
-  for (const result of results) {
-    if (result.status === 'rejected') {
-      const message = `Unexpected external service deletion failure for user ${user.id}: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`;
-      errorExceptInTest(message);
-      captureException(result.reason, {
-        tags: { source: 'external-services-soft-delete' },
-        extra: { userId: user.id },
-      });
-    }
-  }
+  const warnings = results.filter((r): r is string => r !== null);
 
   logExceptInTest(`Completed external service soft-delete for user: ${user.id}`);
+  return warnings;
 }

--- a/apps/web/src/lib/user.test.ts
+++ b/apps/web/src/lib/user.test.ts
@@ -990,6 +990,56 @@ describe('User', () => {
       ).toBe(0);
     });
 
+    it('should delete kiloclaw_subscriptions and kiloclaw_cli_runs linked to a kiloclaw_instance for the user', async () => {
+      const user = await insertTestUser();
+
+      const [instance] = await db
+        .insert(kiloclaw_instances)
+        .values({
+          user_id: user.id,
+          sandbox_id: `test-gdpr-fk-${Date.now()}`,
+        })
+        .returning({ id: kiloclaw_instances.id });
+
+      await db.insert(kiloclaw_subscriptions).values({
+        user_id: user.id,
+        plan: 'standard',
+        status: 'canceled',
+        instance_id: instance.id,
+      });
+
+      await db.insert(kiloclaw_cli_runs).values({
+        user_id: user.id,
+        prompt: 'test fk ordering',
+        status: 'completed',
+        instance_id: instance.id,
+      });
+
+      await softDeleteUser(user.id);
+
+      expect(
+        await db
+          .select({ count: count() })
+          .from(kiloclaw_instances)
+          .where(eq(kiloclaw_instances.user_id, user.id))
+          .then(r => r[0].count)
+      ).toBe(0);
+      expect(
+        await db
+          .select({ count: count() })
+          .from(kiloclaw_subscriptions)
+          .where(eq(kiloclaw_subscriptions.user_id, user.id))
+          .then(r => r[0].count)
+      ).toBe(0);
+      expect(
+        await db
+          .select({ count: count() })
+          .from(kiloclaw_cli_runs)
+          .where(eq(kiloclaw_cli_runs.user_id, user.id))
+          .then(r => r[0].count)
+      ).toBe(0);
+    });
+
     it('should throw SoftDeletePreconditionError for active KiloClaw subscription', async () => {
       const user = await insertTestUser();
       await db.insert(kiloclaw_subscriptions).values({

--- a/apps/web/src/lib/user.ts
+++ b/apps/web/src/lib/user.ts
@@ -651,13 +651,15 @@ export async function softDeleteUser(userId: string) {
     await tx.delete(device_auth_requests).where(eq(device_auth_requests.kilo_user_id, userId));
     await tx.delete(auto_top_up_configs).where(eq(auto_top_up_configs.owned_by_user_id, userId));
     await tx.delete(kiloclaw_access_codes).where(eq(kiloclaw_access_codes.kilo_user_id, userId));
-    await tx.delete(kiloclaw_instances).where(eq(kiloclaw_instances.user_id, userId));
+    // kiloclaw_subscriptions and kiloclaw_cli_runs both have FK references to
+    // kiloclaw_instances, so they must be deleted before instances.
+    await tx.delete(kiloclaw_subscriptions).where(eq(kiloclaw_subscriptions.user_id, userId));
     await tx
       .delete(kiloclaw_earlybird_purchases)
       .where(eq(kiloclaw_earlybird_purchases.user_id, userId));
     await tx.delete(kiloclaw_email_log).where(eq(kiloclaw_email_log.user_id, userId));
     await tx.delete(kiloclaw_cli_runs).where(eq(kiloclaw_cli_runs.user_id, userId));
-    await tx.delete(kiloclaw_subscriptions).where(eq(kiloclaw_subscriptions.user_id, userId));
+    await tx.delete(kiloclaw_instances).where(eq(kiloclaw_instances.user_id, userId));
     await tx.delete(user_period_cache).where(eq(user_period_cache.kilo_user_id, userId));
     await tx
       .delete(kilo_pass_scheduled_changes)


### PR DESCRIPTION
## Summary
- **Fix FK constraint violation in `softDeleteUser()`**: Reordered deletion in `user.ts` so `kiloclaw_subscriptions` and `kiloclaw_cli_runs` (which have foreign key references to `kiloclaw_instances.id` with NO ACTION on delete) are deleted before `kiloclaw_instances`. This caused error 23503 when deleting users with a subscription linked to a provisioned instance.
- **Surface errors in admin GDPR delete UI**: The admin GDPR delete button previously logged errors only to `console.error` with no user-facing feedback. Backend errors (like the FK violation) were re-thrown as generic 500s with no JSON body. Now:
  - Backend catches DB errors and external service failures separately, reports to Sentry, and returns structured JSON responses with safe error messages (no raw exception text leaked to the client).
  - Frontend uses sonner toast notifications for success, partial success (warnings), and failure states.
  - Malformed request bodies now return proper 400 errors instead of unhandled 500s.
- **Regression test**: Added a test that creates a subscription and CLI run both linked to an instance via `instance_id`, then verifies `softDeleteUser` succeeds without FK violation.
## Verification
- [x] `pnpm typecheck` — passes (only pre-existing `linkify-it` type error in unrelated file)
- [x] Six-agent code review (security, logic, types, data, resources, style) — all findings addressed
- [x] Security review: sanitized error messages to avoid leaking SQL/provider details to browser
- [x] Type review: added request body validation, typed frontend response parsing

## Visual Changes
| Before | After |
| ------ | ----- |
| GDPR delete errors silently logged to console only | Error/warning/success toast notifications via sonner |
## Reviewer Notes
- The FK ordering fix resolves an active GDPR blocker for user `f93225b9-...` — deploy priority.
- Error messages sent to the admin UI are intentionally generic ("check Sentry for details") to avoid leaking DB/provider internals. Full details go to Sentry with `gdpr-removal` / `gdpr-removal-external` tags.
- `SoftDeletePreconditionError` messages (e.g. "active subscription") are still returned verbatim since they're controlled, user-facing strings.
- The `route.ts` has one `as Record<string, unknown>` cast for the parsed request body — this is guarded by the preceding `typeof` + `in` checks.