### PR TITLE
fix(kiloclaw): gate instance-ready email on shouldNotify flag

### DIFF
--- a/apps/web/src/app/api/internal/kiloclaw/instance-ready/route.ts
+++ b/apps/web/src/app/api/internal/kiloclaw/instance-ready/route.ts
@@ -24,6 +24,7 @@ const BodySchema = z.object({
   userId: z.string().min(1),
   sandboxId: z.string().min(1),
   instanceId: z.string().uuid().optional(),
+  shouldNotify: z.boolean().optional(),
 });
 
 /** Per-instance email type key. Includes sandboxId to support future multi-instance. */
@@ -62,7 +63,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
   }
 
-  const { userId, sandboxId, instanceId } = parsed.data;
+  const { userId, sandboxId, instanceId, shouldNotify } = parsed.data;
   const emailType = emailTypeKey(sandboxId);
 
   const user = await findUserById(userId);
@@ -79,6 +80,14 @@ export async function POST(req: NextRequest) {
       instanceId: resumeState.instanceId,
       sandboxId,
     });
+  }
+
+  // The controller calls this endpoint on every low-load checkin (for auto-resume
+  // completion above), but only sets shouldNotify=true on the first readiness
+  // detection per DO lifetime. Skip the email when shouldNotify is explicitly false
+  // to avoid sending stale "instance ready" emails to long-running instances.
+  if (shouldNotify === false) {
+    return NextResponse.json({ sent: false, reason: 'not_first_ready' });
   }
 
   // Idempotent: insert-before-send with rollback on failure (matches billing cron pattern).

--- a/services/kiloclaw/src/routes/controller.test.ts
+++ b/services/kiloclaw/src/routes/controller.test.ts
@@ -375,6 +375,7 @@ describe('POST /checkin', () => {
           userId: 'user-1',
           sandboxId: instanceSandboxId,
           instanceId,
+          shouldNotify: true,
         }),
       }
     );
@@ -410,6 +411,7 @@ describe('POST /checkin', () => {
         body: JSON.stringify({
           userId: 'user-1',
           sandboxId,
+          shouldNotify: false,
         }),
       }
     );

--- a/services/kiloclaw/src/routes/controller.ts
+++ b/services/kiloclaw/src/routes/controller.ts
@@ -65,7 +65,8 @@ async function notifyInstanceReady(
   internalSecret: string,
   userId: string,
   sandboxId: string,
-  instanceId?: string
+  instanceId?: string,
+  shouldNotify?: boolean
 ): Promise<void> {
   const res = await fetch(`${backendOrigin}/api/internal/kiloclaw/instance-ready`, {
     method: 'POST',
@@ -73,7 +74,7 @@ async function notifyInstanceReady(
       'Content-Type': 'application/json',
       'X-Internal-Secret': internalSecret,
     },
-    body: JSON.stringify({ userId, sandboxId, instanceId }),
+    body: JSON.stringify({ userId, sandboxId, instanceId, shouldNotify }),
   });
   if (!res.ok) {
     console.error('[controller] instance-ready notification failed:', res.status, await res.text());
@@ -226,7 +227,8 @@ controller.post('/checkin', async (c: Context<AppEnv>) => {
             c.env.INTERNAL_API_SECRET,
             userId,
             data.sandboxId,
-            isInstanceKeyedSandboxId(data.sandboxId) ? doKey : undefined
+            isInstanceKeyedSandboxId(data.sandboxId) ? doKey : undefined,
+            shouldNotify
           ).catch(err => {
             console.error('[controller] instance-ready notification error:', err);
           })


### PR DESCRIPTION
## Summary

Commit 155be81 (`fix(kiloclaw): harden access and async resume`) removed the `shouldNotify` guard from the controller checkin path so the `/api/internal/kiloclaw/instance-ready` endpoint is called on every low-load checkin — this was needed so `completeAutoResumeIfReady` runs on every readiness callback. However, this caused users with long-running instances that predate the instance-ready email feature to receive spurious "Your KiloClaw Instance Is Ready" emails (~700 already sent, ~15k at risk).

The root cause: these users had no `claw_instance_ready:{sandboxId}` entry in `kiloclaw_email_log`, and their DO's `tryMarkInstanceReady()` flag (which previously prevented the endpoint from being called) was being ignored.

This fix threads the `shouldNotify` boolean from the controller through to the route. The endpoint still runs `completeAutoResumeIfReady` on every call (for auto-resume), but skips the email when `shouldNotify` is explicitly `false`.

## Verification

- [x] `pnpm typecheck` — passes (storybook failure is pre-existing, unrelated to these changes)
- [x] `pnpm --filter kiloclaw test -- src/routes/controller.test.ts` — all tests pass

## Visual Changes

N/A

## Reviewer Notes

- The `shouldNotify` field is optional in the body schema for backward compatibility — if omitted (e.g. from an older controller version during rolling deploy), the email path runs as before with the existing `email_log` idempotency as a safety net.
- The ~700 users who already received the spurious email won't receive it again since their `email_log` entry now exists.