### PR TITLE
fix(cloud-agent): fix mobile chat layout

### DIFF
--- a/apps/web/src/app/(app)/components/AppTopbar.tsx
+++ b/apps/web/src/app/(app)/components/AppTopbar.tsx
@@ -19,16 +19,16 @@ export function AppTopbar() {
       </div>
 
       {title && (
-        <div className="flex h-full items-center gap-2">
-          {icon}
-          <Breadcrumb>
-            <BreadcrumbList>
-              <BreadcrumbItem>
-                <BreadcrumbPage>{title}</BreadcrumbPage>
+        <div className="flex h-full min-w-0 flex-1 items-center gap-2 pr-3">
+          {icon && <div className="shrink-0">{icon}</div>}
+          <Breadcrumb className="min-w-0">
+            <BreadcrumbList className="flex-nowrap">
+              <BreadcrumbItem className="min-w-0">
+                <BreadcrumbPage className="block truncate">{title}</BreadcrumbPage>
               </BreadcrumbItem>
             </BreadcrumbList>
           </Breadcrumb>
-          {extras}
+          {extras && <div className="shrink-0">{extras}</div>}
         </div>
       )}
     </header>

--- a/apps/web/src/components/cloud-agent-next/ChatInput.tsx
+++ b/apps/web/src/components/cloud-agent-next/ChatInput.tsx
@@ -231,7 +231,7 @@ export function ChatInput({
               onKeyDown={handleKeyDown}
               placeholder={placeholder}
               disabled={disabled}
-              className="max-h-[200px] w-full resize-none overflow-y-auto border-0 bg-transparent p-4 pb-2 text-sm focus:ring-0 focus:outline-none"
+              className="max-h-[200px] w-full resize-none overflow-y-auto border-0 bg-transparent p-4 pb-2 text-base focus:ring-0 focus:outline-none md:text-sm"
               rows={1}
               role="combobox"
               aria-expanded={showAutocomplete}

--- a/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -292,6 +292,20 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
         ? 'Wrapping up…'
         : 'Ask anything…';
 
+  const sessionActions = (
+    <ChatHeader
+      cloudAgentSessionId={sessionId ?? 'Starting session…'}
+      kiloSessionId={sessionIdFromParams ?? undefined}
+      organizationId={organizationId}
+      repository={sessionConfig?.repository ?? ''}
+      model={sessionConfig?.model}
+      modelDisplayName={modelDisplayName}
+      totalCost={totalCost}
+      soundEnabled={soundEnabled}
+      onToggleSound={handleToggleSound}
+    />
+  );
+
   // -- Render ---------------------------------------------------------------
   return (
     <QuestionContextProvider
@@ -318,28 +332,17 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
             <>
               {showLoadingIndicator && <div className="bg-primary h-0.5 w-full animate-pulse" />}
 
-              <div className="relative min-h-0 flex-1">
-                {/* Mobile sidebar toggle — floating top-left */}
-                <MobileSidebarToggle />
+              <div className="flex shrink-0 items-center justify-between border-b px-3 py-2 lg:hidden">
+                <MobileSidebarToggle variant="inline" label="Sessions" />
+                {sessionActions}
+              </div>
 
-                {/* Session action buttons — floating top-right */}
-                <div className="absolute right-3 top-2 z-10">
-                  <ChatHeader
-                    cloudAgentSessionId={sessionId ?? 'Starting session…'}
-                    kiloSessionId={sessionIdFromParams ?? undefined}
-                    organizationId={organizationId}
-                    repository={sessionConfig?.repository ?? ''}
-                    model={sessionConfig?.model}
-                    modelDisplayName={modelDisplayName}
-                    totalCost={totalCost}
-                    soundEnabled={soundEnabled}
-                    onToggleSound={handleToggleSound}
-                  />
-                </div>
+              <div className="relative min-h-0 flex-1">
+                <div className="absolute right-3 top-2 z-10 hidden lg:block">{sessionActions}</div>
 
                 <div
                   ref={scrollContainerRef}
-                  className={`absolute inset-0 overflow-y-auto px-[max(1rem,calc(50%_-_27rem))] pb-2 pt-12 transition-opacity duration-150 ${showLoadingIndicator ? 'pointer-events-none opacity-40' : 'opacity-100'}`}
+                  className={`absolute inset-0 overflow-y-auto px-[max(1rem,calc(50%_-_27rem))] pb-2 pt-4 transition-opacity duration-150 lg:pt-12 ${showLoadingIndicator ? 'pointer-events-none opacity-40' : 'opacity-100'}`}
                   onScroll={handleScroll}
                 >
                   <StaticMessages messages={staticMessages} getChildMessages={getChildMessages} />

--- a/apps/web/src/components/cloud-agent-next/MobileSidebarToggle.tsx
+++ b/apps/web/src/components/cloud-agent-next/MobileSidebarToggle.tsx
@@ -1,16 +1,28 @@
 'use client';
 
+import { cn } from '@/lib/utils';
 import { useSidebarToggle } from './CloudSidebarLayout';
 
-export function MobileSidebarToggle() {
+type MobileSidebarToggleProps = {
+  variant?: 'floating' | 'inline';
+  label?: string;
+};
+
+export function MobileSidebarToggle({
+  variant = 'floating',
+  label = 'Session list',
+}: MobileSidebarToggleProps = {}) {
   const { toggleMobileSidebar } = useSidebarToggle();
   return (
     <button
       type="button"
       onClick={toggleMobileSidebar}
-      className="text-muted-foreground hover:text-foreground border-border hover:bg-accent absolute left-3 top-3 z-10 cursor-pointer rounded-md border px-2.5 py-1 text-sm transition-colors lg:hidden"
+      className={cn(
+        'text-muted-foreground hover:text-foreground border-border hover:bg-accent cursor-pointer rounded-md border px-2.5 py-1 text-sm transition-colors lg:hidden',
+        variant === 'floating' ? 'absolute left-3 top-3 z-10' : 'shrink-0'
+      )}
     >
-      Session list
+      {label}
     </button>
   );
 }

--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -692,7 +692,7 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
         >
           <textarea
             ref={textareaRef}
-            className="max-h-[50dvh] w-full resize-none overflow-y-auto border-0 bg-transparent p-4 pb-2 text-sm focus:ring-0 focus:outline-none"
+            className="max-h-[50dvh] w-full resize-none overflow-y-auto border-0 bg-transparent p-4 pb-2 text-base focus:ring-0 focus:outline-none md:text-sm"
             placeholder="What would you like to do?"
             rows={5}
             value={prompt}


### PR DESCRIPTION
## Summary

- Fixed mobile Cloud Agent Next chat and new-session composers so focusing the textarea no longer causes iOS Safari to zoom/crop the chat horizontally.
- Hardened the shared app topbar layout so long page/session titles truncate instead of wrapping into Cloud Agent chat controls; topbar extras remain visible.
- No architectural changes.

## Verification

- [x] `pnpm typecheck` — passed
- [x] `pnpm lint` — passed
- [x] `git diff --check` — passed
- [x] manual check

## Visual Changes

<img width="477" height="735" alt="Screenshot 2026-04-09 at 12 25 29" src="https://github.com/user-attachments/assets/04b4b64e-fe7f-4f2c-9e63-8333d7ba3b3d" />

