### PR TITLE
feat(dev): add dev session status, restart commands, and log piping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ next-env.d.ts
 /dev/fixtures/
 /dev/*/fixtures/
 dev-debug-request-logs/*
+/dev/logs/
+/dev/*/logs/
 
 # testing
 /coverage

--- a/.kilo/rules/tools.md
+++ b/.kilo/rules/tools.md
@@ -10,3 +10,9 @@
 - The webserver should already be running. Read the dev server port from the `.dev-port` file in the project root (e.g., `cat .dev-port`), then access it via `http://localhost:<port>/`. If `.dev-port` does not exist, start the dev server by running `pnpm dev:start &` in the background, then wait for `.dev-port` to appear before reading the port from it.
 - If you need to log in as a fake user, open http://localhost:<port>/users/sign_in?fakeUser=<fake-email> where <port> is read from `.dev-port` (falling back to 3000) and <fake-email> is constructed from "kilo-", my username (based on homedir), and the time (include seconds) and then '@example.com'. If you need an admin account, the email address must end in @admin.example.com. After logging in, wait for the creating your account spinner to complete before proceeding. The admin panels can be accessed from your profile via the account icon in the top-right corner, which opens a drop-down, allowing access to the admin panel.
 - be sure to add the callbackPath url parameter to go directly to the page after logging in!
+- Dev services status and management:
+  - `cat dev/logs/manifest.json` — static snapshot of started services and ports (written on `dev:start`)
+  - `pnpm dev:status` — live status of running services with ports
+  - `pnpm dev:status --json` — machine-readable live status (session name, portOffset, services with name/port/status/group)
+  - `pnpm dev:restart <service>` — restart a running service (sends Ctrl-C and re-runs its start command)
+  - `tail -f dev/logs/<service>.log` — follow a service's log output in real time

--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -31,6 +31,7 @@ import {
   enablePaneBorders,
   isTmuxAvailable,
   findServicePane,
+  isPaneRunningCommand,
 } from './tmux';
 import {
   findRepoRoot,
@@ -336,16 +337,17 @@ async function cmdStatus(repoRoot: string, isJson = false): Promise<void> {
   const sessionName = getSessionName();
   if (!sessionExists(sessionName)) {
     if (isJson) {
-      console.log(JSON.stringify({ session: sessionName, services: [] }));
+      console.log(JSON.stringify({ session: sessionName, portOffset, services: [] }));
     } else {
       console.log('No dev session running');
     }
     return;
   }
 
-  const runningServices = [...services.keys()].filter(
-    name => findServicePane(sessionName, name) !== undefined
-  );
+  const runningServices = [...services.keys()].flatMap(name => {
+    const pane = findServicePane(sessionName, name);
+    return pane ? [{ name, pane }] : [];
+  });
   if (runningServices.length === 0) {
     if (isJson) {
       console.log(JSON.stringify({ session: sessionName, portOffset, services: [] }));
@@ -356,10 +358,10 @@ async function cmdStatus(repoRoot: string, isJson = false): Promise<void> {
   }
 
   const entries: StatusEntry[] = await Promise.all(
-    runningServices.map(async (name): Promise<StatusEntry> => {
+    runningServices.map(async ({ name, pane }): Promise<StatusEntry> => {
       const svc = getService(name);
       const port = svc.port;
-      const isUp = port === 0 || (await probePort(port));
+      const isUp = port === 0 ? isPaneRunningCommand(sessionName, pane) : await probePort(port);
       const status: ServiceStatus = isUp ? 'up' : 'down';
       return {
         name,

--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -10,6 +10,7 @@ import {
   resolveGroups,
   topologicalSort,
   portOffset,
+  services,
 } from './services';
 import { syncEnvVars } from './env-sync';
 import {
@@ -29,6 +30,7 @@ import {
   setPaneTitle,
   enablePaneBorders,
   isTmuxAvailable,
+  findServicePane,
 } from './tmux';
 import {
   findRepoRoot,
@@ -37,6 +39,8 @@ import {
   readEnvValue,
   readEnvMtime,
   waitForEnvValueChange,
+  probePort,
+  restartServiceInTmux,
 } from './runner';
 
 // ---------------------------------------------------------------------------
@@ -134,6 +138,13 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
     console.log(`${BOLD}Starting infrastructure…${RESET}`);
     await startInfra(repoRoot, serviceNames);
     console.log();
+  }
+
+  // --- Prepare log directory ---
+  const logDir = path.join(repoRoot, 'dev', 'logs');
+  fs.mkdirSync(logDir, { recursive: true });
+  for (const entry of fs.readdirSync(logDir)) {
+    fs.unlinkSync(path.join(logDir, entry));
   }
 
   // --- Create tmux session ---
@@ -278,8 +289,120 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
   // --- Focus sidebar pane and attach ---
   selectPane(sessionName, 0, 0);
   selectWindow(sessionName, 0);
+
+  // --- Write manifest for agents ---
+  writeManifest(repoRoot, sessionName, serviceNames);
+
   console.log(`${GREEN}Started ${serviceNames.length} services in session ${sessionName}${RESET}`);
   attachSession(sessionName);
+}
+
+type ServiceStatus = 'up' | 'down';
+
+type StatusEntry = {
+  name: string;
+  port: number;
+  status: ServiceStatus;
+  group: string;
+};
+
+type ManifestEntry = {
+  name: string;
+  port: number;
+  group: string;
+  type: string;
+};
+
+type Manifest = {
+  session: string;
+  portOffset: number;
+  services: ManifestEntry[];
+};
+
+function writeManifest(repoRoot: string, sessionName: string, serviceNames: string[]): void {
+  const manifest: Manifest = {
+    session: sessionName,
+    portOffset,
+    services: serviceNames.map(name => {
+      const svc = getService(name);
+      return { name, port: svc.port, group: svc.group, type: svc.type };
+    }),
+  };
+  const manifestPath = path.join(repoRoot, 'dev', 'logs', 'manifest.json');
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+}
+
+async function cmdStatus(repoRoot: string, isJson = false): Promise<void> {
+  const sessionName = getSessionName();
+  if (!sessionExists(sessionName)) {
+    if (isJson) {
+      console.log(JSON.stringify({ session: sessionName, services: [] }));
+    } else {
+      console.log('No dev session running');
+    }
+    return;
+  }
+
+  const windows = listWindows(sessionName);
+  const runningServices = windows.filter(w => w.name !== 'dashboard');
+  if (runningServices.length === 0) {
+    if (isJson) {
+      console.log(JSON.stringify({ session: sessionName, portOffset, services: [] }));
+    } else {
+      console.log('No services running');
+    }
+    return;
+  }
+
+  const entries: StatusEntry[] = await Promise.all(
+    runningServices.map(async w => {
+      const svc = getService(w.name);
+      const port = svc.port;
+      const isUp = port > 0 ? await probePort(port) : false;
+      return {
+        name: w.name,
+        port,
+        status: isUp ? 'up' : ('down' as ServiceStatus),
+        group: svc.group,
+      };
+    })
+  );
+
+  if (isJson) {
+    const result = { session: sessionName, portOffset, services: entries };
+    console.log(JSON.stringify(result));
+    return;
+  }
+
+  const nameWidth = Math.max(...entries.map(e => e.name.length), 8);
+  const portWidth = 6;
+  console.log(`${'SERVICE'.padEnd(nameWidth)}  PORT    STATUS`);
+  for (const e of entries) {
+    const portStr = e.port > 0 ? `:${e.port}` : 'n/a';
+    console.log(`${e.name.padEnd(nameWidth)}  ${portStr.padEnd(portWidth)}  ${e.status}`);
+  }
+}
+
+async function cmdRestart(serviceName: string, repoRoot: string): Promise<void> {
+  if (!services.has(serviceName)) {
+    console.error(`Unknown service: ${serviceName}`);
+    process.exit(1);
+  }
+
+  const sessionName = getSessionName();
+  if (!sessionExists(sessionName)) {
+    console.error('No dev session running');
+    process.exit(1);
+  }
+
+  const pane = findServicePane(sessionName, serviceName);
+  if (!pane) {
+    console.error(`Service ${serviceName} is not running`);
+    process.exit(1);
+  }
+
+  restartServiceInTmux(sessionName, serviceName);
+  console.log(`Restarted ${serviceName}`);
 }
 
 async function cmdStop(repoRoot: string): Promise<void> {
@@ -326,6 +449,8 @@ function printUsage(): void {
 Usage:
   dev:start [targets...]  Start services (default: core)
   dev:stop                Stop all services
+  dev:status [--json]     Show running services and their ports
+  dev:restart <service>   Restart a running service
   dev:env [targets...]    Sync env vars (.dev.vars + .env.development.local)
   dev:env --check         Validate env vars (CI mode)
   dev:env -y              Sync without confirmation
@@ -350,6 +475,18 @@ async function main() {
     case 'stop':
       await cmdStop(repoRoot);
       break;
+    case 'status':
+      await cmdStatus(repoRoot, args.includes('--json'));
+      break;
+    case 'restart': {
+      const serviceName = args[1];
+      if (!serviceName) {
+        console.error('Usage: dev:restart <service>');
+        process.exit(1);
+      }
+      await cmdRestart(serviceName, repoRoot);
+      break;
+    }
     case 'env':
       await cmdEnv(args.slice(1), repoRoot);
       break;

--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -343,8 +343,9 @@ async function cmdStatus(repoRoot: string, isJson = false): Promise<void> {
     return;
   }
 
-  const windows = listWindows(sessionName);
-  const runningServices = windows.filter(w => w.name !== 'dashboard');
+  const runningServices = [...services.keys()].filter(
+    name => findServicePane(sessionName, name) !== undefined
+  );
   if (runningServices.length === 0) {
     if (isJson) {
       console.log(JSON.stringify({ session: sessionName, portOffset, services: [] }));
@@ -355,14 +356,15 @@ async function cmdStatus(repoRoot: string, isJson = false): Promise<void> {
   }
 
   const entries: StatusEntry[] = await Promise.all(
-    runningServices.map(async w => {
-      const svc = getService(w.name);
+    runningServices.map(async (name): Promise<StatusEntry> => {
+      const svc = getService(name);
       const port = svc.port;
-      const isUp = port > 0 ? await probePort(port) : false;
+      const isUp = port === 0 || (await probePort(port));
+      const status: ServiceStatus = isUp ? 'up' : 'down';
       return {
-        name: w.name,
+        name,
         port,
-        status: isUp ? 'up' : ('down' as ServiceStatus),
+        status,
         group: svc.group,
       };
     })
@@ -386,6 +388,12 @@ async function cmdStatus(repoRoot: string, isJson = false): Promise<void> {
 async function cmdRestart(serviceName: string, repoRoot: string): Promise<void> {
   if (!services.has(serviceName)) {
     console.error(`Unknown service: ${serviceName}`);
+    process.exit(1);
+  }
+
+  const svc = getService(serviceName);
+  if (svc.type === 'infra') {
+    console.error(`dev:restart does not support infrastructure service: ${serviceName}`);
     process.exit(1);
   }
 

--- a/dev/local/log-filter.ts
+++ b/dev/local/log-filter.ts
@@ -1,0 +1,149 @@
+type ParserState =
+  | 'normal'
+  | 'escape'
+  | 'csi'
+  | 'osc'
+  | 'oscEscape'
+  | 'controlString'
+  | 'controlStringEscape'
+  | 'skipNext';
+
+let parserState: ParserState = 'normal';
+let line = '';
+let pendingCarriageReturn = false;
+
+process.stdin.setEncoding('utf8');
+
+process.stdin.on('data', (chunk: string) => {
+  for (const char of chunk) {
+    processChar(char);
+  }
+});
+
+process.stdin.on('end', flushLineIfNeeded);
+
+function processChar(char: string): void {
+  switch (parserState) {
+    case 'normal':
+      processNormalChar(char);
+      return;
+    case 'escape':
+      processEscapeChar(char);
+      return;
+    case 'csi':
+      if (isAnsiFinalChar(char)) {
+        parserState = 'normal';
+      }
+      return;
+    case 'osc':
+      if (char === '\x07') {
+        parserState = 'normal';
+      } else if (char === '\x1b') {
+        parserState = 'oscEscape';
+      }
+      return;
+    case 'oscEscape':
+      parserState = char === '\\' ? 'normal' : 'osc';
+      return;
+    case 'controlString':
+      if (char === '\x07') {
+        parserState = 'normal';
+      } else if (char === '\x1b') {
+        parserState = 'controlStringEscape';
+      }
+      return;
+    case 'controlStringEscape':
+      parserState = char === '\\' ? 'normal' : 'controlString';
+      return;
+    case 'skipNext':
+      parserState = 'normal';
+      return;
+  }
+}
+
+function processNormalChar(char: string): void {
+  if (char === '\x1b') {
+    parserState = 'escape';
+    return;
+  }
+
+  if (pendingCarriageReturn) {
+    pendingCarriageReturn = false;
+    if (char === '\n') {
+      emitLine();
+      return;
+    }
+    line = '';
+  }
+
+  if (char === '\r') {
+    pendingCarriageReturn = true;
+    return;
+  }
+
+  if (char === '\n') {
+    emitLine();
+    return;
+  }
+
+  if (char === '\b') {
+    line = line.slice(0, -1);
+    return;
+  }
+
+  if (char === '\t') {
+    line += char;
+    return;
+  }
+
+  const charCode = char.charCodeAt(0);
+  if (charCode >= 0x20 && charCode !== 0x7f) {
+    line += char;
+  }
+}
+
+function processEscapeChar(char: string): void {
+  switch (char) {
+    case '[':
+      parserState = 'csi';
+      return;
+    case ']':
+      parserState = 'osc';
+      return;
+    case 'P':
+    case '^':
+    case '_':
+    case 'X':
+      parserState = 'controlString';
+      return;
+    case '(':
+    case ')':
+    case '*':
+    case '+':
+    case '-':
+    case '.':
+    case '/':
+    case '#':
+      parserState = 'skipNext';
+      return;
+    default:
+      parserState = 'normal';
+  }
+}
+
+function isAnsiFinalChar(char: string): boolean {
+  const charCode = char.charCodeAt(0);
+  return charCode >= 0x40 && charCode <= 0x7e;
+}
+
+function emitLine(): void {
+  pendingCarriageReturn = false;
+  process.stdout.write(`${line}\n`);
+  line = '';
+}
+
+function flushLineIfNeeded(): void {
+  if (line !== '') {
+    process.stdout.write(`${line}\n`);
+  }
+}

--- a/dev/local/runner.ts
+++ b/dev/local/runner.ts
@@ -17,6 +17,7 @@ import {
   selectPane,
   setPaneTitle,
   setMainLeftLayout,
+  pipePane,
 } from './tmux';
 
 // ---------------------------------------------------------------------------
@@ -107,7 +108,7 @@ export function buildStartCommand(serviceName: string): string {
 
 export function startServiceInTmux(sessionName: string, serviceName: string): void {
   const svc = getService(serviceName);
-  createWindow(sessionName, serviceName);
+  const winIndex = createWindow(sessionName, serviceName);
   if (svc.type === 'infra') {
     sendKeys(
       sessionName,
@@ -117,6 +118,12 @@ export function startServiceInTmux(sessionName: string, serviceName: string): vo
   } else {
     sendKeys(sessionName, serviceName, buildStartCommand(serviceName));
   }
+  const logPath = path.join(findRepoRoot(), 'dev', 'logs', `${serviceName}.log`);
+  pipePane(sessionName, winIndex, 0, `cat >> ${shellQuote(logPath)}`);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 export function stopServiceInTmux(sessionName: string, serviceName: string): void {

--- a/dev/local/runner.ts
+++ b/dev/local/runner.ts
@@ -119,7 +119,12 @@ export function startServiceInTmux(sessionName: string, serviceName: string): vo
     sendKeys(sessionName, serviceName, buildStartCommand(serviceName));
   }
   const logPath = path.join(findRepoRoot(), 'dev', 'logs', `${serviceName}.log`);
-  pipePane(sessionName, winIndex, 0, `cat >> ${shellQuote(logPath)}`);
+  pipePane(sessionName, winIndex, 0, buildLogPipeCommand(logPath));
+}
+
+function buildLogPipeCommand(logPath: string): string {
+  const filterPath = path.join(findRepoRoot(), 'dev', 'local', 'log-filter.ts');
+  return `tsx ${shellQuote(filterPath)} >> ${shellQuote(logPath)}`;
 }
 
 function shellQuote(value: string): string {

--- a/dev/local/tmux.ts
+++ b/dev/local/tmux.ts
@@ -330,6 +330,19 @@ function findServicePane(sessionName: string, serviceName: string): PaneInfo | u
   }
 }
 
+function isPaneRunningCommand(sessionName: string, pane: PaneInfo): boolean {
+  try {
+    const command = execSync(
+      `tmux display-message -p -t ${sessionName}:${pane.windowIndex}.${pane.paneIndex} "#{pane_current_command}"`,
+      { encoding: 'utf-8' }
+    ).trim();
+    const commandName = path.basename(command).replace(/^-/, '');
+    return commandName !== '' && !['bash', 'fish', 'nu', 'sh', 'tcsh', 'zsh'].includes(commandName);
+  } catch {
+    return false;
+  }
+}
+
 function selectPane(sessionName: string, windowTarget: string | number, pane: number): void {
   execSync(`tmux select-pane -t ${sessionName}:${windowTarget}.${pane}`, { stdio: 'ignore' });
 }
@@ -424,6 +437,7 @@ export {
   breakPane,
   countPanes,
   findServicePane,
+  isPaneRunningCommand,
   selectPane,
   setPaneTitle,
   enablePaneBorders,

--- a/dev/local/tmux.ts
+++ b/dev/local/tmux.ts
@@ -359,6 +359,22 @@ function enablePaneBorders(sessionName: string, windowTarget: string | number): 
 }
 
 // ---------------------------------------------------------------------------
+// Pane logging
+// ---------------------------------------------------------------------------
+
+function pipePane(
+  sessionName: string,
+  windowTarget: string | number,
+  pane: number,
+  command: string
+): void {
+  execSync(
+    `tmux pipe-pane -t ${paneTarget(sessionName, windowTarget, pane)} -o ${escapeForShell(command)}`,
+    { stdio: 'ignore' }
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Utility
 // ---------------------------------------------------------------------------
 
@@ -411,6 +427,7 @@ export {
   selectPane,
   setPaneTitle,
   enablePaneBorders,
+  pipePane,
   isTmuxAvailable,
   isInsideTmux,
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "worktree:prepare": "bash scripts/worktree-prepare.sh",
     "dev:start": "tsx dev/local/cli.ts up",
     "dev:stop": "tsx dev/local/cli.ts stop",
+    "dev:status": "tsx dev/local/cli.ts status",
+    "dev:restart": "tsx dev/local/cli.ts restart",
     "dev:env": "tsx dev/local/cli.ts env",
     "dev:discord-gateway-cron": "tsx dev/discord-gateway-cron.ts"
   },


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g. feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

**feat(dev): add dev session status, restart commands, and log piping**

## Summary

Adds tooling for managing running dev sessions with live status, service restart, and log piping:

- **New `dev:status` command** — Reports running services with their ports and status (up/down). Supports `--json` for machine-readable output. Reads port status by probing the actual port rather than relying on tmux pane state.
- **New `dev:restart <service>` command** — Restarts a running service by sending Ctrl-C and re-running its start command.
- **Log piping** — Pipes each service pane output to `dev/logs/<service>.log` using `tmux pipe-pane`, enabling real-time log tailing with `tail -f dev/logs/<service>.log`.
- **Manifest file** — Writes `dev/logs/manifest.json` on session start for agents/scripts to discover session metadata (session name, port offset, service ports/groups/types).
- **Updated `.gitignore`** — Excludes `dev/logs/` directory.
- **Updated `tools.md`** — Documents the new commands for Kilo agent instructions.

## Verification

- [x] `pnpm typecheck` — Passed
- [x] User verification

## Visual Changes

N/A

## Reviewer Notes

- Log piping uses `tmux pipe-pane -o` so it survives pane switches. Logs accumulate across the session lifetime (cleared on next `dev:start`).
- Port probing in `dev:status` may report false negatives for services that bind late (e.g., DB migrations). Consider this when interpreting status output.