### PR TITLE
fix(cloud-agent): correlate optimistic user messages

### DIFF
--- a/apps/web/src/components/cloud-agent-next/CloudAgentProvider.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudAgentProvider.tsx
@@ -111,6 +111,7 @@ export function CloudAgentProvider({ children, organizationId }: CloudAgentProvi
           const mode = payload.mode as 'code' | 'plan' | 'debug' | 'orchestrator' | 'ask';
           const model = payload.model as string;
           const variant = payload.variant as string | undefined;
+          const messageId = payload.messageId as string | undefined;
           if (organizationId) {
             return trpcClient.organizations.cloudAgentNext.sendMessage.mutate(
               {
@@ -121,12 +122,21 @@ export function CloudAgentProvider({ children, organizationId }: CloudAgentProvi
                 variant,
                 autoCommit: true,
                 organizationId,
+                messageId,
               },
               { context: { skipBatch: true } }
             );
           }
           return trpcClient.cloudAgentNext.sendMessage.mutate(
-            { cloudAgentSessionId: castSessionId, prompt, mode, model, variant, autoCommit: true },
+            {
+              cloudAgentSessionId: castSessionId,
+              prompt,
+              mode,
+              model,
+              variant,
+              autoCommit: true,
+              messageId,
+            },
             { context: { skipBatch: true } }
           );
         },
@@ -254,6 +264,8 @@ export function CloudAgentProvider({ children, organizationId }: CloudAgentProvi
           isInitiated: Boolean(rs?.initiatedAt),
           needsLegacyPrepare: Boolean(sessionResult.cloud_agent_session_id && !rs),
           isPreparingAsync: Boolean(rs && !rs.preparedAt),
+          prompt: rs?.prompt ?? null,
+          initialMessageId: rs?.initialMessageId ?? null,
         };
       },
 

--- a/apps/web/src/components/cloud-agent-next/CloudSidebarLayout.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudSidebarLayout.tsx
@@ -43,9 +43,12 @@ export function CloudSidebarLayout({ organizationId, children }: CloudSidebarLay
   const projectFilterKey = `cloud-sessions:project-filter:${organizationId ?? 'personal'}`;
   const [platformFilter, setPlatformFilter] = useLocalStorage<string[]>(
     'cloud-sessions:platform-filter',
-    ['cloud-agent']
+    ['cloud-agent'],
+    { initializeWithValue: false }
   );
-  const [projectFilter, setProjectFilter] = useLocalStorage<string[]>(projectFilterKey, []);
+  const [projectFilter, setProjectFilter] = useLocalStorage<string[]>(projectFilterKey, [], {
+    initializeWithValue: false,
+  });
   const [mobileSheetOpen, setMobileSheetOpen] = useState(false);
   const repoUpdatedSince = useMemo(() => startOfDay(subDays(new Date(), 30)).toISOString(), []);
 

--- a/apps/web/src/components/cloud-agent-next/MessageBubble.tsx
+++ b/apps/web/src/components/cloud-agent-next/MessageBubble.tsx
@@ -80,11 +80,16 @@ function InlineFileAttachment({ part }: { part: FilePart }) {
 }
 
 /**
- * Get user content by combining all text parts
+ * Get user content by combining all text parts.
+ * Prefers non-synthetic parts (server-confirmed) over synthetic ones
+ * (optimistic placeholders) to avoid duplication when both coexist.
+ * Only uses non-synthetic parts if they have non-empty text.
  */
 function getUserTextContent(parts: Part[]): string {
   const textParts = parts.filter(isTextPart);
-  return stripImageContext(textParts.map(p => p.text).join(''));
+  const nonSynthetic = textParts.filter(p => !p.synthetic && p.text.length > 0);
+  const effective = nonSynthetic.length > 0 ? nonSynthetic : textParts;
+  return stripImageContext(effective.map(p => p.text).join(''));
 }
 
 /**

--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -65,6 +65,7 @@ import {
   detectGitPlatform,
 } from '@/components/cloud-agent-next/utils/git-utils';
 import type { AgentMode } from './types';
+import { generateMessageId } from '@/lib/cloud-agent-sdk/message-id';
 
 type Repository = {
   id: number;
@@ -516,6 +517,7 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
     setIsPreparing(true);
 
     try {
+      const initialMessageId = generateMessageId();
       const baseInput = {
         prompt: prompt.trim(),
         mode,
@@ -526,6 +528,7 @@ export function NewSessionPanel({ organizationId }: NewSessionPanelProps) {
         profileName: selectedProfile?.name,
         autoCommit: true,
         autoInitiate: true,
+        initialMessageId,
       };
       let result: { kiloSessionId: string; cloudAgentSessionId: string };
 

--- a/apps/web/src/lib/cloud-agent-next/cloud-agent-client.ts
+++ b/apps/web/src/lib/cloud-agent-next/cloud-agent-client.ts
@@ -130,6 +130,8 @@ export type SendMessageInput = {
   condenseOnComplete?: boolean;
   /** Custom text to append to the system prompt */
   appendSystemPrompt?: string;
+  /** Message ID for correlating the request */
+  messageId?: string;
 };
 
 /** Output from V2 mutation procedures (WebSocket-based) */
@@ -199,6 +201,9 @@ export type GetSessionOutput = {
 
   // Callback configuration (debug-friendly, URL + headers)
   callbackTarget?: CallbackTarget;
+
+  // Initial message ID for correlation
+  initialMessageId?: string;
 
   // Versioning
   timestamp: number;

--- a/apps/web/src/lib/cloud-agent-next/processor/event-processor.ts
+++ b/apps/web/src/lib/cloud-agent-next/processor/event-processor.ts
@@ -24,6 +24,7 @@ import {
   isUserMessage,
   isAssistantMessage,
   isToolPart,
+  isTextPart,
   type EventMessageUpdated,
   type EventMessagePartUpdated,
   type EventMessagePartRemoved,
@@ -184,15 +185,25 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
 
   /**
    * Apply a part update to a message — upsert by part id.
+   * Returns false if the update was rejected (no mutation occurred), true otherwise.
    */
-  function applyPartToMessage(message: ProcessedMessage, part: Part): void {
+  function applyPartToMessage(message: ProcessedMessage, part: Part): boolean {
     const existingIndex = message.parts.findIndex(p => p.id === part.id);
+
+    // For user messages, don't allow an update to clear existing text from a text part.
+    if (isUserMessage(message.info) && existingIndex >= 0 && isTextPart(part) && !part.text) {
+      const existing = message.parts[existingIndex];
+      if (isTextPart(existing) && existing.text) {
+        return false;
+      }
+    }
 
     if (existingIndex >= 0) {
       message.parts[existingIndex] = part;
     } else {
       message.parts.push(part);
     }
+    return true;
   }
 
   /**
@@ -282,10 +293,12 @@ export function createEventProcessor(config: EventProcessorConfig = {}): EventPr
       return;
     }
 
-    applyPartToMessage(message, part);
-    const updatedPart = message.parts.find(p => p.id === part.id) ?? part;
-    callbacks.onPartUpdated?.(sessionId, messageId, part.id, updatedPart, parentSessionId);
-    checkAndHandleCompletion(sessionId, messageId, message);
+    const applied = applyPartToMessage(message, part);
+    if (applied) {
+      const updatedPart = message.parts.find(p => p.id === part.id) ?? part;
+      callbacks.onPartUpdated?.(sessionId, messageId, part.id, updatedPart, parentSessionId);
+      checkAndHandleCompletion(sessionId, messageId, message);
+    }
   }
 
   /**

--- a/apps/web/src/lib/cloud-agent-sdk/chat-processor.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/chat-processor.test.ts
@@ -100,6 +100,67 @@ describe('createChatProcessor', () => {
       expect(storedFile.url).toBe('');
       expect(storedFile.source?.text.value).toBe('');
     });
+
+    it('does not replace text with empty non-synthetic part', () => {
+      const storage = createMemoryStorage();
+      const processor = createChatProcessor(storage);
+
+      // Add synthetic optimistic part with text
+      const syntheticPart = {
+        id: 'part-1',
+        sessionID: 'ses-1',
+        messageID: 'msg-1',
+        type: 'text' as const,
+        text: 'user message text',
+        synthetic: true,
+      };
+      processor.process({ type: 'message.part.updated', part: syntheticPart });
+      expect((storage.getParts('msg-1')[0] satisfies Part as TextPart).text).toBe(
+        'user message text'
+      );
+
+      // Server sends non-synthetic part with empty text
+      const nonSyntheticEmptyPart = {
+        id: 'part-1',
+        sessionID: 'ses-1',
+        messageID: 'msg-1',
+        type: 'text' as const,
+        text: '',
+        synthetic: false,
+      };
+      processor.process({ type: 'message.part.updated', part: nonSyntheticEmptyPart });
+
+      // Should preserve the existing text
+      const stored = storage.getParts('msg-1');
+      expect(stored).toHaveLength(1);
+      expect((stored[0] satisfies Part as TextPart).text).toBe('user message text');
+    });
+
+    it('does not replace text with empty server part that omits synthetic', () => {
+      const storage = createMemoryStorage();
+      const processor = createChatProcessor(storage);
+
+      processor.process({
+        type: 'message.part.updated',
+        part: {
+          id: 'part-1',
+          sessionID: 'ses-1',
+          messageID: 'msg-1',
+          type: 'text',
+          text: 'user message text',
+          synthetic: true,
+        },
+      });
+
+      processor.process({
+        type: 'message.part.updated',
+        part: makeTextPart('part-1', 'msg-1', ''),
+      });
+
+      const stored = storage.getParts('msg-1');
+      expect(stored).toHaveLength(1);
+      expect((stored[0] satisfies Part as TextPart).text).toBe('user message text');
+    });
   });
 
   describe('message.part.delta', () => {

--- a/apps/web/src/lib/cloud-agent-sdk/chat-processor.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/chat-processor.ts
@@ -6,6 +6,16 @@ type ChatProcessor = {
   process(event: ChatEvent): void;
 };
 
+function hasTextField(part: { text?: string } | unknown): part is { text: string } {
+  return typeof part === 'object' && part !== null && 'text' in part;
+}
+
+function isSyntheticPart(part: unknown): boolean {
+  return (
+    typeof part === 'object' && part !== null && 'synthetic' in part && part.synthetic === true
+  );
+}
+
 function createChatProcessor(storage: SessionStorage): ChatProcessor {
   return {
     process(event) {
@@ -15,6 +25,13 @@ function createChatProcessor(storage: SessionStorage): ChatProcessor {
           break;
         case 'message.part.updated': {
           const stripped = stripPartContentIfFile(event.part);
+          if (hasTextField(stripped) && stripped.text === '' && !isSyntheticPart(stripped)) {
+            const existingParts = storage.getParts(stripped.messageID);
+            const existing = existingParts.find(p => p.id === stripped.id);
+            if (existing && hasTextField(existing) && existing.text.length > 0) {
+              break;
+            }
+          }
           storage.upsertPart(stripped.messageID, stripped);
           break;
         }

--- a/apps/web/src/lib/cloud-agent-sdk/message-id.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/message-id.ts
@@ -1,0 +1,12 @@
+// Kilo format: msg_ + 6 bytes as hex (12 chars, time-based) + 14 base62 chars (random)
+export function generateMessageId(): string {
+  const timeBytes = new Uint8Array(6);
+  const now = BigInt(Date.now()) * BigInt(0x1000);
+  for (let i = 0; i < 6; i++) {
+    timeBytes[i] = Number((now >> BigInt(40 - 8 * i)) & BigInt(0xff));
+  }
+  const hex = Array.from(timeBytes, b => b.toString(16).padStart(2, '0')).join('');
+  const base62 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const rand = Array.from(crypto.getRandomValues(new Uint8Array(14)), b => base62[b % 62]).join('');
+  return `msg_${hex}${rand}`;
+}

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -10,6 +10,7 @@ import { createCloudAgentSession } from './session';
 import type { JotaiSessionStorage } from './storage/jotai';
 import type { AssistantMessage, UserMessage } from '@/types/opencode.gen';
 import { kiloId, cloudAgentId, stubUserMessage } from './test-helpers';
+import type { ResolvedSession } from './types';
 
 // ---------------------------------------------------------------------------
 // Mock createCloudAgentSession — prevents real WebSocket connections
@@ -47,6 +48,7 @@ const mockSessionCallbacks: {
   onQuestionResolved?: (...args: unknown[]) => void;
   onPermissionAsked?: (...args: unknown[]) => void;
   onPermissionResolved?: (...args: unknown[]) => void;
+  onResolved?: (resolved: ResolvedSession) => void;
 } = {};
 
 let latestStorage: JotaiSessionStorage | null = null;
@@ -61,12 +63,18 @@ jest.mock('./session', () => ({
       onQuestionResolved?: (...args: unknown[]) => void;
       onPermissionAsked?: (...args: unknown[]) => void;
       onPermissionResolved?: (...args: unknown[]) => void;
+      onResolved?: (resolved: ResolvedSession) => void;
     }) => {
       latestStorage = sessionConfig.storage;
       mockSession.storage = sessionConfig.storage;
       // Capture the onSessionCreated callback and fire it when connect() is called,
       // simulating what the real session does after connecting and replaying the snapshot.
       mockSession.connect.mockImplementation(() => {
+        sessionConfig.onResolved?.({
+          type: 'cloud-agent',
+          kiloSessionId: kiloId(sessionConfig.kiloSessionId),
+          cloudAgentSessionId: cloudAgentId('agent-1'),
+        });
         sessionConfig.onSessionCreated?.({ id: sessionConfig.kiloSessionId, parentID: null });
       });
       mockSessionCallbacks.onSessionCreated = sessionConfig.onSessionCreated;
@@ -74,6 +82,7 @@ jest.mock('./session', () => ({
       mockSessionCallbacks.onQuestionResolved = sessionConfig.onQuestionResolved;
       mockSessionCallbacks.onPermissionAsked = sessionConfig.onPermissionAsked;
       mockSessionCallbacks.onPermissionResolved = sessionConfig.onPermissionResolved;
+      mockSessionCallbacks.onResolved = sessionConfig.onResolved;
       return mockSession;
     }
   ),
@@ -97,6 +106,8 @@ const defaultFetchedSession = {
   isInitiated: true,
   needsLegacyPrepare: false,
   isPreparingAsync: false,
+  prompt: null,
+  initialMessageId: null,
 } satisfies FetchedSessionData;
 
 function createMockConfig(overrides: Partial<SessionManagerConfig> = {}): SessionManagerConfig {
@@ -199,6 +210,7 @@ describe('createSessionManager', () => {
     mockSessionCallbacks.onPermissionAsked = undefined;
     mockSessionCallbacks.onPermissionResolved = undefined;
     mockSessionCallbacks.onSessionCreated = undefined;
+    mockSessionCallbacks.onResolved = undefined;
   });
 
   // -------------------------------------------------------------------------
@@ -373,6 +385,70 @@ describe('createSessionManager', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Initial message pre-insertion (new sessions before initiation)
+  // -------------------------------------------------------------------------
+
+  describe('initial message pre-insertion', () => {
+    it('pre-inserts user message for non-initiated sessions with prompt and initialMessageId', async () => {
+      const config = createMockConfig({
+        fetchSession: jest.fn().mockResolvedValue({
+          ...defaultFetchedSession,
+          isInitiated: false,
+          prompt: 'Fix the bug',
+          initialMessageId: 'msg_000000000000AAAAAAAAAAAAAA',
+        }),
+      });
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-1'));
+
+      const messages = atomValue<StoredMessage[]>(config.store, mgr.atoms.messagesList);
+      expect(messages).toHaveLength(1);
+      expect(messages[0]?.info.id).toBe('msg_000000000000AAAAAAAAAAAAAA');
+      expect(messages[0]?.info.role).toBe('user');
+      const textPart = messages[0]?.parts[0];
+      expect(textPart?.type).toBe('text');
+      if (textPart?.type === 'text') {
+        expect(textPart.text).toBe('Fix the bug');
+      }
+    });
+
+    it('does not pre-insert message when session is already initiated', async () => {
+      const config = createMockConfig({
+        fetchSession: jest.fn().mockResolvedValue({
+          ...defaultFetchedSession,
+          isInitiated: true,
+          prompt: 'Fix the bug',
+          initialMessageId: 'msg_000000000000AAAAAAAAAAAAAA',
+        }),
+      });
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-1'));
+
+      const messages = atomValue<StoredMessage[]>(config.store, mgr.atoms.messagesList);
+      expect(messages).toHaveLength(0);
+    });
+
+    it('does not pre-insert message when initialMessageId is null', async () => {
+      const config = createMockConfig({
+        fetchSession: jest.fn().mockResolvedValue({
+          ...defaultFetchedSession,
+          isInitiated: false,
+          prompt: 'Fix the bug',
+          initialMessageId: null,
+        }),
+      });
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-1'));
+
+      const messages = atomValue<StoredMessage[]>(config.store, mgr.atoms.messagesList);
+      expect(messages).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Overlapping switchSession
   // -------------------------------------------------------------------------
 
@@ -420,6 +496,8 @@ describe('createSessionManager', () => {
         ...defaultFetchedSession,
         cloudAgentSessionId: cloudAgentId('stale-agent'),
         model: 'stale-model',
+        prompt: null,
+        initialMessageId: null,
       } satisfies FetchedSessionData;
 
       const config = createMockConfig({
@@ -458,10 +536,35 @@ describe('createSessionManager', () => {
       await mgr.send({ prompt: 'Hello', mode: 'code', model: 'claude-3-5-sonnet' });
 
       expect(mockSession.send).toHaveBeenCalledWith({
+        messageId: expect.stringMatching(/^msg_/),
         prompt: 'Hello',
         mode: 'code',
         model: 'claude-3-5-sonnet',
       });
+
+      const messages = atomValue<StoredMessage[]>(config.store, mgr.atoms.messagesList);
+      expect(messages).toHaveLength(1);
+      expect(messages[0]?.info.role).toBe('user');
+      expect(messages[0]?.info.id).toMatch(/^msg_/);
+    });
+
+    it('does not persist optimistic message for remote sessions', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-1'));
+      mockSessionCallbacks.onResolved?.({ type: 'remote', kiloSessionId: kiloId('ses-1') });
+
+      mockSession.send.mockResolvedValue(undefined);
+      await mgr.send({ prompt: 'Hello', mode: 'code', model: 'claude-3-5-sonnet' });
+
+      expect(mockSession.send).toHaveBeenCalledWith({
+        messageId: expect.stringMatching(/^msg_/),
+        prompt: 'Hello',
+        mode: 'code',
+        model: 'claude-3-5-sonnet',
+      });
+      expect(atomValue<StoredMessage[]>(config.store, mgr.atoms.messagesList)).toHaveLength(0);
     });
 
     it('clears optimistic message and sets error indicator on failure', async () => {
@@ -513,6 +616,7 @@ describe('createSessionManager', () => {
       });
 
       expect(mockSession.send).toHaveBeenCalledWith({
+        messageId: expect.stringMatching(/^msg_/),
         prompt: 'Hello',
         mode: 'code',
         model: 'claude-3-5-sonnet',
@@ -530,6 +634,7 @@ describe('createSessionManager', () => {
       await mgr.send({ prompt: 'Hello', mode: 'code', model: 'claude-3-5-sonnet' });
 
       expect(mockSession.send).toHaveBeenCalledWith({
+        messageId: expect.stringMatching(/^msg_/),
         prompt: 'Hello',
         mode: 'code',
         model: 'claude-3-5-sonnet',

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
@@ -19,9 +19,11 @@ import type {
   PermissionState,
   MessageInfo,
   Part,
+  TextPart,
 } from './types';
 import type { QuestionInfo } from '@/types/opencode.gen';
 import { splitByContiguousPrefix } from '@/lib/utils/splitByContiguousPrefix';
+import { generateMessageId } from './message-id';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -64,6 +66,8 @@ type FetchedSessionData = {
   isInitiated: boolean;
   needsLegacyPrepare: boolean;
   isPreparingAsync: boolean;
+  prompt: string | null;
+  initialMessageId: string | null;
 };
 
 type PrepareInput = {
@@ -228,7 +232,6 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
 
   // Internal atoms
   const sessionStorageAtom = atom<JotaiSessionStorage | null>(null);
-  const optimisticMessageAtom = atom<StoredMessage | null>(null);
   const rootSessionIdAtom = atom<string | null>(null);
 
   // Public writable atoms
@@ -268,8 +271,6 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       if (rootSessionId !== null && info.sessionID !== rootSessionId) continue;
       out.push({ info, parts: partsMap.get(id) ?? [] });
     }
-    const opt = get(optimisticMessageAtom);
-    if (opt) out.push(opt);
     return out;
   });
 
@@ -323,7 +324,6 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
 
   function clearAllAtoms(): void {
     store.set(sessionStorageAtom, null);
-    store.set(optimisticMessageAtom, null);
     store.set(rootSessionIdAtom, null);
     store.set(isStreamingAtom, false);
     store.set(isLoadingAtom, false);
@@ -388,7 +388,6 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       if (act.type !== prevAct) {
         if (act.type === 'busy') {
           setIndicator(null);
-          store.set(optimisticMessageAtom, null);
         } else if (act.type === 'retrying') {
           setIndicator({
             type: 'warning',
@@ -462,6 +461,27 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     });
     store.set(sessionIdAtom, data.cloudAgentSessionId);
     store.set(sessionStorageAtom, jotaiStorage);
+
+    // Insert initial message for non-initiated sessions that have prompt and initialMessageId
+    if (!data.isInitiated && data.prompt && data.initialMessageId) {
+      jotaiStorage.upsertMessage({
+        id: data.initialMessageId,
+        sessionID: kiloSessionId,
+        role: 'user',
+        time: { created: Date.now() / 1000 },
+        agent: '',
+        model: { providerID: '', modelID: '' },
+      } satisfies MessageInfo);
+      jotaiStorage.upsertPart(data.initialMessageId, {
+        id: `${data.initialMessageId}-text`,
+        sessionID: kiloSessionId,
+        messageID: data.initialMessageId,
+        type: 'text',
+        text: data.prompt,
+        synthetic: true,
+      } satisfies TextPart);
+    }
+
     config.onKiloSessionCreated?.(kiloSessionId);
 
     const session = createCloudAgentSession({
@@ -567,36 +587,49 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
   }): Promise<void> {
     store.set(errorAtom, null);
     setIndicator(null);
-    const id = `optimistic-${crypto.randomUUID()}`;
-    store.set(optimisticMessageAtom, {
-      info: {
-        id,
-        sessionID: '',
+
+    const storage = store.get(sessionStorageAtom);
+    const kiloSessionId = activeSessionId;
+    const messageId = generateMessageId();
+    const shouldStoreOptimisticMessage = activeSessionType === 'cloud-agent';
+
+    if (storage && kiloSessionId && shouldStoreOptimisticMessage) {
+      storage.upsertMessage({
+        id: messageId,
+        sessionID: kiloSessionId,
         role: 'user',
         time: { created: Date.now() / 1000 },
         agent: '',
         model: { providerID: '', modelID: payload.model },
-      },
-      parts: [
-        { id: `${id}-text`, sessionID: '', messageID: id, type: 'text', text: payload.prompt },
-      ],
-    } satisfies StoredMessage);
+      });
+      storage.upsertPart(messageId, {
+        id: `${messageId}-text`,
+        sessionID: kiloSessionId,
+        messageID: messageId,
+        type: 'text',
+        text: payload.prompt,
+        synthetic: true,
+      });
+    }
+
     try {
       if (!currentSession) throw new Error('No active session');
       // Snapshot before await — switchSession() can overwrite these while send is in flight.
       const sessionType = activeSessionType;
-      const kiloSessionId = activeSessionId;
       await currentSession.send({
         prompt: payload.prompt,
         mode: payload.mode,
         model: payload.model,
         variant: payload.variant,
+        messageId,
       });
       if (sessionType === 'remote' && kiloSessionId) {
         config.onRemoteSessionMessageSent?.({ kiloSessionId });
       }
     } catch (err) {
-      store.set(optimisticMessageAtom, null);
+      if (storage && shouldStoreOptimisticMessage) {
+        storage.deleteMessage(messageId);
+      }
       store.set(failedPromptAtom, payload.prompt);
       config.onSendFailed?.(payload.prompt);
       setIndicator({ type: 'error', message: formatError(err), timestamp: Date.now() });

--- a/apps/web/src/lib/cloud-agent-sdk/session.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session.ts
@@ -53,6 +53,7 @@ type CloudAgentSessionSendInput = {
   mode?: string;
   model?: string;
   variant?: string;
+  messageId?: string;
 };
 
 type CloudAgentSessionAnswerInput = {

--- a/apps/web/src/lib/cloud-agent-sdk/storage/jotai.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/storage/jotai.ts
@@ -236,6 +236,31 @@ function createJotaiStorage(store: JotaiStore): JotaiSessionStorage {
       }
       notify(subscribers, 'messageIds');
     },
+
+    deleteMessage(messageId) {
+      const messages = store.get(messagesAtom);
+      if (!messages.has(messageId)) return;
+
+      const nextMessages = new Map(messages);
+      nextMessages.delete(messageId);
+      store.set(messagesAtom, nextMessages);
+
+      const messageIds = store.get(messageIdsAtom);
+      const nextMessageIds = messageIds.filter(id => id !== messageId);
+      store.set(messageIdsAtom, nextMessageIds);
+
+      const allParts = store.get(partsAtom);
+      if (allParts.has(messageId)) {
+        const nextParts = new Map(allParts);
+        nextParts.delete(messageId);
+        store.set(partsAtom, nextParts);
+        partsSnapshot.delete(messageId);
+        notify(subscribers, `parts:${messageId}`);
+      }
+
+      notify(subscribers, `message:${messageId}`);
+      notify(subscribers, 'messageIds');
+    },
   };
 }
 

--- a/apps/web/src/lib/cloud-agent-sdk/storage/memory.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/storage/memory.ts
@@ -208,6 +208,22 @@ function createMemoryStorage(): SessionStorage {
       }
       notify(subscribers, 'messageIds');
     },
+
+    deleteMessage(messageId) {
+      if (!messages.has(messageId)) return;
+
+      messages.delete(messageId);
+      messageIds = messageIds.filter(id => id !== messageId);
+
+      if (parts.has(messageId)) {
+        parts.delete(messageId);
+        partsSnapshot.delete(messageId);
+        notify(subscribers, `parts:${messageId}`);
+      }
+
+      notify(subscribers, `message:${messageId}`);
+      notify(subscribers, 'messageIds');
+    },
   };
 }
 

--- a/apps/web/src/lib/cloud-agent-sdk/storage/types.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/storage/types.ts
@@ -23,6 +23,9 @@ type SessionStorage = {
 
   // Bulk operations
   clear(): void;
+
+  // Delete a message and all its parts
+  deleteMessage(messageId: string): void;
 };
 
 /**
@@ -33,6 +36,7 @@ type StorageMutation =
   | { type: 'upsert_message'; info: MessageInfo }
   | { type: 'upsert_part'; messageId: string; part: Part }
   | { type: 'apply_delta'; messageId: string; partId: string; field: string; delta: string }
-  | { type: 'delete_part'; messageId: string; partId: string };
+  | { type: 'delete_part'; messageId: string; partId: string }
+  | { type: 'delete_message'; messageId: string };
 
 export type { SessionStorage, StorageMutation };

--- a/apps/web/src/lib/cloud-agent-sdk/transport.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/transport.ts
@@ -25,6 +25,7 @@ type Transport = {
     mode?: string;
     model?: string;
     variant?: string;
+    messageId?: string;
   }) => Promise<unknown>;
   interrupt?: () => Promise<unknown>;
   answer?: (payload: { requestId: string; answers: string[][] }) => Promise<unknown>;
@@ -50,6 +51,7 @@ type CloudAgentApi = {
     mode?: string;
     model?: string;
     variant?: string;
+    messageId?: string;
   }) => Promise<unknown>;
   interrupt: (payload: { sessionId: CloudAgentSessionId }) => Promise<unknown>;
   answer: (payload: {

--- a/apps/web/src/routers/cloud-agent-next-schemas.ts
+++ b/apps/web/src/routers/cloud-agent-next-schemas.ts
@@ -88,6 +88,7 @@ export const basePrepareSessionNextSchema = z
     upstreamBranch: z.string().optional(),
     autoCommit: z.boolean().optional(),
     autoInitiate: z.boolean().optional(),
+    initialMessageId: z.string().startsWith('msg_').length(30).optional(),
   })
   .refine(
     data => (data.githubRepo || data.gitlabProject) && !(data.githubRepo && data.gitlabProject),
@@ -124,6 +125,7 @@ export const baseSendMessageNextSchema = z.object({
     .regex(/^[a-zA-Z]+$/)
     .optional(),
   autoCommit: z.boolean().optional(),
+  messageId: z.string().startsWith('msg_').length(30).optional(),
 });
 
 // Schema for interrupting a session
@@ -191,6 +193,9 @@ export const baseGetSessionNextOutputSchema = z.object({
 
   // Callback configuration
   callbackTarget: callbackTargetNextSchema.optional(),
+
+  // Initial message ID for correlation
+  initialMessageId: z.string().startsWith('msg_').length(30).optional(),
 
   // Versioning
   timestamp: z.number(),

--- a/services/cloud-agent-next/src/execution/orchestrator.ts
+++ b/services/cloud-agent-next/src/execution/orchestrator.ts
@@ -153,6 +153,7 @@ export class ExecutionOrchestrator {
     try {
       const result = await wrapperClient.prompt({
         prompt,
+        messageId: plan.messageId,
         model: wrapper.model,
         variant: wrapper.variant,
         agent: normalizedMode,

--- a/services/cloud-agent-next/src/execution/types.ts
+++ b/services/cloud-agent-next/src/execution/types.ts
@@ -138,6 +138,7 @@ type InitiateExecutionRequest = BaseExecutionRequest & {
 type InitiatePreparedRequest = BaseExecutionRequest & {
   kind: 'initiatePrepared';
   authToken?: string;
+  messageId?: string;
 };
 
 /**
@@ -151,6 +152,7 @@ type FollowupExecutionRequest = BaseExecutionRequest & {
   variant?: string;
   autoCommit?: boolean;
   condenseOnComplete?: boolean;
+  messageId?: string;
   tokenOverrides?: {
     githubToken?: string;
     gitToken?: string;
@@ -340,6 +342,8 @@ export type ExecutionPlan = {
   wrapper: WrapperPlan;
   /** Optional image attachments */
   images?: Images;
+  /** Optional message ID for correlating the request */
+  messageId?: string;
 };
 
 // ---------------------------------------------------------------------------

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -831,6 +831,7 @@ export class CloudAgentSession extends DurableObject {
     images?: Images;
     createdOnPlatform?: string;
     gateThreshold?: 'off' | 'all' | 'warning' | 'critical';
+    initialMessageId?: string;
     // Workspace metadata (set during prepareSession)
     workspacePath?: string;
     sessionHome?: string;
@@ -889,6 +890,7 @@ export class CloudAgentSession extends DurableObject {
     githubRepo?: string;
     gitUrl?: string;
     platform?: 'github' | 'gitlab';
+    initialMessageId?: string;
   }): Promise<OperationResult> {
     await this.requireSessionId(input.sessionId as SessionId);
     const existing = await this.ctx.storage.get<CloudAgentSessionState>('metadata');
@@ -910,6 +912,7 @@ export class CloudAgentSession extends DurableObject {
       githubRepo: input.githubRepo,
       gitUrl: input.gitUrl,
       platform: input.platform,
+      initialMessageId: input.initialMessageId,
       version: now,
       timestamp: now,
       // NOTE: preparedAt is NOT set — this is the key difference from prepare()
@@ -1052,6 +1055,7 @@ export class CloudAgentSession extends DurableObject {
         sessionHome: result.sessionHome,
         branchName: result.branchName,
         sandboxId: result.sandboxId,
+        initialMessageId: input.initialMessageId,
       });
 
       if (!prepareResult.success) {
@@ -2089,6 +2093,7 @@ export class CloudAgentSession extends DurableObject {
     variant?: string;
     autoCommit?: boolean;
     condenseOnComplete?: boolean;
+    messageId?: string;
     initContext?: InitializeContext;
     resumeContext?: TokenResumeContext;
     existingMetadata?: CloudAgentSessionState;
@@ -2155,6 +2160,7 @@ export class CloudAgentSession extends DurableObject {
         autoCommit: params.autoCommit,
         condenseOnComplete: params.condenseOnComplete,
       },
+      messageId: params.messageId,
     };
   }
 
@@ -2442,6 +2448,7 @@ export class CloudAgentSession extends DurableObject {
           variant: metadata.variant,
           autoCommit: metadata.autoCommit,
           condenseOnComplete: metadata.condenseOnComplete,
+          messageId: metadata.initialMessageId,
           initContext,
           existingMetadata: metadata,
           kiloSessionId: metadata.kiloSessionId,
@@ -2521,6 +2528,7 @@ export class CloudAgentSession extends DurableObject {
         variant,
         autoCommit: request.autoCommit ?? metadata.autoCommit,
         condenseOnComplete: request.condenseOnComplete ?? metadata.condenseOnComplete,
+        messageId: request.messageId,
         resumeContext,
         existingMetadata: metadata,
         kiloSessionId: metadata.kiloSessionId,

--- a/services/cloud-agent-next/src/persistence/schemas.ts
+++ b/services/cloud-agent-next/src/persistence/schemas.ts
@@ -182,6 +182,9 @@ export const MetadataSchema = z.object({
     )
     .transform(s => s as SandboxId)
     .optional(),
+
+  // Initial message ID for correlation
+  initialMessageId: z.string().startsWith('msg_').length(30).optional(),
 });
 
 /**
@@ -226,6 +229,8 @@ export const PreparationInputSchema = z.object({
   kilocodeOrganizationId: z.string().optional(),
   // Auto-initiate after preparation
   autoInitiate: z.boolean(),
+
+  initialMessageId: z.string().optional(),
 });
 
 export type PreparationInput = z.infer<typeof PreparationInputSchema>;

--- a/services/cloud-agent-next/src/persistence/types.ts
+++ b/services/cloud-agent-next/src/persistence/types.ts
@@ -133,6 +133,9 @@ export type CloudAgentSessionState = {
   branchName?: string;
   /** Sandbox ID where the session runs */
   sandboxId?: SandboxId;
+
+  // Initial message ID for correlation
+  initialMessageId?: string;
 };
 
 /**

--- a/services/cloud-agent-next/src/router/handlers/session-execution.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-execution.ts
@@ -173,6 +173,7 @@ export function createSessionExecutionV2Handlers() {
             variant: input.variant,
             autoCommit: input.autoCommit,
             condenseOnComplete: input.condenseOnComplete,
+            messageId: input.messageId,
             tokenOverrides: {
               githubToken: input.githubToken,
               gitToken: input.gitToken,

--- a/services/cloud-agent-next/src/router/handlers/session-management.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-management.ts
@@ -440,6 +440,8 @@ export function createSessionManagementHandlers() {
 
             callbackTarget: metadata.callbackTarget,
 
+            initialMessageId: metadata.initialMessageId,
+
             timestamp: metadata.timestamp,
             version: metadata.version,
           };

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -251,6 +251,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
           githubRepo: input.githubRepo,
           gitUrl: input.gitUrl,
           platform: input.platform,
+          initialMessageId: input.initialMessageId,
         });
 
         if (!registerResult.success) {
@@ -297,6 +298,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
             gateThreshold: input.gateThreshold,
             kilocodeOrganizationId: input.kilocodeOrganizationId,
             autoInitiate: true,
+            initialMessageId: input.initialMessageId,
           });
         } catch (error) {
           await rollbackCliSession();
@@ -504,6 +506,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
           images: input.images,
           createdOnPlatform: input.createdOnPlatform,
           gateThreshold: input.gateThreshold,
+          initialMessageId: input.initialMessageId,
           // Workspace metadata
           workspacePath,
           sessionHome,

--- a/services/cloud-agent-next/src/router/schemas.ts
+++ b/services/cloud-agent-next/src/router/schemas.ts
@@ -109,6 +109,12 @@ export const SendMessageV2Input = z
     images: ImagesSchema.optional().describe(
       'Optional image attachments to download from R2 to the sandbox'
     ),
+    messageId: z
+      .string()
+      .startsWith('msg_')
+      .length(30)
+      .optional()
+      .describe('Optional message ID for correlating the request'),
   })
   .extend(PromptPayload.shape)
   .refine(rejectCustomMode, {
@@ -228,6 +234,12 @@ export const PrepareSessionInput = z
       .describe(
         'When true, return immediately after creating IDs and run preparation asynchronously. Progress events are streamed via WebSocket.'
       ),
+    initialMessageId: z
+      .string()
+      .startsWith('msg_')
+      .length(30)
+      .optional()
+      .describe('Initial message ID for correlation with external systems'),
   })
   .refine(validateGitSource, {
     message: 'Must provide either githubRepo or gitUrl, but not both',
@@ -392,6 +404,9 @@ export const GetSessionOutput = z.object({
   callbackTarget: CallbackTargetSchema.optional().describe(
     'Callback target configuration for execution completion notifications'
   ),
+
+  // Initial message ID for correlation
+  initialMessageId: z.string().startsWith('msg_').length(30).optional(),
 
   // Versioning
   timestamp: z.number().describe('Last update timestamp'),

--- a/services/cloud-agent-next/wrapper/src/kilo-api.ts
+++ b/services/cloud-agent-next/wrapper/src/kilo-api.ts
@@ -35,6 +35,7 @@ export type WrapperKiloClient = {
   getSession: (sessionId: string) => Promise<{ id: string }>;
   sendPromptAsync: (opts: {
     sessionId: string;
+    messageId?: string;
     parts?: Array<{ type: string; text: string }>;
     prompt?: string;
     variant?: string;
@@ -119,6 +120,7 @@ export function createWrapperKiloClient(
       // Use v2 client — it supports `variant` (thinking effort); v1 SDK omits it.
       await v2Client.session.promptAsync({
         sessionID: opts.sessionId,
+        messageID: opts.messageId,
         parts: textParts,
         ...(opts.variant ? { variant: opts.variant } : {}),
         ...(opts.model

--- a/services/cloud-agent-next/wrapper/src/server.ts
+++ b/services/cloud-agent-next/wrapper/src/server.ts
@@ -291,6 +291,7 @@ function createPromptHandler(config: ServerConfig, deps: ServerDependencies) {
     try {
       await kiloClient.sendPromptAsync({
         sessionId: job.kiloSessionId,
+        messageId,
         parts: body.parts,
         prompt: body.prompt,
         variant: body.variant,


### PR DESCRIPTION
## Summary

Generate message id in a browser for kilo CLI to use, so that it is easy to correlate messages later.

## Verification

- [x] Passed: `pnpm test -- apps/web/src/lib/cloud-agent-sdk/chat-processor.test.ts apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts` (67 tests; Jest reported its existing open-handle warning after success)
- [x] Passed: `pnpm typecheck`
- [x] Passed: `pnpm lint`
- [x] Passed: `pnpm format:check`
- [x] Passed: `git diff --check`
- [x] Passed: pre-push checks during `git push -u origin eshurakov/super-crayon`
- [x] User-provided verification: <add details>
