### PR TITLE
fix(kiloclaw-billing): treat destroy 404 as already gone

### DIFF
--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -11,33 +11,64 @@ vi.mock('@kilocode/db', () => ({
 import { runSweep } from './lifecycle.js';
 import type { BillingWorkerEnv } from './types.js';
 
-type SelectResult<T> = {
+let loggedValues: unknown[] = [];
+
+type SelectResult<T> = Promise<T[]> & {
   limit: ReturnType<typeof vi.fn>;
-  then: Promise<T[]>['then'];
+};
+
+type SelectBuilder = {
+  from: ReturnType<typeof vi.fn>;
+  innerJoin: ReturnType<typeof vi.fn>;
+  leftJoin: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
 };
 
 function createSelectResult<T>(rows: T[]): SelectResult<T> {
-  return {
-    limit: vi.fn(async () => rows),
-    then: Promise.resolve(rows).then.bind(Promise.resolve(rows)),
-  };
+  const result = Promise.resolve(rows) as SelectResult<T>;
+  result.limit = vi.fn(async () => rows);
+  return result;
 }
 
 function createMockDb(selectResults: unknown[][]) {
   const updates: Array<Record<string, unknown>> = [];
   const txUpdates: Array<Record<string, unknown>> = [];
+  const deletes: unknown[] = [];
   const txDeletes: unknown[] = [];
-  const select = vi.fn(() => ({
-    from: vi.fn(() => ({
-      where: vi.fn(() => createSelectResult(selectResults.shift() ?? [])),
-    })),
-  }));
+  const inserts: Array<Record<string, unknown>> = [];
+  const nextSelectResult = () => createSelectResult(selectResults.shift() ?? []);
+  const createSelectBuilder = (): SelectBuilder => {
+    const builder: SelectBuilder = {
+      from: vi.fn(() => builder),
+      innerJoin: vi.fn(() => builder),
+      leftJoin: vi.fn(() => builder),
+      where: vi.fn(() => nextSelectResult()),
+      limit: vi.fn(async () => selectResults.shift() ?? []),
+    };
+    return builder;
+  };
+  const select = vi.fn(() => createSelectBuilder());
   const update = vi.fn(() => ({
     set: vi.fn((values: Record<string, unknown>) => {
       updates.push(values);
       return {
         where: vi.fn(async () => undefined),
       };
+    }),
+  }));
+  const insert = vi.fn(() => ({
+    values: vi.fn((values: Record<string, unknown>) => {
+      inserts.push(values);
+      return {
+        onConflictDoNothing: vi.fn(async () => ({ rowCount: 1 })),
+      };
+    }),
+  }));
+  const deleteFrom = vi.fn(() => ({
+    where: vi.fn(async whereArg => {
+      deletes.push(whereArg);
+      return undefined;
     }),
   }));
   const transaction = vi.fn(
@@ -69,11 +100,15 @@ function createMockDb(selectResults: unknown[][]) {
     db: {
       select,
       update,
+      insert,
+      delete: deleteFrom,
       transaction,
     },
     updates,
     txUpdates,
+    deletes,
     txDeletes,
+    inserts,
   };
 }
 
@@ -180,6 +215,42 @@ describe('interrupted auto-resume sweep', () => {
     expect(updates[0]).not.toHaveProperty('destruction_deadline');
   });
 
+  it('keeps 404 from async resume request on the normal failure path', async () => {
+    const instanceId = '11111111-1111-4111-8111-111111111111';
+    const sandboxId = 'ki_11111111111141118111111111111111';
+    const { db, updates } = createMockDb([
+      [{ user_id: 'user-1', instance_id: instanceId, auto_resume_attempt_count: 0 }],
+      [{ id: instanceId, sandbox_id: sandboxId }],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi.fn(
+      async () =>
+        new Response('start target missing', {
+          status: 404,
+          headers: { 'content-type': 'text/plain' },
+        })
+    );
+
+    const summary = await runSweep(
+      createEnv(fetch),
+      {
+        runId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+        sweep: 'interrupted_auto_resume',
+      },
+      1
+    );
+
+    expect(summary.interrupted_auto_resume_requests).toBe(0);
+    expect(summary.errors).toBe(1);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toEqual(
+      expect.objectContaining({
+        auto_resume_attempt_count: 1,
+      })
+    );
+  });
+
   it('clears stale suspension state when no active instance remains', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
     const { db, updates, txUpdates, txDeletes } = createMockDb([
@@ -212,5 +283,189 @@ describe('interrupted auto-resume sweep', () => {
         auto_resume_attempt_count: 0,
       },
     ]);
+  });
+});
+
+describe('instance destruction sweep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetWorkerDb.mockReset();
+    loggedValues = [];
+    vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      loggedValues.push(value);
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ sent: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+    );
+  });
+
+  it('keeps DB/email cleanup unchanged when platform destroy succeeds', async () => {
+    const instanceId = '11111111-1111-4111-8111-111111111111';
+    const { db, updates, inserts, deletes } = createMockDb([
+      [
+        {
+          id: 'sub-1',
+          user_id: 'user-1',
+          instance_id: instanceId,
+          sandbox_id: 'ki_11111111111141118111111111111111',
+          email: 'user-1@example.com',
+        },
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+    );
+
+    const summary = await runSweep(
+      createEnv(fetch),
+      {
+        runId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+        sweep: 'instance_destruction',
+      },
+      1
+    );
+
+    expect(summary.errors).toBe(0);
+    expect(summary.sweep3_instance_destruction).toBe(1);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(inserts).toEqual([
+      {
+        user_id: 'user-1',
+        email_type: 'claw_instance_destroyed',
+      },
+    ]);
+    expect(updates).toHaveLength(2);
+    expect(updates[0].destroyed_at).toEqual(expect.any(String));
+    expect(updates[1]).toEqual({ destruction_deadline: null });
+    expect(deletes).toHaveLength(1);
+  });
+
+  it('treats platform destroy 404 as already gone and continues with later rows', async () => {
+    const firstInstanceId = '11111111-1111-4111-8111-111111111111';
+    const secondInstanceId = '22222222-2222-4222-8222-222222222222';
+    const { db, updates, inserts, deletes } = createMockDb([
+      [
+        {
+          id: 'sub-1',
+          user_id: 'user-1',
+          instance_id: firstInstanceId,
+          sandbox_id: 'ki_11111111111141118111111111111111',
+          email: 'user-1@example.com',
+        },
+        {
+          id: 'sub-2',
+          user_id: 'user-2',
+          instance_id: secondInstanceId,
+          sandbox_id: 'ki_22222222222242228222222222222222',
+          email: 'user-2@example.com',
+        },
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi
+      .fn<BillingWorkerEnv['KILOCLAW']['fetch']>()
+      .mockResolvedValueOnce(
+        new Response('missing', {
+          status: 404,
+          headers: { 'content-type': 'text/plain' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+
+    const summary = await runSweep(
+      createEnv(fetch),
+      {
+        runId: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+        sweep: 'instance_destruction',
+      },
+      1
+    );
+
+    expect(summary.errors).toBe(0);
+    expect(summary.sweep3_instance_destruction).toBe(2);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(loggedValues).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: 'Kiloclaw platform call failed',
+          statusCode: 404,
+        }),
+      ])
+    );
+    expect(inserts).toEqual([
+      { user_id: 'user-1', email_type: 'claw_instance_destroyed' },
+      { user_id: 'user-2', email_type: 'claw_instance_destroyed' },
+    ]);
+    expect(updates).toHaveLength(4);
+    expect(updates[0].destroyed_at).toEqual(expect.any(String));
+    expect(updates[1]).toEqual({ destruction_deadline: null });
+    expect(updates[2].destroyed_at).toEqual(expect.any(String));
+    expect(updates[3]).toEqual({ destruction_deadline: null });
+    expect(deletes).toHaveLength(2);
+  });
+
+  it('keeps non-404 platform destroy failures on the failed-row path', async () => {
+    const instanceId = '11111111-1111-4111-8111-111111111111';
+    const { db, updates, inserts, deletes } = createMockDb([
+      [
+        {
+          id: 'sub-1',
+          user_id: 'user-1',
+          instance_id: instanceId,
+          sandbox_id: 'ki_11111111111141118111111111111111',
+          email: 'user-1@example.com',
+        },
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi.fn(
+      async () =>
+        new Response('destroy failed', {
+          status: 500,
+          headers: { 'content-type': 'text/plain' },
+        })
+    );
+
+    const summary = await runSweep(
+      createEnv(fetch),
+      {
+        runId: '12121212-1212-4212-8212-121212121212',
+        sweep: 'instance_destruction',
+      },
+      1
+    );
+
+    expect(summary.errors).toBe(1);
+    expect(summary.sweep3_instance_destruction).toBe(0);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(updates).toHaveLength(0);
+    expect(inserts).toHaveLength(0);
+    expect(deletes).toHaveLength(0);
+    expect(loggedValues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: 'Kiloclaw platform call failed',
+          statusCode: 500,
+        }),
+      ])
+    );
   });
 });

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -421,7 +421,7 @@ describe('instance destruction sweep', () => {
     expect(deletes).toHaveLength(2);
   });
 
-  it('keeps non-404 platform destroy failures on the failed-row path', async () => {
+  it('logs non-404 platform destroy failures and preserves billing state transition', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
     const { db, updates, inserts, deletes } = createMockDb([
       [
@@ -452,17 +452,28 @@ describe('instance destruction sweep', () => {
       1
     );
 
-    expect(summary.errors).toBe(1);
-    expect(summary.sweep3_instance_destruction).toBe(0);
+    expect(summary.errors).toBe(0);
+    expect(summary.sweep3_instance_destruction).toBe(1);
     expect(fetch).toHaveBeenCalledTimes(1);
-    expect(globalThis.fetch).not.toHaveBeenCalled();
-    expect(updates).toHaveLength(0);
-    expect(inserts).toHaveLength(0);
-    expect(deletes).toHaveLength(0);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(inserts).toEqual([
+      {
+        user_id: 'user-1',
+        email_type: 'claw_instance_destroyed',
+      },
+    ]);
+    expect(updates).toHaveLength(2);
+    expect(updates[0].destroyed_at).toEqual(expect.any(String));
+    expect(updates[1]).toEqual({ destruction_deadline: null });
+    expect(deletes).toHaveLength(1);
     expect(loggedValues).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           message: 'Kiloclaw platform call failed',
+          statusCode: 500,
+        }),
+        expect.objectContaining({
+          message: 'Destroy instance during billing enforcement failed',
           statusCode: 500,
         }),
       ])

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -1153,12 +1153,22 @@ async function destroyInstanceForEnforcement(
 ): Promise<void> {
   if (!row.instance_id) return;
 
-  await destroyInstance(
-    env,
-    context,
-    row.user_id,
-    workerInstanceId({ id: row.instance_id, sandbox_id: row.sandbox_id })
-  );
+  try {
+    await destroyInstance(
+      env,
+      context,
+      row.user_id,
+      workerInstanceId({ id: row.instance_id, sandbox_id: row.sandbox_id })
+    );
+  } catch (error) {
+    const isExpected = error instanceof KiloClawApiError && error.statusCode === 409;
+    log(isExpected ? 'info' : 'error', 'Destroy instance during billing enforcement failed', {
+      userId: row.user_id,
+      instanceId: row.instance_id,
+      statusCode: error instanceof KiloClawApiError ? error.statusCode : null,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 async function runTrialExpirySweep(

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -405,7 +405,8 @@ async function requestKiloClaw<T>(
   context: SweepExecutionContext,
   path: string,
   init?: RequestInit,
-  entityFields: BillingEntityFields = {}
+  entityFields: BillingEntityFields = {},
+  options: { handledErrorStatuses?: readonly number[] } = {}
 ): Promise<T> {
   if (!env.KILOCLAW_INTERNAL_API_SECRET) {
     throw new Error('KILOCLAW_INTERNAL_API_SECRET is not configured');
@@ -447,15 +448,19 @@ async function requestKiloClaw<T>(
       const durationMs = performance.now() - startedAt;
       if (!response.ok) {
         const responseBody = await response.text();
-        log('error', 'Kiloclaw platform call failed', {
-          event: 'downstream_call',
-          outcome: 'failed',
-          action: init?.method ?? 'GET',
-          path,
-          statusCode: response.status,
-          durationMs,
-          ...entityFields,
-        });
+        const isHandledErrorStatus =
+          options.handledErrorStatuses?.includes(response.status) ?? false;
+        if (!isHandledErrorStatus) {
+          log('error', 'Kiloclaw platform call failed', {
+            event: 'downstream_call',
+            outcome: 'failed',
+            action: init?.method ?? 'GET',
+            path,
+            statusCode: response.status,
+            durationMs,
+            ...entityFields,
+          });
+        }
         throw new KiloClawApiError(response.status, responseBody);
       }
 
@@ -509,16 +514,36 @@ async function destroyInstance(
   instanceId?: string
 ): Promise<void> {
   const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
-  await requestKiloClaw<{ ok: true }>(
-    env,
-    context,
-    `/api/platform/destroy${params}`,
-    {
-      method: 'POST',
-      body: JSON.stringify({ userId }),
-    },
-    { userId, instanceId }
-  );
+  const path = `/api/platform/destroy${params}`;
+  try {
+    await requestKiloClaw<{ ok: true }>(
+      env,
+      context,
+      path,
+      {
+        method: 'POST',
+        body: JSON.stringify({ userId }),
+      },
+      { userId, instanceId },
+      { handledErrorStatuses: [404] }
+    );
+  } catch (error) {
+    if (error instanceof KiloClawApiError && error.statusCode === 404) {
+      log('info', 'KiloClaw instance already gone during billing destroy', {
+        event: 'downstream_call',
+        outcome: 'completed',
+        action: 'POST',
+        path,
+        statusCode: 404,
+        idempotent: true,
+        userId,
+        instanceId,
+      });
+      return;
+    }
+
+    throw error;
+  }
 }
 
 async function trySendEmail(
@@ -1128,23 +1153,12 @@ async function destroyInstanceForEnforcement(
 ): Promise<void> {
   if (!row.instance_id) return;
 
-  try {
-    await destroyInstance(
-      env,
-      context,
-      row.user_id,
-      workerInstanceId({ id: row.instance_id, sandbox_id: row.sandbox_id })
-    );
-  } catch (error) {
-    const isExpected =
-      error instanceof KiloClawApiError && (error.statusCode === 404 || error.statusCode === 409);
-    log(isExpected ? 'info' : 'error', 'Destroy instance during billing enforcement failed', {
-      userId: row.user_id,
-      instanceId: row.instance_id,
-      statusCode: error instanceof KiloClawApiError ? error.statusCode : null,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
+  await destroyInstance(
+    env,
+    context,
+    row.user_id,
+    workerInstanceId({ id: row.instance_id, sandbox_id: row.sandbox_id })
+  );
 }
 
 async function runTrialExpirySweep(


### PR DESCRIPTION
## Summary

- Make the KiloClaw billing `instance_destruction` sweep treat platform destroy `404` as an idempotent "already gone" success.
- Scope handled `404` behavior to the billing destroy call only; start/resume and other KiloClaw platform calls still use the existing non-2xx failure path.
- Preserve the existing destruction-sweep lifecycle contract: non-404 destroy failures are error-logged for monitoring, but billing DB/email cleanup still advances for the row.
- Expand lifecycle-worker tests to cover destroy 2xx, destroy 404 + continuation, destroy 500 logging + cleanup, and the unchanged auto-resume 404 failure path.

## Verification

- [x] `pnpm --filter kiloclaw-billing test -- src/lifecycle.test.ts` — passed
- [x] `pnpm --filter kiloclaw-billing test` — passed
- [x] `pnpm --filter kiloclaw-billing typecheck` — passed
- [x] `pnpm lint` — passed
- [x] `git diff --check` — passed
- [x] pre-push checks — passed affected package typecheck, format check, lint
- [ ] `pnpm typecheck` — attempted; blocked before this worker by existing/generated `apps/storybook` error for missing `../../src/app/api/cron/kiloclaw-billing-lifecycle/route.js`
- [ ] TODO: add any additional verification notes before merge

## Visual Changes

N/A

## Reviewer Notes

- The small `requestKiloClaw` API change only suppresses the generic error-level downstream log for caller-declared statuses; it still throws so callers must explicitly convert a handled status to success.
- Destroy `404` now runs the same post-destroy DB/email cleanup as 2xx and skips the generic downstream error log.
- Other destroy failures keep the prior behavior: error logging is preserved, and the destruction sweep still marks the billing instance destroyed / clears the destruction deadline per `.specs/kiloclaw-billing.md`.
- No UI changes, migrations, schema changes, or KiloClaw platform-route changes.