### PR TITLE
fix(kiloclaw): scope subscription selection to personal instances for billing mutations

### DIFF
--- a/apps/web/src/lib/kiloclaw/access-gate.ts
+++ b/apps/web/src/lib/kiloclaw/access-gate.ts
@@ -17,7 +17,8 @@ export async function requireKiloClawAccess(userId: string): Promise<void> {
   const now = new Date();
 
   // 1. Active subscription
-  const { accessReason } = await getEffectiveKiloClawSubscriptionForUser(userId, now);
+  const { subscription, accessReason, subscriptionCount } =
+    await getEffectiveKiloClawSubscriptionForUser(userId, now);
   if (accessReason) {
     return;
   }
@@ -32,6 +33,25 @@ export async function requireKiloClawAccess(userId: string): Promise<void> {
   if (earlybird && new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE) > now) {
     return;
   }
+
+  console.warn(
+    JSON.stringify({
+      event: 'kiloclaw_access_denied',
+      userId,
+      subscriptionCount,
+      effectiveSubscription: subscription
+        ? {
+            id: subscription.id,
+            status: subscription.status,
+            plan: subscription.plan,
+            suspended_at: subscription.suspended_at,
+            instance_id: subscription.instance_id,
+          }
+        : 'none',
+      accessReason,
+      earlybirdFound: !!earlybird,
+    })
+  );
 
   throw new TRPCError({
     code: 'FORBIDDEN',

--- a/apps/web/src/lib/kiloclaw/access-state.ts
+++ b/apps/web/src/lib/kiloclaw/access-state.ts
@@ -71,6 +71,7 @@ export async function getEffectiveKiloClawSubscriptionForUser(
 ): Promise<{
   subscription: KiloClawSubscription | null;
   accessReason: KiloClawAccessReason | null;
+  subscriptionCount: number;
 }> {
   const subscriptions = await db
     .select()
@@ -81,5 +82,6 @@ export async function getEffectiveKiloClawSubscriptionForUser(
   return {
     subscription,
     accessReason: getKiloClawSubscriptionAccessReason(subscription, now),
+    subscriptionCount: subscriptions.length,
   };
 }

--- a/apps/web/src/lib/kiloclaw/stripe-handlers.ts
+++ b/apps/web/src/lib/kiloclaw/stripe-handlers.ts
@@ -442,12 +442,20 @@ export async function handleKiloClawSubscriptionCreated(params: {
   let convertedFromTrial = false;
 
   await db.transaction(async tx => {
-    // Look up the user's active instance to link the subscription.
+    // Look up the user's active personal instance to link the subscription.
+    // Scoped to personal instances (organization_id IS NULL) so a checkout
+    // from the /claw page never attaches to an org-owned instance.  If no
+    // personal instance exists the subscription is inserted with
+    // instance_id = NULL and adoptOrphanedSubscription handles it later.
     const [activeInstance] = await tx
       .select({ id: kiloclaw_instances.id })
       .from(kiloclaw_instances)
       .where(
-        and(eq(kiloclaw_instances.user_id, kiloUserId), isNull(kiloclaw_instances.destroyed_at))
+        and(
+          eq(kiloclaw_instances.user_id, kiloUserId),
+          isNull(kiloclaw_instances.destroyed_at),
+          isNull(kiloclaw_instances.organization_id)
+        )
       )
       .limit(1);
 

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -214,6 +214,77 @@ function makeStripeSubscription(params: {
   } as unknown as Stripe.Subscription;
 }
 
+async function createKiloclawInstance(userId: string, destroyedAt?: string) {
+  const [instance] = await db
+    .insert(kiloclaw_instances)
+    .values({
+      user_id: userId,
+      sandbox_id: `test-sandbox-${crypto.randomUUID()}`,
+      destroyed_at: destroyedAt,
+    })
+    .returning();
+
+  if (!instance) {
+    throw new Error('Failed to insert KiloClaw instance');
+  }
+
+  return instance;
+}
+
+async function createCanceledTrialAndPaidSubscriptions(params?: {
+  userId?: string;
+  paidStatus?: 'active' | 'past_due' | 'unpaid';
+  paidPlan?: 'standard' | 'commit';
+  paidStripeSubscriptionId?: string;
+  paidCancelAtPeriodEnd?: boolean;
+  paidStripeScheduleId?: string;
+  paidScheduledPlan?: 'standard' | 'commit';
+  paidScheduledBy?: 'user' | 'auto';
+}) {
+  const userId = params?.userId ?? user.id;
+  const trialInstance = await createKiloclawInstance(userId, '2026-04-01T00:00:00.000Z');
+  const paidInstance = await createKiloclawInstance(userId);
+
+  const [trialSubscription, paidSubscription] = await db
+    .insert(kiloclaw_subscriptions)
+    .values([
+      {
+        user_id: userId,
+        instance_id: trialInstance.id,
+        plan: 'trial',
+        status: 'canceled',
+        trial_started_at: '2026-03-01T00:00:00.000Z',
+        trial_ends_at: '2026-03-08T00:00:00.000Z',
+      },
+      {
+        user_id: userId,
+        instance_id: paidInstance.id,
+        stripe_subscription_id:
+          params?.paidStripeSubscriptionId ?? `sub-paid-${crypto.randomUUID()}`,
+        plan: params?.paidPlan ?? 'standard',
+        status: params?.paidStatus ?? 'active',
+        cancel_at_period_end: params?.paidCancelAtPeriodEnd ?? false,
+        stripe_schedule_id: params?.paidStripeScheduleId,
+        scheduled_plan: params?.paidScheduledPlan,
+        scheduled_by: params?.paidScheduledBy,
+        current_period_start: '2026-04-01T00:00:00.000Z',
+        current_period_end: '2026-05-01T00:00:00.000Z',
+      },
+    ])
+    .returning();
+
+  if (!trialSubscription || !paidSubscription) {
+    throw new Error('Failed to insert paired KiloClaw subscriptions');
+  }
+
+  return {
+    trialInstance,
+    paidInstance,
+    trialSubscription,
+    paidSubscription,
+  };
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe('getBillingStatus', () => {
@@ -251,6 +322,34 @@ describe('getBillingStatus', () => {
     const result = await caller.kiloclaw.getBillingStatus();
 
     expect(result).not.toBeNull();
+    expect(result.trialEligible).toBe(false);
+  });
+
+  it('returns trialEligible false when user only has an org-backed subscription', async () => {
+    const organization = await createOrganization('Org Trial Test', user.id);
+    const orgInstance = await db
+      .insert(kiloclaw_instances)
+      .values({
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `test-sandbox-${crypto.randomUUID()}`,
+      })
+      .returning()
+      .then(rows => rows[0]!);
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: orgInstance.id,
+      stripe_subscription_id: 'sub_org_trial_test',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.getBillingStatus();
+
+    // Must be false — ensureProvisionAccess checks ALL subscriptions (including
+    // org) and would block trial creation, so trialEligible must agree.
     expect(result.trialEligible).toBe(false);
   });
 
@@ -292,6 +391,99 @@ describe('getBillingStatus', () => {
     expect(result.accessReason).toBe('subscription');
     expect(result.subscription?.status).toBe('active');
     expect(result.subscription?.currentPeriodEnd).toBe('2026-05-01T00:00:00.000Z');
+  });
+
+  it('prefers an active paid subscription over a canceled trial on a destroyed instance', async () => {
+    const { trialInstance } = await createCanceledTrialAndPaidSubscriptions({
+      paidStripeSubscriptionId: 'sub_status_effective_paid',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.getBillingStatus();
+
+    expect(result.hasAccess).toBe(true);
+    expect(result.accessReason).toBe('subscription');
+    expect(result.subscription?.status).toBe('active');
+    expect(result.subscription?.currentPeriodEnd).toBe('2026-05-01T00:00:00.000Z');
+    expect(result.instance?.exists).toBe(true);
+    expect(result.instance?.destroyed).toBe(false);
+
+    const adoptedTrialRows = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.instance_id, trialInstance.id));
+    expect(adoptedTrialRows).toHaveLength(1);
+  });
+});
+
+describe('requireKiloClawAccess', () => {
+  it('logs structured subscription diagnostics before rejecting', async () => {
+    const { requireKiloClawAccess } = await import('@/lib/kiloclaw/access-gate');
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      const destroyedInstance = await createKiloclawInstance(user.id, '2026-04-01T00:00:00.000Z');
+      await db.insert(kiloclaw_subscriptions).values([
+        {
+          user_id: user.id,
+          instance_id: destroyedInstance.id,
+          plan: 'trial',
+          status: 'canceled',
+          trial_started_at: '2026-03-01T00:00:00.000Z',
+          trial_ends_at: '2026-03-08T00:00:00.000Z',
+        },
+        {
+          user_id: user.id,
+          instance_id: null,
+          plan: 'standard',
+          status: 'canceled',
+          current_period_end: '2026-04-01T00:00:00.000Z',
+          suspended_at: '2026-04-02T00:00:00.000Z',
+        },
+      ]);
+
+      await expect(requireKiloClawAccess(user.id)).rejects.toThrow(
+        'KiloClaw access requires an active subscription, trial, or earlybird purchase.'
+      );
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const [warnArg] = warnSpy.mock.calls[0] ?? [];
+      expect(typeof warnArg).toBe('string');
+      const parsed = JSON.parse(warnArg as string) as {
+        event: string;
+        userId: string;
+        subscriptionCount: number;
+        effectiveSubscription:
+          | {
+              id: string;
+              status: string;
+              plan: string;
+              suspended_at: string | null;
+              instance_id: string | null;
+            }
+          | 'none';
+        accessReason: string | null;
+        earlybirdFound: boolean;
+      };
+
+      expect(parsed).toMatchObject({
+        event: 'kiloclaw_access_denied',
+        userId: user.id,
+        subscriptionCount: 2,
+        accessReason: null,
+        earlybirdFound: false,
+      });
+      expect(parsed.effectiveSubscription).not.toBe('none');
+      expect(parsed.effectiveSubscription).toMatchObject({
+        status: 'canceled',
+        plan: 'standard',
+        suspended_at: expect.stringContaining('2026-04-02'),
+        instance_id: null,
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 
@@ -1235,6 +1427,47 @@ describe('handleKiloClawSubscriptionCreated', () => {
     // Should NOT create a schedule
     expect(stripeMock.subscriptionSchedules.create).not.toHaveBeenCalled();
   });
+
+  it('does not attach a personal subscription to an org-owned instance', async () => {
+    const organization = await createOrganization('Org Webhook Test', user.id);
+    const orgInstance = await db
+      .insert(kiloclaw_instances)
+      .values({
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `test-sandbox-${crypto.randomUUID()}`,
+      })
+      .returning()
+      .then(rows => rows[0]!);
+
+    const subscription = makeStripeSubscription({
+      id: 'sub_personal_checkout',
+      metadata: { type: 'kiloclaw', plan: 'standard', kiloUserId: user.id },
+      status: 'active',
+      priceId: 'price_standard',
+    });
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard' } }] },
+    });
+
+    await handleKiloClawSubscriptionCreated({
+      eventId: 'evt_org_scope_test',
+      subscription,
+    });
+
+    // The subscription should be inserted with instance_id = NULL (no personal
+    // instance available), not attached to the org instance.
+    const rows = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.stripe_subscription_id, 'sub_personal_checkout'));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.instance_id).toBeNull();
+    expect(rows[0]!.instance_id).not.toBe(orgInstance.id);
+  });
 });
 
 describe('cancelSubscription', () => {
@@ -1265,6 +1498,33 @@ describe('cancelSubscription', () => {
       .limit(1);
 
     expect(row.cancel_at_period_end).toBe(true);
+  });
+
+  it('cancels the effective paid subscription when a canceled trial also exists', async () => {
+    const { paidSubscription, trialSubscription } = await createCanceledTrialAndPaidSubscriptions({
+      paidStripeSubscriptionId: 'sub_effective_cancel',
+    });
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({ schedule: null });
+    stripeMock.subscriptions.update.mockResolvedValue({});
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.cancelSubscription();
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptions.update).toHaveBeenCalledWith('sub_effective_cancel', {
+      cancel_at_period_end: true,
+    });
+
+    const rows = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+    const updatedPaid = rows.find(row => row.id === paidSubscription.id);
+    const unchangedTrial = rows.find(row => row.id === trialSubscription.id);
+
+    expect(updatedPaid?.cancel_at_period_end).toBe(true);
+    expect(unchangedTrial?.cancel_at_period_end).toBe(false);
   });
 
   it('releases user-initiated plan switch schedule on cancel', async () => {
@@ -1440,6 +1700,37 @@ describe('reactivateSubscription', () => {
     expect(stripeMock.subscriptionSchedules.create).toHaveBeenCalled();
   });
 
+  it('reactivates the effective paid subscription when a canceled trial also exists', async () => {
+    const { paidSubscription, trialSubscription } = await createCanceledTrialAndPaidSubscriptions({
+      paidStripeSubscriptionId: 'sub_reactivate_effective',
+      paidCancelAtPeriodEnd: true,
+    });
+
+    stripeMock.subscriptions.update.mockResolvedValue({});
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard' } }] },
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.reactivateSubscription();
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptions.update).toHaveBeenCalledWith('sub_reactivate_effective', {
+      cancel_at_period_end: false,
+    });
+
+    const rows = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+    const updatedPaid = rows.find(row => row.id === paidSubscription.id);
+    const unchangedTrial = rows.find(row => row.id === trialSubscription.id);
+
+    expect(updatedPaid?.cancel_at_period_end).toBe(false);
+    expect(unchangedTrial?.cancel_at_period_end).toBe(false);
+  });
+
   it('succeeds even if ensureAutoIntroSchedule throws after reactivation', async () => {
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
@@ -1464,6 +1755,14 @@ describe('reactivateSubscription', () => {
       .where(eq(kiloclaw_subscriptions.user_id, user.id))
       .limit(1);
     expect(row.cancel_at_period_end).toBe(false);
+  });
+
+  it('rejects when the user has no subscriptions', async () => {
+    const caller = await createCallerForUser(user.id);
+
+    await expect(caller.kiloclaw.reactivateSubscription()).rejects.toThrow(
+      'No pending cancellation to reactivate.'
+    );
   });
 });
 
@@ -1501,6 +1800,43 @@ describe('switchPlan', () => {
     expect(dbRow.stripe_schedule_id).toBe('sub_sched_new');
     expect(dbRow.scheduled_plan).toBe('commit');
     expect(dbRow.scheduled_by).toBe('user');
+  });
+
+  it('switches the effective paid subscription when a canceled trial also exists', async () => {
+    const { paidSubscription, trialSubscription } = await createCanceledTrialAndPaidSubscriptions({
+      paidStripeSubscriptionId: 'sub_switch_effective',
+      paidPlan: 'standard',
+    });
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard' } }] },
+    });
+    stripeMock.subscriptionSchedules.create.mockResolvedValue({
+      id: 'sub_sched_effective',
+      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+    });
+    stripeMock.subscriptionSchedules.update.mockResolvedValue({});
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.switchPlan({ toPlan: 'commit' });
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptionSchedules.create).toHaveBeenCalledWith({
+      from_subscription: 'sub_switch_effective',
+    });
+
+    const rows = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+    const updatedPaid = rows.find(row => row.id === paidSubscription.id);
+    const unchangedTrial = rows.find(row => row.id === trialSubscription.id);
+
+    expect(updatedPaid?.stripe_schedule_id).toBe('sub_sched_effective');
+    expect(updatedPaid?.scheduled_plan).toBe('commit');
+    expect(updatedPaid?.scheduled_by).toBe('user');
+    expect(unchangedTrial?.scheduled_plan).toBeNull();
   });
 
   it('rejects switch when user-initiated schedule already exists', async () => {
@@ -1752,6 +2088,41 @@ describe('cancelPlanSwitch', () => {
     expect(row.scheduled_by).toBeNull();
   });
 
+  it('cancels the effective paid plan switch when a canceled trial also exists', async () => {
+    const { paidSubscription, trialSubscription } = await createCanceledTrialAndPaidSubscriptions({
+      paidStripeSubscriptionId: 'sub_cancel_switch_effective',
+      paidStripeScheduleId: 'sched_effective_user_switch',
+      paidScheduledPlan: 'commit',
+      paidScheduledBy: 'user',
+    });
+
+    stripeMock.subscriptionSchedules.release.mockResolvedValue({});
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard' } }] },
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.cancelPlanSwitch();
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptionSchedules.release).toHaveBeenCalledWith(
+      'sched_effective_user_switch'
+    );
+
+    const rows = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+    const updatedPaid = rows.find(row => row.id === paidSubscription.id);
+    const unchangedTrial = rows.find(row => row.id === trialSubscription.id);
+
+    expect(updatedPaid?.stripe_schedule_id).toBeNull();
+    expect(updatedPaid?.scheduled_plan).toBeNull();
+    expect(updatedPaid?.scheduled_by).toBeNull();
+    expect(unchangedTrial?.scheduled_plan).toBeNull();
+  });
+
   it('restores auto schedule when canceling switch during intro month', async () => {
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
@@ -1890,6 +2261,260 @@ describe('createSubscriptionCheckout — concurrent checkout guard', () => {
     await expect(caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' })).rejects.toThrow(
       'You already have an active subscription'
     );
+  });
+
+  it('rejects when a canceled trial and an active paid subscription both exist locally', async () => {
+    await createCanceledTrialAndPaidSubscriptions({
+      paidStripeSubscriptionId: 'sub_checkout_blocked',
+    });
+
+    const caller = await createCallerForUser(user.id);
+
+    await expect(caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' })).rejects.toThrow(
+      'You already have an active subscription'
+    );
+
+    expect(stripeMock.subscriptions.list).not.toHaveBeenCalled();
+    expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects when a canceled trial and a past-due paid subscription both exist locally', async () => {
+    await createCanceledTrialAndPaidSubscriptions({
+      paidStatus: 'past_due',
+      paidStripeSubscriptionId: 'sub_checkout_past_due',
+    });
+
+    const caller = await createCallerForUser(user.id);
+
+    await expect(caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' })).rejects.toThrow(
+      'You already have an active subscription'
+    );
+
+    expect(stripeMock.subscriptions.list).not.toHaveBeenCalled();
+    expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects when a canceled trial and an unpaid paid subscription both exist locally', async () => {
+    await createCanceledTrialAndPaidSubscriptions({
+      paidStatus: 'unpaid',
+      paidStripeSubscriptionId: 'sub_checkout_unpaid',
+    });
+
+    const caller = await createCallerForUser(user.id);
+
+    await expect(caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' })).rejects.toThrow(
+      'You already have an active subscription'
+    );
+
+    expect(stripeMock.subscriptions.list).not.toHaveBeenCalled();
+    expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it('does not block personal checkout when only an org-backed subscription is active', async () => {
+    const organization = await createOrganization('Org Checkout Test', user.id);
+    const orgInstance = await db
+      .insert(kiloclaw_instances)
+      .values({
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `test-sandbox-${crypto.randomUUID()}`,
+      })
+      .returning()
+      .then(rows => rows[0]!);
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: orgInstance.id,
+      stripe_subscription_id: 'sub_org_active',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    stripeMock.subscriptions.list.mockResolvedValue({ data: [] });
+    stripeMock.checkout.sessions.list.mockResolvedValue({ data: [] });
+    stripeMock.checkout.sessions.create.mockResolvedValue({
+      id: 'cs_personal',
+      url: 'https://checkout.stripe.com/personal',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' });
+
+    expect(result).toEqual({ url: 'https://checkout.stripe.com/personal' });
+    expect(stripeMock.checkout.sessions.create).toHaveBeenCalled();
+  });
+});
+
+// ── org-subscription coexistence ──────────────────────────────────────────
+
+describe('personal billing mutations do not affect org subscriptions', () => {
+  async function createPersonalAndOrgSubscriptions(overrides?: {
+    personalCancelAtPeriodEnd?: boolean;
+    personalScheduledPlan?: 'standard' | 'commit';
+    personalScheduledBy?: 'user' | 'auto';
+    personalStripeScheduleId?: string;
+  }) {
+    const organization = await createOrganization('Org Coexistence', user.id);
+    const orgInstance = await db
+      .insert(kiloclaw_instances)
+      .values({
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `test-sandbox-${crypto.randomUUID()}`,
+      })
+      .returning()
+      .then(rows => rows[0]!);
+
+    const personalInstance = await createKiloclawInstance(user.id);
+
+    const [orgSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: orgInstance.id,
+        stripe_subscription_id: 'sub_org_coexist',
+        plan: 'standard',
+        status: 'active',
+        current_period_end: '2026-06-01T00:00:00.000Z',
+      })
+      .returning();
+
+    const [personalSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: personalInstance.id,
+        stripe_subscription_id: 'sub_personal_coexist',
+        plan: 'standard',
+        status: 'active',
+        cancel_at_period_end: overrides?.personalCancelAtPeriodEnd ?? false,
+        stripe_schedule_id: overrides?.personalStripeScheduleId,
+        scheduled_plan: overrides?.personalScheduledPlan,
+        scheduled_by: overrides?.personalScheduledBy,
+        current_period_start: '2026-04-01T00:00:00.000Z',
+        current_period_end: '2026-05-01T00:00:00.000Z',
+      })
+      .returning();
+
+    return { orgInstance, personalInstance, orgSub: orgSub!, personalSub: personalSub! };
+  }
+
+  it('cancelSubscription targets the personal subscription, not the org one', async () => {
+    const { orgSub, personalSub } = await createPersonalAndOrgSubscriptions();
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({ schedule: null });
+    stripeMock.subscriptions.update.mockResolvedValue({});
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.cancelSubscription();
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptions.update).toHaveBeenCalledWith('sub_personal_coexist', {
+      cancel_at_period_end: true,
+    });
+
+    const rows = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+    const updatedPersonal = rows.find(row => row.id === personalSub.id);
+    const unchangedOrg = rows.find(row => row.id === orgSub.id);
+
+    expect(updatedPersonal?.cancel_at_period_end).toBe(true);
+    expect(unchangedOrg?.cancel_at_period_end).toBe(false);
+  });
+
+  it('reactivateSubscription targets the personal subscription, not the org one', async () => {
+    const { orgSub, personalSub } = await createPersonalAndOrgSubscriptions({
+      personalCancelAtPeriodEnd: true,
+    });
+
+    stripeMock.subscriptions.update.mockResolvedValue({});
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard' } }] },
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.reactivateSubscription();
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptions.update).toHaveBeenCalledWith('sub_personal_coexist', {
+      cancel_at_period_end: false,
+    });
+
+    const rows = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+    const updatedPersonal = rows.find(row => row.id === personalSub.id);
+    const unchangedOrg = rows.find(row => row.id === orgSub.id);
+
+    expect(updatedPersonal?.cancel_at_period_end).toBe(false);
+    expect(unchangedOrg?.cancel_at_period_end).toBe(false);
+  });
+
+  it('switchPlan targets the personal subscription, not the org one', async () => {
+    const { orgSub, personalSub } = await createPersonalAndOrgSubscriptions();
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard' } }] },
+    });
+    stripeMock.subscriptionSchedules.create.mockResolvedValue({
+      id: 'sub_sched_personal',
+      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+    });
+    stripeMock.subscriptionSchedules.update.mockResolvedValue({});
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.switchPlan({ toPlan: 'commit' });
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptionSchedules.create).toHaveBeenCalledWith({
+      from_subscription: 'sub_personal_coexist',
+    });
+
+    const rows = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+    const updatedPersonal = rows.find(row => row.id === personalSub.id);
+    const unchangedOrg = rows.find(row => row.id === orgSub.id);
+
+    expect(updatedPersonal?.scheduled_plan).toBe('commit');
+    expect(unchangedOrg?.scheduled_plan).toBeNull();
+  });
+
+  it('cancelPlanSwitch targets the personal subscription, not the org one', async () => {
+    const { orgSub, personalSub } = await createPersonalAndOrgSubscriptions({
+      personalStripeScheduleId: 'sched_personal_switch',
+      personalScheduledPlan: 'commit',
+      personalScheduledBy: 'user',
+    });
+
+    stripeMock.subscriptionSchedules.release.mockResolvedValue({});
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard' } }] },
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.cancelPlanSwitch();
+
+    expect(result).toEqual({ success: true });
+    expect(stripeMock.subscriptionSchedules.release).toHaveBeenCalledWith('sched_personal_switch');
+
+    const rows = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+    const updatedPersonal = rows.find(row => row.id === personalSub.id);
+    const unchangedOrg = rows.find(row => row.id === orgSub.id);
+
+    expect(updatedPersonal?.stripe_schedule_id).toBeNull();
+    expect(updatedPersonal?.scheduled_plan).toBeNull();
+    expect(unchangedOrg?.scheduled_plan).toBeNull();
   });
 });
 

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -196,6 +196,93 @@ async function getOrCreateInstanceForBilling(userId: string): Promise<ActiveKilo
   return newInstance;
 }
 
+type PersonalBillingInstanceRow = {
+  id: string;
+  destroyed_at: string | null;
+};
+
+async function getLatestPersonalBillingInstance(
+  userId: string
+): Promise<PersonalBillingInstanceRow | null> {
+  const [instance] = await db
+    .select({
+      id: kiloclaw_instances.id,
+      destroyed_at: kiloclaw_instances.destroyed_at,
+    })
+    .from(kiloclaw_instances)
+    .where(and(eq(kiloclaw_instances.user_id, userId), isNull(kiloclaw_instances.organization_id)))
+    .orderBy(desc(kiloclaw_instances.created_at))
+    .limit(1);
+
+  return instance ?? null;
+}
+
+async function getDisplayedPersonalKiloclawSubscription(params: {
+  userId: string;
+  now?: Date;
+}): Promise<{
+  latestPersonalInstance: PersonalBillingInstanceRow | null;
+  subscription: typeof kiloclaw_subscriptions.$inferSelect | null;
+}> {
+  const now = params.now ?? new Date();
+  const latestPersonalInstance = await getLatestPersonalBillingInstance(params.userId);
+
+  if (latestPersonalInstance && !latestPersonalInstance.destroyed_at) {
+    await adoptOrphanedSubscription(params.userId, latestPersonalInstance.id);
+  }
+
+  const subscriptions = await db
+    .select()
+    .from(kiloclaw_subscriptions)
+    .where(eq(kiloclaw_subscriptions.user_id, params.userId));
+
+  const subscription =
+    latestPersonalInstance && !latestPersonalInstance.destroyed_at
+      ? (subscriptions.find(row => row.instance_id === latestPersonalInstance.id) ??
+        getEffectiveKiloClawSubscription(subscriptions, now))
+      : getEffectiveKiloClawSubscription(subscriptions, now);
+
+  if (subscription?.instance_id && latestPersonalInstance?.id !== subscription.instance_id) {
+    const [instance] = await db
+      .select({ organization_id: kiloclaw_instances.organization_id })
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.id, subscription.instance_id))
+      .limit(1);
+
+    if (instance?.organization_id) {
+      return {
+        latestPersonalInstance,
+        subscription: null,
+      };
+    }
+  }
+
+  return {
+    latestPersonalInstance,
+    subscription,
+  };
+}
+
+async function hasBlockingPersonalKiloclawSubscription(userId: string): Promise<boolean> {
+  const [blockingSubscription] = await db
+    .select({ id: kiloclaw_subscriptions.id })
+    .from(kiloclaw_subscriptions)
+    .leftJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, userId),
+        inArray(kiloclaw_subscriptions.status, ['active', 'past_due', 'unpaid']),
+        or(
+          isNull(kiloclaw_subscriptions.instance_id),
+          and(eq(kiloclaw_instances.user_id, userId), isNull(kiloclaw_instances.organization_id))
+        )
+      )
+    )
+    .limit(1);
+
+  return !!blockingSubscription;
+}
+
 /**
  * Map KiloClawApiError responses to TRPCErrors for file operations.
  * Always throws — call as `handleFileOperationError(err, 'read file')`.
@@ -2509,40 +2596,12 @@ export const kiloclawRouter = createTRPCRouter({
   // ── Billing endpoints ────────────────────────────────────────────────
 
   getBillingStatus: baseProcedure.query(async ({ ctx }) => {
-    // Scope to personal instances only (organization_id IS NULL) so an org
-    // instance is never used for personal billing status or orphan adoption.
-    const [activeInstance] = await db
-      .select({
-        id: kiloclaw_instances.id,
-        destroyed_at: kiloclaw_instances.destroyed_at,
-      })
-      .from(kiloclaw_instances)
-      .where(
-        and(eq(kiloclaw_instances.user_id, ctx.user.id), isNull(kiloclaw_instances.organization_id))
-      )
-      .orderBy(desc(kiloclaw_instances.created_at))
-      .limit(1);
-
-    // If an active personal instance exists, adopt any orphaned subscription
-    // before reading billing status.
-    if (activeInstance && !activeInstance.destroyed_at) {
-      await adoptOrphanedSubscription(ctx.user.id, activeInstance.id);
-    }
-
-    // Query subscription scoped to the active instance when possible.
-    // Falls back to the user's effective subscription when no active instance exists
-    // (e.g. user never provisioned — billing status is still useful for
-    // showing trial eligibility).
     const now = new Date();
-    const subscriptions = await db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id));
-    const sub =
-      activeInstance && !activeInstance.destroyed_at
-        ? (subscriptions.find(subscription => subscription.instance_id === activeInstance.id) ??
-          getEffectiveKiloClawSubscription(subscriptions, now))
-        : getEffectiveKiloClawSubscription(subscriptions, now);
+    const { latestPersonalInstance: activeInstance, subscription: sub } =
+      await getDisplayedPersonalKiloclawSubscription({
+        userId: ctx.user.id,
+        now,
+      });
 
     const [earlybird] = await db
       .select({ id: kiloclaw_earlybird_purchases.id })
@@ -2642,6 +2701,16 @@ export const kiloclawRouter = createTRPCRouter({
       };
     }
 
+    // Trial eligibility must match ensureProvisionAccess (spec Trial Eligibility
+    // rule 2): no subscription of any kind, including org-backed ones.  The
+    // personal-scoped `sub` above intentionally hides org subscriptions for
+    // billing display, so we need a separate user-wide existence check here.
+    const [anySubscription] = await db
+      .select({ id: kiloclaw_subscriptions.id })
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
+      .limit(1);
+
     // First-month credit discount eligibility (spec Credit Enrollment rule 3).
     const creditIntroEligible = !(await hadPriorPaidSubscription(ctx.user.id));
     const creditBalanceMicrodollars =
@@ -2671,7 +2740,7 @@ export const kiloclawRouter = createTRPCRouter({
     return {
       hasAccess,
       accessReason,
-      trialEligible: !activeInstance && !sub && !earlybird,
+      trialEligible: !activeInstance && !anySubscription && !earlybird,
       creditBalanceMicrodollars,
       creditIntroEligible,
       hasActiveKiloPass,
@@ -2911,13 +2980,7 @@ export const kiloclawRouter = createTRPCRouter({
 
       // Reject checkout if any non-ended subscription exists (active, past_due, unpaid).
       // The trialing status is exempted so trial users can convert to paid.
-      const [existing] = await db
-        .select({ status: kiloclaw_subscriptions.status, plan: kiloclaw_subscriptions.plan })
-        .from(kiloclaw_subscriptions)
-        .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
-        .limit(1);
-
-      if (existing && existing.status !== 'canceled' && existing.status !== 'trialing') {
+      if (await hasBlockingPersonalKiloclawSubscription(ctx.user.id)) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'You already have an active subscription.',
@@ -3073,7 +3136,8 @@ export const kiloclawRouter = createTRPCRouter({
       // registry row and reassign any existing subscription to it.
       const instance = await getOrCreateInstanceForBilling(ctx.user.id);
 
-      // Reject if this instance already has a non-ended KiloClaw subscription
+      // Reject if this instance already has a non-ended KiloClaw subscription.
+      // Safe with LIMIT 1: kiloclaw_subscriptions has a partial unique index on instance_id.
       const [existing] = await db
         .select({ status: kiloclaw_subscriptions.status })
         .from(kiloclaw_subscriptions)
@@ -3149,11 +3213,9 @@ export const kiloclawRouter = createTRPCRouter({
     }),
 
   cancelSubscription: baseProcedure.mutation(async ({ ctx }) => {
-    const [sub] = await db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
-      .limit(1);
+    const { subscription: sub } = await getDisplayedPersonalKiloclawSubscription({
+      userId: ctx.user.id,
+    });
 
     if (!sub || sub.status !== 'active') {
       throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active subscription to cancel.' });
@@ -3379,11 +3441,9 @@ export const kiloclawRouter = createTRPCRouter({
   }),
 
   reactivateSubscription: baseProcedure.mutation(async ({ ctx }) => {
-    const [sub] = await db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
-      .limit(1);
+    const { subscription: sub } = await getDisplayedPersonalKiloclawSubscription({
+      userId: ctx.user.id,
+    });
 
     if (!sub || sub.status !== 'active' || !sub.cancel_at_period_end) {
       throw new TRPCError({
@@ -3431,11 +3491,9 @@ export const kiloclawRouter = createTRPCRouter({
   switchPlan: baseProcedure
     .input(z.object({ toPlan: z.enum(['commit', 'standard']) }))
     .mutation(async ({ ctx, input }) => {
-      const [sub] = await db
-        .select()
-        .from(kiloclaw_subscriptions)
-        .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
-        .limit(1);
+      const { subscription: sub } = await getDisplayedPersonalKiloclawSubscription({
+        userId: ctx.user.id,
+      });
 
       if (!sub || sub.status !== 'active') {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active subscription to switch.' });
@@ -3641,11 +3699,9 @@ export const kiloclawRouter = createTRPCRouter({
     }),
 
   cancelPlanSwitch: baseProcedure.mutation(async ({ ctx }) => {
-    const [sub] = await db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
-      .limit(1);
+    const { subscription: sub } = await getDisplayedPersonalKiloclawSubscription({
+      userId: ctx.user.id,
+    });
 
     if (!sub?.scheduled_plan) {
       throw new TRPCError({ code: 'BAD_REQUEST', message: 'No pending plan switch to cancel.' });


### PR DESCRIPTION
## Summary

Fix subscription-selection bugs causing users with multiple `kiloclaw_subscriptions` rows to hit spurious "need a paid subscription" errors after destroying and recreating their KiloClaw instance.

**Root cause:** `LIMIT 1` queries without `ORDER BY` non-deterministically picked a canceled trial over an active paid subscription.

## Verification

- [ ] CI with full test database

## Visual Changes

N/A

## Code Reviewer Notes

<details>
<summary>Detailed technical context for code review</summary>

### Architecture

The `/claw` personal billing page scopes everything to personal instances (`organization_id IS NULL`). Before this fix, the billing mutation endpoints used user-wide subscription queries that could pick up org-backed subscriptions or the wrong personal subscription.

Three new private helper functions in `kiloclaw-router.ts` replace the user-wide `getEffectiveKiloClawSubscriptionForUser` for billing mutations:

1. **`getLatestPersonalBillingInstance(userId)`** — finds the user's most recent personal instance, matching the same query `getBillingStatus` previously inlined.

2. **`getDisplayedPersonalKiloclawSubscription({ userId, now? })`** — resolves the subscription the `/claw` page actually displays: tries the subscription attached to the active personal instance first, falls back to `getEffectiveKiloClawSubscription` across all rows. Runs `adoptOrphanedSubscription` on the active-instance path. This is the key invariant: mutations target the same row the UI shows.

3. **`hasBlockingPersonalKiloclawSubscription(userId)`** — LEFT JOIN through `kiloclaw_instances` to match only personal (`organization_id IS NULL`) or detached (`instance_id IS NULL`) subscriptions with blocking statuses (`active`, `past_due`, `unpaid`).

### Scope boundaries

- **Access gate (`requireKiloClawAccess`)** intentionally remains user-wide. If a user has any active subscription (personal or org), they should be allowed to interact with their instance. Only billing mutations are scoped to personal.
- **Instance-scoped `*AtInstance` endpoints** (e.g., `cancelSubscriptionAtInstance`) already use `getKiloclawPersonalSubscriptionRow` which filters by instance ID + `organization_id IS NULL` — these were already correct and unchanged.
- **`getEffectiveKiloClawSubscriptionForUser`** import removed from the router; still used correctly in `access-gate.ts`.

### Key files

| File | Change |
|------|--------|
| `access-state.ts` | Added `subscriptionCount` to return type |
| `access-gate.ts` | Structured `console.warn` before FORBIDDEN throw |
| `kiloclaw-router.ts` | 3 new helpers, 5 endpoint fixes, `getBillingStatus` refactored to use shared helper |
| `kiloclaw-billing-router.test.ts` | +555 lines: 15 new test cases |

### Test coverage added

- **Multi-subscription selection:** canceled trial + active paid for `cancel`, `reactivate`, `switchPlan`, `cancelPlanSwitch`, `getBillingStatus`, `createSubscriptionCheckout` (including `past_due` and `unpaid` variants)
- **Org coexistence:** all 5 mutation endpoints verified to target personal subscription and leave org subscription untouched
- **Access gate logging:** verifies structured JSON output with expected diagnostic fields
- **No-subscription edge case:** `reactivateSubscription` with zero subscriptions

### Risk areas

- The `getDisplayedPersonalKiloclawSubscription` helper duplicates the instance-lookup + adoption + subscription-selection pattern from `getBillingStatus`. If `getBillingStatus`'s selection logic changes in the future, the helper must be updated in lockstep. Consider whether to extract `getBillingStatus` to call this helper (deferred to keep this PR focused on the bug fix).
- The `hasBlockingPersonalKiloclawSubscription` LEFT JOIN assumes that a subscription with `instance_id IS NULL` is personal. This matches current behavior: org subscriptions always have an `instance_id` pointing to an org-owned instance.

</details>