### PR TITLE
fix(kiloclaw): clarify subscription-required dialog title

### DIFF
--- a/apps/web/src/app/(app)/claw/components/billing/AccessLockedDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/AccessLockedDialog.tsx
@@ -99,7 +99,7 @@ function getLockContent(reason: ClawLockReason, billing: ClawBillingStatus) {
       };
     case 'no_access':
       return {
-        title: 'Subscription Required',
+        title: 'KiloClaw Subscription Required',
         description:
           'A KiloClaw subscription is required to continue. Subscribe to keep your instance running.',
         cta: 'Subscribe',


### PR DESCRIPTION
## Summary

- Rename the no-access KiloClaw modal heading to "KiloClaw Subscription Required."
- Architectural changes: N/A.

## Verification

- [x] `pnpm --filter web typecheck` passed.
- [x] `git diff --check` passed.
- [ ] `pnpm typecheck` attempted; blocked by an existing Storybook generated-route type error.
- [ ] Additional verification: TODO.

## Visual Changes

| Before | After |
| ------ | ----- |
| Modal heading: "Subscription Required" | Modal heading: "KiloClaw Subscription Required" |

## Reviewer Notes

- Copy-only change; billing behavior is unchanged.