### PR TITLE
ci(deploy): remove gastown from worker deploy workflow

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -20,7 +20,6 @@ on:
           - services/db-proxy
           - services/deploy-infra/builder
           - services/deploy-infra/dispatcher
-          - services/gastown
           - services/git-token-service
           - services/gmail-push
           - services/images-mcp
@@ -104,7 +103,6 @@ jobs:
             services/db-proxy
             services/deploy-infra/builder
             services/deploy-infra/dispatcher
-            services/gastown
             services/git-token-service
             services/gmail-push
             services/images-mcp


### PR DESCRIPTION
## Summary

Remove `services/gastown` from the deploy-workers workflow. This prevents gastown from being auto-deployed on push to main and removes it from the manual dispatch dropdown.

## Verification

- Confirmed gastown was removed from both the `workflow_dispatch` input choices and the `WORKERS` array in the `detect-changes` job.

## Visual Changes

N/A

## Reviewer Notes

N/A