### PR TITLE
change links in kiloclaw

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawDashboard.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawDashboard.tsx
@@ -16,7 +16,6 @@ import { ClawHeader } from './ClawHeader';
 import { CreateInstanceCard } from './CreateInstanceCard';
 import { InstanceControls } from './InstanceControls';
 import { InstanceTab } from './InstanceTab';
-import { OpenClawButton } from './OpenClawButton';
 import { ChangelogTab } from './ChangelogTab';
 import { SubscriptionTab } from './SubscriptionTab';
 import { ChannelPairingStep } from './ChannelPairingStep';
@@ -326,13 +325,20 @@ function ClawDashboardInner({
                 </div>
               )}
               <div className="flex w-full flex-col gap-3">
-                <OpenClawButton
-                  canShow={gatewayStatus?.state === 'running'}
-                  gatewayUrl={gatewayUrl}
-                  look="hero"
-                  label="Open KiloClaw"
-                  className="w-full py-6 text-base"
-                />
+                {gatewayStatus?.state === 'running' && (
+                  <Button
+                    variant="primary"
+                    className="w-full min-w-[180px] bg-emerald-600 py-6 text-base text-white hover:bg-emerald-700"
+                    onClick={() => {
+                      const base = organizationId
+                        ? `/organizations/${organizationId}/claw`
+                        : '/claw';
+                      window.location.href = `${base}/chat`;
+                    }}
+                  >
+                    Open KiloClaw
+                  </Button>
+                )}
                 <Button
                   className="w-full py-6 text-base"
                   variant="outline"

--- a/services/kiloclaw/google-setup/setup.mjs
+++ b/services/kiloclaw/google-setup/setup.mjs
@@ -722,7 +722,7 @@ console.log('  Your bot can now use Gmail, Calendar, Drive, Docs, Sheets, and mo
 console.log('');
 console.log('  Next steps:');
 console.log('  1. Redeploy your kiloclaw instance to activate Google services');
-console.log('     Go to: https://app.kilo.ai/claw#settings');
+console.log('     Go to: https://app.kilo.ai/claw/settings');
 if (pushSetupOk) {
   console.log('  2. Gmail push notifications have been enabled automatically.');
 } else {


### PR DESCRIPTION
this PR does two things:
1. it updates the link in the docker set up script
2. it changes the "open kiloclaw" at the end of the onboarding flow to the chat link 