### PR TITLE
feat(gastown): Add Small Model configuration field to user-facing town settings page

### DIFF
--- a/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -264,6 +264,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
   const [gitlabToken, setGitlabToken] = useState('');
   const [gitlabInstanceUrl, setGitlabInstanceUrl] = useState('');
   const [defaultModel, setDefaultModel] = useState('');
+  const [smallModel, setSmallModel] = useState('');
   const [mayorModel, setMayorModel] = useState('');
   const [refineryModel, setRefineryModel] = useState('');
   const [polecatModel, setPolecatModel] = useState('');
@@ -298,6 +299,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
     setGitlabInstanceUrl(cfg.git_auth?.gitlab_instance_url ?? '');
     setDefaultModel(cfg.default_model ?? '');
     savedModelRef.current = cfg.default_model ?? '';
+    setSmallModel(cfg.small_model ?? '');
     setMayorModel(cfg.role_models?.mayor ?? '');
     setRefineryModel(cfg.role_models?.refinery ?? '');
     setPolecatModel(cfg.role_models?.polecat ?? '');
@@ -352,6 +354,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
           gitlab_instance_url: gitlabInstanceUrl,
         },
         default_model: defaultModel,
+        small_model: smallModel || undefined,
         role_models: {
           mayor: mayorModel || undefined,
           refinery: refineryModel || undefined,
@@ -666,6 +669,27 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
                         onValueChange={setDefaultModel}
                         isLoading={isLoadingModels}
                         placeholder="Select a model"
+                        className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
+                      />
+                    )}
+                  </FieldGroup>
+
+                  <FieldGroup label="Small Model" hint="Lightweight model for titles, summaries, and explore subagent. Defaults to Claude Haiku if not set.">
+                    {modelsError ? (
+                      <Input
+                        value={smallModel}
+                        onChange={e => setSmallModel(e.target.value)}
+                        placeholder="e.g. anthropic/claude-haiku-4.5"
+                        className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
+                      />
+                    ) : (
+                      <ModelCombobox
+                        label=""
+                        models={modelOptions}
+                        value={smallModel}
+                        onValueChange={setSmallModel}
+                        isLoading={isLoadingModels}
+                        placeholder="Default (Claude Haiku)"
                         className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
                       />
                     )}

--- a/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -675,24 +675,37 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
                   </FieldGroup>
 
                   <FieldGroup label="Small Model" hint="Lightweight model for titles, summaries, and explore subagent. Defaults to Claude Haiku if not set.">
-                    {modelsError ? (
-                      <Input
-                        value={smallModel}
-                        onChange={e => setSmallModel(e.target.value)}
-                        placeholder="e.g. anthropic/claude-haiku-4.5"
-                        className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
-                      />
-                    ) : (
-                      <ModelCombobox
-                        label=""
-                        models={modelOptions}
-                        value={smallModel}
-                        onValueChange={setSmallModel}
-                        isLoading={isLoadingModels}
-                        placeholder="Default (Claude Haiku)"
-                        className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
-                      />
-                    )}
+                    <div className="flex items-center gap-2">
+                      <div className="flex-1">
+                        {modelsError ? (
+                          <Input
+                            value={smallModel}
+                            onChange={e => setSmallModel(e.target.value)}
+                            placeholder="e.g. anthropic/claude-haiku-4.5"
+                            className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
+                          />
+                        ) : (
+                          <ModelCombobox
+                            label=""
+                            models={modelOptions}
+                            value={smallModel}
+                            onValueChange={setSmallModel}
+                            isLoading={isLoadingModels}
+                            placeholder="Default (Claude Haiku)"
+                            className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
+                          />
+                        )}
+                      </div>
+                      {smallModel && (
+                        <button
+                          onClick={() => setSmallModel('')}
+                          className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                          title="Reset to default"
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      )}
+                    </div>
                   </FieldGroup>
 
                   <Accordion type="single" collapsible className="border-none">


### PR DESCRIPTION
## Summary

Adds a "Small Model" configuration field to the user-facing town settings page at . This allows users to configure the lightweight model used for title generation, summaries, and the explore subagent.

The field follows the same pattern as the existing "Default Model" field:
- State management with 
- Initialization from config ()
- Included in the save handler ()
- UI field with  and fallback  for error states

## Verification

- 
> kilocode-monorepo@0.1.0 typecheck /workspace/rigs/d1e0e21b-a220-4bda-ae66-be1d470cda90/worktrees/gt__toast__b767846c
> scripts/typecheck-all.sh


> @kilocode/trpc@0.0.1 build /workspace/rigs/d1e0e21b-a220-4bda-ae66-be1d470cda90/worktrees/gt__toast__b767846c/packages/trpc
> tsgo -p tsconfig.json && rollup -c rollup.config.mjs

[typecheck] checking all workspace packages
Scope: 31 of 33 workspace projects
apps/mobile typecheck$ tsgo --noEmit
apps/storybook typecheck$ tsgo --noEmit
packages/db typecheck$ tsgo --noEmit
packages/encryption typecheck$ tsgo --noEmit
packages/encryption typecheck: Done
packages/kiloclaw-secret-catalog typecheck$ tsgo --noEmit
packages/kiloclaw-secret-catalog typecheck: Done
packages/worker-utils typecheck$ tsgo --noEmit
packages/db typecheck: Done
services/cloud-agent-next/wrapper typecheck$ tsgo --noEmit
packages/worker-utils typecheck: Done
services/cloud-agent/wrapper typecheck$ tsgo --noEmit
services/cloud-agent/wrapper typecheck: Done
services/deploy-infra/dispatcher typecheck$ tsgo --noEmit
services/cloud-agent-next/wrapper typecheck: Done
services/gastown/container typecheck$ tsc --noEmit
apps/mobile typecheck: Done
services/gmail-push typecheck$ tsgo --noEmit
services/deploy-infra/dispatcher typecheck: Done
services/images-mcp typecheck$ tsgo --noEmit
services/images-mcp typecheck: Done
services/gmail-push typecheck: Done
services/gastown/container typecheck: Done
apps/storybook typecheck: Done
services/app-builder typecheck$ tsgo --noEmit
services/auto-fix-infra typecheck$ tsgo --noEmit
services/auto-triage-infra typecheck$ tsgo --noEmit
services/ai-attribution typecheck$ tsgo --noEmit
services/auto-fix-infra typecheck: Done
services/cloud-agent typecheck$ tsgo --noEmit && pnpm -C wrapper run typecheck
services/auto-triage-infra typecheck: Done
services/cloud-agent-next typecheck$ tsgo --noEmit && pnpm -C wrapper run typecheck
services/ai-attribution typecheck: Done
services/code-review-infra typecheck$ tsgo --noEmit
services/app-builder typecheck: Done
services/db-proxy typecheck$ tsgo --noEmit
services/code-review-infra typecheck: Done
services/deploy-infra/builder typecheck$ tsgo --noEmit
services/db-proxy typecheck: Done
services/gastown typecheck$ tsgo --noEmit
services/deploy-infra/builder typecheck: Done
services/git-token-service typecheck$ tsgo --noEmit
services/cloud-agent typecheck: > @kilocode/cloud-agent-wrapper@1.0.0 typecheck /workspace/rigs/d1e0e21b-a220-4bda-ae66-be1d470cda90/worktrees/gt__toast__b767846c/services/cloud-agent/wrapper
services/cloud-agent typecheck: > tsgo --noEmit
services/git-token-service typecheck: Done
services/kiloclaw typecheck$ tsgo --noEmit
services/cloud-agent-next typecheck: > @kilocode/cloud-agent-wrapper@1.0.0 typecheck /workspace/rigs/d1e0e21b-a220-4bda-ae66-be1d470cda90/worktrees/gt__toast__b767846c/services/cloud-agent-next/wrapper
services/cloud-agent-next typecheck: > tsgo --noEmit
services/cloud-agent typecheck: Done
services/kiloclaw-billing typecheck$ tsgo --noEmit
services/gastown typecheck: Done
services/o11y typecheck$ tsgo --noEmit
services/cloud-agent-next typecheck: Done
services/security-auto-analysis typecheck$ tsgo --noEmit
services/o11y typecheck: Done
services/security-sync typecheck$ tsgo --noEmit
services/kiloclaw-billing typecheck: Done
services/session-ingest typecheck$ tsgo --noEmit
services/security-auto-analysis typecheck: Done
services/webhook-agent-ingest typecheck$ tsgo --noEmit
services/security-sync typecheck: Done
services/session-ingest typecheck: Done
services/kiloclaw typecheck: Done
services/webhook-agent-ingest typecheck: Done passes
- The "Small Model" field appears in the "Agent Defaults" section between "Default Model" and the role overrides accordion
- Empty/unset values use the default fallback (Claude Haiku)

## Visual Changes

N/A

## Reviewer Notes

N/A