### PR TITLE
feat(admin): add KiloClaw subscription management and tabbed user detail layout

### DIFF
--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import { PaymentMethodStatusBadge } from '@/components/admin/PaymentMethodStatusBadge';
 import { UserStatusBadge } from '@/components/admin/UserStatusBadge';
 import { CopyTextButton } from '@/components/admin/CopyEmailButton';
@@ -10,44 +10,52 @@ import ResetAPIKeyButton from './ResetAPIKeyButton';
 import ResetToMagicLinkLoginButton from './ResetToMagicLinkLoginButton';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
-import { Webhook } from 'lucide-react';
+import { SquareArrowOutUpRight, Webhook } from 'lucide-react';
+import { createHash } from 'crypto';
+
+function getGravatarUrl(email: string, size: number = 80): string {
+  const hash = createHash('md5').update(email.toLowerCase().trim()).digest('hex');
+  return `https://www.gravatar.com/avatar/${hash}?s=${size}&d=mp`;
+}
 
 type UserAdminAccountInfoProps = UserDetailProps;
 
 export function UserAdminAccountInfo(user: UserAdminAccountInfoProps) {
+  const gravatarUrl = getGravatarUrl(user.google_user_email);
+  const stripeUrl = `https://dashboard.stripe.com/${process.env.NODE_ENV === 'development' ? 'test/' : ''}customers/${user.stripe_customer_id}`;
+  const hibpUrl = `https://haveibeenpwned.com/account/${encodeURIComponent(user.google_user_email)}`;
+
   return (
     <Card
-      className={`flex-1 ${user.blocked_reason || user.is_blacklisted_by_domain ? 'border-red-500 bg-red-950/50' : ''}`}
+      className={
+        user.blocked_reason || user.is_blacklisted_by_domain ? 'border-red-500 bg-red-950/50' : ''
+      }
     >
-      <CardHeader>
-        <div className="flex flex-wrap items-center gap-4">
-          <div className="flex min-w-max items-center gap-4">
+      <CardContent className="pt-5">
+        {/* Top row: identity + badges/actions */}
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
             <img
               src={user.google_user_image_url}
               alt={user.google_user_name}
-              className="h-16 w-16 rounded-full"
+              className="h-12 w-12 rounded-full"
               onError={e => {
                 const target = e.target as HTMLImageElement;
                 target.src = '/default-avatar.svg';
               }}
             />
             <div>
-              <CardTitle className="text-2xl">{user.google_user_name}</CardTitle>
-              <div className="flex items-center gap-2">
-                <CardDescription className="text-lg">{user.google_user_email}</CardDescription>
+              <h2 className="text-lg font-semibold leading-tight">{user.google_user_name}</h2>
+              <div className="flex items-center gap-1">
+                <span className="text-muted-foreground text-sm">{user.google_user_email}</span>
                 <CopyTextButton text={user.google_user_email} />
               </div>
             </div>
           </div>
-          <div className="ml-auto flex min-w-min shrink flex-wrap items-center gap-2">
+
+          <div className="flex flex-wrap items-center gap-2">
             <UserStatusBadge is_detail={true} user={user} />
             <PaymentMethodStatusBadge paymentMethodStatus={user.paymentMethodStatus} />
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent>
-        <div className="flex flex-row-reverse flex-wrap justify-between gap-6">
-          <div className="flex grow basis-auto flex-col items-end space-y-2">
             <ResetAPIKeyButton userId={user.id} />
             {!user.is_sso_protected_domain && <ResetToMagicLinkLoginButton userId={user.id} />}
             <Button variant="outline" size="sm" asChild>
@@ -57,75 +65,95 @@ export function UserAdminAccountInfo(user: UserAdminAccountInfoProps) {
             </Button>
             <Button variant="outline" size="sm" asChild>
               <Link href={`/admin/users/${encodeURIComponent(user.id)}/webhooks`}>
-                <Webhook className="mr-2 h-4 w-4" />
-                View webhooks
+                <Webhook className="mr-1 h-3.5 w-3.5" />
+                Webhooks
               </Link>
             </Button>
+            <a
+              href={stripeUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-md bg-purple-950 px-2.5 py-1.5 text-xs font-medium text-purple-200 transition-colors hover:bg-purple-900"
+            >
+              Stripe
+              <SquareArrowOutUpRight size={12} />
+            </a>
+            <a
+              href={hibpUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-md bg-orange-950 px-2.5 py-1.5 text-xs font-medium text-orange-200 transition-colors hover:bg-orange-900"
+              title="Check if this email has been exposed in any data breaches"
+            >
+              HIBP
+              <SquareArrowOutUpRight size={12} />
+            </a>
+            <img
+              src={gravatarUrl}
+              alt={`Gravatar for ${user.google_user_name}`}
+              className="border-border h-7 w-7 rounded-full border"
+              title="Gravatar"
+            />
           </div>
-          <div className="grow basis-auto space-y-4">
-            <div>
-              <h4 className="text-muted-foreground text-sm font-medium">Updated At</h4>
-              <p>{formatDate(user.updated_at)}</p>
-            </div>
-            <div>
-              <h4 className="text-muted-foreground text-sm font-medium">Hosted Domain</h4>
-              <p>
-                {user.hosted_domain || 'N/A'}{' '}
-                {user.hosted_domain && <CopyTextButton text={user.hosted_domain} />}
-              </p>
-            </div>
-          </div>
-          <div className="grow basis-auto space-y-4">
-            <div>
-              <h4 className="text-muted-foreground text-sm font-medium">User ID</h4>
-              <p className="font-mono text-sm break-all">
-                {user.id} <CopyTextButton text={user.id} />
-              </p>
-            </div>
-            <div>
-              <h4 className="text-muted-foreground text-sm font-medium">Email</h4>
-              <div className="flex items-center gap-2">
-                <p className="break-all">{user.google_user_email}</p>
-                <CopyTextButton text={user.google_user_email} />
-              </div>
-            </div>
-            <div>
-              <h4 className="text-muted-foreground text-sm font-medium">Created At</h4>
-              <p>{formatDate(user.created_at)}</p>
-            </div>
-            <div>
-              <h4 className="text-muted-foreground text-sm font-medium">
-                OpenRouter Upstream Safety Identifier
-              </h4>
-              {user.openrouter_upstream_safety_identifier ? (
-                <div className="flex items-center gap-2">
-                  <p className="font-mono text-sm break-all">
-                    {user.openrouter_upstream_safety_identifier}
-                  </p>
-                  <CopyTextButton text={user.openrouter_upstream_safety_identifier} />
-                </div>
-              ) : (
-                <p className="text-muted-foreground">N/A</p>
-              )}
-            </div>
-            <div>
-              <h4 className="text-muted-foreground text-sm font-medium">
-                Vercel Downstream Safety Identifier
-              </h4>
-              {user.vercel_downstream_safety_identifier ? (
-                <div className="flex items-center gap-2">
-                  <p className="font-mono text-sm break-all">
-                    {user.vercel_downstream_safety_identifier}
-                  </p>
-                  <CopyTextButton text={user.vercel_downstream_safety_identifier} />
-                </div>
-              ) : (
-                <p className="text-muted-foreground">N/A</p>
-              )}
-            </div>
-          </div>
+        </div>
+
+        {/* Metadata grid */}
+        <div className="mt-4 grid grid-cols-2 gap-x-8 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
+          <Field label="User ID" mono>
+            {user.id} <CopyTextButton text={user.id} />
+          </Field>
+          <Field label="Email">
+            {user.google_user_email} <CopyTextButton text={user.google_user_email} />
+          </Field>
+          <Field label="Hosted Domain">
+            {user.hosted_domain || 'N/A'}
+            {user.hosted_domain ? <CopyTextButton text={user.hosted_domain} /> : null}
+          </Field>
+          <Field label="Created">{formatDate(user.created_at)}</Field>
+          <Field label="Updated">{formatDate(user.updated_at)}</Field>
+          <Field label="OpenRouter Upstream Safety ID" mono>
+            {user.openrouter_upstream_safety_identifier ? (
+              <>
+                {user.openrouter_upstream_safety_identifier}
+                <CopyTextButton text={user.openrouter_upstream_safety_identifier} />
+              </>
+            ) : (
+              <span className="text-muted-foreground">N/A</span>
+            )}
+          </Field>
+          <Field label="Vercel Downstream Safety ID" mono>
+            {user.vercel_downstream_safety_identifier ? (
+              <>
+                {user.vercel_downstream_safety_identifier}
+                <CopyTextButton text={user.vercel_downstream_safety_identifier} />
+              </>
+            ) : (
+              <span className="text-muted-foreground">N/A</span>
+            )}
+          </Field>
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+function Field({
+  label,
+  mono,
+  children,
+}: {
+  label: string;
+  mono?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-w-0">
+      <h4 className="text-muted-foreground text-xs font-medium">{label}</h4>
+      <div
+        className={`flex items-center gap-1 text-sm break-all ${mono ? 'font-mono text-xs' : ''}`}
+      >
+        {children}
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminDashboard.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminDashboard.tsx
@@ -1,17 +1,4 @@
 import type { UserDetailProps } from '@/types/admin';
-import { UserAdminExternalLinks } from './UserAdminExternalLinks';
-import { UserAdminCreditGrant } from './UserAdminCreditGrant';
-import { UserAdminCreditTransactions } from './UserAdminCreditTransactions';
-import { UserAdminPaymentMethods } from './UserAdminPaymentMethods';
-import { UserAdminUsageBilling } from './UserAdminUsageBilling';
-import { UserAdminAccountInfo } from './UserAdminAccountInfo';
-import { UserAdminNotes } from './UserAdminNotes';
-import { UserAdminGdprRemoval } from './UserAdminGdprRemoval';
-import { UserAdminReferrals } from './UserAdminReferrals';
-import { UserAdminStytchFingerprints } from './UserAdminStytchFingerprints';
-import { UserAdminInvoices } from './UserAdminInvoices';
-import { promoCreditCategories } from '@/lib/promoCreditCategories';
-import { toGuiCreditCategory } from '@/lib/PromoCreditCategoryConfig';
 import AdminPage from '@/app/admin/components/AdminPage';
 import {
   BreadcrumbItem,
@@ -19,10 +6,11 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
-import { UserAdminOrganizations } from '@/app/admin/components/UserAdmin/UserAdminOrganizations';
-import { UserAdminKiloPass } from '@/app/admin/components/UserAdmin/UserAdminKiloPass';
-import { UserAdminKiloClaw } from '@/app/admin/components/UserAdmin/UserAdminKiloClaw';
-import { UserAdminGastown } from '@/app/admin/components/UserAdmin/UserAdminGastown';
+import { UserAdminTabbedSections } from '@/app/admin/components/UserAdmin/UserAdminTabbedSections';
+import { promoCreditCategories } from '@/lib/promoCreditCategories';
+import { toGuiCreditCategory } from '@/lib/PromoCreditCategoryConfig';
+
+const guiCreditCategories = promoCreditCategories.map(toGuiCreditCategory);
 
 export function UserAdminDashboard({ ...user }: UserDetailProps) {
   const breadcrumbs = (
@@ -39,31 +27,8 @@ export function UserAdminDashboard({ ...user }: UserDetailProps) {
 
   return (
     <AdminPage breadcrumbs={breadcrumbs}>
-      <div className="flex w-full flex-col gap-y-8">
-        <div className="flex flex-wrap gap-8">
-          <UserAdminAccountInfo {...user} />
-          <UserAdminExternalLinks {...user} />
-        </div>
-
-        <div className="grid grid-cols-1 gap-8 lg:grid-cols-4">
-          <UserAdminOrganizations organization_memberships={user.organization_memberships} />
-          <UserAdminNotes {...user} />
-          <UserAdminGdprRemoval {...user} />
-          <UserAdminKiloPass userId={user.id} />
-          <UserAdminKiloClaw userId={user.id} />
-          <UserAdminUsageBilling {...user} />
-          <UserAdminCreditGrant
-            {...user}
-            promoCreditCategories={promoCreditCategories.map(toGuiCreditCategory)}
-          />
-          <UserAdminStytchFingerprints {...user} />
-          <UserAdminCreditTransactions {...user} />
-          <UserAdminPaymentMethods {...user} />
-          <UserAdminInvoices stripe_customer_id={user.stripe_customer_id} />
-          <UserAdminReferrals kilo_user_id={user.id} />
-        </div>
-
-        <UserAdminGastown userId={user.id} />
+      <div className="flex w-full flex-col gap-y-4">
+        <UserAdminTabbedSections {...user} promoCreditCategories={guiCreditCategories} />
       </div>
     </AdminPage>
   );

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminExternalLinks.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminExternalLinks.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import { SquareArrowOutUpRight } from 'lucide-react';
 import type { UserDetailProps } from '@/types/admin';
 import { createHash } from 'crypto';
@@ -17,42 +17,33 @@ export function UserAdminExternalLinks({
 
   return (
     <Card className="h-fit">
-      <CardHeader>
-        <CardTitle>External Links </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-3">
-            <a
-              href={`https://dashboard.stripe.com/${process.env.NODE_ENV === 'development' ? 'test/' : ''}customers/${stripe_customer_id}`}
-              target="_blank"
-              className="inline-flex items-center justify-between gap-2 rounded-md bg-purple-950 px-4 py-3 text-sm font-medium text-purple-200 transition-colors hover:bg-purple-900"
-            >
-              View in Stripe
-              <SquareArrowOutUpRight size={16} />
-            </a>
-
-            <a
-              href={`https://haveibeenpwned.com/account/${encodeURIComponent(google_user_email)}`}
-              target="_blank"
-              className="inline-flex items-center justify-between gap-2 rounded-md bg-orange-950 px-4 py-3 text-sm font-medium text-orange-200 transition-colors hover:bg-orange-900"
-              title="Check if this email has been exposed in any data breaches"
-            >
-              <span className="flex items-center gap-2">Check on Have I Been Pwned</span>
-              <SquareArrowOutUpRight size={16} />
-            </a>
-            <div className="bg-background flex items-center gap-3 rounded-md p-3">
-              <div className="flex-1">
-                <p className="text-foreground text-sm font-medium">Gravatar</p>
-                <p className="text-muted-foreground truncate text-xs">{google_user_email}</p>
-              </div>
-              <img
-                src={gravatarUrl}
-                alt={`Gravatar for ${google_user_name}`}
-                className="border-border h-16 w-16 rounded-full border-2"
-              />
-            </div>
-          </div>
+      <CardContent className="flex flex-wrap items-center gap-3 pt-5">
+        <a
+          href={`https://dashboard.stripe.com/${process.env.NODE_ENV === 'development' ? 'test/' : ''}customers/${stripe_customer_id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 rounded-md bg-purple-950 px-3 py-2 text-sm font-medium text-purple-200 transition-colors hover:bg-purple-900"
+        >
+          Stripe
+          <SquareArrowOutUpRight size={14} />
+        </a>
+        <a
+          href={`https://haveibeenpwned.com/account/${encodeURIComponent(google_user_email)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 rounded-md bg-orange-950 px-3 py-2 text-sm font-medium text-orange-200 transition-colors hover:bg-orange-900"
+          title="Check if this email has been exposed in any data breaches"
+        >
+          HIBP
+          <SquareArrowOutUpRight size={14} />
+        </a>
+        <div className="flex items-center gap-2">
+          <img
+            src={gravatarUrl}
+            alt={`Gravatar for ${google_user_name}`}
+            className="border-border h-8 w-8 rounded-full border"
+          />
+          <span className="text-muted-foreground text-xs">Gravatar</span>
         </div>
       </CardContent>
     </Card>

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
@@ -138,12 +138,16 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
   );
 
   const handleTrialSave = () => {
-    if (!selectedDate) {
+    if (!selectedDate || !trialSubscriptionId) {
       toast.error('Select a trial end date');
       return;
     }
     const trialEndsAt = localDateInputToEndOfDayIso(selectedDate);
-    updateTrialEndAt.mutate({ userId, trial_ends_at: trialEndsAt });
+    updateTrialEndAt.mutate({
+      userId,
+      subscriptionId: trialSubscriptionId,
+      trial_ends_at: trialEndsAt,
+    });
   };
 
   const handleCancelConfirm = () => {
@@ -160,9 +164,9 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
     setTrialDialogOpen(true);
   };
 
-  const openCancelDialog = (subscriptionId: string) => {
+  const openCancelDialog = (subscriptionId: string, status: string) => {
     setCancelSubscriptionId(subscriptionId);
-    setCancelMode('period_end');
+    setCancelMode(status === 'past_due' ? 'immediate' : 'period_end');
     setCancelDialogOpen(true);
   };
 
@@ -347,7 +351,7 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
                             variant="outline"
                             size="sm"
                             className="border-red-500/30 text-red-400 hover:bg-red-950/30"
-                            onClick={() => openCancelDialog(sub.id)}
+                            onClick={() => openCancelDialog(sub.id, sub.status)}
                           >
                             Cancel
                           </Button>
@@ -357,7 +361,7 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
                             variant="outline"
                             size="sm"
                             className="border-red-500/30 text-red-400 hover:bg-red-950/30"
-                            onClick={() => openCancelDialog(sub.id)}
+                            onClick={() => openCancelDialog(sub.id, sub.status)}
                           >
                             Cancel Immediately
                           </Button>
@@ -470,21 +474,30 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
           </DialogHeader>
           <div className="space-y-3 py-4">
             <Label>Cancellation timing</Label>
-            <RadioButtonGroup
-              options={[
-                { value: 'period_end', label: 'At period end' },
-                { value: 'immediate', label: 'Immediately' },
-              ]}
-              value={cancelMode}
-              onChange={v => {
-                if (isCancelMode(v)) setCancelMode(v);
-              }}
-            />
-            <p className="text-muted-foreground text-xs">
-              {cancelMode === 'period_end'
-                ? 'No refund. The user keeps access until the current billing period ends.'
-                : 'No refund. Local access ends now. The lifecycle will suspend/stop the instance on its next run.'}
-            </p>
+            {cancelingSubscription?.status === 'past_due' ? (
+              <p className="text-muted-foreground text-xs">
+                Past-due subscriptions can only be canceled immediately. No refund. Local access
+                ends now. The lifecycle will suspend/stop the instance on its next run.
+              </p>
+            ) : (
+              <>
+                <RadioButtonGroup
+                  options={[
+                    { value: 'period_end', label: 'At period end' },
+                    { value: 'immediate', label: 'Immediately' },
+                  ]}
+                  value={cancelMode}
+                  onChange={v => {
+                    if (isCancelMode(v)) setCancelMode(v);
+                  }}
+                />
+                <p className="text-muted-foreground text-xs">
+                  {cancelMode === 'period_end'
+                    ? 'No refund. The user keeps access until the current billing period ends.'
+                    : 'No refund. Local access ends now. The lifecycle will suspend/stop the instance on its next run.'}
+                </p>
+              </>
+            )}
           </div>
           <DialogFooter>
             <Button

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
@@ -17,13 +17,14 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { RadioButtonGroup } from '@/components/ui/RadioGroup';
 import { useTRPC } from '@/lib/trpc/utils';
 import { formatDate } from '@/lib/admin-utils';
 import { toast } from 'sonner';
 
 const DEFAULT_TRIAL_DAYS = 7;
 
-function formatDateOrDash(date: string | null): string {
+function formatDateOrDash(date: string | null | undefined): string {
   return date ? formatDate(date) : '—';
 }
 
@@ -60,28 +61,47 @@ function getSubscriptionStatusBadgeClass(status: string) {
   }
 }
 
+const CANCEL_MODES = ['period_end', 'immediate'] as const;
+type CancelMode = (typeof CANCEL_MODES)[number];
+function isCancelMode(value: string): value is CancelMode {
+  return (CANCEL_MODES as readonly string[]).includes(value);
+}
+
 export function UserAdminKiloClaw({ userId }: { userId: string }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
-  const [dialogOpen, setDialogOpen] = useState(false);
+
+  // Trial edit dialog
+  const [trialDialogOpen, setTrialDialogOpen] = useState(false);
+  const [trialSubscriptionId, setTrialSubscriptionId] = useState<string | null>(null);
   const [selectedDate, setSelectedDate] = useState('');
+
+  // Cancel dialog
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+  const [cancelSubscriptionId, setCancelSubscriptionId] = useState<string | null>(null);
+  const [cancelMode, setCancelMode] = useState<CancelMode>('period_end');
+
+  // Hide inactive toggle
+  const [hideInactive, setHideInactive] = useState(true);
 
   const { data, isLoading, error } = useQuery(
     trpc.admin.users.getKiloClawState.queryOptions({ userId })
   );
 
-  useEffect(() => {
-    if (!dialogOpen) return;
+  const trialSubscription = data?.subscriptions?.find(s => s.id === trialSubscriptionId);
 
-    const currentTrialEndAt = data?.subscription?.trial_ends_at;
-    if (currentTrialEndAt && data?.subscription?.status !== 'canceled') {
+  useEffect(() => {
+    if (!trialDialogOpen) return;
+
+    const currentTrialEndAt = trialSubscription?.trial_ends_at;
+    if (currentTrialEndAt && trialSubscription?.status !== 'canceled') {
       setSelectedDate(toLocalDateInputValue(currentTrialEndAt));
     } else {
       const defaultTrialEnd = new Date();
       defaultTrialEnd.setDate(defaultTrialEnd.getDate() + DEFAULT_TRIAL_DAYS);
       setSelectedDate(toLocalDateInputValue(defaultTrialEnd.toISOString()));
     }
-  }, [data?.subscription?.trial_ends_at, data?.subscription?.status, dialogOpen]);
+  }, [trialSubscription?.trial_ends_at, trialSubscription?.status, trialDialogOpen]);
 
   const updateTrialEndAt = useMutation(
     trpc.admin.users.updateKiloClawTrialEndAt.mutationOptions({
@@ -89,7 +109,7 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
         await queryClient.invalidateQueries({
           queryKey: trpc.admin.users.getKiloClawState.queryKey({ userId }),
         });
-        setDialogOpen(false);
+        setTrialDialogOpen(false);
         toast.success('KiloClaw trial end date updated');
       },
       onError: mutationError => {
@@ -98,22 +118,57 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
     })
   );
 
-  const handleSave = () => {
+  const cancelSubscription = useMutation(
+    trpc.admin.users.cancelKiloClawSubscription.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: trpc.admin.users.getKiloClawState.queryKey({ userId }),
+        });
+        setCancelDialogOpen(false);
+        toast.success(
+          cancelMode === 'immediate'
+            ? 'KiloClaw subscription canceled immediately'
+            : 'KiloClaw subscription set to cancel at period end'
+        );
+      },
+      onError: mutationError => {
+        toast.error(mutationError.message || 'Failed to cancel KiloClaw subscription');
+      },
+    })
+  );
+
+  const handleTrialSave = () => {
     if (!selectedDate) {
       toast.error('Select a trial end date');
       return;
     }
-
     const trialEndsAt = localDateInputToEndOfDayIso(selectedDate);
-    updateTrialEndAt.mutate({
+    updateTrialEndAt.mutate({ userId, trial_ends_at: trialEndsAt });
+  };
+
+  const handleCancelConfirm = () => {
+    if (!cancelSubscriptionId) return;
+    cancelSubscription.mutate({
       userId,
-      trial_ends_at: trialEndsAt,
+      subscriptionId: cancelSubscriptionId,
+      mode: cancelMode,
     });
+  };
+
+  const openTrialDialog = (subscriptionId: string) => {
+    setTrialSubscriptionId(subscriptionId);
+    setTrialDialogOpen(true);
+  };
+
+  const openCancelDialog = (subscriptionId: string) => {
+    setCancelSubscriptionId(subscriptionId);
+    setCancelMode('period_end');
+    setCancelDialogOpen(true);
   };
 
   if (isLoading) {
     return (
-      <Card className="lg:col-span-2">
+      <Card className="lg:col-span-4">
         <CardHeader>
           <CardTitle>KiloClaw</CardTitle>
         </CardHeader>
@@ -126,7 +181,7 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
 
   if (error) {
     return (
-      <Card className="lg:col-span-2">
+      <Card className="lg:col-span-4">
         <CardHeader>
           <CardTitle>KiloClaw</CardTitle>
         </CardHeader>
@@ -137,170 +192,239 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
     );
   }
 
-  if (!data?.subscription) {
-    return (
-      <Card className="lg:col-span-2">
-        <CardHeader>
-          <div className="flex items-start justify-between gap-3">
-            <div>
-              <CardTitle>KiloClaw</CardTitle>
-              <CardDescription>n/a</CardDescription>
-            </div>
-            {data?.activeInstanceId && (
-              <Button variant="outline" size="sm" asChild>
-                <Link href={`/admin/kiloclaw/${data.activeInstanceId}`}>
-                  <ExternalLink className="mr-1 h-3 w-3" />
-                  View KiloClaw
-                </Link>
-              </Button>
-            )}
-          </div>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          {data?.earlybird ? (
-            <div className="rounded-lg border p-3">
-              <div className="mb-2 flex items-center justify-between">
-                <span className="text-sm font-medium">Earlybird Access</span>
-                <Badge className={getAccessBadgeClass(data.hasAccess)}>
-                  {data.hasAccess ? 'has access' : 'no access'}
-                </Badge>
-              </div>
-              <div className="grid grid-cols-2 gap-3 text-sm">
-                <div>
-                  <span className="text-muted-foreground">Expires</span>
-                  <p>{formatDate(data.earlybird.expiresAt)}</p>
-                </div>
-                <div>
-                  <span className="text-muted-foreground">Days remaining</span>
-                  <p>{data.earlybird.daysRemaining}</p>
-                </div>
-              </div>
-            </div>
-          ) : (
-            <p className="text-muted-foreground text-sm">
-              This user does not have a KiloClaw subscription row.
-            </p>
-          )}
-        </CardContent>
-      </Card>
-    );
-  }
+  const subscriptions = data?.subscriptions ?? [];
+  const visibleSubscriptions = hideInactive
+    ? subscriptions.filter(s => s.status !== 'canceled')
+    : subscriptions;
+  const hiddenCount = subscriptions.length - visibleSubscriptions.length;
 
-  const { subscription } = data;
-  const canEditTrialEnd = subscription.status === 'trialing' || subscription.status === 'canceled';
-  const isTrialReset = subscription.status === 'canceled';
+  const cancelingSubscription = subscriptions.find(s => s.id === cancelSubscriptionId);
 
   return (
     <>
-      <Card className="lg:col-span-2">
+      <Card className="lg:col-span-4">
         <CardHeader>
           <div className="flex items-start justify-between gap-3">
             <div>
               <CardTitle>KiloClaw</CardTitle>
-              <CardDescription>KiloClaw subscription and trial status</CardDescription>
+              <CardDescription>
+                {subscriptions.length === 0
+                  ? 'No subscriptions'
+                  : `${subscriptions.length} subscription${subscriptions.length !== 1 ? 's' : ''}`}
+              </CardDescription>
             </div>
-            <div className="flex gap-2">
-              {data.activeInstanceId && (
+            <div className="flex items-center gap-3">
+              {data?.activeInstanceId && (
                 <Button variant="outline" size="sm" asChild>
                   <Link href={`/admin/kiloclaw/${data.activeInstanceId}`}>
                     <ExternalLink className="mr-1 h-3 w-3" />
-                    View KiloClaw
+                    View Instance
                   </Link>
-                </Button>
-              )}
-              {canEditTrialEnd && (
-                <Button variant="outline" size="sm" onClick={() => setDialogOpen(true)}>
-                  {isTrialReset ? 'Reset Trial' : 'Edit Trial End'}
                 </Button>
               )}
             </div>
           </div>
         </CardHeader>
         <CardContent className="space-y-6">
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+          {/* Access & earlybird summary */}
+          <div className="flex items-center gap-4">
             <div>
               <h4 className="text-muted-foreground text-xs font-medium">Access</h4>
-              <Badge className={getAccessBadgeClass(data.hasAccess)}>
-                {data.hasAccess ? 'has access' : 'no access'}
+              <Badge className={getAccessBadgeClass(data?.hasAccess ?? false)}>
+                {data?.hasAccess ? 'has access' : 'no access'}
               </Badge>
-              {data.accessReason ? (
+              {data?.accessReason ? (
                 <p className="text-muted-foreground mt-1 text-xs">{data.accessReason}</p>
               ) : null}
             </div>
-            <div>
-              <h4 className="text-muted-foreground text-xs font-medium">Status</h4>
-              <Badge className={getSubscriptionStatusBadgeClass(subscription.status)}>
-                {subscription.status}
-              </Badge>
-            </div>
-            <div>
-              <h4 className="text-muted-foreground text-xs font-medium">Plan</h4>
-              <p className="text-sm font-semibold">{subscription.plan}</p>
-            </div>
-            <div>
-              <h4 className="text-muted-foreground text-xs font-medium">Trial Started</h4>
-              <p className="text-sm">{formatDateOrDash(subscription.trial_started_at)}</p>
-            </div>
-            <div>
-              <h4 className="text-muted-foreground text-xs font-medium">Trial Ends</h4>
-              <p className="text-sm">{formatDateOrDash(subscription.trial_ends_at)}</p>
-            </div>
-            <div>
-              <h4 className="text-muted-foreground text-xs font-medium">Current Period End</h4>
-              <p className="text-sm">{formatDateOrDash(subscription.current_period_end)}</p>
-            </div>
-            <div>
-              <h4 className="text-muted-foreground text-xs font-medium">Commit Ends</h4>
-              <p className="text-sm">{formatDateOrDash(subscription.commit_ends_at)}</p>
-            </div>
-            <div>
-              <h4 className="text-muted-foreground text-xs font-medium">Scheduled Plan</h4>
-              <p className="text-sm">{subscription.scheduled_plan ?? '—'}</p>
-            </div>
-            <div>
-              <h4 className="text-muted-foreground text-xs font-medium">Scheduled By</h4>
-              <p className="text-sm">{subscription.scheduled_by ?? '—'}</p>
-            </div>
-            <div>
-              <h4 className="text-muted-foreground text-xs font-medium">Suspended At</h4>
-              <p className="text-sm">{formatDateOrDash(subscription.suspended_at)}</p>
-            </div>
-            <div>
-              <h4 className="text-muted-foreground text-xs font-medium">Destruction Deadline</h4>
-              <p className="text-sm">{formatDateOrDash(subscription.destruction_deadline)}</p>
-            </div>
-            <div>
-              <h4 className="text-muted-foreground text-xs font-medium">Updated</h4>
-              <p className="text-sm">{formatDate(subscription.updated_at)}</p>
-            </div>
-          </div>
 
-          {data.earlybird ? (
-            <div className="rounded-lg border p-3">
-              <h4 className="mb-2 text-sm font-medium">Earlybird</h4>
-              <div className="grid grid-cols-2 gap-3 text-sm">
-                <div>
-                  <span className="text-muted-foreground">Expires</span>
-                  <p>{formatDate(data.earlybird.expiresAt)}</p>
-                </div>
-                <div>
-                  <span className="text-muted-foreground">Days remaining</span>
-                  <p>{data.earlybird.daysRemaining}</p>
+            {data?.earlybird ? (
+              <div className="rounded-lg border p-3">
+                <h4 className="mb-1 text-sm font-medium">Earlybird</h4>
+                <div className="flex gap-4 text-sm">
+                  <div>
+                    <span className="text-muted-foreground">Expires</span>
+                    <p>{formatDate(data.earlybird.expiresAt)}</p>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Days remaining</span>
+                    <p>{data.earlybird.daysRemaining}</p>
+                  </div>
                 </div>
               </div>
+            ) : null}
+          </div>
+
+          {/* Hide inactive toggle */}
+          {subscriptions.some(s => s.status === 'canceled') && (
+            <div className="flex items-center gap-2">
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={hideInactive}
+                  onChange={e => setHideInactive(e.target.checked)}
+                  className="rounded"
+                />
+                Hide inactive subscriptions
+                {hiddenCount > 0 && (
+                  <span className="text-muted-foreground">({hiddenCount} hidden)</span>
+                )}
+              </label>
             </div>
-          ) : null}
+          )}
+
+          {/* Subscription list */}
+          {visibleSubscriptions.length === 0 && subscriptions.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              This user does not have any KiloClaw subscription rows.
+            </p>
+          ) : visibleSubscriptions.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              All subscriptions are inactive. Uncheck &quot;Hide inactive subscriptions&quot; to
+              view them.
+            </p>
+          ) : (
+            <div className="space-y-4">
+              {visibleSubscriptions.map(sub => {
+                const isEffective = sub.id === data?.effectiveSubscriptionId;
+                const canEditTrialEnd = sub.status === 'trialing' || sub.status === 'canceled';
+                const isTrialReset = sub.status === 'canceled';
+                const canCancel =
+                  (sub.status === 'active' || sub.status === 'past_due') &&
+                  sub.plan !== 'trial' &&
+                  !sub.cancel_at_period_end;
+                const canImmediateCancel =
+                  (sub.status === 'active' || sub.status === 'past_due') && sub.plan !== 'trial';
+
+                return (
+                  <div
+                    key={sub.id}
+                    className={`rounded-lg border p-4 ${isEffective ? 'border-blue-500/40 bg-blue-950/10' : ''}`}
+                  >
+                    {/* Header row */}
+                    <div className="mb-3 flex items-center justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        <Badge className={getSubscriptionStatusBadgeClass(sub.status)}>
+                          {sub.status}
+                        </Badge>
+                        <span className="text-sm font-semibold">{sub.plan}</span>
+                        {isEffective && (
+                          <Badge variant="outline" className="text-xs">
+                            effective
+                          </Badge>
+                        )}
+                        {sub.cancel_at_period_end && (
+                          <Badge className="bg-orange-900/20 text-orange-400">
+                            cancels at period end
+                          </Badge>
+                        )}
+                        {sub.pending_conversion && (
+                          <Badge className="bg-purple-900/20 text-purple-400">
+                            pending conversion
+                          </Badge>
+                        )}
+                      </div>
+                      <div className="flex gap-2">
+                        {sub.instance && (
+                          <Button variant="outline" size="sm" asChild>
+                            <Link href={`/admin/kiloclaw/${sub.instance.id}`}>
+                              <ExternalLink className="mr-1 h-3 w-3" />
+                              {sub.instance.name ?? 'Instance'}
+                            </Link>
+                          </Button>
+                        )}
+                        {canEditTrialEnd && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => openTrialDialog(sub.id)}
+                          >
+                            {isTrialReset ? 'Reset Trial' : 'Edit Trial End'}
+                          </Button>
+                        )}
+                        {canCancel && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="border-red-500/30 text-red-400 hover:bg-red-950/30"
+                            onClick={() => openCancelDialog(sub.id)}
+                          >
+                            Cancel
+                          </Button>
+                        )}
+                        {!canCancel && canImmediateCancel && sub.cancel_at_period_end && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="border-red-500/30 text-red-400 hover:bg-red-950/30"
+                            onClick={() => openCancelDialog(sub.id)}
+                          >
+                            Cancel Immediately
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Detail grid */}
+                    <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+                      <Field label="Payment Source" value={sub.payment_source ?? '—'} />
+                      <Field
+                        label="Stripe Subscription"
+                        value={sub.stripe_subscription_id ?? '—'}
+                        mono
+                      />
+                      <Field label="Instance ID" value={sub.instance_id ?? '—'} mono />
+                      <Field
+                        label="Instance"
+                        value={
+                          sub.instance
+                            ? `${sub.instance.name ?? sub.instance.sandbox_id}${sub.instance.destroyed_at ? ' (destroyed)' : ''}`
+                            : '—'
+                        }
+                      />
+                      <Field label="Trial Started" value={formatDateOrDash(sub.trial_started_at)} />
+                      <Field label="Trial Ends" value={formatDateOrDash(sub.trial_ends_at)} />
+                      <Field
+                        label="Period Start"
+                        value={formatDateOrDash(sub.current_period_start)}
+                      />
+                      <Field label="Period End" value={formatDateOrDash(sub.current_period_end)} />
+                      <Field label="Commit Ends" value={formatDateOrDash(sub.commit_ends_at)} />
+                      <Field
+                        label="Credit Renewal"
+                        value={formatDateOrDash(sub.credit_renewal_at)}
+                      />
+                      <Field label="Scheduled Plan" value={sub.scheduled_plan ?? '—'} />
+                      <Field label="Scheduled By" value={sub.scheduled_by ?? '—'} />
+                      <Field label="Stripe Schedule" value={sub.stripe_schedule_id ?? '—'} mono />
+                      <Field label="Suspended At" value={formatDateOrDash(sub.suspended_at)} />
+                      <Field
+                        label="Destruction Deadline"
+                        value={formatDateOrDash(sub.destruction_deadline)}
+                      />
+                      <Field label="Past Due Since" value={formatDateOrDash(sub.past_due_since)} />
+                      <Field label="Created" value={formatDate(sub.created_at)} />
+                      <Field label="Updated" value={formatDate(sub.updated_at)} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </CardContent>
       </Card>
 
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      {/* Trial edit dialog */}
+      <Dialog open={trialDialogOpen} onOpenChange={setTrialDialogOpen}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
-              {isTrialReset ? 'Reset KiloClaw Trial' : 'Edit KiloClaw Trial End Date'}
+              {trialSubscription?.status === 'canceled'
+                ? 'Reset KiloClaw Trial'
+                : 'Edit KiloClaw Trial End Date'}
             </DialogTitle>
             <DialogDescription>
-              {isTrialReset
+              {trialSubscription?.status === 'canceled'
                 ? 'Reset this canceled subscription to a new trial. This will restore access, clear suspension state, and attempt to restart the instance.'
                 : "Set the day this user's KiloClaw trial ends. The trial will end at the end of the selected day."}
             </DialogDescription>
@@ -317,17 +441,82 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
           <DialogFooter>
             <Button
               variant="outline"
-              onClick={() => setDialogOpen(false)}
+              onClick={() => setTrialDialogOpen(false)}
               disabled={updateTrialEndAt.isPending}
             >
               Cancel
             </Button>
-            <Button onClick={handleSave} disabled={updateTrialEndAt.isPending || !selectedDate}>
+            <Button
+              onClick={handleTrialSave}
+              disabled={updateTrialEndAt.isPending || !selectedDate}
+            >
               {updateTrialEndAt.isPending ? 'Saving...' : 'Save Changes'}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Cancel subscription dialog */}
+      <Dialog open={cancelDialogOpen} onOpenChange={setCancelDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Cancel KiloClaw Subscription</DialogTitle>
+            <DialogDescription>
+              This will cancel the subscription for this user. No refund will be issued.
+              {cancelingSubscription?.stripe_subscription_id
+                ? ' This is a Stripe-funded subscription — Stripe will be updated.'
+                : ' This is a credit-funded subscription — only the local database will be updated.'}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 py-4">
+            <Label>Cancellation timing</Label>
+            <RadioButtonGroup
+              options={[
+                { value: 'period_end', label: 'At period end' },
+                { value: 'immediate', label: 'Immediately' },
+              ]}
+              value={cancelMode}
+              onChange={v => {
+                if (isCancelMode(v)) setCancelMode(v);
+              }}
+            />
+            <p className="text-muted-foreground text-xs">
+              {cancelMode === 'period_end'
+                ? 'No refund. The user keeps access until the current billing period ends.'
+                : 'No refund. Local access ends now. The lifecycle will suspend/stop the instance on its next run.'}
+            </p>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setCancelDialogOpen(false)}
+              disabled={cancelSubscription.isPending}
+            >
+              Back
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleCancelConfirm}
+              disabled={cancelSubscription.isPending}
+            >
+              {cancelSubscription.isPending
+                ? 'Canceling...'
+                : cancelMode === 'immediate'
+                  ? 'Cancel Immediately'
+                  : 'Cancel at Period End'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
+  );
+}
+
+function Field({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div>
+      <h4 className="text-muted-foreground text-xs font-medium">{label}</h4>
+      <p className={`text-sm ${mono ? 'font-mono' : ''}`}>{value}</p>
+    </div>
   );
 }

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminTabbedSections.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminTabbedSections.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+import { useCallback } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import type { UserDetailProps } from '@/types/admin';
+import type { GuiCreditCategory } from '@/lib/PromoCreditCategoryConfig';
+import { UserAdminCreditGrant } from './UserAdminCreditGrant';
+import { UserAdminCreditTransactions } from './UserAdminCreditTransactions';
+import { UserAdminPaymentMethods } from './UserAdminPaymentMethods';
+import { UserAdminUsageBilling } from './UserAdminUsageBilling';
+import { UserAdminAccountInfo } from './UserAdminAccountInfo';
+import { UserAdminNotes } from './UserAdminNotes';
+import { UserAdminGdprRemoval } from './UserAdminGdprRemoval';
+import { UserAdminReferrals } from './UserAdminReferrals';
+import { UserAdminStytchFingerprints } from './UserAdminStytchFingerprints';
+import { UserAdminInvoices } from './UserAdminInvoices';
+import { UserAdminOrganizations } from './UserAdminOrganizations';
+import { UserAdminKiloPass } from './UserAdminKiloPass';
+import { UserAdminKiloClaw } from './UserAdminKiloClaw';
+import { UserAdminGastown } from './UserAdminGastown';
+
+const VALID_TABS = ['billing', 'organizations', 'kiloclaw', 'gastown', 'admin-tools'] as const;
+type Tab = (typeof VALID_TABS)[number];
+const isValidTab = (value: string | null): value is Tab =>
+  value !== null && (VALID_TABS as readonly string[]).includes(value);
+
+const tabTriggerClass =
+  'text-muted-foreground hover:text-foreground data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none border-b-2 border-transparent px-0 py-3 text-sm font-medium transition-colors data-[state=active]:border-0 data-[state=active]:border-b-2 data-[state=active]:bg-transparent data-[state=active]:shadow-none';
+
+export function UserAdminTabbedSections(
+  user: UserDetailProps & { promoCreditCategories: readonly GuiCreditCategory[] }
+) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const tabParam = searchParams.get('tab');
+  const activeTab: Tab = isValidTab(tabParam) ? tabParam : 'billing';
+
+  const onTabChange = useCallback(
+    (value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value === 'billing') {
+        params.delete('tab');
+      } else {
+        params.set('tab', value);
+      }
+      const qs = params.toString();
+      router.replace(`${pathname}${qs ? `?${qs}` : ''}`, { scroll: false });
+    },
+    [searchParams, router, pathname]
+  );
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Account info — always visible above the tabs */}
+      <UserAdminAccountInfo {...user} />
+
+      <Tabs value={activeTab} onValueChange={onTabChange}>
+        <TabsList className="h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent p-0">
+          <TabsTrigger value="billing" className={tabTriggerClass}>
+            Billing
+          </TabsTrigger>
+          <TabsTrigger value="organizations" className={tabTriggerClass}>
+            Organizations
+          </TabsTrigger>
+          <TabsTrigger value="kiloclaw" className={tabTriggerClass}>
+            KiloClaw
+          </TabsTrigger>
+          <TabsTrigger value="gastown" className={tabTriggerClass}>
+            Gas Town
+          </TabsTrigger>
+          <TabsTrigger value="admin-tools" className={tabTriggerClass}>
+            Admin Tools
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="billing" className="mt-4">
+          <div className="grid grid-cols-1 gap-8 lg:grid-cols-4">
+            <UserAdminUsageBilling {...user} />
+            <UserAdminCreditGrant {...user} promoCreditCategories={user.promoCreditCategories} />
+            <UserAdminCreditTransactions {...user} />
+            <UserAdminPaymentMethods {...user} />
+            <UserAdminInvoices stripe_customer_id={user.stripe_customer_id} />
+            <UserAdminKiloPass userId={user.id} />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="organizations" className="mt-4">
+          <div className="grid grid-cols-1 gap-8 lg:grid-cols-4">
+            <UserAdminOrganizations organization_memberships={user.organization_memberships} />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="kiloclaw" className="mt-4">
+          <div className="grid grid-cols-1 gap-8 lg:grid-cols-4">
+            <UserAdminKiloClaw userId={user.id} />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="gastown" className="mt-4">
+          <UserAdminGastown userId={user.id} />
+        </TabsContent>
+
+        <TabsContent value="admin-tools" className="mt-4">
+          <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+            <UserAdminNotes {...user} />
+            <UserAdminStytchFingerprints {...user} />
+            <UserAdminReferrals kilo_user_id={user.id} />
+            <UserAdminGdprRemoval {...user} />
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
@@ -49,6 +49,8 @@ describe('admin.users.getKiloClawState', () => {
 
     expect(result).toEqual({
       subscription: null,
+      effectiveSubscriptionId: null,
+      subscriptions: [],
       hasAccess: false,
       accessReason: null,
       earlybird: null,
@@ -72,6 +74,11 @@ describe('admin.users.getKiloClawState', () => {
     expect(result.hasAccess).toBe(true);
     expect(result.accessReason).toBe('subscription');
     expect(result.earlybird).toBeNull();
+
+    // New fields
+    expect(result.subscriptions).toHaveLength(1);
+    expect(result.subscriptions[0].status).toBe('active');
+    expect(result.effectiveSubscriptionId).toBe(result.subscriptions[0].id);
   });
 
   it('prefers an active subscription over an older canceled row', async () => {
@@ -99,6 +106,10 @@ describe('admin.users.getKiloClawState', () => {
     expect(result.subscription?.stripe_subscription_id).toBe('sub_admin_kiloclaw_active_latest');
     expect(result.hasAccess).toBe(true);
     expect(result.accessReason).toBe('subscription');
+
+    // Both rows returned in subscriptions
+    expect(result.subscriptions).toHaveLength(2);
+    expect(result.effectiveSubscriptionId).toBe(result.subscription?.id);
   });
 
   it('returns trial access for future trial end dates', async () => {
@@ -119,6 +130,7 @@ describe('admin.users.getKiloClawState', () => {
     expectSameInstant(result.subscription?.trial_ends_at, futureTrialEnd);
     expect(result.hasAccess).toBe(true);
     expect(result.accessReason).toBe('trial');
+    expect(result.subscriptions).toHaveLength(1);
   });
 
   it('shows expired trial rows without trial access', async () => {
@@ -159,6 +171,7 @@ describe('admin.users.getKiloClawState', () => {
         daysRemaining: expect.any(Number),
       })
     );
+    expect(result.subscriptions).toHaveLength(0);
   });
 
   it('returns activeInstanceId when the user has an active instance', async () => {
@@ -187,6 +200,87 @@ describe('admin.users.getKiloClawState', () => {
     const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
 
     expect(result.activeInstanceId).toBeNull();
+  });
+
+  it('includes joined instance metadata on subscription rows', async () => {
+    const [instance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        user_id: targetUser.id,
+        sandbox_id: 'sandbox-inst-meta',
+        name: 'my-instance',
+      })
+      .returning();
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: targetUser.id,
+      plan: 'standard',
+      status: 'active',
+      instance_id: instance.id,
+      payment_source: 'credits',
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
+
+    expect(result.subscriptions).toHaveLength(1);
+    const sub = result.subscriptions[0];
+    expect(sub.instance).toEqual(
+      expect.objectContaining({
+        id: instance.id,
+        name: 'my-instance',
+        sandbox_id: 'sandbox-inst-meta',
+        destroyed_at: null,
+      })
+    );
+  });
+
+  it('returns multiple subscription rows with correct effective selection', async () => {
+    const [instanceOld, instanceNew] = await db
+      .insert(kiloclaw_instances)
+      .values([
+        {
+          user_id: targetUser.id,
+          sandbox_id: 'sandbox-multi-old',
+          destroyed_at: new Date().toISOString(),
+        },
+        {
+          user_id: targetUser.id,
+          sandbox_id: 'sandbox-multi-new',
+        },
+      ])
+      .returning();
+
+    await db.insert(kiloclaw_subscriptions).values([
+      {
+        user_id: targetUser.id,
+        plan: 'trial',
+        status: 'canceled',
+        instance_id: instanceOld.id,
+        trial_started_at: '2026-01-01T00:00:00.000Z',
+        trial_ends_at: '2026-01-08T00:00:00.000Z',
+      },
+      {
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        instance_id: instanceNew.id,
+        payment_source: 'credits',
+        current_period_end: '2026-05-01T00:00:00.000Z',
+      },
+    ]);
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
+
+    expect(result.subscriptions).toHaveLength(2);
+    expect(result.subscription?.status).toBe('active');
+    expect(result.effectiveSubscriptionId).toBe(result.subscription?.id);
+    // Each subscription should have its respective instance joined
+    const activeSub = result.subscriptions.find(s => s.status === 'active');
+    const canceledSub = result.subscriptions.find(s => s.status === 'canceled');
+    expect(activeSub?.instance?.id).toBe(instanceNew.id);
+    expect(canceledSub?.instance?.id).toBe(instanceOld.id);
   });
 });
 
@@ -330,5 +424,240 @@ describe('admin.users.updateKiloClawTrialEndAt', () => {
     expect(auditLog.message).toContain('reset from canceled to trialing');
     expect(auditLog.metadata?.isReset).toBe(true);
     expect(auditLog.metadata?.previousStatus).toBe('canceled');
+  });
+});
+
+describe('admin.users.cancelKiloClawSubscription', () => {
+  it('period-end cancel on pure-credit row is DB-only', async () => {
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+        credit_renewal_at: new Date(Date.now() + 30 * 86_400_000).toISOString(),
+      })
+      .returning();
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.cancelKiloClawSubscription({
+      userId: targetUser.id,
+      subscriptionId: sub.id,
+      mode: 'period_end',
+    });
+
+    expect(result).toEqual({ success: true });
+
+    // DB updated
+    const updated = await db.query.kiloclaw_subscriptions.findFirst({
+      where: eq(kiloclaw_subscriptions.id, sub.id),
+    });
+    expect(updated?.cancel_at_period_end).toBe(true);
+    expect(updated?.scheduled_plan).toBeNull();
+    expect(updated?.scheduled_by).toBeNull();
+  });
+
+  it('immediate cancel on pure-credit row sets local canceled', async () => {
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+        credit_renewal_at: new Date(Date.now() + 30 * 86_400_000).toISOString(),
+      })
+      .returning();
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.cancelKiloClawSubscription({
+      userId: targetUser.id,
+      subscriptionId: sub.id,
+      mode: 'immediate',
+    });
+
+    expect(result).toEqual({ success: true });
+
+    // DB updated — immediate cancel sets terminal state
+    const updated = await db.query.kiloclaw_subscriptions.findFirst({
+      where: eq(kiloclaw_subscriptions.id, sub.id),
+    });
+    expect(updated?.status).toBe('canceled');
+    expect(updated?.cancel_at_period_end).toBe(false);
+    expect(updated?.pending_conversion).toBe(false);
+    expect(updated?.stripe_schedule_id).toBeNull();
+    expect(updated?.scheduled_plan).toBeNull();
+    expect(updated?.scheduled_by).toBeNull();
+    // current_period_end and credit_renewal_at should be set to ~now
+    expect(updated?.current_period_end).not.toBeNull();
+    expect(updated?.credit_renewal_at).not.toBeNull();
+  });
+
+  it('immediate cancel can cancel a row already pending period-end cancellation', async () => {
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+        cancel_at_period_end: true,
+      })
+      .returning();
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.cancelKiloClawSubscription({
+      userId: targetUser.id,
+      subscriptionId: sub.id,
+      mode: 'immediate',
+    });
+
+    expect(result).toEqual({ success: true });
+
+    const updated = await db.query.kiloclaw_subscriptions.findFirst({
+      where: eq(kiloclaw_subscriptions.id, sub.id),
+    });
+    expect(updated?.status).toBe('canceled');
+    expect(updated?.cancel_at_period_end).toBe(false);
+  });
+
+  it("rejects another user's subscription id", async () => {
+    const otherUser = await insertTestUser({
+      google_user_email: 'other-kiloclaw@example.com',
+      google_user_name: 'Other User',
+    });
+
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: otherUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+      })
+      .returning();
+
+    const caller = await createCallerForUser(adminUser.id);
+
+    await expect(
+      caller.admin.users.cancelKiloClawSubscription({
+        userId: targetUser.id,
+        subscriptionId: sub.id,
+        mode: 'period_end',
+      })
+    ).rejects.toThrow('Subscription not found or does not belong to this user');
+  });
+
+  it('writes an admin audit log', async () => {
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+      })
+      .returning();
+
+    const caller = await createCallerForUser(adminUser.id);
+    await caller.admin.users.cancelKiloClawSubscription({
+      userId: targetUser.id,
+      subscriptionId: sub.id,
+      mode: 'immediate',
+    });
+
+    const [auditLog] = await db
+      .select()
+      .from(kiloclaw_admin_audit_logs)
+      .where(eq(kiloclaw_admin_audit_logs.target_user_id, targetUser.id));
+
+    expect(auditLog).toEqual(
+      expect.objectContaining({
+        action: 'kiloclaw.subscription.admin_cancel',
+        actor_id: adminUser.id,
+        actor_email: adminUser.google_user_email,
+        actor_name: adminUser.google_user_name,
+        target_user_id: targetUser.id,
+      })
+    );
+    expect(auditLog.metadata?.subscriptionId).toBe(sub.id);
+    expect(auditLog.metadata?.mode).toBe('immediate');
+    expect(auditLog.metadata?.previousStatus).toBe('active');
+  });
+
+  it('period-end cancel clears scheduled plan on pure-credit row', async () => {
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        scheduled_plan: 'commit',
+        scheduled_by: 'user',
+        payment_source: 'credits',
+      })
+      .returning();
+
+    const caller = await createCallerForUser(adminUser.id);
+    await caller.admin.users.cancelKiloClawSubscription({
+      userId: targetUser.id,
+      subscriptionId: sub.id,
+      mode: 'period_end',
+    });
+
+    // DB cleared schedule fields
+    const updated = await db.query.kiloclaw_subscriptions.findFirst({
+      where: eq(kiloclaw_subscriptions.id, sub.id),
+    });
+    expect(updated?.stripe_schedule_id).toBeNull();
+    expect(updated?.scheduled_plan).toBeNull();
+    expect(updated?.scheduled_by).toBeNull();
+    expect(updated?.cancel_at_period_end).toBe(true);
+  });
+
+  it('rejects period-end cancel on already-canceling subscription', async () => {
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+        cancel_at_period_end: true,
+      })
+      .returning();
+
+    const caller = await createCallerForUser(adminUser.id);
+
+    await expect(
+      caller.admin.users.cancelKiloClawSubscription({
+        userId: targetUser.id,
+        subscriptionId: sub.id,
+        mode: 'period_end',
+      })
+    ).rejects.toThrow('already set to cancel at period end');
+  });
+
+  it('rejects period-end cancel on non-active subscription', async () => {
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'canceled',
+        payment_source: 'credits',
+      })
+      .returning();
+
+    const caller = await createCallerForUser(adminUser.id);
+
+    await expect(
+      caller.admin.users.cancelKiloClawSubscription({
+        userId: targetUser.id,
+        subscriptionId: sub.id,
+        mode: 'period_end',
+      })
+    ).rejects.toThrow('Only active subscriptions can be canceled at period end');
   });
 });

--- a/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
@@ -289,17 +289,21 @@ describe('admin.users.updateKiloClawTrialEndAt', () => {
     const previousTrialEndsAt = '2026-03-20T23:59:59.000Z';
     const newTrialEndsAt = '2026-03-25T23:59:59.000Z';
 
-    await db.insert(kiloclaw_subscriptions).values({
-      user_id: targetUser.id,
-      plan: 'trial',
-      status: 'trialing',
-      trial_started_at: '2026-03-13T12:00:00.000Z',
-      trial_ends_at: previousTrialEndsAt,
-    });
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'trial',
+        status: 'trialing',
+        trial_started_at: '2026-03-13T12:00:00.000Z',
+        trial_ends_at: previousTrialEndsAt,
+      })
+      .returning();
 
     const caller = await createCallerForUser(adminUser.id);
     const result = await caller.admin.users.updateKiloClawTrialEndAt({
       userId: targetUser.id,
+      subscriptionId: sub.id,
       trial_ends_at: newTrialEndsAt,
     });
 
@@ -339,35 +343,41 @@ describe('admin.users.updateKiloClawTrialEndAt', () => {
     await expect(
       caller.admin.users.updateKiloClawTrialEndAt({
         userId: 'missing-user',
+        subscriptionId: '00000000-0000-0000-0000-000000000000',
         trial_ends_at: '2026-03-25T23:59:59.000Z',
       })
     ).rejects.toThrow('User not found');
   });
 
-  it('rejects users without a KiloClaw subscription row', async () => {
+  it('rejects users without a matching KiloClaw subscription row', async () => {
     const caller = await createCallerForUser(adminUser.id);
 
     await expect(
       caller.admin.users.updateKiloClawTrialEndAt({
         userId: targetUser.id,
+        subscriptionId: '00000000-0000-0000-0000-000000000000',
         trial_ends_at: '2026-03-25T23:59:59.000Z',
       })
     ).rejects.toThrow('No KiloClaw subscription found for this user');
   });
 
   it('rejects non-trialing and non-canceled subscription rows', async () => {
-    await db.insert(kiloclaw_subscriptions).values({
-      user_id: targetUser.id,
-      plan: 'standard',
-      status: 'active',
-      stripe_subscription_id: 'sub_admin_kiloclaw_non_trial',
-    });
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        stripe_subscription_id: 'sub_admin_kiloclaw_non_trial',
+      })
+      .returning();
 
     const caller = await createCallerForUser(adminUser.id);
 
     await expect(
       caller.admin.users.updateKiloClawTrialEndAt({
         userId: targetUser.id,
+        subscriptionId: sub.id,
         trial_ends_at: '2026-03-25T23:59:59.000Z',
       })
     ).rejects.toThrow(
@@ -379,19 +389,23 @@ describe('admin.users.updateKiloClawTrialEndAt', () => {
     const previousTrialEndsAt = '2026-03-15T23:59:59.000Z';
     const newTrialEndsAt = '2026-04-01T23:59:59.000Z';
 
-    await db.insert(kiloclaw_subscriptions).values({
-      user_id: targetUser.id,
-      plan: 'trial',
-      status: 'canceled',
-      trial_started_at: '2026-03-08T12:00:00.000Z',
-      trial_ends_at: previousTrialEndsAt,
-      suspended_at: '2026-03-16T00:00:00.000Z',
-      destruction_deadline: '2026-03-23T00:00:00.000Z',
-    });
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'trial',
+        status: 'canceled',
+        trial_started_at: '2026-03-08T12:00:00.000Z',
+        trial_ends_at: previousTrialEndsAt,
+        suspended_at: '2026-03-16T00:00:00.000Z',
+        destruction_deadline: '2026-03-23T00:00:00.000Z',
+      })
+      .returning();
 
     const caller = await createCallerForUser(adminUser.id);
     const result = await caller.admin.users.updateKiloClawTrialEndAt({
       userId: targetUser.id,
+      subscriptionId: sub.id,
       trial_ends_at: newTrialEndsAt,
     });
 

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -181,6 +181,7 @@ const GetKiloClawStateSchema = z.object({
 
 const UpdateKiloClawTrialEndAtSchema = z.object({
   userId: z.string(),
+  subscriptionId: z.string(),
   trial_ends_at: z.string().datetime(),
 });
 
@@ -590,7 +591,10 @@ export const adminRouter = createTRPCRouter({
         }
 
         const subscription = await db.query.kiloclaw_subscriptions.findFirst({
-          where: eq(kiloclaw_subscriptions.user_id, input.userId),
+          where: and(
+            eq(kiloclaw_subscriptions.id, input.subscriptionId),
+            eq(kiloclaw_subscriptions.user_id, input.userId)
+          ),
         });
 
         if (!subscription) {
@@ -633,7 +637,7 @@ export const adminRouter = createTRPCRouter({
                 suspended_at: null,
                 destruction_deadline: null,
               })
-              .where(eq(kiloclaw_subscriptions.user_id, input.userId));
+              .where(eq(kiloclaw_subscriptions.id, subscription.id));
 
             // Clear email logs so notifications can fire again for the new trial.
             // Unlike autoResumeIfSuspended (which preserves trial warnings as one-time events),
@@ -660,7 +664,7 @@ export const adminRouter = createTRPCRouter({
             await tx
               .update(kiloclaw_subscriptions)
               .set({ trial_ends_at: input.trial_ends_at })
-              .where(eq(kiloclaw_subscriptions.user_id, input.userId));
+              .where(eq(kiloclaw_subscriptions.id, subscription.id));
           }
 
           await createKiloClawAdminAuditLog({

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -63,7 +63,10 @@ import { client as stripeClient } from '@/lib/stripe-client';
 import { releaseScheduledChangeForSubscription } from '@/lib/kilo-pass/scheduled-change-release';
 import { kilo_pass_scheduled_changes } from '@kilocode/db/schema';
 import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
-import { getEffectiveKiloClawSubscriptionForUser } from '@/lib/kiloclaw/access-state';
+import {
+  getEffectiveKiloClawSubscription,
+  getKiloClawSubscriptionAccessReason,
+} from '@/lib/kiloclaw/access-state';
 import { createKiloClawAdminAuditLog } from '@/lib/kiloclaw/admin-audit-log';
 import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import {
@@ -179,6 +182,12 @@ const GetKiloClawStateSchema = z.object({
 const UpdateKiloClawTrialEndAtSchema = z.object({
   userId: z.string(),
   trial_ends_at: z.string().datetime(),
+});
+
+const CancelKiloClawSubscriptionSchema = z.object({
+  userId: z.string(),
+  subscriptionId: z.string(),
+  mode: z.enum(['period_end', 'immediate']),
 });
 
 export const adminRouter = createTRPCRouter({
@@ -502,8 +511,11 @@ export const adminRouter = createTRPCRouter({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
       }
 
-      const [entitlement, earlybird, activeInstance] = await Promise.all([
-        getEffectiveKiloClawSubscriptionForUser(input.userId),
+      const [allSubscriptions, earlybird, activeInstance, allInstances] = await Promise.all([
+        db
+          .select()
+          .from(kiloclaw_subscriptions)
+          .where(eq(kiloclaw_subscriptions.user_id, input.userId)),
         db.query.kiloclaw_earlybird_purchases.findFirst({
           columns: { id: true },
           where: eq(kiloclaw_earlybird_purchases.user_id, input.userId),
@@ -515,7 +527,19 @@ export const adminRouter = createTRPCRouter({
             isNull(kiloclaw_instances.destroyed_at)
           ),
         }),
+        db
+          .select({
+            id: kiloclaw_instances.id,
+            name: kiloclaw_instances.name,
+            sandbox_id: kiloclaw_instances.sandbox_id,
+            destroyed_at: kiloclaw_instances.destroyed_at,
+          })
+          .from(kiloclaw_instances)
+          .where(eq(kiloclaw_instances.user_id, input.userId)),
       ]);
+
+      const effectiveSub = getEffectiveKiloClawSubscription(allSubscriptions);
+      const accessReason = getKiloClawSubscriptionAccessReason(effectiveSub);
 
       const now = new Date();
       const earlybirdDaysRemaining = earlybird
@@ -525,13 +549,23 @@ export const adminRouter = createTRPCRouter({
         : 0;
 
       const hasEarlybirdAccess = !!earlybird && new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE) > now;
-      const hasAccess = hasEarlybirdAccess || entitlement.accessReason !== null;
-      const accessReason = hasEarlybirdAccess ? 'earlybird' : entitlement.accessReason;
+      const hasAccess = hasEarlybirdAccess || accessReason !== null;
+      const effectiveAccessReason = hasEarlybirdAccess ? 'earlybird' : accessReason;
+
+      // Build instance lookup for per-subscription context
+      const instancesById = new Map(allInstances.map(inst => [inst.id, inst]));
+
+      const subscriptions = allSubscriptions.map(sub => ({
+        ...sub,
+        instance: sub.instance_id ? (instancesById.get(sub.instance_id) ?? null) : null,
+      }));
 
       return {
-        subscription: entitlement.subscription,
+        subscription: effectiveSub,
+        effectiveSubscriptionId: effectiveSub?.id ?? null,
+        subscriptions,
         hasAccess,
-        accessReason,
+        accessReason: effectiveAccessReason,
         earlybird: earlybird
           ? {
               purchased: true,
@@ -675,6 +709,178 @@ export const adminRouter = createTRPCRouter({
             }
           }
         }
+
+        return successResult();
+      }),
+
+    cancelKiloClawSubscription: adminProcedure
+      .input(CancelKiloClawSubscriptionSchema)
+      .mutation(async ({ input, ctx }) => {
+        const subscription = await db.query.kiloclaw_subscriptions.findFirst({
+          where: and(
+            eq(kiloclaw_subscriptions.id, input.subscriptionId),
+            eq(kiloclaw_subscriptions.user_id, input.userId)
+          ),
+        });
+
+        if (!subscription) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Subscription not found or does not belong to this user',
+          });
+        }
+
+        const previousStatus = subscription.status;
+        let scheduleReleased = false;
+
+        if (input.mode === 'period_end') {
+          if (subscription.status !== 'active') {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: 'Only active subscriptions can be canceled at period end',
+            });
+          }
+          if (subscription.cancel_at_period_end) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: 'Subscription is already set to cancel at period end',
+            });
+          }
+
+          if (subscription.stripe_subscription_id) {
+            // Stripe-funded: release pending schedule, then set cancel_at_period_end
+            const liveSub = await stripeClient.subscriptions.retrieve(
+              subscription.stripe_subscription_id
+            );
+            const scheduleRef = liveSub.schedule;
+            const scheduleIdToRelease =
+              subscription.stripe_schedule_id ??
+              (scheduleRef
+                ? typeof scheduleRef === 'string'
+                  ? scheduleRef
+                  : scheduleRef.id
+                : null);
+
+            if (scheduleIdToRelease) {
+              try {
+                await stripeClient.subscriptionSchedules.release(scheduleIdToRelease);
+                scheduleReleased = true;
+              } catch (error) {
+                const msg = error instanceof Error ? error.message : String(error);
+                const alreadyInactive =
+                  msg.includes('not active') ||
+                  msg.includes('released') ||
+                  msg.includes('canceled') ||
+                  msg.includes('completed');
+                if (!alreadyInactive) {
+                  throw new TRPCError({
+                    code: 'INTERNAL_SERVER_ERROR',
+                    message:
+                      'Unable to cancel: failed to release pending plan schedule. Please try again.',
+                  });
+                }
+                scheduleReleased = true;
+              }
+            }
+
+            await stripeClient.subscriptions.update(subscription.stripe_subscription_id, {
+              cancel_at_period_end: true,
+            });
+
+            await db
+              .update(kiloclaw_subscriptions)
+              .set({
+                cancel_at_period_end: true,
+                ...(scheduleIdToRelease
+                  ? { stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null }
+                  : {}),
+              })
+              .where(eq(kiloclaw_subscriptions.id, subscription.id));
+          } else {
+            // Pure-credit: set local cancel_at_period_end and clear schedule state
+            await db
+              .update(kiloclaw_subscriptions)
+              .set({
+                cancel_at_period_end: true,
+                stripe_schedule_id: null,
+                scheduled_plan: null,
+                scheduled_by: null,
+              })
+              .where(eq(kiloclaw_subscriptions.id, subscription.id));
+          }
+        } else {
+          // mode === 'immediate'
+          if (subscription.status !== 'active' && subscription.status !== 'past_due') {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: 'Only active or past-due subscriptions can be immediately canceled',
+            });
+          }
+
+          // Release any schedule first
+          const scheduleIdToRelease = subscription.stripe_schedule_id;
+          if (scheduleIdToRelease) {
+            try {
+              await stripeClient.subscriptionSchedules.release(scheduleIdToRelease);
+              scheduleReleased = true;
+            } catch (error) {
+              const msg = error instanceof Error ? error.message : String(error);
+              const alreadyInactive =
+                msg.includes('not active') ||
+                msg.includes('released') ||
+                msg.includes('canceled') ||
+                msg.includes('completed');
+              if (!alreadyInactive) {
+                throw new TRPCError({
+                  code: 'INTERNAL_SERVER_ERROR',
+                  message:
+                    'Unable to cancel: failed to release pending plan schedule. Please try again.',
+                });
+              }
+              scheduleReleased = true;
+            }
+          }
+
+          // Cancel Stripe subscription immediately if present
+          if (subscription.stripe_subscription_id) {
+            await stripeClient.subscriptions.cancel(subscription.stripe_subscription_id, {
+              prorate: false,
+              invoice_now: false,
+            });
+          }
+
+          // Update local subscription to canceled
+          const now = new Date().toISOString();
+          await db
+            .update(kiloclaw_subscriptions)
+            .set({
+              status: 'canceled',
+              cancel_at_period_end: false,
+              pending_conversion: false,
+              stripe_schedule_id: null,
+              scheduled_plan: null,
+              scheduled_by: null,
+              current_period_end: now,
+              credit_renewal_at: now,
+            })
+            .where(eq(kiloclaw_subscriptions.id, subscription.id));
+        }
+
+        await createKiloClawAdminAuditLog({
+          action: 'kiloclaw.subscription.admin_cancel',
+          actor_id: ctx.user.id,
+          actor_email: ctx.user.google_user_email,
+          actor_name: ctx.user.google_user_name,
+          target_user_id: input.userId,
+          message: `Admin ${input.mode === 'immediate' ? 'immediately canceled' : 'set cancel-at-period-end on'} KiloClaw subscription ${subscription.id} (status was ${previousStatus}, stripe_sub=${subscription.stripe_subscription_id ?? 'none'})`,
+          metadata: {
+            subscriptionId: subscription.id,
+            mode: input.mode,
+            previousStatus,
+            stripeSubscriptionId: subscription.stripe_subscription_id,
+            scheduleReleased,
+          },
+        });
 
         return successResult();
       }),

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -179,6 +179,7 @@ export const KiloClawAdminAuditAction = z.enum([
   'kiloclaw.doctor.run',
   'kiloclaw.machine.destroy_fly',
   'kiloclaw.subscription.bulk_trial_grant',
+  'kiloclaw.subscription.admin_cancel',
 ]);
 
 export type KiloClawAdminAuditAction = z.infer<typeof KiloClawAdminAuditAction>;


### PR DESCRIPTION
## Summary

- **Tabbed layout**: Admin user detail page now has a persistent account info header with URL-backed tabs (Billing, Organizations, KiloClaw, Gas Town, Admin Tools)
- **Full subscription visibility**: KiloClaw tab shows all subscription rows with status badges, metadata, and a hide-inactive toggle
- **Admin cancellation**: New cancel action with period-end and immediate modes, audit logged

## Verification
- [x] Manual verification of UI layout and tab navigation

## Visual Changes

| Before | After |
| ------ | ----- |
| Flat single-page layout with all sections visible | <img width="2970" height="1878" alt="Helium 2026-04-08 18 02 08" src="https://github.com/user-attachments/assets/3306c595-ad48-4a64-9b48-d1fd8adb5020" /> |
| Cancel at the end of subscription |  <img width="1126" height="746" alt="Helium 2026-04-08 18 02 09" src="https://github.com/user-attachments/assets/0b67d725-416c-4d35-af7b-c392596ceb95" /> |
|Cancel Immediately|<img width="1124" height="764" alt="Helium 2026-04-08 18 02 10" src="https://github.com/user-attachments/assets/63efd562-fab4-420e-8388-e3c7c4502bfa" />|

## Reviewer Notes
<details>
<summary>Code Reviewer Notes</summary>

- `getKiloClawState` now returns all subscription rows with joined instance metadata alongside the existing `subscription` (effective) field.
- `cancelKiloClawSubscription` mutation handles Stripe schedule release, Stripe subscription cancellation (no refund), and local DB state transitions. Writes `kiloclaw.subscription.admin_cancel` audit log entries.
- Stripe-funded cancel paths are tested end-to-end in the billing-router test suite. Admin-router tests cover pure-credit paths and validation/authorization, because the admin-router's Stripe client mock doesn't take effect in the Jest worker context (SWC transform + module caching).
- New audit action `kiloclaw.subscription.admin_cancel` added to `KiloClawAdminAuditAction` in `schema-types.ts`.

</details>