### PR TITLE
fix(claw): sync instance display name between DO and Postgres

### DIFF
--- a/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
@@ -152,7 +152,7 @@ export function InstanceControls({
                 if (e.key === 'Enter') handleSaveName();
                 if (e.key === 'Escape') {
                   setIsEditingName(false);
-                  setNameValue(status.name ?? '');
+                  setNameValue(status.name || status.botName || '');
                 }
               }}
             />
@@ -165,7 +165,7 @@ export function InstanceControls({
               className="h-8 w-8"
               onClick={() => {
                 setIsEditingName(false);
-                setNameValue(status.name ?? '');
+                setNameValue(status.name || status.botName || '');
               }}
             >
               <X className="h-4 w-4" />
@@ -173,13 +173,15 @@ export function InstanceControls({
           </>
         ) : (
           <>
-            <h2 className="text-lg font-semibold">{status.name || 'Unnamed instance'}</h2>
+            <h2 className="text-lg font-semibold">
+              {status.name || status.botName || 'Unnamed instance'}
+            </h2>
             <Button
               variant="ghost"
               size="icon"
               className="h-8 w-8"
               onClick={() => {
-                setNameValue(status.name ?? '');
+                setNameValue(status.name || status.botName || '');
                 setIsEditingName(true);
               }}
             >

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -1334,6 +1334,19 @@ export const kiloclawRouter = createTRPCRouter({
           message: error instanceof Error ? error.message : 'Failed to rename instance',
         });
       }
+
+      // Best-effort: propagate the new name to the DO so IDENTITY.md stays in sync
+      try {
+        const instance = await getActiveInstance(ctx.user.id);
+        const client = new KiloClawInternalClient();
+        await client.patchBotIdentity(
+          ctx.user.id,
+          { botName: input.name },
+          workerInstanceId(instance)
+        );
+      } catch {
+        // Non-critical — the DB is the source of truth for the display name
+      }
     }),
 
   getActiveInstanceId: clawAccessProcedure.query(async ({ ctx }) => {
@@ -1600,7 +1613,19 @@ export const kiloclawRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const instance = await getActiveInstance(ctx.user.id);
       const client = new KiloClawInternalClient();
-      return client.patchBotIdentity(ctx.user.id, input, workerInstanceId(instance));
+      const result = await client.patchBotIdentity(ctx.user.id, input, workerInstanceId(instance));
+
+      // Sync botName → Postgres so the dashboard display name stays in sync
+      if (input.botName !== undefined) {
+        try {
+          await renameInstance(ctx.user.id, input.botName);
+        } catch {
+          // Best-effort: don't fail the mutation if the DB rename fails
+          // (e.g. botName exceeds 50-char DB limit)
+        }
+      }
+
+      return result;
     }),
 
   /**

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -57,7 +57,7 @@ import {
 import { client as stripe } from '@/lib/stripe-client';
 import { APP_URL } from '@/lib/constants';
 import { getAffiliateAttribution } from '@/lib/affiliate-attribution';
-import { clawAccessProcedure } from '@/lib/kiloclaw/access-gate';
+import { clawAccessProcedure, requireKiloClawAccess } from '@/lib/kiloclaw/access-gate';
 import {
   getStripePriceIdForClawPlan,
   getStripePriceIdForClawPlanIntro,
@@ -1335,8 +1335,11 @@ export const kiloclawRouter = createTRPCRouter({
         });
       }
 
-      // Best-effort: propagate the new name to the DO so IDENTITY.md stays in sync
+      // Best-effort: propagate the new name to the DO so IDENTITY.md stays in sync.
+      // Guard with requireKiloClawAccess so users without active access can't
+      // mutate live DO state through the baseProcedure-gated rename endpoint.
       try {
+        await requireKiloClawAccess(ctx.user.id);
         const instance = await getActiveInstance(ctx.user.id);
         const client = new KiloClawInternalClient();
         await client.patchBotIdentity(

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -308,6 +308,18 @@ export const organizationKiloclawRouter = createTRPCRouter({
         const code = message === 'No active instance found' ? 'NOT_FOUND' : 'BAD_REQUEST';
         throw new TRPCError({ code, message });
       }
+
+      // Best-effort: propagate the new name to the DO so IDENTITY.md stays in sync
+      try {
+        const client = new KiloClawInternalClient();
+        await client.patchBotIdentity(
+          ctx.user.id,
+          { botName: input.name },
+          workerInstanceId(instance)
+        );
+      } catch {
+        // Non-critical — the DB is the source of truth for the display name
+      }
     }),
 
   // ── Lifecycle ─────────────────────────────────────────────────
@@ -530,7 +542,19 @@ export const organizationKiloclawRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
       const client = new KiloClawInternalClient();
-      return client.patchBotIdentity(ctx.user.id, input, workerInstanceId(instance));
+      const result = await client.patchBotIdentity(ctx.user.id, input, workerInstanceId(instance));
+
+      // Sync botName → Postgres so the dashboard display name stays in sync
+      if (input.botName !== undefined) {
+        try {
+          await renameOrgInstance(instance.id, ctx.user.id, input.organizationId, input.botName);
+        } catch {
+          // Best-effort: don't fail the mutation if the DB rename fails
+          // (e.g. botName exceeds 50-char DB limit)
+        }
+      }
+
+      return result;
     }),
 
   patchSecrets: organizationMemberMutationProcedure


### PR DESCRIPTION
## Summary

The bot name picked during onboarding (`botName` in DO storage) and the instance display name (`name` in Postgres) were two separate values that were never synced. This caused the /claw dashboard to show "Unnamed instance" even after the user picked a name during onboarding.

Three changes across 3 files:

1. **Display fallback** (`InstanceControls.tsx`): The heading and edit pre-fill now fall back to `status.botName` before showing "Unnamed instance". No type changes needed — `botName` is already on `PlatformStatusResponse`.

2. **Sync botName → Postgres** (both routers): `patchBotIdentity` now writes `botName` to `kiloclaw_instances.name` via `renameInstance()`/`renameOrgInstance()` after the DO update succeeds. This keeps the DB in sync when identity is set during onboarding or later.

3. **Propagate pencil rename → DO** (both routers): `renameInstance` now calls `client.patchBotIdentity({ botName: name })` after the DB update, so the DO storage and `IDENTITY.md` on the running machine stay in sync with pencil edits.

All cross-store syncs are best-effort (wrapped in try/catch) so a failure in the secondary store doesn't block the primary operation. No schema changes needed.

## Verification

- [x] `pnpm typecheck` — passes (including `apps/web`)
- [x] `pnpm format` — applied, no remaining formatting issues
- [x] Pre-push hooks pass (format:check, typecheck, lint)

## Visual Changes

N/A

## Reviewer Notes

- The `renameInstance` DB function rejects names >50 chars while `patchBotIdentitySchema.botName` allows up to 80. The best-effort catch handles this gracefully — and in practice the pencil edit Input enforces `maxLength={50}`.
- The personal `renameInstance` mutation uses `baseProcedure` (no claw access check), so the best-effort DO patch uses the internal client with API key auth — this is fine since it runs server-side after a successful DB write.
- `input.botName !== undefined` is the correct guard since the schema uses `.nullable().optional()` — `undefined` means "don't touch", `null` means "clear it".