### PR TITLE
fix(kiloclaw): preserve legacy instance routing after user ID migration

### DIFF
--- a/services/kiloclaw/src/db/index.ts
+++ b/services/kiloclaw/src/db/index.ts
@@ -69,7 +69,14 @@ export async function getActiveInstance(db: WorkerDb, userId: string) {
       organization_id: kiloclaw_instances.organization_id,
     })
     .from(kiloclaw_instances)
-    .where(and(eq(kiloclaw_instances.user_id, userId), isNull(kiloclaw_instances.destroyed_at)))
+    .where(
+      and(
+        eq(kiloclaw_instances.user_id, userId),
+        isNull(kiloclaw_instances.organization_id),
+        isNull(kiloclaw_instances.destroyed_at)
+      )
+    )
+    .orderBy(kiloclaw_instances.created_at)
     .limit(1)
     .then(rows => rows[0] ?? null);
 

--- a/services/kiloclaw/src/db/index.ts
+++ b/services/kiloclaw/src/db/index.ts
@@ -61,7 +61,7 @@ export async function validateAndRedeemAccessCode(db: WorkerDb, code: string, us
   });
 }
 
-export async function getActiveInstance(db: WorkerDb, userId: string) {
+export async function getActivePersonalInstance(db: WorkerDb, userId: string) {
   const row = await db
     .select({
       id: kiloclaw_instances.id,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -67,7 +67,7 @@ vi.mock('../lib/image-version', async () => {
 // -- Mock db --
 vi.mock('../db', () => ({
   getWorkerDb: vi.fn(() => ({})),
-  getActiveInstance: vi.fn().mockResolvedValue(null),
+  getActivePersonalInstance: vi.fn().mockResolvedValue(null),
   findPepperByUserId: vi.fn().mockResolvedValue({
     id: 'user-1',
     api_token_pepper: 'pepper-1',
@@ -5080,7 +5080,7 @@ describe('auto-destroy stale provisioned instances', () => {
 
     const markDestroyed = vi.fn(markImpl);
     (db.getWorkerDb as Mock).mockReturnValue({});
-    (db.getActiveInstance as Mock).mockResolvedValue(null);
+    (db.getActivePersonalInstance as Mock).mockResolvedValue(null);
     (db.markInstanceDestroyed as Mock).mockImplementation(markDestroyed);
 
     const { instance, storage } = createInstance(undefined, env);

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -69,6 +69,7 @@ import {
   markRestartSuccessful,
 } from './reconcile';
 import { restoreFromPostgres, markDestroyedInPostgresHelper } from './postgres';
+import { legacyDoKeysForIdentity } from '../../lib/instance-routing';
 import {
   beginUnexpectedStopRecovery,
   cleanupPendingRecoveryVolumeIfNeeded,
@@ -1440,22 +1441,23 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
               instanceId: registryInstanceId,
             });
           } else {
-            // Legacy: find active entry by doKey=userId
+            const legacyDoKeys = legacyDoKeysForIdentity(preDestroyUserId, preDestroySandboxId);
             const entries = await registryStub.listInstances(registryKey);
-            const legacyEntry = entries.find(e => e.doKey === preDestroyUserId);
+            const legacyEntry = entries.find(e => legacyDoKeys.includes(e.doKey));
             if (legacyEntry) {
               await registryStub.destroyInstance(registryKey, legacyEntry.instanceId);
               console.log('[DO] Registry entry destroyed on finalization (legacy):', {
                 registryKey,
                 instanceId: legacyEntry.instanceId,
-                doKey: preDestroyUserId,
+                doKeysTried: legacyDoKeys,
+                matchedDoKey: legacyEntry.doKey,
               });
             } else {
               console.log(
                 '[DO] Registry cleanup: no active entry found (already cleaned or never existed):',
                 {
                   registryKey,
-                  doKey: preDestroyUserId,
+                  doKeysTried: legacyDoKeys,
                   activeEntryCount: entries.length,
                 }
               );

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/postgres.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/postgres.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { fallbackAppNameForRestore } from './postgres';
+import { sandboxIdFromUserId } from '../../auth/sandbox-id';
+import { appNameFromUserId, appNameFromInstanceId } from '../../fly/apps';
+
+describe('fallbackAppNameForRestore', () => {
+  it('keeps migrated legacy sandboxes on the acct-* naming path', async () => {
+    const legacyUserId = 'oauth/google:117453785559478190551';
+    const migratedUserId = '199e2b19-aa40-488d-9442-9a18a620ba68';
+
+    await expect(
+      fallbackAppNameForRestore(migratedUserId, sandboxIdFromUserId(legacyUserId))
+    ).resolves.toBe(await appNameFromUserId(legacyUserId));
+  });
+
+  it('keeps ki_ sandboxes on the inst-* naming path', async () => {
+    const instanceId = '11111111-1111-4111-8111-111111111111';
+
+    await expect(
+      fallbackAppNameForRestore(
+        '199e2b19-aa40-488d-9442-9a18a620ba68',
+        'ki_11111111111141118111111111111111'
+      )
+    ).resolves.toBe(await appNameFromInstanceId(instanceId));
+  });
+});

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/postgres.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/postgres.ts
@@ -12,11 +12,23 @@ import { getAppKey, getFlyConfig } from './types';
 import { storageUpdate } from './state';
 import { attemptMetadataRecovery } from './reconcile';
 import { doError, doWarn, toLoggable, createReconcileContext } from './log';
+import { isInstanceKeyedSandboxId } from '@kilocode/worker-utils/instance-id';
 
 type RestoreOpts = {
   /** If the DO has a stored sandboxId, use it for precise lookup. */
   sandboxId?: string | null;
 };
+
+export async function fallbackAppNameForRestore(
+  userId: string,
+  sandboxId: string,
+  prefix?: string
+): Promise<string> {
+  const appKey = getAppKey({ userId, sandboxId });
+  return isInstanceKeyedSandboxId(sandboxId)
+    ? appNameFromInstanceId(appKey, prefix)
+    : appNameFromUserId(appKey, prefix);
+}
 
 /**
  * Restore DO state from Postgres backup if SQLite was wiped.
@@ -63,10 +75,7 @@ export async function restoreFromPostgres(
     const appKey = getAppKey({ userId, sandboxId: instance.sandboxId });
     const appStub = env.KILOCLAW_APP.get(env.KILOCLAW_APP.idFromName(appKey));
     const prefix = env.WORKER_ENV === 'development' ? 'dev' : undefined;
-    const isInstanceKeyed = appKey !== userId;
-    const fallbackAppName = isInstanceKeyed
-      ? await appNameFromInstanceId(appKey, prefix)
-      : await appNameFromUserId(userId, prefix);
+    const fallbackAppName = await fallbackAppNameForRestore(userId, instance.sandboxId, prefix);
     const recoveredAppName = (await appStub.getAppName()) ?? fallbackAppName;
 
     await ctx.storage.put(

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/postgres.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/postgres.ts
@@ -2,7 +2,7 @@ import type { KiloClawEnv } from '../../types';
 import type { EncryptedEnvelope } from '../../schemas/instance-config';
 import {
   getWorkerDb,
-  getActiveInstance,
+  getActivePersonalInstance,
   getInstanceBySandboxId,
   markInstanceDestroyed,
 } from '../../db';
@@ -35,7 +35,7 @@ export async function fallbackAppNameForRestore(
  *
  * Lookup priority:
  * 1. If opts.sandboxId is provided, look up by sandbox_id (precise, multi-instance safe).
- * 2. Otherwise, fall back to getActiveInstance(db, userId) (legacy single-instance).
+ * 2. Otherwise, fall back to getActivePersonalInstance(db, userId) (legacy personal instance).
  */
 export async function restoreFromPostgres(
   env: KiloClawEnv,
@@ -56,7 +56,7 @@ export async function restoreFromPostgres(
     // Prefer sandboxId lookup (multi-instance safe) over userId lookup (ambiguous).
     const instance = opts?.sandboxId
       ? await getInstanceBySandboxId(db, opts.sandboxId)
-      : await getActiveInstance(db, userId);
+      : await getActivePersonalInstance(db, userId);
 
     if (!instance) {
       doWarn(state, 'No active instance found in Postgres', { userId });

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/types.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/types.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { getAppKey } from './types';
+import { sandboxIdFromUserId } from '../../auth/sandbox-id';
+
+describe('getAppKey', () => {
+  it('derives the legacy app owner key from sandboxId instead of migrated userId', () => {
+    const legacyUserId = 'oauth/google:117453785559478190551';
+
+    expect(
+      getAppKey({
+        userId: '199e2b19-aa40-488d-9442-9a18a620ba68',
+        sandboxId: sandboxIdFromUserId(legacyUserId),
+      })
+    ).toBe(legacyUserId);
+  });
+
+  it('keeps instance-keyed sandboxes on the instanceId owner key', () => {
+    expect(
+      getAppKey({
+        userId: '199e2b19-aa40-488d-9442-9a18a620ba68',
+        sandboxId: 'ki_11111111111141118111111111111111',
+      })
+    ).toBe('11111111-1111-4111-8111-111111111111');
+  });
+});

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
@@ -1,6 +1,7 @@
 import type { KiloClawEnv } from '../../types';
 import type { GoogleCredentials, PersistedState, MachineSize } from '../../schemas/instance-config';
 import type { FlyClientConfig } from '../../fly/client';
+import { userIdFromSandboxId } from '../../auth/sandbox-id';
 import {
   isInstanceKeyedSandboxId,
   instanceIdFromSandboxId,
@@ -135,6 +136,14 @@ export type InstanceMutableState = {
 export function getAppKey(state: { userId: string | null; sandboxId: string | null }): string {
   if (state.sandboxId && isInstanceKeyedSandboxId(state.sandboxId)) {
     return instanceIdFromSandboxId(state.sandboxId);
+  }
+  if (state.sandboxId) {
+    try {
+      return userIdFromSandboxId(state.sandboxId);
+    } catch {
+      // Older tests and malformed legacy state can still carry placeholder
+      // sandboxIds that are not reversible base64url encodings.
+    }
   }
   if (state.userId) return state.userId;
   throw new Error('Cannot derive app key: no sandboxId or userId');

--- a/services/kiloclaw/src/durable-objects/kiloclaw-registry.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-registry.ts
@@ -4,7 +4,7 @@ import { migrate } from 'drizzle-orm/durable-sqlite/migrator';
 import { eq, isNull, and } from 'drizzle-orm';
 import migrations from '../../drizzle/migrations';
 import { registryInstances } from '../db/sqlite-schema';
-import { getWorkerDb, getActiveInstance } from '../db';
+import { getWorkerDb, getActivePersonalInstance } from '../db';
 import type { KiloClawEnv } from '../types';
 import { doKeyFromActiveInstance } from '../lib/instance-routing';
 
@@ -203,7 +203,7 @@ export class KiloClawRegistry extends DurableObject<KiloClawEnv> {
 
     try {
       const db = getWorkerDb(connectionString);
-      const instance = await getActiveInstance(db, userId);
+      const instance = await getActivePersonalInstance(db, userId);
 
       if (instance) {
         const doKey = doKeyFromActiveInstance(instance);

--- a/services/kiloclaw/src/durable-objects/kiloclaw-registry.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-registry.ts
@@ -5,11 +5,8 @@ import { eq, isNull, and } from 'drizzle-orm';
 import migrations from '../../drizzle/migrations';
 import { registryInstances } from '../db/sqlite-schema';
 import { getWorkerDb, getActiveInstance } from '../db';
-import {
-  isInstanceKeyedSandboxId,
-  instanceIdFromSandboxId,
-} from '@kilocode/worker-utils/instance-id';
 import type { KiloClawEnv } from '../types';
+import { doKeyFromActiveInstance } from '../lib/instance-routing';
 
 export type RegistryEntry = {
   instanceId: string;
@@ -209,13 +206,7 @@ export class KiloClawRegistry extends DurableObject<KiloClawEnv> {
       const instance = await getActiveInstance(db, userId);
 
       if (instance) {
-        // Backfill registry entry from Postgres row.
-        // Derive doKey from the row's sandboxId format:
-        // - ki_ prefix → instance-keyed DO at idFromName(instanceId)
-        // - base64url  → legacy DO at idFromName(userId)
-        const doKey = isInstanceKeyedSandboxId(instance.sandboxId)
-          ? instanceIdFromSandboxId(instance.sandboxId)
-          : userId;
+        const doKey = doKeyFromActiveInstance(instance);
         this.db
           .insert(registryInstances)
           .values({

--- a/services/kiloclaw/src/index.ts
+++ b/services/kiloclaw/src/index.ts
@@ -25,6 +25,7 @@ import { sandboxIdFromUserId } from './auth/sandbox-id';
 import { InstanceIdParam } from './schemas/instance-config';
 import { isValidInstanceId } from '@kilocode/worker-utils/instance-id';
 import { registerVersionIfNeeded } from './lib/image-version';
+import { resolveDoKeyForUser } from './lib/instance-routing';
 import { startingUpPage } from './pages/starting-up';
 import { buildForwardHeaders } from './utils/proxy-headers';
 import { KILOCLAW_ACTIVE_INSTANCE_COOKIE } from './config';
@@ -349,16 +350,21 @@ async function resolveRegistryEntry(c: Context<AppEnv>) {
     const stub = c.env.KILOCLAW_INSTANCE.get(c.env.KILOCLAW_INSTANCE.idFromName(entry.doKey));
     return { stub, entry };
   } catch (err) {
-    // Registry DO failed. Fall back to the legacy userId-keyed DO.
-    // Only preserves access for legacy instances (doKey = userId).
-    // For instance-keyed DOs (doKey = instanceId), this hits the wrong
-    // (empty) DO — the user sees "not provisioned" until the registry
-    // recovers. Acceptable: a broken registry is transient, and silently
-    // routing to the wrong DO would be worse.
-    console.error('[PROXY] Registry lookup failed, falling back to legacy DO:', err);
-    const stub = c.env.KILOCLAW_INSTANCE.get(c.env.KILOCLAW_INSTANCE.idFromName(userId));
+    console.error(
+      '[PROXY] Registry lookup failed, falling back to Postgres-backed DO lookup:',
+      err
+    );
+    const fallbackDoKey =
+      (await resolveDoKeyForUser(c.env.HYPERDRIVE?.connectionString, userId).catch(fallbackErr => {
+        console.error(
+          '[PROXY] Postgres-backed DO lookup failed, falling back to userId:',
+          fallbackErr
+        );
+        return null;
+      })) ?? userId;
+    const stub = c.env.KILOCLAW_INSTANCE.get(c.env.KILOCLAW_INSTANCE.idFromName(fallbackDoKey));
     const fallbackEntry: RegistryEntry = {
-      doKey: userId,
+      doKey: fallbackDoKey,
       instanceId: '',
       assignedUserId: userId,
       createdAt: '',

--- a/services/kiloclaw/src/lib/instance-routing.ts
+++ b/services/kiloclaw/src/lib/instance-routing.ts
@@ -1,0 +1,43 @@
+import { getActiveInstance, getWorkerDb } from '../db';
+import { userIdFromSandboxId } from '../auth/sandbox-id';
+import {
+  instanceIdFromSandboxId,
+  isInstanceKeyedSandboxId,
+} from '@kilocode/worker-utils/instance-id';
+
+type ActiveInstanceIdentity = {
+  id: string;
+  sandboxId: string;
+};
+
+export function legacyDoKeysForIdentity(userId: string, sandboxId: string): string[] {
+  const keys = new Set<string>([userId]);
+
+  if (!isInstanceKeyedSandboxId(sandboxId)) {
+    try {
+      keys.add(userIdFromSandboxId(sandboxId));
+    } catch {
+      // Placeholder sandboxIds can exist in old tests or malformed state.
+    }
+  }
+
+  return [...keys];
+}
+
+export function doKeyFromActiveInstance(instance: ActiveInstanceIdentity): string {
+  return isInstanceKeyedSandboxId(instance.sandboxId)
+    ? instanceIdFromSandboxId(instance.sandboxId)
+    : userIdFromSandboxId(instance.sandboxId);
+}
+
+export async function resolveDoKeyForUser(
+  connectionString: string | undefined,
+  userId: string
+): Promise<string | null> {
+  if (!connectionString) return null;
+
+  const instance = await getActiveInstance(getWorkerDb(connectionString), userId);
+  if (!instance) return null;
+
+  return doKeyFromActiveInstance(instance);
+}

--- a/services/kiloclaw/src/lib/instance-routing.ts
+++ b/services/kiloclaw/src/lib/instance-routing.ts
@@ -1,4 +1,4 @@
-import { getActiveInstance, getWorkerDb } from '../db';
+import { getActivePersonalInstance, getWorkerDb } from '../db';
 import { userIdFromSandboxId } from '../auth/sandbox-id';
 import {
   instanceIdFromSandboxId,
@@ -36,7 +36,7 @@ export async function resolveDoKeyForUser(
 ): Promise<string | null> {
   if (!connectionString) return null;
 
-  const instance = await getActiveInstance(getWorkerDb(connectionString), userId);
+  const instance = await getActivePersonalInstance(getWorkerDb(connectionString), userId);
   if (!instance) return null;
 
   return doKeyFromActiveInstance(instance);

--- a/services/kiloclaw/src/routes/platform-legacy-routing.test.ts
+++ b/services/kiloclaw/src/routes/platform-legacy-routing.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('cloudflare:workers', () => ({
+  DurableObject: class {},
+  waitUntil: (promise: Promise<unknown>) => promise,
+}));
+
+vi.mock('../db', () => ({
+  getWorkerDb: vi.fn(() => ({})),
+  getActiveInstance: vi.fn(),
+}));
+
+import { platform, resolveInstanceDoKey } from './platform';
+import { sandboxIdFromUserId } from '../auth/sandbox-id';
+import { getActiveInstance } from '../db';
+
+const currentUserId = '199e2b19-aa40-488d-9442-9a18a620ba68';
+const legacyDoKey = 'oauth/google:117453785559478190551';
+const legacySandboxId = sandboxIdFromUserId(legacyDoKey);
+
+function makeEnv() {
+  const idFromName = vi.fn((id: string) => id);
+  const getStatus = vi.fn().mockResolvedValue({
+    userId: currentUserId,
+    sandboxId: legacySandboxId,
+    status: 'running',
+    flyMachineId: 'machine-1',
+    flyAppName: 'acct-legacy',
+  });
+
+  return {
+    env: {
+      HYPERDRIVE: { connectionString: 'postgresql://fake' },
+      KILOCLAW_INSTANCE: {
+        idFromName,
+        get: () => ({ getStatus, destroy: vi.fn().mockResolvedValue(undefined) }),
+      },
+      KILOCLAW_AE: { writeDataPoint: vi.fn() },
+      KILOCLAW_REGISTRY: {
+        idFromName: vi.fn((id: string) => id),
+        get: () => ({
+          listInstances: vi.fn().mockResolvedValue([]),
+          destroyInstance: vi.fn().mockResolvedValue(undefined),
+        }),
+      },
+      KV_CLAW_CACHE: {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        list: vi.fn().mockResolvedValue({ keys: [], list_complete: true }),
+        getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null }),
+      },
+    } as never,
+    idFromName,
+    getStatus,
+  };
+}
+
+describe('legacy platform DO routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves the original legacy DO key from the active instance row', async () => {
+    vi.mocked(getActiveInstance).mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      sandboxId: legacySandboxId,
+      orgId: null,
+    });
+
+    const { env, idFromName, getStatus } = makeEnv();
+    const response = await platform.request(`/status?userId=${currentUserId}`, {}, env);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        sandboxId: legacySandboxId,
+        flyAppName: 'acct-legacy',
+      })
+    );
+    expect(idFromName).toHaveBeenCalledWith(legacyDoKey);
+    expect(getStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the instanceId for instance-keyed rows when instanceId is omitted', async () => {
+    vi.mocked(getActiveInstance).mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      sandboxId: 'ki_11111111111141118111111111111111',
+      orgId: null,
+    });
+
+    await expect(
+      resolveInstanceDoKey(
+        {
+          HYPERDRIVE: { connectionString: 'postgresql://fake' },
+        } as never,
+        currentUserId
+      )
+    ).resolves.toBe('11111111-1111-4111-8111-111111111111');
+  });
+
+  it('destroys preexisting legacy registry rows keyed by the migrated user id', async () => {
+    vi.mocked(getActiveInstance).mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      sandboxId: legacySandboxId,
+      orgId: null,
+    });
+
+    const destroyInstance = vi.fn().mockResolvedValue(undefined);
+    const listInstances = vi.fn().mockResolvedValue([
+      {
+        instanceId: '11111111-1111-4111-8111-111111111111',
+        doKey: currentUserId,
+        assignedUserId: currentUserId,
+        createdAt: new Date().toISOString(),
+        destroyedAt: null,
+      },
+    ]);
+
+    const { env } = makeEnv();
+    (
+      env as unknown as {
+        KILOCLAW_REGISTRY: {
+          idFromName: (id: string) => string;
+          get: () => {
+            listInstances: typeof listInstances;
+            destroyInstance: typeof destroyInstance;
+          };
+        };
+      }
+    ).KILOCLAW_REGISTRY = {
+      idFromName: vi.fn((id: string) => id),
+      get: () => ({ listInstances, destroyInstance }),
+    };
+
+    const response = await platform.request(
+      '/destroy',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: currentUserId }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(destroyInstance).toHaveBeenCalledWith(
+      `user:${currentUserId}`,
+      '11111111-1111-4111-8111-111111111111'
+    );
+  });
+});

--- a/services/kiloclaw/src/routes/platform-legacy-routing.test.ts
+++ b/services/kiloclaw/src/routes/platform-legacy-routing.test.ts
@@ -5,14 +5,18 @@ vi.mock('cloudflare:workers', () => ({
   waitUntil: (promise: Promise<unknown>) => promise,
 }));
 
-vi.mock('../db', () => ({
-  getWorkerDb: vi.fn(() => ({})),
-  getActiveInstance: vi.fn(),
-}));
+vi.mock('../db', async importOriginal => {
+  const actual = await importOriginal<typeof import('../db')>();
+  return {
+    ...actual,
+    getWorkerDb: vi.fn(() => ({})),
+    getActivePersonalInstance: vi.fn(),
+  };
+});
 
 import { platform, resolveInstanceDoKey } from './platform';
 import { sandboxIdFromUserId } from '../auth/sandbox-id';
-import { getActiveInstance } from '../db';
+import { getActivePersonalInstance } from '../db';
 
 const currentUserId = '199e2b19-aa40-488d-9442-9a18a620ba68';
 const legacyDoKey = 'oauth/google:117453785559478190551';
@@ -62,7 +66,7 @@ describe('legacy platform DO routing', () => {
   });
 
   it('resolves the original legacy DO key from the active instance row', async () => {
-    vi.mocked(getActiveInstance).mockResolvedValue({
+    vi.mocked(getActivePersonalInstance).mockResolvedValue({
       id: '11111111-1111-4111-8111-111111111111',
       sandboxId: legacySandboxId,
       orgId: null,
@@ -83,7 +87,7 @@ describe('legacy platform DO routing', () => {
   });
 
   it('returns the instanceId for instance-keyed rows when instanceId is omitted', async () => {
-    vi.mocked(getActiveInstance).mockResolvedValue({
+    vi.mocked(getActivePersonalInstance).mockResolvedValue({
       id: '11111111-1111-4111-8111-111111111111',
       sandboxId: 'ki_11111111111141118111111111111111',
       orgId: null,
@@ -100,7 +104,7 @@ describe('legacy platform DO routing', () => {
   });
 
   it('destroys preexisting legacy registry rows keyed by the migrated user id', async () => {
-    vi.mocked(getActiveInstance).mockResolvedValue({
+    vi.mocked(getActivePersonalInstance).mockResolvedValue({
       id: '11111111-1111-4111-8111-111111111111',
       sandboxId: legacySandboxId,
       orgId: null,

--- a/services/kiloclaw/src/routes/platform-legacy-routing.test.ts
+++ b/services/kiloclaw/src/routes/platform-legacy-routing.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type * as DbModule from '../db';
 
 vi.mock('cloudflare:workers', () => ({
   DurableObject: class {},
@@ -6,7 +7,7 @@ vi.mock('cloudflare:workers', () => ({
 }));
 
 vi.mock('../db', async importOriginal => {
-  const actual = await importOriginal<typeof import('../db')>();
+  const actual = await importOriginal<typeof DbModule>();
   return {
     ...actual,
     getWorkerDb: vi.fn(() => ({})),

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -32,6 +32,7 @@ import { sandboxIdFromUserId } from '../auth/sandbox-id';
 import { writeEvent } from '../utils/analytics';
 import { deriveHttpEventName } from '../middleware/analytics';
 import { sendMessage } from '../stream-chat/client';
+import { resolveDoKeyForUser } from '../lib/instance-routing';
 
 const GmailHistoryIdSchema = z.object({
   userId: z.string().min(1),
@@ -53,6 +54,7 @@ const KiloCodeConfigPatchSchema = z.object({
 });
 
 const platform = new Hono<AppEnv>();
+type KiloClawInstanceStub = ReturnType<AppEnv['Bindings']['KILOCLAW_INSTANCE']['get']>;
 
 type BillingPlatformLogFields = {
   billingFlow?: string;
@@ -190,15 +192,51 @@ function setValidatedQueryUserId(c: Context<AppEnv>): string | null {
 }
 
 /**
+ * Resolve the DO key for a platform request.
+ *
+ * When instanceId is provided, it is always authoritative. Otherwise the
+ * active Postgres row is the source of truth so legacy sandboxes continue to
+ * route to the original userId-keyed DO after kilocode_users.id migrations.
+ */
+export async function resolveInstanceDoKey(
+  env: AppEnv['Bindings'],
+  userId: string,
+  instanceId?: string
+): Promise<string> {
+  if (instanceId) return instanceId;
+
+  try {
+    return (await resolveDoKeyForUser(env.HYPERDRIVE?.connectionString, userId)) ?? userId;
+  } catch (err) {
+    console.warn('[platform] Failed to resolve DO key from Postgres, falling back to userId', {
+      userId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return userId;
+  }
+}
+
+/**
  * Create a fresh KiloClawInstance DO stub.
  * Returns a factory (not the stub itself) so withDORetry can get a fresh stub per attempt.
- *
- * When instanceId is provided, uses it as the DO key (multi-instance).
- * When absent, uses userId as the DO key (legacy single-instance).
  */
-function instanceStubFactory(env: AppEnv['Bindings'], userId: string, instanceId?: string) {
-  const doKey = instanceId ?? userId;
+async function instanceStubFactory(
+  env: AppEnv['Bindings'],
+  userId: string,
+  instanceId?: string
+): Promise<() => KiloClawInstanceStub> {
+  const doKey = await resolveInstanceDoKey(env, userId, instanceId);
   return () => env.KILOCLAW_INSTANCE.get(env.KILOCLAW_INSTANCE.idFromName(doKey));
+}
+
+async function withResolvedDORetry<TResult>(
+  env: AppEnv['Bindings'],
+  userId: string,
+  instanceId: string | undefined,
+  operation: (stub: KiloClawInstanceStub) => Promise<TResult>,
+  operationName: string
+): Promise<TResult> {
+  return withDORetry(await instanceStubFactory(env, userId, instanceId), operation, operationName);
 }
 
 /** Parse and validate optional ?instanceId= query param. Returns 400 on invalid format. */
@@ -393,8 +431,10 @@ platform.post('/provision', async c => {
 
   let provision;
   try {
-    provision = await withDORetry(
-      instanceStubFactory(c.env, userId, instanceId),
+    provision = await withResolvedDORetry(
+      c.env,
+      userId,
+      instanceId,
       stub =>
         stub.provision(
           userId,
@@ -458,8 +498,10 @@ platform.patch('/kilocode-config', async c => {
   const { userId, kilocodeApiKey, kilocodeApiKeyExpiresAt, kilocodeDefaultModel } = result.data;
 
   try {
-    const updated = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const updated = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub =>
         stub.updateKiloCodeConfig({
           kilocodeApiKey,
@@ -486,8 +528,10 @@ platform.patch('/channels', async c => {
   const { userId, channels } = result.data;
 
   try {
-    const updated = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const updated = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.updateChannels(channels),
       'updateChannels'
     );
@@ -523,8 +567,10 @@ platform.patch('/exec-preset', async c => {
   const { userId, security, ask } = result.data;
 
   try {
-    const updated = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const updated = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.updateExecPreset({ security, ask }),
       'updateExecPreset'
     );
@@ -545,8 +591,10 @@ platform.patch('/bot-identity', async c => {
   const { userId, botName, botNature, botVibe, botEmoji } = result.data;
 
   try {
-    const updated = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const updated = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.updateBotIdentity({ botName, botNature, botVibe, botEmoji }),
       'updateBotIdentity'
     );
@@ -573,8 +621,10 @@ platform.post('/google-credentials', async c => {
   const { userId, googleCredentials } = result.data;
 
   try {
-    const updated = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const updated = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.updateGoogleCredentials(googleCredentials),
       'updateGoogleCredentials'
     );
@@ -594,8 +644,10 @@ platform.delete('/google-credentials', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const updated = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const updated = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.clearGoogleCredentials(),
       'clearGoogleCredentials'
     );
@@ -617,8 +669,10 @@ platform.post('/gmail-notifications', async c => {
   const { userId } = result.data;
 
   try {
-    const updated = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const updated = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.updateGmailNotifications(true),
       'enableGmailNotifications'
     );
@@ -638,8 +692,10 @@ platform.delete('/gmail-notifications', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const updated = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const updated = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.updateGmailNotifications(false),
       'disableGmailNotifications'
     );
@@ -661,8 +717,10 @@ platform.post('/gmail-history-id', async c => {
   const { userId, historyId } = result.data;
 
   try {
-    await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.updateGmailHistoryId(historyId),
       'updateGmailHistoryId'
     );
@@ -683,8 +741,10 @@ platform.get('/gmail-oidc-email', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const result = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const result = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.getGmailOidcEmail(),
       'getGmailOidcEmail'
     );
@@ -706,8 +766,10 @@ platform.patch('/secrets', async c => {
   const { userId, secrets, meta } = result.data;
 
   try {
-    const updated = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const updated = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.updateSecrets(secrets, meta),
       'updateSecrets'
     );
@@ -729,8 +791,10 @@ platform.get('/pairing', async c => {
   const forceRefresh = c.req.query('refresh') === 'true';
 
   try {
-    const pairing = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const pairing = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.listPairingRequests(forceRefresh),
       'listPairingRequests'
     );
@@ -758,8 +822,10 @@ platform.post('/pairing/approve', async c => {
   const { userId, channel, code } = result.data;
 
   try {
-    const approved = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const approved = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.approvePairingRequest(channel, code),
       'approvePairingRequest'
     );
@@ -781,8 +847,10 @@ platform.get('/device-pairing', async c => {
   const forceRefresh = c.req.query('refresh') === 'true';
 
   try {
-    const pairing = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const pairing = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.listDevicePairingRequests(forceRefresh),
       'listDevicePairingRequests'
     );
@@ -809,8 +877,10 @@ platform.post('/device-pairing/approve', async c => {
   const { userId, requestId } = result.data;
 
   try {
-    const approved = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const approved = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.approveDevicePairingRequest(requestId),
       'approveDevicePairingRequest'
     );
@@ -832,8 +902,10 @@ platform.get('/gateway/status', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const gatewayStatus = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const gatewayStatus = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.getGatewayProcessStatus(),
       'getGatewayProcessStatus'
     );
@@ -857,8 +929,10 @@ platform.get('/gateway/ready', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const result = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const result = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.getGatewayReady(),
       'getGatewayReady'
     );
@@ -880,8 +954,10 @@ platform.get('/controller-version', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const result = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const result = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.getControllerVersion(),
       'getControllerVersion'
     );
@@ -904,8 +980,10 @@ platform.post('/gateway/start', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const response = await withDORetry(
-      instanceStubFactory(c.env, result.data.userId, iidResult.instanceId),
+    const response = await withResolvedDORetry(
+      c.env,
+      result.data.userId,
+      iidResult.instanceId,
       stub => stub.startGatewayProcess(),
       'startGatewayProcess'
     );
@@ -925,8 +1003,10 @@ platform.post('/gateway/stop', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const response = await withDORetry(
-      instanceStubFactory(c.env, result.data.userId, iidResult.instanceId),
+    const response = await withResolvedDORetry(
+      c.env,
+      result.data.userId,
+      iidResult.instanceId,
       stub => stub.stopGatewayProcess(),
       'stopGatewayProcess'
     );
@@ -946,8 +1026,10 @@ platform.post('/gateway/restart', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const response = await withDORetry(
-      instanceStubFactory(c.env, result.data.userId, iidResult.instanceId),
+    const response = await withResolvedDORetry(
+      c.env,
+      result.data.userId,
+      iidResult.instanceId,
       stub => stub.restartGatewayProcess(),
       'restartGatewayProcess'
     );
@@ -974,8 +1056,10 @@ platform.post('/config/restore', async c => {
   const { userId, version } = result.data;
 
   try {
-    const response = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const response = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.restoreConfig(version),
       'restoreConfig'
     );
@@ -1000,8 +1084,10 @@ platform.get('/openclaw-config', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const config = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const config = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.getOpenclawConfig(),
       'getOpenclawConfig'
     );
@@ -1033,8 +1119,10 @@ platform.post('/openclaw-config', async c => {
   const { userId, config, etag } = result.data;
 
   try {
-    const response = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const response = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.replaceConfigOnMachine(config, etag),
       'replaceConfigOnMachine'
     );
@@ -1065,8 +1153,10 @@ platform.patch('/openclaw-config', async c => {
   const { userId, patch } = result.data;
 
   try {
-    const response = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const response = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.patchOpenclawConfig(patch),
       'patchOpenclawConfig'
     );
@@ -1088,8 +1178,10 @@ platform.get('/files/tree', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const result = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const result = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.getFileTree(),
       'getFileTree'
     );
@@ -1122,8 +1214,10 @@ platform.get('/files/read', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const result = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const result = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.readFile(filePath),
       'readFile'
     );
@@ -1158,8 +1252,10 @@ platform.post('/files/write', async c => {
 
   const { userId, path: filePath, content, etag } = result.data;
   try {
-    const response = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const response = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.writeFile(filePath, content, etag),
       'writeFile'
     );
@@ -1186,8 +1282,10 @@ platform.post('/doctor', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const doctor = await withDORetry(
-      instanceStubFactory(c.env, result.data.userId, iidResult.instanceId),
+    const doctor = await withResolvedDORetry(
+      c.env,
+      result.data.userId,
+      iidResult.instanceId,
       stub => stub.runDoctor(),
       'runDoctor'
     );
@@ -1213,8 +1311,10 @@ platform.post('/kilo-cli-run/start', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const response = await withDORetry(
-      instanceStubFactory(c.env, result.data.userId, iidResult.instanceId),
+    const response = await withResolvedDORetry(
+      c.env,
+      result.data.userId,
+      iidResult.instanceId,
       stub => stub.startKiloCliRun(result.data.prompt),
       'startKiloCliRun'
     );
@@ -1240,8 +1340,10 @@ platform.get('/kilo-cli-run/status', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const response = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const response = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.getKiloCliRunStatus(),
       'getKiloCliRunStatus'
     );
@@ -1260,8 +1362,10 @@ platform.post('/kilo-cli-run/cancel', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const response = await withDORetry(
-      instanceStubFactory(c.env, result.data.userId, iidResult.instanceId),
+    const response = await withResolvedDORetry(
+      c.env,
+      result.data.userId,
+      iidResult.instanceId,
       stub => stub.cancelKiloCliRun(),
       'cancelKiloCliRun'
     );
@@ -1293,14 +1397,18 @@ async function handleStartRequest(c: Context<AppEnv>, mode: 'sync' | 'async') {
     const options = result.data.skipCooldown ? { skipCooldown: true } : undefined;
 
     if (mode === 'async') {
-      await withDORetry(
-        instanceStubFactory(c.env, result.data.userId, instanceId),
+      await withResolvedDORetry(
+        c.env,
+        result.data.userId,
+        instanceId,
         stub => stub.startAsync(result.data.userId),
         'startAsync'
       );
     } else {
-      const { started } = await withDORetry(
-        instanceStubFactory(c.env, result.data.userId, instanceId),
+      const { started } = await withResolvedDORetry(
+        c.env,
+        result.data.userId,
+        instanceId,
         stub => stub.start(result.data.userId, options),
         'start'
       );
@@ -1351,8 +1459,10 @@ platform.post('/force-retry-recovery', async c => {
   const startedAt = performance.now();
 
   try {
-    const { ok } = await withDORetry(
-      instanceStubFactory(c.env, result.data.userId, iidResult.instanceId),
+    const { ok } = await withResolvedDORetry(
+      c.env,
+      result.data.userId,
+      iidResult.instanceId,
       stub => stub.forceRetryRecovery(),
       'forceRetryRecovery'
     );
@@ -1387,8 +1497,10 @@ platform.post('/cleanup-recovery-previous-volume', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const response = await withDORetry(
-      instanceStubFactory(c.env, result.data.userId, iidResult.instanceId),
+    const response = await withResolvedDORetry(
+      c.env,
+      result.data.userId,
+      iidResult.instanceId,
       stub => stub.cleanupRecoveryPreviousVolume(),
       'cleanupRecoveryPreviousVolume'
     );
@@ -1409,11 +1521,7 @@ platform.post('/stop', async c => {
   const { instanceId } = iidResult;
 
   try {
-    await withDORetry(
-      instanceStubFactory(c.env, result.data.userId, instanceId),
-      stub => stub.stop(),
-      'stop'
-    );
+    await withResolvedDORetry(c.env, result.data.userId, instanceId, stub => stub.stop(), 'stop');
     return c.json({ ok: true });
   } catch (err) {
     const { message, status } = sanitizeError(err, 'stop');
@@ -1431,12 +1539,13 @@ platform.post('/destroy', async c => {
   const { instanceId } = iidResult;
 
   const { userId } = result.data;
+  const doKey = await resolveInstanceDoKey(c.env, userId, instanceId);
 
   // Read the instance's orgId before destroying so we can update the correct registry.
   let orgId: string | null = null;
   if (instanceId) {
     try {
-      const statusStub = instanceStubFactory(c.env, userId, instanceId)();
+      const statusStub = (await instanceStubFactory(c.env, userId, instanceId))();
       const status = await statusStub.getStatus();
       orgId = status.orgId;
     } catch {
@@ -1450,11 +1559,7 @@ platform.post('/destroy', async c => {
   }
 
   try {
-    await withDORetry(
-      instanceStubFactory(c.env, userId, instanceId),
-      stub => stub.destroy(),
-      'destroy'
-    );
+    await withResolvedDORetry(c.env, userId, instanceId, stub => stub.destroy(), 'destroy');
 
     // Remove the instance from the registry (best-effort).
     // When instanceId is provided, destroy by instanceId directly.
@@ -1472,21 +1577,23 @@ platform.post('/destroy', async c => {
           await registryStub.destroyInstance(registryKey, instanceId);
           console.log('[platform] Registry entry destroyed:', { registryKey, instanceId });
         } else {
-          // Legacy destroy (no instanceId): the DO was keyed by userId,
-          // so find the registry entry with doKey=userId.
+          // Legacy destroy (no instanceId): find the registry entry by the
+          // original legacy DO key recovered from sandboxId/Postgres state.
           const entries = await registryStub.listInstances(registryKey);
-          const legacyEntry = entries.find(e => e.doKey === userId);
+          const doKeysToMatch = doKey === userId ? [userId] : [userId, doKey];
+          const legacyEntry = entries.find(e => doKeysToMatch.includes(e.doKey));
           if (legacyEntry) {
             await registryStub.destroyInstance(registryKey, legacyEntry.instanceId);
             console.log('[platform] Registry entry destroyed (legacy):', {
               registryKey,
               instanceId: legacyEntry.instanceId,
-              doKey: userId,
+              doKeysTried: doKeysToMatch,
+              matchedDoKey: legacyEntry.doKey,
             });
           } else {
             console.log('[platform] No registry entry found for legacy destroy:', {
               registryKey,
-              doKey: userId,
+              doKeysTried: doKeysToMatch,
               entriesCount: entries.length,
             });
           }
@@ -1514,8 +1621,10 @@ platform.get('/status', async c => {
   const { instanceId } = iidResult;
 
   try {
-    const status = await withDORetry(
-      instanceStubFactory(c.env, userId, instanceId),
+    const status = await withResolvedDORetry(
+      c.env,
+      userId,
+      instanceId,
       stub => stub.getStatus(),
       'getStatus'
     );
@@ -1537,8 +1646,10 @@ platform.get('/stream-chat-credentials', async c => {
   const { instanceId } = iidResult;
 
   try {
-    const creds = await withDORetry(
-      instanceStubFactory(c.env, userId, instanceId),
+    const creds = await withResolvedDORetry(
+      c.env,
+      userId,
+      instanceId,
       stub => stub.getStreamChatCredentials(),
       'getStreamChatCredentials'
     );
@@ -1577,8 +1688,10 @@ platform.post('/send-chat-message', async c => {
   try {
     // Use instanceId as the DO key when available (matches how other endpoints resolve DOs).
     // Falls back to userId for backward compatibility with triggers that predate instanceId.
-    const creds = await withDORetry(
-      instanceStubFactory(c.env, userId, instanceId),
+    const creds = await withResolvedDORetry(
+      c.env,
+      userId,
+      instanceId,
       stub => stub.getStreamChatCredentials(),
       'getStreamChatCredentials'
     );
@@ -1627,8 +1740,10 @@ platform.get('/debug-status', async c => {
   const { instanceId } = iidResult;
 
   try {
-    const status = await withDORetry(
-      instanceStubFactory(c.env, userId, instanceId),
+    const status = await withResolvedDORetry(
+      c.env,
+      userId,
+      instanceId,
       stub => stub.getDebugState(),
       'getDebugState'
     );
@@ -1698,8 +1813,10 @@ platform.get('/gateway-token', async c => {
   }
 
   try {
-    const status = await withDORetry(
-      instanceStubFactory(c.env, userId, instanceId),
+    const status = await withResolvedDORetry(
+      c.env,
+      userId,
+      instanceId,
       stub => stub.getStatus(),
       'getStatus'
     );
@@ -1728,8 +1845,10 @@ platform.get('/volume-snapshots', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const snapshots = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const snapshots = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.listVolumeSnapshots(),
       'listVolumeSnapshots'
     );
@@ -1752,8 +1871,10 @@ platform.get('/candidate-volumes', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const result = await withDORetry(
-      instanceStubFactory(c.env, userId, iidResult.instanceId),
+    const result = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
       stub => stub.listCandidateVolumes(),
       'listCandidateVolumes'
     );
@@ -1780,8 +1901,10 @@ platform.post('/reassociate-volume', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const response = await withDORetry(
-      instanceStubFactory(c.env, result.data.userId, iidResult.instanceId),
+    const response = await withResolvedDORetry(
+      c.env,
+      result.data.userId,
+      iidResult.instanceId,
       stub => stub.reassociateVolume(result.data.newVolumeId, result.data.reason),
       'reassociateVolume'
     );
@@ -1807,8 +1930,10 @@ platform.post('/restore-volume-snapshot', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const response = await withDORetry(
-      instanceStubFactory(c.env, result.data.userId, iidResult.instanceId),
+    const response = await withResolvedDORetry(
+      c.env,
+      result.data.userId,
+      iidResult.instanceId,
       stub => stub.enqueueSnapshotRestore(result.data.snapshotId),
       'enqueueSnapshotRestore'
     );
@@ -2021,8 +2146,10 @@ platform.post('/destroy-fly-machine', async c => {
 
     // Trigger immediate reconcile so the DO discovers the machine is gone.
     try {
-      await withDORetry(
-        instanceStubFactory(c.env, userId, iidResult.instanceId),
+      await withResolvedDORetry(
+        c.env,
+        userId,
+        iidResult.instanceId,
         stub => stub.forceRetryRecovery(),
         'forceRetryRecovery'
       );


### PR DESCRIPTION
## Summary
- Fix legacy KiloClaw instance routing after user ID migrations.
- Reuse persisted instance identity for platform, proxy, registry, restore, and destroy paths.
- Add regression tests for legacy-vs-instance-keyed routing behavior.

### Why this is needed
The bug this PR fixes is a post-user-ID-migration routing regression, not just “legacy routing” in the abstract.
 Historically, personal KiloClaw instances predated multi-instance support, so many of them were keyed by the original user identity encoded in sandboxId, and platform calls without instanceId implicitly routed by that legacy DO key. 
 
After a `kilocode_users.id` migration, those same requests could start defaulting to the user’s current ID instead of the persisted instance identity. That means service can look up the wrong DO or wrong Fly app name and act as if the instance is missing.

I opted for this fix because the active Postgres instance row is already the durable source of truth for the instance’s identity. It tells us whether the sandbox is legacy user-keyed or newer instance-keyed, so we can derive the correct DO key from persisted state instead of guessing from the caller’s current userId. 

## Verification

- [x] `pnpm --filter ./services/kiloclaw test -- services/kiloclaw/src/routes/platform-legacy-routing.test.ts services/kiloclaw/src/durable-objects/kiloclaw-instance/postgres.test.ts services/kiloclaw/src/durable-objects/kiloclaw-instance/types.test.ts` — passed

## Visual Changes

N/A

## Reviewer Notes
<details>
<summary>Routing and identity details</summary>

- No database schema or migration changes.
- Platform routes now resolve the omitted-`instanceId` DO key from the active personal KiloClaw instance row instead of assuming the current `kilocode_users.id`.
- Legacy sandbox IDs recover the original user identity for DO keys and `acct-*` Fly app fallback names.
- Instance-keyed `ki_...` sandbox IDs continue to route by instance ID and use the `inst-*` Fly app naming path.
- Registry backfill, proxy fallback, platform destroy, and DO finalization share the same persisted-identity routing model.
- Legacy registry cleanup intentionally tries both the migrated user ID and recovered legacy DO key so old registry rows can be removed.
- The code falls back to the current user ID when Postgres-backed lookup fails; review the new fallback logs for production signal/noise.

</details>