### PR TITLE
feat(kiloclaw): instrument setup wizard funnel steps

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawDashboard.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawDashboard.tsx
@@ -162,8 +162,8 @@ function ClawDashboardInner({
     if (initialIsNewSetupRef.current) {
       posthog?.capture('claw_setup_identity_viewed');
     }
-  // Intentionally mount-only. Re-entry is handled by the reset effect below.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Intentionally mount-only. Re-entry is handled by the reset effect below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Reset onboarding wizard to step 1 whenever we enter setup mode so that
@@ -315,7 +315,9 @@ function ClawDashboardInner({
             totalSteps={hasPairingStep ? 6 : 5}
             onComplete={() => {
               posthog?.capture('claw_setup_provisioned');
-              posthog?.capture(hasPairingStep ? 'claw_setup_pairing_viewed' : 'claw_setup_done_viewed');
+              posthog?.capture(
+                hasPairingStep ? 'claw_setup_pairing_viewed' : 'claw_setup_done_viewed'
+              );
               setOnboardingStep(hasPairingStep ? 'pairing' : 'done');
             }}
           />

--- a/apps/web/src/app/(app)/claw/components/ClawDashboard.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawDashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
+import { usePostHog } from 'posthog-js/react';
 import { Check, Sparkles, TriangleAlert, X, Zap } from 'lucide-react';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { useKiloClawGatewayStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
@@ -108,6 +109,8 @@ function ClawDashboardInner({
 
   const { data: isServiceDegraded } = useClawServiceDegraded();
 
+  const posthog = usePostHog();
+
   const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
   const instanceYoung =
     instanceStatus !== null &&
@@ -148,6 +151,25 @@ function ClawDashboardInner({
   const [channelTokens, setChannelTokens] = useState<Record<string, string> | null>(null);
   const [selectedChannelId, setSelectedChannelId] = useState<string | null>(null);
   const hasPairingStep = selectedChannelId === 'telegram' || selectedChannelId === 'discord';
+
+  // Fire a per-step viewed event whenever the active onboarding step changes.
+  // Distinct event names make PostHog Funnel charts trivial to build (no
+  // per-step property filters needed).
+  const STEP_VIEWED_EVENT: Record<typeof onboardingStep, string> = {
+    identity: 'claw_setup_identity_viewed',
+    permissions: 'claw_setup_permissions_viewed',
+    channels: 'claw_setup_channels_viewed',
+    provisioning: 'claw_setup_provisioning_viewed',
+    pairing: 'claw_setup_pairing_viewed',
+    done: 'claw_setup_done_viewed',
+  };
+  useEffect(() => {
+    if (!isNewSetup) return;
+    posthog?.capture(STEP_VIEWED_EVENT[onboardingStep]);
+    // STEP_VIEWED_EVENT is a derived constant — only the meaningful state
+    // values that compose it need to be in the dep array.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onboardingStep, isNewSetup]);
 
   // Reset onboarding wizard to step 1 whenever we enter setup mode so that
   // a destroy → re-provision cycle always starts fresh.
@@ -243,6 +265,11 @@ function ClawDashboardInner({
           <BotIdentityStep
             instanceRunning={isRunning && gatewayStatus?.state === 'running'}
             onContinue={identity => {
+              posthog?.capture('claw_setup_identity_completed', {
+                bot_name_is_custom: identity.botName !== 'KiloClaw',
+                bot_nature: identity.botNature,
+                bot_emoji_is_custom: identity.botEmoji !== '🤖',
+              });
               setBotIdentity(identity);
               setOnboardingStep('permissions');
             }}
@@ -251,6 +278,7 @@ function ClawDashboardInner({
           <PermissionStep
             instanceRunning={isRunning && gatewayStatus?.state === 'running'}
             onSelect={preset => {
+              posthog?.capture('claw_setup_permissions_completed', { preset });
               setSelectedPreset(preset);
               setOnboardingStep('channels');
             }}
@@ -259,11 +287,19 @@ function ClawDashboardInner({
           <ChannelSelectionStepView
             instanceRunning={isRunning && gatewayStatus?.state === 'running'}
             onSelect={(channelId, tokens) => {
+              posthog?.capture('claw_setup_channels_completed', {
+                channel: channelId,
+                skipped: false,
+              });
               setSelectedChannelId(channelId);
               setChannelTokens(tokens);
               setOnboardingStep('provisioning');
             }}
             onSkip={() => {
+              posthog?.capture('claw_setup_channels_completed', {
+                channel: null,
+                skipped: true,
+              });
               setSelectedChannelId(null);
               setChannelTokens(null);
               setOnboardingStep('provisioning');
@@ -277,7 +313,10 @@ function ClawDashboardInner({
             instanceRunning={isRunning && gatewayStatus?.state === 'running'}
             mutations={mutations}
             totalSteps={hasPairingStep ? 6 : 5}
-            onComplete={() => setOnboardingStep(hasPairingStep ? 'pairing' : 'done')}
+            onComplete={() => {
+              posthog?.capture('claw_setup_provisioned');
+              setOnboardingStep(hasPairingStep ? 'pairing' : 'done');
+            }}
           />
         ) : isNewSetup &&
           onboardingStep === 'pairing' &&
@@ -285,8 +324,20 @@ function ClawDashboardInner({
           <ChannelPairingStep
             channelId={selectedChannelId}
             mutations={mutations}
-            onComplete={() => setOnboardingStep('done')}
-            onSkip={() => setOnboardingStep('done')}
+            onComplete={() => {
+              posthog?.capture('claw_setup_pairing_completed', {
+                channel: selectedChannelId,
+                skipped: false,
+              });
+              setOnboardingStep('done');
+            }}
+            onSkip={() => {
+              posthog?.capture('claw_setup_pairing_completed', {
+                channel: selectedChannelId,
+                skipped: true,
+              });
+              setOnboardingStep('done');
+            }}
           />
         ) : isNewSetup ? (
           <Card className="mt-6 overflow-hidden">
@@ -331,6 +382,7 @@ function ClawDashboardInner({
                     asChild
                     variant="primary"
                     className="w-full min-w-[180px] bg-emerald-600 py-6 text-base text-white hover:bg-emerald-700"
+                    onClick={() => posthog?.capture('claw_setup_open_chat_clicked')}
                   >
                     <Link
                       href={`${organizationId ? `/organizations/${organizationId}/claw` : '/claw'}/chat`}
@@ -342,7 +394,10 @@ function ClawDashboardInner({
                 <Button
                   className="w-full py-6 text-base"
                   variant="outline"
-                  onClick={() => onNewSetupChange(false)}
+                  onClick={() => {
+                    posthog?.capture('claw_setup_close_wizard_clicked');
+                    onNewSetupChange(false);
+                  }}
                 >
                   <X className="mr-2 h-4 w-4" />
                   Close Wizard

--- a/apps/web/src/app/(app)/claw/components/ClawDashboard.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawDashboard.tsx
@@ -152,24 +152,19 @@ function ClawDashboardInner({
   const [selectedChannelId, setSelectedChannelId] = useState<string | null>(null);
   const hasPairingStep = selectedChannelId === 'telegram' || selectedChannelId === 'discord';
 
-  // Fire a per-step viewed event whenever the active onboarding step changes.
-  // Distinct event names make PostHog Funnel charts trivial to build (no
-  // per-step property filters needed).
-  const STEP_VIEWED_EVENT: Record<typeof onboardingStep, string> = {
-    identity: 'claw_setup_identity_viewed',
-    permissions: 'claw_setup_permissions_viewed',
-    channels: 'claw_setup_channels_viewed',
-    provisioning: 'claw_setup_provisioning_viewed',
-    pairing: 'claw_setup_pairing_viewed',
-    done: 'claw_setup_done_viewed',
-  };
+  // Fire identity_viewed when the wizard first becomes active. Two entry
+  // points: initial mount with isNewSetup already true, and re-entry after a
+  // destroy + provision cycle. We avoid useEffect([onboardingStep, isNewSetup])
+  // because on re-entry that effect would fire with the stale step from the
+  // previous wizard run before the reset below can update onboardingStep.
+  const initialIsNewSetupRef = useRef(isNewSetup);
   useEffect(() => {
-    if (!isNewSetup) return;
-    posthog?.capture(STEP_VIEWED_EVENT[onboardingStep]);
-    // STEP_VIEWED_EVENT is a derived constant — only the meaningful state
-    // values that compose it need to be in the dep array.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onboardingStep, isNewSetup]);
+    if (initialIsNewSetupRef.current) {
+      posthog?.capture('claw_setup_identity_viewed');
+    }
+  // Intentionally mount-only. Re-entry is handled by the reset effect below.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Reset onboarding wizard to step 1 whenever we enter setup mode so that
   // a destroy → re-provision cycle always starts fresh.
@@ -181,6 +176,7 @@ function ClawDashboardInner({
       setBotIdentity(null);
       setChannelTokens(null);
       setSelectedChannelId(null);
+      posthog?.capture('claw_setup_identity_viewed');
     }
     prevIsNewSetup.current = isNewSetup;
   }, [isNewSetup]);
@@ -270,6 +266,7 @@ function ClawDashboardInner({
                 bot_nature: identity.botNature,
                 bot_emoji_is_custom: identity.botEmoji !== '🤖',
               });
+              posthog?.capture('claw_setup_permissions_viewed');
               setBotIdentity(identity);
               setOnboardingStep('permissions');
             }}
@@ -279,6 +276,7 @@ function ClawDashboardInner({
             instanceRunning={isRunning && gatewayStatus?.state === 'running'}
             onSelect={preset => {
               posthog?.capture('claw_setup_permissions_completed', { preset });
+              posthog?.capture('claw_setup_channels_viewed');
               setSelectedPreset(preset);
               setOnboardingStep('channels');
             }}
@@ -291,6 +289,7 @@ function ClawDashboardInner({
                 channel: channelId,
                 skipped: false,
               });
+              posthog?.capture('claw_setup_provisioning_viewed');
               setSelectedChannelId(channelId);
               setChannelTokens(tokens);
               setOnboardingStep('provisioning');
@@ -300,6 +299,7 @@ function ClawDashboardInner({
                 channel: null,
                 skipped: true,
               });
+              posthog?.capture('claw_setup_provisioning_viewed');
               setSelectedChannelId(null);
               setChannelTokens(null);
               setOnboardingStep('provisioning');
@@ -315,6 +315,7 @@ function ClawDashboardInner({
             totalSteps={hasPairingStep ? 6 : 5}
             onComplete={() => {
               posthog?.capture('claw_setup_provisioned');
+              posthog?.capture(hasPairingStep ? 'claw_setup_pairing_viewed' : 'claw_setup_done_viewed');
               setOnboardingStep(hasPairingStep ? 'pairing' : 'done');
             }}
           />
@@ -329,6 +330,7 @@ function ClawDashboardInner({
                 channel: selectedChannelId,
                 skipped: false,
               });
+              posthog?.capture('claw_setup_done_viewed');
               setOnboardingStep('done');
             }}
             onSkip={() => {
@@ -336,6 +338,7 @@ function ClawDashboardInner({
                 channel: selectedChannelId,
                 skipped: true,
               });
+              posthog?.capture('claw_setup_done_viewed');
               setOnboardingStep('done');
             }}
           />


### PR DESCRIPTION
## Motivation

The KiloClaw setup wizard has grown to six steps: bot identity, exec permissions, channel selection, provisioning, channel pairing, and a done screen. Before this PR, only `claw_create_instance_clicked` existed for the entire flow, fired when the user clicks Get Started before the wizard even begins. There was no telemetry on the wizard itself, so it was impossible to know where users were dropping off, which channels they were connecting, or whether users who reached the done screen were actually opening the chat.

## Implementation

All instrumentation is in `ClawDashboard.tsx`, where the wizard step transitions are already centralized. Two event categories cover each step: a `*_viewed` event fires via `useEffect` whenever `onboardingStep` changes while `isNewSetup` is true, and a `*_completed` event fires inline at each step's callback with step-specific properties. The identity step captures bot customization signals; permissions captures the exec preset; channels and pairing each capture the channel name and whether the step was skipped. The done screen adds two events that distinguish users who click into the chat from those who close the wizard without opening it.

The events use distinct names per step (`claw_setup_identity_completed`, `claw_setup_channels_completed`, and so on) rather than a generic `claw_setup_step_completed` event with a `step` property. PostHog's Funnel chart maps directly to event names, so distinct names let anyone build the funnel by dragging the events in order without needing per-step property filters.

## Testing

TypeScript typecheck passes with no new errors in `ClawDashboard.tsx`. Pre-existing module-not-found errors from packages absent in this worktree are unrelated to these changes.

## Notes

The `*_viewed` events fire on every wizard visit, including re-provision cycles after a destroy, so they should be read as view counts rather than unique-user signals. The `*_completed` events are the clean funnel signal.