### PR TITLE
fix(dev): gate kiloclaw startup on tunnel URL capture

### DIFF
--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -70,6 +70,7 @@ const RESET = '\x1b[0m';
 const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
 const GREEN = '\x1b[32m';
+const CAPTURE_TIMEOUT_MS = 30_000;
 
 // ---------------------------------------------------------------------------
 // Commands
@@ -158,6 +159,8 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
   const captureServiceSet = new Set(['kiloclaw-tunnel', 'kiloclaw-stripe', 'app-builder-tunnel']);
   const captureServices = serviceNames.filter(n => captureServiceSet.has(n));
   const otherServices = serviceNames.filter(n => !captureServiceSet.has(n));
+  const startedServices: string[] = [];
+  let kiloclawTunnelCaptured = true;
 
   if (captureServices.length > 0) {
     const oldValues = new Map<string, string | undefined>();
@@ -180,6 +183,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
 
     for (const name of captureServices) {
       startServiceInTmux(sessionName, name);
+      startedServices.push(name);
       await sleep(300);
     }
 
@@ -192,13 +196,16 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
           path.join(repoRoot, 'services/kiloclaw/.dev.vars'),
           'KILOCODE_API_BASE_URL',
           oldValues.get('tunnel'),
-          30_000,
+          CAPTURE_TIMEOUT_MS,
           oldMtimes.get('tunnel')
         ).then(ready => {
+          kiloclawTunnelCaptured = ready;
           if (ready) {
             console.log('  Tunnel URL captured');
           } else {
-            console.warn('  Tunnel URL not captured after 30s - check kiloclaw-tunnel window');
+            console.warn(
+              '  Tunnel URL not captured after 30s - kiloclaw startup will wait for a retry'
+            );
           }
         })
       );
@@ -210,7 +217,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
           path.join(repoRoot, '.env.development.local'),
           'STRIPE_WEBHOOK_SECRET',
           oldValues.get('stripe'),
-          30_000,
+          CAPTURE_TIMEOUT_MS,
           oldMtimes.get('stripe')
         ).then(ready => {
           if (ready) {
@@ -228,7 +235,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
           path.join(repoRoot, 'services/app-builder/.dev.vars'),
           'BUILDER_HOSTNAME',
           oldValues.get('app-builder-tunnel'),
-          30_000,
+          CAPTURE_TIMEOUT_MS,
           oldMtimes.get('app-builder-tunnel')
         ).then(ready => {
           if (ready) {
@@ -246,17 +253,32 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
     console.log();
   }
 
+  const skippedServices: string[] = [];
   for (const name of otherServices) {
+    const dependsOnKiloclaw = getService(name).dependsOn.includes('kiloclaw');
+    if (!kiloclawTunnelCaptured && (name === 'kiloclaw' || dependsOnKiloclaw)) {
+      skippedServices.push(name);
+      continue;
+    }
+
     startServiceInTmux(sessionName, name);
+    startedServices.push(name);
     await sleep(300);
+  }
+
+  if (skippedServices.length > 0) {
+    console.warn(
+      `Skipped startup for ${skippedServices.join(', ')} until KILOCODE_API_BASE_URL is captured.`
+    );
+    console.warn('Start or restart these services after the tunnel URL is ready.');
   }
 
   // --- Set up split layout in window 0: left=sidebar, right=service terminal ---
   // Join the preferred service's pane into window 0 as pane 1 (right column).
   // join-pane moves the pane process — no ghost shells.
   let initialViewedService = '';
-  if (serviceNames.length > 0) {
-    const preferred = serviceNames.includes('nextjs') ? 'nextjs' : serviceNames[0];
+  if (startedServices.length > 0) {
+    const preferred = startedServices.includes('nextjs') ? 'nextjs' : startedServices[0];
     const windows = listWindows(sessionName);
     const preferredWin = windows.find(w => w.name === preferred);
     if (preferredWin) {
@@ -278,9 +300,9 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
   }
 
   // --- Start sidebar TUI in left pane (0.0) ---
-  const enabledGroupIds = determineEnabledGroups(serviceNames);
+  const enabledGroupIds = determineEnabledGroups(startedServices);
   const dashboardArgs = [
-    JSON.stringify(serviceNames),
+    JSON.stringify(startedServices),
     initialViewedService,
     JSON.stringify(enabledGroupIds),
   ];
@@ -292,9 +314,11 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
   selectWindow(sessionName, 0);
 
   // --- Write manifest for agents ---
-  writeManifest(repoRoot, sessionName, serviceNames);
+  writeManifest(repoRoot, sessionName, startedServices);
 
-  console.log(`${GREEN}Started ${serviceNames.length} services in session ${sessionName}${RESET}`);
+  console.log(
+    `${GREEN}Started ${startedServices.length} services in session ${sessionName}${RESET}`
+  );
   attachSession(sessionName);
 }
 

--- a/dev/local/dashboard.tsx
+++ b/dev/local/dashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { render, Box, Text, useInput, useApp, useStdout } from 'ink';
 import { execSync } from 'node:child_process';
+import * as path from 'node:path';
 import {
   getService,
   getGroups,
@@ -12,12 +13,16 @@ import {
 import type { ServiceGroup } from './services';
 import { getSessionName, killSession } from './tmux';
 import {
+  findRepoRoot,
   probePort,
   startServiceInTmux,
   stopServiceInTmux,
   restartServiceInTmux,
   showServiceInTmux,
   showGroupInTmux,
+  readEnvValue,
+  readEnvMtime,
+  waitForEnvValueChange,
 } from './runner';
 
 // ---------------------------------------------------------------------------
@@ -47,11 +52,15 @@ const REFRESH_MS = 2000;
 const STARTING_GRACE_MS = 30_000;
 const START_DELAY_MS = 300;
 const SIDEBAR_WIDTH = 40;
+const CAPTURE_TIMEOUT_MS = 30_000;
 
 // Resolved once at module level
 const sessionName = getSessionName();
+const repoRoot = findRepoRoot();
+const kiloclawDevVarsPath = path.join(repoRoot, 'services/kiloclaw/.dev.vars');
 const alwaysOnGroupIds = new Set(getAlwaysOnGroupIds());
 const groupsById = new Map(getGroups().map(g => [g.id, g]));
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
 
 // ---------------------------------------------------------------------------
 // Sidebar item list builder
@@ -367,52 +376,152 @@ function Dashboard({
       if (togglingRef.current) return;
       togglingRef.current = true;
 
-      // Resolve transitive group-level deps (e.g. app-builder → cloud-agent)
-      const allGroupIds = resolveGroupTransitiveDeps([groupId]);
-      const allNeeded = resolveGroups(allGroupIds);
-      const toStart = allNeeded.filter(name => !runningServices.has(name));
+      void (async () => {
+        try {
+          // Resolve transitive group-level deps (e.g. app-builder → cloud-agent)
+          const allGroupIds = resolveGroupTransitiveDeps([groupId]);
+          const allNeeded = resolveGroups(allGroupIds);
+          const toStart = allNeeded.filter(name => !runningServices.has(name));
 
-      // Start services with staggered delays
-      let delay = 0;
-      for (const name of toStart) {
-        setTimeout(() => {
-          try {
-            startServiceInTmux(sessionName, name);
-          } catch {
-            // tmux command failed
-          }
-        }, delay);
-        delay += START_DELAY_MS;
-      }
+          const gatedStarts: string[] = [];
+          const immediateStarts: string[] = [];
+          const shouldWaitForKiloclawTunnel =
+            toStart.includes('kiloclaw') && toStart.includes('kiloclaw-tunnel');
 
-      // Update state after last service started
-      setTimeout(() => {
-        setRunningServices(prev => {
-          const next = new Set(prev);
-          for (const name of toStart) next.add(name);
-          return next;
-        });
-        setStatuses(prev => {
-          const next = new Map(prev);
           for (const name of toStart) {
-            if (!next.has(name)) next.set(name, 'starting');
+            const dependsOnKiloclaw = getService(name).dependsOn.includes('kiloclaw');
+            if (shouldWaitForKiloclawTunnel && (name === 'kiloclaw' || dependsOnKiloclaw)) {
+              gatedStarts.push(name);
+            } else {
+              immediateStarts.push(name);
+            }
           }
-          return next;
-        });
-        setEnabledGroups(prev => {
-          const next = new Set(prev);
-          for (const id of allGroupIds) next.add(id);
-          return next;
-        });
-        // Reset starting grace for newly started services
-        startTimeRef.current = Date.now();
-        togglingRef.current = false;
 
-        // Show the group in multi-pane view
-        const groupServices = getGroupServiceNames(groupId);
-        const running = groupServices.filter(n => runningServices.has(n) || toStart.includes(n));
-        doShowGroup(groupId, running, viewedRef);
-      }, delay + 100);
+          const oldTunnelValue = shouldWaitForKiloclawTunnel
+            ? readEnvValue(kiloclawDevVarsPath, 'KILOCODE_API_BASE_URL')
+            : undefined;
+          const oldTunnelMtime = shouldWaitForKiloclawTunnel
+            ? readEnvMtime(kiloclawDevVarsPath)
+            : undefined;
+
+          const startedNow: string[] = [];
+          for (const name of immediateStarts) {
+            try {
+              startServiceInTmux(sessionName, name);
+              startedNow.push(name);
+            } catch {
+              // tmux command failed
+            }
+            await sleep(START_DELAY_MS);
+          }
+
+          const nextRunningServices = new Set(runningServices);
+          for (const name of startedNow) nextRunningServices.add(name);
+
+          setRunningServices(prev => {
+            const next = new Set(prev);
+            for (const name of startedNow) next.add(name);
+            return next;
+          });
+          setStatuses(prev => {
+            const next = new Map(prev);
+            for (const name of startedNow) {
+              if (!next.has(name)) next.set(name, 'starting');
+            }
+            return next;
+          });
+          setEnabledGroups(prev => {
+            const next = new Set(prev);
+            for (const id of allGroupIds) next.add(id);
+            return next;
+          });
+
+          if (startedNow.length > 0) {
+            // Reset starting grace for newly started services
+            startTimeRef.current = Date.now();
+          }
+
+          // Show the group in multi-pane view
+          const running = getGroupServiceNames(groupId).filter(n => nextRunningServices.has(n));
+          doShowGroup(groupId, running, viewedRef);
+
+          // Phase 1 is complete; keep UI responsive while tunnel gate runs in background.
+          togglingRef.current = false;
+
+          if (!shouldWaitForKiloclawTunnel || gatedStarts.length === 0) {
+            return;
+          }
+
+          const kiloclawTunnelCaptured = await waitForEnvValueChange(
+            kiloclawDevVarsPath,
+            'KILOCODE_API_BASE_URL',
+            oldTunnelValue,
+            CAPTURE_TIMEOUT_MS,
+            oldTunnelMtime
+          );
+
+          if (!kiloclawTunnelCaptured) {
+            console.warn(
+              'Tunnel URL not captured after 30s - kiloclaw services are waiting for tunnel readiness'
+            );
+            return;
+          }
+
+          if (!mouseStateRef.current.enabledGroups.has(groupId)) {
+            return;
+          }
+
+          const startedAfterCapture: string[] = [];
+          const runningAtCapture = new Set(mouseStateRef.current.runningServices);
+          for (const name of gatedStarts) {
+            if (runningAtCapture.has(name)) {
+              continue;
+            }
+            try {
+              startServiceInTmux(sessionName, name);
+              startedAfterCapture.push(name);
+            } catch {
+              // tmux command failed
+            }
+            await sleep(START_DELAY_MS);
+          }
+
+          if (startedAfterCapture.length === 0) {
+            return;
+          }
+
+          const runningAfterCapture = new Set(runningAtCapture);
+          for (const name of startedAfterCapture) runningAfterCapture.add(name);
+
+          setRunningServices(prev => {
+            const next = new Set(prev);
+            for (const name of startedAfterCapture) next.add(name);
+            return next;
+          });
+          setStatuses(prev => {
+            const next = new Map(prev);
+            for (const name of startedAfterCapture) {
+              if (!next.has(name)) next.set(name, 'starting');
+            }
+            return next;
+          });
+
+          // Only update the pane layout when this group is still in view.
+          const viewed = viewedRef.current;
+          if (viewed && viewed.kind === 'group' && viewed.groupId === groupId) {
+            const updatedRunning = getGroupServiceNames(groupId).filter(n =>
+              runningAfterCapture.has(n)
+            );
+            doShowGroup(groupId, updatedRunning, viewedRef);
+          }
+
+          startTimeRef.current = Date.now();
+        } finally {
+          if (togglingRef.current) {
+            togglingRef.current = false;
+          }
+        }
+      })();
     },
     [runningServices]
   );


### PR DESCRIPTION
## Summary

- Gate KiloClaw startup in `dev:start` on successful `KILOCODE_API_BASE_URL` capture from `kiloclaw-tunnel` so Wrangler does not boot with a stale URL snapshot.
- Skip startup of `kiloclaw` and services that depend on it when tunnel capture times out, while still starting other services and reporting actionable logs.
- Update dashboard group-start behavior for KiloClaw to a two-phase flow: start immediate services first, then start `kiloclaw`/dependents only after tunnel URL capture succeeds.
- Ensure dashboard initialization, initial pane selection, and manifest output reflect only services that were actually started.

## Verification

- [X] `pnpm typecheck`
- [X] `pnpm dev:stop && pnpm dev:start`
- [X] In dashboard, start **KILOCLAW** and verify `kiloclaw` does not start before tunnel URL capture.
- [X] Provision a fresh machine and confirm `KILOCODE_API_BASE_URL` in Fly machine env matches the latest value in `services/kiloclaw/.dev.vars`.

## Visual Changes

N/A

## Reviewer Notes

- This change is intentionally scoped to local dev orchestration in `dev/local/cli.ts` and `dev/local/dashboard.tsx`.
- No runtime KiloClaw worker/startup env-merging logic is changed; this only tightens startup ordering to avoid stale env propagation during local development.
- Timeout behavior is explicit: tunnel capture timeout blocks `kiloclaw` startup and requires a follow-up retry/restart once capture succeeds.