### PR TITLE
fix(kiloclaw): pin Go 1.25.8 for stable image builds

### DIFF
--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -66,7 +66,10 @@ RUN npm install -g @steipete/summarize@0.12.0
 RUN npm install -g @kilocode/cli@7.1.13
 
 # Install Go (available at runtime for users to `go install` additional tools)
-ENV GO_VERSION=1.26.0
+# Go 1.26.0 has been unstable under linux/amd64 emulation during image builds.
+# Use 1.25.x for stability, but keep >=1.25.8 for gogcli's minimum toolchain.
+ENV GO_VERSION=1.25.8
+ENV GOTOOLCHAIN=local
 RUN ARCH="$(dpkg --print-architecture)" \
     && curl -fsSL https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz -o /tmp/go.tar.gz \
     && EXPECTED_SHA256="$(curl -fsSL https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz.sha256)" \

--- a/services/kiloclaw/Dockerfile.local
+++ b/services/kiloclaw/Dockerfile.local
@@ -62,7 +62,10 @@ RUN npm install -g @steipete/summarize@0.12.0
 RUN npm install -g @kilocode/cli@7.1.13
 
 # Install Go (available at runtime for users to `go install` additional tools)
-ENV GO_VERSION=1.26.0
+# Go 1.26.0 has been unstable under linux/amd64 emulation during image builds.
+# Use 1.25.x for stability, but keep >=1.25.8 for gogcli's minimum toolchain.
+ENV GO_VERSION=1.25.8
+ENV GOTOOLCHAIN=local
 RUN ARCH="$(dpkg --print-architecture)" \
     && curl -fsSL https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz -o /tmp/go.tar.gz \
     && EXPECTED_SHA256="$(curl -fsSL https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz.sha256)" \


### PR DESCRIPTION
## Summary

- This pins Go to 1.25.8 in the Kiloclaw `Dockerfile` addressing a repeatable total failure in `./push-dev.sh`
- The repeatable total failure took the shape of crash within Go

## Verification

- After applying these changes, the failure was resolved and Docker images successfully built

## Visual Changes

N/A

## Reviewer Notes

- `1.26.0` appears to be a problematic version. However, the `gog` dependency requires `>= 1.25.8`. The pinned version achieves both stability and satisfies dependency requirements.