### PR TITLE
refactor(claw): move what's new into sidebar

### DIFF
--- a/apps/web/src/app/(app)/claw/changelog/page.tsx
+++ b/apps/web/src/app/(app)/claw/changelog/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ClawChangelogPage } from '../components/ClawChangelogPage';
+
+export default function PersonalClawChangelogPage() {
+  return <ClawChangelogPage />;
+}

--- a/apps/web/src/app/(app)/claw/components/ClawChangelogPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawChangelogPage.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Sparkles } from 'lucide-react';
+import { SetPageTitle } from '@/components/SetPageTitle';
+import { Card, CardContent } from '@/components/ui/card';
+import { ChangelogTab } from './ChangelogTab';
+import { BillingWrapper } from './billing/BillingWrapper';
+
+function ChangelogCard() {
+  return (
+    <Card>
+      <CardContent className="p-5">
+        <ChangelogTab />
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ClawChangelogPage({ organizationId }: { organizationId?: string }) {
+  const content = <ChangelogCard />;
+
+  return (
+    <div className="container m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
+      <SetPageTitle
+        title="What's New"
+        icon={<Sparkles className="text-muted-foreground h-4 w-4" />}
+      />
+      {organizationId ? content : <BillingWrapper>{content}</BillingWrapper>}
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/claw/components/ClawDashboard.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawDashboard.tsx
@@ -18,7 +18,6 @@ import { ClawHeader } from './ClawHeader';
 import { CreateInstanceCard } from './CreateInstanceCard';
 import { InstanceControls } from './InstanceControls';
 import { InstanceTab } from './InstanceTab';
-import { ChangelogTab } from './ChangelogTab';
 import { SubscriptionTab } from './SubscriptionTab';
 import { ChannelPairingStep } from './ChannelPairingStep';
 import { BotIdentityStep } from './BotIdentityStep';
@@ -118,7 +117,7 @@ function ClawDashboardInner({
     Date.now() - instanceStatus.provisionedAt < SEVEN_DAYS_MS;
   const configServiceNudgeVisible = !instanceStatus || instanceYoung;
 
-  const VALID_TABS = ['instance', 'subscription', 'changelog'] as const;
+  const VALID_TABS = ['instance', 'subscription'] as const;
   type TabValue = (typeof VALID_TABS)[number];
 
   function tabFromHash(): TabValue {
@@ -432,9 +431,6 @@ function ClawDashboardInner({
                       Subscription
                     </TabsTrigger>
                   )}
-                  <TabsTrigger value="changelog" className={tabTriggerClass}>
-                    What&apos;s New <Sparkles className="ml-1 inline h-3 w-3 text-amber-400" />
-                  </TabsTrigger>
                 </TabsList>
               </div>
               <CardContent className="p-5">
@@ -448,9 +444,6 @@ function ClawDashboardInner({
                 </TabsContent>
                 <TabsContent value="subscription" className="mt-0">
                   <SubscriptionTab />
-                </TabsContent>
-                <TabsContent value="changelog" className="mt-0">
-                  <ChangelogTab />
                 </TabsContent>
               </CardContent>
             </Tabs>

--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -141,14 +141,14 @@ export default function OrganizationAppSidebar({
       url: `/organizations/${organizationId}/claw/chat`,
     },
     {
-      title: "What's New",
-      icon: Sparkles,
-      url: `/organizations/${organizationId}/claw/changelog`,
-    },
-    {
       title: 'Settings',
       icon: Settings,
       url: `/organizations/${organizationId}/claw/settings`,
+    },
+    {
+      title: "What's New",
+      icon: Sparkles,
+      url: `/organizations/${organizationId}/claw/changelog`,
     },
   ];
 

--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -141,6 +141,11 @@ export default function OrganizationAppSidebar({
       url: `/organizations/${organizationId}/claw/chat`,
     },
     {
+      title: "What's New",
+      icon: Sparkles,
+      url: `/organizations/${organizationId}/claw/changelog`,
+    },
+    {
       title: 'Settings',
       icon: Settings,
       url: `/organizations/${organizationId}/claw/settings`,

--- a/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -89,14 +89,14 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
       url: '/claw/chat',
     },
     {
-      title: "What's New",
-      icon: Sparkles,
-      url: '/claw/changelog',
-    },
-    {
       title: 'Settings',
       icon: Settings,
       url: '/claw/settings',
+    },
+    {
+      title: "What's New",
+      icon: Sparkles,
+      url: '/claw/changelog',
     },
   ];
 

--- a/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -28,6 +28,7 @@ import {
   Settings,
   CreditCard,
   MessageSquare,
+  Sparkles,
 } from 'lucide-react';
 import HeaderLogo from '@/components/HeaderLogo';
 import OrganizationSwitcher from './OrganizationSwitcher';
@@ -86,6 +87,11 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
       title: 'Chat',
       icon: MessageSquare,
       url: '/claw/chat',
+    },
+    {
+      title: "What's New",
+      icon: Sparkles,
+      url: '/claw/changelog',
     },
     {
       title: 'Settings',

--- a/apps/web/src/app/(app)/organizations/[id]/claw/changelog/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/claw/changelog/page.tsx
@@ -1,0 +1,15 @@
+import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import { ClawChangelogPage } from '@/app/(app)/claw/components/ClawChangelogPage';
+
+type OrgClawChangelogPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function OrgClawChangelogPage({ params }: OrgClawChangelogPageProps) {
+  return (
+    <OrganizationByPageLayout
+      params={params}
+      render={org => <ClawChangelogPage organizationId={org.organization.id} />}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Moved KiloClaw What's New out of the dashboard tab bar and into the personal and organization KiloClaw sidebar groups.
- Added dedicated personal and organization changelog routes that reuse the existing changelog content.
- Kept the personal changelog page inside the existing billing wrapper for access-state handling.

## Visual Changes

<img width="4388" height="2708" alt="CleanShot 2026-04-09 at 10 00 58@2x" src="https://github.com/user-attachments/assets/e6fa1a10-ec77-485c-b4d4-77e16610a466" />
