### PR TITLE
feat(kiloclaw): add dev machine size overrides

### DIFF
--- a/services/kiloclaw/.dev.vars.example
+++ b/services/kiloclaw/.dev.vars.example
@@ -58,6 +58,11 @@ FLY_REGISTRY_APP=kiloclaw-registry-dev
 # Examples: "us,eu" (try US first, then Europe), "lhr,fra" (London first, then Frankfurt)
 # The platform API can override per-user at provision time.
 FLY_REGION=us,eu
+# Development-only default Fly Machine guest spec overrides. These only apply
+# when WORKER_ENV=development and no explicit machineSize is provided.
+# KILOCLAW_DEV_MACHINE_CPUS=4
+# KILOCLAW_DEV_MACHINE_MEMORY_MB=8192
+# KILOCLAW_DEV_MACHINE_CPU_KIND=shared
 # Docker image tag on registry.fly.io/{FLY_REGISTRY_APP}:{tag}.
 # Set automatically by scripts/push-dev.sh, or use "latest" to start.
 FLY_IMAGE_TAG=latest

--- a/services/kiloclaw/src/config.test.ts
+++ b/services/kiloclaw/src/config.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { getProactiveRefreshThresholdMs, PROACTIVE_REFRESH_THRESHOLD_MS } from './config';
+import {
+  DEFAULT_MACHINE_GUEST,
+  getDefaultMachineGuest,
+  getProactiveRefreshThresholdMs,
+  PROACTIVE_REFRESH_THRESHOLD_MS,
+} from './config';
+import { guestFromSize } from './durable-objects/machine-config';
 
 describe('getProactiveRefreshThresholdMs', () => {
   it('returns default when no override', () => {
@@ -32,5 +38,54 @@ describe('getProactiveRefreshThresholdMs', () => {
 
   it('accepts large values for testing', () => {
     expect(getProactiveRefreshThresholdMs('8760')).toBe(365 * 24 * 60 * 60 * 1000);
+  });
+});
+
+describe('getDefaultMachineGuest', () => {
+  it('returns the production default without development mode', () => {
+    expect(
+      getDefaultMachineGuest({
+        WORKER_ENV: 'production',
+        KILOCLAW_DEV_MACHINE_CPUS: '4',
+        KILOCLAW_DEV_MACHINE_MEMORY_MB: '8192',
+        KILOCLAW_DEV_MACHINE_CPU_KIND: 'performance',
+      })
+    ).toEqual(DEFAULT_MACHINE_GUEST);
+  });
+
+  it('uses valid development overrides', () => {
+    expect(
+      getDefaultMachineGuest({
+        WORKER_ENV: 'development',
+        KILOCLAW_DEV_MACHINE_CPUS: '4',
+        KILOCLAW_DEV_MACHINE_MEMORY_MB: '8192',
+        KILOCLAW_DEV_MACHINE_CPU_KIND: 'performance',
+      })
+    ).toEqual({ cpus: 4, memory_mb: 8192, cpu_kind: 'performance' });
+  });
+
+  it('falls back field-by-field for missing or invalid development overrides', () => {
+    expect(
+      getDefaultMachineGuest({
+        WORKER_ENV: 'development',
+        KILOCLAW_DEV_MACHINE_CPUS: '0',
+        KILOCLAW_DEV_MACHINE_MEMORY_MB: '4096',
+        KILOCLAW_DEV_MACHINE_CPU_KIND: 'turbo',
+      })
+    ).toEqual({ cpus: DEFAULT_MACHINE_GUEST.cpus, memory_mb: 4096, cpu_kind: 'shared' });
+  });
+
+  it('keeps explicit machineSize ahead of development defaults', () => {
+    expect(
+      guestFromSize(
+        { cpus: 1, memory_mb: 1024, cpu_kind: 'shared' },
+        {
+          WORKER_ENV: 'development',
+          KILOCLAW_DEV_MACHINE_CPUS: '4',
+          KILOCLAW_DEV_MACHINE_MEMORY_MB: '8192',
+          KILOCLAW_DEV_MACHINE_CPU_KIND: 'performance',
+        }
+      )
+    ).toEqual({ cpus: 1, memory_mb: 1024, cpu_kind: 'shared' });
   });
 });

--- a/services/kiloclaw/src/config.ts
+++ b/services/kiloclaw/src/config.ts
@@ -1,3 +1,5 @@
+import type { FlyMachineGuest } from './fly/types';
+
 export { KILO_TOKEN_VERSION } from '@kilocode/worker-utils';
 
 /**
@@ -40,8 +42,39 @@ export const KILOCODE_API_KEY_EXPIRY_SECONDS = 30 * 24 * 60 * 60;
 export const DEFAULT_MACHINE_GUEST = {
   cpus: 2,
   memory_mb: 3072,
-  cpu_kind: 'shared' as const,
+  cpu_kind: 'shared',
+} satisfies FlyMachineGuest;
+
+export type MachineGuestOverrideEnv = {
+  WORKER_ENV?: string;
+  KILOCLAW_DEV_MACHINE_CPUS?: string;
+  KILOCLAW_DEV_MACHINE_MEMORY_MB?: string;
+  KILOCLAW_DEV_MACHINE_CPU_KIND?: string;
 };
+
+function parseIntegerInRange(value: string | undefined, min: number, max: number): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) return null;
+  return parsed;
+}
+
+function parseCpuKind(value: string | undefined): FlyMachineGuest['cpu_kind'] | null {
+  if (value === 'shared' || value === 'performance') return value;
+  return null;
+}
+
+export function getDefaultMachineGuest(env?: MachineGuestOverrideEnv): FlyMachineGuest {
+  if (env?.WORKER_ENV !== 'development') return DEFAULT_MACHINE_GUEST;
+
+  return {
+    cpus: parseIntegerInRange(env.KILOCLAW_DEV_MACHINE_CPUS, 1, 8) ?? DEFAULT_MACHINE_GUEST.cpus,
+    memory_mb:
+      parseIntegerInRange(env.KILOCLAW_DEV_MACHINE_MEMORY_MB, 256, 16384) ??
+      DEFAULT_MACHINE_GUEST.memory_mb,
+    cpu_kind: parseCpuKind(env.KILOCLAW_DEV_MACHINE_CPU_KIND) ?? DEFAULT_MACHINE_GUEST.cpu_kind,
+  };
+}
 
 /** Default Fly Volume size in GB */
 export const DEFAULT_VOLUME_SIZE_GB = 10;

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -4804,6 +4804,38 @@ describe('provision: auto-start after fresh provision', () => {
     expect(storage._store.get('flyMachineId')).toBe('machine-1');
   });
 
+  it('uses development machine size defaults for initial volume and machine creation', async () => {
+    const env = {
+      ...createFakeEnv(),
+      KILOCLAW_DEV_MACHINE_CPUS: '4',
+      KILOCLAW_DEV_MACHINE_MEMORY_MB: '8192',
+      KILOCLAW_DEV_MACHINE_CPU_KIND: 'performance',
+    };
+    const { instance, waitUntilPromises } = createInstance(undefined, env);
+
+    (flyClient.createVolumeWithFallback as Mock).mockResolvedValue({
+      id: 'vol-1',
+      region: 'iad',
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1', region: 'iad' });
+    (flyClient.createMachine as Mock).mockResolvedValue({ id: 'machine-1', region: 'iad' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+
+    await instance.provision('user-1', {});
+    await Promise.all(waitUntilPromises);
+
+    expect((flyClient.createVolumeWithFallback as Mock).mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        compute: { cpus: 4, memory_mb: 8192, cpu_kind: 'performance' },
+      })
+    );
+    expect((flyClient.createMachine as Mock).mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        guest: { cpus: 4, memory_mb: 8192, cpu_kind: 'performance' },
+      })
+    );
+  });
+
   it('wires capacity eviction callback during initial volume provisioning', async () => {
     const env = createFakeEnv();
     const { instance, waitUntilPromises } = createInstance(undefined, env);

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
@@ -39,7 +39,7 @@ export async function ensureVolume(
     {
       name: volumeNameFromSandboxId(state.sandboxId),
       size_gb: DEFAULT_VOLUME_SIZE_GB,
-      compute: guestFromSize(state.machineSize),
+      compute: guestFromSize(state.machineSize, env),
     },
     regions,
     {
@@ -77,7 +77,7 @@ export async function replaceStrandedVolume(
   const hasUserData = state.lastStartedAt !== null;
   const allRegions = await resolveRegions(env.KV_CLAW_CACHE, env.FLY_REGION);
   const regions = deprioritizeRegion(allRegions, oldRegion);
-  const compute = guestFromSize(state.machineSize);
+  const compute = guestFromSize(state.machineSize, env);
 
   // Destroy existing machine if any — it's stuck on the constrained host.
   if (state.flyMachineId) {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -271,7 +271,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       const regions = config.region
         ? prepareRegions(parseRegions(config.region))
         : await resolveRegions(this.env.KV_CLAW_CACHE, this.env.FLY_REGION);
-      const guest = guestFromSize(config.machineSize ?? null);
+      const guest = guestFromSize(config.machineSize ?? null, this.env);
       const volume = await fly.createVolumeWithFallback(
         flyConfig,
         {
@@ -1100,7 +1100,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     }
 
     const { envVars, minSecretsVersion } = await buildUserEnvVars(this.env, this.ctx, this.s);
-    const guest = guestFromSize(this.s.machineSize);
+    const guest = guestFromSize(this.s.machineSize, this.env);
     const imageTag = resolveImageTag(this.s, this.env);
     console.log(
       '[DO] startGateway: deploying with imageTag:',
@@ -2287,7 +2287,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       const flyConfig = getFlyConfig(this.env, this.s);
 
       const { envVars, minSecretsVersion } = await buildUserEnvVars(this.env, this.ctx, this.s);
-      const guest = guestFromSize(this.s.machineSize);
+      const guest = guestFromSize(this.s.machineSize, this.env);
       const imageTag = resolveImageTag(this.s, this.env);
       doLog(this.s, 'restartMachine: deploying update', {
         imageTag,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
@@ -366,7 +366,7 @@ export async function runUnexpectedStopRecoveryInBackground(
         {
           name: volumeNameFromSandboxId(state.sandboxId),
           source_volume_id: oldVolumeId,
-          compute: guestFromSize(state.machineSize),
+          compute: guestFromSize(state.machineSize, env),
         },
         regions,
         {
@@ -395,7 +395,7 @@ export async function runUnexpectedStopRecoveryInBackground(
       getRegistryApp(env),
       imageTag,
       envVars,
-      guestFromSize(state.machineSize),
+      guestFromSize(state.machineSize, env),
       recoveryVolumeId,
       identity
     );

--- a/services/kiloclaw/src/durable-objects/machine-config.ts
+++ b/services/kiloclaw/src/durable-objects/machine-config.ts
@@ -1,6 +1,6 @@
 import type { FlyMachineConfig } from '../fly/types';
 import type { MachineSize } from '../schemas/instance-config';
-import { OPENCLAW_PORT, DEFAULT_MACHINE_GUEST } from '../config';
+import { OPENCLAW_PORT, getDefaultMachineGuest, type MachineGuestOverrideEnv } from '../config';
 
 // ============================================================================
 // Metadata keys set on every Fly Machine for recovery/orphan detection.
@@ -73,8 +73,11 @@ export function buildMachineConfig(
   };
 }
 
-export function guestFromSize(machineSize: MachineSize | null): FlyMachineConfig['guest'] {
-  if (!machineSize) return DEFAULT_MACHINE_GUEST;
+export function guestFromSize(
+  machineSize: MachineSize | null,
+  env?: MachineGuestOverrideEnv
+): FlyMachineConfig['guest'] {
+  if (!machineSize) return getDefaultMachineGuest(env);
   return {
     cpus: machineSize.cpus,
     memory_mb: machineSize.memory_mb,

--- a/services/kiloclaw/src/types.ts
+++ b/services/kiloclaw/src/types.ts
@@ -45,6 +45,9 @@ export type KiloClawEnv = {
   FLY_IMAGE_TAG?: string;
   FLY_IMAGE_DIGEST?: string;
   OPENCLAW_VERSION?: string;
+  KILOCLAW_DEV_MACHINE_CPUS?: string;
+  KILOCLAW_DEV_MACHINE_MEMORY_MB?: string;
+  KILOCLAW_DEV_MACHINE_CPU_KIND?: string;
 
   // Developer identity (development only, auto-populated by dev-start from `fly auth whoami`)
   DEV_CREATOR?: string;


### PR DESCRIPTION
## Summary
- Add development-only KiloClaw Fly Machine guest spec overrides via `KILOCLAW_DEV_MACHINE_CPUS`, `KILOCLAW_DEV_MACHINE_MEMORY_MB`, and `KILOCLAW_DEV_MACHINE_CPU_KIND`.
- Apply the effective default to machine configs and volume compute hints while preserving explicit `machineSize` precedence.
- Document local `.dev.vars` usage and add parser/DO provisioning coverage.

## Verification
- `pnpm --filter kiloclaw test -- src/config.test.ts src/durable-objects/kiloclaw-instance.test.ts`
- `pnpm --filter kiloclaw typecheck`
- `pnpm --filter kiloclaw lint`

## Visual Changes
N/A

## Reviewer Notes
Development overrides only apply when `WORKER_ENV=development`; production keeps the hardcoded default even if override vars are present. Existing Fly machines pick up the new default only when a start/restart/update path applies a new machine config.