### PR TITLE
fix(ci): auto-discover workers instead of maintaining a whitelist

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -76,6 +76,7 @@ jobs:
           EXCLUDED=(
             services/kiloclaw  # Docker-based deploy in deploy-production.yml
             services/gastown   # Deployed separately
+            services/deploy-infra/builder-docker-container/container-files  # Build artifact template, not a deployable worker
           )
 
           # Discover all workers with a wrangler.jsonc

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -8,27 +8,7 @@ on:
       worker:
         description: 'Worker folder to deploy (e.g. services/app-builder)'
         required: true
-        type: choice
-        options:
-          - services/cloud-agent
-          - services/cloud-agent-next
-          - services/ai-attribution
-          - services/app-builder
-          - services/auto-fix-infra
-          - services/auto-triage-infra
-          - services/code-review-infra
-          - services/db-proxy
-          - services/deploy-infra/builder
-          - services/deploy-infra/dispatcher
-          - services/git-token-service
-          - services/gmail-push
-          - services/images-mcp
-          - services/kiloclaw-billing
-          - services/o11y
-          - services/security-auto-analysis
-          - services/security-sync
-          - services/session-ingest
-          - services/webhook-agent-ingest
+        type: string
 
 permissions:
   contents: read
@@ -84,38 +64,44 @@ jobs:
       - name: Find changed workers
         id: set-matrix
         run: |
-          # All deployable workers (folders containing wrangler.jsonc).
-          # kiloclaw is excluded — it has a custom Docker-based deploy in deploy-production.yml.
-          # builder-docker-container is excluded — it is a build artifact, not a deployable worker.
+          # Auto-discover all deployable workers (folders containing wrangler.jsonc)
+          # and exclude workers that have their own deploy pipelines.
           #
           # Diff against the SHA before the push so that multi-commit pushes
           # (e.g. a merge commit that squashes several commits) don't miss workers
           # that were only touched in earlier commits of the same push.
           BASE_SHA="${{ github.event.before }}"
-          WORKERS=(
-            services/cloud-agent
-            services/cloud-agent-next
-            services/ai-attribution
-            services/app-builder
-            services/auto-fix-infra
-            services/auto-triage-infra
-            services/code-review-infra
-            services/db-proxy
-            services/deploy-infra/builder
-            services/deploy-infra/dispatcher
-            services/git-token-service
-            services/gmail-push
-            services/images-mcp
-            services/kiloclaw-billing
-            services/o11y
-            services/security-auto-analysis
-            services/security-sync
-            services/session-ingest
-            services/webhook-agent-ingest
+
+          # Workers excluded from this workflow (they have custom deploy pipelines):
+          EXCLUDED=(
+            services/kiloclaw  # Docker-based deploy in deploy-production.yml
+            services/gastown   # Deployed separately
           )
 
-          CHANGED=()
+          # Discover all workers with a wrangler.jsonc
+          WORKERS=()
+          while IFS= read -r cfg; do
+            dir=$(dirname "$cfg")
+            WORKERS+=("$dir")
+          done < <(find services -name "wrangler.jsonc" -not -path "*/node_modules/*" | sort)
+
+          # Filter out excluded workers
+          DEPLOYABLE=()
           for dir in "${WORKERS[@]}"; do
+            skip=false
+            for excluded in "${EXCLUDED[@]}"; do
+              if [[ "$dir" == "$excluded" ]]; then
+                skip=true
+                break
+              fi
+            done
+            if [[ "$skip" == false ]]; then
+              DEPLOYABLE+=("$dir")
+            fi
+          done
+
+          CHANGED=()
+          for dir in "${DEPLOYABLE[@]}"; do
             if git diff --name-only "$BASE_SHA" HEAD -- "$dir/" | grep -q .; then
               CHANGED+=("$dir")
             fi

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "patchedDependencies": {
       "@storybook/nextjs@9.1.20": "patches/@storybook__nextjs@9.1.20.patch",
       "@gorhom/bottom-sheet@5.1.8": "patches/@gorhom__bottom-sheet@5.1.8.patch",
-      "stream-chat-react-native-core": "patches/stream-chat-react-native-core.patch"
+      "stream-chat-react-native-core": "patches/stream-chat-react-native-core.patch",
+      "expo-server-sdk@6.1.0": "patches/expo-server-sdk@6.1.0.patch"
     },
     "onlyBuiltDependencies": [
       "@swc/core",

--- a/patches/expo-server-sdk@6.1.0.patch
+++ b/patches/expo-server-sdk@6.1.0.patch
@@ -1,0 +1,30 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+deleted file mode 100644
+index 0332465d53ab851fc1de26cd8624af494c1363f3..0000000000000000000000000000000000000000
+diff --git a/build/ExpoClient.js b/build/ExpoClient.js
+index 0754d32755e3e34ed14cdb2070ac4a1ea18c7535..06c10bf62082f2fe5129363d656d456d0eaa5126 100644
+--- a/build/ExpoClient.js
++++ b/build/ExpoClient.js
+@@ -6,13 +6,11 @@
+  * https://expo.dev
+  */
+ import assert from 'node:assert';
+-import { createRequire } from 'node:module';
+ import { gzipSync } from 'node:zlib';
+ import promiseLimit from 'promise-limit';
+ import promiseRetry from 'promise-retry';
+ import { fetch } from 'undici';
+ import { defaultConcurrentRequestLimit, getReceiptsApiUrl, pushNotificationChunkLimit, pushNotificationReceiptChunkLimit, requestRetryMinTimeout, sendApiUrl, } from "./ExpoClientValues.js";
+-const require = createRequire(import.meta.url);
+ export class Expo {
+     static pushNotificationChunkSizeLimit = pushNotificationChunkLimit;
+     static pushNotificationReceiptChunkSizeLimit = pushNotificationReceiptChunkLimit;
+@@ -162,7 +160,7 @@ export class Expo {
+         // NOTE: This can be replaced with an import with the `{ type: "json" }`
+         // attribute when we drop support for node versions below v20.10.0, when
+         // import attributes were stabilized
+-        const sdkVersion = require('../package.json').version;
++        const sdkVersion = '6.1.0';
+         const requestHeaders = new Headers({
+             Accept: 'application/json',
+             'Accept-Encoding': 'gzip, deflate',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ patchedDependencies:
   '@storybook/nextjs@9.1.20':
     hash: e1857649664eed8f87877c352d277c90d4af5a58d0ad931105f033c8c08165c1
     path: patches/@storybook__nextjs@9.1.20.patch
+  expo-server-sdk@6.1.0:
+    hash: c585457628f3c0d87f2f8f0a5e7071fd450414800ed307fac6eb26dfe2308d02
+    path: patches/expo-server-sdk@6.1.0.patch
   stream-chat-react-native-core:
     hash: 6fa2fe7a3ddb0ab3312ee1adc4e07d3fc9c46f7bc5bb861675bef4078808b8c0
     path: patches/stream-chat-react-native-core.patch
@@ -1442,7 +1445,7 @@ importers:
         version: 7.0.0-dev.20260319.1
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))
+        version: 30.3.0(@types/node@24.12.0)(esbuild-register@3.6.0(esbuild@0.27.4))
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1743,7 +1746,7 @@ importers:
         version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       expo-server-sdk:
         specifier: ^6.1.0
-        version: 6.1.0
+        version: 6.1.0(patch_hash=c585457628f3c0d87f2f8f0a5e7071fd450414800ed307fac6eb26dfe2308d02)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -16309,7 +16312,7 @@ snapshots:
       cjs-module-lexer: 1.4.3
       esbuild: 0.27.4
       miniflare: 4.20260310.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       wrangler: 4.72.0(@cloudflare/workers-types@4.20260313.1)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -21841,7 +21844,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -24042,7 +24045,7 @@ snapshots:
     dependencies:
       expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.11)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
-  expo-server-sdk@6.1.0:
+  expo-server-sdk@6.1.0(patch_hash=c585457628f3c0d87f2f8f0a5e7071fd450414800ed307fac6eb26dfe2308d02):
     dependencies:
       promise-limit: 2.7.0
       promise-retry: 2.0.1
@@ -25211,25 +25214,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4)):
-    dependencies:
-      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   jest-config@29.7.0(@types/node@24.12.0):
     dependencies:
       '@babel/core': 7.29.0
@@ -25874,19 +25858,6 @@ snapshots:
       '@jest/types': 30.3.0
       import-local: 3.2.0
       jest-cli: 30.3.0(@types/node@24.12.0)(esbuild-register@3.6.0(esbuild@0.27.4))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4)):
-    dependencies:
-      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros


### PR DESCRIPTION
## Summary
- Switched deploy-workers workflow from a hardcoded whitelist to auto-discovering all `services/*/wrangler.jsonc` files
- Only `kiloclaw` (Docker deploy) and `gastown` are blacklisted
- Changed `workflow_dispatch` input from `choice` to `string` since a static dropdown can't auto-discover
- Fixes `notifications` (and any future workers) being silently skipped on deploy
- Patches `expo-server-sdk@6.1.0` for Cloudflare Workers compatibility — removes `createRequire(import.meta.url)` which fails in Workers because `import.meta.url` is undefined during the build

## Test plan
- [ ] Trigger workflow manually with `services/notifications` to verify string input works
- [ ] Merge a change to a worker and verify the matrix picks it up
- [ ] Verify `notifications` worker deploys successfully with the expo-server-sdk patch