### PR TITLE
fix(mobile): misc fixes

### DIFF
--- a/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/settings/model-list.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/settings/model-list.tsx
@@ -1,0 +1,166 @@
+import { useQuery } from '@tanstack/react-query';
+import { Check, Eye } from 'lucide-react-native';
+import { useCallback, useRef, useState } from 'react';
+import { FlatList, Pressable, TextInput, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { toast } from 'sonner-native';
+
+import { QueryError } from '@/components/query-error';
+import { ScreenHeader } from '@/components/screen-header';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Text } from '@/components/ui/text';
+import { useKiloClawConfig, useKiloClawMutations } from '@/lib/hooks/use-kiloclaw';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { useTRPC } from '@/lib/trpc';
+
+type ModelItem = {
+  id: string;
+  name: string;
+  supportsVision: boolean;
+  isPreferred: boolean;
+};
+
+function stripPrefix(modelId: string | null | undefined): string {
+  if (!modelId) {
+    return '';
+  }
+  return modelId.replace(/^kilocode\//, '');
+}
+
+export default function ModelListScreen() {
+  const router = useRouter();
+  const colors = useThemeColors();
+  const { bottom } = useSafeAreaInsets();
+  const trpc = useTRPC();
+  const searchRef = useRef('');
+  const [searchFilter, setSearchFilter] = useState('');
+
+  const { data: config } = useKiloClawConfig();
+  const mutations = useKiloClawMutations();
+  const currentModel = stripPrefix(config?.kilocodeDefaultModel);
+
+  const {
+    data: models,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery(trpc.models.list.queryOptions(undefined, { staleTime: 5 * 60_000 }));
+
+  const filtered = (models ?? []).filter((m: ModelItem) => {
+    if (!searchFilter) {
+      return true;
+    }
+    const q = searchFilter.toLowerCase();
+    return m.name.toLowerCase().includes(q) || m.id.toLowerCase().includes(q);
+  });
+
+  const preferred = filtered.filter(m => m.isPreferred);
+  const rest = filtered.filter(m => !m.isPreferred);
+
+  const handleSelect = useCallback(
+    (modelId: string) => {
+      mutations.updateModel.mutate(
+        { kilocodeDefaultModel: `kilocode/${modelId}` },
+        {
+          onSuccess: () => {
+            toast.success(`Model set to ${modelId}`);
+            router.back();
+          },
+        }
+      );
+    },
+    [mutations.updateModel, router]
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: ModelItem }) => {
+      const selected = currentModel === item.id;
+      return (
+        <Pressable
+          className="flex-row items-center gap-3 px-4 py-3 active:opacity-70"
+          onPress={() => {
+            handleSelect(item.id);
+          }}
+          disabled={mutations.updateModel.isPending}
+        >
+          <View className="flex-1">
+            <Text className="text-sm font-medium">{item.name}</Text>
+            <Text className="text-xs text-muted-foreground">{item.id}</Text>
+          </View>
+          {item.supportsVision && <Eye size={14} color={colors.mutedForeground} />}
+          {selected && <Check size={16} color="#3b82f6" />}
+        </Pressable>
+      );
+    },
+    [currentModel, handleSelect, mutations.updateModel.isPending, colors.mutedForeground]
+  );
+
+  const sections = [
+    ...(preferred.length > 0
+      ? [
+          { type: 'header' as const, title: 'Recommended' },
+          ...preferred.map(m => ({ type: 'model' as const, model: m })),
+        ]
+      : []),
+    ...(rest.length > 0
+      ? [
+          { type: 'header' as const, title: 'All Models' },
+          ...rest.map(m => ({ type: 'model' as const, model: m })),
+        ]
+      : []),
+  ];
+
+  return (
+    <View className="flex-1 bg-background">
+      <ScreenHeader title="All Models" />
+      <View className="px-4 pb-2 pt-2">
+        <TextInput
+          className="rounded-lg bg-secondary px-4 py-3 text-sm text-foreground"
+          placeholder="Search models..."
+          placeholderTextColor={colors.mutedForeground}
+          autoCapitalize="none"
+          autoCorrect={false}
+          defaultValue=""
+          onChangeText={text => {
+            searchRef.current = text;
+            setSearchFilter(text);
+          }}
+        />
+      </View>
+      {isLoading && (
+        <View className="gap-2 px-4 pt-2">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full rounded-lg" />
+          ))}
+        </View>
+      )}
+      {isError && (
+        <View className="flex-1 items-center justify-center">
+          <QueryError message="Could not load models" onRetry={() => void refetch()} />
+        </View>
+      )}
+      {!isLoading && !isError && (
+        <FlatList
+          data={sections}
+          keyExtractor={(item, index) =>
+            item.type === 'header' ? `header-${item.title}` : `model-${item.model.id}-${index}`
+          }
+          contentContainerStyle={{ paddingBottom: Math.max(bottom, 16) }}
+          renderItem={({ item }) => {
+            if (item.type === 'header') {
+              return (
+                <View className="px-4 pb-1 pt-4">
+                  <Text className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {item.title}
+                  </Text>
+                </View>
+              );
+            }
+            return renderItem({ item: item.model });
+          }}
+        />
+      )}
+    </View>
+  );
+}

--- a/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/settings/model-list.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/settings/model-list.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { Check, Eye } from 'lucide-react-native';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { FlatList, Pressable, TextInput, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
@@ -12,6 +12,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { useKiloClawConfig, useKiloClawMutations } from '@/lib/hooks/use-kiloclaw';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { addModelPrefix, stripModelPrefix } from '@/lib/model-id';
 import { useTRPC } from '@/lib/trpc';
 
 type ModelItem = {
@@ -21,24 +22,16 @@ type ModelItem = {
   isPreferred: boolean;
 };
 
-function stripPrefix(modelId: string | null | undefined): string {
-  if (!modelId) {
-    return '';
-  }
-  return modelId.replace(/^kilocode\//, '');
-}
-
 export default function ModelListScreen() {
   const router = useRouter();
   const colors = useThemeColors();
   const { bottom } = useSafeAreaInsets();
   const trpc = useTRPC();
-  const searchRef = useRef('');
   const [searchFilter, setSearchFilter] = useState('');
 
   const { data: config } = useKiloClawConfig();
   const mutations = useKiloClawMutations();
-  const currentModel = stripPrefix(config?.kilocodeDefaultModel);
+  const currentModel = stripModelPrefix(config?.kilocodeDefaultModel);
 
   const {
     data: models,
@@ -61,7 +54,7 @@ export default function ModelListScreen() {
   const handleSelect = useCallback(
     (modelId: string) => {
       mutations.updateModel.mutate(
-        { kilocodeDefaultModel: `kilocode/${modelId}` },
+        { kilocodeDefaultModel: addModelPrefix(modelId) },
         {
           onSuccess: () => {
             toast.success(`Model set to ${modelId}`);
@@ -122,10 +115,7 @@ export default function ModelListScreen() {
           autoCapitalize="none"
           autoCorrect={false}
           defaultValue=""
-          onChangeText={text => {
-            searchRef.current = text;
-            setSearchFilter(text);
-          }}
+          onChangeText={setSearchFilter}
         />
       </View>
       {isLoading && (

--- a/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/settings/model.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/[instance-id]/settings/model.tsx
@@ -1,0 +1,15 @@
+import { ScrollView, View } from 'react-native';
+
+import { ModelPicker } from '@/components/kiloclaw/model-picker';
+import { ScreenHeader } from '@/components/screen-header';
+
+export default function ModelSettingsScreen() {
+  return (
+    <View className="flex-1 bg-background">
+      <ScreenHeader title="Model" />
+      <ScrollView className="flex-1 px-4 pt-4" contentContainerClassName="pb-8">
+        <ModelPicker />
+      </ScrollView>
+    </View>
+  );
+}

--- a/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/index.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/index.tsx
@@ -1,8 +1,6 @@
 import { useRouter } from 'expo-router';
-import * as Notifications from 'expo-notifications';
 import * as WebBrowser from 'expo-web-browser';
 import { Plus, Server } from 'lucide-react-native';
-import { useEffect } from 'react';
 import { Platform, View } from 'react-native';
 import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
 
@@ -20,30 +18,6 @@ import { deriveLockReason } from '@/lib/hooks/use-kiloclaw-billing';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 
 export default function KiloClawInstanceList() {
-  // TODO: remove — mock notification for styling (repeats every 5s)
-  useEffect(() => {
-    const fire = () => {
-      void Notifications.scheduleNotificationAsync({
-        content: {
-          title: 'KiloClaw',
-          body: 'There are more possible iterations of a game of chess than there are atoms in the observable univ...',
-          data: {
-            type: 'chat',
-            instanceId: 'Y2UxMmVmM2QtYWU5NS00ZDc3LWI0ZjAtMjM3MzVmMGEwNTkx',
-          },
-          sound: 'default',
-        },
-        trigger: null,
-      });
-    };
-    const timer = setTimeout(fire, 2000);
-    const interval = setInterval(fire, 5000);
-    return () => {
-      clearTimeout(timer);
-      clearInterval(interval);
-    };
-  }, []);
-
   const router = useRouter();
   const colors = useThemeColors();
   const { context, clearContext } = useAppContext();

--- a/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/index.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/index.tsx
@@ -1,6 +1,8 @@
 import { useRouter } from 'expo-router';
+import * as Notifications from 'expo-notifications';
 import * as WebBrowser from 'expo-web-browser';
 import { Plus, Server } from 'lucide-react-native';
+import { useEffect } from 'react';
 import { Platform, View } from 'react-native';
 import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
 
@@ -18,6 +20,27 @@ import { deriveLockReason } from '@/lib/hooks/use-kiloclaw-billing';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 
 export default function KiloClawInstanceList() {
+  // TODO: remove — mock notification for styling
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      void Notifications.scheduleNotificationAsync({
+        content: {
+          title: 'KiloClaw',
+          body: 'There are more possible iterations of a game of chess than there are atoms in the observable univ...',
+          data: {
+            type: 'chat',
+            instanceId: 'Y2UxMmVmM2QtYWU5NS00ZDc3LWI0ZjAtMjM3MzVmMGEwNTkx',
+          },
+          sound: 'default',
+        },
+        trigger: null,
+      });
+    }, 3000);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, []);
+
   const router = useRouter();
   const colors = useThemeColors();
   const { context, clearContext } = useAppContext();

--- a/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/index.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(1_kiloclaw)/index.tsx
@@ -20,9 +20,9 @@ import { deriveLockReason } from '@/lib/hooks/use-kiloclaw-billing';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 
 export default function KiloClawInstanceList() {
-  // TODO: remove — mock notification for styling
+  // TODO: remove — mock notification for styling (repeats every 5s)
   useEffect(() => {
-    const timer = setTimeout(() => {
+    const fire = () => {
       void Notifications.scheduleNotificationAsync({
         content: {
           title: 'KiloClaw',
@@ -35,9 +35,12 @@ export default function KiloClawInstanceList() {
         },
         trigger: null,
       });
-    }, 3000);
+    };
+    const timer = setTimeout(fire, 2000);
+    const interval = setInterval(fire, 5000);
     return () => {
       clearTimeout(timer);
+      clearInterval(interval);
     };
   }, []);
 

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -4,7 +4,7 @@ import { PortalHost } from '@rn-primitives/portal';
 import * as Sentry from '@sentry/react-native';
 import { QueryClientProvider, useMutation } from '@tanstack/react-query';
 import { isRunningInExpoGo } from 'expo';
-import { Slot, useNavigationContainerRef, useRouter, useSegments } from 'expo-router';
+import { type Href, Slot, useNavigationContainerRef, useRouter, useSegments } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import { requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
@@ -17,7 +17,9 @@ import { AuthProvider, useAuth } from '@/lib/auth/auth-context';
 import { initAppsFlyer } from '@/lib/appsflyer';
 import { ContextProvider, useAppContext } from '@/lib/context/context-context';
 import {
+  checkInitialNotification,
   getNotificationPermissionStatus,
+  getPendingNotificationLink,
   getPlatform,
   registerForPushNotifications,
   setupNotificationHandler,
@@ -60,6 +62,7 @@ Sentry.init({
 
 void SplashScreen.preventAutoHideAsync();
 setupNotificationHandler();
+checkInitialNotification();
 
 function RootLayoutNav() {
   const { token, isLoading: authLoading } = useAuth();
@@ -109,6 +112,11 @@ function RootLayoutNav() {
       router.replace('/(app)');
     } else {
       void SplashScreen.hideAsync();
+      // Navigate to pending notification deep link (cold start / background tap)
+      const pendingLink = getPendingNotificationLink();
+      if (pendingLink) {
+        router.push(pendingLink as Href);
+      }
     }
   }, [
     token,

--- a/apps/mobile/src/components/chat-notification-toast.tsx
+++ b/apps/mobile/src/components/chat-notification-toast.tsx
@@ -1,0 +1,36 @@
+import { type Href, router } from 'expo-router';
+import { Pressable, View } from 'react-native';
+
+import logo from '@/../assets/images/logo.png';
+import { Image } from '@/components/ui/image';
+import { Text } from '@/components/ui/text';
+
+type ChatNotificationToastProps = {
+  title: string;
+  body: string;
+  instanceId: string;
+};
+
+export function ChatNotificationToast({ title, body, instanceId }: ChatNotificationToastProps) {
+  return (
+    <Pressable
+      className="w-full flex-row items-center gap-3 rounded-2xl bg-secondary px-4 py-3 shadow-lg active:opacity-80"
+      onPress={() => {
+        router.push(`/(app)/chat/${instanceId}` as Href);
+      }}
+    >
+      <Image
+        source={logo}
+        className="h-10 w-10 rounded-full"
+        accessibilityLabel="KiloClaw"
+        transition={0}
+      />
+      <View className="flex-1">
+        <Text className="text-sm font-semibold">{title}</Text>
+        <Text className="text-xs text-muted-foreground" numberOfLines={2}>
+          {body}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/components/chat-notification-toast.tsx
+++ b/apps/mobile/src/components/chat-notification-toast.tsx
@@ -1,21 +1,24 @@
 import { type Href, router } from 'expo-router';
 import { Pressable, View } from 'react-native';
+import { toast } from 'sonner-native';
 
 import logo from '@/../assets/images/logo.png';
 import { Image } from '@/components/ui/image';
 import { Text } from '@/components/ui/text';
 
 type ChatNotificationToastProps = {
+  id: string | number;
   title: string;
   body: string;
   instanceId: string;
 };
 
-export function ChatNotificationToast({ title, body, instanceId }: ChatNotificationToastProps) {
+export function ChatNotificationToast({ id, title, body, instanceId }: ChatNotificationToastProps) {
   return (
     <Pressable
       className="w-full flex-row items-center gap-3 rounded-2xl bg-secondary px-4 py-3 shadow-lg active:opacity-80"
       onPress={() => {
+        toast.dismiss(id);
         router.push(`/(app)/chat/${instanceId}` as Href);
       }}
     >

--- a/apps/mobile/src/components/kiloclaw/chat-avatar.tsx
+++ b/apps/mobile/src/components/kiloclaw/chat-avatar.tsx
@@ -6,7 +6,7 @@ import { Image } from '@/components/ui/image';
 
 export function KiloClawMessageAvatar(_props: MessageAvatarProps) {
   const { message, lastGroupMessage } = useMessageContext();
-  const isBotMessage = message.user?.id.startsWith('bot-');
+  const isBotMessage = message?.user?.id?.startsWith('bot-');
 
   if (!lastGroupMessage) {
     return <View className="w-8" />;

--- a/apps/mobile/src/components/kiloclaw/chat-avatar.tsx
+++ b/apps/mobile/src/components/kiloclaw/chat-avatar.tsx
@@ -1,0 +1,29 @@
+import { View } from 'react-native';
+import { type MessageAvatarProps, useMessageContext } from 'stream-chat-expo';
+
+import logo from '@/../assets/images/logo.png';
+import { Image } from '@/components/ui/image';
+
+export function KiloClawMessageAvatar(_props: MessageAvatarProps) {
+  const { message, lastGroupMessage } = useMessageContext();
+  const isBotMessage = message.user?.id.startsWith('bot-');
+
+  if (!lastGroupMessage) {
+    return <View className="w-8" />;
+  }
+
+  if (isBotMessage) {
+    return (
+      <View className="h-8 w-8">
+        <Image
+          source={logo}
+          className="h-8 w-8 rounded-full"
+          accessibilityLabel="KiloClaw"
+          transition={0}
+        />
+      </View>
+    );
+  }
+
+  return <View className="w-8" />;
+}

--- a/apps/mobile/src/components/kiloclaw/chat-avatar.tsx
+++ b/apps/mobile/src/components/kiloclaw/chat-avatar.tsx
@@ -14,7 +14,7 @@ export function KiloClawMessageAvatar(_props: MessageAvatarProps) {
 
   if (isBotMessage) {
     return (
-      <View className="h-8 w-8">
+      <View className="mr-2 h-8 w-8">
         <Image
           source={logo}
           className="h-8 w-8 rounded-full"

--- a/apps/mobile/src/components/kiloclaw/chat-avatar.tsx
+++ b/apps/mobile/src/components/kiloclaw/chat-avatar.tsx
@@ -6,6 +6,7 @@ import { Image } from '@/components/ui/image';
 
 export function KiloClawMessageAvatar(_props: MessageAvatarProps) {
   const { message, lastGroupMessage } = useMessageContext();
+  // eslint-disable-next-line typescript-eslint/no-unnecessary-condition -- message can be undefined at runtime in reply swipe context
   const isBotMessage = message?.user?.id?.startsWith('bot-');
 
   if (!lastGroupMessage) {

--- a/apps/mobile/src/components/kiloclaw/chat.tsx
+++ b/apps/mobile/src/components/kiloclaw/chat.tsx
@@ -82,8 +82,6 @@ export function KiloClawChat({ instanceId, name, enabled }: Readonly<KiloClawCha
   );
 }
 
-// ─── Internal components ────────────────────────────────────────────────────
-
 function ChatShell({
   instanceId,
   name,
@@ -183,61 +181,64 @@ function StreamChatUI({
   const [client, setClient] = useState<StreamChat | null>(null);
   const [channel, setChannel] = useState<StreamChannel | null>(null);
   const [connectError, setConnectError] = useState<string | null>(null);
-  const cancelledRef = useRef(false);
-
-  const connect = useCallback(async () => {
-    const chatClient = StreamChat.getInstance(apiKey);
-    setConnectError(null);
-
-    try {
-      if (chatClient.userID) {
-        try {
-          await chatClient.disconnectUser();
-        } catch {
-          // Ignore disconnect errors on a potentially dead connection
-        }
-      }
-      if (cancelledRef.current) {
-        return;
-      }
-      await chatClient.connectUser({ id: userId }, tokenProvider);
-      const ch = chatClient.channel('messaging', channelId);
-      await ch.watch({ presence: true });
-      // eslint-disable-next-line typescript-eslint/no-unnecessary-condition -- ref can change across awaits
-      if (!cancelledRef.current) {
-        setClient(chatClient);
-        setChannel(ch);
-      }
-    } catch (error) {
-      if (!cancelledRef.current) {
-        setConnectError(error instanceof Error ? error.message : 'Failed to connect to chat.');
-      }
-    }
-  }, [apiKey, userId, channelId, tokenProvider]);
 
   useEffect(() => {
-    cancelledRef.current = false;
+    const chatClient = StreamChat.getInstance(apiKey);
+
+    let cancelled = false;
+    setConnectError(null);
+
+    const connect = async () => {
+      try {
+        // Await disconnect to prevent tokenManager.reset() from racing with the new connection
+        if (chatClient.userID) {
+          await chatClient.disconnectUser();
+        }
+        if (cancelled) {
+          return;
+        }
+        await chatClient.connectUser({ id: userId }, tokenProvider);
+        const ch = chatClient.channel('messaging', channelId);
+        await ch.watch({ presence: true });
+        // eslint-disable-next-line typescript-eslint/no-unnecessary-condition -- cancelled can change across awaits
+        if (!cancelled) {
+          setClient(chatClient);
+          setChannel(ch);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setConnectError(error instanceof Error ? error.message : 'Failed to connect to chat.');
+        }
+      }
+    };
+
     void connect();
+
     return () => {
-      cancelledRef.current = true;
+      cancelled = true;
       setClient(null);
       setChannel(null);
     };
-  }, [connect]);
+  }, [apiKey, userId, channelId, tokenProvider]);
 
-  // Reconnect when app returns to foreground (websocket may have died while backgrounded)
+  // Gracefully close/reopen the websocket on background/foreground.
+  // This preserves the client and channel state (no disconnect/reconnect).
   const appState = useRef(AppState.currentState);
   useEffect(() => {
     const subscription = AppState.addEventListener('change', nextAppState => {
-      if (/inactive|background/.exec(appState.current) && nextAppState === 'active') {
-        void connect();
+      if (client) {
+        if (appState.current === 'active' && /inactive|background/.exec(nextAppState)) {
+          void client.closeConnection();
+        } else if (/inactive|background/.exec(appState.current) && nextAppState === 'active') {
+          void client.openConnection();
+        }
       }
       appState.current = nextAppState;
     });
     return () => {
       subscription.remove();
     };
-  }, [connect]);
+  }, [client]);
 
   // Bot presence tracking
   const sandboxId = channelId.replace(/^default-/, '');

--- a/apps/mobile/src/components/kiloclaw/chat.tsx
+++ b/apps/mobile/src/components/kiloclaw/chat.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
-import { ActivityIndicator, Pressable, View } from 'react-native';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ActivityIndicator, AppState, Pressable, View } from 'react-native';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { type Href, useFocusEffect, useRouter } from 'expo-router';
@@ -183,51 +183,61 @@ function StreamChatUI({
   const [client, setClient] = useState<StreamChat | null>(null);
   const [channel, setChannel] = useState<StreamChannel | null>(null);
   const [connectError, setConnectError] = useState<string | null>(null);
+  const cancelledRef = useRef(false);
 
-  useEffect(() => {
+  const connect = useCallback(async () => {
     const chatClient = StreamChat.getInstance(apiKey);
-
-    let cancelled = false;
     setConnectError(null);
 
-    const connect = async () => {
-      try {
-        // Disconnect any stale connection (e.g. after app was backgrounded)
-        // to prevent "can't use channel after disconnect" errors
-        if (chatClient.userID || chatClient.wsConnection) {
-          try {
-            await chatClient.disconnectUser();
-          } catch {
-            // Ignore disconnect errors on a potentially dead connection
-          }
-        }
-        if (cancelled) {
-          return;
-        }
-        await chatClient.connectUser({ id: userId }, tokenProvider);
-        const ch = chatClient.channel('messaging', channelId);
-        await ch.watch({ presence: true });
-        // cancelled may change across awaits above
-        // eslint-disable-next-line typescript-eslint/no-unnecessary-condition
-        if (!cancelled) {
-          setClient(chatClient);
-          setChannel(ch);
-        }
-      } catch (error) {
-        if (!cancelled) {
-          setConnectError(error instanceof Error ? error.message : 'Failed to connect to chat.');
+    try {
+      if (chatClient.userID) {
+        try {
+          await chatClient.disconnectUser();
+        } catch {
+          // Ignore disconnect errors on a potentially dead connection
         }
       }
-    };
+      if (cancelledRef.current) {
+        return;
+      }
+      await chatClient.connectUser({ id: userId }, tokenProvider);
+      const ch = chatClient.channel('messaging', channelId);
+      await ch.watch({ presence: true });
+      // eslint-disable-next-line typescript-eslint/no-unnecessary-condition -- ref can change across awaits
+      if (!cancelledRef.current) {
+        setClient(chatClient);
+        setChannel(ch);
+      }
+    } catch (error) {
+      if (!cancelledRef.current) {
+        setConnectError(error instanceof Error ? error.message : 'Failed to connect to chat.');
+      }
+    }
+  }, [apiKey, userId, channelId, tokenProvider]);
 
+  useEffect(() => {
+    cancelledRef.current = false;
     void connect();
-
     return () => {
-      cancelled = true;
+      cancelledRef.current = true;
       setClient(null);
       setChannel(null);
     };
-  }, [apiKey, userId, channelId, tokenProvider]);
+  }, [connect]);
+
+  // Reconnect when app returns to foreground (websocket may have died while backgrounded)
+  const appState = useRef(AppState.currentState);
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', nextAppState => {
+      if (/inactive|background/.exec(appState.current) && nextAppState === 'active') {
+        void connect();
+      }
+      appState.current = nextAppState;
+    });
+    return () => {
+      subscription.remove();
+    };
+  }, [connect]);
 
   // Bot presence tracking
   const sandboxId = channelId.replace(/^default-/, '');

--- a/apps/mobile/src/components/kiloclaw/chat.tsx
+++ b/apps/mobile/src/components/kiloclaw/chat.tsx
@@ -192,9 +192,14 @@ function StreamChatUI({
 
     const connect = async () => {
       try {
-        // Await disconnect to prevent tokenManager.reset() from racing with the new connection
-        if (chatClient.userID) {
-          await chatClient.disconnectUser();
+        // Disconnect any stale connection (e.g. after app was backgrounded)
+        // to prevent "can't use channel after disconnect" errors
+        if (chatClient.userID || chatClient.wsConnection) {
+          try {
+            await chatClient.disconnectUser();
+          } catch {
+            // Ignore disconnect errors on a potentially dead connection
+          }
         }
         if (cancelled) {
           return;

--- a/apps/mobile/src/components/kiloclaw/chat.tsx
+++ b/apps/mobile/src/components/kiloclaw/chat.tsx
@@ -8,6 +8,7 @@ import { Settings } from 'lucide-react-native';
 import { type Channel as StreamChannel, StreamChat } from 'stream-chat';
 import { Channel, Chat, MessageInput, MessageList, OverlayProvider } from 'stream-chat-expo';
 
+import { KiloClawMessageAvatar } from '@/components/kiloclaw/chat-avatar';
 import { useBotOnlineStatus } from '@/components/kiloclaw/chat-hooks';
 import { NotificationPrompt } from '@/components/kiloclaw/notification-prompt';
 import { useStreamChatTheme } from '@/components/kiloclaw/chat-theme';
@@ -259,7 +260,11 @@ function StreamChatUI({
         <OverlayProvider value={{ style: chatTheme }}>
           {/* eslint-disable-next-line typescript-eslint/no-unsafe-assignment -- expo-image is API-compatible with RN Image */}
           <Chat client={client} style={chatTheme} ImageComponent={ExpoImage as never}>
-            <Channel channel={channel} keyboardVerticalOffset={headerHeight}>
+            <Channel
+              channel={channel}
+              keyboardVerticalOffset={headerHeight}
+              MessageAvatar={KiloClawMessageAvatar}
+            >
               <NotificationPrompt enabled={Boolean(channel)} />
               <MessageList />
               <MessageInput />

--- a/apps/mobile/src/components/kiloclaw/chat.tsx
+++ b/apps/mobile/src/components/kiloclaw/chat.tsx
@@ -291,11 +291,10 @@ function StreamChatUI({
     </View>
   );
 }
-
 function ChatPlaceholder({ message }: { message: string }) {
   return (
     <View className="flex-1 items-center justify-center px-6">
-      <Text className="text-sm text-muted-foreground text-center">{message}</Text>
+      <Text className="text-center text-sm text-muted-foreground">{message}</Text>
     </View>
   );
 }

--- a/apps/mobile/src/components/kiloclaw/model-picker.tsx
+++ b/apps/mobile/src/components/kiloclaw/model-picker.tsx
@@ -1,0 +1,189 @@
+import { type Href, useLocalSearchParams, useRouter } from 'expo-router';
+import { CheckCircle2, type LucideIcon, Scale, Zap } from 'lucide-react-native';
+import { Pressable, View } from 'react-native';
+import { toast } from 'sonner-native';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { Text } from '@/components/ui/text';
+import { useKiloClawConfig, useKiloClawMutations } from '@/lib/hooks/use-kiloclaw';
+
+type AutoModelCard = {
+  id: string;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  iconBg: string;
+  iconColor: string;
+  cost: number;
+  performance: number;
+  performanceDotColor: string;
+};
+
+const AUTO_MODEL_CARDS: AutoModelCard[] = [
+  {
+    id: 'kilo-auto/frontier',
+    label: 'Frontier',
+    description: 'Highest performance. Routes to frontier models with reasoning.',
+    icon: Zap,
+    iconBg: 'bg-purple-500/20',
+    iconColor: '#a855f7',
+    cost: 3,
+    performance: 3,
+    performanceDotColor: 'bg-purple-400',
+  },
+  {
+    id: 'kilo-auto/balanced',
+    label: 'Balanced',
+    description: 'Smart balance of speed and capability at lower cost.',
+    icon: Scale,
+    iconBg: 'bg-blue-500/20',
+    iconColor: '#3b82f6',
+    cost: 2,
+    performance: 2,
+    performanceDotColor: 'bg-blue-400',
+  },
+];
+
+const AUTO_MODEL_IDS = new Set(AUTO_MODEL_CARDS.map(c => c.id));
+
+function stripPrefix(modelId: string | null | undefined): string {
+  if (!modelId) {
+    return '';
+  }
+  return modelId.replace(/^kilocode\//, '');
+}
+
+function addPrefix(modelId: string): string {
+  return `kilocode/${modelId}`;
+}
+
+function CostIndicator({ level }: { level: number }) {
+  return (
+    <View className="flex-row items-center justify-between">
+      <Text className="text-xs text-muted-foreground">Cost</Text>
+      <View className="flex-row gap-0.5">
+        {[0, 1, 2].map(i => (
+          <Text
+            key={i}
+            className={`text-sm font-medium ${i < level ? 'text-foreground' : 'text-neutral-300 dark:text-neutral-700'}`}
+          >
+            $
+          </Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function PerformanceIndicator({ level, dotColor }: { level: number; dotColor: string }) {
+  return (
+    <View className="flex-row items-center justify-between">
+      <Text className="text-xs text-muted-foreground">Performance</Text>
+      <View className="flex-row gap-1">
+        {[0, 1, 2].map(i => (
+          <View
+            key={i}
+            className={`h-2.5 w-5 rounded-full ${i < level ? dotColor : 'bg-neutral-200 dark:bg-neutral-700'}`}
+          />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+export function ModelPicker() {
+  const router = useRouter();
+  const { 'instance-id': instanceId } = useLocalSearchParams<{ 'instance-id': string }>();
+  const { data: config, isLoading } = useKiloClawConfig();
+  const mutations = useKiloClawMutations();
+
+  const currentModel = stripPrefix(config?.kilocodeDefaultModel);
+  const isAutoModel = AUTO_MODEL_IDS.has(currentModel);
+
+  const handleSelectAutoModel = (modelId: string) => {
+    if (currentModel === modelId) {
+      return;
+    }
+    mutations.updateModel.mutate(
+      { kilocodeDefaultModel: addPrefix(modelId) },
+      {
+        onSuccess: () => {
+          toast.success(`Switched to ${modelId.split('/').pop()}`);
+        },
+      }
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <View className="gap-3">
+        <Skeleton className="h-40 w-full rounded-lg" />
+        <Skeleton className="h-40 w-full rounded-lg" />
+      </View>
+    );
+  }
+
+  return (
+    <View className="gap-4">
+      <View className="gap-3">
+        <Text className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Kilo Auto
+        </Text>
+        {AUTO_MODEL_CARDS.map(card => {
+          const selected = currentModel === card.id;
+          const Icon = card.icon;
+          return (
+            <Pressable
+              key={card.id}
+              className={`relative gap-3 rounded-lg border p-4 ${selected ? 'border-blue-500 bg-blue-500/5' : 'border-border bg-secondary'}`}
+              disabled={mutations.updateModel.isPending}
+              onPress={() => {
+                handleSelectAutoModel(card.id);
+              }}
+            >
+              {selected && (
+                <View className="absolute right-3 top-3">
+                  <CheckCircle2 size={20} color="#3b82f6" />
+                </View>
+              )}
+              <View className={`h-9 w-9 items-center justify-center rounded-lg ${card.iconBg}`}>
+                <Icon size={20} color={card.iconColor} />
+              </View>
+              <View className="gap-1">
+                <Text className="font-semibold">{card.label}</Text>
+                <Text className="text-xs leading-relaxed text-muted-foreground">
+                  {card.description}
+                </Text>
+              </View>
+              <View className="gap-1.5">
+                <CostIndicator level={card.cost} />
+                <PerformanceIndicator
+                  level={card.performance}
+                  dotColor={card.performanceDotColor}
+                />
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {/* Current non-auto model display */}
+      {!isAutoModel && currentModel && (
+        <View className="rounded-lg bg-secondary p-3">
+          <Text className="text-xs text-muted-foreground">Current model</Text>
+          <Text className="text-sm font-medium">{currentModel}</Text>
+        </View>
+      )}
+
+      {/* Navigate to full model list */}
+      <Pressable
+        className="items-center py-2 active:opacity-70"
+        onPress={() => {
+          router.push(`/(app)/(tabs)/(1_kiloclaw)/${instanceId}/settings/model-list` as Href);
+        }}
+      >
+        <Text className="text-sm text-muted-foreground">or select from 500+ models</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/kiloclaw/model-picker.tsx
+++ b/apps/mobile/src/components/kiloclaw/model-picker.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner-native';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { useKiloClawConfig, useKiloClawMutations } from '@/lib/hooks/use-kiloclaw';
+import { addModelPrefix, stripModelPrefix } from '@/lib/model-id';
 
 type AutoModelCard = {
   id: string;
@@ -45,17 +46,6 @@ const AUTO_MODEL_CARDS: AutoModelCard[] = [
 ];
 
 const AUTO_MODEL_IDS = new Set(AUTO_MODEL_CARDS.map(c => c.id));
-
-function stripPrefix(modelId: string | null | undefined): string {
-  if (!modelId) {
-    return '';
-  }
-  return modelId.replace(/^kilocode\//, '');
-}
-
-function addPrefix(modelId: string): string {
-  return `kilocode/${modelId}`;
-}
 
 function CostIndicator({ level }: { level: number }) {
   return (
@@ -97,7 +87,7 @@ export function ModelPicker() {
   const { data: config, isLoading } = useKiloClawConfig();
   const mutations = useKiloClawMutations();
 
-  const currentModel = stripPrefix(config?.kilocodeDefaultModel);
+  const currentModel = stripModelPrefix(config?.kilocodeDefaultModel);
   const isAutoModel = AUTO_MODEL_IDS.has(currentModel);
 
   const handleSelectAutoModel = (modelId: string) => {
@@ -105,7 +95,7 @@ export function ModelPicker() {
       return;
     }
     mutations.updateModel.mutate(
-      { kilocodeDefaultModel: addPrefix(modelId) },
+      { kilocodeDefaultModel: addModelPrefix(modelId) },
       {
         onSuccess: () => {
           toast.success(`Switched to ${modelId.split('/').pop()}`);

--- a/apps/mobile/src/components/kiloclaw/settings-list.tsx
+++ b/apps/mobile/src/components/kiloclaw/settings-list.tsx
@@ -7,6 +7,7 @@ import {
   Monitor,
   Pin,
   Shield,
+  Sparkles,
 } from 'lucide-react-native';
 import type React from 'react';
 import { Pressable, View } from 'react-native';
@@ -24,6 +25,13 @@ type SettingsItem = {
 };
 
 const SETTINGS_ITEMS: SettingsItem[] = [
+  {
+    icon: Sparkles,
+    iconColor: '#a855f7',
+    label: 'Model',
+    description: 'AI model selection',
+    path: 'settings/model',
+  },
   {
     icon: Lock,
     iconColor: '#f59e0b',

--- a/apps/mobile/src/components/notifications-card.tsx
+++ b/apps/mobile/src/components/notifications-card.tsx
@@ -1,7 +1,7 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { Bell } from 'lucide-react-native';
-import { useCallback, useEffect, useState } from 'react';
-import { Alert, Linking, Switch, View } from 'react-native';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Bell, MessageSquare } from 'lucide-react-native';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Alert, AppState, Linking, Switch, View } from 'react-native';
 import { toast } from 'sonner-native';
 
 import { Skeleton } from '@/components/ui/skeleton';
@@ -17,19 +17,27 @@ import { useTRPC } from '@/lib/trpc';
 
 export function NotificationsCard() {
   const trpc = useTRPC();
+  const queryClient = useQueryClient();
   const colors = useThemeColors();
-  const [notificationsEnabled, setNotificationsEnabled] = useState(false);
-  const [notificationsLoading, setNotificationsLoading] = useState(true);
+  const [permissionGranted, setPermissionGranted] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   const { data: pushTokens } = useQuery(trpc.user.getMyPushTokens.queryOptions());
+  const hasTokens = (pushTokens?.length ?? 0) > 0;
+
+  const invalidateTokens = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: trpc.user.getMyPushTokens.queryOptions().queryKey,
+    });
+  }, [queryClient, trpc]);
 
   const registerToken = useMutation(
     trpc.user.registerPushToken.mutationOptions({
       onSuccess: () => {
-        toast.success('Notifications enabled');
+        invalidateTokens();
+        toast.success('Chat notifications enabled');
       },
       onError: error => {
-        setNotificationsEnabled(false);
         toast.error(error.message);
       },
     })
@@ -38,8 +46,8 @@ export function NotificationsCard() {
   const unregisterToken = useMutation(
     trpc.user.unregisterPushToken.mutationOptions({
       onSuccess: () => {
-        toast.success('Notifications disabled');
-        setNotificationsEnabled(false);
+        invalidateTokens();
+        toast.success('Chat notifications disabled');
       },
       onError: error => {
         toast.error(error.message);
@@ -47,44 +55,74 @@ export function NotificationsCard() {
     })
   );
 
-  useEffect(() => {
-    async function checkStatus() {
-      const status = await getNotificationPermissionStatus();
-      const hasTokens = (pushTokens?.length ?? 0) > 0;
-      setNotificationsEnabled(status === 'granted' && hasTokens);
-      setNotificationsLoading(false);
-    }
-    void checkStatus();
-  }, [pushTokens]);
+  // Check system permission on mount and foreground resume
+  const checkPermission = useCallback(async () => {
+    const status = await getNotificationPermissionStatus();
+    setPermissionGranted(status === 'granted');
+    setLoading(false);
+  }, []);
 
-  const handleToggleNotifications = useCallback(
+  useEffect(() => {
+    void checkPermission();
+  }, [checkPermission]);
+
+  const appState = useRef(AppState.currentState);
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', nextAppState => {
+      if (/inactive|background/.exec(appState.current) && nextAppState === 'active') {
+        void checkPermission();
+      }
+      appState.current = nextAppState;
+    });
+    return () => {
+      subscription.remove();
+    };
+  }, [checkPermission]);
+
+  const handleToggleNotifications = useCallback(async (value: boolean) => {
+    if (value) {
+      const status = await getNotificationPermissionStatus();
+      if (status === 'denied') {
+        // Already denied once — OS won't show the prompt again, must go to Settings
+        Alert.alert(
+          'Notifications Disabled',
+          'To enable notifications, turn them on in your device settings.',
+          [
+            { text: 'Cancel', style: 'cancel' },
+            { text: 'Open Settings', onPress: () => void Linking.openSettings() },
+          ]
+        );
+        return;
+      }
+      // Undetermined — triggers the OS permission prompt
+      const token = await registerForPushNotifications();
+      if (token) {
+        setPermissionGranted(true);
+      }
+    } else {
+      // Can't revoke permission programmatically — send user to Settings
+      Alert.alert(
+        'Disable Notifications',
+        'To disable notifications, turn them off in your device settings.',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Open Settings', onPress: () => void Linking.openSettings() },
+        ]
+      );
+    }
+  }, []);
+
+  const handleToggleChatMessages = useCallback(
     async (value: boolean) => {
       if (value) {
-        const status = await getNotificationPermissionStatus();
-        if (status === 'denied') {
-          Alert.alert(
-            'Notifications Disabled',
-            'To enable notifications, open your device settings and allow notifications for Kilo.',
-            [
-              { text: 'Cancel', style: 'cancel' },
-              { text: 'Open Settings', onPress: () => void Linking.openSettings() },
-            ]
-          );
-          return;
-        }
-
         const token = await registerForPushNotifications();
         if (token) {
           registerToken.mutate({ token, platform: getPlatform() });
-          setNotificationsEnabled(true);
         }
       } else {
         const deviceToken = await getDevicePushToken();
         if (deviceToken) {
           unregisterToken.mutate({ token: deviceToken });
-        } else {
-          // Token unavailable (e.g. permission revoked) — update UI to match
-          setNotificationsEnabled(false);
         }
       }
     },
@@ -96,16 +134,34 @@ export function NotificationsCard() {
       <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
         Notifications
       </Text>
+
+      {/* System permission toggle */}
       <View className="flex-row items-center gap-3 rounded-lg bg-secondary p-3">
         <Bell size={18} color={colors.secondaryForeground} />
-        <Text className="flex-1 text-sm font-medium">Push Notifications</Text>
-        {notificationsLoading ? (
+        <Text className="flex-1 text-sm font-medium">Notifications</Text>
+        {loading ? (
           <Skeleton className="h-8 w-12 rounded-full" />
         ) : (
           <Switch
-            value={notificationsEnabled}
-            disabled={registerToken.isPending || unregisterToken.isPending}
+            value={permissionGranted}
             onValueChange={value => void handleToggleNotifications(value)}
+          />
+        )}
+      </View>
+
+      {/* Chat messages — controls DB token registration */}
+      <View
+        className={`flex-row items-center gap-3 rounded-lg bg-secondary p-3 ${!permissionGranted ? 'opacity-40' : ''}`}
+      >
+        <MessageSquare size={18} color={colors.secondaryForeground} />
+        <Text className="flex-1 text-sm font-medium">Chat Messages</Text>
+        {loading ? (
+          <Skeleton className="h-8 w-12 rounded-full" />
+        ) : (
+          <Switch
+            value={hasTokens}
+            disabled={!permissionGranted || registerToken.isPending || unregisterToken.isPending}
+            onValueChange={value => void handleToggleChatMessages(value)}
           />
         )}
       </View>

--- a/apps/mobile/src/components/notifications-card.tsx
+++ b/apps/mobile/src/components/notifications-card.tsx
@@ -7,6 +7,8 @@ import { toast } from 'sonner-native';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import * as Notifications from 'expo-notifications';
+
 import {
   getDevicePushToken,
   getNotificationPermissionStatus,
@@ -81,8 +83,8 @@ export function NotificationsCard() {
 
   const handleToggleNotifications = useCallback(async (value: boolean) => {
     if (value) {
-      const status = await getNotificationPermissionStatus();
-      if (status === 'denied') {
+      const currentStatus = await getNotificationPermissionStatus();
+      if (currentStatus === 'denied') {
         // Already denied once — OS won't show the prompt again, must go to Settings
         Alert.alert(
           'Notifications Disabled',
@@ -95,10 +97,8 @@ export function NotificationsCard() {
         return;
       }
       // Undetermined — triggers the OS permission prompt
-      const token = await registerForPushNotifications();
-      if (token) {
-        setPermissionGranted(true);
-      }
+      const result = await Notifications.requestPermissionsAsync();
+      setPermissionGranted(result.status === Notifications.PermissionStatus.GRANTED);
     } else {
       // Can't revoke permission programmatically — send user to Settings
       Alert.alert(

--- a/apps/mobile/src/lib/hooks/use-kiloclaw-mutations.ts
+++ b/apps/mobile/src/lib/hooks/use-kiloclaw-mutations.ts
@@ -1,0 +1,165 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner-native';
+
+import { useTRPC } from '@/lib/trpc';
+
+const onMutationError = (error: { message: string }) => {
+  toast.error(error.message || 'Something went wrong');
+};
+
+export function useKiloClawMutations() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const invalidateStatus = async () => {
+    await queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getStatus.queryKey() });
+    await queryClient.invalidateQueries({
+      queryKey: trpc.kiloclaw.controllerVersion.queryKey(),
+    });
+  };
+
+  return {
+    start: useMutation(
+      trpc.kiloclaw.start.mutationOptions({ onSuccess: invalidateStatus, onError: onMutationError })
+    ),
+    stop: useMutation(
+      trpc.kiloclaw.stop.mutationOptions({ onSuccess: invalidateStatus, onError: onMutationError })
+    ),
+    restartMachine: useMutation(
+      trpc.kiloclaw.restartMachine.mutationOptions({
+        onSuccess: async () => {
+          await invalidateStatus();
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.gatewayStatus.queryKey(),
+          });
+        },
+        onError: onMutationError,
+      })
+    ),
+    restartOpenClaw: useMutation(
+      trpc.kiloclaw.restartOpenClaw.mutationOptions({
+        onSuccess: async () => {
+          await invalidateStatus();
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.gatewayStatus.queryKey(),
+          });
+        },
+        onError: onMutationError,
+      })
+    ),
+    patchSecrets: useMutation(
+      trpc.kiloclaw.patchSecrets.mutationOptions({
+        onSuccess: async () => {
+          await invalidateStatus();
+          await queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getConfig.queryKey() });
+          // Small delay to let the worker process the secret before refetching catalog
+          await new Promise<void>(resolve => {
+            setTimeout(resolve, 1000);
+          });
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.getSecretCatalog.queryKey(),
+          });
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.getChannelCatalog.queryKey(),
+          });
+        },
+        onError: onMutationError,
+      })
+    ),
+    patchChannels: useMutation(
+      trpc.kiloclaw.patchChannels.mutationOptions({
+        onSuccess: async () => {
+          await invalidateStatus();
+          await queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getConfig.queryKey() });
+          await new Promise<void>(resolve => {
+            setTimeout(resolve, 1000);
+          });
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.getChannelCatalog.queryKey(),
+          });
+        },
+        onError: onMutationError,
+      })
+    ),
+    patchExecPreset: useMutation(
+      trpc.kiloclaw.patchExecPreset.mutationOptions({
+        onSuccess: invalidateStatus,
+        onError: onMutationError,
+      })
+    ),
+    setMyPin: useMutation(
+      trpc.kiloclaw.setMyPin.mutationOptions({
+        onSuccess: async () => {
+          await invalidateStatus();
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.getMyPin.queryKey(),
+          });
+        },
+        onError: onMutationError,
+      })
+    ),
+    removeMyPin: useMutation(
+      trpc.kiloclaw.removeMyPin.mutationOptions({
+        onSuccess: async () => {
+          await invalidateStatus();
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.getMyPin.queryKey(),
+          });
+        },
+        onError: onMutationError,
+      })
+    ),
+    approvePairingRequest: useMutation(
+      trpc.kiloclaw.approvePairingRequest.mutationOptions({
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.listPairingRequests.queryKey(),
+          });
+        },
+        onError: onMutationError,
+      })
+    ),
+    approveDevicePairingRequest: useMutation(
+      trpc.kiloclaw.approveDevicePairingRequest.mutationOptions({
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.listDevicePairingRequests.queryKey(),
+          });
+        },
+        onError: onMutationError,
+      })
+    ),
+    disconnectGoogle: useMutation(
+      trpc.kiloclaw.disconnectGoogle.mutationOptions({
+        onSuccess: invalidateStatus,
+        onError: onMutationError,
+      })
+    ),
+    setGmailNotifications: useMutation(
+      trpc.kiloclaw.setGmailNotifications.mutationOptions({
+        onSuccess: invalidateStatus,
+        onError: onMutationError,
+      })
+    ),
+    renameInstance: useMutation(
+      trpc.kiloclaw.renameInstance.mutationOptions({
+        onSuccess: invalidateStatus,
+        onError: onMutationError,
+      })
+    ),
+    destroy: useMutation(
+      trpc.kiloclaw.destroy.mutationOptions({
+        onSuccess: invalidateStatus,
+        onError: onMutationError,
+      })
+    ),
+    updateModel: useMutation(
+      trpc.kiloclaw.updateKiloCodeConfig.mutationOptions({
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getConfig.queryKey() });
+        },
+        onError: onMutationError,
+      })
+    ),
+  };
+}

--- a/apps/mobile/src/lib/hooks/use-kiloclaw.ts
+++ b/apps/mobile/src/lib/hooks/use-kiloclaw.ts
@@ -1,16 +1,13 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner-native';
+import { useQuery } from '@tanstack/react-query';
 
 import { useTRPC } from '@/lib/trpc';
 
-// ── Derived types ───────────────────────────────────────────────────
+export { useKiloClawMutations } from '@/lib/hooks/use-kiloclaw-mutations';
 
 export type InstanceStatus = NonNullable<ReturnType<typeof useKiloClawStatus>['data']>['status'];
 export type GatewayState = NonNullable<
   ReturnType<typeof useKiloClawGatewayStatus>['data']
 >['state'];
-
-// ── Queries ──────────────────────────────────────────────────────────
 
 export function useKiloClawStatus(enabled = true) {
   const trpc = useTRPC();
@@ -144,157 +141,11 @@ export function useStreamChatCredentials(enabled: boolean) {
   );
 }
 
-// ── Mutations ────────────────────────────────────────────────────────
-
-const onMutationError = (error: { message: string }) => {
-  toast.error(error.message || 'Something went wrong');
-};
-
-export function useKiloClawMutations() {
+export function useKiloClawConfig() {
   const trpc = useTRPC();
-  const queryClient = useQueryClient();
-
-  const invalidateStatus = async () => {
-    await queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getStatus.queryKey() });
-    await queryClient.invalidateQueries({
-      queryKey: trpc.kiloclaw.controllerVersion.queryKey(),
-    });
-  };
-
-  return {
-    start: useMutation(
-      trpc.kiloclaw.start.mutationOptions({ onSuccess: invalidateStatus, onError: onMutationError })
-    ),
-    stop: useMutation(
-      trpc.kiloclaw.stop.mutationOptions({ onSuccess: invalidateStatus, onError: onMutationError })
-    ),
-    restartMachine: useMutation(
-      trpc.kiloclaw.restartMachine.mutationOptions({
-        onSuccess: async () => {
-          await invalidateStatus();
-          await queryClient.invalidateQueries({
-            queryKey: trpc.kiloclaw.gatewayStatus.queryKey(),
-          });
-        },
-        onError: onMutationError,
-      })
-    ),
-    restartOpenClaw: useMutation(
-      trpc.kiloclaw.restartOpenClaw.mutationOptions({
-        onSuccess: async () => {
-          await invalidateStatus();
-          await queryClient.invalidateQueries({
-            queryKey: trpc.kiloclaw.gatewayStatus.queryKey(),
-          });
-        },
-        onError: onMutationError,
-      })
-    ),
-    patchSecrets: useMutation(
-      trpc.kiloclaw.patchSecrets.mutationOptions({
-        onSuccess: async () => {
-          await invalidateStatus();
-          await queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getConfig.queryKey() });
-          // Small delay to let the worker process the secret before refetching catalog
-          await new Promise<void>(resolve => {
-            setTimeout(resolve, 1000);
-          });
-          await queryClient.invalidateQueries({
-            queryKey: trpc.kiloclaw.getSecretCatalog.queryKey(),
-          });
-          await queryClient.invalidateQueries({
-            queryKey: trpc.kiloclaw.getChannelCatalog.queryKey(),
-          });
-        },
-        onError: onMutationError,
-      })
-    ),
-    patchChannels: useMutation(
-      trpc.kiloclaw.patchChannels.mutationOptions({
-        onSuccess: async () => {
-          await invalidateStatus();
-          await queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getConfig.queryKey() });
-          await new Promise<void>(resolve => {
-            setTimeout(resolve, 1000);
-          });
-          await queryClient.invalidateQueries({
-            queryKey: trpc.kiloclaw.getChannelCatalog.queryKey(),
-          });
-        },
-        onError: onMutationError,
-      })
-    ),
-    patchExecPreset: useMutation(
-      trpc.kiloclaw.patchExecPreset.mutationOptions({
-        onSuccess: invalidateStatus,
-        onError: onMutationError,
-      })
-    ),
-    setMyPin: useMutation(
-      trpc.kiloclaw.setMyPin.mutationOptions({
-        onSuccess: async () => {
-          await invalidateStatus();
-          await queryClient.invalidateQueries({
-            queryKey: trpc.kiloclaw.getMyPin.queryKey(),
-          });
-        },
-        onError: onMutationError,
-      })
-    ),
-    removeMyPin: useMutation(
-      trpc.kiloclaw.removeMyPin.mutationOptions({
-        onSuccess: async () => {
-          await invalidateStatus();
-          await queryClient.invalidateQueries({
-            queryKey: trpc.kiloclaw.getMyPin.queryKey(),
-          });
-        },
-        onError: onMutationError,
-      })
-    ),
-    approvePairingRequest: useMutation(
-      trpc.kiloclaw.approvePairingRequest.mutationOptions({
-        onSuccess: async () => {
-          await queryClient.invalidateQueries({
-            queryKey: trpc.kiloclaw.listPairingRequests.queryKey(),
-          });
-        },
-        onError: onMutationError,
-      })
-    ),
-    approveDevicePairingRequest: useMutation(
-      trpc.kiloclaw.approveDevicePairingRequest.mutationOptions({
-        onSuccess: async () => {
-          await queryClient.invalidateQueries({
-            queryKey: trpc.kiloclaw.listDevicePairingRequests.queryKey(),
-          });
-        },
-        onError: onMutationError,
-      })
-    ),
-    disconnectGoogle: useMutation(
-      trpc.kiloclaw.disconnectGoogle.mutationOptions({
-        onSuccess: invalidateStatus,
-        onError: onMutationError,
-      })
-    ),
-    setGmailNotifications: useMutation(
-      trpc.kiloclaw.setGmailNotifications.mutationOptions({
-        onSuccess: invalidateStatus,
-        onError: onMutationError,
-      })
-    ),
-    renameInstance: useMutation(
-      trpc.kiloclaw.renameInstance.mutationOptions({
-        onSuccess: invalidateStatus,
-        onError: onMutationError,
-      })
-    ),
-    destroy: useMutation(
-      trpc.kiloclaw.destroy.mutationOptions({
-        onSuccess: invalidateStatus,
-        onError: onMutationError,
-      })
-    ),
-  };
+  return useQuery(
+    trpc.kiloclaw.getConfig.queryOptions(undefined, {
+      staleTime: 60_000,
+    })
+  );
 }

--- a/apps/mobile/src/lib/model-id.ts
+++ b/apps/mobile/src/lib/model-id.ts
@@ -1,0 +1,12 @@
+const MODEL_PREFIX = 'kilocode/';
+
+export function stripModelPrefix(modelId: string | null | undefined): string {
+  if (!modelId) {
+    return '';
+  }
+  return modelId.replace(/^kilocode\//, '');
+}
+
+export function addModelPrefix(modelId: string): string {
+  return `${MODEL_PREFIX}${modelId}`;
+}

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -34,7 +34,6 @@ export function setupNotificationHandler() {
   Notifications.setNotificationHandler({
     // eslint-disable-next-line require-await -- expo-notifications requires async callback type but logic is synchronous
     handleNotification: async notification => {
-      console.log('[NOTIF] received:', JSON.stringify(notification.request.content, null, 2));
       const data = notification.request.content.data as NotificationData | undefined;
 
       const suppressed = {

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -1,8 +1,11 @@
+import React from 'react';
 import expoConstants from 'expo-constants';
 import * as Notifications from 'expo-notifications';
 import { type Href, router } from 'expo-router';
 import { Platform } from 'react-native';
 import { toast } from 'sonner-native';
+
+import { ChatNotificationToast } from '@/components/chat-notification-toast';
 
 function getProjectId(): string {
   const eas = expoConstants.expoConfig?.extra?.eas as { projectId?: string } | undefined;
@@ -52,15 +55,14 @@ export function setupNotificationHandler() {
         // and suppress the system notification
         const title = notification.request.content.title ?? 'Kilo';
         const body = notification.request.content.body ?? '';
-        toast(title, {
-          description: body,
-          action: {
-            label: 'View',
-            onClick: () => {
-              router.push(`/(app)/chat/${data.instanceId}` as Href);
-            },
-          },
-        });
+        toast.custom(
+          React.createElement(ChatNotificationToast, {
+            title,
+            body,
+            instanceId: data.instanceId,
+          }),
+          { duration: 4000 }
+        );
         return suppressed;
       }
 

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -55,13 +55,15 @@ export function setupNotificationHandler() {
         // and suppress the system notification
         const title = notification.request.content.title ?? 'Kilo';
         const body = notification.request.content.body ?? '';
+        const toastId = Date.now();
         toast.custom(
           React.createElement(ChatNotificationToast, {
+            id: toastId,
             title,
             body,
             instanceId: data.instanceId,
           }),
-          { duration: 4000 }
+          { id: toastId, duration: 4000 }
         );
         return suppressed;
       }

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -31,6 +31,7 @@ export function setupNotificationHandler() {
   Notifications.setNotificationHandler({
     // eslint-disable-next-line require-await -- expo-notifications requires async callback type but logic is synchronous
     handleNotification: async notification => {
+      console.log('[NOTIF] received:', JSON.stringify(notification.request.content, null, 2));
       const data = notification.request.content.data as NotificationData | undefined;
 
       const suppressed = {

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -79,16 +79,45 @@ export function setupNotificationHandler() {
   });
 }
 
+// Pending deep link from a notification tap (cold start or background).
+// Consumed by the root nav after auth/navigation is ready.
+let pendingNotificationLink: string | null = null;
+
+export function getPendingNotificationLink(): string | null {
+  const link = pendingNotificationLink;
+  pendingNotificationLink = null;
+  return link;
+}
+
 export function setupNotificationResponseHandler() {
   const subscription = Notifications.addNotificationResponseReceivedListener(response => {
     const data = response.notification.request.content.data as NotificationData | undefined;
 
     if (data?.type === 'chat') {
-      router.push(`/(app)/chat/${data.instanceId}` as Href);
+      const path = `/(app)/chat/${data.instanceId}`;
+      // If the router is ready (has segments), navigate immediately.
+      // Otherwise store as pending for consumption after auth completes.
+      try {
+        router.replace(path as Href);
+      } catch {
+        pendingNotificationLink = path;
+      }
     }
   });
 
   return subscription;
+}
+
+// Check for notification that launched the app (cold start)
+export function checkInitialNotification(): void {
+  const response = Notifications.getLastNotificationResponse();
+  if (!response) {
+    return;
+  }
+  const data = response.notification.request.content.data as NotificationData | undefined;
+  if (data?.type === 'chat') {
+    pendingNotificationLink = `/(app)/chat/${data.instanceId}`;
+  }
 }
 
 export async function registerForPushNotifications(): Promise<string | null> {

--- a/apps/web/src/routers/models-router.ts
+++ b/apps/web/src/routers/models-router.ts
@@ -1,0 +1,18 @@
+import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
+import { preferredModels } from '@/lib/models';
+import { getEnhancedOpenRouterModels } from '@/lib/providers/openrouter';
+
+const preferredSet = new Set(preferredModels);
+
+export const modelsRouter = createTRPCRouter({
+  list: baseProcedure.query(async () => {
+    const response = await getEnhancedOpenRouterModels();
+
+    return (response.data ?? []).map(model => ({
+      id: model.id,
+      name: model.name,
+      supportsVision: model.architecture.input_modalities.includes('image'),
+      isPreferred: preferredSet.has(model.id),
+    }));
+  }),
+});

--- a/apps/web/src/routers/root-router.ts
+++ b/apps/web/src/routers/root-router.ts
@@ -33,6 +33,7 @@ import { userFeedbackRouter } from '@/routers/user-feedback-router';
 import { appBuilderFeedbackRouter } from '@/routers/app-builder-feedback-router';
 import { cloudAgentNextFeedbackRouter } from '@/routers/cloud-agent-next-feedback-router';
 import { kiloclawRouter } from '@/routers/kiloclaw-router';
+import { modelsRouter } from '@/routers/models-router';
 import { unifiedSessionsRouter } from '@/routers/unified-sessions-router';
 import { activeSessionsRouter } from '@/routers/active-sessions-router';
 export const rootRouter = createTRPCRouter({
@@ -69,6 +70,7 @@ export const rootRouter = createTRPCRouter({
   appBuilderFeedback: appBuilderFeedbackRouter,
   cloudAgentNextFeedback: cloudAgentNextFeedbackRouter,
   kiloclaw: kiloclawRouter,
+  models: modelsRouter,
   unifiedSessions: unifiedSessionsRouter,
   activeSessions: activeSessionsRouter,
 });

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
       "@storybook/nextjs@9.1.20": "patches/@storybook__nextjs@9.1.20.patch",
       "@gorhom/bottom-sheet@5.1.8": "patches/@gorhom__bottom-sheet@5.1.8.patch",
       "stream-chat-react-native-core": "patches/stream-chat-react-native-core.patch",
-      "expo-server-sdk@6.1.0": "patches/expo-server-sdk@6.1.0.patch"
+      "expo-server-sdk": "patches/expo-server-sdk.patch"
     },
     "onlyBuiltDependencies": [
       "@swc/core",

--- a/patches/expo-server-sdk.patch
+++ b/patches/expo-server-sdk.patch
@@ -2,7 +2,7 @@ diff --git a/CHANGELOG.md b/CHANGELOG.md
 deleted file mode 100644
 index 0332465d53ab851fc1de26cd8624af494c1363f3..0000000000000000000000000000000000000000
 diff --git a/build/ExpoClient.js b/build/ExpoClient.js
-index 0754d32755e3e34ed14cdb2070ac4a1ea18c7535..06c10bf62082f2fe5129363d656d456d0eaa5126 100644
+index 0754d32755e3e34ed14cdb2070ac4a1ea18c7535..679ba19bf21510c78429dbad519ace9f7e31e94d 100644
 --- a/build/ExpoClient.js
 +++ b/build/ExpoClient.js
 @@ -6,13 +6,11 @@
@@ -13,7 +13,8 @@ index 0754d32755e3e34ed14cdb2070ac4a1ea18c7535..06c10bf62082f2fe5129363d656d456d
  import { gzipSync } from 'node:zlib';
  import promiseLimit from 'promise-limit';
  import promiseRetry from 'promise-retry';
- import { fetch } from 'undici';
+-import { fetch } from 'undici';
++const { fetch } = globalThis;
  import { defaultConcurrentRequestLimit, getReceiptsApiUrl, pushNotificationChunkLimit, pushNotificationReceiptChunkLimit, requestRetryMinTimeout, sendApiUrl, } from "./ExpoClientValues.js";
 -const require = createRequire(import.meta.url);
  export class Expo {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,9 +91,9 @@ patchedDependencies:
   '@storybook/nextjs@9.1.20':
     hash: e1857649664eed8f87877c352d277c90d4af5a58d0ad931105f033c8c08165c1
     path: patches/@storybook__nextjs@9.1.20.patch
-  expo-server-sdk@6.1.0:
-    hash: c585457628f3c0d87f2f8f0a5e7071fd450414800ed307fac6eb26dfe2308d02
-    path: patches/expo-server-sdk@6.1.0.patch
+  expo-server-sdk:
+    hash: 7850520582b5b394397b35d1ea195192fe78589d8a6a748fe15177b818c4ed0b
+    path: patches/expo-server-sdk.patch
   stream-chat-react-native-core:
     hash: 6fa2fe7a3ddb0ab3312ee1adc4e07d3fc9c46f7bc5bb861675bef4078808b8c0
     path: patches/stream-chat-react-native-core.patch
@@ -1746,7 +1746,7 @@ importers:
         version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       expo-server-sdk:
         specifier: ^6.1.0
-        version: 6.1.0(patch_hash=c585457628f3c0d87f2f8f0a5e7071fd450414800ed307fac6eb26dfe2308d02)
+        version: 6.1.0(patch_hash=7850520582b5b394397b35d1ea195192fe78589d8a6a748fe15177b818c4ed0b)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -24045,7 +24045,7 @@ snapshots:
     dependencies:
       expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.11)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
-  expo-server-sdk@6.1.0(patch_hash=c585457628f3c0d87f2f8f0a5e7071fd450414800ed307fac6eb26dfe2308d02):
+  expo-server-sdk@6.1.0(patch_hash=7850520582b5b394397b35d1ea195192fe78589d8a6a748fe15177b818c4ed0b):
     dependencies:
       promise-limit: 2.7.0
       promise-retry: 2.0.1

--- a/services/notifications/src/dos/NotificationChannelDO.ts
+++ b/services/notifications/src/dos/NotificationChannelDO.ts
@@ -11,30 +11,135 @@ type ReceiptCheckMessage = {
   ticketTokenPairs: TicketTokenPair[];
 };
 
+type PendingMessage = {
+  messageId: string;
+  senderId: string;
+  text: string;
+  notified: boolean;
+  createdAt: number;
+};
+
 const DEDUP_PREFIX = 'dedup:';
+const MSG_PREFIX = 'msg:';
 const DEDUP_TTL_MS = 60 * 60 * 1000; // 1 hour
+const DEBOUNCE_MS = 5_000; // 5 seconds
 
 export class NotificationChannelDO extends DurableObject<Env> {
   async processWebhook(payload: Event, webhookId: string): Promise<Response> {
-    // Dedup: skip if we've seen this webhook ID recently
+    console.log(`[DEBUG] DO received: type=${payload.type}, webhookId=${webhookId}`);
+
+    // Webhook-level dedup (prevents reprocessing the same delivery)
     const existing = await this.ctx.storage.get<number>(`${DEDUP_PREFIX}${webhookId}`);
     if (existing) {
+      console.log(`[DEBUG] Deduplicated webhook ${webhookId}`);
       return Response.json({ ok: true, deduplicated: true });
     }
+    await this.markWebhookSeen(webhookId);
 
+    const messageId = payload.message?.id;
     const senderId = payload.message?.user?.id;
-    const messageText = payload.message?.text;
+    const messageText = payload.message?.text ?? '';
 
-    if (!senderId?.startsWith('bot-') || !messageText) {
+    console.log(
+      `[DEBUG] messageId=${messageId}, senderId=${senderId}, text="${messageText.slice(0, 50)}"`
+    );
+
+    if (!messageId || !senderId?.startsWith('bot-')) {
+      console.log(`[DEBUG] Skipping: no messageId or not a bot`);
       return Response.json({ ok: true });
     }
 
-    // Extract sandbox ID from bot user ID: "bot-{sandboxId}" → sandboxId
-    const sandboxId = senderId.slice(4);
+    const msgKey = `${MSG_PREFIX}${messageId}`;
+    const pendingMessage = await this.ctx.storage.get<PendingMessage>(msgKey);
 
+    if (pendingMessage?.notified) {
+      console.log(`[DEBUG] Already notified for message ${messageId}, ignoring`);
+      return Response.json({ ok: true });
+    }
+
+    if (payload.type === 'message.new') {
+      // Store pending message, set debounce alarm
+      const pending: PendingMessage = {
+        messageId,
+        senderId,
+        text: messageText,
+        notified: false,
+        createdAt: Date.now(),
+      };
+      await this.ctx.storage.put(msgKey, pending);
+      await this.scheduleAlarm(DEBOUNCE_MS);
+      console.log(`[DEBUG] Stored pending message ${messageId}, alarm in ${DEBOUNCE_MS}ms`);
+    } else if (payload.type === 'message.updated') {
+      if (!pendingMessage) {
+        console.log(`[DEBUG] message.updated for unknown message ${messageId}, ignoring`);
+        return Response.json({ ok: true });
+      }
+      // Update text, reset debounce
+      pendingMessage.text = messageText;
+      await this.ctx.storage.put(msgKey, pendingMessage);
+      await this.scheduleAlarm(DEBOUNCE_MS);
+      console.log(
+        `[DEBUG] Updated pending message ${messageId}, text="${messageText.slice(0, 50)}", alarm reset`
+      );
+    }
+
+    return Response.json({ ok: true });
+  }
+
+  override async alarm(): Promise<void> {
+    console.log(`[DEBUG] Alarm fired`);
+
+    // Prune expired dedup entries
+    const dedupEntries = await this.ctx.storage.list<number>({ prefix: DEDUP_PREFIX });
+    const now = Date.now();
+    const expired: string[] = [];
+    for (const [key, timestamp] of dedupEntries) {
+      if (now - timestamp > DEDUP_TTL_MS) {
+        expired.push(key);
+      }
+    }
+    if (expired.length > 0) {
+      await this.ctx.storage.delete(expired);
+    }
+
+    // Process pending messages that have debounced
+    const pendingEntries = await this.ctx.storage.list<PendingMessage>({ prefix: MSG_PREFIX });
+    let hasRemainingPending = false;
+
+    for (const [key, msg] of pendingEntries) {
+      if (msg.notified) {
+        // Clean up old notified messages
+        if (now - msg.createdAt > DEDUP_TTL_MS) {
+          await this.ctx.storage.delete(key);
+        }
+        continue;
+      }
+
+      if (!msg.text) {
+        // No text yet — keep waiting but schedule another alarm
+        console.log(`[DEBUG] Message ${msg.messageId} still has no text, waiting`);
+        hasRemainingPending = true;
+        continue;
+      }
+
+      console.log(
+        `[DEBUG] Sending notification for message ${msg.messageId}: "${msg.text.slice(0, 50)}"`
+      );
+      await this.sendNotification(msg);
+      msg.notified = true;
+      await this.ctx.storage.put(key, msg);
+    }
+
+    // Re-schedule alarm if we still have pending messages without text
+    if (hasRemainingPending) {
+      await this.scheduleAlarm(DEBOUNCE_MS);
+    }
+  }
+
+  private async sendNotification(msg: PendingMessage): Promise<void> {
+    const sandboxId = msg.senderId.slice(4);
     const db = getWorkerDb(this.env.HYPERDRIVE.connectionString);
 
-    // Look up the active instance for this sandbox
     const [instance] = await db
       .select({
         id: kiloclaw_instances.id,
@@ -47,23 +152,28 @@ export class NotificationChannelDO extends DurableObject<Env> {
       )
       .limit(1);
 
+    console.log(
+      `[DEBUG] Instance lookup: ${instance ? `id=${instance.id}, user_id=${instance.user_id}, name=${instance.name}` : 'NOT FOUND'}`
+    );
+
     if (!instance) {
-      return Response.json({ ok: true });
+      return;
     }
 
-    // Fetch user's push tokens
     const tokens = await db
       .select({ token: user_push_tokens.token })
       .from(user_push_tokens)
       .where(eq(user_push_tokens.user_id, instance.user_id));
 
+    console.log(
+      `[DEBUG] Push tokens: ${tokens.length} found${tokens.length > 0 ? ` (${tokens.map(t => t.token).join(', ')})` : ''}`
+    );
+
     if (tokens.length === 0) {
-      await this.markSeen(webhookId);
-      return Response.json({ ok: true });
+      return;
     }
 
-    const truncatedMessage =
-      messageText.length > 100 ? messageText.slice(0, 97) + '...' : messageText;
+    const truncatedMessage = msg.text.length > 100 ? msg.text.slice(0, 97) + '...' : msg.text;
 
     const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
       to: token,
@@ -75,50 +185,40 @@ export class NotificationChannelDO extends DurableObject<Env> {
       priority: 'high' as const,
     }));
 
-    // Send push notifications
     const accessToken = await this.env.EXPO_ACCESS_TOKEN.get();
+    console.log(
+      `[DEBUG] Expo token: ${accessToken ? `present (${accessToken.length} chars)` : 'MISSING'}`
+    );
+    console.log(`[DEBUG] Sending:`, JSON.stringify(messages));
+
     const { ticketTokenPairs, staleTokens } = await sendPushNotifications(messages, accessToken);
 
-    // Immediately clean up tokens that are known stale
+    console.log(
+      `[DEBUG] Result: ${ticketTokenPairs.length} ticket(s), ${staleTokens.length} stale token(s)`
+    );
+    if (ticketTokenPairs.length > 0) {
+      console.log(`[DEBUG] Tickets:`, JSON.stringify(ticketTokenPairs));
+    }
+
     if (staleTokens.length > 0) {
       await db.delete(user_push_tokens).where(inArray(user_push_tokens.token, staleTokens));
-      console.log(`Cleaned up ${staleTokens.length} stale push token(s)`);
+      console.log(`[DEBUG] Cleaned up ${staleTokens.length} stale token(s)`);
     }
 
-    // Enqueue delayed receipt check if we have tickets to follow up on
     if (ticketTokenPairs.length > 0) {
-      const message: ReceiptCheckMessage = { ticketTokenPairs };
-      await this.env.RECEIPTS_QUEUE.send(message, { delaySeconds: 900 });
-    }
-
-    // Mark webhook as processed
-    await this.markSeen(webhookId);
-
-    return Response.json({ ok: true });
-  }
-
-  override async alarm(): Promise<void> {
-    // Prune expired dedup entries
-    const all = await this.ctx.storage.list<number>({ prefix: DEDUP_PREFIX });
-    const now = Date.now();
-    const expired: string[] = [];
-    for (const [key, timestamp] of all) {
-      if (now - timestamp > DEDUP_TTL_MS) {
-        expired.push(key);
-      }
-    }
-    if (expired.length > 0) {
-      await this.ctx.storage.delete(expired);
+      const receiptMsg: ReceiptCheckMessage = { ticketTokenPairs };
+      await this.env.RECEIPTS_QUEUE.send(receiptMsg, { delaySeconds: 900 });
     }
   }
 
-  private async markSeen(webhookId: string): Promise<void> {
+  private async markWebhookSeen(webhookId: string): Promise<void> {
     await this.ctx.storage.put(`${DEDUP_PREFIX}${webhookId}`, Date.now());
-    // Ensure a cleanup alarm is scheduled
-    const currentAlarm = await this.ctx.storage.getAlarm();
-    if (!currentAlarm) {
-      await this.ctx.storage.setAlarm(Date.now() + DEDUP_TTL_MS);
-    }
+  }
+
+  private async scheduleAlarm(delayMs: number): Promise<void> {
+    // Always reset the alarm to the new debounce window
+    await this.ctx.storage.setAlarm(Date.now() + delayMs);
+    console.log(`[DEBUG] Alarm scheduled for ${delayMs}ms from now`);
   }
 }
 

--- a/services/notifications/src/dos/NotificationChannelDO.ts
+++ b/services/notifications/src/dos/NotificationChannelDO.ts
@@ -181,7 +181,7 @@ export class NotificationChannelDO extends DurableObject<Env> {
       title: instance.name ?? 'Kilo',
       body: truncatedMessage,
       // Keep in sync with NotificationData in apps/mobile/src/lib/notifications.ts
-      data: { type: 'chat', instanceId: instance.id },
+      data: { type: 'chat', instanceId: sandboxId },
       sound: 'default' as const,
       priority: 'high' as const,
     }));

--- a/services/notifications/src/dos/NotificationChannelDO.ts
+++ b/services/notifications/src/dos/NotificationChannelDO.ts
@@ -17,12 +17,14 @@ type PendingMessage = {
   text: string;
   notified: boolean;
   createdAt: number;
+  updatedAt: string; // ISO timestamp from Stream Chat payload
 };
 
 const DEDUP_PREFIX = 'dedup:';
 const MSG_PREFIX = 'msg:';
 const DEDUP_TTL_MS = 60 * 60 * 1000; // 1 hour
-const DEBOUNCE_MS = 5_000; // 5 seconds
+const INITIAL_DEBOUNCE_MS = 10_000; // 10 seconds for first event
+const UPDATE_DEBOUNCE_MS = 5_000; // 5 seconds for updates
 
 export class NotificationChannelDO extends DurableObject<Env> {
   async processWebhook(payload: Event, webhookId: string): Promise<Response> {
@@ -39,9 +41,10 @@ export class NotificationChannelDO extends DurableObject<Env> {
     const messageId = payload.message?.id;
     const senderId = payload.message?.user?.id;
     const messageText = payload.message?.text ?? '';
+    const messageUpdatedAt = payload.message?.updated_at ?? payload.created_at ?? '';
 
     console.log(
-      `[DEBUG] messageId=${messageId}, senderId=${senderId}, text="${messageText.slice(0, 50)}"`
+      `[DEBUG] messageId=${messageId}, senderId=${senderId}, updatedAt=${messageUpdatedAt}, text="${messageText.slice(0, 50)}"`
     );
 
     if (!messageId || !senderId?.startsWith('bot-')) {
@@ -57,30 +60,36 @@ export class NotificationChannelDO extends DurableObject<Env> {
       return Response.json({ ok: true });
     }
 
-    if (payload.type === 'message.new') {
-      // Store pending message, set debounce alarm
+    if (pendingMessage) {
+      // Only accept if this event is newer than what we have
+      if (messageUpdatedAt <= pendingMessage.updatedAt) {
+        console.log(
+          `[DEBUG] Stale event for message ${messageId}: ${messageUpdatedAt} <= ${pendingMessage.updatedAt}, ignoring`
+        );
+        return Response.json({ ok: true });
+      }
+      if (messageText) {
+        pendingMessage.text = messageText;
+      }
+      pendingMessage.updatedAt = messageUpdatedAt;
+      await this.ctx.storage.put(msgKey, pendingMessage);
+      await this.scheduleAlarm(UPDATE_DEBOUNCE_MS);
+      console.log(
+        `[DEBUG] Updated message ${messageId}, text="${pendingMessage.text.slice(0, 50)}", alarm reset to ${UPDATE_DEBOUNCE_MS}ms`
+      );
+    } else {
+      // First event for this message (could be message.new or a late message.updated)
       const pending: PendingMessage = {
         messageId,
         senderId,
         text: messageText,
         notified: false,
         createdAt: Date.now(),
+        updatedAt: messageUpdatedAt,
       };
       await this.ctx.storage.put(msgKey, pending);
-      await this.scheduleAlarm(DEBOUNCE_MS);
-      console.log(`[DEBUG] Stored pending message ${messageId}, alarm in ${DEBOUNCE_MS}ms`);
-    } else if (payload.type === 'message.updated') {
-      if (!pendingMessage) {
-        console.log(`[DEBUG] message.updated for unknown message ${messageId}, ignoring`);
-        return Response.json({ ok: true });
-      }
-      // Update text, reset debounce
-      pendingMessage.text = messageText;
-      await this.ctx.storage.put(msgKey, pendingMessage);
-      await this.scheduleAlarm(DEBOUNCE_MS);
-      console.log(
-        `[DEBUG] Updated pending message ${messageId}, text="${messageText.slice(0, 50)}", alarm reset`
-      );
+      await this.scheduleAlarm(INITIAL_DEBOUNCE_MS);
+      console.log(`[DEBUG] Stored pending message ${messageId}, alarm in ${INITIAL_DEBOUNCE_MS}ms`);
     }
 
     return Response.json({ ok: true });
@@ -104,8 +113,6 @@ export class NotificationChannelDO extends DurableObject<Env> {
 
     // Process pending messages that have debounced
     const pendingEntries = await this.ctx.storage.list<PendingMessage>({ prefix: MSG_PREFIX });
-    let hasRemainingPending = false;
-
     for (const [key, msg] of pendingEntries) {
       if (msg.notified) {
         // Clean up old notified messages
@@ -116,9 +123,9 @@ export class NotificationChannelDO extends DurableObject<Env> {
       }
 
       if (!msg.text) {
-        // No text yet — keep waiting but schedule another alarm
-        console.log(`[DEBUG] Message ${msg.messageId} still has no text, waiting`);
-        hasRemainingPending = true;
+        // No text — nothing to notify about, discard
+        console.log(`[DEBUG] Message ${msg.messageId} has no text, discarding`);
+        await this.ctx.storage.delete(key);
         continue;
       }
 
@@ -128,11 +135,6 @@ export class NotificationChannelDO extends DurableObject<Env> {
       await this.sendNotification(msg);
       msg.notified = true;
       await this.ctx.storage.put(key, msg);
-    }
-
-    // Re-schedule alarm if we still have pending messages without text
-    if (hasRemainingPending) {
-      await this.scheduleAlarm(DEBOUNCE_MS);
     }
   }
 

--- a/services/notifications/src/dos/NotificationChannelDO.ts
+++ b/services/notifications/src/dos/NotificationChannelDO.ts
@@ -178,7 +178,7 @@ export class NotificationChannelDO extends DurableObject<Env> {
 
     const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
       to: token,
-      title: instance.name ?? 'Kilo',
+      title: instance.name ?? 'KiloClaw',
       body: truncatedMessage,
       // Keep in sync with NotificationData in apps/mobile/src/lib/notifications.ts
       data: { type: 'chat', instanceId: sandboxId },

--- a/services/notifications/src/dos/NotificationChannelDO.ts
+++ b/services/notifications/src/dos/NotificationChannelDO.ts
@@ -23,8 +23,7 @@ type PendingMessage = {
 const DEDUP_PREFIX = 'dedup:';
 const MSG_PREFIX = 'msg:';
 const DEDUP_TTL_MS = 60 * 60 * 1000; // 1 hour
-const INITIAL_DEBOUNCE_MS = 10_000; // 10 seconds for first event
-const UPDATE_DEBOUNCE_MS = 5_000; // 5 seconds for updates
+const DEBOUNCE_MS = 10_000; // 10 seconds
 
 export class NotificationChannelDO extends DurableObject<Env> {
   async processWebhook(payload: Event, webhookId: string): Promise<Response> {
@@ -73,9 +72,9 @@ export class NotificationChannelDO extends DurableObject<Env> {
       }
       pendingMessage.updatedAt = messageUpdatedAt;
       await this.ctx.storage.put(msgKey, pendingMessage);
-      await this.scheduleAlarm(UPDATE_DEBOUNCE_MS);
+      await this.scheduleAlarm(DEBOUNCE_MS);
       console.log(
-        `[DEBUG] Updated message ${messageId}, text="${pendingMessage.text.slice(0, 50)}", alarm reset to ${UPDATE_DEBOUNCE_MS}ms`
+        `[DEBUG] Updated message ${messageId}, text="${pendingMessage.text.slice(0, 50)}", alarm reset to ${DEBOUNCE_MS}ms`
       );
     } else {
       // First event for this message (could be message.new or a late message.updated)
@@ -88,8 +87,8 @@ export class NotificationChannelDO extends DurableObject<Env> {
         updatedAt: messageUpdatedAt,
       };
       await this.ctx.storage.put(msgKey, pending);
-      await this.scheduleAlarm(INITIAL_DEBOUNCE_MS);
-      console.log(`[DEBUG] Stored pending message ${messageId}, alarm in ${INITIAL_DEBOUNCE_MS}ms`);
+      await this.scheduleAlarm(DEBOUNCE_MS);
+      console.log(`[DEBUG] Stored pending message ${messageId}, alarm in ${DEBOUNCE_MS}ms`);
     }
 
     return Response.json({ ok: true });

--- a/services/notifications/src/dos/NotificationChannelDO.ts
+++ b/services/notifications/src/dos/NotificationChannelDO.ts
@@ -27,12 +27,9 @@ const DEBOUNCE_MS = 10_000; // 10 seconds
 
 export class NotificationChannelDO extends DurableObject<Env> {
   async processWebhook(payload: Event, webhookId: string): Promise<Response> {
-    console.log(`[DEBUG] DO received: type=${payload.type}, webhookId=${webhookId}`);
-
     // Webhook-level dedup (prevents reprocessing the same delivery)
     const existing = await this.ctx.storage.get<number>(`${DEDUP_PREFIX}${webhookId}`);
     if (existing) {
-      console.log(`[DEBUG] Deduplicated webhook ${webhookId}`);
       return Response.json({ ok: true, deduplicated: true });
     }
     await this.markWebhookSeen(webhookId);
@@ -42,12 +39,7 @@ export class NotificationChannelDO extends DurableObject<Env> {
     const messageText = payload.message?.text ?? '';
     const messageUpdatedAt = payload.message?.updated_at ?? payload.created_at ?? '';
 
-    console.log(
-      `[DEBUG] messageId=${messageId}, senderId=${senderId}, updatedAt=${messageUpdatedAt}, text="${messageText.slice(0, 50)}"`
-    );
-
     if (!messageId || !senderId?.startsWith('bot-')) {
-      console.log(`[DEBUG] Skipping: no messageId or not a bot`);
       return Response.json({ ok: true });
     }
 
@@ -55,16 +47,12 @@ export class NotificationChannelDO extends DurableObject<Env> {
     const pendingMessage = await this.ctx.storage.get<PendingMessage>(msgKey);
 
     if (pendingMessage?.notified) {
-      console.log(`[DEBUG] Already notified for message ${messageId}, ignoring`);
       return Response.json({ ok: true });
     }
 
     if (pendingMessage) {
       // Only accept if this event is newer than what we have
       if (messageUpdatedAt <= pendingMessage.updatedAt) {
-        console.log(
-          `[DEBUG] Stale event for message ${messageId}: ${messageUpdatedAt} <= ${pendingMessage.updatedAt}, ignoring`
-        );
         return Response.json({ ok: true });
       }
       if (messageText) {
@@ -73,9 +61,6 @@ export class NotificationChannelDO extends DurableObject<Env> {
       pendingMessage.updatedAt = messageUpdatedAt;
       await this.ctx.storage.put(msgKey, pendingMessage);
       await this.scheduleAlarm(DEBOUNCE_MS);
-      console.log(
-        `[DEBUG] Updated message ${messageId}, text="${pendingMessage.text.slice(0, 50)}", alarm reset to ${DEBOUNCE_MS}ms`
-      );
     } else {
       // First event for this message (could be message.new or a late message.updated)
       const pending: PendingMessage = {
@@ -88,15 +73,12 @@ export class NotificationChannelDO extends DurableObject<Env> {
       };
       await this.ctx.storage.put(msgKey, pending);
       await this.scheduleAlarm(DEBOUNCE_MS);
-      console.log(`[DEBUG] Stored pending message ${messageId}, alarm in ${DEBOUNCE_MS}ms`);
     }
 
     return Response.json({ ok: true });
   }
 
   override async alarm(): Promise<void> {
-    console.log(`[DEBUG] Alarm fired`);
-
     // Prune expired dedup entries
     const dedupEntries = await this.ctx.storage.list<number>({ prefix: DEDUP_PREFIX });
     const now = Date.now();
@@ -123,14 +105,10 @@ export class NotificationChannelDO extends DurableObject<Env> {
 
       if (!msg.text) {
         // No text — nothing to notify about, discard
-        console.log(`[DEBUG] Message ${msg.messageId} has no text, discarding`);
         await this.ctx.storage.delete(key);
         continue;
       }
 
-      console.log(
-        `[DEBUG] Sending notification for message ${msg.messageId}: "${msg.text.slice(0, 50)}"`
-      );
       await this.sendNotification(msg);
       msg.notified = true;
       await this.ctx.storage.put(key, msg);
@@ -153,10 +131,6 @@ export class NotificationChannelDO extends DurableObject<Env> {
       )
       .limit(1);
 
-    console.log(
-      `[DEBUG] Instance lookup: ${instance ? `id=${instance.id}, user_id=${instance.user_id}, name=${instance.name}` : 'NOT FOUND'}`
-    );
-
     if (!instance) {
       return;
     }
@@ -165,10 +139,6 @@ export class NotificationChannelDO extends DurableObject<Env> {
       .select({ token: user_push_tokens.token })
       .from(user_push_tokens)
       .where(eq(user_push_tokens.user_id, instance.user_id));
-
-    console.log(
-      `[DEBUG] Push tokens: ${tokens.length} found${tokens.length > 0 ? ` (${tokens.map(t => t.token).join(', ')})` : ''}`
-    );
 
     if (tokens.length === 0) {
       return;
@@ -187,23 +157,10 @@ export class NotificationChannelDO extends DurableObject<Env> {
     }));
 
     const accessToken = await this.env.EXPO_ACCESS_TOKEN.get();
-    console.log(
-      `[DEBUG] Expo token: ${accessToken ? `present (${accessToken.length} chars)` : 'MISSING'}`
-    );
-    console.log(`[DEBUG] Sending:`, JSON.stringify(messages));
-
     const { ticketTokenPairs, staleTokens } = await sendPushNotifications(messages, accessToken);
-
-    console.log(
-      `[DEBUG] Result: ${ticketTokenPairs.length} ticket(s), ${staleTokens.length} stale token(s)`
-    );
-    if (ticketTokenPairs.length > 0) {
-      console.log(`[DEBUG] Tickets:`, JSON.stringify(ticketTokenPairs));
-    }
 
     if (staleTokens.length > 0) {
       await db.delete(user_push_tokens).where(inArray(user_push_tokens.token, staleTokens));
-      console.log(`[DEBUG] Cleaned up ${staleTokens.length} stale token(s)`);
     }
 
     if (ticketTokenPairs.length > 0) {
@@ -219,7 +176,6 @@ export class NotificationChannelDO extends DurableObject<Env> {
   private async scheduleAlarm(delayMs: number): Promise<void> {
     // Always reset the alarm to the new debounce window
     await this.ctx.storage.setAlarm(Date.now() + delayMs);
-    console.log(`[DEBUG] Alarm scheduled for ${delayMs}ms from now`);
   }
 }
 

--- a/services/notifications/src/routes/webhooks.ts
+++ b/services/notifications/src/routes/webhooks.ts
@@ -27,13 +27,18 @@ webhooks.post('/stream-chat', async c => {
 
   const payload = JSON.parse(rawBody) as Event;
 
-  // Only handle new messages
-  if (payload.type !== 'message.new') {
+  // Only handle new and updated messages
+  if (payload.type !== 'message.new' && payload.type !== 'message.updated') {
     return c.json({ ok: true });
   }
 
   const channelId = payload.channel_id;
   if (!channelId || !webhookId) {
+    return c.json({ ok: true });
+  }
+
+  // TODO: remove after debugging — only process my channel
+  if (channelId !== 'default-Y2UxMmVmM2QtYWU5NS00ZDc3LWI0ZjAtMjM3MzVmMGEwNTkx') {
     return c.json({ ok: true });
   }
 

--- a/services/notifications/src/routes/webhooks.ts
+++ b/services/notifications/src/routes/webhooks.ts
@@ -37,11 +37,6 @@ webhooks.post('/stream-chat', async c => {
     return c.json({ ok: true });
   }
 
-  // TODO: remove after debugging — only process my channel
-  if (channelId !== 'default-Y2UxMmVmM2QtYWU5NS00ZDc3LWI0ZjAtMjM3MzVmMGEwNTkx') {
-    return c.json({ ok: true });
-  }
-
   // Forward to the channel's Durable Object for dedup + delivery
   const stub = getNotificationChannelDO(c.env, channelId);
   return stub.processWebhook(payload, webhookId);


### PR DESCRIPTION
## Summary

- **Notification settings**: Split single toggle into system permission control + chat messages toggle that reflects/controls DB token registration
- **Push notification debouncing**: Use Durable Object alarm to debounce Stream Chat's `message.new` → `message.updated` pattern (10s window), with dedup on webhookId and messageId
- **Out-of-order guard**: Reject stale events using `message.updated_at` timestamp
- **expo-server-sdk patch**: Replace undici fetch import with `globalThis.fetch` for workerd compatibility
- **Notification routing fix**: Use `sandboxId` in push payload to match app route params (was sending DB UUID)
- **In-app notifications**: Styled `ChatNotificationToast` with logo, title, body preview, and tap-to-navigate + dismiss
- **Bot avatar**: Custom `KiloClawMessageAvatar` showing Kilo logo for bot messages
- **Stream Chat reconnection**: Use `closeConnection`/`openConnection` on app background/foreground to handle stale WebSocket connections
- **Deep link handling**: `router.replace` for notification taps, pending deep link store for cold start, `getLastNotificationResponse` check on launch
- **Model picker**: New `models` tRPC router, model settings screen with Kilo Auto featured cards (Frontier/Balanced), full-screen searchable model list with 500+ models

## Test plan

- [ ] Toggle system notification permission on/off, verify settings screen reflects state
- [ ] Send chat message, verify push arrives after ~10s debounce (not on initial empty `message.new`)
- [ ] Tap push notification from background and cold start, verify navigation to correct chat
- [ ] Verify in-app toast appears for messages in other chats, dismiss on tap navigates correctly
- [ ] Background app for 30s+, return, verify chat reconnects without errors
- [ ] Open model picker, search models, select one, verify it persists