### PR TITLE
fix(dev): preserve local env overrides

### DIFF
--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -168,7 +168,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
       oldMtimes.set('tunnel', readEnvMtime(tunnelEnvPath));
     }
     if (captureServices.includes('kiloclaw-stripe')) {
-      const stripeEnvPath = path.join(repoRoot, '.env.development.local');
+      const stripeEnvPath = path.join(repoRoot, 'apps/web/.env.development.local');
       oldValues.set('stripe', readEnvValue(stripeEnvPath, 'STRIPE_WEBHOOK_SECRET'));
       oldMtimes.set('stripe', readEnvMtime(stripeEnvPath));
     }
@@ -207,7 +207,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
     if (captureServices.includes('kiloclaw-stripe')) {
       waits.push(
         waitForEnvValueChange(
-          path.join(repoRoot, '.env.development.local'),
+          path.join(repoRoot, 'apps/web/.env.development.local'),
           'STRIPE_WEBHOOK_SECRET',
           oldValues.get('stripe'),
           30_000,

--- a/dev/local/env-sync/index.ts
+++ b/dev/local/env-sync/index.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import * as readline from 'node:readline';
 import { resolveTargets } from '../services';
 import { computePlan, findDevVarsExamples } from './plan';
-import { planHasChanges, displayPlan, applyPlan } from './output';
+import { planHasChanges, displayPlan, applyEnvLocalAutoCreates, applyPlan } from './output';
 import type { SyncResult, CheckResult } from './types';
 
 // ---------------------------------------------------------------------------
@@ -57,20 +57,31 @@ async function syncEnvVars(options: {
   displayPlan(plan);
 
   if (check) {
-    return { ok: !hasChanges, changed: plan.devVarsChanges.length, missing: totalMissing };
+    return {
+      ok: !hasChanges,
+      changed: plan.devVarsChanges.length + plan.envLocalAutoCreates.length,
+      missing: totalMissing,
+    };
   }
 
   if (hasChanges) {
     const shouldApply = yes || (await confirm(`\nApply changes? [y/N] `));
     if (shouldApply) {
-      applyPlan(plan, repoRoot);
+      applyEnvLocalAutoCreates(plan.envLocalAutoCreates, repoRoot);
+      const applyReadyPlan =
+        plan.envLocalAutoCreates.length > 0 ? computePlan(repoRoot, serviceFilter) : plan;
+      applyPlan(applyReadyPlan, repoRoot);
       console.log(`\n${GREEN}✓ Applied${RESET}`);
     } else {
       console.log('Skipped.');
     }
   }
 
-  return { ok: true, changed: plan.devVarsChanges.length, missing: totalMissing };
+  return {
+    ok: true,
+    changed: plan.devVarsChanges.length + plan.envLocalAutoCreates.length,
+    missing: totalMissing,
+  };
 }
 
 async function checkEnvVars(repoRoot: string, targets?: string[]): Promise<CheckResult> {
@@ -87,7 +98,8 @@ async function checkEnvVars(repoRoot: string, targets?: string[]): Promise<Check
   return {
     ok:
       !plan.devVarsChanges.some(c => c.isNew || c.keyChanges.length > 0) &&
-      plan.envDevLocalChanges.length === 0,
+      plan.envDevLocalChanges.length === 0 &&
+      plan.envLocalAutoCreates.length === 0,
     envLocalExists: true,
     missing: totalMissing,
     workerCount,

--- a/dev/local/env-sync/output.ts
+++ b/dev/local/env-sync/output.ts
@@ -3,11 +3,12 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type {
   DevVarsFileChange,
+  EnvLocalAutoCreate,
   EnvSyncPlan,
   SecretStoreAutoCreate,
   SecretStoreWarning,
 } from './types';
-import { formatValue } from './parse';
+import { formatValue, readEnvFile } from './parse';
 
 // ---------------------------------------------------------------------------
 // ANSI color constants
@@ -27,7 +28,10 @@ const CYAN = '\x1b[36m';
 function planHasChanges(plan: EnvSyncPlan): boolean {
   const hasDevVarsDrift = plan.devVarsChanges.some(c => c.isNew || c.keyChanges.length > 0);
   return (
-    hasDevVarsDrift || plan.envDevLocalChanges.length > 0 || plan.secretStoreAutoCreates.length > 0
+    hasDevVarsDrift ||
+    plan.envDevLocalChanges.length > 0 ||
+    plan.envLocalAutoCreates.length > 0 ||
+    plan.secretStoreAutoCreates.length > 0
   );
 }
 
@@ -111,6 +115,18 @@ function displayPlan(plan: EnvSyncPlan): void {
     hasOutput = true;
   }
 
+  // ── .env.local auto-created values ───────────────────────────────────
+
+  if (plan.envLocalAutoCreates.length > 0) {
+    if (hasOutput) console.log();
+    console.log(`${CYAN}✎ .env.local${RESET}`);
+    for (const create of plan.envLocalAutoCreates) {
+      const cmd = [create.command, ...create.args].join(' ');
+      console.log(`    ${GREEN}⊕ ${create.key}${RESET} ${DIM}from \`${cmd}\`${RESET}`);
+    }
+    hasOutput = true;
+  }
+
   // ── .env.development.local (not per-service) ─────────────────────────
 
   if (plan.envDevLocalChanges.length > 0) {
@@ -175,6 +191,66 @@ function displayPlan(plan: EnvSyncPlan): void {
 
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function upsertEnvValue(filePath: string, key: string, value: string): void {
+  let content = '';
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    // File doesn't exist yet
+  }
+
+  const line = `${key}=${formatValue(value)}`;
+  if (!content) {
+    fs.writeFileSync(filePath, `${line}\n`, 'utf-8');
+    return;
+  }
+
+  const regex = new RegExp(`^${escapeRegex(key)}=.*$`, 'm');
+  if (regex.test(content)) {
+    fs.writeFileSync(filePath, content.replace(regex, line), 'utf-8');
+    return;
+  }
+
+  fs.writeFileSync(filePath, `${content.trimEnd()}\n${line}\n`, 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// .env.local auto-created values
+// ---------------------------------------------------------------------------
+
+function applyEnvLocalAutoCreates(creates: EnvLocalAutoCreate[], repoRoot: string): void {
+  if (creates.length === 0) return;
+
+  const envLocalPath = path.join(repoRoot, '.env.local');
+  console.log('\nCreating .env.local values...');
+
+  for (const create of creates) {
+    const currentValue = readEnvFile(envLocalPath).get(create.key);
+    if (currentValue) {
+      console.log(`  ✓ ${create.key} already exists`);
+      continue;
+    }
+
+    const result = spawnSync(create.command, create.args, {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 30000,
+    });
+
+    const value = result.stdout.trim();
+    if (result.status !== 0 || !value) {
+      const cmd = [create.command, ...create.args].join(' ');
+      const errorOutput = result.stderr.trim();
+      const suffix = errorOutput ? `: ${errorOutput}` : '';
+      throw new Error(`Failed to create ${create.key} with \`${cmd}\`${suffix}`);
+    }
+
+    upsertEnvValue(envLocalPath, create.key, value);
+    console.log(`  ✓ ${create.key}`);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -289,4 +365,4 @@ function applyPlan(plan: EnvSyncPlan, repoRoot: string): void {
   }
 }
 
-export { planHasChanges, displayPlan, applyPlan };
+export { planHasChanges, displayPlan, applyEnvLocalAutoCreates, applyPlan };

--- a/dev/local/env-sync/parse.ts
+++ b/dev/local/env-sync/parse.ts
@@ -200,19 +200,23 @@ function toPkcs8IfNeeded(pem: string): string {
 // Annotation-based value resolution
 // ---------------------------------------------------------------------------
 
+type ResolvedValueSource = 'env-local' | 'generated' | 'exec' | 'default' | 'missing';
+
 function resolveAnnotatedValue(
   key: string,
   entry: ExampleEntry,
   envLocal: Map<string, string>,
   lanIp: string | undefined,
   serviceUsesLanIp: boolean
-): { value: string; resolved: boolean } {
+): { value: string; resolved: boolean; source: ResolvedValueSource } {
   switch (entry.annotation.type) {
     case 'from': {
       const val = envLocal.get(entry.annotation.envLocalKey);
-      if (val !== undefined) return { value: val, resolved: true };
-      if (entry.defaultValue) return { value: entry.defaultValue, resolved: true };
-      return { value: '', resolved: false };
+      if (val !== undefined) return { value: val, resolved: true, source: 'env-local' };
+      if (entry.defaultValue) {
+        return { value: entry.defaultValue, resolved: true, source: 'default' };
+      }
+      return { value: '', resolved: false, source: 'missing' };
     }
 
     case 'url': {
@@ -241,18 +245,24 @@ function resolveAnnotatedValue(
       }
 
       if (resolvedParts.length > 0) {
-        return { value: resolvedParts.join(','), resolved: true };
+        return { value: resolvedParts.join(','), resolved: true, source: 'generated' };
       }
       // All services unknown — fall back to default
-      if (entry.defaultValue) return { value: entry.defaultValue, resolved: true };
-      return { value: '', resolved: false };
+      if (entry.defaultValue) {
+        return { value: entry.defaultValue, resolved: true, source: 'default' };
+      }
+      return { value: '', resolved: false, source: 'missing' };
     }
 
     case 'pkcs8': {
       const val = envLocal.get(key);
-      if (val !== undefined) return { value: toPkcs8IfNeeded(val), resolved: true };
-      if (entry.defaultValue) return { value: entry.defaultValue, resolved: true };
-      return { value: '', resolved: false };
+      if (val !== undefined) {
+        return { value: toPkcs8IfNeeded(val), resolved: true, source: 'env-local' };
+      }
+      if (entry.defaultValue) {
+        return { value: entry.defaultValue, resolved: true, source: 'default' };
+      }
+      return { value: '', resolved: false, source: 'missing' };
     }
 
     case 'exec': {
@@ -262,17 +272,21 @@ function resolveAnnotatedValue(
         timeout: 5000,
       });
       if (result.status === 0 && result.stdout.trim()) {
-        return { value: result.stdout.trim(), resolved: true };
+        return { value: result.stdout.trim(), resolved: true, source: 'exec' };
       }
-      if (entry.defaultValue) return { value: entry.defaultValue, resolved: true };
-      return { value: '', resolved: false };
+      if (entry.defaultValue) {
+        return { value: entry.defaultValue, resolved: true, source: 'default' };
+      }
+      return { value: '', resolved: false, source: 'missing' };
     }
 
     case 'passthrough': {
       const val = envLocal.get(key);
-      if (val !== undefined) return { value: val, resolved: true };
-      if (entry.defaultValue) return { value: entry.defaultValue, resolved: true };
-      return { value: '', resolved: false };
+      if (val !== undefined) return { value: val, resolved: true, source: 'env-local' };
+      if (entry.defaultValue) {
+        return { value: entry.defaultValue, resolved: true, source: 'default' };
+      }
+      return { value: '', resolved: false, source: 'missing' };
     }
   }
 }

--- a/dev/local/env-sync/plan.ts
+++ b/dev/local/env-sync/plan.ts
@@ -30,11 +30,16 @@ import {
 // ---------------------------------------------------------------------------
 
 const FLY_TOKEN_ENV_KEY = 'FLY_API_TOKEN';
-const FLY_TOKEN_AUTO_CREATE: EnvLocalAutoCreate = {
-  key: FLY_TOKEN_ENV_KEY,
-  command: 'fly',
-  args: ['tokens', 'create', 'org', 'kilo-dev'],
-};
+const FLY_ORG_SLUG_ENV_KEY = 'FLY_ORG_SLUG';
+const DEFAULT_FLY_ORG_SLUG = 'kilo-dev';
+
+function createFlyTokenAutoCreate(flyOrgSlug: string): EnvLocalAutoCreate {
+  return {
+    key: FLY_TOKEN_ENV_KEY,
+    command: 'fly',
+    args: ['tokens', 'create', 'org', flyOrgSlug],
+  };
+}
 
 // ---------------------------------------------------------------------------
 // LAN IP detection
@@ -235,6 +240,16 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
     const exampleContent = fs.readFileSync(examplePath, 'utf-8');
     const entries = parseExampleFile(exampleContent);
     const serviceUsesLanIp = dirUsesLanIp.get(workerDir) ?? false;
+    const devVarsPath = path.join(repoRoot, workerDir, '.dev.vars');
+
+    let existingContent: string | null = null;
+    try {
+      existingContent = fs.readFileSync(devVarsPath, 'utf-8');
+    } catch {
+      // File doesn't exist yet
+    }
+    const oldVars =
+      existingContent !== null ? parseEnvFile(existingContent) : new Map<string, string>();
 
     const resolvedVars = new Map<string, string>();
     const resolvedSources = new Map<
@@ -242,6 +257,7 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
       'env-local' | 'generated' | 'exec' | 'default' | 'missing'
     >();
     const unresolvedKeys: string[] = [];
+    let shouldCreateFlyToken = false;
 
     for (const entry of entries) {
       const { value, resolved, source } = resolveAnnotatedValue(
@@ -256,11 +272,8 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
 
       const autoCreatesFlyToken =
         entry.key === FLY_TOKEN_ENV_KEY && !envLocal.get(FLY_TOKEN_ENV_KEY);
-      if (
-        autoCreatesFlyToken &&
-        !envLocalAutoCreates.some(create => create.key === FLY_TOKEN_ENV_KEY)
-      ) {
-        envLocalAutoCreates.push(FLY_TOKEN_AUTO_CREATE);
+      if (autoCreatesFlyToken) {
+        shouldCreateFlyToken = true;
       }
 
       if (!resolved && !autoCreatesFlyToken) {
@@ -276,23 +289,24 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
       }
     }
 
-    allResolvedEntries.set(workerDir, { vars: resolvedVars, entries });
-
-    const devVarsPath = path.join(repoRoot, workerDir, '.dev.vars');
-
-    let existingContent: string | null = null;
-    try {
-      existingContent = fs.readFileSync(devVarsPath, 'utf-8');
-    } catch {
-      // File doesn't exist yet
+    if (
+      shouldCreateFlyToken &&
+      !envLocalAutoCreates.some(create => create.key === FLY_TOKEN_ENV_KEY)
+    ) {
+      const flyOrgSlug =
+        oldVars.get(FLY_ORG_SLUG_ENV_KEY) ||
+        resolvedVars.get(FLY_ORG_SLUG_ENV_KEY) ||
+        DEFAULT_FLY_ORG_SLUG;
+      envLocalAutoCreates.push(createFlyTokenAutoCreate(flyOrgSlug));
     }
+
+    allResolvedEntries.set(workerDir, { vars: resolvedVars, entries });
 
     const isNew = existingContent === null;
     const keyChanges: KeyChange[] = [];
     let missingValues: string[];
 
     if (existingContent !== null) {
-      const oldVars = parseEnvFile(existingContent);
       // Only report keys as missing if the existing .dev.vars also lacks a value.
       // Keys that couldn't be resolved but already have a value in .dev.vars are
       // kept as-is — skip them from both missing warnings and key change diffs.
@@ -302,6 +316,7 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
         if (unresolvedSet.has(key)) continue;
         const oldVal = oldVars.get(key);
         const source = resolvedSources.get(key);
+        if (key === FLY_TOKEN_ENV_KEY && shouldCreateFlyToken) continue;
         if (oldVal && source === 'default') continue;
         if (oldVal !== newVal) {
           keyChanges.push({ key, oldValue: oldVal, newValue: newVal });

--- a/dev/local/env-sync/plan.ts
+++ b/dev/local/env-sync/plan.ts
@@ -14,6 +14,7 @@ import type {
   SecretStoreBinding,
   SecretStoreWarning,
   ConsistencyWarning,
+  EnvLocalAutoCreate,
 } from './types';
 import {
   parseEnvFile,
@@ -23,6 +24,17 @@ import {
   parseJsonc,
   generateDevVars,
 } from './parse';
+
+// ---------------------------------------------------------------------------
+// Auto-created local secrets
+// ---------------------------------------------------------------------------
+
+const FLY_TOKEN_ENV_KEY = 'FLY_API_TOKEN';
+const FLY_TOKEN_AUTO_CREATE: EnvLocalAutoCreate = {
+  key: FLY_TOKEN_ENV_KEY,
+  command: 'fly',
+  args: ['tokens', 'create', 'org', 'kilo-dev'],
+};
 
 // ---------------------------------------------------------------------------
 // LAN IP detection
@@ -175,6 +187,7 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
       lanIp: undefined,
       devVarsChanges: [],
       envDevLocalChanges: [],
+      envLocalAutoCreates: [],
       secretStoreWarnings: [],
       secretStoreAutoCreates: [],
       consistencyWarnings: [],
@@ -210,6 +223,7 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
 
   // --- .dev.vars changes ---
   const devVarsChanges: DevVarsFileChange[] = [];
+  const envLocalAutoCreates: EnvLocalAutoCreate[] = [];
   const execWarnings: ExecWarning[] = [];
   const allResolvedEntries = new Map<
     string,
@@ -223,10 +237,14 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
     const serviceUsesLanIp = dirUsesLanIp.get(workerDir) ?? false;
 
     const resolvedVars = new Map<string, string>();
+    const resolvedSources = new Map<
+      string,
+      'env-local' | 'generated' | 'exec' | 'default' | 'missing'
+    >();
     const unresolvedKeys: string[] = [];
 
     for (const entry of entries) {
-      const { value, resolved } = resolveAnnotatedValue(
+      const { value, resolved, source } = resolveAnnotatedValue(
         entry.key,
         entry,
         envLocal,
@@ -234,7 +252,18 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
         serviceUsesLanIp
       );
       resolvedVars.set(entry.key, value);
-      if (!resolved) {
+      resolvedSources.set(entry.key, source);
+
+      const autoCreatesFlyToken =
+        entry.key === FLY_TOKEN_ENV_KEY && !envLocal.get(FLY_TOKEN_ENV_KEY);
+      if (
+        autoCreatesFlyToken &&
+        !envLocalAutoCreates.some(create => create.key === FLY_TOKEN_ENV_KEY)
+      ) {
+        envLocalAutoCreates.push(FLY_TOKEN_AUTO_CREATE);
+      }
+
+      if (!resolved && !autoCreatesFlyToken) {
         unresolvedKeys.push(entry.key);
         if (entry.annotation.type === 'exec') {
           execWarnings.push({
@@ -272,6 +301,8 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
       for (const [key, newVal] of resolvedVars) {
         if (unresolvedSet.has(key)) continue;
         const oldVal = oldVars.get(key);
+        const source = resolvedSources.get(key);
+        if (oldVal && source === 'default') continue;
         if (oldVal !== newVal) {
           keyChanges.push({ key, oldValue: oldVal, newValue: newVal });
         }
@@ -409,6 +440,7 @@ function computePlan(repoRoot: string, serviceFilter?: Set<string>): EnvSyncPlan
     lanIp,
     devVarsChanges,
     envDevLocalChanges,
+    envLocalAutoCreates,
     secretStoreWarnings,
     secretStoreAutoCreates,
     consistencyWarnings,

--- a/dev/local/env-sync/types.ts
+++ b/dev/local/env-sync/types.ts
@@ -23,6 +23,12 @@ type EnvDevLocalChange = {
   newValue: string;
 };
 
+type EnvLocalAutoCreate = {
+  key: string;
+  command: string;
+  args: string[];
+};
+
 type SecretStoreBinding = {
   binding: string;
   store_id: string;
@@ -56,6 +62,7 @@ type EnvSyncPlan = {
   lanIp: string | undefined;
   devVarsChanges: DevVarsFileChange[];
   envDevLocalChanges: EnvDevLocalChange[];
+  envLocalAutoCreates: EnvLocalAutoCreate[];
   secretStoreWarnings: SecretStoreWarning[];
   secretStoreAutoCreates: SecretStoreAutoCreate[];
   consistencyWarnings: ConsistencyWarning[];
@@ -101,6 +108,7 @@ export type {
   KeyChange,
   DevVarsFileChange,
   EnvDevLocalChange,
+  EnvLocalAutoCreate,
   SecretStoreBinding,
   SecretStoreWarning,
   SecretStoreAutoCreate,

--- a/dev/local/scripts/start-stripe.ts
+++ b/dev/local/scripts/start-stripe.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 const repoRoot = path.resolve(import.meta.dirname, '../../..');
-const envFilePath = path.join(repoRoot, '.env.development.local');
+const envFilePath = path.join(repoRoot, 'apps/web/.env.development.local');
 
 function updateEnvValue(filePath: string, key: string, value: string): void {
   let content = '';
@@ -49,7 +49,7 @@ function handleOutput(data: Buffer) {
   const secret = match[0];
   updateEnvValue(envFilePath, 'STRIPE_WEBHOOK_SECRET', `"${secret}"`);
 
-  console.log('\nSet STRIPE_WEBHOOK_SECRET in .env.development.local');
+  console.log('\nSet STRIPE_WEBHOOK_SECRET in apps/web/.env.development.local');
 
   // Only capture once
   secretPattern = null;

--- a/services/kiloclaw/.dev.vars.example
+++ b/services/kiloclaw/.dev.vars.example
@@ -3,7 +3,7 @@
 #
 # Most values below are working defaults. The script auto-manages:
 #   NEXTAUTH_SECRET, INTERNAL_API_SECRET  (synced from Vercel)
-#   FLY_API_TOKEN                         (auto-created/refreshed)
+#   FLY_API_TOKEN                         (auto-created once in .env.local)
 #   KILOCODE_API_BASE_URL                 (set from tunnel URL)
 #
 # Values you may need to set manually:
@@ -44,8 +44,9 @@ BACKEND_API_URL=http://localhost:3000
 # KILOCODE_API_BASE_URL=https://<tunnel>.trycloudflare.com/api/gateway/
 
 # Fly.io Machines API
-# Token is auto-created/refreshed by the dev-start script.
-# @exec fly auth token
+# Token is auto-created once in .env.local by `pnpm dev:env` using
+# `fly tokens create org kilo-dev`, then synced here.
+# @from FLY_API_TOKEN
 FLY_API_TOKEN=
 # Fly org slug. The dev-start script reads this value for token creation.
 # Use "kilo-dev" for Kilo team members, or "personal" for your own Fly account.

--- a/services/kiloclaw/.dev.vars.example
+++ b/services/kiloclaw/.dev.vars.example
@@ -45,7 +45,7 @@ BACKEND_API_URL=http://localhost:3000
 
 # Fly.io Machines API
 # Token is auto-created once in .env.local by `pnpm dev:env` using
-# `fly tokens create org kilo-dev`, then synced here.
+# `fly tokens create org <FLY_ORG_SLUG>`, then synced here.
 # @from FLY_API_TOKEN
 FLY_API_TOKEN=
 # Fly org slug. The dev-start script reads this value for token creation.


### PR DESCRIPTION
## Summary
- Change KiloClaw dev env sync to create `FLY_API_TOKEN` once in `.env.local` with `fly tokens create org kilo-dev`, then sync that stored value into `.dev.vars` files.
- Preserve existing `.dev.vars` values when the example only provides defaults, preventing image tag and OpenClaw version overrides on every `pnpm dev:env` run.
- Write captured Stripe webhook secrets to `apps/web/.env.development.local` and update the dev startup watcher to read the same file.

## Verification
- `pnpm exec oxfmt dev/local/env-sync/types.ts dev/local/env-sync/parse.ts dev/local/env-sync/plan.ts dev/local/env-sync/output.ts dev/local/env-sync/index.ts services/kiloclaw/.dev.vars.example`
- `pnpm exec oxfmt dev/local/scripts/start-stripe.ts dev/local/cli.ts`
- `pnpm typecheck`
- `pnpm dev:env --check kiloclaw` (expected non-zero locally because `FLY_API_TOKEN` is absent from `.env.local`; verified it proposes one-time creation via `fly tokens create org kilo-dev`)

## Visual Changes
N/A

## Reviewer Notes
- Applying `pnpm dev:env -y kiloclaw` with no `FLY_API_TOKEN` in `.env.local` will create one Fly org token, persist it to `.env.local`, recompute the plan, and then sync it into `services/kiloclaw/.dev.vars`.
- Existing non-empty `.dev.vars` values that come only from example defaults are intentionally left untouched.