### PR TITLE
feat(gastown): hide app topbar on town pages, use gastown header for sidebar toggle

### DIFF
--- a/apps/web/src/app/(app)/components/AppTopbar.tsx
+++ b/apps/web/src/app/(app)/components/AppTopbar.tsx
@@ -10,7 +10,9 @@ import {
 } from '@/components/ui/breadcrumb';
 
 export function AppTopbar() {
-  const { title, icon, extras } = usePageTitle();
+  const { title, icon, extras, hideTopbar } = usePageTitle();
+
+  if (hideTopbar) return null;
 
   return (
     <header className="bg-background sticky top-0 z-10 h-14 shrink-0 border-b flex items-center">

--- a/apps/web/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -37,6 +37,7 @@ import { motion, AnimatePresence } from 'motion/react';
 import type { GastownOutputs } from '@/lib/gastown/trpc';
 import { AdminViewingBanner } from '@/components/gastown/AdminViewingBanner';
 import { DrainStatusBanner } from '@/components/gastown/DrainStatusBanner';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 
 type Agent = GastownOutputs['gastown']['listAgents'][number];
 
@@ -215,6 +216,7 @@ export function TownOverviewPageClient({
       {/* Top bar — sticky */}
       <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-3">
+          <SidebarTrigger className="-ml-3" />
           {townQuery.isLoading ? (
             <Skeleton className="h-6 w-40" />
           ) : (

--- a/apps/web/src/app/(app)/gastown/[townId]/agents/AgentsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/agents/AgentsPageClient.tsx
@@ -6,6 +6,7 @@ import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { sortAgentsByStatus } from '@/lib/gastown/sort-agents';
 import { useDrawerStack } from '@/components/gastown/DrawerStack';
 import { Bot, Crown, Shield, Eye, Clock, Hexagon, MessageSquare } from 'lucide-react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import { formatDistanceToNow } from 'date-fns';
 import { motion, AnimatePresence } from 'motion/react';
 import type { GastownOutputs } from '@/lib/gastown/trpc';
@@ -57,8 +58,9 @@ export function AgentsPageClient({ townId }: { townId: string }) {
   return (
     <div className="flex h-full flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-2">
+          <SidebarTrigger className="-ml-3" />
           <Bot className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Agents</h1>
           <span className="ml-1 font-mono text-xs text-white/30">{allAgents.length}</span>

--- a/apps/web/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
@@ -5,6 +5,7 @@ import { useQuery, useQueries } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { useDrawerStack } from '@/components/gastown/DrawerStack';
 import { Hexagon, Search } from 'lucide-react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import { formatDistanceToNow } from 'date-fns';
 import { motion, AnimatePresence } from 'motion/react';
 import type { GastownOutputs } from '@/lib/gastown/trpc';
@@ -82,8 +83,9 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
   return (
     <div className="flex h-full flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-2">
+          <SidebarTrigger className="-ml-3" />
           <Hexagon className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Beads</h1>
           <span className="ml-1 font-mono text-xs text-white/30">{allBeads.length}</span>

--- a/apps/web/src/app/(app)/gastown/[townId]/layout.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/layout.tsx
@@ -2,6 +2,7 @@ import { TerminalBarProvider } from '@/components/gastown/TerminalBarContext';
 import { DrawerStackProvider } from '@/components/gastown/DrawerStack';
 import { renderDrawerContent } from '@/components/gastown/DrawerStackContent';
 import { TerminalBarPadding } from '@/components/gastown/TerminalBarPadding';
+import { HideAppTopbar } from '@/components/gastown/HideAppTopbar';
 import { MayorTerminalBar } from './MayorTerminalBar';
 import { OnboardingTooltipsWrapper } from './OnboardingTooltipsWrapper';
 
@@ -15,6 +16,7 @@ export default function TownLayout({
   return (
     <TerminalBarProvider>
       <DrawerStackProvider renderContent={renderDrawerContent}>
+        <HideAppTopbar />
         <TerminalBarPadding>{children}</TerminalBarPadding>
         <MayorTerminalBar params={params} />
         <OnboardingTooltipsWrapper params={params} />

--- a/apps/web/src/app/(app)/gastown/[townId]/mail/MailPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/mail/MailPageClient.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { Mail } from 'lucide-react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import { formatDistanceToNow } from 'date-fns';
 
 export function MailPageClient({ townId }: { townId: string }) {
@@ -17,8 +18,9 @@ export function MailPageClient({ townId }: { townId: string }) {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-2">
+          <SidebarTrigger className="-ml-3" />
           <Mail className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Mail</h1>
           <span className="ml-1 font-mono text-xs text-white/30">{mailEvents.length}</span>

--- a/apps/web/src/app/(app)/gastown/[townId]/merges/MergesPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/merges/MergesPageClient.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { GitMerge, AlertCircle, Loader2, Activity, Server } from 'lucide-react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import {
   Select,
   SelectContent,
@@ -44,8 +45,9 @@ export function MergesPageClient({ townId }: { townId: string }) {
   return (
     <div className="flex h-full flex-col">
       {/* Page header */}
-      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-2">
+          <SidebarTrigger className="-ml-3" />
           <GitMerge className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Merge Queue</h1>
           {totalAttention > 0 && (

--- a/apps/web/src/app/(app)/gastown/[townId]/observability/ObservabilityPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/observability/ObservabilityPageClient.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { Activity, Clock, Hexagon, Bot, GitMerge, AlertTriangle, Mail } from 'lucide-react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import { formatDistanceToNow, format, subHours, differenceInMinutes } from 'date-fns';
 import {
   AreaChart,
@@ -87,8 +88,9 @@ export function ObservabilityPageClient({ townId }: { townId: string }) {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-2">
+          <SidebarTrigger className="-ml-3" />
           <Activity className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Observability</h1>
           <span className="ml-1 font-mono text-xs text-white/30">{events.length} events</span>

--- a/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
@@ -13,6 +13,7 @@ import { ConvoyTimeline } from '@/components/gastown/ConvoyTimeline';
 import { SlingDialog } from '@/components/gastown/SlingDialog';
 import { useDrawerStack } from '@/components/gastown/DrawerStack';
 import { Plus, GitBranch, Hexagon, Bot, Layers, ChevronRight, ChevronDown } from 'lucide-react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import { motion, AnimatePresence } from 'motion/react';
 
 type RigDetailPageClientProps = {
@@ -111,8 +112,9 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
   return (
     <div className="flex h-full flex-col">
       {/* Top bar */}
-      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-3">
+          <SidebarTrigger className="-ml-3" />
           {rigQuery.isLoading ? (
             <Skeleton className="h-6 w-40" />
           ) : (

--- a/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -44,6 +44,7 @@ import { Slider } from '@/components/ui/slider';
 import { Textarea } from '@/components/ui/textarea';
 import { motion } from 'motion/react';
 import { AdminViewingBanner } from '@/components/gastown/AdminViewingBanner';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import { useRouter } from 'next/navigation';
 import {
   AlertDialog,
@@ -436,6 +437,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
         className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3"
       >
         <div className="flex items-center gap-2.5">
+          <SidebarTrigger className="-ml-3" />
           <Settings className="size-4 text-white/40" />
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Settings</h1>
           <span className="text-sm text-white/30">{townQuery.data?.name}</span>

--- a/apps/web/src/app/(app)/organizations/[id]/gastown/[townId]/layout.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/gastown/[townId]/layout.tsx
@@ -2,6 +2,7 @@ import { TerminalBarProvider } from '@/components/gastown/TerminalBarContext';
 import { DrawerStackProvider } from '@/components/gastown/DrawerStack';
 import { renderDrawerContent } from '@/components/gastown/DrawerStackContent';
 import { TerminalBarPadding } from '@/components/gastown/TerminalBarPadding';
+import { HideAppTopbar } from '@/components/gastown/HideAppTopbar';
 import { MayorTerminalBar } from '@/app/(app)/gastown/[townId]/MayorTerminalBar';
 import { OnboardingTooltips } from '@/components/gastown/OnboardingTooltips';
 
@@ -18,6 +19,7 @@ export default async function OrgTownLayout({
   return (
     <TerminalBarProvider>
       <DrawerStackProvider renderContent={renderDrawerContent}>
+        <HideAppTopbar />
         <TerminalBarPadding>{children}</TerminalBarPadding>
         <MayorTerminalBar params={params} basePath={basePath} />
         <OnboardingTooltips townId={townId} />

--- a/apps/web/src/components/gastown/HideAppTopbar.tsx
+++ b/apps/web/src/components/gastown/HideAppTopbar.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePageTitle } from '@/contexts/PageTitleContext';
+
+/**
+ * Hides the app-level top bar (AppTopbar) while this component is mounted.
+ * Used by gastown town pages which render their own page-level header
+ * with a sidebar toggle built in.
+ */
+export function HideAppTopbar() {
+  const { setHideTopbar } = usePageTitle();
+
+  useEffect(() => {
+    setHideTopbar(true);
+    return () => setHideTopbar(false);
+  }, [setHideTopbar]);
+
+  return null;
+}

--- a/apps/web/src/contexts/PageTitleContext.tsx
+++ b/apps/web/src/contexts/PageTitleContext.tsx
@@ -6,9 +6,11 @@ type PageTitleContextValue = {
   title: string;
   icon: ReactNode;
   extras: ReactNode;
+  hideTopbar: boolean;
   setTitle: (title: string) => void;
   setIcon: (icon: ReactNode) => void;
   setExtras: (extras: ReactNode) => void;
+  setHideTopbar: (hide: boolean) => void;
 };
 
 const PageTitleContext = createContext<PageTitleContextValue | undefined>(undefined);
@@ -17,11 +19,15 @@ export function PageTitleProvider({ children }: { children: ReactNode }) {
   const [title, setTitleState] = useState('');
   const [icon, setIconState] = useState<ReactNode>(null);
   const [extras, setExtrasState] = useState<ReactNode>(null);
+  const [hideTopbar, setHideTopbarState] = useState(false);
   const setTitle = useCallback((next: string) => setTitleState(next), []);
   const setIcon = useCallback((next: ReactNode) => setIconState(next), []);
   const setExtras = useCallback((next: ReactNode) => setExtrasState(next), []);
+  const setHideTopbar = useCallback((next: boolean) => setHideTopbarState(next), []);
   return (
-    <PageTitleContext.Provider value={{ title, icon, extras, setTitle, setIcon, setExtras }}>
+    <PageTitleContext.Provider
+      value={{ title, icon, extras, hideTopbar, setTitle, setIcon, setExtras, setHideTopbar }}
+    >
       {children}
     </PageTitleContext.Provider>
   );


### PR DESCRIPTION
## Summary

Gastown town pages had two stacked header bars — the generic app-level `AppTopbar` (sidebar toggle + breadcrumb) and the gastown page-specific header (town/rig name + CTAs). The app topbar was wasting vertical real estate since gastown has its own header.

- Hide the app-level `AppTopbar` on all gastown town pages via a `hideTopbar` flag in `PageTitleContext`
- Add `SidebarTrigger` to all 8 gastown page headers so users can still toggle the sidebar
- Non-gastown pages are completely unaffected (`hideTopbar` defaults to `false`)

Closes #2247

## Verification

- `pnpm typecheck` passes cleanly across all packages
- Verified all 8 gastown page headers updated: Overview, Rig Detail, Settings, Merges, Beads, Agents, Observability, Mail
- Both personal and org-scoped town layouts include the `HideAppTopbar` component

## Visual Changes

Before: Two header bars stacked (app topbar with sidebar toggle + gastown header with page title/CTAs)
After: Single gastown header with sidebar toggle integrated alongside page title/CTAs

<img width="1684" height="1237" alt="image" src="https://github.com/user-attachments/assets/24bc5d3c-5f44-4cd4-822d-a5e31d0c77c6" />


## Reviewer Notes

- The `HideAppTopbar` client component uses `useEffect` cleanup to restore the topbar when navigating away from town pages
- Settings page has a scrollspy sticky sidebar at `lg:top-[53px]` — may need visual check that this still aligns correctly with the topbar gone