### PR TITLE
fix(gastown): persist GASTOWN_ORGANIZATION_ID across restarts

### DIFF
--- a/apps/web/src/lib/organizations/organizations.test.ts
+++ b/apps/web/src/lib/organizations/organizations.test.ts
@@ -24,6 +24,12 @@ import { DEFAULT_MEMBER_DAILY_LIMIT_USD } from '@/lib/organizations/constants';
 describe('Organizations', () => {
   afterEach(async () => {
     // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organization_user_limits);
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organization_invitations);
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organization_memberships);
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
     await db.delete(organizations);
   });
 

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -1233,6 +1233,13 @@ export async function updateAgentModel(
     }
     hotSwapEnv[key] = value;
   }
+  // Inject live values for LIVE_ENV_KEYS that were absent from startupEnv
+  // (e.g. GASTOWN_ORGANIZATION_ID added after initial dispatch).
+  for (const key of LIVE_ENV_KEYS) {
+    if (key in hotSwapEnv) continue;
+    const live = process.env[key];
+    if (live) hotSwapEnv[key] = live;
+  }
 
   // Re-derive GH_TOKEN from live values using the same priority chain
   // as buildAgentEnv: GITHUB_CLI_PAT > GIT_TOKEN > GITHUB_TOKEN.

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -1221,6 +1221,7 @@ export async function updateAgentModel(
     'GASTOWN_GIT_AUTHOR_EMAIL',
     'GASTOWN_DISABLE_AI_COAUTHOR',
     'KILOCODE_TOKEN',
+    'GASTOWN_ORGANIZATION_ID',
   ]);
   const hotSwapEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(agent.startupEnv)) {


### PR DESCRIPTION
## Summary
Added GASTOWN_ORGANIZATION_ID to LIVE_ENV_KEYS in `services/gastown/container/src/process-manager.ts` to ensure it is correctly preserved and hot-swapped across container restarts and model updates for org-owned towns.

## Verification
- Verified GASTOWN_ORGANIZATION_ID is now in `LIVE_ENV_KEYS` to ensure persistence.
- Verified `container-dispatch.ts` correctly passes `organizationId` from `townConfig`.

## Visual Changes
N/A

## Reviewer Notes
- This ensures that when the model is hot-swapped or config is synced, the organization ID remains available to `buildKiloConfigContent`, preventing team/provider connection loss for org towns.