### PR TITLE
Feat(kiloclaw) no response resilience

### DIFF
--- a/services/kiloclaw/controller/src/proxy.test.ts
+++ b/services/kiloclaw/controller/src/proxy.test.ts
@@ -112,6 +112,7 @@ describe('HTTP proxy', () => {
       headers: { 'x-kiloclaw-proxy-token': 'token-1' },
     });
     expect(resp.status).toBe(503);
+    expect(resp.headers.get('Retry-After')).toBe('5');
     expect(await resp.json()).toEqual({ error: 'Gateway not ready' });
   });
 
@@ -191,7 +192,9 @@ describe('WebSocket proxy', () => {
       supervisor: createMockSupervisor('crashed'),
     });
 
-    expect((socket as unknown as FakeSocket).written.join('')).toContain('HTTP/1.1 503');
+    const written = (socket as unknown as FakeSocket).written.join('');
+    expect(written).toContain('HTTP/1.1 503');
+    expect(written).toContain('Retry-After: 5');
     expect((socket as unknown as FakeSocket).destroyed).toBe(true);
   });
 
@@ -287,7 +290,9 @@ describe('WebSocket proxy', () => {
       wsState: { activeConnections: 100 },
     });
 
-    expect((socket as unknown as FakeSocket).written.join('')).toContain('HTTP/1.1 503');
+    const written = (socket as unknown as FakeSocket).written.join('');
+    expect(written).toContain('HTTP/1.1 503');
+    expect(written).toContain('Retry-After: 5');
     expect((socket as unknown as FakeSocket).destroyed).toBe(true);
   });
 

--- a/services/kiloclaw/controller/src/proxy.ts
+++ b/services/kiloclaw/controller/src/proxy.ts
@@ -55,7 +55,7 @@ export function createHttpProxy(options: ProxyOptions) {
     }
 
     if (options.supervisor && options.supervisor.getState() !== 'running') {
-      return c.json({ error: 'Gateway not ready' }, 503);
+      return c.json({ error: 'Gateway not ready' }, { status: 503, headers: { 'Retry-After': '5' } });
     }
 
     const incomingUrl = new URL(c.req.url);
@@ -101,7 +101,7 @@ function socketWriteBadGateway(socket: Duplex): void {
 }
 
 function socketWriteServiceUnavailable(socket: Duplex): void {
-  socket.write('HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n\r\n');
+  socket.write('HTTP/1.1 503 Service Unavailable\r\nRetry-After: 5\r\nConnection: close\r\n\r\n');
   socket.destroy();
 }
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -494,7 +494,7 @@ export async function waitForHealthy(
   env: KiloClawEnv,
   appName: string,
   machineId: string
-): Promise<void> {
+): Promise<boolean> {
   const url = `https://${appName}.fly.dev/_kilo/gateway/status`;
   const deadline = Date.now() + HEALTH_PROBE_TIMEOUT_SECONDS * 1000;
 
@@ -526,7 +526,7 @@ export async function waitForHealthy(
                 rootRes.status,
                 ')'
               );
-              return;
+              return true;
             }
             console.log('[DO] Gateway reports running but root returned 502 — retrying');
           } catch {
@@ -547,4 +547,5 @@ export async function waitForHealthy(
   doWarn(state, 'Gateway health probe timed out — proceeding anyway', {
     timeoutSeconds: HEALTH_PROBE_TIMEOUT_SECONDS,
   });
+  return false;
 }

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -1197,7 +1197,15 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     }
 
     if (this.s.flyMachineId) {
-      await gateway.waitForHealthy(this.s, this.env, flyConfig.appName, this.s.flyMachineId);
+      const healthy = await gateway.waitForHealthy(
+        this.s,
+        this.env,
+        flyConfig.appName,
+        this.s.flyMachineId
+      );
+      if (!healthy) {
+        console.warn('[DO] start: gateway health probe timed out, proceeding with running status');
+      }
     }
 
     // Re-check status directly from storage: if the instance was destroyed while
@@ -2342,7 +2350,17 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         STARTUP_TIMEOUT_SECONDS,
         updated.instance_id
       );
-      await gateway.waitForHealthy(this.s, this.env, flyConfig.appName, this.s.flyMachineId);
+      const healthy = await gateway.waitForHealthy(
+        this.s,
+        this.env,
+        flyConfig.appName,
+        this.s.flyMachineId
+      );
+      if (!healthy) {
+        console.warn(
+          '[DO] restartMachine: gateway health probe timed out, proceeding with running status'
+        );
+      }
 
       // Final ownership check before persisting success.
       const preSuccessStatus = await this.ctx.storage.get('status');

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
@@ -226,7 +226,12 @@ export async function completeUnexpectedStopRecovery(runtime: RecoveryRuntime): 
   const recoveryVolume = await fly.getVolume(flyConfig, recoveryVolumeId);
   const recoveryVolumeRegion = recoveryVolume.region;
 
-  await gateway.waitForHealthy(state, env, flyConfig.appName, state.flyMachineId);
+  const healthy = await gateway.waitForHealthy(state, env, flyConfig.appName, state.flyMachineId);
+  if (!healthy) {
+    console.warn(
+      '[DO] completeUnexpectedStopRecovery: gateway health probe timed out, proceeding with running status'
+    );
+  }
 
   let retainedRecoveryVolumeId: string | null = null;
   let retainedRecoveryVolumeCleanupAfter: number | null = null;

--- a/services/kiloclaw/src/index.test.ts
+++ b/services/kiloclaw/src/index.test.ts
@@ -67,6 +67,7 @@ describe('platform route env validation', () => {
     );
 
     expect(response.status).toBe(503);
+    expect(response.headers.get('Retry-After')).toBe('5');
     await expect(response.json()).resolves.toEqual({ error: 'Configuration error' });
     expect(console.error).toHaveBeenCalledWith(
       '[CONFIG] Platform route missing bindings:',

--- a/services/kiloclaw/src/index.ts
+++ b/services/kiloclaw/src/index.ts
@@ -49,6 +49,55 @@ function transformErrorMessage(message: string): string {
 }
 
 /**
+ * Sanitize a WebSocket close reason: transform internal error messages and
+ * truncate to the 123-char WebSocket spec limit for close reasons.
+ */
+function sanitizeCloseReason(reason: string): string {
+  let r = transformErrorMessage(reason);
+  if (r.length > 123) r = r.slice(0, 120) + '...';
+  return r;
+}
+
+/**
+ * Transform a WebSocket message from the container before relaying to the client.
+ * Rewrites JSON error payloads that leak internal gateway auth details.
+ */
+function transformWsMessage(data: string | ArrayBuffer): string | ArrayBuffer {
+  if (typeof data !== 'string') return data;
+  try {
+    const parsed: unknown = JSON.parse(data);
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'error' in parsed &&
+      typeof (parsed as Record<string, unknown>).error === 'object' &&
+      (parsed as Record<string, unknown>).error !== null
+    ) {
+      const error = (parsed as Record<string, Record<string, unknown>>).error;
+      if (typeof error.message === 'string') {
+        error.message = transformErrorMessage(error.message);
+        return JSON.stringify(parsed);
+      }
+    }
+  } catch {
+    // Not JSON — pass through
+  }
+  return data;
+}
+
+/**
+ * Safely close a WebSocket, tolerating already-closed sockets and invalid
+ * close codes/reasons that the CF Workers runtime rejects.
+ */
+function safeClose(ws: WebSocket, code: number, reason: string): void {
+  try {
+    ws.close(code, reason);
+  } catch {
+    // Already closed, invalid code, or reason too long — nothing to do.
+  }
+}
+
+/**
  * Validate required environment variables.
  * Only checks auth secrets -- AI provider keys are not required at the worker
  * level since users can bring their own keys (BYOK) via encrypted secrets.
@@ -97,7 +146,10 @@ async function requireEnvVars(c: Context<AppEnv>, next: Next) {
     if (!c.env.FLY_API_TOKEN) missing.push('FLY_API_TOKEN');
     if (missing.length > 0) {
       console.error('[CONFIG] Platform route missing bindings:', missing.join(', '));
-      return c.json({ error: 'Configuration error' }, 503);
+      return c.json(
+        { error: 'Configuration error' },
+        { status: 503, headers: { 'Retry-After': '5' } }
+      );
     }
     return next();
   }
@@ -105,7 +157,10 @@ async function requireEnvVars(c: Context<AppEnv>, next: Next) {
   const missingVars = validateRequiredEnv(c.env);
   if (missingVars.length > 0) {
     console.error('[CONFIG] Missing required environment variables:', missingVars.join(', '));
-    return c.json({ error: 'Configuration error' }, 503);
+    return c.json(
+      { error: 'Configuration error' },
+      { status: 503, headers: { 'Retry-After': '5' } }
+    );
   }
 
   return next();
@@ -196,7 +251,10 @@ app.all('/i/:instanceId/*', async c => {
   const instanceId = parsed.data;
 
   if (!c.env.GATEWAY_TOKEN_SECRET) {
-    return c.json({ error: 'Configuration error' }, 503);
+    return c.json(
+      { error: 'Configuration error' },
+      { status: 503, headers: { 'Retry-After': '5' } }
+    );
   }
 
   const stub = c.env.KILOCLAW_INSTANCE.get(c.env.KILOCLAW_INSTANCE.idFromName(instanceId));
@@ -264,11 +322,17 @@ app.all('/i/:instanceId/*', async c => {
       containerResponse = await fetch(targetUrl, { headers: forwardHeaders });
     } catch (err) {
       console.error('[PROXY /i] Fly Proxy fetch failed:', err);
-      return c.json({ error: 'Instance not reachable' }, 503);
+      return c.json(
+        { error: 'Instance not reachable' },
+        { status: 503, headers: { 'Retry-After': '5' } }
+      );
     }
 
     if (containerResponse.status === 502) {
-      return c.json({ error: 'Instance is starting up' }, 503);
+      return c.json(
+        { error: 'Instance is starting up' },
+        { status: 503, headers: { 'Retry-After': '5' } }
+      );
     }
 
     const containerWs = containerResponse.webSocket;
@@ -280,24 +344,64 @@ app.all('/i/:instanceId/*', async c => {
     serverWs.accept();
     containerWs.accept();
 
+    let droppedToContainer = 0;
+    let droppedToClient = 0;
+
     serverWs.addEventListener('message', event => {
       if (containerWs.readyState === WebSocket.OPEN) {
         containerWs.send(event.data as string | ArrayBuffer);
+      } else {
+        droppedToContainer++;
+        if (droppedToContainer === 1) {
+          console.warn(
+            '[WS /i] First dropped client->container message (readyState:',
+            containerWs.readyState,
+            ')'
+          );
+        }
       }
     });
     containerWs.addEventListener('message', event => {
+      const data = transformWsMessage(event.data as string | ArrayBuffer);
       if (serverWs.readyState === WebSocket.OPEN) {
-        serverWs.send(event.data as string | ArrayBuffer);
+        serverWs.send(data);
+      } else {
+        droppedToClient++;
+        if (droppedToClient === 1) {
+          console.warn(
+            '[WS /i] First dropped container->client message (readyState:',
+            serverWs.readyState,
+            ')'
+          );
+        }
       }
     });
+
+    const logDropSummary = () => {
+      const totalDropped = droppedToClient + droppedToContainer;
+      if (totalDropped > 0) {
+        console.warn(
+          '[WS /i] Connection closed with',
+          totalDropped,
+          'dropped messages (toClient:',
+          droppedToClient,
+          'toContainer:',
+          droppedToContainer,
+          ')'
+        );
+      }
+    };
+
     serverWs.addEventListener('close', event => {
-      containerWs.close(event.code, event.reason);
+      logDropSummary();
+      safeClose(containerWs, event.code, event.reason);
     });
     containerWs.addEventListener('close', event => {
-      serverWs.close(event.code, event.reason);
+      logDropSummary();
+      safeClose(serverWs, event.code, sanitizeCloseReason(event.reason));
     });
-    serverWs.addEventListener('error', () => containerWs.close(1011, 'Client error'));
-    containerWs.addEventListener('error', () => serverWs.close(1011, 'Container error'));
+    serverWs.addEventListener('error', () => safeClose(containerWs, 1011, 'Client error'));
+    containerWs.addEventListener('error', () => safeClose(serverWs, 1011, 'Container error'));
 
     return new Response(null, { status: 101, webSocket: clientWs });
   }
@@ -316,7 +420,10 @@ app.all('/i/:instanceId/*', async c => {
     return httpResponse;
   } catch (err) {
     console.error('[PROXY /i] HTTP fetch failed:', err);
-    return c.json({ error: 'Instance not reachable' }, 503);
+    return c.json(
+      { error: 'Instance not reachable' },
+      { status: 503, headers: { 'Retry-After': '5' } }
+    );
   }
 });
 
@@ -528,7 +635,10 @@ app.all('*', async c => {
           const targetUrl = flyProxyUrl(appName, url);
 
           if (!c.env.GATEWAY_TOKEN_SECRET) {
-            return c.json({ error: 'Configuration error' }, 503);
+            return c.json(
+              { error: 'Configuration error' },
+              { status: 503, headers: { 'Retry-After': '5' } }
+            );
           }
 
           const forwardHeaders = await buildForwardHeaders({
@@ -546,7 +656,10 @@ app.all('*', async c => {
               containerResponse = await fetch(targetUrl, { headers: forwardHeaders });
             } catch (err) {
               console.error('[PROXY] Cookie-routed WS fetch failed:', err);
-              return c.json({ error: 'Instance not reachable' }, 503);
+              return c.json(
+                { error: 'Instance not reachable' },
+                { status: 503, headers: { 'Retry-After': '5' } }
+              );
             }
             const containerWs = containerResponse.webSocket;
             if (!containerWs) {
@@ -555,24 +668,67 @@ app.all('*', async c => {
             containerWs.accept();
             const [clientWs, serverWs] = Object.values(new WebSocketPair());
             serverWs.accept();
+
+            let cookieDroppedToContainer = 0;
+            let cookieDroppedToClient = 0;
+
             serverWs.addEventListener('message', event => {
               if (containerWs.readyState === WebSocket.OPEN) {
                 containerWs.send(event.data as string | ArrayBuffer);
+              } else {
+                cookieDroppedToContainer++;
+                if (cookieDroppedToContainer === 1) {
+                  console.warn(
+                    '[WS cookie] First dropped client->container message (readyState:',
+                    containerWs.readyState,
+                    ')'
+                  );
+                }
               }
             });
             containerWs.addEventListener('message', event => {
+              const data = transformWsMessage(event.data as string | ArrayBuffer);
               if (serverWs.readyState === WebSocket.OPEN) {
-                serverWs.send(event.data as string | ArrayBuffer);
+                serverWs.send(data);
+              } else {
+                cookieDroppedToClient++;
+                if (cookieDroppedToClient === 1) {
+                  console.warn(
+                    '[WS cookie] First dropped container->client message (readyState:',
+                    serverWs.readyState,
+                    ')'
+                  );
+                }
               }
             });
-            serverWs.addEventListener('close', event =>
-              containerWs.close(event.code, event.reason)
+
+            const logCookieDropSummary = () => {
+              const totalDropped = cookieDroppedToClient + cookieDroppedToContainer;
+              if (totalDropped > 0) {
+                console.warn(
+                  '[WS cookie] Connection closed with',
+                  totalDropped,
+                  'dropped messages (toClient:',
+                  cookieDroppedToClient,
+                  'toContainer:',
+                  cookieDroppedToContainer,
+                  ')'
+                );
+              }
+            };
+
+            serverWs.addEventListener('close', event => {
+              logCookieDropSummary();
+              safeClose(containerWs, event.code, event.reason);
+            });
+            containerWs.addEventListener('close', event => {
+              logCookieDropSummary();
+              safeClose(serverWs, event.code, sanitizeCloseReason(event.reason));
+            });
+            serverWs.addEventListener('error', () => safeClose(containerWs, 1011, 'Client error'));
+            containerWs.addEventListener('error', () =>
+              safeClose(serverWs, 1011, 'Container error')
             );
-            containerWs.addEventListener('close', event =>
-              serverWs.close(event.code, event.reason)
-            );
-            serverWs.addEventListener('error', () => containerWs.close(1011, 'Client error'));
-            containerWs.addEventListener('error', () => serverWs.close(1011, 'Container error'));
             return new Response(null, { status: 101, webSocket: clientWs });
           }
 
@@ -590,7 +746,10 @@ app.all('*', async c => {
             return httpResponse;
           } catch (err) {
             console.error('[PROXY] Cookie-routed HTTP fetch failed:', err);
-            return c.json({ error: 'Instance not reachable' }, 503);
+            return c.json(
+              { error: 'Instance not reachable' },
+              { status: 503, headers: { 'Retry-After': '5' } }
+            );
           }
         }
       }
@@ -639,7 +798,10 @@ app.all('*', async c => {
   // Per-user app name, with legacy fallback for existing instances
   const appName = flyAppName ?? c.env.FLY_APP_NAME;
   if (!appName) {
-    return c.json({ error: 'No Fly app name for this instance' }, 503);
+    return c.json(
+      { error: 'No Fly app name for this instance' },
+      { status: 503, headers: { 'Retry-After': '5' } }
+    );
   }
 
   const request = c.req.raw;
@@ -652,7 +814,10 @@ app.all('*', async c => {
 
   if (!c.env.GATEWAY_TOKEN_SECRET) {
     console.error('[CONFIG] Missing required environment variables: GATEWAY_TOKEN_SECRET');
-    return c.json({ error: 'Configuration error' }, 503);
+    return c.json(
+      { error: 'Configuration error' },
+      { status: 503, headers: { 'Retry-After': '5' } }
+    );
   }
 
   // Use the DO's authoritative sandboxId for gateway token derivation.
@@ -683,7 +848,10 @@ app.all('*', async c => {
         // Machine may have been recreated — refresh the instance routing header
         const { machineId: newMachineId } = await resolveInstance(c);
         if (!newMachineId) {
-          return c.json({ error: 'Instance not reachable after restart' }, 503);
+          return c.json(
+            { error: 'Instance not reachable after restart' },
+            { status: 503, headers: { 'Retry-After': '5' } }
+          );
         }
         forwardHeaders.set('fly-force-instance-id', newMachineId);
 
@@ -693,7 +861,10 @@ app.all('*', async c => {
           });
         } catch (retryErr) {
           console.error('[WS] Retry after recovery failed:', retryErr);
-          return c.json({ error: 'Instance not reachable after restart attempt' }, 503);
+          return c.json(
+            { error: 'Instance not reachable after restart attempt' },
+            { status: 503, headers: { 'Retry-After': '5' } }
+          );
         }
       } else {
         return c.json(
@@ -701,7 +872,7 @@ app.all('*', async c => {
             error: 'Instance not reachable',
             hint: 'Your instance may not be running. Start it from the dashboard.',
           },
-          503
+          { status: 503, headers: { 'Retry-After': '5' } }
         );
       }
     }
@@ -714,7 +885,7 @@ app.all('*', async c => {
           error: 'Instance is starting up',
           hint: 'The gateway process is still initializing. Please retry shortly.',
         },
-        503
+        { status: 503, headers: { 'Retry-After': '5' } }
       );
     }
 
@@ -729,65 +900,77 @@ app.all('*', async c => {
     serverWs.accept();
     containerWs.accept();
 
+    let catchAllDroppedToContainer = 0;
+    let catchAllDroppedToClient = 0;
+
     // Client -> Container relay
     serverWs.addEventListener('message', event => {
       if (containerWs.readyState === WebSocket.OPEN) {
         containerWs.send(event.data as string | ArrayBuffer);
+      } else {
+        catchAllDroppedToContainer++;
+        if (catchAllDroppedToContainer === 1) {
+          console.warn(
+            '[WS] First dropped client->container message (readyState:',
+            containerWs.readyState,
+            ')'
+          );
+        }
       }
     });
 
     // Container -> Client relay with error transformation
     containerWs.addEventListener('message', event => {
-      let data = event.data as string | ArrayBuffer;
-
-      if (typeof data === 'string') {
-        try {
-          const parsed: unknown = JSON.parse(data);
-          if (
-            typeof parsed === 'object' &&
-            parsed !== null &&
-            'error' in parsed &&
-            typeof (parsed as Record<string, unknown>).error === 'object' &&
-            (parsed as Record<string, unknown>).error !== null
-          ) {
-            const error = (parsed as Record<string, Record<string, unknown>>).error;
-            if (typeof error.message === 'string') {
-              error.message = transformErrorMessage(error.message);
-              data = JSON.stringify(parsed);
-            }
-          }
-        } catch {
-          // Not JSON -- pass through
-        }
-      }
-
+      const data = transformWsMessage(event.data as string | ArrayBuffer);
       if (serverWs.readyState === WebSocket.OPEN) {
         serverWs.send(data);
+      } else {
+        catchAllDroppedToClient++;
+        if (catchAllDroppedToClient === 1) {
+          console.warn(
+            '[WS] First dropped container->client message (readyState:',
+            serverWs.readyState,
+            ')'
+          );
+        }
       }
     });
+
+    const logCatchAllDropSummary = () => {
+      const totalDropped = catchAllDroppedToClient + catchAllDroppedToContainer;
+      if (totalDropped > 0) {
+        console.warn(
+          '[WS] Connection closed with',
+          totalDropped,
+          'dropped messages (toClient:',
+          catchAllDroppedToClient,
+          'toContainer:',
+          catchAllDroppedToContainer,
+          ')'
+        );
+      }
+    };
 
     // Close relay
     serverWs.addEventListener('close', event => {
-      containerWs.close(event.code, event.reason);
+      logCatchAllDropSummary();
+      safeClose(containerWs, event.code, event.reason);
     });
 
     containerWs.addEventListener('close', event => {
-      let reason = transformErrorMessage(event.reason);
-      if (reason.length > 123) {
-        reason = reason.slice(0, 120) + '...';
-      }
-      serverWs.close(event.code, reason);
+      logCatchAllDropSummary();
+      safeClose(serverWs, event.code, sanitizeCloseReason(event.reason));
     });
 
     // Error relay
     serverWs.addEventListener('error', event => {
       console.error('[WS] Client error:', event);
-      containerWs.close(1011, 'Client error');
+      safeClose(containerWs, 1011, 'Client error');
     });
 
     containerWs.addEventListener('error', event => {
       console.error('[WS] Container error:', event);
-      serverWs.close(1011, 'Container error');
+      safeClose(serverWs, 1011, 'Container error');
     });
 
     return new Response(null, {
@@ -815,7 +998,10 @@ app.all('*', async c => {
       // Machine may have been recreated — refresh the instance routing header
       const { machineId: newMachineId } = await resolveInstance(c);
       if (!newMachineId) {
-        return c.json({ error: 'Instance not reachable after restart' }, 503);
+        return c.json(
+          { error: 'Instance not reachable after restart' },
+          { status: 503, headers: { 'Retry-After': '5' } }
+        );
       }
       forwardHeaders.set('fly-force-instance-id', newMachineId);
 
@@ -827,7 +1013,10 @@ app.all('*', async c => {
         });
       } catch (retryErr) {
         console.error('[HTTP] Retry after recovery failed:', retryErr);
-        return c.json({ error: 'Instance not reachable after restart attempt' }, 503);
+        return c.json(
+          { error: 'Instance not reachable after restart attempt' },
+          { status: 503, headers: { 'Retry-After': '5' } }
+        );
       }
     } else {
       return c.json(
@@ -835,7 +1024,7 @@ app.all('*', async c => {
           error: 'Instance not reachable',
           hint: 'Your instance may not be running. Start it from the dashboard.',
         },
-        503
+        { status: 503, headers: { 'Retry-After': '5' } }
       );
     }
   }

--- a/services/kiloclaw/src/index.ts
+++ b/services/kiloclaw/src/index.ts
@@ -89,12 +89,21 @@ function transformWsMessage(data: string | ArrayBuffer): string | ArrayBuffer {
 /**
  * Safely close a WebSocket, tolerating already-closed sockets and invalid
  * close codes/reasons that the CF Workers runtime rejects.
+ *
+ * CloseEvent.code can be 1005 (no status), 1006 (abnormal), or 1015 (TLS failure)
+ * on abnormal disconnects. These are not valid arguments to WebSocket.close().
+ * We normalize to 1000 (normal) on first failure and retry so the relay still
+ * tears down cleanly.
  */
 function safeClose(ws: WebSocket, code: number, reason: string): void {
   try {
     ws.close(code, reason);
   } catch {
-    // Already closed, invalid code, or reason too long — nothing to do.
+    try {
+      ws.close(1000, reason);
+    } catch {
+      // Already closed — nothing to do.
+    }
   }
 }
 
@@ -667,6 +676,14 @@ app.all('*', async c => {
                 { status: 503, headers: { 'Retry-After': '5' } }
               );
             }
+
+            if (containerResponse.status === 502) {
+              return c.json(
+                { error: 'Instance is starting up' },
+                { status: 503, headers: { 'Retry-After': '5' } }
+              );
+            }
+
             const containerWs = containerResponse.webSocket;
             if (!containerWs) {
               return c.json({ error: 'WebSocket upgrade failed' }, 502);


### PR DESCRIPTION

## Summary
KiloClaw users sometimes see "(No response)" in the chat UI. While part of this is the LLM literally     
  outputting that text (an OpenClaw-side issue), infrastructure-level failures on the KiloClaw proxy side
  can also cause lost messages or silent failures that produce the same user experience. This PR adds      
  observability and low-risk proxy-level improvements to help diagnose and reduce these failures.
                                                    
  WebSocket drop logging: Added first-drop + close-summary logging to all 6 silent message drop locations  
  across the three WS proxy paths (/i/, cookie-routed, catch-all). Previously, when either side's
  readyState was not OPEN, messages were silently discarded with zero observability. Now each connection   
  logs on first drop and emits a summary with total drop counts on close. Uses path-specific prefixes ([WS
  /i], [WS cookie], [WS]) for log filtering.        

  Retry-After headers: All 503 responses across both the worker (src/index.ts) and the controller proxy    
  (controller/src/proxy.ts) now include a Retry-After: 5 header. This covers HTTP JSON responses and raw
  WebSocket upgrade rejections. This is a passive, standards-compliant change that lays groundwork for     
  future client-side retry logic.                              
                                                    
  WS handler normalization: The /i/ and cookie-routed proxy paths were missing error message transformation
   and close reason sanitization that the catch-all path already had. Extracted transformWsMessage() and
  sanitizeCloseReason() shared helpers from the existing catch-all logic and applied them to all three     
  paths. This prevents leaking internal "gateway token mismatch" error strings to clients and avoids
  WebSocket protocol errors from close reasons exceeding 123 characters.

  waitForHealthy return type: Changed from Promise to Promise, returning true on successful health check   
  and false on timeout. All three callers (start(), restartMachine(), completeUnexpectedStopRecovery()) now
   log a warning on false but still proceed. This is observability-first with no behavior change.          
                                                               
  safeClose guard: Fixed a pre-existing uncaught error where calling .close() on an already-closed         
  WebSocket throws in the CF Workers runtime. Added a safeClose() helper that wraps all WebSocket close
  calls in try/catch across all three proxy paths.  

## Verification                                                                                             
   
- pnpm typecheck (tsgo --noEmit): pass                                                                   
- pnpm lint (oxlint): 0 warnings, 0 errors                   
- pnpm test (vitest): 53 test files, 1199 tests passed                                                   
- pnpm run format:check: clean                                                                           
- Local dev testing: confirmed WS drop logging fires correctly (saw "[WS cookie] First dropped           
  container->client message (readyState: 3)" and "[WS cookie] Connection closed with 10 dropped messages"),
   confirmed safeClose prevents the uncaught Error that was occurring without it 


## Visual Changes                                               
                                                    
  N/A

## Reviewer Notes

  The drop logging uses a first-drop + close-summary pattern (at most 2 log lines per connection) to avoid 
  flooding Axiom at scale. Per-message logging was intentionally avoided.
                                                                                                           
  Crash recovery expansion to /i/ and cookie paths is intentionally deferred pending drop data from this   
  change. The DO lifecycle layer is already ~4,300 lines with significant recovery complexity, and we need
  data before adding more recovery paths.                                                                  
                                                               
  The safeClose fix was discovered during local testing of the drop logging. The CF Workers runtime throws 
  when .close() is called on a WebSocket that is already in CLOSED state or when relaying invalid close
  codes from the peer. A try/catch was chosen over a readyState guard because the readyState check alone   
  was insufficient (the runtime can also reject valid-looking close calls for other reasons).

