### PR TITLE
feat(gastown): add RigOverrideConfigSchema and updateRigConfig()

### DIFF
--- a/apps/web/src/components/gastown/AgentDetailDrawer.tsx
+++ b/apps/web/src/components/gastown/AgentDetailDrawer.tsx
@@ -183,9 +183,7 @@ export function AgentDetailDrawer({
                         <span className="text-sm text-white/75">{agent.dispatch_attempts}</span>
                         {agent.dispatch_attempts > 0 && (
                           <button
-                            onClick={() =>
-                              resetMutation.mutate({ rigId, agentId: agent.id })
-                            }
+                            onClick={() => resetMutation.mutate({ rigId, agentId: agent.id })}
                             disabled={resetMutation.isPending}
                             title="Reset dispatch attempts to 0"
                             className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-amber-300 ring-1 ring-amber-400/30 transition-colors hover:bg-amber-400/10 disabled:opacity-50"

--- a/apps/web/src/components/gastown/drawer-panels/AgentPanel.tsx
+++ b/apps/web/src/components/gastown/drawer-panels/AgentPanel.tsx
@@ -166,9 +166,7 @@ export function AgentPanel({
             <span className="text-sm text-white/75">{agent.dispatch_attempts}</span>
             {agent.dispatch_attempts > 0 && (
               <button
-                onClick={() =>
-                  resetMutation.mutate({ rigId, agentId: agent.id })
-                }
+                onClick={() => resetMutation.mutate({ rigId, agentId: agent.id })}
                 disabled={resetMutation.isPending}
                 title="Reset dispatch attempts to 0"
                 className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-amber-300 ring-1 ring-amber-400/30 transition-colors hover:bg-amber-400/10 disabled:opacity-50"
@@ -177,9 +175,7 @@ export function AgentPanel({
                 Reset
               </button>
             )}
-            {resetMutation.isError && (
-              <span className="text-[10px] text-red-400">Failed</span>
-            )}
+            {resetMutation.isError && <span className="text-[10px] text-red-400">Failed</span>}
           </div>
         </div>
         <MetaCell

--- a/services/gastown/src/dos/town/rigs.ts
+++ b/services/gastown/src/dos/town/rigs.ts
@@ -132,5 +132,6 @@ export function removeRig(sql: SqlStorage, rigId: string): void {
 }
 
 export function updateRigConfig(sql: SqlStorage, rigId: string, config: RigOverrideConfig): void {
-  query(sql, /* sql */ `UPDATE rigs SET config = ? WHERE id = ?`, [JSON.stringify(config), rigId]);
+  const validated = RigOverrideConfigSchema.parse(config);
+  query(sql, /* sql */ `UPDATE rigs SET config = ? WHERE id = ?`, [JSON.stringify(validated), rigId]);
 }

--- a/services/gastown/src/dos/town/rigs.ts
+++ b/services/gastown/src/dos/town/rigs.ts
@@ -5,7 +5,7 @@
 
 import { z } from 'zod';
 import { query } from '../../util/query.util';
-import { RigOverrideConfig, RigOverrideConfigSchema } from '../../types';
+import { type RigOverrideConfig, RigOverrideConfigSchema } from '../../types';
 
 const RIG_TABLE_CREATE = /* sql */ `
   CREATE TABLE IF NOT EXISTS "rigs" (
@@ -27,9 +27,9 @@ export const RigRecord = z.object({
   default_branch: z.string(),
   config: z
     .string()
-    .transform((v) => {
+    .transform((v): unknown => {
       try {
-        return JSON.parse(v);
+        return JSON.parse(v) as unknown;
       } catch {
         return {};
       }

--- a/services/gastown/src/dos/town/rigs.ts
+++ b/services/gastown/src/dos/town/rigs.ts
@@ -5,6 +5,7 @@
 
 import { z } from 'zod';
 import { query } from '../../util/query.util';
+import { RigOverrideConfig, RigOverrideConfigSchema } from '../../types';
 
 const RIG_TABLE_CREATE = /* sql */ `
   CREATE TABLE IF NOT EXISTS "rigs" (
@@ -26,14 +27,14 @@ export const RigRecord = z.object({
   default_branch: z.string(),
   config: z
     .string()
-    .transform((v): Record<string, unknown> => {
+    .transform((v) => {
       try {
-        return JSON.parse(v) as Record<string, unknown>;
+        return JSON.parse(v);
       } catch {
         return {};
       }
     })
-    .pipe(z.record(z.string(), z.unknown())),
+    .pipe(RigOverrideConfigSchema),
   created_at: z.string(),
 });
 
@@ -128,4 +129,8 @@ export function listRigs(sql: SqlStorage): RigRecord[] {
 
 export function removeRig(sql: SqlStorage, rigId: string): void {
   query(sql, /* sql */ `DELETE FROM rigs WHERE id = ?`, [rigId]);
+}
+
+export function updateRigConfig(sql: SqlStorage, rigId: string, config: RigOverrideConfig): void {
+  query(sql, /* sql */ `UPDATE rigs SET config = ? WHERE id = ?`, [JSON.stringify(config), rigId]);
 }

--- a/services/gastown/src/types.ts
+++ b/services/gastown/src/types.ts
@@ -330,6 +330,47 @@ export const TownConfigSchema = z.object({
 
 export type TownConfig = z.infer<typeof TownConfigSchema>;
 
+// -- Rig Override Configuration --
+
+export const RigOverrideConfigSchema = z.object({
+  // Model overrides (override townConfig.default_model / role_models)
+  default_model: z.string().optional(),
+  role_models: z
+    .object({
+      polecat: z.string().optional(),
+      refinery: z.string().optional(),
+    })
+    .optional(),
+
+  // Review behavior
+  review_mode: z.enum(['rework', 'comments']).optional(),
+  /** false = skip refinery entirely */
+  code_review: z.boolean().optional(),
+  auto_resolve_pr_feedback: z.boolean().optional(),
+  auto_merge_delay_minutes: z.number().nullable().optional(),
+
+  // Merge strategy
+  merge_strategy: z.enum(['direct', 'pr']).optional(),
+  convoy_merge_mode: z.enum(['review-then-land', 'review-and-merge']).optional(),
+
+  // Custom instructions
+  custom_instructions: z
+    .object({
+      polecat: z.string().optional(),
+      refinery: z.string().optional(),
+    })
+    .optional(),
+
+  // Git
+  git_push_flags: z.string().optional(),
+
+  // Agent limits
+  max_concurrent_polecats: z.number().int().positive().optional(),
+  max_dispatch_attempts: z.number().int().positive().optional(),
+});
+
+export type RigOverrideConfig = z.infer<typeof RigOverrideConfigSchema>;
+
 /**
  * Partial update schema — all fields optional, NO defaults.
  * TownConfigSchema.partial() can't be used here because Zod still fires

--- a/services/gastown/src/types.ts
+++ b/services/gastown/src/types.ts
@@ -347,7 +347,7 @@ export const RigOverrideConfigSchema = z.object({
   /** false = skip refinery entirely */
   code_review: z.boolean().optional(),
   auto_resolve_pr_feedback: z.boolean().optional(),
-  auto_merge_delay_minutes: z.number().nullable().optional(),
+  auto_merge_delay_minutes: z.number().int().min(0).nullable().optional(),
 
   // Merge strategy
   merge_strategy: z.enum(['direct', 'pr']).optional(),


### PR DESCRIPTION
## Summary
- Adds `RigOverrideConfigSchema` and `RigOverrideConfig` type to `services/gastown/src/types.ts` near `TownConfigSchema`. All fields are optional — undefined means inherit from town.
- Updates `RigRecord.config` in `rigs.ts` to parse the stored JSON string into `RigOverrideConfig` (replacing the old `Record<string, unknown>` type). Existing `'{}'` rows parse correctly to an empty object with all fields undefined.
- Adds `updateRigConfig(sql, rigId, config)` exported from `rigs.ts` that persists a validated `RigOverrideConfig` to the `rigs.config` column.

## Verification
- Reviewed types for correctness and backwards compatibility (`'{}'` → empty object passes `RigOverrideConfigSchema` since all fields are optional).

## Visual Changes
N/A

## Reviewer Notes
N/A