### PR TITLE
feat(gastown): add updateRigConfig tRPC mutation and expose config in getRig output

### DIFF
--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -88,6 +88,7 @@ import type {
   MergeStrategy,
   ConvoyMergeMode,
   UiAction,
+  RigOverrideConfig,
 } from '../types';
 
 const TOWN_LOG = '[Town.do]';
@@ -841,6 +842,11 @@ export class TownDO extends DurableObject<Env> {
   }
 
   async getRigAsync(rigId: string): Promise<rigs.RigRecord | null> {
+    return rigs.getRig(this.sql, rigId);
+  }
+
+  async updateRigConfig(rigId: string, config: RigOverrideConfig): Promise<rigs.RigRecord | null> {
+    rigs.updateRigConfig(this.sql, rigId, config);
     return rigs.getRig(this.sql, rigId);
   }
 

--- a/services/gastown/src/dos/town/rigs.ts
+++ b/services/gastown/src/dos/town/rigs.ts
@@ -132,6 +132,7 @@ export function removeRig(sql: SqlStorage, rigId: string): void {
 }
 
 export function updateRigConfig(sql: SqlStorage, rigId: string, config: RigOverrideConfig): void {
-  const validated = RigOverrideConfigSchema.parse(config);
-  query(sql, /* sql */ `UPDATE rigs SET config = ? WHERE id = ?`, [JSON.stringify(validated), rigId]);
+  const existing = getRig(sql, rigId);
+  const merged = RigOverrideConfigSchema.parse({ ...(existing?.config ?? {}), ...config });
+  query(sql, /* sql */ `UPDATE rigs SET config = ? WHERE id = ?`, [JSON.stringify(merged), rigId]);
 }

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -16,7 +16,7 @@ import { getGastownOrgStub } from '../dos/GastownOrg.do';
 import type { JwtOrgMembership } from '../middleware/auth.middleware';
 import { generateKiloApiToken } from '../util/kilo-token.util';
 import { resolveSecret } from '../util/secret.util';
-import { TownConfigSchema, TownConfigUpdateSchema } from '../types';
+import { TownConfigSchema, TownConfigUpdateSchema, RigOverrideConfigSchema } from '../types';
 import { resolveModel } from '../dos/town/config';
 import type { UserRigRecord } from '../db/tables/user-rigs.table';
 import {
@@ -558,7 +558,8 @@ export const gastownRouter = router({
       // Sequential to avoid "excessively deep" type inference with Rpc.Promisified DO stubs.
       const agentList = await townStub.listAgents({ rig_id: rig.id });
       const beadList = await townStub.listBeads({ rig_id: rig.id, status: 'in_progress' });
-      return { ...rig, agents: agentList, beads: beadList };
+      const townRig = await townStub.getRigAsync(rig.id);
+      return { ...rig, agents: agentList, beads: beadList, config: townRig?.config };
     }),
 
   deleteRig: gastownProcedure
@@ -585,6 +586,22 @@ export const gastownRouter = router({
       await townStub.removeRig(input.rigId);
       const ownerStub = ownership.stub;
       await ownerStub.deleteRig(input.rigId);
+    }),
+
+  updateRigConfig: gastownProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid().optional(),
+        rigId: z.string().uuid(),
+        config: RigOverrideConfigSchema,
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
+      const townStub = getTownDOStub(ctx.env, rig.town_id);
+      await townStub.updateRigConfig(input.rigId, input.config);
+      const updatedRig = await townStub.getRigAsync(input.rigId);
+      return updatedRig;
     }),
 
   // ── Beads ───────────────────────────────────────────────────────────

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -598,6 +598,31 @@ export const gastownRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
+      const ownership = await resolveTownOwnership(ctx.env, ctx, rig.town_id);
+
+      // Admins cannot modify rig config for towns they do not own
+      if (ownership.type === 'admin') {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Admins cannot modify rig configuration for rigs they do not own',
+        });
+      }
+
+      // For org towns, only owners or the town creator can update rig config
+      if (ownership.type === 'org') {
+        const townStubForCheck = getTownDOStub(ctx.env, rig.town_id);
+        const townConfig = await townStubForCheck.getTownConfig();
+        const membership = getOrgMembership(ctx.orgMemberships, ownership.orgId);
+        const isOrgOwner = membership?.role === 'owner';
+        const isTownCreator = ctx.userId === townConfig.created_by_user_id;
+        if (!isOrgOwner && !isTownCreator) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'Only town creators and org owners can update rig config',
+          });
+        }
+      }
+
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       await townStub.updateRigConfig(input.rigId, input.config);
       const updatedRig = await townStub.getRigAsync(input.rigId);

--- a/services/gastown/src/trpc/schemas.ts
+++ b/services/gastown/src/trpc/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { RigOverrideConfigSchema } from '../types';
 
 /**
  * Wraps a Zod schema in z.any().pipe(schema) so the TS input type is `any`
@@ -164,6 +165,7 @@ export const RigDetailOutput = z.object({
   platform_integration_id: z.string().nullable().optional().default(null),
   created_at: z.string(),
   updated_at: z.string(),
+  config: RigOverrideConfigSchema.optional(),
   agents: z.array(AgentOutput),
   beads: z.array(BeadOutput),
 });


### PR DESCRIPTION
## Summary
- Add `config` field (typed as `RigOverrideConfigSchema`) to `RigDetailOutput` / `RpcRigDetailOutput` in `trpc/schemas.ts` so the UI can read current rig settings
- Update `getRig` tRPC procedure to fetch rig record from Town DO and include `config` in the response
- Add `updateRigConfig` tRPC mutation that validates input against `RigOverrideConfigSchema` and persists to SQLite via the Town DO
- Add `updateRigConfig` RPC method to `Town.do.ts` that delegates to `rigs.updateRigConfig(sql, rigId, config)`

## Verification
- TypeScript compiles cleanly (`tsgo --noEmit` on `cloudflare-gastown`)
- All acceptance criteria from bead 1127880a met: mutation exists, `getRig` includes `config`, invalid fields rejected by Zod

## Visual Changes
N/A

## Reviewer Notes
- `getRig` now makes an extra call to `townStub.getRigAsync(rig.id)` to fetch the config stored in Town DO SQLite (the rig returned by `verifyRigOwnership` comes from the owner DO and does not carry the `config` field)
- `updateRigConfig` returns the updated `RigRecord | null` from the Town DO; callers can use it to update their local cache