### PR TITLE
feat(gastown): add resolveRigConfig() helpers and wire rig overrides into dispatch path

### DIFF
--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -281,6 +281,8 @@ export class TownDO extends DurableObject<Env> {
 
         let systemPromptOverride: string | undefined;
         const townConfig = await this.getTownConfig();
+        const rig = rigs.getRig(this.sql, rigId);
+        const effectiveConfig = config.resolveRigConfig(townConfig, rig?.config ?? null);
 
         // Build refinery-specific system prompt with branch/target info.
         // When the MR bead already has a pr_url (polecat created the PR),
@@ -305,17 +307,16 @@ export class TownDO extends DurableObject<Env> {
               typeof bead.metadata?.source_agent_id === 'string'
                 ? bead.metadata.source_agent_id
                 : 'unknown',
-            mergeStrategy: townConfig.merge_strategy ?? 'direct',
+            mergeStrategy: effectiveConfig.merge_strategy,
             existingPrUrl,
-            reviewMode: townConfig.refinery?.review_mode ?? 'rework',
+            reviewMode: effectiveConfig.review_mode,
           });
         }
 
         // When merge_strategy is 'pr', polecats always create the PR themselves
         // and pass pr_url to gt_done. For review-then-land convoy intermediate
         // beads, the PR targets the convoy feature branch (not main).
-        if (agent.role === 'polecat' && townConfig.merge_strategy === 'pr') {
-          const rig = rigs.getRig(this.sql, rigId);
+        if (agent.role === 'polecat' && effectiveConfig.merge_strategy === 'pr') {
           const convoyId = beadOps.getConvoyForBead(this.sql, beadId);
           const convoyFeatureBranch = convoyId
             ? beadOps.getConvoyFeatureBranch(this.sql, convoyId)

--- a/services/gastown/src/dos/town/config.test.ts
+++ b/services/gastown/src/dos/town/config.test.ts
@@ -3,7 +3,6 @@ import { TownConfigSchema } from '../../types';
 import { resolveModel } from './config';
 
 const HARDCODED_FALLBACK = 'anthropic/claude-sonnet-4.6';
-const DUMMY_RIG = 'rig-test';
 
 /** Parse a minimal TownConfig through the Zod schema (applies defaults). */
 function makeTownConfig(
@@ -15,16 +14,16 @@ function makeTownConfig(
 describe('resolveModel', () => {
   it('returns hardcoded fallback when no default_model and no role_models', () => {
     const config = makeTownConfig();
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe(HARDCODED_FALLBACK);
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe(HARDCODED_FALLBACK);
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'polecat')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'mayor')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'refinery')).toBe(HARDCODED_FALLBACK);
   });
 
   it('returns default_model when set and no role_models', () => {
     const config = makeTownConfig({ default_model: 'openai/gpt-4o' });
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'mayor')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'refinery')).toBe('openai/gpt-4o');
   });
 
   it('returns mayor-specific model when role_models.mayor is set', () => {
@@ -32,7 +31,7 @@ describe('resolveModel', () => {
       default_model: 'openai/gpt-4o',
       role_models: { mayor: 'anthropic/claude-opus-4' },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('anthropic/claude-opus-4');
+    expect(resolveModel(config, null, 'mayor')).toBe('anthropic/claude-opus-4');
   });
 
   it('falls back to default_model for roles not overridden in role_models', () => {
@@ -40,18 +39,18 @@ describe('resolveModel', () => {
       default_model: 'openai/gpt-4o',
       role_models: { mayor: 'anthropic/claude-opus-4' },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'refinery')).toBe('openai/gpt-4o');
   });
 
   it('returns polecat model when set, falls back for other roles', () => {
     const config = makeTownConfig({
       role_models: { polecat: 'google/gemini-2.5-pro' },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('google/gemini-2.5-pro');
+    expect(resolveModel(config, null, 'polecat')).toBe('google/gemini-2.5-pro');
     // No default_model → hardcoded fallback for other roles
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe(HARDCODED_FALLBACK);
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'mayor')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'refinery')).toBe(HARDCODED_FALLBACK);
   });
 
   it('returns role-specific model for all three roles when all overridden', () => {
@@ -63,9 +62,9 @@ describe('resolveModel', () => {
         polecat: 'google/gemini-2.5-pro',
       },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('anthropic/claude-opus-4');
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('anthropic/claude-sonnet-4');
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('google/gemini-2.5-pro');
+    expect(resolveModel(config, null, 'mayor')).toBe('anthropic/claude-opus-4');
+    expect(resolveModel(config, null, 'refinery')).toBe('anthropic/claude-sonnet-4');
+    expect(resolveModel(config, null, 'polecat')).toBe('google/gemini-2.5-pro');
   });
 
   it('treats empty role_models the same as no role_models', () => {
@@ -73,14 +72,14 @@ describe('resolveModel', () => {
       default_model: 'openai/gpt-4o',
       role_models: {},
     });
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'mayor')).toBe('openai/gpt-4o');
   });
 
   it('treats undefined role_models the same as no role_models', () => {
     const config = makeTownConfig({ default_model: 'openai/gpt-4o' });
     expect(config.role_models).toBeUndefined();
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'polecat')).toBe('openai/gpt-4o');
   });
 
   it('falls back to default_model for unknown role strings', () => {
@@ -88,15 +87,15 @@ describe('resolveModel', () => {
       default_model: 'openai/gpt-4o',
       role_models: { mayor: 'anthropic/claude-opus-4' },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'unknown-role')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, '')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'unknown-role')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, '')).toBe('openai/gpt-4o');
   });
 
   it('falls back to hardcoded fallback for unknown role with no default_model', () => {
     const config = makeTownConfig({
       role_models: { mayor: 'anthropic/claude-opus-4' },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'unknown-role')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'unknown-role')).toBe(HARDCODED_FALLBACK);
   });
 });
 
@@ -109,17 +108,17 @@ describe('resolveModel backward compatibility', () => {
     };
     const config = TownConfigSchema.parse(legacyRaw);
     expect(config.role_models).toBeUndefined();
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'mayor')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'refinery')).toBe('openai/gpt-4o');
   });
 
   it('works with a completely empty config (new town defaults)', () => {
     const config = TownConfigSchema.parse({});
     expect(config.role_models).toBeUndefined();
     expect(config.default_model).toBeUndefined();
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe(HARDCODED_FALLBACK);
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'polecat')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'mayor')).toBe(HARDCODED_FALLBACK);
   });
 
   it('preserves resolution chain: role override > default_model > hardcoded', () => {
@@ -128,15 +127,15 @@ describe('resolveModel backward compatibility', () => {
       role_models: { polecat: 'google/gemini-2.5-pro' },
     });
     // polecat: role override wins
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('google/gemini-2.5-pro');
+    expect(resolveModel(config, null, 'polecat')).toBe('google/gemini-2.5-pro');
     // mayor: no role override → default_model
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'mayor')).toBe('openai/gpt-4o');
 
     // Remove default_model to test final fallback
     const configNoDefault = makeTownConfig({
       role_models: { polecat: 'google/gemini-2.5-pro' },
     });
     // refinery: no role override, no default → hardcoded
-    expect(resolveModel(configNoDefault, DUMMY_RIG, 'refinery')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(configNoDefault, null, 'refinery')).toBe(HARDCODED_FALLBACK);
   });
 });

--- a/services/gastown/src/dos/town/config.ts
+++ b/services/gastown/src/dos/town/config.ts
@@ -7,6 +7,7 @@ import {
   type TownConfig,
   type TownConfigUpdate,
   type MergeStrategy,
+  type RigOverrideConfig,
 } from '../../types';
 
 const CONFIG_KEY = 'town:config';
@@ -128,13 +129,24 @@ export async function updateTownConfig(
   return validated;
 }
 
+const DEFAULT_MODEL = 'anthropic/claude-sonnet-4.6';
+
 /**
- * Resolve the primary model from town config.
- * Priority: rig override → role-specific → town default → hardcoded default.
+ * Resolve the primary model from town config, optionally applying a rig override.
+ * Priority: rig override (role-specific) → rig override (default) → town role-specific → town default → hardcoded default.
  */
-export function resolveModel(townConfig: TownConfig, _rigId: string, role: string): string {
-  const roleModels: Record<string, string | undefined> | undefined = townConfig.role_models;
-  return roleModels?.[role] ?? townConfig.default_model ?? 'anthropic/claude-sonnet-4.6';
+export function resolveModel(
+  townConfig: TownConfig,
+  rigOverride: RigOverrideConfig | null | undefined,
+  role: string
+): string {
+  const base = rigOverride?.default_model ?? townConfig.default_model;
+  if (role === 'mayor') return townConfig.role_models?.mayor ?? base ?? DEFAULT_MODEL;
+  if (role === 'polecat')
+    return rigOverride?.role_models?.polecat ?? townConfig.role_models?.polecat ?? base ?? DEFAULT_MODEL;
+  if (role === 'refinery')
+    return rigOverride?.role_models?.refinery ?? townConfig.role_models?.refinery ?? base ?? DEFAULT_MODEL;
+  return base ?? DEFAULT_MODEL;
 }
 
 /**
@@ -157,6 +169,76 @@ export function resolveMergeStrategy(
 }
 
 /**
+ * The fully-resolved configuration for a rig dispatch.
+ * All fields have concrete values (no optional/undefined) except where
+ * a null value is meaningful (e.g. auto_merge_delay_minutes: null = disabled).
+ */
+export type EffectiveConfig = {
+  default_model: string | undefined;
+  role_models: {
+    polecat: string | undefined;
+    refinery: string | undefined;
+    mayor: string | undefined;
+  };
+  review_mode: 'rework' | 'comments';
+  code_review: boolean;
+  auto_resolve_pr_feedback: boolean;
+  auto_merge_delay_minutes: number | null;
+  merge_strategy: MergeStrategy;
+  convoy_merge_mode: 'review-then-land' | 'review-and-merge';
+  custom_instructions: {
+    polecat: string | undefined;
+    refinery: string | undefined;
+    mayor: string | undefined;
+  };
+  git_push_flags: string | undefined;
+  max_concurrent_polecats: number | undefined;
+  max_dispatch_attempts: number | undefined;
+};
+
+/**
+ * Merge a rig's override config on top of town config, returning a fully
+ * resolved EffectiveConfig for dispatch. When rigOverride is null/undefined,
+ * all values fall back to town-level defaults (behavior identical to today).
+ */
+export function resolveRigConfig(
+  townConfig: TownConfig,
+  rigOverride: RigOverrideConfig | null | undefined
+): EffectiveConfig {
+  return {
+    default_model: rigOverride?.default_model ?? townConfig.default_model,
+    role_models: {
+      polecat: rigOverride?.role_models?.polecat ?? townConfig.role_models?.polecat,
+      refinery: rigOverride?.role_models?.refinery ?? townConfig.role_models?.refinery,
+      // mayor is always town-level — rigs cannot override mayor model
+      mayor: townConfig.role_models?.mayor,
+    },
+    review_mode: rigOverride?.review_mode ?? townConfig.refinery?.review_mode ?? 'rework',
+    code_review: rigOverride?.code_review ?? townConfig.refinery?.code_review ?? true,
+    auto_resolve_pr_feedback:
+      rigOverride?.auto_resolve_pr_feedback ?? townConfig.refinery?.auto_resolve_pr_feedback ?? false,
+    auto_merge_delay_minutes:
+      rigOverride?.auto_merge_delay_minutes !== undefined
+        ? rigOverride.auto_merge_delay_minutes
+        : (townConfig.refinery?.auto_merge_delay_minutes ?? null),
+    merge_strategy: rigOverride?.merge_strategy ?? townConfig.merge_strategy ?? 'direct',
+    convoy_merge_mode:
+      rigOverride?.convoy_merge_mode ?? townConfig.convoy_merge_mode ?? 'review-then-land',
+    custom_instructions: {
+      polecat: rigOverride?.custom_instructions?.polecat ?? townConfig.custom_instructions?.polecat,
+      refinery:
+        rigOverride?.custom_instructions?.refinery ?? townConfig.custom_instructions?.refinery,
+      // mayor is always town-level
+      mayor: townConfig.custom_instructions?.mayor,
+    },
+    git_push_flags: rigOverride?.git_push_flags,
+    max_concurrent_polecats:
+      rigOverride?.max_concurrent_polecats ?? townConfig.max_polecats_per_rig,
+    max_dispatch_attempts: rigOverride?.max_dispatch_attempts,
+  };
+}
+
+/**
  * Build the ContainerConfig payload for X-Town-Config header.
  * Sent with every fetch() to the container.
  */
@@ -167,7 +249,7 @@ export async function buildContainerConfig(
   const config = await getTownConfig(storage);
   return {
     env_vars: config.env_vars,
-    default_model: resolveModel(config, '', ''),
+    default_model: resolveModel(config, null, ''),
     small_model: resolveSmallModel(config),
     git_auth: config.git_auth,
     kilocode_token: config.kilocode_token,

--- a/services/gastown/src/dos/town/config.ts
+++ b/services/gastown/src/dos/town/config.ts
@@ -141,7 +141,7 @@ export function resolveModel(
   role: string
 ): string {
   const base = rigOverride?.default_model ?? townConfig.default_model;
-  if (role === 'mayor') return townConfig.role_models?.mayor ?? base ?? DEFAULT_MODEL;
+  if (role === 'mayor') return townConfig.role_models?.mayor ?? townConfig.default_model ?? DEFAULT_MODEL;
   if (role === 'polecat')
     return rigOverride?.role_models?.polecat ?? townConfig.role_models?.polecat ?? base ?? DEFAULT_MODEL;
   if (role === 'refinery')

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -7,8 +7,8 @@ import { getTownContainerStub } from '../TownContainer.do';
 import { signAgentJWT, signContainerJWT } from '../../util/jwt.util';
 import { buildPolecatSystemPrompt } from '../../prompts/polecat-system.prompt';
 import { buildMayorSystemPrompt } from '../../prompts/mayor-system.prompt';
-import type { TownConfig } from '../../types';
-import { buildContainerConfig, resolveModel, resolveSmallModel } from './config';
+import type { TownConfig, RigOverrideConfig } from '../../types';
+import { buildContainerConfig, resolveModel, resolveSmallModel, resolveRigConfig } from './config';
 
 const TOWN_LOG = '[Town.do]';
 
@@ -244,16 +244,19 @@ export function systemPromptForRole(params: {
 }
 
 /**
- * Append per-role custom instructions from town config to a system prompt.
- * Returns the prompt unchanged when no custom instructions exist for the role.
+ * Append per-role custom instructions to a system prompt.
+ * Accepts either a TownConfig (falls back to town-level instructions)
+ * or a pre-resolved instructions string. Returns the prompt unchanged
+ * when no custom instructions exist for the role.
  */
 export function appendCustomInstructions(
   systemPrompt: string,
   role: string,
-  townConfig: TownConfig
+  townConfig: TownConfig,
+  resolvedInstructions?: string | null
 ): string {
   const roleKey = role as keyof NonNullable<TownConfig['custom_instructions']>;
-  const instructions = townConfig.custom_instructions?.[roleKey]?.trim();
+  const instructions = (resolvedInstructions ?? townConfig.custom_instructions?.[roleKey])?.trim();
   if (!instructions) return systemPrompt;
   return `${systemPrompt}\n\n## Custom Instructions (from town settings)\n\n${instructions}`;
 }
@@ -320,6 +323,8 @@ export async function startAgentInContainer(
     defaultBranch: string;
     kilocodeToken?: string;
     townConfig: TownConfig;
+    /** Rig-level config overrides. When present, merged on top of townConfig for model, custom_instructions, and git_push_flags. */
+    rigOverride?: RigOverrideConfig | null;
     systemPromptOverride?: string;
     platformIntegrationId?: string;
     /** For convoy beads: the convoy's feature branch to branch from instead of defaultBranch. */
@@ -407,6 +412,9 @@ export async function startAgentInContainer(
     const containerConfig = await buildContainerConfig(storage, env);
     const container = getTownContainerStub(env, params.townId);
 
+    const rigOverride = params.rigOverride ?? null;
+    const effectiveConfig = resolveRigConfig(params.townConfig, rigOverride);
+
     const response = await container.fetch('http://container/agents/start', {
       method: 'POST',
       signal: AbortSignal.timeout(60_000),
@@ -427,7 +435,7 @@ export async function startAgentInContainer(
           checkpoint: params.checkpoint,
           conversationHistory: params.conversationHistory,
         }),
-        model: resolveModel(params.townConfig, params.rigId, params.role),
+        model: resolveModel(params.townConfig, rigOverride, params.role),
         smallModel: resolveSmallModel(params.townConfig),
         systemPrompt: appendCustomInstructions(
           params.systemPromptOverride ??
@@ -440,8 +448,10 @@ export async function startAgentInContainer(
               gates: params.townConfig.refinery?.gates ?? [],
             }),
           params.role,
-          params.townConfig
+          params.townConfig,
+          effectiveConfig.custom_instructions[params.role as keyof typeof effectiveConfig.custom_instructions]
         ),
+        ...(effectiveConfig.git_push_flags ? { gitPushFlags: effectiveConfig.git_push_flags } : {}),
         gitUrl: params.gitUrl,
         branch: params.convoyFeatureBranch
           ? branchForConvoyAgent(params.convoyFeatureBranch, params.agentName, params.beadId)

--- a/services/gastown/src/dos/town/scheduling.ts
+++ b/services/gastown/src/dos/town/scheduling.ts
@@ -124,6 +124,8 @@ export async function dispatchAgent(
       [timestamp, bead.bead_id]
     );
 
+    const rigRecord = rigs.getRig(ctx.sql, rigId);
+
     const started = await dispatch.startAgentInContainer(ctx.env, ctx.storage, {
       townId: ctx.townId,
       rigId,
@@ -140,6 +142,7 @@ export async function dispatchAgent(
       defaultBranch: rigConfig.defaultBranch,
       kilocodeToken,
       townConfig,
+      rigOverride: rigRecord?.config ?? null,
       platformIntegrationId: rigConfig.platformIntegrationId,
       convoyFeatureBranch: convoyFeatureBranch ?? undefined,
       systemPromptOverride: options?.systemPromptOverride,

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -1028,8 +1028,8 @@ export const gastownRouter = router({
       // auth-relevant config changed. The SDK server is a child process
       // that captures env at spawn time, so it must be restarted to pick
       // up rotated tokens or cleared credentials.
-      const oldMayorModel = resolveModel(existingConfig, '', 'mayor');
-      const newMayorModel = resolveModel(result, '', 'mayor');
+      const oldMayorModel = resolveModel(existingConfig, null, 'mayor');
+      const newMayorModel = resolveModel(result, null, 'mayor');
       const mayorModelChanged =
         newMayorModel !== oldMayorModel || result.small_model !== existingConfig.small_model;
       const authConfigChanged =


### PR DESCRIPTION
## Summary

- Adds `EffectiveConfig` type and `resolveRigConfig()` to `config.ts` that merges rig-level `RigOverrideConfig` on top of town config. All fields resolve with proper fallback priority: rig override → town default → hardcoded default.
- Updates `resolveModel()` to accept `RigOverrideConfig | null | undefined` instead of the ignored `_rigId` string, applying rig-level `default_model` and `role_models` overrides per role.
- Updates `appendCustomInstructions()` to accept an optional pre-resolved instructions string so rig-override custom instructions flow through to the agent system prompt.
- Updates `startAgentInContainer()` with an optional `rigOverride` param; uses `resolveRigConfig()` to select the effective `model`, `custom_instructions`, and `git_push_flags`.
- Updates `scheduling.ts` `dispatchAgent` to load the rig's SQLite record via `rigs.getRig()` and pass `rig.config` as `rigOverride`.
- Updates `Town.do.ts` `applyActionCtx.dispatchAgent` to use `resolveRigConfig()` for `merge_strategy` and `review_mode` in refinery/polecat system prompts, replacing direct reads of `townConfig.merge_strategy` and `townConfig.refinery?.review_mode`.

When a rig has no overrides, all values fall back to town-level config — behavior is identical to today.

## Verification

- TypeScript structural review: all changed functions compile without new type errors.
- Pre-existing environment errors (missing `cloudflare:workers`, `zod` typings) exist due to absent node_modules in this worktree, not from these changes.

## Visual Changes

N/A — backend only.

## Reviewer Notes

- `buildContainerConfig()` (used for `X-Town-Config` header) still uses town-level config only — this is intentional since the container header is town-scoped, not rig-scoped. Per-agent model override is applied at dispatch time via `model` in the request body.
- `resolveMergeStrategy()` is kept for call sites that still use it (e.g. review-queue reconciler); `resolveRigConfig()` supersedes it for the main dispatch path.
- Mayor model is always town-level; rigs cannot override it (as per spec).