### PR TITLE
feat(convoy): create feature branch on remote at convoy creation time

### DIFF
--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -2996,6 +2996,26 @@ export class TownDO extends DurableObject<Env> {
       [convoyId, input.tasks.length, 0, null, featureBranch, mergeMode, stagedValue]
     );
 
+    // Push the convoy feature branch to the remote so polecats can immediately
+    // open PRs targeting it and the refinery can merge into it.
+    const rig = rigs.getRig(this.sql, input.rigId);
+    if (rig) {
+      await scm
+        .createConvoyBranch(
+          { env: this.env, townId: this.townId, getTownConfig: () => this.getTownConfig() },
+          {
+            gitUrl: rig.git_url,
+            defaultBranch: rig.default_branch,
+            featureBranch,
+          }
+        )
+        .catch(err =>
+          console.warn(`${TOWN_LOG} slingConvoy: createConvoyBranch failed (non-fatal)`, {
+            error: err instanceof Error ? err.message : String(err),
+          })
+        );
+    }
+
     // 2. Create all beads and track their IDs (needed for depends_on resolution)
     const beadIds: string[] = [];
     const results: Array<{ bead: Bead; agent: Agent | null }> = [];

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -3000,9 +3000,15 @@ export class TownDO extends DurableObject<Env> {
     // open PRs targeting it and the refinery can merge into it.
     const rig = rigs.getRig(this.sql, input.rigId);
     if (rig) {
+      const rigConfig = await this.getRigConfig(input.rigId);
       await scm
         .createConvoyBranch(
-          { env: this.env, townId: this.townId, getTownConfig: () => this.getTownConfig() },
+          {
+            env: this.env,
+            townId: this.townId,
+            getTownConfig: () => this.getTownConfig(),
+            platformIntegrationId: rigConfig?.platformIntegrationId,
+          },
           {
             gitUrl: rig.git_url,
             defaultBranch: rig.default_branch,

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -447,9 +447,9 @@ export async function startAgentInContainer(
           ? branchForConvoyAgent(params.convoyFeatureBranch, params.agentName, params.beadId)
           : branchForAgent(params.agentName, params.beadId),
         // Always use the rig's real default branch for the initial git clone.
-        // The convoy feature branch may not exist on the remote yet (the first
-        // agent's work creates it via the refinery merge). The agent's working
-        // branch is created as a worktree from HEAD after clone.
+        // The agent's working branch is created as a worktree from HEAD after
+        // clone; for convoy agents the startPoint below positions that worktree
+        // at the convoy's feature branch tip.
         defaultBranch: params.defaultBranch,
         envVars,
         platformIntegrationId: params.platformIntegrationId,

--- a/services/gastown/src/dos/town/town-scm.ts
+++ b/services/gastown/src/dos/town/town-scm.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
 import type { TownConfig } from '../../types';
 import type { PRFeedbackCheckResult } from './actions';
-import { GitHubPRStatusSchema, GitLabMRStatusSchema } from '../../util/platform-pr.util';
+import {
+  GitHubPRStatusSchema,
+  GitLabMRStatusSchema,
+  parseGitUrl,
+} from '../../util/platform-pr.util';
 import { writeEvent } from '../../util/analytics.util';
 
 const TOWN_LOG = '[town-scm]';
@@ -476,4 +480,94 @@ export async function mergePR(ctx: SCMContext, prUrl: string): Promise<boolean> 
 
   console.warn(`${TOWN_LOG} mergePR: all merge methods rejected for ${prUrl}`);
   return false;
+}
+
+/**
+ * Create the convoy feature branch on the remote GitHub repository so that it
+ * exists before any polecat tries to open a PR targeting it.
+ *
+ * The branch is created at the current tip of the rig's default branch.
+ * If the branch already exists (HTTP 422) the call is treated as a no-op.
+ * If no GitHub token is available, the error is logged and the function
+ * returns without throwing — convoy creation continues, but branch creation
+ * is skipped.
+ */
+export async function createConvoyBranch(
+  ctx: SCMContext,
+  opts: {
+    gitUrl: string;
+    defaultBranch: string;
+    featureBranch: string;
+  }
+): Promise<void> {
+  const token = await resolveGitHubToken(ctx);
+  if (!token) {
+    console.warn(
+      `${TOWN_LOG} createConvoyBranch: no GitHub token available — skipping branch creation for ${opts.featureBranch}`
+    );
+    return;
+  }
+
+  const coords = parseGitUrl(opts.gitUrl);
+  if (!coords || coords.platform !== 'github') {
+    // Non-GitHub repos or unparseable URLs: skip silently (GitLab uses a
+    // different flow; nothing breaks if the branch doesn't pre-exist there).
+    return;
+  }
+
+  const { owner, repo } = coords;
+  const apiBase = `https://api.github.com/repos/${owner}/${repo}`;
+  const headers = {
+    Authorization: `token ${token}`,
+    Accept: 'application/vnd.github.v3+json',
+    'User-Agent': 'Gastown/1.0',
+    'Content-Type': 'application/json',
+  };
+
+  // 1. Resolve the SHA at the tip of the default branch.
+  const refRes = await fetch(`${apiBase}/git/ref/heads/${opts.defaultBranch}`, { headers });
+  if (!refRes.ok) {
+    const text = await refRes.text().catch(() => '(unreadable)');
+    console.warn(
+      `${TOWN_LOG} createConvoyBranch: failed to resolve default branch SHA (${refRes.status}): ${text.slice(0, 200)}`
+    );
+    return;
+  }
+
+  const refJson = await refRes.json().catch(() => null);
+  const shaResult = z
+    .object({ object: z.object({ sha: z.string() }) })
+    .safeParse(refJson);
+  if (!shaResult.success) {
+    console.warn(`${TOWN_LOG} createConvoyBranch: unexpected ref response shape`);
+    return;
+  }
+  const sha = shaResult.data.object.sha;
+
+  // 2. Create the convoy feature branch pointing at that SHA.
+  const createRes = await fetch(`${apiBase}/git/refs`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ ref: `refs/heads/${opts.featureBranch}`, sha }),
+  });
+
+  if (createRes.ok) {
+    console.log(
+      `${TOWN_LOG} createConvoyBranch: created ${opts.featureBranch} at ${sha.slice(0, 8)} in ${owner}/${repo}`
+    );
+    return;
+  }
+
+  if (createRes.status === 422) {
+    // Branch already exists — idempotent, treat as success.
+    console.log(
+      `${TOWN_LOG} createConvoyBranch: branch ${opts.featureBranch} already exists in ${owner}/${repo} — skipping`
+    );
+    return;
+  }
+
+  const errText = await createRes.text().catch(() => '(unreadable)');
+  console.warn(
+    `${TOWN_LOG} createConvoyBranch: GitHub API returned ${createRes.status} when creating ${opts.featureBranch}: ${errText.slice(0, 200)}`
+  );
 }

--- a/services/gastown/src/dos/town/town-scm.ts
+++ b/services/gastown/src/dos/town/town-scm.ts
@@ -14,17 +14,24 @@ export type SCMContext = {
   env: Env;
   townId: string;
   getTownConfig: () => Promise<TownConfig>;
+  /**
+   * Rig-level platform integration ID. When provided, it is tried as a
+   * fallback after town-level git_auth so that rigs authenticated solely
+   * through a rig-scoped GitHub App installation can still resolve a token.
+   */
+  platformIntegrationId?: string;
 };
 
 /**
  * Resolve a GitHub API token from the town config.
- * Fallback chain: github_token → github_cli_pat → platform integration (GitHub App).
+ * Fallback chain: github_token → github_cli_pat → town platform integration → rig platform integration.
  */
 export async function resolveGitHubToken(ctx: SCMContext): Promise<string | null> {
   const townConfig = await ctx.getTownConfig();
   let token = townConfig.git_auth?.github_token ?? townConfig.github_cli_pat;
   if (!token) {
-    const integrationId = townConfig.git_auth?.platform_integration_id;
+    const integrationId =
+      townConfig.git_auth?.platform_integration_id ?? ctx.platformIntegrationId;
     if (integrationId && ctx.env.GIT_TOKEN_SERVICE) {
       try {
         token = await ctx.env.GIT_TOKEN_SERVICE.getToken(integrationId);


### PR DESCRIPTION
## Summary

- Add `createConvoyBranch()` to `town-scm.ts` that calls the GitHub REST API (`POST /repos/{owner}/{repo}/git/refs`) to create the convoy feature branch pointing at the default branch tip immediately when a convoy is created.
- Call `createConvoyBranch()` in `slingConvoy()` in `Town.do.ts` right after `convoy_metadata` is stored, so the branch exists before any polecat opens a PR targeting it.
- Remove the stale comment in `container-dispatch.ts` that acknowledged the convoy branch "may not exist yet".

**Failure modes handled gracefully (no crash, just a log warning):**
- No GitHub token available → skip branch creation
- Non-GitHub repo (GitLab or unparseable URL) → skip silently
- HTTP 422 (branch already exists) → idempotent no-op
- Any unexpected GitHub API error → logged, does not abort convoy creation

Fixes: https://github.com/Kilo-Org/cloud/issues/2263

## Verification

- Code reviewed manually for type correctness (`tsgo` not available in this environment)
- `parseGitUrl` already handles all supported git URL formats (HTTPS and SSH)
- `resolveGitHubToken` already handles the full token fallback chain (github_token → github_cli_pat → platform integration)

## Visual Changes

N/A

## Reviewer Notes

The `createConvoyBranch` call is wrapped in `.catch()` so a GitHub API failure can never abort convoy creation. The branch creation is awaited (not fire-and-forget) so that if it succeeds the first polecat dispatched will find the branch ready. If it fails, the convoy still exists and a human can manually create the branch as a fallback.