### PR TITLE
feat(api): add optimized, filtered variant of `/api/modelstats`

### DIFF
--- a/apps/web/src/app/api/modelstats/route.test.ts
+++ b/apps/web/src/app/api/modelstats/route.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { NextRequest } from 'next/server';
+
+type ModelLookupRow = {
+  requested_model: string;
+  cost: string;
+  costPerRequest: string;
+};
+
+type ModelLookupResult = {
+  rows: ModelLookupRow[];
+};
+
+const mockExecute = jest.fn<(query: unknown) => Promise<ModelLookupResult>>();
+
+jest.mock('next/cache', () => ({
+  unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
+jest.mock('@/lib/drizzle', () => ({
+  readDb: {
+    execute: mockExecute,
+  },
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
+}));
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+}));
+
+describe('GET /api/modelstats', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockExecute.mockReset();
+  });
+
+  test('returns 400 when model is omitted', async () => {
+    const { GET } = await import('./route');
+    const response = await GET(new NextRequest('http://localhost:3000/api/modelstats'));
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(await response.json()).toEqual({
+      error: '`model` parameter must be specified',
+    });
+  });
+
+  test('returns live stats for the requested model', async () => {
+    mockExecute.mockResolvedValue({
+      rows: [
+        {
+          requested_model: 'openai/gpt-5.4',
+          cost: '1.05938032698464',
+          costPerRequest: '0.0800828164797871',
+        },
+      ],
+    });
+
+    const { GET } = await import('./route');
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/modelstats?model=openai%2Fgpt-5.4')
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(await response.json()).toEqual({
+      model: 'openai/gpt-5.4',
+      cost: 1.05938032698464,
+      costPerRequest: 0.0800828164797871,
+    });
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns 404 when the requested model has no data', async () => {
+    mockExecute.mockResolvedValue({ rows: [] });
+
+    const { GET } = await import('./route');
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/modelstats?model=does-not-exist')
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(await response.json()).toEqual({ error: 'Model stats not found' });
+  });
+
+  test('treats an empty model parameter as a lookup instead of falling back', async () => {
+    mockExecute.mockResolvedValue({ rows: [] });
+
+    const { GET } = await import('./route');
+    const response = await GET(new NextRequest('http://localhost:3000/api/modelstats?model='));
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/app/api/modelstats/route.ts
+++ b/apps/web/src/app/api/modelstats/route.ts
@@ -1,0 +1,106 @@
+import { readDb, sql } from '@/lib/drizzle';
+import { microdollar_usage } from '@kilocode/db/schema';
+import { captureException } from '@sentry/nextjs';
+import { unstable_cache } from 'next/cache';
+import { NextResponse } from 'next/server';
+
+type ModelStat = {
+  model: string;
+  cost: number;
+  costPerRequest: number;
+};
+
+type ModelStatsError = {
+  error: string;
+};
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': '*',
+} satisfies Record<string, string>;
+
+const getCachedModelStat = unstable_cache(
+  async (model: string): Promise<ModelStat | null> => {
+    const result = await readDb.execute<{
+      requested_model: string;
+      cost: string;
+      costPerRequest: string;
+    }>(sql`
+      select
+        requested_model,
+        sum(cost) / sum(input_tokens + output_tokens) as cost,
+        sum(cost) / count(*) / 1000000 as "costPerRequest"
+      from ${microdollar_usage}
+      where
+        created_at > now() - interval '7 days'
+        and requested_model = ${model}
+        and input_tokens + output_tokens > 0
+        and cost > 0
+      group by requested_model
+    `);
+
+    const row = result.rows[0];
+    if (!row) {
+      return null;
+    }
+
+    return {
+      model: row.requested_model,
+      cost: Number(row.cost),
+      costPerRequest: Number(row.costPerRequest),
+    };
+  },
+  undefined,
+  { revalidate: 3600 }
+);
+
+type ModelStatsResponse = ModelStat[] | ModelStat | ModelStatsError;
+
+export async function GET(request: Request): Promise<NextResponse<ModelStatsResponse>> {
+  const { searchParams } = new URL(request.url);
+  const model = searchParams.get('model');
+
+  if (model === null) {
+    return NextResponse.json(
+      { error: '`model` parameter must be specified' },
+      {
+        status: 400,
+        headers: CORS_HEADERS,
+      }
+    );
+  }
+
+  // this route with `?model=` filtering is optimized
+  // to be usable moving forward
+  try {
+    const stat = await getCachedModelStat(model);
+
+    if (!stat) {
+      return NextResponse.json(
+        { error: 'Model stats not found' },
+        {
+          status: 404,
+          headers: CORS_HEADERS,
+        }
+      );
+    }
+
+    return NextResponse.json(stat, {
+      headers: CORS_HEADERS,
+    });
+  } catch (error) {
+    captureException(error, {
+      tags: { endpoint: 'modelstats', source: 'model_lookup' },
+      extra: { model },
+    });
+
+    return NextResponse.json(
+      { error: 'Failed to load model stats' },
+      {
+        status: 500,
+        headers: CORS_HEADERS,
+      }
+    );
+  }
+}


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

The old `/api/modelstats` endpoint was replaced with hardcoded snapshot data due to performance concerns. However, this removed the ability to get real average cost calculations, which was a desirable feature for some users to help make model selection decisions.

This change adds a `model` query parameter to the endpoint, allowing callers to choose a specific model to retrieve usage stats for. This reduces the amount of data needing to be grouped and returned by the DB, since on average users will be querying these stats for fewer than 30 different models in the model picker. This also caches the results per model, with a TTL of 1 hour, to avoid repeated database queries for this data where we don't care about small fluctuations over the course of short time periods.

This can be used in the new extension UI in the near future.

The endpoint will return an error when no `model` parameter is present.