### PR TITLE
feat(promo): add KiloClaw email campaign promo code

### DIFF
--- a/apps/web/src/lib/promoCreditCategories.ts
+++ b/apps/web/src/lib/promoCreditCategories.ts
@@ -694,6 +694,15 @@ const encryptedSelfServicePromos: readonly EncryptedSelfServicePromoCreditCatego
     description: 'Miami ClawCon Credits',
     total_redemptions_allowed: 1050,
   },
+  {
+    encrypted_credit_category:
+      'vJgJcT7c/a9FMk3NKVsbgA==:21MktBLukQU8qyUX4OHDQA==:PPkWdB0MzOPAynfY/5Cla2c=',
+    is_user_selfservicable: true,
+    is_idempotent: true,
+    amount_usd: 9,
+    promotion_ends_at: new Date('2026-04-30'),
+    total_redemptions_allowed: 563,
+  },
 ];
 
 const selfServicePromos: readonly SelfServicePromoCreditCategoryConfig[] =

--- a/apps/web/src/scripts/encrypt-promo-codes.ts
+++ b/apps/web/src/scripts/encrypt-promo-codes.ts
@@ -6,10 +6,14 @@
  *   vercel env run -e production -- pnpm promo decrypt <encrypted>
  *
  * Requires CREDIT_CATEGORIES_ENCRYPTION_KEY environment variable (injected via `vercel env run`).
+ *
+ * NOTE: This script intentionally avoids importing from promoCreditEncryption or
+ * config.server to prevent top-level env var validation (e.g. NEXTAUTH_SECRET)
+ * from failing in a CLI context.
  */
 
 import { getEnvVariable } from '@/lib/dotenvx';
-import { decryptPromoCode, encryptPromoCode } from '@/lib/promoCreditEncryption';
+import { decryptWithSymmetricKey, encryptWithSymmetricKey } from '@kilocode/encryption';
 
 const CREDIT_CATEGORIES_ENCRYPTION_KEY = getEnvVariable('CREDIT_CATEGORIES_ENCRYPTION_KEY');
 
@@ -26,10 +30,10 @@ if (!operation || !value) {
 }
 
 if (operation === 'encrypt') {
-  const encrypted = encryptPromoCode(value);
+  const encrypted = encryptWithSymmetricKey(value, CREDIT_CATEGORIES_ENCRYPTION_KEY);
   console.log(`Encrypted: ${encrypted}`);
 } else if (operation === 'decrypt') {
-  const decrypted = decryptPromoCode(value);
+  const decrypted = decryptWithSymmetricKey(value, CREDIT_CATEGORIES_ENCRYPTION_KEY);
   console.log(`Decrypted: ${decrypted}`);
 } else {
   console.error(`Unknown operation: ${operation}. Use 'encrypt' or 'decrypt'.`);


### PR DESCRIPTION
## Summary

Adds a new self-service promo code for the KiloClaw email campaign. The promo grants $9 in credits, expires April 30 2026, and is capped at 563 redemptions.

Also refactors the `encrypt-promo-codes` CLI script to import encryption functions directly from `@kilocode/encryption` instead of the `promoCreditEncryption` wrapper. The wrapper triggers top-level env var validation (e.g. `NEXTAUTH_SECRET`) that fails in a CLI context — the script only needs `CREDIT_CATEGORIES_ENCRYPTION_KEY`.

## Verification

- [ ] _Add any manual verification steps here_

## Visual Changes

N/A

## Reviewer Notes

<details>
<summary>Code Reviewer Notes</summary>

- New promo entry omits `description` — the field is optional on `PromoCreditCategoryConfigCore`. If a human-readable label is needed in admin UI, it can be added later.
- The encrypt script now takes the key as an explicit argument to `encryptWithSymmetricKey`/`decryptWithSymmetricKey` rather than relying on the wrapper that reads it internally. This makes the dependency on `CREDIT_CATEGORIES_ENCRYPTION_KEY` explicit.

</details>