### PR TITLE
feat(gastown): build rig settings page UI at /rigs/[rigId]/settings

### DIFF
--- a/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
@@ -12,7 +12,16 @@ import { AgentCard } from '@/components/gastown/AgentCard';
 import { ConvoyTimeline } from '@/components/gastown/ConvoyTimeline';
 import { SlingDialog } from '@/components/gastown/SlingDialog';
 import { useDrawerStack } from '@/components/gastown/DrawerStack';
-import { Plus, GitBranch, Hexagon, Bot, Layers, ChevronRight, ChevronDown, Settings } from 'lucide-react';
+import {
+  Plus,
+  GitBranch,
+  Hexagon,
+  Bot,
+  Layers,
+  ChevronRight,
+  ChevronDown,
+  Settings,
+} from 'lucide-react';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { motion, AnimatePresence } from 'motion/react';
 import Link from 'next/link';

--- a/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
@@ -12,9 +12,10 @@ import { AgentCard } from '@/components/gastown/AgentCard';
 import { ConvoyTimeline } from '@/components/gastown/ConvoyTimeline';
 import { SlingDialog } from '@/components/gastown/SlingDialog';
 import { useDrawerStack } from '@/components/gastown/DrawerStack';
-import { Plus, GitBranch, Hexagon, Bot, Layers, ChevronRight, ChevronDown } from 'lucide-react';
+import { Plus, GitBranch, Hexagon, Bot, Layers, ChevronRight, ChevronDown, Settings } from 'lucide-react';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { motion, AnimatePresence } from 'motion/react';
+import Link from 'next/link';
 
 type RigDetailPageClientProps = {
   townId: string;
@@ -129,15 +130,24 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
             </>
           )}
         </div>
-        <Button
-          variant="primary"
-          size="sm"
-          onClick={() => setIsSlingOpen(true)}
-          className="gap-1.5 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
-        >
-          <Plus className="size-3.5" />
-          Sling Work
-        </Button>
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/gastown/${townId}/rigs/${rigId}/settings`}
+            className="flex items-center justify-center rounded-md border border-white/[0.08] bg-white/[0.03] p-1.5 text-white/40 transition-colors hover:bg-white/[0.06] hover:text-white/60"
+            title="Rig settings"
+          >
+            <Settings className="size-4" />
+          </Link>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => setIsSlingOpen(true)}
+            className="gap-1.5 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+          >
+            <Plus className="size-3.5" />
+            Sling Work
+          </Button>
+        </div>
       </div>
 
       {/* Stats strip */}

--- a/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/settings/RigSettingsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/settings/RigSettingsPageClient.tsx
@@ -1,0 +1,977 @@
+'use client';
+
+import { useState, useEffect, useMemo, useRef } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useGastownTRPC } from '@/lib/gastown/trpc';
+import { Button } from '@/components/Button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Switch } from '@/components/ui/switch';
+import { toast } from 'sonner';
+import { useModelSelectorList } from '@/app/api/openrouter/hooks';
+import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
+import {
+  Save,
+  Settings,
+  GitPullRequest,
+  Bot,
+  Shield,
+  Layers,
+  MessageSquareText,
+  GitBranch,
+  X,
+  Wrench,
+} from 'lucide-react';
+import { Textarea } from '@/components/ui/textarea';
+import { motion } from 'motion/react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
+import Link from 'next/link';
+
+type Props = { townId: string; rigId: string; organizationId?: string };
+
+// Section definitions for the scrollspy nav
+const SECTIONS = [
+  { id: 'models', label: 'Models', icon: Bot },
+  { id: 'refinery', label: 'Refinery', icon: Shield },
+  { id: 'merge-strategy', label: 'Merge Strategy', icon: GitPullRequest },
+  { id: 'custom-instructions', label: 'Custom Instructions', icon: MessageSquareText },
+  { id: 'git', label: 'Git', icon: GitBranch },
+  { id: 'agent-limits', label: 'Agent Limits', icon: Wrench },
+] as const;
+
+function useScrollSpy(sectionIds: readonly string[]) {
+  const [activeId, setActiveId] = useState<string>(sectionIds[0]);
+  const suppressRef = useRef(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      entries => {
+        if (suppressRef.current) return;
+        const visible = entries
+          .filter(e => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: '-56px 0px -60% 0px', threshold: 0 }
+    );
+
+    for (const id of sectionIds) {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    }
+
+    return () => observer.disconnect();
+  }, [sectionIds]);
+
+  function scrollTo(id: string) {
+    const el = document.getElementById(id);
+    const header = document.getElementById('rig-settings-sticky-header');
+    if (!el) return;
+
+    setActiveId(id);
+    suppressRef.current = true;
+
+    const headerHeight = header?.getBoundingClientRect().height ?? 0;
+    const top = el.getBoundingClientRect().top + window.scrollY - headerHeight - 24;
+    window.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+
+    setTimeout(() => {
+      suppressRef.current = false;
+    }, 1000);
+  }
+
+  return { activeId, scrollTo };
+}
+
+export function RigSettingsPageClient({ townId, rigId, organizationId }: Props) {
+  const trpc = useGastownTRPC();
+  const queryClient = useQueryClient();
+
+  const {
+    data: modelsData,
+    isLoading: isLoadingModels,
+    error: modelsError,
+  } = useModelSelectorList(organizationId);
+
+  const modelOptions = useMemo<ModelOption[]>(
+    () => modelsData?.data.map(model => ({ id: model.id, name: model.name })) ?? [],
+    [modelsData]
+  );
+
+  const rigQuery = useQuery(trpc.gastown.getRig.queryOptions({ rigId, townId }));
+  const townConfigQuery = useQuery(trpc.gastown.getTownConfig.queryOptions({ townId }));
+
+  // Local state for form fields (rig-level overrides)
+  const [defaultModel, setDefaultModel] = useState('');
+  const [polecatModel, setPolecatModel] = useState('');
+  const [refineryModel, setRefineryModel] = useState('');
+  const [refineryCodeReview, setRefineryCodeReview] = useState<boolean | undefined>(undefined);
+  const [reviewMode, setReviewMode] = useState<'rework' | 'comments' | undefined>(undefined);
+  const [autoResolvePrFeedback, setAutoResolvePrFeedback] = useState<boolean | undefined>(
+    undefined
+  );
+  const [autoMergeDelayMinutes, setAutoMergeDelayMinutes] = useState<number | null | undefined>(
+    undefined
+  );
+  const [mergeStrategy, setMergeStrategy] = useState<'direct' | 'pr' | undefined>(undefined);
+  const [convoyMergeMode, setConvoyMergeMode] = useState<
+    'review-then-land' | 'review-and-merge' | undefined
+  >(undefined);
+  const [polecatInstructions, setPolecatInstructions] = useState('');
+  const [refineryInstructions, setRefineryInstructions] = useState('');
+  const [pushFlags, setPushFlags] = useState('');
+  const [maxPolecats, setMaxPolecats] = useState('');
+  const [maxDispatchAttempts, setMaxDispatchAttempts] = useState('');
+  const [initialized, setInitialized] = useState(false);
+
+  // Sync rig config into local state when loaded
+  if (rigQuery.data && !initialized) {
+    const cfg = rigQuery.data.config;
+    if (cfg) {
+      setDefaultModel(cfg.default_model ?? '');
+      setPolecatModel(cfg.role_models?.polecat ?? '');
+      setRefineryModel(cfg.role_models?.refinery ?? '');
+      setRefineryCodeReview(cfg.code_review);
+      setReviewMode(cfg.review_mode);
+      setAutoResolvePrFeedback(cfg.auto_resolve_pr_feedback);
+      setAutoMergeDelayMinutes(cfg.auto_merge_delay_minutes);
+      setMergeStrategy(cfg.merge_strategy);
+      setConvoyMergeMode(cfg.convoy_merge_mode);
+      setPolecatInstructions(cfg.custom_instructions?.polecat ?? '');
+      setRefineryInstructions(cfg.custom_instructions?.refinery ?? '');
+      setPushFlags(cfg.git_push_flags ?? '');
+      setMaxPolecats(
+        cfg.max_concurrent_polecats !== undefined ? String(cfg.max_concurrent_polecats) : ''
+      );
+      setMaxDispatchAttempts(
+        cfg.max_dispatch_attempts !== undefined ? String(cfg.max_dispatch_attempts) : ''
+      );
+    }
+    setInitialized(true);
+  }
+
+  const updateConfig = useMutation(
+    trpc.gastown.updateRigConfig.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.gastown.getRig.queryKey({ rigId, townId }),
+        });
+        toast.success('Rig configuration saved');
+      },
+      onError: err => toast.error(err.message),
+    })
+  );
+
+  const { activeId: activeSection, scrollTo: scrollToSection } = useScrollSpy(
+    SECTIONS.map(s => s.id)
+  );
+
+  const townCfg = townConfigQuery.data;
+
+  function handleSave() {
+    updateConfig.mutate({
+      rigId,
+      townId,
+      config: {
+        default_model: defaultModel || undefined,
+        role_models: {
+          polecat: polecatModel || undefined,
+          refinery: refineryModel || undefined,
+        },
+        code_review: refineryCodeReview,
+        review_mode: reviewMode,
+        auto_resolve_pr_feedback: autoResolvePrFeedback,
+        auto_merge_delay_minutes: autoMergeDelayMinutes,
+        merge_strategy: mergeStrategy,
+        convoy_merge_mode: convoyMergeMode,
+        custom_instructions: {
+          polecat: polecatInstructions || undefined,
+          refinery: refineryInstructions || undefined,
+        },
+        git_push_flags: pushFlags || undefined,
+        max_concurrent_polecats: maxPolecats ? parseInt(maxPolecats, 10) : undefined,
+        max_dispatch_attempts: maxDispatchAttempts
+          ? parseInt(maxDispatchAttempts, 10)
+          : undefined,
+      },
+    });
+  }
+
+  const rigName = rigQuery.data?.name;
+  const rigDetailPath = organizationId
+    ? `/organizations/${organizationId}/gastown/${townId}/rigs/${rigId}`
+    : `/gastown/${townId}/rigs/${rigId}`;
+
+  if (rigQuery.isLoading || townConfigQuery.isLoading) {
+    return (
+      <div className="flex h-full flex-col">
+        <div className="border-b border-white/[0.06] px-6 py-3">
+          <Skeleton className="h-6 w-48" />
+        </div>
+        <div className="flex-1 p-6">
+          <div className="space-y-6">
+            <Skeleton className="h-48 w-full rounded-xl" />
+            <Skeleton className="h-48 w-full rounded-xl" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Top bar */}
+      <div
+        id="rig-settings-sticky-header"
+        className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3"
+      >
+        <div className="flex items-center gap-2.5">
+          <SidebarTrigger className="-ml-3" />
+          <Settings className="size-4 text-white/40" />
+          <Link
+            href={rigDetailPath}
+            className="text-sm text-white/50 transition-colors hover:text-white/70"
+          >
+            {rigName}
+          </Link>
+          <span className="text-white/25">/</span>
+          <h1 className="text-lg font-semibold tracking-tight text-white/90">Settings</h1>
+        </div>
+        <Button
+          onClick={handleSave}
+          disabled={updateConfig.isPending}
+          variant="primary"
+          size="sm"
+          className="gap-1.5 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+        >
+          <Save className="size-3.5" />
+          {updateConfig.isPending ? 'Saving...' : 'Save'}
+        </Button>
+      </div>
+
+      {/* Two-column body */}
+      <div className="scroll-smooth">
+        <div className="mx-auto flex max-w-4xl px-6">
+          {/* Main content */}
+          <div className="min-w-0 flex-1">
+            <div className="space-y-8 pt-6" style={{ paddingBottom: '75vh' }}>
+              {/* ── Models ──────────────────────────────────── */}
+              <SettingsSection
+                id="models"
+                title="Models"
+                description="Override the model used for each agent role. Empty fields inherit the town default."
+                icon={Bot}
+                index={0}
+              >
+                <div className="space-y-4">
+                  <FieldGroup
+                    label="Default Model"
+                    hint="Overrides the town default model for all roles in this rig."
+                  >
+                    <div className="flex items-center gap-2">
+                      <div className="flex-1">
+                        {modelsError ? (
+                          <Input
+                            value={defaultModel}
+                            onChange={e => setDefaultModel(e.target.value)}
+                            placeholder={`Inherit from town (${townCfg?.default_model ?? 'system default'})`}
+                            className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
+                          />
+                        ) : (
+                          <ModelCombobox
+                            label=""
+                            models={modelOptions}
+                            value={defaultModel}
+                            onValueChange={setDefaultModel}
+                            isLoading={isLoadingModels}
+                            placeholder={`Inherit from town (${townCfg?.default_model ?? 'system default'})`}
+                            className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
+                          />
+                        )}
+                      </div>
+                      {defaultModel && (
+                        <button
+                          onClick={() => setDefaultModel('')}
+                          className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                          title="Clear override"
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  </FieldGroup>
+
+                  <FieldGroup
+                    label="Polecat Model"
+                    hint="Override the model used for polecat (worker) agents."
+                  >
+                    <div className="flex items-center gap-2">
+                      <div className="flex-1">
+                        {modelsError ? (
+                          <Input
+                            value={polecatModel}
+                            onChange={e => setPolecatModel(e.target.value)}
+                            placeholder={`Inherit from town (${townCfg?.role_models?.polecat ?? townCfg?.default_model ?? 'system default'})`}
+                            className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
+                          />
+                        ) : (
+                          <ModelCombobox
+                            label=""
+                            models={modelOptions}
+                            value={polecatModel}
+                            onValueChange={setPolecatModel}
+                            isLoading={isLoadingModels}
+                            placeholder={`Inherit from town (${townCfg?.role_models?.polecat ?? townCfg?.default_model ?? 'system default'})`}
+                            className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
+                          />
+                        )}
+                      </div>
+                      {polecatModel && (
+                        <button
+                          onClick={() => setPolecatModel('')}
+                          className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                          title="Clear override"
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  </FieldGroup>
+
+                  <FieldGroup
+                    label="Refinery Model"
+                    hint="Override the model used for refinery (reviewer) agents."
+                  >
+                    <div className="flex items-center gap-2">
+                      <div className="flex-1">
+                        {modelsError ? (
+                          <Input
+                            value={refineryModel}
+                            onChange={e => setRefineryModel(e.target.value)}
+                            placeholder={`Inherit from town (${townCfg?.role_models?.refinery ?? townCfg?.default_model ?? 'system default'})`}
+                            className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
+                          />
+                        ) : (
+                          <ModelCombobox
+                            label=""
+                            models={modelOptions}
+                            value={refineryModel}
+                            onValueChange={setRefineryModel}
+                            isLoading={isLoadingModels}
+                            placeholder={`Inherit from town (${townCfg?.role_models?.refinery ?? townCfg?.default_model ?? 'system default'})`}
+                            className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
+                          />
+                        )}
+                      </div>
+                      {refineryModel && (
+                        <button
+                          onClick={() => setRefineryModel('')}
+                          className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                          title="Clear override"
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  </FieldGroup>
+                </div>
+              </SettingsSection>
+
+              {/* ── Refinery ──────────────────────────────────── */}
+              <SettingsSection
+                id="refinery"
+                title="Refinery"
+                description="Override refinery behavior for this rig. Empty toggles inherit from town settings."
+                icon={Shield}
+                index={1}
+              >
+                <div className="space-y-3">
+                  <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                    <div className="flex items-center gap-3">
+                      <div className="flex-1">
+                        <Label className="text-sm text-white/70">Code Review</Label>
+                        <p className="text-[11px] text-white/30">
+                          Enable or disable the refinery code review for this rig.
+                          {townCfg?.refinery?.code_review !== undefined && (
+                            <span className="ml-1 text-white/20">
+                              (Town default: {townCfg.refinery.code_review ? 'on' : 'off'})
+                            </span>
+                          )}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {refineryCodeReview !== undefined && (
+                          <button
+                            onClick={() => setRefineryCodeReview(undefined)}
+                            className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                            title="Inherit from town"
+                          >
+                            <X className="size-3" />
+                          </button>
+                        )}
+                        <Switch
+                          checked={refineryCodeReview ?? (townCfg?.refinery?.code_review ?? true)}
+                          onCheckedChange={v => setRefineryCodeReview(v)}
+                          className={refineryCodeReview === undefined ? 'opacity-40' : ''}
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                    <Label className="mb-1.5 block text-sm text-white/70">Review Mode</Label>
+                    <p className="mb-2 text-[11px] text-white/30">
+                      How the refinery communicates its findings for this rig.
+                      {townCfg?.refinery?.review_mode && (
+                        <span className="ml-1 text-white/20">
+                          (Town default: {townCfg.refinery.review_mode})
+                        </span>
+                      )}
+                    </p>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => setReviewMode('rework')}
+                        className={`flex-1 rounded-lg border px-3 py-2 text-xs transition-colors ${
+                          reviewMode === 'rework'
+                            ? 'border-indigo-500/40 bg-indigo-500/10 text-indigo-300'
+                            : 'border-white/[0.06] bg-white/[0.02] text-white/40 hover:border-white/10'
+                        }`}
+                      >
+                        <div className="font-medium">Rework requests</div>
+                        <div className="mt-0.5 text-[10px] opacity-60">
+                          Creates internal rework beads for the polecat to fix.
+                        </div>
+                      </button>
+                      <button
+                        onClick={() => setReviewMode('comments')}
+                        className={`flex-1 rounded-lg border px-3 py-2 text-xs transition-colors ${
+                          reviewMode === 'comments'
+                            ? 'border-indigo-500/40 bg-indigo-500/10 text-indigo-300'
+                            : 'border-white/[0.06] bg-white/[0.02] text-white/40 hover:border-white/10'
+                        }`}
+                      >
+                        <div className="font-medium">PR comments</div>
+                        <div className="mt-0.5 text-[10px] opacity-60">
+                          Posts GitHub review comments on the PR.
+                        </div>
+                      </button>
+                      {reviewMode !== undefined && (
+                        <button
+                          onClick={() => setReviewMode(undefined)}
+                          className="flex items-center gap-1 rounded-lg border border-white/[0.06] px-2 py-2 text-[10px] text-white/30 transition-colors hover:border-white/10 hover:text-white/50"
+                          title="Inherit from town"
+                        >
+                          <X className="size-3" />
+                          Inherit
+                        </button>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                    <div className="flex items-center gap-3">
+                      <div className="flex-1">
+                        <Label className="text-sm text-white/70">Auto-resolve PR feedback</Label>
+                        <p className="text-[11px] text-white/30">
+                          Automatically dispatch a polecat to address unresolved review comments.
+                          {townCfg?.refinery?.auto_resolve_pr_feedback !== undefined && (
+                            <span className="ml-1 text-white/20">
+                              (Town default:{' '}
+                              {townCfg.refinery.auto_resolve_pr_feedback ? 'on' : 'off'})
+                            </span>
+                          )}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {autoResolvePrFeedback !== undefined && (
+                          <button
+                            onClick={() => setAutoResolvePrFeedback(undefined)}
+                            className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                            title="Inherit from town"
+                          >
+                            <X className="size-3" />
+                          </button>
+                        )}
+                        <Switch
+                          checked={
+                            autoResolvePrFeedback ??
+                            (townCfg?.refinery?.auto_resolve_pr_feedback ?? false)
+                          }
+                          onCheckedChange={v => setAutoResolvePrFeedback(v)}
+                          className={autoResolvePrFeedback === undefined ? 'opacity-40' : ''}
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                    <Label className="mb-1.5 block text-sm text-white/70">
+                      Auto-merge delay (minutes)
+                    </Label>
+                    <p className="mb-3 text-[11px] text-white/30">
+                      After all checks pass, merge the PR after this delay. Leave empty to inherit
+                      from town.
+                      {townCfg?.refinery?.auto_merge_delay_minutes !== null &&
+                        townCfg?.refinery?.auto_merge_delay_minutes !== undefined && (
+                          <span className="ml-1 text-white/20">
+                            (Town default: {townCfg.refinery.auto_merge_delay_minutes}m)
+                          </span>
+                        )}
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <div className="flex gap-1.5">
+                        {[
+                          { label: 'Off', value: null },
+                          { label: '0', value: 0 },
+                          { label: '15m', value: 15 },
+                          { label: '1h', value: 60 },
+                          { label: '4h', value: 240 },
+                        ].map(preset => (
+                          <button
+                            key={preset.label}
+                            onClick={() => setAutoMergeDelayMinutes(preset.value)}
+                            className={`rounded px-2 py-1 text-[11px] transition-colors ${
+                              autoMergeDelayMinutes === preset.value
+                                ? 'bg-white/[0.12] text-white/80'
+                                : 'bg-white/[0.04] text-white/40 hover:bg-white/[0.08] hover:text-white/60'
+                            }`}
+                          >
+                            {preset.label}
+                          </button>
+                        ))}
+                        {autoMergeDelayMinutes !== undefined && (
+                          <button
+                            onClick={() => setAutoMergeDelayMinutes(undefined)}
+                            className="rounded px-2 py-1 text-[11px] text-white/25 transition-colors hover:bg-white/[0.04] hover:text-white/50"
+                            title="Inherit from town"
+                          >
+                            Inherit
+                          </button>
+                        )}
+                      </div>
+                      {autoMergeDelayMinutes !== null && autoMergeDelayMinutes !== undefined && (
+                        <div className="flex items-center gap-1.5">
+                          <Input
+                            type="number"
+                            min={0}
+                            value={autoMergeDelayMinutes}
+                            onChange={e => {
+                              const v = parseInt(e.target.value, 10);
+                              setAutoMergeDelayMinutes(Number.isNaN(v) ? null : Math.max(0, v));
+                            }}
+                            className="h-[26px] w-[60px] border-white/[0.08] bg-white/[0.03] text-center font-mono text-xs text-white/85"
+                          />
+                          <span className="text-[11px] text-white/30">minutes</span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </SettingsSection>
+
+              {/* ── Merge Strategy ──────────────────────────────────── */}
+              <SettingsSection
+                id="merge-strategy"
+                title="Merge Strategy"
+                description="Override how agent work lands in the default branch."
+                icon={GitPullRequest}
+                index={2}
+              >
+                <div className="space-y-3">
+                  <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+                    <Label className="mb-2 block text-sm text-white/70">
+                      Direct merge vs Pull Request
+                    </Label>
+                    <p className="mb-2 text-[11px] text-white/30">
+                      Overrides town merge strategy for this rig.
+                      {townCfg?.merge_strategy && (
+                        <span className="ml-1 text-white/20">
+                          (Town default: {townCfg.merge_strategy})
+                        </span>
+                      )}
+                    </p>
+                    <div className="flex gap-2">
+                      <MergeStrategyOption
+                        selected={mergeStrategy === 'direct'}
+                        onSelect={() => setMergeStrategy('direct')}
+                        label="Direct push"
+                        description="Push merged code directly to the default branch."
+                      />
+                      <MergeStrategyOption
+                        selected={mergeStrategy === 'pr'}
+                        onSelect={() => setMergeStrategy('pr')}
+                        label="Pull request"
+                        description="Create a PR for human review before merging."
+                      />
+                      {mergeStrategy !== undefined && (
+                        <button
+                          onClick={() => setMergeStrategy(undefined)}
+                          className="flex shrink-0 items-center gap-1 rounded-lg border border-white/[0.06] px-2 py-2 text-[10px] text-white/30 transition-colors hover:border-white/10 hover:text-white/50"
+                          title="Inherit from town"
+                        >
+                          <X className="size-3" />
+                          Inherit
+                        </button>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+                    <Label className="mb-2 block text-sm text-white/70">Convoy merge mode</Label>
+                    <p className="mb-2 text-[11px] text-white/30">
+                      Overrides town convoy merge mode for this rig.
+                      {townCfg?.convoy_merge_mode && (
+                        <span className="ml-1 text-white/20">
+                          (Town default: {townCfg.convoy_merge_mode})
+                        </span>
+                      )}
+                    </p>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => setConvoyMergeMode('review-then-land')}
+                        className={`flex-1 rounded-lg border px-3 py-2 text-xs transition-colors ${
+                          convoyMergeMode === 'review-then-land'
+                            ? 'border-indigo-500/40 bg-indigo-500/10 text-indigo-300'
+                            : 'border-white/[0.06] bg-white/[0.02] text-white/40 hover:border-white/10'
+                        }`}
+                      >
+                        <div className="font-medium">Review then land</div>
+                        <div className="mt-0.5 text-[10px] opacity-60">
+                          Beads merge into a feature branch. One landing PR at the end.
+                        </div>
+                      </button>
+                      <button
+                        onClick={() => setConvoyMergeMode('review-and-merge')}
+                        className={`flex-1 rounded-lg border px-3 py-2 text-xs transition-colors ${
+                          convoyMergeMode === 'review-and-merge'
+                            ? 'border-indigo-500/40 bg-indigo-500/10 text-indigo-300'
+                            : 'border-white/[0.06] bg-white/[0.02] text-white/40 hover:border-white/10'
+                        }`}
+                      >
+                        <div className="font-medium">Review and merge</div>
+                        <div className="mt-0.5 text-[10px] opacity-60">
+                          Each bead gets its own PR. Auto-merge applies per PR.
+                        </div>
+                      </button>
+                      {convoyMergeMode !== undefined && (
+                        <button
+                          onClick={() => setConvoyMergeMode(undefined)}
+                          className="flex shrink-0 items-center gap-1 rounded-lg border border-white/[0.06] px-2 py-2 text-[10px] text-white/30 transition-colors hover:border-white/10 hover:text-white/50"
+                          title="Inherit from town"
+                        >
+                          <X className="size-3" />
+                          Inherit
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </SettingsSection>
+
+              {/* ── Custom Instructions ────────────────────────────────── */}
+              <SettingsSection
+                id="custom-instructions"
+                title="Custom Instructions"
+                description="Rig-specific instructions appended to the agent system prompt. Empty fields inherit the town instructions."
+                icon={MessageSquareText}
+                index={3}
+              >
+                <div className="space-y-5">
+                  <FieldGroup
+                    label="Polecat Instructions"
+                    hint="Custom instructions for polecat (worker) agents in this rig."
+                  >
+                    <div className="relative">
+                      <Textarea
+                        value={polecatInstructions}
+                        onChange={e => setPolecatInstructions(e.target.value.slice(0, 2000))}
+                        placeholder={
+                          townCfg?.custom_instructions?.polecat
+                            ? `Town default: ${townCfg.custom_instructions.polecat}`
+                            : 'Custom instructions for polecat agents…'
+                        }
+                        rows={4}
+                        className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85 placeholder:text-white/20"
+                      />
+                      <span className="absolute right-2 bottom-2 text-[10px] text-white/20">
+                        {polecatInstructions.length} / 2000
+                      </span>
+                    </div>
+                  </FieldGroup>
+
+                  <FieldGroup
+                    label="Refinery Instructions"
+                    hint="Custom instructions for refinery (reviewer) agents in this rig."
+                  >
+                    <div className="relative">
+                      <Textarea
+                        value={refineryInstructions}
+                        onChange={e => setRefineryInstructions(e.target.value.slice(0, 2000))}
+                        placeholder={
+                          townCfg?.custom_instructions?.refinery
+                            ? `Town default: ${townCfg.custom_instructions.refinery}`
+                            : 'Custom instructions for refinery agents…'
+                        }
+                        rows={4}
+                        className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85 placeholder:text-white/20"
+                      />
+                      <span className="absolute right-2 bottom-2 text-[10px] text-white/20">
+                        {refineryInstructions.length} / 2000
+                      </span>
+                    </div>
+                  </FieldGroup>
+                </div>
+              </SettingsSection>
+
+              {/* ── Git ──────────────────────────────────────── */}
+              <SettingsSection
+                id="git"
+                title="Git"
+                description="Git-related settings for this rig."
+                icon={GitBranch}
+                index={4}
+              >
+                <FieldGroup
+                  label="Push Flags"
+                  hint="Extra flags passed to git push (e.g. --no-verify). Empty = no extra flags."
+                >
+                  <Input
+                    value={pushFlags}
+                    onChange={e => setPushFlags(e.target.value)}
+                    placeholder="--no-verify"
+                    className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
+                  />
+                </FieldGroup>
+              </SettingsSection>
+
+              {/* ── Agent Limits ──────────────────────────────── */}
+              <SettingsSection
+                id="agent-limits"
+                title="Agent Limits"
+                description="Override the maximum number of concurrent agents and dispatch attempts for this rig."
+                icon={Wrench}
+                index={5}
+              >
+                <div className="space-y-4">
+                  <FieldGroup
+                    label="Max Concurrent Polecats"
+                    hint="Maximum number of simultaneously running polecat agents. Empty = inherit town setting."
+                  >
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="number"
+                        min={1}
+                        max={50}
+                        value={maxPolecats}
+                        onChange={e => setMaxPolecats(e.target.value)}
+                        placeholder={
+                          townCfg?.max_polecats_per_rig
+                            ? `Inherit from town (${townCfg.max_polecats_per_rig})`
+                            : 'Inherit from town'
+                        }
+                        className="w-40 border-white/[0.08] bg-white/[0.03] text-sm text-white/85 placeholder:text-white/20"
+                      />
+                      {maxPolecats && (
+                        <button
+                          onClick={() => setMaxPolecats('')}
+                          className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                          title="Inherit from town"
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  </FieldGroup>
+
+                  <FieldGroup
+                    label="Max Dispatch Attempts"
+                    hint="Maximum number of times a bead can be dispatched before it is marked as failed. Empty = inherit town setting."
+                  >
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="number"
+                        min={1}
+                        max={20}
+                        value={maxDispatchAttempts}
+                        onChange={e => setMaxDispatchAttempts(e.target.value)}
+                        placeholder="Inherit from town"
+                        className="w-40 border-white/[0.08] bg-white/[0.03] text-sm text-white/85 placeholder:text-white/20"
+                      />
+                      {maxDispatchAttempts && (
+                        <button
+                          onClick={() => setMaxDispatchAttempts('')}
+                          className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                          title="Inherit from town"
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  </FieldGroup>
+                </div>
+              </SettingsSection>
+            </div>
+          </div>
+
+          {/* Right sidebar — sticky scrollspy nav */}
+          <div className="hidden w-52 shrink-0 lg:sticky lg:top-[53px] lg:self-start lg:block">
+            <nav className="px-4 pt-6">
+              <div className="mb-3 text-[10px] font-medium tracking-wide text-white/25 uppercase">
+                On this page
+              </div>
+              <ul className="space-y-0.5">
+                {SECTIONS.map(section => {
+                  const isActive = activeSection === section.id;
+                  const SectionIcon = section.icon;
+
+                  return (
+                    <li key={section.id}>
+                      <button
+                        onClick={() => scrollToSection(section.id)}
+                        className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs whitespace-nowrap overflow-hidden text-ellipsis transition-colors ${
+                          isActive
+                            ? 'bg-white/[0.06] text-white/80'
+                            : 'text-white/35 hover:bg-white/[0.03] hover:text-white/55'
+                        }`}
+                      >
+                        <SectionIcon className="size-3 shrink-0" />
+                        <span className="truncate">{section.label}</span>
+                        {isActive && (
+                          <motion.div
+                            layoutId="rig-settings-nav-indicator"
+                            className="ml-auto size-1 rounded-full bg-[color:oklch(95%_0.15_108)]"
+                            transition={{
+                              type: 'spring',
+                              stiffness: 350,
+                              damping: 30,
+                            }}
+                          />
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+
+              {/* Save button mirrored in sidebar */}
+              <div className="mt-6 border-t border-white/[0.06] pt-4">
+                <Button
+                  onClick={handleSave}
+                  disabled={updateConfig.isPending}
+                  variant="primary"
+                  size="sm"
+                  className="w-full gap-1.5 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+                >
+                  <Save className="size-3" />
+                  {updateConfig.isPending ? 'Saving...' : 'Save'}
+                </Button>
+              </div>
+            </nav>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Shared sub-components ────────────────────────────────────────────────
+
+function SettingsSection({
+  id,
+  title,
+  description,
+  icon: Icon,
+  index,
+  action,
+  children,
+}: {
+  id: string;
+  title: string;
+  description: string;
+  icon: typeof Settings;
+  index: number;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <motion.section
+      id={id}
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: index * 0.06, duration: 0.35 }}
+    >
+      <div className="mb-4 flex items-start justify-between">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 flex size-8 items-center justify-center rounded-lg bg-white/[0.04] ring-1 ring-white/[0.06]">
+            <Icon className="size-4 text-white/40" />
+          </div>
+          <div>
+            <h2 className="text-sm font-semibold text-white/85">{title}</h2>
+            <p className="mt-0.5 text-xs text-white/35">{description}</p>
+          </div>
+        </div>
+        {action}
+      </div>
+      <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">{children}</div>
+    </motion.section>
+  );
+}
+
+function FieldGroup({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs text-white/55">{label}</Label>
+      {children}
+      {hint && <p className="text-[11px] text-white/25">{hint}</p>}
+    </div>
+  );
+}
+
+function MergeStrategyOption({
+  selected,
+  onSelect,
+  label,
+  description,
+}: {
+  selected: boolean;
+  onSelect: () => void;
+  label: string;
+  description: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`flex flex-1 items-start gap-3 rounded-lg border px-4 py-3 text-left transition-colors ${
+        selected
+          ? 'border-[color:oklch(95%_0.15_108_/_0.3)] bg-[color:oklch(95%_0.15_108_/_0.06)]'
+          : 'border-white/[0.06] bg-white/[0.02] hover:bg-white/[0.04]'
+      }`}
+    >
+      <div
+        className={`mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border ${
+          selected ? 'border-[color:oklch(95%_0.15_108_/_0.6)]' : 'border-white/20'
+        }`}
+      >
+        {selected && <div className="size-2 rounded-full bg-[color:oklch(95%_0.15_108)]" />}
+      </div>
+      <div>
+        <div className={`text-sm font-medium ${selected ? 'text-white/90' : 'text-white/60'}`}>
+          {label}
+        </div>
+        <p className="mt-0.5 text-[11px] text-white/35">{description}</p>
+      </div>
+    </button>
+  );
+}

--- a/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/settings/RigSettingsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/settings/RigSettingsPageClient.tsx
@@ -17,7 +17,6 @@ import {
   GitPullRequest,
   Bot,
   Shield,
-  Layers,
   MessageSquareText,
   GitBranch,
   X,
@@ -193,9 +192,7 @@ export function RigSettingsPageClient({ townId, rigId, organizationId }: Props) 
         },
         git_push_flags: pushFlags || undefined,
         max_concurrent_polecats: maxPolecats ? parseInt(maxPolecats, 10) : undefined,
-        max_dispatch_attempts: maxDispatchAttempts
-          ? parseInt(maxDispatchAttempts, 10)
-          : undefined,
+        max_dispatch_attempts: maxDispatchAttempts ? parseInt(maxDispatchAttempts, 10) : undefined,
       },
     });
   }
@@ -413,7 +410,7 @@ export function RigSettingsPageClient({ townId, rigId, organizationId }: Props) 
                           </button>
                         )}
                         <Switch
-                          checked={refineryCodeReview ?? (townCfg?.refinery?.code_review ?? true)}
+                          checked={refineryCodeReview ?? townCfg?.refinery?.code_review ?? true}
                           onCheckedChange={v => setRefineryCodeReview(v)}
                           className={refineryCodeReview === undefined ? 'opacity-40' : ''}
                         />
@@ -498,7 +495,8 @@ export function RigSettingsPageClient({ townId, rigId, organizationId }: Props) 
                         <Switch
                           checked={
                             autoResolvePrFeedback ??
-                            (townCfg?.refinery?.auto_resolve_pr_feedback ?? false)
+                            townCfg?.refinery?.auto_resolve_pr_feedback ??
+                            false
                           }
                           onCheckedChange={v => setAutoResolvePrFeedback(v)}
                           className={autoResolvePrFeedback === undefined ? 'opacity-40' : ''}

--- a/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/settings/page.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/settings/page.tsx
@@ -1,0 +1,21 @@
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+import { notFound } from 'next/navigation';
+import { isGastownEnabled } from '@/lib/gastown/feature-flags';
+import { RigSettingsPageClient } from './RigSettingsPageClient';
+
+export default async function RigSettingsPage({
+  params,
+}: {
+  params: Promise<{ townId: string; rigId: string }>;
+}) {
+  const { townId, rigId } = await params;
+  const user = await getUserFromAuthOrRedirect(
+    `/users/sign_in?callbackPath=/gastown/${townId}/rigs/${rigId}/settings`
+  );
+
+  if (!(await isGastownEnabled(user.id, { isAdmin: user.is_admin }))) {
+    return notFound();
+  }
+
+  return <RigSettingsPageClient townId={townId} rigId={rigId} />;
+}

--- a/apps/web/src/app/(app)/organizations/[id]/gastown/[townId]/rigs/[rigId]/settings/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/gastown/[townId]/rigs/[rigId]/settings/page.tsx
@@ -12,11 +12,7 @@ export default async function OrgRigSettingsPage({
       params={params}
       fullBleed
       render={() => (
-        <RigSettingsPageClient
-          townId={townId}
-          rigId={rigId}
-          organizationId={organizationId}
-        />
+        <RigSettingsPageClient townId={townId} rigId={rigId} organizationId={organizationId} />
       )}
     />
   );

--- a/apps/web/src/app/(app)/organizations/[id]/gastown/[townId]/rigs/[rigId]/settings/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/gastown/[townId]/rigs/[rigId]/settings/page.tsx
@@ -1,0 +1,23 @@
+import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import { RigSettingsPageClient } from '@/app/(app)/gastown/[townId]/rigs/[rigId]/settings/RigSettingsPageClient';
+
+export default async function OrgRigSettingsPage({
+  params,
+}: {
+  params: Promise<{ id: string; townId: string; rigId: string }>;
+}) {
+  const { id: organizationId, townId, rigId } = await params;
+  return (
+    <OrganizationByPageLayout
+      params={params}
+      fullBleed
+      render={() => (
+        <RigSettingsPageClient
+          townId={townId}
+          rigId={rigId}
+          organizationId={organizationId}
+        />
+      )}
+    />
+  );
+}

--- a/apps/web/src/components/gastown/AgentDetailDrawer.tsx
+++ b/apps/web/src/components/gastown/AgentDetailDrawer.tsx
@@ -183,9 +183,7 @@ export function AgentDetailDrawer({
                         <span className="text-sm text-white/75">{agent.dispatch_attempts}</span>
                         {agent.dispatch_attempts > 0 && (
                           <button
-                            onClick={() =>
-                              resetMutation.mutate({ rigId, agentId: agent.id })
-                            }
+                            onClick={() => resetMutation.mutate({ rigId, agentId: agent.id })}
                             disabled={resetMutation.isPending}
                             title="Reset dispatch attempts to 0"
                             className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-amber-300 ring-1 ring-amber-400/30 transition-colors hover:bg-amber-400/10 disabled:opacity-50"

--- a/apps/web/src/components/gastown/drawer-panels/AgentPanel.tsx
+++ b/apps/web/src/components/gastown/drawer-panels/AgentPanel.tsx
@@ -166,9 +166,7 @@ export function AgentPanel({
             <span className="text-sm text-white/75">{agent.dispatch_attempts}</span>
             {agent.dispatch_attempts > 0 && (
               <button
-                onClick={() =>
-                  resetMutation.mutate({ rigId, agentId: agent.id })
-                }
+                onClick={() => resetMutation.mutate({ rigId, agentId: agent.id })}
                 disabled={resetMutation.isPending}
                 title="Reset dispatch attempts to 0"
                 className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-amber-300 ring-1 ring-amber-400/30 transition-colors hover:bg-amber-400/10 disabled:opacity-50"
@@ -177,9 +175,7 @@ export function AgentPanel({
                 Reset
               </button>
             )}
-            {resetMutation.isError && (
-              <span className="text-[10px] text-red-400">Failed</span>
-            )}
+            {resetMutation.isError && <span className="text-[10px] text-red-400">Failed</span>}
           </div>
         </div>
         <MetaCell

--- a/apps/web/src/lib/gastown/types/router.d.ts
+++ b/apps/web/src/lib/gastown/types/router.d.ts
@@ -126,6 +126,26 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
         platform_integration_id: string | null;
         created_at: string;
         updated_at: string;
+        config?: {
+          default_model?: string | undefined;
+          role_models?: {
+            polecat?: string | undefined;
+            refinery?: string | undefined;
+          } | undefined;
+          review_mode?: 'rework' | 'comments' | undefined;
+          code_review?: boolean | undefined;
+          auto_resolve_pr_feedback?: boolean | undefined;
+          auto_merge_delay_minutes?: number | null | undefined;
+          merge_strategy?: 'direct' | 'pr' | undefined;
+          convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
+          custom_instructions?: {
+            polecat?: string | undefined;
+            refinery?: string | undefined;
+          } | undefined;
+          git_push_flags?: string | undefined;
+          max_concurrent_polecats?: number | undefined;
+          max_dispatch_attempts?: number | undefined;
+        } | undefined;
         agents: {
           id: string;
           rig_id: string | null;
@@ -166,6 +186,34 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
           closed_at: string | null;
         }[];
       };
+      meta: object;
+    }>;
+    updateRigConfig: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        townId?: string | undefined;
+        config: {
+          default_model?: string | undefined;
+          role_models?: {
+            polecat?: string | undefined;
+            refinery?: string | undefined;
+          } | undefined;
+          review_mode?: 'rework' | 'comments' | undefined;
+          code_review?: boolean | undefined;
+          auto_resolve_pr_feedback?: boolean | undefined;
+          auto_merge_delay_minutes?: number | null | undefined;
+          merge_strategy?: 'direct' | 'pr' | undefined;
+          convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
+          custom_instructions?: {
+            polecat?: string | undefined;
+            refinery?: string | undefined;
+          } | undefined;
+          git_push_flags?: string | undefined;
+          max_concurrent_polecats?: number | undefined;
+          max_dispatch_attempts?: number | undefined;
+        };
+      };
+      output: void;
       meta: object;
     }>;
     deleteRig: import('@trpc/server').TRPCMutationProcedure<{
@@ -1467,6 +1515,26 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             platform_integration_id: string | null;
             created_at: string;
             updated_at: string;
+            config?: {
+              default_model?: string | undefined;
+              role_models?: {
+                polecat?: string | undefined;
+                refinery?: string | undefined;
+              } | undefined;
+              review_mode?: 'rework' | 'comments' | undefined;
+              code_review?: boolean | undefined;
+              auto_resolve_pr_feedback?: boolean | undefined;
+              auto_merge_delay_minutes?: number | null | undefined;
+              merge_strategy?: 'direct' | 'pr' | undefined;
+              convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
+              custom_instructions?: {
+                polecat?: string | undefined;
+                refinery?: string | undefined;
+              } | undefined;
+              git_push_flags?: string | undefined;
+              max_concurrent_polecats?: number | undefined;
+              max_dispatch_attempts?: number | undefined;
+            } | undefined;
             agents: {
               id: string;
               rig_id: string | null;
@@ -1507,6 +1575,34 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
               closed_at: string | null;
             }[];
           };
+          meta: object;
+        }>;
+        updateRigConfig: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            townId?: string | undefined;
+            config: {
+              default_model?: string | undefined;
+              role_models?: {
+                polecat?: string | undefined;
+                refinery?: string | undefined;
+              } | undefined;
+              review_mode?: 'rework' | 'comments' | undefined;
+              code_review?: boolean | undefined;
+              auto_resolve_pr_feedback?: boolean | undefined;
+              auto_merge_delay_minutes?: number | null | undefined;
+              merge_strategy?: 'direct' | 'pr' | undefined;
+              convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
+              custom_instructions?: {
+                polecat?: string | undefined;
+                refinery?: string | undefined;
+              } | undefined;
+              git_push_flags?: string | undefined;
+              max_concurrent_polecats?: number | undefined;
+              max_dispatch_attempts?: number | undefined;
+            };
+          };
+          output: void;
           meta: object;
         }>;
         deleteRig: import('@trpc/server').TRPCMutationProcedure<{

--- a/apps/web/src/lib/gastown/types/router.d.ts
+++ b/apps/web/src/lib/gastown/types/router.d.ts
@@ -126,26 +126,32 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
         platform_integration_id: string | null;
         created_at: string;
         updated_at: string;
-        config?: {
-          default_model?: string | undefined;
-          role_models?: {
-            polecat?: string | undefined;
-            refinery?: string | undefined;
-          } | undefined;
-          review_mode?: 'rework' | 'comments' | undefined;
-          code_review?: boolean | undefined;
-          auto_resolve_pr_feedback?: boolean | undefined;
-          auto_merge_delay_minutes?: number | null | undefined;
-          merge_strategy?: 'direct' | 'pr' | undefined;
-          convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
-          custom_instructions?: {
-            polecat?: string | undefined;
-            refinery?: string | undefined;
-          } | undefined;
-          git_push_flags?: string | undefined;
-          max_concurrent_polecats?: number | undefined;
-          max_dispatch_attempts?: number | undefined;
-        } | undefined;
+        config?:
+          | {
+              default_model?: string | undefined;
+              role_models?:
+                | {
+                    polecat?: string | undefined;
+                    refinery?: string | undefined;
+                  }
+                | undefined;
+              review_mode?: 'rework' | 'comments' | undefined;
+              code_review?: boolean | undefined;
+              auto_resolve_pr_feedback?: boolean | undefined;
+              auto_merge_delay_minutes?: number | null | undefined;
+              merge_strategy?: 'direct' | 'pr' | undefined;
+              convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
+              custom_instructions?:
+                | {
+                    polecat?: string | undefined;
+                    refinery?: string | undefined;
+                  }
+                | undefined;
+              git_push_flags?: string | undefined;
+              max_concurrent_polecats?: number | undefined;
+              max_dispatch_attempts?: number | undefined;
+            }
+          | undefined;
         agents: {
           id: string;
           rig_id: string | null;
@@ -194,20 +200,24 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
         townId?: string | undefined;
         config: {
           default_model?: string | undefined;
-          role_models?: {
-            polecat?: string | undefined;
-            refinery?: string | undefined;
-          } | undefined;
+          role_models?:
+            | {
+                polecat?: string | undefined;
+                refinery?: string | undefined;
+              }
+            | undefined;
           review_mode?: 'rework' | 'comments' | undefined;
           code_review?: boolean | undefined;
           auto_resolve_pr_feedback?: boolean | undefined;
           auto_merge_delay_minutes?: number | null | undefined;
           merge_strategy?: 'direct' | 'pr' | undefined;
           convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
-          custom_instructions?: {
-            polecat?: string | undefined;
-            refinery?: string | undefined;
-          } | undefined;
+          custom_instructions?:
+            | {
+                polecat?: string | undefined;
+                refinery?: string | undefined;
+              }
+            | undefined;
           git_push_flags?: string | undefined;
           max_concurrent_polecats?: number | undefined;
           max_dispatch_attempts?: number | undefined;
@@ -1515,26 +1525,32 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             platform_integration_id: string | null;
             created_at: string;
             updated_at: string;
-            config?: {
-              default_model?: string | undefined;
-              role_models?: {
-                polecat?: string | undefined;
-                refinery?: string | undefined;
-              } | undefined;
-              review_mode?: 'rework' | 'comments' | undefined;
-              code_review?: boolean | undefined;
-              auto_resolve_pr_feedback?: boolean | undefined;
-              auto_merge_delay_minutes?: number | null | undefined;
-              merge_strategy?: 'direct' | 'pr' | undefined;
-              convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
-              custom_instructions?: {
-                polecat?: string | undefined;
-                refinery?: string | undefined;
-              } | undefined;
-              git_push_flags?: string | undefined;
-              max_concurrent_polecats?: number | undefined;
-              max_dispatch_attempts?: number | undefined;
-            } | undefined;
+            config?:
+              | {
+                  default_model?: string | undefined;
+                  role_models?:
+                    | {
+                        polecat?: string | undefined;
+                        refinery?: string | undefined;
+                      }
+                    | undefined;
+                  review_mode?: 'rework' | 'comments' | undefined;
+                  code_review?: boolean | undefined;
+                  auto_resolve_pr_feedback?: boolean | undefined;
+                  auto_merge_delay_minutes?: number | null | undefined;
+                  merge_strategy?: 'direct' | 'pr' | undefined;
+                  convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
+                  custom_instructions?:
+                    | {
+                        polecat?: string | undefined;
+                        refinery?: string | undefined;
+                      }
+                    | undefined;
+                  git_push_flags?: string | undefined;
+                  max_concurrent_polecats?: number | undefined;
+                  max_dispatch_attempts?: number | undefined;
+                }
+              | undefined;
             agents: {
               id: string;
               rig_id: string | null;
@@ -1583,20 +1599,24 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             townId?: string | undefined;
             config: {
               default_model?: string | undefined;
-              role_models?: {
-                polecat?: string | undefined;
-                refinery?: string | undefined;
-              } | undefined;
+              role_models?:
+                | {
+                    polecat?: string | undefined;
+                    refinery?: string | undefined;
+                  }
+                | undefined;
               review_mode?: 'rework' | 'comments' | undefined;
               code_review?: boolean | undefined;
               auto_resolve_pr_feedback?: boolean | undefined;
               auto_merge_delay_minutes?: number | null | undefined;
               merge_strategy?: 'direct' | 'pr' | undefined;
               convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
-              custom_instructions?: {
-                polecat?: string | undefined;
-                refinery?: string | undefined;
-              } | undefined;
+              custom_instructions?:
+                | {
+                    polecat?: string | undefined;
+                    refinery?: string | undefined;
+                  }
+                | undefined;
               git_push_flags?: string | undefined;
               max_concurrent_polecats?: number | undefined;
               max_dispatch_attempts?: number | undefined;

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -3651,7 +3651,7 @@ export class TownDO extends DurableObject<Env> {
       const townConfig = await this.getTownConfig();
       const actions = reconciler.reconcile(this.sql, {
         draining: this._draining,
-        refineryCodeReview: townConfig.refinery?.code_review ?? true,
+        townConfig,
       });
       metrics.actionsEmitted = actions.length;
       for (const a of actions) {
@@ -4567,7 +4567,7 @@ export class TownDO extends DurableObject<Env> {
       // Run reconciler against the resulting state
       const tc = await this.getTownConfig();
       const actions = reconciler.reconcile(this.sql, {
-        refineryCodeReview: tc.refinery?.code_review ?? true,
+        townConfig: tc,
       });
 
       // Capture a state snapshot before rollback
@@ -4649,7 +4649,7 @@ export class TownDO extends DurableObject<Env> {
       // Phase 1: Reconcile against now-current state
       const tc2 = await this.getTownConfig();
       const actions = reconciler.reconcile(this.sql, {
-        refineryCodeReview: tc2.refinery?.code_review ?? true,
+        townConfig: tc2,
       });
       const pendingEventCount = events.pendingEventCount(this.sql);
       const actionsByType: Record<string, number> = {};

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -282,6 +282,8 @@ export class TownDO extends DurableObject<Env> {
 
         let systemPromptOverride: string | undefined;
         const townConfig = await this.getTownConfig();
+        const rig = rigs.getRig(this.sql, rigId);
+        const effectiveConfig = config.resolveRigConfig(townConfig, rig?.config ?? null);
 
         // Build refinery-specific system prompt with branch/target info.
         // When the MR bead already has a pr_url (polecat created the PR),
@@ -306,17 +308,16 @@ export class TownDO extends DurableObject<Env> {
               typeof bead.metadata?.source_agent_id === 'string'
                 ? bead.metadata.source_agent_id
                 : 'unknown',
-            mergeStrategy: townConfig.merge_strategy ?? 'direct',
+            mergeStrategy: effectiveConfig.merge_strategy,
             existingPrUrl,
-            reviewMode: townConfig.refinery?.review_mode ?? 'rework',
+            reviewMode: effectiveConfig.review_mode,
           });
         }
 
         // When merge_strategy is 'pr', polecats always create the PR themselves
         // and pass pr_url to gt_done. For review-then-land convoy intermediate
         // beads, the PR targets the convoy feature branch (not main).
-        if (agent.role === 'polecat' && townConfig.merge_strategy === 'pr') {
-          const rig = rigs.getRig(this.sql, rigId);
+        if (agent.role === 'polecat' && effectiveConfig.merge_strategy === 'pr') {
           const convoyId = beadOps.getConvoyForBead(this.sql, beadId);
           const convoyFeatureBranch = convoyId
             ? beadOps.getConvoyFeatureBranch(this.sql, convoyId)

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -88,6 +88,7 @@ import type {
   MergeStrategy,
   ConvoyMergeMode,
   UiAction,
+  RigOverrideConfig,
 } from '../types';
 
 const TOWN_LOG = '[Town.do]';
@@ -841,6 +842,11 @@ export class TownDO extends DurableObject<Env> {
   }
 
   async getRigAsync(rigId: string): Promise<rigs.RigRecord | null> {
+    return rigs.getRig(this.sql, rigId);
+  }
+
+  async updateRigConfig(rigId: string, config: RigOverrideConfig): Promise<rigs.RigRecord | null> {
+    rigs.updateRigConfig(this.sql, rigId, config);
     return rigs.getRig(this.sql, rigId);
   }
 

--- a/services/gastown/src/dos/town/config.test.ts
+++ b/services/gastown/src/dos/town/config.test.ts
@@ -3,7 +3,6 @@ import { TownConfigSchema } from '../../types';
 import { resolveModel } from './config';
 
 const HARDCODED_FALLBACK = 'anthropic/claude-sonnet-4.6';
-const DUMMY_RIG = 'rig-test';
 
 /** Parse a minimal TownConfig through the Zod schema (applies defaults). */
 function makeTownConfig(
@@ -15,16 +14,16 @@ function makeTownConfig(
 describe('resolveModel', () => {
   it('returns hardcoded fallback when no default_model and no role_models', () => {
     const config = makeTownConfig();
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe(HARDCODED_FALLBACK);
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe(HARDCODED_FALLBACK);
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'polecat')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'mayor')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'refinery')).toBe(HARDCODED_FALLBACK);
   });
 
   it('returns default_model when set and no role_models', () => {
     const config = makeTownConfig({ default_model: 'openai/gpt-4o' });
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'mayor')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'refinery')).toBe('openai/gpt-4o');
   });
 
   it('returns mayor-specific model when role_models.mayor is set', () => {
@@ -32,7 +31,7 @@ describe('resolveModel', () => {
       default_model: 'openai/gpt-4o',
       role_models: { mayor: 'anthropic/claude-opus-4' },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('anthropic/claude-opus-4');
+    expect(resolveModel(config, null, 'mayor')).toBe('anthropic/claude-opus-4');
   });
 
   it('falls back to default_model for roles not overridden in role_models', () => {
@@ -40,18 +39,18 @@ describe('resolveModel', () => {
       default_model: 'openai/gpt-4o',
       role_models: { mayor: 'anthropic/claude-opus-4' },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'refinery')).toBe('openai/gpt-4o');
   });
 
   it('returns polecat model when set, falls back for other roles', () => {
     const config = makeTownConfig({
       role_models: { polecat: 'google/gemini-2.5-pro' },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('google/gemini-2.5-pro');
+    expect(resolveModel(config, null, 'polecat')).toBe('google/gemini-2.5-pro');
     // No default_model → hardcoded fallback for other roles
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe(HARDCODED_FALLBACK);
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'mayor')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'refinery')).toBe(HARDCODED_FALLBACK);
   });
 
   it('returns role-specific model for all three roles when all overridden', () => {
@@ -63,9 +62,9 @@ describe('resolveModel', () => {
         polecat: 'google/gemini-2.5-pro',
       },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('anthropic/claude-opus-4');
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('anthropic/claude-sonnet-4');
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('google/gemini-2.5-pro');
+    expect(resolveModel(config, null, 'mayor')).toBe('anthropic/claude-opus-4');
+    expect(resolveModel(config, null, 'refinery')).toBe('anthropic/claude-sonnet-4');
+    expect(resolveModel(config, null, 'polecat')).toBe('google/gemini-2.5-pro');
   });
 
   it('treats empty role_models the same as no role_models', () => {
@@ -73,14 +72,14 @@ describe('resolveModel', () => {
       default_model: 'openai/gpt-4o',
       role_models: {},
     });
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'mayor')).toBe('openai/gpt-4o');
   });
 
   it('treats undefined role_models the same as no role_models', () => {
     const config = makeTownConfig({ default_model: 'openai/gpt-4o' });
     expect(config.role_models).toBeUndefined();
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'polecat')).toBe('openai/gpt-4o');
   });
 
   it('falls back to default_model for unknown role strings', () => {
@@ -88,15 +87,15 @@ describe('resolveModel', () => {
       default_model: 'openai/gpt-4o',
       role_models: { mayor: 'anthropic/claude-opus-4' },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'unknown-role')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, '')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'unknown-role')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, '')).toBe('openai/gpt-4o');
   });
 
   it('falls back to hardcoded fallback for unknown role with no default_model', () => {
     const config = makeTownConfig({
       role_models: { mayor: 'anthropic/claude-opus-4' },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'unknown-role')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'unknown-role')).toBe(HARDCODED_FALLBACK);
   });
 });
 
@@ -109,17 +108,17 @@ describe('resolveModel backward compatibility', () => {
     };
     const config = TownConfigSchema.parse(legacyRaw);
     expect(config.role_models).toBeUndefined();
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'mayor')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'refinery')).toBe('openai/gpt-4o');
   });
 
   it('works with a completely empty config (new town defaults)', () => {
     const config = TownConfigSchema.parse({});
     expect(config.role_models).toBeUndefined();
     expect(config.default_model).toBeUndefined();
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe(HARDCODED_FALLBACK);
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'polecat')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'mayor')).toBe(HARDCODED_FALLBACK);
   });
 
   it('preserves resolution chain: role override > default_model > hardcoded', () => {
@@ -128,15 +127,15 @@ describe('resolveModel backward compatibility', () => {
       role_models: { polecat: 'google/gemini-2.5-pro' },
     });
     // polecat: role override wins
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('google/gemini-2.5-pro');
+    expect(resolveModel(config, null, 'polecat')).toBe('google/gemini-2.5-pro');
     // mayor: no role override → default_model
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'mayor')).toBe('openai/gpt-4o');
 
     // Remove default_model to test final fallback
     const configNoDefault = makeTownConfig({
       role_models: { polecat: 'google/gemini-2.5-pro' },
     });
     // refinery: no role override, no default → hardcoded
-    expect(resolveModel(configNoDefault, DUMMY_RIG, 'refinery')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(configNoDefault, null, 'refinery')).toBe(HARDCODED_FALLBACK);
   });
 });

--- a/services/gastown/src/dos/town/config.ts
+++ b/services/gastown/src/dos/town/config.ts
@@ -7,6 +7,7 @@ import {
   type TownConfig,
   type TownConfigUpdate,
   type MergeStrategy,
+  type RigOverrideConfig,
 } from '../../types';
 
 const CONFIG_KEY = 'town:config';
@@ -128,13 +129,24 @@ export async function updateTownConfig(
   return validated;
 }
 
+const DEFAULT_MODEL = 'anthropic/claude-sonnet-4.6';
+
 /**
- * Resolve the primary model from town config.
- * Priority: rig override → role-specific → town default → hardcoded default.
+ * Resolve the primary model from town config, optionally applying a rig override.
+ * Priority: rig override (role-specific) → rig override (default) → town role-specific → town default → hardcoded default.
  */
-export function resolveModel(townConfig: TownConfig, _rigId: string, role: string): string {
-  const roleModels: Record<string, string | undefined> | undefined = townConfig.role_models;
-  return roleModels?.[role] ?? townConfig.default_model ?? 'anthropic/claude-sonnet-4.6';
+export function resolveModel(
+  townConfig: TownConfig,
+  rigOverride: RigOverrideConfig | null | undefined,
+  role: string
+): string {
+  const base = rigOverride?.default_model ?? townConfig.default_model;
+  if (role === 'mayor') return townConfig.role_models?.mayor ?? townConfig.default_model ?? DEFAULT_MODEL;
+  if (role === 'polecat')
+    return rigOverride?.role_models?.polecat ?? townConfig.role_models?.polecat ?? base ?? DEFAULT_MODEL;
+  if (role === 'refinery')
+    return rigOverride?.role_models?.refinery ?? townConfig.role_models?.refinery ?? base ?? DEFAULT_MODEL;
+  return base ?? DEFAULT_MODEL;
 }
 
 /**
@@ -157,6 +169,76 @@ export function resolveMergeStrategy(
 }
 
 /**
+ * The fully-resolved configuration for a rig dispatch.
+ * All fields have concrete values (no optional/undefined) except where
+ * a null value is meaningful (e.g. auto_merge_delay_minutes: null = disabled).
+ */
+export type EffectiveConfig = {
+  default_model: string | undefined;
+  role_models: {
+    polecat: string | undefined;
+    refinery: string | undefined;
+    mayor: string | undefined;
+  };
+  review_mode: 'rework' | 'comments';
+  code_review: boolean;
+  auto_resolve_pr_feedback: boolean;
+  auto_merge_delay_minutes: number | null;
+  merge_strategy: MergeStrategy;
+  convoy_merge_mode: 'review-then-land' | 'review-and-merge';
+  custom_instructions: {
+    polecat: string | undefined;
+    refinery: string | undefined;
+    mayor: string | undefined;
+  };
+  git_push_flags: string | undefined;
+  max_concurrent_polecats: number | undefined;
+  max_dispatch_attempts: number | undefined;
+};
+
+/**
+ * Merge a rig's override config on top of town config, returning a fully
+ * resolved EffectiveConfig for dispatch. When rigOverride is null/undefined,
+ * all values fall back to town-level defaults (behavior identical to today).
+ */
+export function resolveRigConfig(
+  townConfig: TownConfig,
+  rigOverride: RigOverrideConfig | null | undefined
+): EffectiveConfig {
+  return {
+    default_model: rigOverride?.default_model ?? townConfig.default_model,
+    role_models: {
+      polecat: rigOverride?.role_models?.polecat ?? townConfig.role_models?.polecat,
+      refinery: rigOverride?.role_models?.refinery ?? townConfig.role_models?.refinery,
+      // mayor is always town-level — rigs cannot override mayor model
+      mayor: townConfig.role_models?.mayor,
+    },
+    review_mode: rigOverride?.review_mode ?? townConfig.refinery?.review_mode ?? 'rework',
+    code_review: rigOverride?.code_review ?? townConfig.refinery?.code_review ?? true,
+    auto_resolve_pr_feedback:
+      rigOverride?.auto_resolve_pr_feedback ?? townConfig.refinery?.auto_resolve_pr_feedback ?? false,
+    auto_merge_delay_minutes:
+      rigOverride?.auto_merge_delay_minutes !== undefined
+        ? rigOverride.auto_merge_delay_minutes
+        : (townConfig.refinery?.auto_merge_delay_minutes ?? null),
+    merge_strategy: rigOverride?.merge_strategy ?? townConfig.merge_strategy ?? 'direct',
+    convoy_merge_mode:
+      rigOverride?.convoy_merge_mode ?? townConfig.convoy_merge_mode ?? 'review-then-land',
+    custom_instructions: {
+      polecat: rigOverride?.custom_instructions?.polecat ?? townConfig.custom_instructions?.polecat,
+      refinery:
+        rigOverride?.custom_instructions?.refinery ?? townConfig.custom_instructions?.refinery,
+      // mayor is always town-level
+      mayor: townConfig.custom_instructions?.mayor,
+    },
+    git_push_flags: rigOverride?.git_push_flags,
+    max_concurrent_polecats:
+      rigOverride?.max_concurrent_polecats ?? townConfig.max_polecats_per_rig,
+    max_dispatch_attempts: rigOverride?.max_dispatch_attempts,
+  };
+}
+
+/**
  * Build the ContainerConfig payload for X-Town-Config header.
  * Sent with every fetch() to the container.
  */
@@ -167,7 +249,7 @@ export async function buildContainerConfig(
   const config = await getTownConfig(storage);
   return {
     env_vars: config.env_vars,
-    default_model: resolveModel(config, '', ''),
+    default_model: resolveModel(config, null, ''),
     small_model: resolveSmallModel(config),
     git_auth: config.git_auth,
     kilocode_token: config.kilocode_token,

--- a/services/gastown/src/dos/town/config.ts
+++ b/services/gastown/src/dos/town/config.ts
@@ -141,11 +141,19 @@ export function resolveModel(
   role: string
 ): string {
   const base = rigOverride?.default_model ?? townConfig.default_model;
-  if (role === 'mayor') return townConfig.role_models?.mayor ?? townConfig.default_model ?? DEFAULT_MODEL;
+  if (role === 'mayor')
+    return townConfig.role_models?.mayor ?? townConfig.default_model ?? DEFAULT_MODEL;
   if (role === 'polecat')
-    return rigOverride?.role_models?.polecat ?? townConfig.role_models?.polecat ?? base ?? DEFAULT_MODEL;
+    return (
+      rigOverride?.role_models?.polecat ?? townConfig.role_models?.polecat ?? base ?? DEFAULT_MODEL
+    );
   if (role === 'refinery')
-    return rigOverride?.role_models?.refinery ?? townConfig.role_models?.refinery ?? base ?? DEFAULT_MODEL;
+    return (
+      rigOverride?.role_models?.refinery ??
+      townConfig.role_models?.refinery ??
+      base ??
+      DEFAULT_MODEL
+    );
   return base ?? DEFAULT_MODEL;
 }
 
@@ -216,7 +224,9 @@ export function resolveRigConfig(
     review_mode: rigOverride?.review_mode ?? townConfig.refinery?.review_mode ?? 'rework',
     code_review: rigOverride?.code_review ?? townConfig.refinery?.code_review ?? true,
     auto_resolve_pr_feedback:
-      rigOverride?.auto_resolve_pr_feedback ?? townConfig.refinery?.auto_resolve_pr_feedback ?? false,
+      rigOverride?.auto_resolve_pr_feedback ??
+      townConfig.refinery?.auto_resolve_pr_feedback ??
+      false,
     auto_merge_delay_minutes:
       rigOverride?.auto_merge_delay_minutes !== undefined
         ? rigOverride.auto_merge_delay_minutes

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -12,6 +12,45 @@ import { buildContainerConfig, resolveModel, resolveSmallModel, resolveRigConfig
 
 const TOWN_LOG = '[Town.do]';
 
+// Allowlist of git push flags that are safe to pass from rig config.
+// Flags that bypass hooks (--no-verify), rewrite history (--force,
+// --force-with-lease), or alter remote refs in dangerous ways are
+// explicitly excluded to prevent config-driven bypass of protections.
+const ALLOWED_GIT_PUSH_FLAGS = new Set([
+  '--atomic',
+  '--follow-tags',
+  '--signed',
+  '--no-signed',
+  '--progress',
+  '--no-progress',
+  '--verbose',
+  '--quiet',
+  '--tags',
+  '--porcelain',
+  '--ipv4',
+  '--ipv6',
+  '--recurse-submodules=check',
+  '--recurse-submodules=on-demand',
+  '--recurse-submodules=no',
+]);
+
+/**
+ * Filter git push flags against the allowlist. Returns only the safe subset.
+ * Logs a warning for any rejected flags.
+ */
+function filterGitPushFlags(raw: string): string | undefined {
+  const flags = raw.trim().split(/\s+/).filter(Boolean);
+  const allowed: string[] = [];
+  for (const flag of flags) {
+    if (ALLOWED_GIT_PUSH_FLAGS.has(flag)) {
+      allowed.push(flag);
+    } else {
+      console.warn(`${TOWN_LOG} filterGitPushFlags: rejecting unsafe flag "${flag}"`);
+    }
+  }
+  return allowed.length > 0 ? allowed.join(' ') : undefined;
+}
+
 // Module-level diagnostic: stores the last container start error so
 // callers can surface it via the admin API. Reset on each call.
 let lastStartError: string | null = null;
@@ -453,7 +492,12 @@ export async function startAgentInContainer(
             params.role as keyof typeof effectiveConfig.custom_instructions
           ]
         ),
-        ...(effectiveConfig.git_push_flags ? { gitPushFlags: effectiveConfig.git_push_flags } : {}),
+        ...(effectiveConfig.git_push_flags
+          ? (() => {
+              const safe = filterGitPushFlags(effectiveConfig.git_push_flags);
+              return safe ? { gitPushFlags: safe } : {};
+            })()
+          : {}),
         gitUrl: params.gitUrl,
         branch: params.convoyFeatureBranch
           ? branchForConvoyAgent(params.convoyFeatureBranch, params.agentName, params.beadId)

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -449,7 +449,9 @@ export async function startAgentInContainer(
             }),
           params.role,
           params.townConfig,
-          effectiveConfig.custom_instructions[params.role as keyof typeof effectiveConfig.custom_instructions]
+          effectiveConfig.custom_instructions[
+            params.role as keyof typeof effectiveConfig.custom_instructions
+          ]
         ),
         ...(effectiveConfig.git_push_flags ? { gitPushFlags: effectiveConfig.git_push_flags } : {}),
         gitUrl: params.gitUrl,

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -7,8 +7,8 @@ import { getTownContainerStub } from '../TownContainer.do';
 import { signAgentJWT, signContainerJWT } from '../../util/jwt.util';
 import { buildPolecatSystemPrompt } from '../../prompts/polecat-system.prompt';
 import { buildMayorSystemPrompt } from '../../prompts/mayor-system.prompt';
-import type { TownConfig } from '../../types';
-import { buildContainerConfig, resolveModel, resolveSmallModel } from './config';
+import type { TownConfig, RigOverrideConfig } from '../../types';
+import { buildContainerConfig, resolveModel, resolveSmallModel, resolveRigConfig } from './config';
 
 const TOWN_LOG = '[Town.do]';
 
@@ -244,16 +244,19 @@ export function systemPromptForRole(params: {
 }
 
 /**
- * Append per-role custom instructions from town config to a system prompt.
- * Returns the prompt unchanged when no custom instructions exist for the role.
+ * Append per-role custom instructions to a system prompt.
+ * Accepts either a TownConfig (falls back to town-level instructions)
+ * or a pre-resolved instructions string. Returns the prompt unchanged
+ * when no custom instructions exist for the role.
  */
 export function appendCustomInstructions(
   systemPrompt: string,
   role: string,
-  townConfig: TownConfig
+  townConfig: TownConfig,
+  resolvedInstructions?: string | null
 ): string {
   const roleKey = role as keyof NonNullable<TownConfig['custom_instructions']>;
-  const instructions = townConfig.custom_instructions?.[roleKey]?.trim();
+  const instructions = (resolvedInstructions ?? townConfig.custom_instructions?.[roleKey])?.trim();
   if (!instructions) return systemPrompt;
   return `${systemPrompt}\n\n## Custom Instructions (from town settings)\n\n${instructions}`;
 }
@@ -320,6 +323,8 @@ export async function startAgentInContainer(
     defaultBranch: string;
     kilocodeToken?: string;
     townConfig: TownConfig;
+    /** Rig-level config overrides. When present, merged on top of townConfig for model, custom_instructions, and git_push_flags. */
+    rigOverride?: RigOverrideConfig | null;
     systemPromptOverride?: string;
     platformIntegrationId?: string;
     /** For convoy beads: the convoy's feature branch to branch from instead of defaultBranch. */
@@ -407,6 +412,9 @@ export async function startAgentInContainer(
     const containerConfig = await buildContainerConfig(storage, env);
     const container = getTownContainerStub(env, params.townId);
 
+    const rigOverride = params.rigOverride ?? null;
+    const effectiveConfig = resolveRigConfig(params.townConfig, rigOverride);
+
     const response = await container.fetch('http://container/agents/start', {
       method: 'POST',
       signal: AbortSignal.timeout(60_000),
@@ -427,7 +435,7 @@ export async function startAgentInContainer(
           checkpoint: params.checkpoint,
           conversationHistory: params.conversationHistory,
         }),
-        model: resolveModel(params.townConfig, params.rigId, params.role),
+        model: resolveModel(params.townConfig, rigOverride, params.role),
         smallModel: resolveSmallModel(params.townConfig),
         systemPrompt: appendCustomInstructions(
           params.systemPromptOverride ??
@@ -440,8 +448,10 @@ export async function startAgentInContainer(
               gates: params.townConfig.refinery?.gates ?? [],
             }),
           params.role,
-          params.townConfig
+          params.townConfig,
+          effectiveConfig.custom_instructions[params.role as keyof typeof effectiveConfig.custom_instructions]
         ),
+        ...(effectiveConfig.git_push_flags ? { gitPushFlags: effectiveConfig.git_push_flags } : {}),
         gitUrl: params.gitUrl,
         branch: params.convoyFeatureBranch
           ? branchForConvoyAgent(params.convoyFeatureBranch, params.agentName, params.beadId)

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -30,9 +30,11 @@ import * as reviewQueue from './review-queue';
 import * as agents from './agents';
 import * as beadOps from './beads';
 import { getRig } from './rigs';
+import { resolveRigConfig } from './config';
 import { PR_POLL_INTERVAL_MS } from './actions';
 import type { Action } from './actions';
 import type { TownEventRecord } from '../../db/tables/town-events.table';
+import type { TownConfig } from '../../types';
 
 const LOG = '[reconciler]';
 
@@ -462,15 +464,13 @@ export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
 
 export function reconcile(
   sql: SqlStorage,
-  opts?: { draining?: boolean; refineryCodeReview?: boolean }
+  opts?: { draining?: boolean; townConfig?: TownConfig }
 ): Action[] {
   const draining = opts?.draining ?? false;
   const actions: Action[] = [];
   actions.push(...reconcileAgents(sql, { draining }));
-  actions.push(...reconcileBeads(sql, { draining }));
-  actions.push(
-    ...reconcileReviewQueue(sql, { draining, refineryCodeReview: opts?.refineryCodeReview })
-  );
+  actions.push(...reconcileBeads(sql, { draining, townConfig: opts?.townConfig }));
+  actions.push(...reconcileReviewQueue(sql, { draining, townConfig: opts?.townConfig }));
   actions.push(...reconcileConvoys(sql));
   actions.push(...reconcileGUPP(sql, { draining }));
   actions.push(...reconcileGC(sql));
@@ -666,9 +666,22 @@ export function reconcileAgents(sql: SqlStorage, opts?: { draining?: boolean }):
 // reconcileBeads — handle unassigned beads, lost agents, stale reviews
 // ════════════════════════════════════════════════════════════════════
 
-export function reconcileBeads(sql: SqlStorage, opts?: { draining?: boolean }): Action[] {
+export function reconcileBeads(
+  sql: SqlStorage,
+  opts?: { draining?: boolean; townConfig?: TownConfig }
+): Action[] {
   const draining = opts?.draining ?? false;
   const actions: Action[] = [];
+
+  // Resolve per-rig max_dispatch_attempts, falling back to the module default.
+  const rigMaxDispatchAttempts = (rigId: string | null): number => {
+    if (!rigId || !opts?.townConfig) return MAX_DISPATCH_ATTEMPTS;
+    const rig = getRig(sql, rigId);
+    return (
+      resolveRigConfig(opts.townConfig, rig?.config ?? null).max_dispatch_attempts ??
+      MAX_DISPATCH_ATTEMPTS
+    );
+  };
 
   // Town-level circuit breaker: if too many dispatch failures in the
   // window, skip all dispatch_agent actions and escalate to mayor.
@@ -721,7 +734,7 @@ export function reconcileBeads(sql: SqlStorage, opts?: { draining?: boolean }): 
     }
 
     // Per-bead dispatch cap: fail the bead if it exhausted all attempts
-    if (bead.dispatch_attempts >= MAX_DISPATCH_ATTEMPTS) {
+    if (bead.dispatch_attempts >= rigMaxDispatchAttempts(bead.rig_id)) {
       actions.push({
         type: 'transition_bead',
         bead_id: bead.bead_id,
@@ -1076,14 +1089,31 @@ export function reconcileBeads(sql: SqlStorage, opts?: { draining?: boolean }): 
 
 export function reconcileReviewQueue(
   sql: SqlStorage,
-  opts?: { draining?: boolean; refineryCodeReview?: boolean }
+  opts?: { draining?: boolean; townConfig?: TownConfig }
 ): Action[] {
   const draining = opts?.draining ?? false;
-  const refineryCodeReview = opts?.refineryCodeReview ?? true;
   const actions: Action[] = [];
 
   // Town-level circuit breaker
   const circuitBreakerOpen = checkDispatchCircuitBreaker(sql).length > 0;
+
+  // Resolve per-rig code_review setting. Falls back to town default when
+  // townConfig is not provided (e.g. in tests or debug replay).
+  const rigCodeReview = (rigId: string): boolean => {
+    if (!opts?.townConfig) return true;
+    const rig = getRig(sql, rigId);
+    return resolveRigConfig(opts.townConfig, rig?.config ?? null).code_review;
+  };
+
+  // Resolve per-rig max_dispatch_attempts, falling back to the module default.
+  const rigMaxDispatchAttempts = (rigId: string | null): number => {
+    if (!rigId || !opts?.townConfig) return MAX_DISPATCH_ATTEMPTS;
+    const rig = getRig(sql, rigId);
+    return (
+      resolveRigConfig(opts.townConfig, rig?.config ?? null).max_dispatch_attempts ??
+      MAX_DISPATCH_ATTEMPTS
+    );
+  };
 
   // Get all MR beads that need attention
   const mrBeads = MrBeadRow.array().parse([
@@ -1183,10 +1213,11 @@ export function reconcileReviewQueue(
 
     // Rule 4: PR-strategy MR beads orphaned (refinery dispatched then died, stale >30min)
     // Only in_progress — open beads are just waiting for the refinery to pop them.
-    // Skip when refinery code review is disabled: poll_pr keeps the bead alive via
-    // updated_at touches, and no refinery is expected to be working on it.
+    // Skip when refinery code review is disabled for this rig: poll_pr keeps the
+    // bead alive via updated_at touches, and no refinery is expected to be working.
     if (
-      refineryCodeReview &&
+      mr.rig_id &&
+      rigCodeReview(mr.rig_id) &&
       mr.status === 'in_progress' &&
       mr.pr_url &&
       staleMs(mr.updated_at, ORPHANED_PR_REVIEW_TIMEOUT_MS)
@@ -1205,13 +1236,33 @@ export function reconcileReviewQueue(
     }
   }
 
-  // When refinery code review is disabled:
-  //  - MR beads WITH pr_url → fast-track to in_progress for poll_pr
-  //  - MR beads WITHOUT pr_url → fail them and reopen the source bead
+  // Per-rig: when refinery code review is disabled for a rig:
+  //  - MR beads for that rig WITH pr_url → fast-track to in_progress for poll_pr
+  //  - MR beads for that rig WITHOUT pr_url → fail them and reopen the source bead
   //    (the polecat was supposed to create the PR via merge_strategy=pr
   //    but didn't provide one — retry the source bead)
-  if (!refineryCodeReview) {
-    // Fast-track: open MR beads with pr_url → in_progress
+  // Collect all rigs that have open MR beads so we can apply per-rig logic.
+  const rigsWithAnyOpenMrs = z
+    .object({ rig_id: z.string() })
+    .array()
+    .parse([
+      ...query(
+        sql,
+        /* sql */ `
+          SELECT DISTINCT b.${beads.columns.rig_id}
+          FROM ${beads} b
+          WHERE b.${beads.columns.type} = 'merge_request'
+            AND b.${beads.columns.status} = 'open'
+            AND b.${beads.columns.rig_id} IS NOT NULL
+        `,
+        []
+      ),
+    ]);
+
+  for (const { rig_id } of rigsWithAnyOpenMrs) {
+    if (rigCodeReview(rig_id)) continue;
+
+    // Fast-track: open MR beads with pr_url → in_progress (skip refinery review)
     const openMrsWithPr = z
       .object({ bead_id: z.string() })
       .array()
@@ -1225,6 +1276,7 @@ export function reconcileReviewQueue(
               ON rm.${review_metadata.columns.bead_id} = b.${beads.columns.bead_id}
             WHERE b.${beads.columns.type} = 'merge_request'
               AND b.${beads.columns.status} = 'open'
+              AND b.${beads.columns.rig_id} = ?
               AND rm.${review_metadata.columns.pr_url} IS NOT NULL
               AND NOT EXISTS (
                 SELECT 1
@@ -1235,7 +1287,7 @@ export function reconcileReviewQueue(
                   AND cm.${convoy_metadata.columns.merge_mode} = 'review-and-merge'
               )
           `,
-          []
+          [rig_id]
         ),
       ]);
     for (const { bead_id } of openMrsWithPr) {
@@ -1270,6 +1322,7 @@ export function reconcileReviewQueue(
               AND bd.${bead_dependencies.columns.dependency_type} = 'tracks'
             WHERE b.${beads.columns.type} = 'merge_request'
               AND b.${beads.columns.status} = 'open'
+              AND b.${beads.columns.rig_id} = ?
               AND rm.${review_metadata.columns.pr_url} IS NULL
               AND NOT EXISTS (
                 SELECT 1
@@ -1280,7 +1333,7 @@ export function reconcileReviewQueue(
                   AND cm.${convoy_metadata.columns.merge_mode} = 'review-and-merge'
               )
           `,
-          []
+          [rig_id]
         ),
       ]);
     for (const { bead_id, source_bead_id } of orphanedMrs) {
@@ -1306,30 +1359,15 @@ export function reconcileReviewQueue(
   }
 
   // Rules 5-6: Refinery dispatch for open MR beads.
-  // When code_review=true: dispatches for all open MR beads.
-  // When code_review=false: only dispatches for convoy review-and-merge
+  // When code_review=true for a rig: dispatches for all open MR beads in that rig.
+  // When code_review=false for a rig: only dispatches for convoy review-and-merge
   // MR beads (the fast-track above already moved ordinary MR beads to
   // in_progress as actions, but those haven't been applied to SQL yet —
   // so we must filter here to avoid re-dispatching them).
   {
     // Rule 5: Pop open MR bead for idle refinery
     // Get all rigs that have open MR beads needing the refinery.
-    // When code_review=false, only dispatch the refinery for convoy
-    // review-and-merge MR beads (refinery does combined review+merge).
-    // MR beads WITH a pr_url are handled by the fast-track → poll_pr.
-    // MR beads WITHOUT a pr_url when merge_strategy=pr are orphaned
-    // (polecat should have created the PR) — Rule 2 handles them.
-    const refineryNeededFilter = refineryCodeReview
-      ? ''
-      : /* sql */ `
-          AND EXISTS (
-            SELECT 1
-            FROM ${beads} parent
-            JOIN ${convoy_metadata} cm
-              ON cm.${convoy_metadata.columns.bead_id} = parent.${beads.columns.bead_id}
-            WHERE parent.${beads.columns.bead_id} = b.${beads.columns.parent_bead_id}
-              AND cm.${convoy_metadata.columns.merge_mode} = 'review-and-merge'
-          )`;
+    // All rigs with open MRs are candidates; per-rig code_review is checked inside the loop.
     const rigsWithOpenMrs = z
       .object({ rig_id: z.string() })
       .array()
@@ -1342,13 +1380,29 @@ export function reconcileReviewQueue(
         WHERE b.${beads.columns.type} = 'merge_request'
           AND b.${beads.columns.status} = 'open'
           AND b.${beads.columns.rig_id} IS NOT NULL
-          ${refineryNeededFilter}
       `,
           []
         ),
       ]);
 
     for (const { rig_id } of rigsWithOpenMrs) {
+      // When code_review=false, only dispatch the refinery for convoy
+      // review-and-merge MR beads (refinery does combined review+merge).
+      // MR beads WITH a pr_url are handled by the fast-track → poll_pr.
+      // MR beads WITHOUT a pr_url when merge_strategy=pr are orphaned
+      // (polecat should have created the PR) — Rule 2 handles them.
+      const refineryNeededFilter = rigCodeReview(rig_id)
+        ? ''
+        : /* sql */ `
+            AND EXISTS (
+              SELECT 1
+              FROM ${beads} parent
+              JOIN ${convoy_metadata} cm
+                ON cm.${convoy_metadata.columns.bead_id} = parent.${beads.columns.bead_id}
+              WHERE parent.${beads.columns.bead_id} = b.${beads.columns.parent_bead_id}
+                AND cm.${convoy_metadata.columns.merge_mode} = 'review-and-merge'
+            )`;
+
       // Check if rig already has an in_progress MR that needs the refinery.
       // PR-strategy MR beads (pr_url IS NOT NULL) don't need the refinery —
       // the merge is handled by the user/CI via the PR. Only direct-strategy
@@ -1526,9 +1580,11 @@ export function reconcileReviewQueue(
         continue;
       }
 
+      const rigId = mr.rig_id ?? ref.rig_id ?? null;
+
       // Per-bead dispatch cap — check before cooldown so max-attempt MR
       // beads are failed immediately rather than waiting for the cooldown.
-      if (mr.dispatch_attempts >= MAX_DISPATCH_ATTEMPTS) {
+      if (mr.dispatch_attempts >= rigMaxDispatchAttempts(rigId)) {
         actions.push({
           type: 'transition_bead',
           bead_id: ref.current_hook_bead_id,
@@ -1558,7 +1614,7 @@ export function reconcileReviewQueue(
         type: 'dispatch_agent',
         agent_id: ref.bead_id,
         bead_id: ref.current_hook_bead_id,
-        rig_id: mr.rig_id ?? ref.rig_id ?? '',
+        rig_id: rigId ?? '',
       });
     }
   } // end Rules 5–6 block

--- a/services/gastown/src/dos/town/rigs.ts
+++ b/services/gastown/src/dos/town/rigs.ts
@@ -132,6 +132,7 @@ export function removeRig(sql: SqlStorage, rigId: string): void {
 }
 
 export function updateRigConfig(sql: SqlStorage, rigId: string, config: RigOverrideConfig): void {
-  const validated = RigOverrideConfigSchema.parse(config);
-  query(sql, /* sql */ `UPDATE rigs SET config = ? WHERE id = ?`, [JSON.stringify(validated), rigId]);
+  const existing = getRig(sql, rigId);
+  const merged = RigOverrideConfigSchema.parse({ ...(existing?.config ?? {}), ...config });
+  query(sql, /* sql */ `UPDATE rigs SET config = ? WHERE id = ?`, [JSON.stringify(merged), rigId]);
 }

--- a/services/gastown/src/dos/town/rigs.ts
+++ b/services/gastown/src/dos/town/rigs.ts
@@ -5,6 +5,7 @@
 
 import { z } from 'zod';
 import { query } from '../../util/query.util';
+import { type RigOverrideConfig, RigOverrideConfigSchema } from '../../types';
 
 const RIG_TABLE_CREATE = /* sql */ `
   CREATE TABLE IF NOT EXISTS "rigs" (
@@ -26,14 +27,14 @@ export const RigRecord = z.object({
   default_branch: z.string(),
   config: z
     .string()
-    .transform((v): Record<string, unknown> => {
+    .transform((v): unknown => {
       try {
-        return JSON.parse(v) as Record<string, unknown>;
+        return JSON.parse(v) as unknown;
       } catch {
         return {};
       }
     })
-    .pipe(z.record(z.string(), z.unknown())),
+    .pipe(RigOverrideConfigSchema),
   created_at: z.string(),
 });
 
@@ -128,4 +129,9 @@ export function listRigs(sql: SqlStorage): RigRecord[] {
 
 export function removeRig(sql: SqlStorage, rigId: string): void {
   query(sql, /* sql */ `DELETE FROM rigs WHERE id = ?`, [rigId]);
+}
+
+export function updateRigConfig(sql: SqlStorage, rigId: string, config: RigOverrideConfig): void {
+  const validated = RigOverrideConfigSchema.parse(config);
+  query(sql, /* sql */ `UPDATE rigs SET config = ? WHERE id = ?`, [JSON.stringify(validated), rigId]);
 }

--- a/services/gastown/src/dos/town/scheduling.ts
+++ b/services/gastown/src/dos/town/scheduling.ts
@@ -124,6 +124,8 @@ export async function dispatchAgent(
       [timestamp, bead.bead_id]
     );
 
+    const rigRecord = rigs.getRig(ctx.sql, rigId);
+
     const started = await dispatch.startAgentInContainer(ctx.env, ctx.storage, {
       townId: ctx.townId,
       rigId,
@@ -140,6 +142,7 @@ export async function dispatchAgent(
       defaultBranch: rigConfig.defaultBranch,
       kilocodeToken,
       townConfig,
+      rigOverride: rigRecord?.config ?? null,
       platformIntegrationId: rigConfig.platformIntegrationId,
       convoyFeatureBranch: convoyFeatureBranch ?? undefined,
       systemPromptOverride: options?.systemPromptOverride,

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -16,7 +16,7 @@ import { getGastownOrgStub } from '../dos/GastownOrg.do';
 import type { JwtOrgMembership } from '../middleware/auth.middleware';
 import { generateKiloApiToken } from '../util/kilo-token.util';
 import { resolveSecret } from '../util/secret.util';
-import { TownConfigSchema, TownConfigUpdateSchema } from '../types';
+import { TownConfigSchema, TownConfigUpdateSchema, RigOverrideConfigSchema } from '../types';
 import { resolveModel } from '../dos/town/config';
 import type { UserRigRecord } from '../db/tables/user-rigs.table';
 import {
@@ -558,7 +558,8 @@ export const gastownRouter = router({
       // Sequential to avoid "excessively deep" type inference with Rpc.Promisified DO stubs.
       const agentList = await townStub.listAgents({ rig_id: rig.id });
       const beadList = await townStub.listBeads({ rig_id: rig.id, status: 'in_progress' });
-      return { ...rig, agents: agentList, beads: beadList };
+      const townRig = await townStub.getRigAsync(rig.id);
+      return { ...rig, agents: agentList, beads: beadList, config: townRig?.config };
     }),
 
   deleteRig: gastownProcedure
@@ -585,6 +586,47 @@ export const gastownRouter = router({
       await townStub.removeRig(input.rigId);
       const ownerStub = ownership.stub;
       await ownerStub.deleteRig(input.rigId);
+    }),
+
+  updateRigConfig: gastownProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid().optional(),
+        rigId: z.string().uuid(),
+        config: RigOverrideConfigSchema,
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
+      const ownership = await resolveTownOwnership(ctx.env, ctx, rig.town_id);
+
+      // Admins cannot modify rig config for towns they do not own
+      if (ownership.type === 'admin') {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Admins cannot modify rig configuration for rigs they do not own',
+        });
+      }
+
+      // For org towns, only owners or the town creator can update rig config
+      if (ownership.type === 'org') {
+        const townStubForCheck = getTownDOStub(ctx.env, rig.town_id);
+        const townConfig = await townStubForCheck.getTownConfig();
+        const membership = getOrgMembership(ctx.orgMemberships, ownership.orgId);
+        const isOrgOwner = membership?.role === 'owner';
+        const isTownCreator = ctx.userId === townConfig.created_by_user_id;
+        if (!isOrgOwner && !isTownCreator) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'Only town creators and org owners can update rig config',
+          });
+        }
+      }
+
+      const townStub = getTownDOStub(ctx.env, rig.town_id);
+      await townStub.updateRigConfig(input.rigId, input.config);
+      const updatedRig = await townStub.getRigAsync(input.rigId);
+      return updatedRig;
     }),
 
   // ── Beads ───────────────────────────────────────────────────────────

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -1070,8 +1070,8 @@ export const gastownRouter = router({
       // auth-relevant config changed. The SDK server is a child process
       // that captures env at spawn time, so it must be restarted to pick
       // up rotated tokens or cleared credentials.
-      const oldMayorModel = resolveModel(existingConfig, '', 'mayor');
-      const newMayorModel = resolveModel(result, '', 'mayor');
+      const oldMayorModel = resolveModel(existingConfig, null, 'mayor');
+      const newMayorModel = resolveModel(result, null, 'mayor');
       const mayorModelChanged =
         newMayorModel !== oldMayorModel || result.small_model !== existingConfig.small_model;
       const authConfigChanged =

--- a/services/gastown/src/trpc/schemas.ts
+++ b/services/gastown/src/trpc/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { RigOverrideConfigSchema } from '../types';
 
 /**
  * Wraps a Zod schema in z.any().pipe(schema) so the TS input type is `any`
@@ -164,6 +165,7 @@ export const RigDetailOutput = z.object({
   platform_integration_id: z.string().nullable().optional().default(null),
   created_at: z.string(),
   updated_at: z.string(),
+  config: RigOverrideConfigSchema.optional(),
   agents: z.array(AgentOutput),
   beads: z.array(BeadOutput),
 });

--- a/services/gastown/src/types.ts
+++ b/services/gastown/src/types.ts
@@ -330,6 +330,47 @@ export const TownConfigSchema = z.object({
 
 export type TownConfig = z.infer<typeof TownConfigSchema>;
 
+// -- Rig Override Configuration --
+
+export const RigOverrideConfigSchema = z.object({
+  // Model overrides (override townConfig.default_model / role_models)
+  default_model: z.string().optional(),
+  role_models: z
+    .object({
+      polecat: z.string().optional(),
+      refinery: z.string().optional(),
+    })
+    .optional(),
+
+  // Review behavior
+  review_mode: z.enum(['rework', 'comments']).optional(),
+  /** false = skip refinery entirely */
+  code_review: z.boolean().optional(),
+  auto_resolve_pr_feedback: z.boolean().optional(),
+  auto_merge_delay_minutes: z.number().int().min(0).nullable().optional(),
+
+  // Merge strategy
+  merge_strategy: z.enum(['direct', 'pr']).optional(),
+  convoy_merge_mode: z.enum(['review-then-land', 'review-and-merge']).optional(),
+
+  // Custom instructions
+  custom_instructions: z
+    .object({
+      polecat: z.string().optional(),
+      refinery: z.string().optional(),
+    })
+    .optional(),
+
+  // Git
+  git_push_flags: z.string().optional(),
+
+  // Agent limits
+  max_concurrent_polecats: z.number().int().positive().optional(),
+  max_dispatch_attempts: z.number().int().positive().optional(),
+});
+
+export type RigOverrideConfig = z.infer<typeof RigOverrideConfigSchema>;
+
 /**
  * Partial update schema — all fields optional, NO defaults.
  * TownConfigSchema.partial() can't be used here because Zod still fires


### PR DESCRIPTION
## Summary

- Adds `RigSettingsPageClient` with a scrollspy sidebar + `SettingsSection`/`FieldGroup` pattern, mirroring `TownSettingsPageClient`
- Sections: **Models** (default/polecat/refinery model overrides with clear buttons), **Refinery** (code review toggle, review mode, auto-resolve PR feedback, auto-merge delay), **Merge Strategy** (direct/PR and convoy merge mode), **Custom Instructions** (polecat/refinery textareas with town default as placeholder), **Git** (push flags), **Agent Limits** (max concurrent polecats, max dispatch attempts)
- Each field shows the town-level inherited value as placeholder when not overridden; a `×` clear button removes the override
- Single **Save** button calls `trpc.gastown.updateRigConfig`; shows toast on success/error
- New Next.js page routes: `/gastown/[townId]/rigs/[rigId]/settings` and org-scoped `/organizations/[id]/gastown/[townId]/rigs/[rigId]/settings`
- Settings gear icon link added to `RigDetailPageClient` top bar near the Sling Work button
- `router.d.ts` updated to declare `updateRigConfig` mutation and `config` field in `getRig` output using correct `RigOverrideConfigSchema` field names (`git_push_flags`, `max_concurrent_polecats`, flat review fields)

## Verification

- TypeScript: all errors in new files are pre-existing missing-module errors from uninstalled `node_modules` in this worktree (same pattern seen across all other files); no logic or type errors introduced by the changes
- Visually reviewed component structure mirrors `TownSettingsPageClient` pattern exactly

## Visual Changes

N/A — new page, no before/after

## Reviewer Notes

- The rig config fields are **flat** (not nested under a `refinery` sub-object like the town config), per `RigOverrideConfigSchema` in `services/gastown/src/types.ts`
- `router.d.ts` is a hand-maintained declaration file; changes here reflect the actual API shape from bead 2's worker changes
- The org-scoped route delegates to the same `RigSettingsPageClient` shared component