### PR TITLE
feat(kiloclaw): add docker-local provider demo

### DIFF
--- a/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
@@ -76,6 +76,7 @@ export function InstanceControls({
   const isStopped = status.status === 'stopped';
   const isStartable = isStopped || isProvisioned;
   const isDestroying = status.status === 'destroying';
+  const isFlyProvider = status.provider === 'fly';
   // Auto-start runs only on fresh provision (status=provisioned), not re-provision
   const isAutoStarting = isProvisioned && mutations.provision.isPending;
   const [isEditingName, setIsEditingName] = useState(false);
@@ -113,7 +114,8 @@ export function InstanceControls({
     setManuallyDismissed(true);
   }, [dismissKey]);
 
-  const showUpgradeBanner = updateAvailable && !isDismissedInStorage && !manuallyDismissed;
+  const showUpgradeBanner =
+    isFlyProvider && updateAvailable && !isDismissedInStorage && !manuallyDismissed;
 
   const handleSaveName = () => {
     const trimmed = nameValue.trim();
@@ -135,12 +137,13 @@ export function InstanceControls({
   // with "upgrade" preselected, then immediately reset via onUpgradeHandled.
   // Safe for single-click flows; won't re-fire if already true (no state change).
   useEffect(() => {
-    if (upgradeRequested) {
+    if (!upgradeRequested) return;
+    if (isFlyProvider) {
       setRedeployMode('upgrade');
       setConfirmRedeploy(true);
-      onUpgradeHandled?.();
     }
-  }, [upgradeRequested, onUpgradeHandled]);
+    onUpgradeHandled?.();
+  }, [upgradeRequested, isFlyProvider, onUpgradeHandled]);
 
   return (
     <div>
@@ -309,7 +312,7 @@ export function InstanceControls({
           className="border-amber-500/30 text-amber-400 hover:bg-amber-500/10 hover:text-amber-300"
           disabled={
             (!isRunning && !isStopped) ||
-            !status.flyMachineId ||
+            !status.runtimeId ||
             mutations.restartMachine.isPending ||
             isDestroying ||
             isStarting ||
@@ -323,7 +326,7 @@ export function InstanceControls({
           }}
         >
           <RotateCw className="h-4 w-4" />
-          Redeploy or Upgrade
+          {isFlyProvider ? 'Redeploy or Upgrade' : 'Redeploy'}
         </Button>
         <Button
           size="sm"
@@ -395,10 +398,10 @@ export function InstanceControls({
       >
         <DialogContent className="max-w-md">
           <DialogHeader>
-            <DialogTitle>Redeploy or Upgrade</DialogTitle>
+            <DialogTitle>{isFlyProvider ? 'Redeploy or Upgrade' : 'Redeploy'}</DialogTitle>
             <DialogDescription>
-              This will stop the machine, rebuild environment variables and secrets, and restart it.
-              The machine will be briefly offline.
+              This will stop the runtime, rebuild environment variables and secrets, and restart it.
+              The runtime will be briefly offline.
             </DialogDescription>
           </DialogHeader>
           <RadioGroup
@@ -417,16 +420,18 @@ export function InstanceControls({
                 </span>
               </Label>
             </div>
-            <div className="flex items-start gap-3">
-              <RadioGroupItem value="upgrade" id="upgrade" className="mt-0.5" />
-              <Label htmlFor="upgrade" className="block cursor-pointer leading-tight">
-                <span className="text-foreground text-sm font-medium">Upgrade to latest</span>
-                <span className="text-muted-foreground mt-0.5 block text-xs">
-                  Upgrade to the latest supported KiloClaw version, redeploy and apply pending
-                  config changes.
-                </span>
-              </Label>
-            </div>
+            {isFlyProvider && (
+              <div className="flex items-start gap-3">
+                <RadioGroupItem value="upgrade" id="upgrade" className="mt-0.5" />
+                <Label htmlFor="upgrade" className="block cursor-pointer leading-tight">
+                  <span className="text-foreground text-sm font-medium">Upgrade to latest</span>
+                  <span className="text-muted-foreground mt-0.5 block text-xs">
+                    Upgrade to the latest supported KiloClaw version, redeploy and apply pending
+                    config changes.
+                  </span>
+                </Label>
+              </div>
+            )}
           </RadioGroup>
           <DialogFooter>
             <Button

--- a/apps/web/src/app/(app)/claw/components/withStatusQueryBoundary.test.ts
+++ b/apps/web/src/app/(app)/claw/components/withStatusQueryBoundary.test.ts
@@ -7,6 +7,10 @@ import { withStatusQueryBoundary } from '@/app/(app)/claw/components';
 const baseStatus: KiloClawDashboardStatus = {
   userId: 'user-1',
   sandboxId: 'sandbox-1',
+  provider: 'fly',
+  runtimeId: 'machine-1',
+  storageId: 'vol-1',
+  region: 'iad',
   name: null,
   status: 'running',
   provisionedAt: 1,

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1292,6 +1292,8 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
   const runtimeId = data?.workerStatus?.runtimeId ?? null;
   const storageId = data?.workerStatus?.storageId ?? null;
   const flyMachineId = data?.workerStatus?.flyMachineId ?? null;
+  const canShowFlySshCommand =
+    isFlyProvider && !!data?.workerStatus?.runtimeId && !!data.workerStatus.flyAppName;
   const volumeId = isFlyProvider ? storageId : null;
   const snapshotsEnabled = data !== undefined && data.destroyed_at === null && !!volumeId;
 
@@ -2019,7 +2021,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                 <div className="flex items-center gap-2">
                   <Server className="text-muted-foreground h-4 w-4 shrink-0" />
                   <DetailField label="Runtime ID">
-                    {isFlyProvider &&
+                    {canShowFlySshCommand &&
                     data.workerStatus.runtimeId &&
                     data.workerStatus.flyAppName ? (
                       <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1287,7 +1287,12 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     })
   );
 
-  const volumeId = data?.workerStatus?.flyVolumeId;
+  const provider = data?.workerStatus?.provider ?? null;
+  const isFlyProvider = provider === 'fly';
+  const runtimeId = data?.workerStatus?.runtimeId ?? null;
+  const storageId = data?.workerStatus?.storageId ?? null;
+  const flyMachineId = data?.workerStatus?.flyMachineId ?? null;
+  const volumeId = isFlyProvider ? storageId : null;
   const snapshotsEnabled = data !== undefined && data.destroyed_at === null && !!volumeId;
 
   const {
@@ -1312,9 +1317,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
   });
 
   const gatewayControlsEnabled =
-    data?.destroyed_at === null &&
-    !!data?.workerStatus?.flyMachineId &&
-    data?.workerStatus?.status !== 'restoring';
+    data?.destroyed_at === null && !!runtimeId && data?.workerStatus?.status !== 'restoring';
 
   const {
     data: gatewayStatus,
@@ -1420,10 +1423,12 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     data?.destroyed_at === null &&
     data?.workerStatus?.status !== 'restoring' &&
     data?.workerStatus?.status !== 'recovering';
-  const hasMachine = !!data?.workerStatus?.flyMachineId;
+  const hasRuntime = !!runtimeId;
+  const hasFlyMachine = isFlyProvider && !!flyMachineId;
   const canRetryMetadataRecovery =
     data?.destroyed_at === null &&
-    !data?.workerStatus?.flyMachineId &&
+    isFlyProvider &&
+    !flyMachineId &&
     data?.workerStatus?.status === 'stopped';
 
   const invalidateMachineQueries = () => {
@@ -1589,8 +1594,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     }
   };
 
-  // Reset the destroyed success state when the machine ID changes (e.g. new machine created)
-  const flyMachineId = data?.workerStatus?.flyMachineId;
+  // Reset the destroyed success state when the Fly machine ID changes (e.g. new machine created)
   useEffect(() => {
     resetDestroyFlyMachine();
   }, [flyMachineId, resetDestroyFlyMachine]);
@@ -2014,32 +2018,34 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
 
                 <div className="flex items-center gap-2">
                   <Server className="text-muted-foreground h-4 w-4 shrink-0" />
-                  <DetailField label="Fly Machine ID">
-                    {data.workerStatus.flyMachineId && data.workerStatus.flyAppName ? (
+                  <DetailField label="Runtime ID">
+                    {isFlyProvider &&
+                    data.workerStatus.runtimeId &&
+                    data.workerStatus.flyAppName ? (
                       <div className="flex flex-wrap items-center gap-2">
                         <a
-                          href={`https://fly.io/apps/${data.workerStatus.flyAppName}/machines/${data.workerStatus.flyMachineId}`}
+                          href={`https://fly.io/apps/${data.workerStatus.flyAppName}/machines/${data.workerStatus.runtimeId}`}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="inline-flex items-center gap-1 text-blue-600 hover:underline"
                         >
-                          <code className="text-sm">{data.workerStatus.flyMachineId}</code>
+                          <code className="text-sm">{data.workerStatus.runtimeId}</code>
                           <ExternalLink className="h-3 w-3" />
                         </a>
                         <CopySshCommandButton
                           flyAppName={data.workerStatus.flyAppName}
-                          flyMachineId={data.workerStatus.flyMachineId}
+                          flyMachineId={data.workerStatus.runtimeId}
                         />
                       </div>
                     ) : (
-                      <code className="text-sm">{data.workerStatus.flyMachineId ?? '—'}</code>
+                      <code className="text-sm">{data.workerStatus.runtimeId ?? '—'}</code>
                     )}
                   </DetailField>
                 </div>
 
                 <div className="flex items-center gap-2">
                   <Globe className="text-muted-foreground h-4 w-4 shrink-0" />
-                  <DetailField label="Fly Region">{data.workerStatus.flyRegion ?? '—'}</DetailField>
+                  <DetailField label="Region">{data.workerStatus.region ?? '—'}</DetailField>
                 </div>
 
                 <div className="flex items-center gap-2">
@@ -2061,36 +2067,38 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
 
                 <div className="flex items-center gap-2">
                   <HardDrive className="text-muted-foreground h-4 w-4 shrink-0" />
-                  <DetailField label="Fly Volume ID">
-                    <code className="text-sm">{data.workerStatus.flyVolumeId ?? '—'}</code>
+                  <DetailField label="Storage ID">
+                    <code className="text-sm">{data.workerStatus.storageId ?? '—'}</code>
                   </DetailField>
                 </div>
 
-                <div className="flex items-center gap-2">
-                  <Server className="text-muted-foreground h-4 w-4 shrink-0" />
-                  <DetailField label="Fly App">
-                    {data.workerStatus.flyAppName ? (
-                      <a
-                        href={`https://fly.io/apps/${data.workerStatus.flyAppName}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 text-blue-600 hover:underline"
-                      >
-                        <code className="text-sm">{data.workerStatus.flyAppName}</code>
-                        <ExternalLink className="h-3 w-3" />
-                      </a>
-                    ) : (
-                      '—'
-                    )}
-                  </DetailField>
-                </div>
+                {isFlyProvider && (
+                  <div className="flex items-center gap-2">
+                    <Server className="text-muted-foreground h-4 w-4 shrink-0" />
+                    <DetailField label="Fly App">
+                      {data.workerStatus.flyAppName ? (
+                        <a
+                          href={`https://fly.io/apps/${data.workerStatus.flyAppName}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-blue-600 hover:underline"
+                        >
+                          <code className="text-sm">{data.workerStatus.flyAppName}</code>
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      ) : (
+                        '—'
+                      )}
+                    </DetailField>
+                  </div>
+                )}
 
-                {data.workerStatus.flyAppName && data.workerStatus.flyMachineId && (
+                {isFlyProvider && data.workerStatus.flyAppName && data.workerStatus.runtimeId && (
                   <div className="flex items-center gap-2">
                     <BarChart className="text-muted-foreground h-4 w-4 shrink-0" />
                     <DetailField label="Metrics">
                       <a
-                        href={`https://fly-metrics.net/d/fly-instance/fly-instance?from=now-1h&orgId=1480569&to=now&var-app=${data.workerStatus.flyAppName}&var-instance=${data.workerStatus.flyMachineId}`}
+                        href={`https://fly-metrics.net/d/fly-instance/fly-instance?from=now-1h&orgId=1480569&to=now&var-app=${data.workerStatus.flyAppName}&var-instance=${data.workerStatus.runtimeId}`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex items-center gap-1 text-blue-600 hover:underline"
@@ -2300,14 +2308,16 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
           />
         )}
 
-        {/* Machine Controls */}
+        {/* Runtime Controls */}
         {isActive && machineControlsEnabled && (
           <Card>
             <CardHeader>
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <CardTitle>Machine Controls</CardTitle>
-                  <CardDescription>Start, stop, resize, or destroy the Fly machine</CardDescription>
+                  <CardTitle>Runtime Controls</CardTitle>
+                  <CardDescription>
+                    Start, stop, resize, or redeploy the provider runtime
+                  </CardDescription>
                 </div>
                 <StatusBadge status={data.workerStatus?.status ?? null} />
               </div>
@@ -2325,12 +2335,12 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                   ) : (
                     <Play className="mr-1 h-4 w-4" />
                   )}
-                  Start Machine
+                  Start Runtime
                 </Button>
                 <Button
                   size="sm"
                   variant="outline"
-                  disabled={machineActionPending || !hasMachine}
+                  disabled={machineActionPending || !hasRuntime}
                   onClick={() => void machineStop({ userId: data.user_id, instanceId: data.id })}
                 >
                   {isMachineStopping ? (
@@ -2338,12 +2348,12 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                   ) : (
                     <Square className="mr-1 h-4 w-4" />
                   )}
-                  Stop Machine
+                  Stop Runtime
                 </Button>
                 <Button
                   size="sm"
                   variant="outline"
-                  disabled={machineActionPending || machineRestartBlocked || !hasMachine}
+                  disabled={machineActionPending || machineRestartBlocked || !hasRuntime}
                   onClick={() => void machineRedeploy({ instanceId: data.id, imageTag: undefined })}
                 >
                   {isMachineRedeploying ? (
@@ -2353,19 +2363,21 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                   )}
                   Redeploy
                 </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={machineActionPending || machineRestartBlocked || !hasMachine}
-                  onClick={() => void machineUpgrade({ instanceId: data.id, imageTag: 'latest' })}
-                >
-                  {isMachineUpgrading ? (
-                    <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-                  ) : (
-                    <ArrowUpCircle className="mr-1 h-4 w-4" />
-                  )}
-                  Upgrade to Latest
-                </Button>
+                {isFlyProvider && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={machineActionPending || machineRestartBlocked || !hasRuntime}
+                    onClick={() => void machineUpgrade({ instanceId: data.id, imageTag: 'latest' })}
+                  >
+                    {isMachineUpgrading ? (
+                      <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                    ) : (
+                      <ArrowUpCircle className="mr-1 h-4 w-4" />
+                    )}
+                    Upgrade to Latest
+                  </Button>
+                )}
                 <Button
                   size="sm"
                   variant="outline"
@@ -2382,28 +2394,30 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                   }}
                 >
                   <ArrowUpDown className="mr-1 h-4 w-4" />
-                  Resize Machine
+                  Resize Runtime
                 </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className={
-                    isFlyMachineDestroyed
-                      ? 'border-green-500 text-green-500'
-                      : 'border-orange-500 text-orange-500 hover:bg-orange-500/10'
-                  }
-                  disabled={machineActionPending || !hasMachine || isFlyMachineDestroyed}
-                  onClick={() => setDestroyMachineDialogOpen(true)}
-                >
-                  {isDestroyingFlyMachine ? (
-                    <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-                  ) : isFlyMachineDestroyed ? (
-                    <CheckCircle2 className="mr-1 h-4 w-4" />
-                  ) : (
-                    <Trash2 className="mr-1 h-4 w-4" />
-                  )}
-                  {isFlyMachineDestroyed ? 'Machine Destroyed' : 'Destroy Machine'}
-                </Button>
+                {isFlyProvider && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className={
+                      isFlyMachineDestroyed
+                        ? 'border-green-500 text-green-500'
+                        : 'border-orange-500 text-orange-500 hover:bg-orange-500/10'
+                    }
+                    disabled={machineActionPending || !hasFlyMachine || isFlyMachineDestroyed}
+                    onClick={() => setDestroyMachineDialogOpen(true)}
+                  >
+                    {isDestroyingFlyMachine ? (
+                      <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                    ) : isFlyMachineDestroyed ? (
+                      <CheckCircle2 className="mr-1 h-4 w-4" />
+                    ) : (
+                      <Trash2 className="mr-1 h-4 w-4" />
+                    )}
+                    {isFlyMachineDestroyed ? 'Machine Destroyed' : 'Destroy Fly Machine'}
+                  </Button>
+                )}
               </div>
             </CardContent>
           </Card>
@@ -2674,7 +2688,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
             <CardContent className="space-y-4">
               {!gatewayControlsEnabled && (
                 <p className="text-muted-foreground text-sm">
-                  Gateway process controls are available when the instance has a machine ID.
+                  Gateway process controls are available when the instance has a runtime ID.
                 </p>
               )}
 
@@ -2802,16 +2816,19 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         )}
 
         {/* Volume Reassociation (danger zone) */}
-        {isActive && data.workerStatus && data.workerStatus.status !== 'recovering' && (
-          <VolumeReassociationCard
-            userId={data.user_id}
-            instanceId={data.id}
-            currentStatus={data.workerStatus.status}
-            currentMachineId={data.workerStatus.flyMachineId}
-            previousVolumeId={data.workerStatus.previousVolumeId ?? null}
-            onStatusChange={invalidateMachineQueries}
-          />
-        )}
+        {isActive &&
+          isFlyProvider &&
+          data.workerStatus &&
+          data.workerStatus.status !== 'recovering' && (
+            <VolumeReassociationCard
+              userId={data.user_id}
+              instanceId={data.id}
+              currentStatus={data.workerStatus.status}
+              currentMachineId={data.workerStatus.flyMachineId}
+              previousVolumeId={data.workerStatus.previousVolumeId ?? null}
+              onStatusChange={invalidateMachineQueries}
+            />
+          )}
 
         {/* Volume Snapshots */}
         {snapshotsEnabled && (

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -130,6 +130,8 @@ export type MachineSize = {
   cpu_kind?: 'shared' | 'performance';
 };
 
+export type KiloClawProviderId = 'fly' | 'docker-local' | 'northflank' | 'aws' | 'k8s';
+
 /** Response from POST /api/platform/restore-volume-snapshot */
 export type RestoreVolumeSnapshotResponse = {
   acknowledged: boolean;
@@ -140,6 +142,10 @@ export type RestoreVolumeSnapshotResponse = {
 export type PlatformStatusResponse = {
   userId: string | null;
   sandboxId: string | null;
+  provider: KiloClawProviderId | null;
+  runtimeId: string | null;
+  storageId: string | null;
+  region: string | null;
   status:
     | 'provisioned'
     | 'starting'
@@ -196,7 +202,6 @@ export type RegistryEntriesResponse = {
 /** Response from GET /api/platform/debug-status (internal/admin only). */
 export type PlatformDebugStatusResponse = PlatformStatusResponse & {
   orgId: string | null;
-  provider: 'fly' | 'northflank' | 'aws' | 'k8s';
   pendingDestroyMachineId: string | null;
   pendingDestroyVolumeId: string | null;
   pendingPostgresMarkOnFinalize: boolean;

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -131,7 +131,7 @@ export type MachineSize = {
 };
 
 // Keep in sync with services/kiloclaw/src/schemas/instance-config.ts ProviderIdSchema.
-export type KiloClawProviderId = 'fly' | 'docker-local' | 'northflank' | 'aws' | 'k8s';
+export type KiloClawProviderId = 'fly' | 'docker-local' | 'northflank';
 
 /** Response from POST /api/platform/restore-volume-snapshot */
 export type RestoreVolumeSnapshotResponse = {

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -130,6 +130,7 @@ export type MachineSize = {
   cpu_kind?: 'shared' | 'performance';
 };
 
+// Keep in sync with services/kiloclaw/src/schemas/instance-config.ts ProviderIdSchema.
 export type KiloClawProviderId = 'fly' | 'docker-local' | 'northflank' | 'aws' | 'k8s';
 
 /** Response from POST /api/platform/restore-volume-snapshot */

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -33,6 +33,19 @@ const testAppName = 'acct-abc123def456';
 const testMachineId = 'd8901e123456';
 const testUserId = 'test-target-user-id';
 
+function flyDebugStatus(overrides: Record<string, unknown> = {}) {
+  return {
+    provider: 'fly',
+    runtimeId: testMachineId,
+    storageId: 'vol-test',
+    region: 'iad',
+    flyAppName: testAppName,
+    flyMachineId: testMachineId,
+    status: 'running',
+    ...overrides,
+  };
+}
+
 beforeAll(async () => {
   regularUser = await insertTestUser({
     google_user_email: 'regular-destroy-machine@example.com',
@@ -80,11 +93,7 @@ describe('admin.kiloclawInstances.destroyFlyMachine', () => {
   });
 
   it('destroys the Fly machine when appName/machineId match DO state', async () => {
-    mockGetDebugStatus.mockResolvedValue({
-      flyAppName: testAppName,
-      flyMachineId: testMachineId,
-      status: 'running',
-    });
+    mockGetDebugStatus.mockResolvedValue(flyDebugStatus());
     mockDestroyFlyMachine.mockResolvedValue({ ok: true });
 
     const caller = await createCallerForUser(adminUser.id);
@@ -105,11 +114,7 @@ describe('admin.kiloclawInstances.destroyFlyMachine', () => {
   });
 
   it('throws BAD_REQUEST when appName does not match DO state', async () => {
-    mockGetDebugStatus.mockResolvedValue({
-      flyAppName: 'acct-different',
-      flyMachineId: testMachineId,
-      status: 'running',
-    });
+    mockGetDebugStatus.mockResolvedValue(flyDebugStatus({ flyAppName: 'acct-different' }));
 
     const caller = await createCallerForUser(adminUser.id);
     await expect(
@@ -124,11 +129,7 @@ describe('admin.kiloclawInstances.destroyFlyMachine', () => {
   });
 
   it('throws BAD_REQUEST when machineId does not match DO state', async () => {
-    mockGetDebugStatus.mockResolvedValue({
-      flyAppName: testAppName,
-      flyMachineId: 'differentmachineid',
-      status: 'running',
-    });
+    mockGetDebugStatus.mockResolvedValue(flyDebugStatus({ flyMachineId: 'differentmachineid' }));
 
     const caller = await createCallerForUser(adminUser.id);
     await expect(
@@ -143,11 +144,7 @@ describe('admin.kiloclawInstances.destroyFlyMachine', () => {
   });
 
   it('writes an audit log on success', async () => {
-    mockGetDebugStatus.mockResolvedValue({
-      flyAppName: testAppName,
-      flyMachineId: testMachineId,
-      status: 'running',
-    });
+    mockGetDebugStatus.mockResolvedValue(flyDebugStatus());
     mockDestroyFlyMachine.mockResolvedValue({ ok: true });
 
     const caller = await createCallerForUser(adminUser.id);
@@ -176,11 +173,7 @@ describe('admin.kiloclawInstances.destroyFlyMachine', () => {
   });
 
   it('wraps generic errors as INTERNAL_SERVER_ERROR', async () => {
-    mockGetDebugStatus.mockResolvedValue({
-      flyAppName: testAppName,
-      flyMachineId: testMachineId,
-      status: 'running',
-    });
+    mockGetDebugStatus.mockResolvedValue(flyDebugStatus());
     mockDestroyFlyMachine.mockRejectedValue(new Error('Fly API timeout'));
 
     const caller = await createCallerForUser(adminUser.id);
@@ -199,11 +192,7 @@ describe('admin.kiloclawInstances.destroyFlyMachine', () => {
       KiloClawApiError: new (statusCode: number, responseBody: string) => any;
     }>('@/lib/kiloclaw/kiloclaw-internal-client');
 
-    mockGetDebugStatus.mockResolvedValue({
-      flyAppName: testAppName,
-      flyMachineId: testMachineId,
-      status: 'running',
-    });
+    mockGetDebugStatus.mockResolvedValue(flyDebugStatus());
     mockDestroyFlyMachine.mockRejectedValue(
       new KiloClawApiError(404, JSON.stringify({ error: 'machine not found' }))
     );

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -897,6 +897,12 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       } catch (err) {
         throwKiloclawAdminError(err, 'Failed to verify machine state before destroy');
       }
+      if (status.provider !== 'fly') {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `Direct Fly machine destroy is not supported for provider ${status.provider}`,
+        });
+      }
       if (status.flyAppName !== input.appName || status.flyMachineId !== input.machineId) {
         throw new TRPCError({
           code: 'BAD_REQUEST',

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -462,6 +462,10 @@ function createNoInstanceStatus(userId: string, workerUrl: string): KiloClawDash
   return {
     userId,
     sandboxId: null,
+    provider: null,
+    runtimeId: null,
+    storageId: null,
+    region: null,
     status: null,
     provisionedAt: null,
     lastStartedAt: null,

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -256,6 +256,10 @@ export const organizationKiloclawRouter = createTRPCRouter({
       return {
         userId: ctx.user.id,
         sandboxId: null,
+        provider: null,
+        runtimeId: null,
+        storageId: null,
+        region: null,
         status: null,
         provisionedAt: null,
         lastStartedAt: null,

--- a/services/kiloclaw/.dev.vars.example
+++ b/services/kiloclaw/.dev.vars.example
@@ -23,10 +23,19 @@ INTERNAL_API_SECRET=dev-internal-secret
 # Auth (static defaults — these work as-is for local dev)
 # HMAC secret for deriving per-sandbox gateway tokens (machine authentication)
 GATEWAY_TOKEN_SECRET=dev-gateway-secret-kiloclaw
+# Default provider for new provisions in local dev. Use "fly" or "docker-local".
+KILOCLAW_DEFAULT_PROVIDER=fly
 # Override WORKER_ENV to "development" for local development.
 # Production default is set in wrangler.jsonc. This selects the development
 # Fly app naming prefix ("dev-") for per-user app creation.
 WORKER_ENV=development
+
+# Docker-local demo provider (wrangler dev only).
+# Expose the Docker socket over loopback first:
+#   socat TCP-LISTEN:23750,bind=127.0.0.1,reuseaddr,fork UNIX-CONNECT:/var/run/docker.sock
+DOCKER_LOCAL_API_BASE=http://127.0.0.1:23750
+DOCKER_LOCAL_IMAGE=kiloclaw:local
+DOCKER_LOCAL_PORT_RANGE=45000-45999
 
 # Auto-populated by dev-start from `fly auth whoami`.
 # Tags Fly machines with developer identity for cleanup.

--- a/services/kiloclaw/README.md
+++ b/services/kiloclaw/README.md
@@ -16,7 +16,7 @@ Browser → CF Worker (claw.kilo.ai)
             │ Fly Volume mounted at /root (persistent storage)
 ```
 
-Each authenticated user gets a dedicated Fly Machine running an OpenClaw gateway. The CF Worker handles auth, config management, and proxies HTTP/WebSocket traffic to each user's machine via Fly Proxy.
+Each authenticated user gets a dedicated provider-backed runtime running an OpenClaw gateway. In production today that runtime is a Fly Machine. In local development, `docker-local` can provision Docker containers on the developer machine. The CF Worker handles auth, config management, and proxies HTTP/WebSocket traffic to each user's runtime.
 
 ## The Durable Object as Coordination Atom
 
@@ -72,6 +72,51 @@ pnpm test             # vitest
 pnpm format           # oxfmt
 pnpm start            # wrangler dev
 ```
+
+## Docker-Local Provider
+
+`docker-local` is a development-only provider that lets `wrangler dev` provision one or more KiloClaw instances as Docker containers on your machine. It uses the same controller image and injects the same runtime env vars as Fly, but routes through a host port instead of the Fly proxy.
+
+1. Expose the local Docker socket over loopback for Wrangler:
+
+   ```bash
+   socat TCP-LISTEN:23750,bind=127.0.0.1,reuseaddr,fork UNIX-CONNECT:/var/run/docker.sock
+   ```
+
+2. Build the local KiloClaw runtime image from this directory:
+
+   ```bash
+   cd services/kiloclaw
+   ./scripts/build-local-image.sh
+   ```
+
+   The script reads `DOCKER_LOCAL_IMAGE` from `.dev.vars` when present and defaults to `kiloclaw:local`. To build against a local OpenClaw package tarball, place `openclaw-*.tgz` under `services/kiloclaw/openclaw-build/` and run:
+
+   ```bash
+   ./scripts/build-local-image.sh --local
+   ```
+
+3. Update `services/kiloclaw/.dev.vars` after it has been created by `pnpm dev:env` or `./scripts/dev-start.sh`:
+
+   ```bash
+   WORKER_ENV=development
+   KILOCLAW_DEFAULT_PROVIDER=docker-local
+   DOCKER_LOCAL_API_BASE=http://127.0.0.1:23750
+   DOCKER_LOCAL_IMAGE=kiloclaw:local
+   DOCKER_LOCAL_PORT_RANGE=45000-45999
+   ```
+
+   `DOCKER_LOCAL_API_BASE` should be an origin only, without a Docker API version path such as `/v1.44`.
+
+4. Start KiloClaw locally:
+
+   ```bash
+   pnpm start
+   ```
+
+   New provisions without an explicit provider use `KILOCLAW_DEFAULT_PROVIDER`. You can also pass `provider: "docker-local"` to the platform provision endpoint when you want Fly to remain the default.
+
+Rebuild the image after controller or Dockerfile changes, then restart or redeploy the instance so the container is recreated with the new image/env/config. A plain `start` leaves an already-running docker-local container intact.
 
 ## Environment
 

--- a/services/kiloclaw/README.md
+++ b/services/kiloclaw/README.md
@@ -1,6 +1,6 @@
 # KiloClaw
 
-Multi-tenant OpenClaw on Fly.io Machines, orchestrated by a Cloudflare Worker.
+Multi-tenant OpenClaw runtimes, orchestrated by a Cloudflare Worker.
 
 ## Architecture
 
@@ -80,6 +80,9 @@ See `.dev.vars.example` for required environment variables. Key ones:
 - `FLY_API_TOKEN` — Bearer token for Fly Machines API
 - `FLY_APP_NAME` — Fly App hosting all user machines
 - `FLY_REGION` — Default region (comma-separated priority list, e.g., `us,eu`)
+- `KILOCLAW_DEFAULT_PROVIDER` — Local default provider (`fly` or `docker-local`)
+- `DOCKER_LOCAL_API_BASE` — Loopback Docker HTTP bridge for `docker-local`
+- `DOCKER_LOCAL_IMAGE` — Local image tag used by `docker-local`
 - `NEXTAUTH_SECRET` — JWT verification (shared with Next.js)
 - `GATEWAY_TOKEN_SECRET` — Per-user gateway token HMAC secret
 

--- a/services/kiloclaw/scripts/build-local-image.sh
+++ b/services/kiloclaw/scripts/build-local-image.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Build a local Docker image for the docker-local provider.
+#
+# Usage: ./scripts/build-local-image.sh [--local] [image-tag]
+#   --local    Use Dockerfile.local and a local openclaw tarball from openclaw-build/
+#   image-tag  defaults to DOCKER_LOCAL_IMAGE from .dev.vars, or "kiloclaw:local"
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+KILOCLAW_DIR="$(dirname "$SCRIPT_DIR")"
+
+USE_LOCAL=false
+for arg in "$@"; do
+  case "$arg" in
+    --local) USE_LOCAL=true; shift ;;
+  esac
+done
+
+if [ "$USE_LOCAL" = true ]; then
+  DOCKERFILE="$KILOCLAW_DIR/Dockerfile.local"
+  if ! ls "$KILOCLAW_DIR"/openclaw-build/openclaw-*.tgz 1>/dev/null 2>&1; then
+    echo "Error: No openclaw-*.tgz found in openclaw-build/." >&2
+    echo "Build your fork first:" >&2
+    echo "  cd /path/to/openclaw && pnpm build && npm pack" >&2
+    echo "  cp openclaw-*.tgz $(cd "$KILOCLAW_DIR" && pwd)/openclaw-build/" >&2
+    exit 1
+  fi
+  echo "Using Dockerfile.local (local OpenClaw tarball)"
+else
+  DOCKERFILE="$KILOCLAW_DIR/Dockerfile"
+fi
+
+IMAGE="${1:-}"
+if [ -z "$IMAGE" ] && [ -f "$KILOCLAW_DIR/.dev.vars" ]; then
+  IMAGE=$(grep '^DOCKER_LOCAL_IMAGE=' "$KILOCLAW_DIR/.dev.vars" | cut -d= -f2)
+fi
+IMAGE="${IMAGE:-kiloclaw:local}"
+GIT_SHA="$(git -C "$KILOCLAW_DIR" rev-parse HEAD 2>/dev/null || echo 'unknown')"
+
+echo "Building local image $IMAGE ..."
+docker build \
+  -f "$DOCKERFILE" \
+  --build-arg "CONTROLLER_COMMIT=$GIT_SHA" \
+  --build-arg "CONTROLLER_CACHE_BUST=$(date +%s)" \
+  -t "$IMAGE" \
+  "$KILOCLAW_DIR"
+
+echo ""
+echo "Done. docker-local can now use:"
+echo "  DOCKER_LOCAL_IMAGE=$IMAGE"

--- a/services/kiloclaw/src/durable-objects/kiloclaw-app.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-app.test.ts
@@ -371,6 +371,20 @@ describe('alarm retry', () => {
 });
 
 describe('ensureEnvKey', () => {
+  it('creates and persists a provider-neutral key before any Fly app exists', async () => {
+    const storage = createFakeStorage();
+    const { appDO } = createAppDO(storage);
+
+    const { key, secretsVersion } = await appDO.ensureEnvKey('user-1');
+
+    expect(key).toBeTruthy();
+    expect(secretsVersion).toBe(0);
+    expect(secretsClient.setAppSecret).not.toHaveBeenCalled();
+    expect(storage._store.get('userId')).toBe('user-1');
+    expect(storage._store.get('envKey')).toBe(key);
+    expect(storage._store.get('envKeySet')).toBe(true);
+  });
+
   it('always re-sets Fly secret (self-healing) even when key exists', async () => {
     const { appDO } = createAppDO();
     await appDO.ensureApp('user-1');

--- a/services/kiloclaw/src/durable-objects/kiloclaw-app.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-app.ts
@@ -1,15 +1,21 @@
 /**
  * KiloClawApp Durable Object
  *
- * Manages the per-user Fly App lifecycle: creation, IP allocation, env key setup, and deletion.
+ * Manages owner-scoped bootstrap state shared across KiloClaw providers.
+ *
+ * Today that includes:
+ * - Fly App lifecycle for Fly-backed runtimes
+ * - the env encryption key used to encrypt sensitive controller env vars
+ *
+ * The env key is provider-neutral durable state. Fly secret propagation is
+ * best-effort provider-specific bootstrap layered on top when a Fly app exists.
  * Keyed by userId: env.KILOCLAW_APP.idFromName(userId) — one per user.
  *
  * Separate from KiloClawInstance to support future multi-instance per user,
  * where one Fly App contains multiple instances (machines + volumes).
  *
- * The App DO ensures that each user has a Fly App with allocated IPs and
- * an encryption key before any machines are created. ensureApp() is idempotent:
- * safe to call multiple times, only creates the app + IPs + key on first call.
+ * ensureApp() remains Fly-specific and idempotent: safe to call multiple times,
+ * only creates the Fly app + IPs + synced env key on first call.
  *
  * If setup partially fails, the alarm retries.
  */
@@ -77,7 +83,7 @@ export class KiloClawApp extends DurableObject<KiloClawEnv> {
     this.loaded = true;
   }
 
-  /** Check if all setup steps are complete. */
+  /** Check if Fly app setup is complete. */
   private isSetupComplete(): boolean {
     return this.ipv4Allocated && this.ipv6Allocated && this.envKeySet;
   }
@@ -185,16 +191,19 @@ export class KiloClawApp extends DurableObject<KiloClawEnv> {
 
   /**
    * Ensure the env encryption key exists, creating it if needed.
-   * Always re-sets the Fly app secret (idempotent) to self-heal if the
-   * secret was deleted externally.
+   *
+   * The key itself is provider-neutral durable state and may exist even when
+   * no Fly app has been created yet. When a Fly app exists, this method also
+   * re-sets the Fly secret (idempotent) to self-heal if it was deleted.
    *
    * Interleaving safety: the key is generated and persisted to in-memory state
-   * + durable storage before the setAppSecret() fetch. Any interleaved call
+   * + durable storage before the optional setAppSecret() fetch. Any interleaved call
    * entering during the await will see this.envKey already set and reuse it,
    * so no two calls can generate different keys.
    *
-   * Called by Instance DO at machine start time. This ensures legacy apps that
-   * were created before the encryption feature get their key on first start.
+   * Called by Instance DO at machine start time. This ensures every provider can
+   * bootstrap encrypted env vars, while legacy Fly apps still get their Fly secret
+   * synced on first start.
    */
   async ensureEnvKey(ownerKey: string): Promise<{ key: string; secretsVersion: number }> {
     await this.loadState();
@@ -203,15 +212,13 @@ export class KiloClawApp extends DurableObject<KiloClawEnv> {
       throw new Error(`ownerKey mismatch: DO has ${this.userId}, caller passed ${ownerKey}`);
     }
 
-    const apiToken = this.env.FLY_API_TOKEN;
-    if (!apiToken) throw new Error('FLY_API_TOKEN is not configured');
-
-    if (!this.flyAppName) {
-      throw new Error('Cannot create env key: Fly App not yet created (call ensureApp first)');
+    if (!this.userId) {
+      this.userId = ownerKey;
+      await this.ctx.storage.put({ userId: ownerKey } satisfies Partial<AppState>);
     }
 
     // Persist key before any async I/O so interleaved calls reuse the same key.
-    // envKeySet: false means "key generated but not yet confirmed in Fly."
+    // envKeySet: false means "key generated but not yet confirmed in a provider secret store."
     if (!this.envKey) {
       this.envKey = generateEnvKey();
       await this.ctx.storage.put({
@@ -220,19 +227,29 @@ export class KiloClawApp extends DurableObject<KiloClawEnv> {
       } satisfies Partial<AppState>);
     }
 
+    if (!this.envKeySet) {
+      this.envKeySet = true;
+      await this.ctx.storage.put({ envKeySet: true } satisfies Partial<AppState>);
+      console.log(
+        '[AppDO] Persisted env encryption key for:',
+        this.flyAppName ?? `owner ${ownerKey}`
+      );
+    }
+
+    if (!this.flyAppName) {
+      return { key: this.envKey, secretsVersion: 0 };
+    }
+
+    const apiToken = this.env.FLY_API_TOKEN;
+    if (!apiToken) throw new Error('FLY_API_TOKEN is not configured');
+
     // Always re-set the Fly secret (idempotent) to self-heal if deleted externally.
-    // Returns the secrets version for use with min_secrets_version on machine create/update.
+    // Returns the secrets version for use with min_secrets_version on Fly machine create/update.
     const { version: secretsVersion } = await setAppSecret(
       { apiToken, appName: this.flyAppName },
       ENV_KEY_SECRET_NAME,
       this.envKey
     );
-
-    if (!this.envKeySet) {
-      this.envKeySet = true;
-      await this.ctx.storage.put({ envKeySet: true } satisfies Partial<AppState>);
-      console.log('[AppDO] Set env encryption key for:', this.flyAppName);
-    }
 
     return { key: this.envKey, secretsVersion };
   }

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -326,6 +326,30 @@ async function seedRecovering(
   });
 }
 
+function dockerProviderState(overrides: Record<string, unknown> = {}) {
+  return {
+    provider: 'docker-local',
+    containerName: 'kiloclaw-sandbox-1',
+    volumeName: 'kiloclaw-root-sandbox-1',
+    hostPort: 45001,
+    ...overrides,
+  };
+}
+
+async function seedDockerInstance(
+  storage: ReturnType<typeof createFakeStorage>,
+  overrides: Record<string, unknown> = {}
+) {
+  await seedProvisioned(storage, {
+    provider: 'docker-local',
+    flyMachineId: null,
+    flyVolumeId: null,
+    flyRegion: null,
+    providerState: dockerProviderState(),
+    ...overrides,
+  });
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -5305,6 +5329,7 @@ describe('startAsync: catch handler writes stopped state on pre-machine failure'
     (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1', region: 'iad' });
     // Machine is created (ID will be persisted) but waitForState throws
     (flyClient.createMachine as Mock).mockResolvedValue({ id: 'machine-1', region: 'iad' });
+    (flyClient.getMachine as Mock).mockResolvedValue({ state: 'created' });
     (flyClient.waitForState as Mock).mockRejectedValue(new Error('timeout waiting for started'));
 
     await instance.provision('user-1', {});
@@ -5316,6 +5341,143 @@ describe('startAsync: catch handler writes stopped state on pre-machine failure'
     expect(storage._store.get('status')).toBe('starting');
     // Error fields should NOT be populated for post-machine failures
     expect(storage._store.get('lastStartErrorMessage')).toBeFalsy();
+    expect(flyClient.getMachine).not.toHaveBeenCalled();
+  });
+
+  it('does NOT overwrite Fly state when start() fails after machine ID is persisted and inspect would fail', async () => {
+    const { instance, storage, waitUntilPromises } = createInstance();
+
+    (flyClient.createVolumeWithFallback as Mock).mockResolvedValue({
+      id: 'vol-1',
+      region: 'iad',
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1', region: 'iad' });
+    (flyClient.createMachine as Mock).mockResolvedValue({ id: 'machine-1', region: 'iad' });
+    (flyClient.getMachine as Mock).mockRejectedValue(new Error('transient Fly API failure'));
+    (flyClient.waitForState as Mock).mockRejectedValue(new Error('timeout waiting for started'));
+
+    await instance.provision('user-1', {});
+    await Promise.all(waitUntilPromises);
+
+    expect(storage._store.get('flyMachineId')).toBe('machine-1');
+    expect(storage._store.get('status')).toBe('starting');
+    expect(storage._store.get('lastStartErrorMessage')).toBeFalsy();
+    expect(flyClient.getMachine).not.toHaveBeenCalled();
+  });
+
+  it('transitions docker-local to stopped when start fails after deterministic names are seeded', async () => {
+    const env = {
+      ...createFakeEnv(),
+      DOCKER_LOCAL_API_BASE: 'http://127.0.0.1:23750',
+      DOCKER_LOCAL_PORT_RANGE: '45000-45010',
+    };
+    const { instance, storage, waitUntilPromises } = createInstance(undefined, env);
+    await seedDockerInstance(storage, {
+      status: 'provisioned',
+      providerState: dockerProviderState({ hostPort: null }),
+    });
+
+    vi.mocked(fetch).mockImplementation(async input => {
+      const url = String(input);
+      if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
+        return new Response(JSON.stringify({ Name: 'kiloclaw-root-sandbox-1' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.includes('/containers/json?all=1')) {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/containers/kiloclaw-sandbox-1/json')) {
+        return new Response('', { status: 404 });
+      }
+      if (url.includes('/containers/create?name=kiloclaw-sandbox-1')) {
+        return new Response('create failed', { status: 500 });
+      }
+      throw new Error(`Unhandled Docker API request: ${url}`);
+    });
+
+    await instance.startAsync();
+    await Promise.all(waitUntilPromises);
+
+    expect(storage._store.get('status')).toBe('stopped');
+    expect(storage._store.get('startingAt')).toBeNull();
+    expect(storage._store.get('lastStartErrorMessage')).toContain('create failed');
+    expect(storage._store.get('providerState')).toEqual(dockerProviderState({ hostPort: 45000 }));
+  });
+});
+
+describe('non-Fly runtime reconciliation via alarm', () => {
+  it("transitions a docker-local starting runtime to 'running' when inspect reports running", async () => {
+    const env = { ...createFakeEnv(), DOCKER_LOCAL_API_BASE: 'http://127.0.0.1:23750' };
+    const { instance, storage } = createInstance(undefined, env);
+    await seedDockerInstance(storage, {
+      status: 'starting',
+      startingAt: Date.now(),
+      lastStartedAt: null,
+    });
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          Id: 'container-1',
+          Name: '/kiloclaw-sandbox-1',
+          State: { Running: true, Status: 'running' },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+
+    await instance.alarm();
+
+    expect(storage._store.get('status')).toBe('running');
+    expect(storage._store.get('startingAt')).toBeNull();
+    expect(storage._store.get('lastStartedAt')).toBeGreaterThan(0);
+  });
+
+  it("transitions a docker-local restarting runtime to 'running' when inspect reports running", async () => {
+    const env = { ...createFakeEnv(), DOCKER_LOCAL_API_BASE: 'http://127.0.0.1:23750' };
+    const { instance, storage } = createInstance(undefined, env);
+    await seedDockerInstance(storage, {
+      status: 'restarting',
+      restartingAt: Date.now(),
+      lastRestartErrorMessage: 'previous failure',
+      lastRestartErrorAt: Date.now() - 1_000,
+    });
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          Id: 'container-1',
+          Name: '/kiloclaw-sandbox-1',
+          State: { Running: true, Status: 'running' },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+
+    await instance.alarm();
+
+    expect(storage._store.get('status')).toBe('running');
+    expect(storage._store.get('restartingAt')).toBeNull();
+    expect(storage._store.get('lastRestartErrorMessage')).toBeNull();
+    expect(storage._store.get('lastRestartErrorAt')).toBeNull();
+  });
+
+  it("transitions a docker-local running runtime to 'stopped' when inspect reports missing", async () => {
+    const env = { ...createFakeEnv(), DOCKER_LOCAL_API_BASE: 'http://127.0.0.1:23750' };
+    const { instance, storage } = createInstance(undefined, env);
+    await seedDockerInstance(storage, {
+      status: 'running',
+      lastStoppedAt: null,
+    });
+    vi.mocked(fetch).mockResolvedValue(new Response('', { status: 404 }));
+
+    await instance.alarm();
+
+    expect(storage._store.get('status')).toBe('stopped');
+    expect(storage._store.get('lastStoppedAt')).toBeGreaterThan(0);
   });
 });
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -235,6 +235,12 @@ function analyticsEventsByName(
   });
 }
 
+function fetchInputUrl(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
 function createInstance(
   storage = createFakeStorage(),
   env = createFakeEnv()
@@ -535,7 +541,7 @@ describe('two-phase destroy', () => {
     });
 
     vi.mocked(fetch).mockImplementation(async input => {
-      const url = String(input);
+      const url = fetchInputUrl(input);
       if (url.endsWith('/containers/kiloclaw-sandbox-1?force=true')) {
         return new Response(null, { status: 204 });
       }
@@ -574,7 +580,7 @@ describe('two-phase destroy', () => {
     });
 
     vi.mocked(fetch).mockImplementation(async input => {
-      const url = String(input);
+      const url = fetchInputUrl(input);
       if (url.endsWith('/containers/kiloclaw-sandbox-1?force=true')) {
         return new Response(null, { status: 204 });
       }
@@ -597,7 +603,7 @@ describe('two-phase destroy', () => {
     });
 
     vi.mocked(fetch).mockImplementation(async input => {
-      const url = String(input);
+      const url = fetchInputUrl(input);
       if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
         return new Response(null, { status: 204 });
       }
@@ -5378,7 +5384,7 @@ describe('startAsync: catch handler writes stopped state on pre-machine failure'
     });
 
     vi.mocked(fetch).mockImplementation(async input => {
-      const url = String(input);
+      const url = fetchInputUrl(input);
       if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
         return new Response(JSON.stringify({ Name: 'kiloclaw-root-sandbox-1' }), {
           status: 200,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -5436,8 +5436,8 @@ describe('provision: auto-start after fresh provision', () => {
   it('does not leave the hot DO on an unsupported provider after failed provision', async () => {
     const { instance, storage, waitUntilPromises } = createInstance();
 
-    await expect(instance.provision('user-1', {}, { provider: 'k8s' })).rejects.toThrow(
-      'Provider k8s is not implemented yet'
+    await expect(instance.provision('user-1', {}, { provider: 'northflank' })).rejects.toThrow(
+      'Provider northflank is not implemented yet'
     );
 
     expect(storage._store.get('userId')).toBeUndefined();

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -490,6 +490,102 @@ describe('two-phase destroy', () => {
     expect(storage._store.size).toBe(0);
     expect(storage._getAlarm()).toBeNull();
   });
+
+  it('fully destroys docker-local instances when container and volume deletes succeed', async () => {
+    const env = {
+      ...createFakeEnv(),
+      DOCKER_LOCAL_API_BASE: 'http://127.0.0.1:23750',
+    };
+    const { instance, storage } = createInstance(undefined, env);
+    await seedRunning(storage, {
+      provider: 'docker-local',
+      flyMachineId: null,
+      flyVolumeId: null,
+      flyRegion: null,
+      providerState: {
+        provider: 'docker-local',
+        containerName: 'kiloclaw-sandbox-1',
+        volumeName: 'kiloclaw-root-sandbox-1',
+        hostPort: 45001,
+      },
+    });
+
+    vi.mocked(fetch).mockImplementation(async input => {
+      const url = String(input);
+      if (url.endsWith('/containers/kiloclaw-sandbox-1?force=true')) {
+        return new Response(null, { status: 204 });
+      }
+      if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unhandled Docker API request: ${url}`);
+    });
+
+    await instance.destroy();
+
+    expect(storage._store.size).toBe(0);
+    expect(storage._getAlarm()).toBeNull();
+  });
+
+  it('retries docker-local destroy over multiple alarms when storage deletion fails', async () => {
+    const env = {
+      ...createFakeEnv(),
+      DOCKER_LOCAL_API_BASE: 'http://127.0.0.1:23750',
+    };
+    const { storage } = createInstance(undefined, env);
+    await seedProvisioned(storage, {
+      provider: 'docker-local',
+      status: 'destroying',
+      flyMachineId: null,
+      flyVolumeId: null,
+      flyRegion: null,
+      providerState: {
+        provider: 'docker-local',
+        containerName: 'kiloclaw-sandbox-1',
+        volumeName: 'kiloclaw-root-sandbox-1',
+        hostPort: 45001,
+      },
+      pendingDestroyMachineId: 'kiloclaw-sandbox-1',
+      pendingDestroyVolumeId: 'kiloclaw-root-sandbox-1',
+    });
+
+    vi.mocked(fetch).mockImplementation(async input => {
+      const url = String(input);
+      if (url.endsWith('/containers/kiloclaw-sandbox-1?force=true')) {
+        return new Response(null, { status: 204 });
+      }
+      if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
+        return new Response('volume busy', { status: 409 });
+      }
+      throw new Error(`Unhandled Docker API request: ${url}`);
+    });
+
+    const { instance } = createInstance(storage, env);
+    await instance.alarm();
+
+    expect(storage._store.get('pendingDestroyMachineId')).toBeNull();
+    expect(storage._store.get('pendingDestroyVolumeId')).toBe('kiloclaw-root-sandbox-1');
+    expect(storage._store.get('providerState')).toEqual({
+      provider: 'docker-local',
+      containerName: null,
+      volumeName: 'kiloclaw-root-sandbox-1',
+      hostPort: null,
+    });
+
+    vi.mocked(fetch).mockImplementation(async input => {
+      const url = String(input);
+      if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unhandled Docker API request: ${url}`);
+    });
+
+    const { instance: retryInstance } = createInstance(storage, env);
+    await retryInstance.alarm();
+
+    expect(storage._store.size).toBe(0);
+    expect(storage._getAlarm()).toBeNull();
+  });
 });
 
 describe('destroy: recover bound machine from volume', () => {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -5484,6 +5484,22 @@ describe('non-Fly runtime reconciliation via alarm', () => {
 
     expect(storage._store.get('status')).toBe('stopped');
     expect(storage._store.get('lastStoppedAt')).toBeGreaterThan(0);
+    expect(storage._getAlarm()).not.toBeNull();
+  });
+
+  it('keeps the alarm chain alive for idle docker-local statuses', async () => {
+    const env = { ...createFakeEnv(), DOCKER_LOCAL_API_BASE: 'http://127.0.0.1:23750' };
+    const { instance, storage } = createInstance(undefined, env);
+    await seedDockerInstance(storage, {
+      status: 'stopped',
+      lastStoppedAt: Date.now(),
+    });
+
+    await instance.alarm();
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(storage._store.get('status')).toBe('stopped');
+    expect(storage._getAlarm()).not.toBeNull();
   });
 });
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -4379,6 +4379,32 @@ describe('controller-first pairing', () => {
     fetchSpy.mockRestore();
   });
 
+  it('channel list via controller works for docker-local without flyMachineId', async () => {
+    const { instance, storage } = createInstance();
+    await seedDockerInstance(storage, { status: 'running' });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          requests: [{ code: 'DOCKER1', id: 'r-docker', channel: 'telegram' }],
+          lastUpdated: '2026-04-13T00:00:00Z',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const result = await instance.listPairingRequests(true);
+
+    expect(result).toEqual({
+      requests: [{ code: 'DOCKER1', id: 'r-docker', channel: 'telegram' }],
+    });
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      'http://127.0.0.1:45001/_kilo/pairing/channels?refresh=true'
+    );
+    expect(flyClient.execCommand).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
   it('channel list fallback on 404 — runs fly exec', async () => {
     const { instance, storage } = createInstance();
     await seedRunning(storage, { flyAppName: 'acct-test' });
@@ -4546,6 +4572,48 @@ describe('controller-first pairing', () => {
     fetchSpy.mockRestore();
   });
 
+  it('channel approve via controller works for docker-local without flyMachineId', async () => {
+    const { instance, storage } = createInstance();
+    await seedDockerInstance(storage, { status: 'running' });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: true, message: 'Pairing approved' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const result = await instance.approvePairingRequest('telegram', 'ABC123');
+
+    expect(result).toEqual({ success: true, message: 'Pairing approved' });
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      'http://127.0.0.1:45001/_kilo/pairing/channels/approve'
+    );
+    expect(flyClient.execCommand).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it('channel approve returns redeploy-required when non-Fly controller route is unavailable', async () => {
+    const { instance, storage } = createInstance();
+    await seedDockerInstance(storage, { status: 'running' });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const result = await instance.approvePairingRequest('telegram', 'ABC123');
+
+    expect(result).toEqual({
+      success: false,
+      message: 'Controller pairing route unavailable; redeploy required',
+    });
+    expect(flyClient.execCommand).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
   it('channel approve 400 with { error } body — returns failure without throwing', async () => {
     const { instance, storage } = createInstance();
     await seedRunning(storage, { flyAppName: 'acct-test' });
@@ -4623,6 +4691,32 @@ describe('controller-first pairing', () => {
     );
 
     expect(result).toEqual({ success: true, message: 'Device pairing approved' });
+    expect(flyClient.execCommand).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it('device list via controller works for docker-local without flyMachineId', async () => {
+    const { instance, storage } = createInstance();
+    await seedDockerInstance(storage, { status: 'running' });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          requests: [{ requestId: 'req-docker', deviceId: 'dev-docker', role: 'operator' }],
+          lastUpdated: '2026-04-13T00:00:00Z',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const result = await instance.listDevicePairingRequests(true);
+
+    expect(result).toEqual({
+      requests: [{ requestId: 'req-docker', deviceId: 'dev-docker', role: 'operator' }],
+    });
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      'http://127.0.0.1:45001/_kilo/pairing/devices?refresh=true'
+    );
     expect(flyClient.execCommand).not.toHaveBeenCalled();
     fetchSpy.mockRestore();
   });
@@ -5048,6 +5142,78 @@ describe('controller-first pairing', () => {
     expect(fetchSpy.mock.calls[0]?.[0]).toBe(
       'https://acct-test.fly.dev/_kilo/pairing/devices?refresh=true'
     );
+    fetchSpy.mockRestore();
+  });
+});
+
+// ============================================================================
+// Kilo CLI run controller routing
+// ============================================================================
+
+describe('kilo CLI run routing', () => {
+  it('starts a Kilo CLI run for docker-local via controller without flyMachineId', async () => {
+    const { instance, storage } = createInstance();
+    await seedDockerInstance(storage, { status: 'running' });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true, startedAt: '2026-04-13T18:45:00.000Z' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const result = await instance.startKiloCliRun('fix the thing');
+
+    expect(result).toEqual({ ok: true, startedAt: '2026-04-13T18:45:00.000Z' });
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe('http://127.0.0.1:45001/_kilo/cli-run/start');
+    expect(flyClient.execCommand).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it('gets Kilo CLI run status for docker-local via controller without flyMachineId', async () => {
+    const { instance, storage } = createInstance();
+    await seedDockerInstance(storage, { status: 'running' });
+
+    const controllerStatus = {
+      hasRun: true,
+      status: 'running',
+      output: 'working',
+      exitCode: null,
+      startedAt: '2026-04-13T18:45:00.000Z',
+      completedAt: null,
+      prompt: 'fix the thing',
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(controllerStatus), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const result = await instance.getKiloCliRunStatus();
+
+    expect(result).toEqual(controllerStatus);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe('http://127.0.0.1:45001/_kilo/cli-run/status');
+    expect(flyClient.execCommand).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it('cancels a Kilo CLI run for docker-local via controller without flyMachineId', async () => {
+    const { instance, storage } = createInstance();
+    await seedDockerInstance(storage, { status: 'running' });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const result = await instance.cancelKiloCliRun();
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe('http://127.0.0.1:45001/_kilo/cli-run/cancel');
+    expect(flyClient.execCommand).not.toHaveBeenCalled();
     fetchSpy.mockRestore();
   });
 });

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -1606,6 +1606,7 @@ describe('buildUserEnvVars API key refresh', () => {
       instance as unknown as {
         buildUserEnvVars: () => Promise<{
           envVars: Record<string, string>;
+          bootstrapEnv: Record<string, string>;
           minSecretsVersion: number;
         }>;
       }

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
@@ -33,6 +33,13 @@ export function resolveImageRef(state: InstanceMutableState, env: KiloClawEnv): 
   return `registry.fly.io/${getRegistryApp(env)}:${resolveImageTag(state, env)}`;
 }
 
+export function resolveRuntimeImageRef(state: InstanceMutableState, env: KiloClawEnv): string {
+  if (state.provider === 'docker-local') {
+    return env.DOCKER_LOCAL_IMAGE ?? 'kiloclaw:local';
+  }
+  return resolveImageRef(state, env);
+}
+
 /**
  * Check whether the stored API key has expired.
  */

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
@@ -99,6 +99,7 @@ export async function buildUserEnvVars(
   state: InstanceMutableState
 ): Promise<{
   envVars: Record<string, string>;
+  bootstrapEnv: Record<string, string>;
   minSecretsVersion: number;
 }> {
   if (!state.sandboxId || !env.GATEWAY_TOKEN_SECRET) {
@@ -195,5 +196,11 @@ export async function buildUserEnvVars(
     result[`${ENCRYPTED_ENV_PREFIX}${name}`] = encryptEnvValue(envKey, value);
   }
 
-  return { envVars: result, minSecretsVersion: secretsVersion };
+  return {
+    envVars: result,
+    bootstrapEnv: {
+      KILOCLAW_ENV_KEY: envKey,
+    },
+    minSecretsVersion: secretsVersion,
+  };
 }

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -17,6 +17,7 @@ import { HEALTH_PROBE_TIMEOUT_SECONDS, HEALTH_PROBE_INTERVAL_MS } from '../../co
 import type { InstanceMutableState } from './types';
 import { doWarn, toLoggable } from './log';
 import { getProviderAdapter } from '../../providers';
+import { getRuntimeId } from './state';
 import type { ProviderRoutingTarget } from '../../providers/types';
 
 /**
@@ -435,7 +436,7 @@ export async function patchEnvOnMachine(
   env: KiloClawEnv,
   patch: Record<string, string>
 ): Promise<{ ok: boolean; signaled: boolean } | null> {
-  if (state.status !== 'running' || !state.flyMachineId) return null;
+  if (state.status !== 'running' || !getRuntimeId(state)) return null;
   return callGatewayController(
     state,
     env,
@@ -455,7 +456,7 @@ export async function patchConfigOnMachine(
   env: KiloClawEnv,
   patch: Record<string, unknown>
 ): Promise<void> {
-  if (state.status !== 'running' || !state.flyMachineId) return;
+  if (state.status !== 'running' || !getRuntimeId(state)) return;
   try {
     await callGatewayController(
       state,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -1258,7 +1258,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       );
     }
 
-    const { envVars, minSecretsVersion } = await buildUserEnvVars(this.env, this.ctx, this.s);
+    const { envVars, bootstrapEnv, minSecretsVersion } = await buildUserEnvVars(
+      this.env,
+      this.ctx,
+      this.s
+    );
     const imageTag = resolveImageTag(this.s, this.env);
     console.log(
       '[DO] startGateway: deploying with imageTag:',
@@ -1279,6 +1283,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     const runtimeSpec = buildRuntimeSpec(
       resolveRuntimeImageRef(this.s, this.env),
       envVars,
+      bootstrapEnv,
       this.s.machineSize,
       identity
     );
@@ -2462,7 +2467,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         }
       }
 
-      const { envVars, minSecretsVersion } = await buildUserEnvVars(this.env, this.ctx, this.s);
+      const { envVars, bootstrapEnv, minSecretsVersion } = await buildUserEnvVars(
+        this.env,
+        this.ctx,
+        this.s
+      );
       const imageTag = resolveImageTag(this.s, this.env);
       doLog(this.s, 'restartMachine: deploying update', {
         imageTag,
@@ -2479,6 +2488,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       const runtimeSpec = buildRuntimeSpec(
         resolveRuntimeImageRef(this.s, this.env),
         envVars,
+        bootstrapEnv,
         this.s.machineSize,
         identity
       );

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -337,7 +337,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       } else if (this.s.status === 'starting') {
         await this.markNonFlyRunningFromProvider('start');
       }
-      await this.scheduleAlarm();
       return;
     }
 
@@ -350,7 +349,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         this.emitProvisioningFailed('provider_runtime_not_running', message);
         return;
       }
-      await this.scheduleAlarm();
       return;
     }
 
@@ -363,7 +361,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         );
         return;
       }
-      await this.scheduleAlarm();
       return;
     }
 
@@ -2791,9 +2788,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
             (userId, sandboxId) =>
               markDestroyedInPostgresHelper(this.env, this.ctx, this.s, userId, sandboxId)
           );
-          if (!finalized.finalized) {
-            await this.scheduleAlarm();
-          }
         } else {
           await this.reconcileNonFlyRuntimeFromAlarm();
         }

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -2781,7 +2781,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       if (this.s.provider !== 'fly') {
         if (this.s.status === 'destroying') {
           await this.retryNonFlyDestroy();
-          const finalized = await finalizeDestroyIfComplete(
+          await finalizeDestroyIfComplete(
             this.ctx,
             this.s,
             createReconcileContext(this.s, this.env, 'alarm_destroy'),

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -18,8 +18,9 @@ import type {
   MachineSize,
   CustomSecretMeta,
   ProviderId,
+  ProviderState,
 } from '../../schemas/instance-config';
-import { DEFAULT_INSTANCE_FEATURES } from '../../schemas/instance-config';
+import { DEFAULT_INSTANCE_FEATURES, ProviderStateSchema } from '../../schemas/instance-config';
 import type { FlyVolume, FlyVolumeSnapshot } from '../../fly/types';
 import * as fly from '../../fly/client';
 import { sandboxIdFromUserId, sandboxIdFromInstanceId } from '../../auth/sandbox-id';
@@ -50,13 +51,16 @@ import {
   applyProviderState,
   createMutableState,
   getFlyProviderState,
+  getProviderRegion,
+  getRuntimeId,
+  getStorageId,
   loadState,
   storageUpdate,
   syncProviderStateForStorage,
 } from './state';
 import { nextAlarmTime, doLog, doError, doWarn, toLoggable, createReconcileContext } from './log';
 import { attemptMetadataRecovery } from './reconcile';
-import { buildUserEnvVars, resolveImageRef, resolveImageTag } from './config';
+import { buildUserEnvVars, resolveImageTag, resolveRuntimeImageRef } from './config';
 import * as gateway from './gateway';
 import * as pairing from './pairing';
 import * as kiloCliRun from './kilo-cli-run';
@@ -88,7 +92,7 @@ import {
 } from '../../stream-chat/client';
 import { writeEvent } from '../../utils/analytics';
 import type { KiloClawEventData, KiloClawEventName } from '../../utils/analytics';
-import { getProviderAdapter } from '../../providers';
+import { getProviderAdapter, resolveDefaultProvider } from '../../providers';
 import type {
   ProviderCapabilities,
   ProviderResult,
@@ -171,6 +175,63 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       providerState: result.providerState,
       ...(result.corePatch ?? {}),
     });
+  }
+
+  private async persistProviderResultWithPatch(
+    result: ProviderResult,
+    patch: Partial<PersistedState>
+  ): Promise<void> {
+    this.applyProviderResult(result);
+    await this.persist({
+      provider: result.providerState.provider,
+      providerState: result.providerState,
+      ...(result.corePatch ?? {}),
+      ...patch,
+    });
+  }
+
+  private async retryNonFlyDestroy(): Promise<void> {
+    if (this.s.provider === 'fly') {
+      throw new Error('retryNonFlyDestroy should not be used for Fly providers');
+    }
+
+    if (this.s.pendingDestroyMachineId) {
+      try {
+        const result = await this.provider().destroyRuntime({
+          env: this.env,
+          state: this.s,
+        });
+        this.s.pendingDestroyMachineId = null;
+        await this.persistProviderResultWithPatch(result, {
+          pendingDestroyMachineId: null,
+        });
+      } catch (err) {
+        doWarn(this.s, 'Non-Fly runtime destroy failed, alarm will retry', {
+          provider: this.s.provider,
+          runtimeId: this.s.pendingDestroyMachineId,
+          error: toLoggable(err),
+        });
+      }
+    }
+
+    if (this.s.pendingDestroyVolumeId) {
+      try {
+        const result = await this.provider().destroyStorage({
+          env: this.env,
+          state: this.s,
+        });
+        this.s.pendingDestroyVolumeId = null;
+        await this.persistProviderResultWithPatch(result, {
+          pendingDestroyVolumeId: null,
+        });
+      } catch (err) {
+        doWarn(this.s, 'Non-Fly storage destroy failed, alarm will retry', {
+          provider: this.s.provider,
+          storageId: this.s.pendingDestroyVolumeId,
+          error: toLoggable(err),
+        });
+      }
+    }
   }
 
   async getRoutingTarget(): Promise<ProviderRoutingTarget | null> {
@@ -319,7 +380,14 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       ? sandboxIdFromInstanceId(opts.instanceId)
       : sandboxIdFromUserId(userId);
     const isNew = !this.s.status;
-    const providerId = opts?.provider ?? this.s.provider ?? 'fly';
+    if (!isNew && opts?.provider && opts.provider !== this.s.provider) {
+      throw Object.assign(
+        new Error(`Cannot change provider from ${this.s.provider} to ${opts.provider}`),
+        { status: 409 }
+      );
+    }
+    const providerId =
+      opts?.provider ?? (isNew ? resolveDefaultProvider(this.env) : this.s.provider);
     const orgId = opts?.orgId ?? null;
     const provider = getProviderAdapter(this.env, { provider: providerId });
     const provisioningState = {
@@ -1082,97 +1150,112 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       throw Object.assign(new Error('Instance not provisioned'), { status: 404 });
     }
 
-    const flyConfig = getFlyConfig(this.env, this.s);
+    const isFlyProvider = this.s.provider === 'fly';
+    if (isFlyProvider) {
+      const flyConfig = getFlyConfig(this.env, this.s);
 
-    // If the DO has identity but lost its machine ID, try to recover it
-    // from Fly metadata before creating a duplicate machine.
-    // Skip recovery when the machine was intentionally destroyed for a volume swap
-    // (snapshot restore or reassociation). Both paths set previousVolumeId and clear
-    // flyMachineId in the same persist call, leaving status === 'stopped'. This triple
-    // condition is only true immediately after an intentional destroy — once start()
-    // creates a new machine, flyMachineId is no longer null and this won't match.
-    const machineIntentionallyDestroyed =
-      !this.s.flyMachineId && this.s.previousVolumeId !== null && this.s.status === 'stopped';
-    if (!this.s.flyMachineId && !machineIntentionallyDestroyed) {
-      const recovered = await attemptMetadataRecovery(
-        flyConfig,
-        this.ctx,
-        this.s,
-        createReconcileContext(this.s, this.env, 'start_recovery'),
-        options?.skipCooldown
-      );
-      if (!recovered && !this.s.flyMachineId) {
-        throw new Error(
-          'Metadata recovery failed; aborting start to avoid creating a duplicate machine'
+      // If the DO has identity but lost its machine ID, try to recover it
+      // from Fly metadata before creating a duplicate machine.
+      // Skip recovery when the machine was intentionally destroyed for a volume swap
+      // (snapshot restore or reassociation). Both paths set previousVolumeId and clear
+      // flyMachineId in the same persist call, leaving status === 'stopped'. This triple
+      // condition is only true immediately after an intentional destroy — once start()
+      // creates a new machine, flyMachineId is no longer null and this won't match.
+      const machineIntentionallyDestroyed =
+        !this.s.flyMachineId && this.s.previousVolumeId !== null && this.s.status === 'stopped';
+      if (!this.s.flyMachineId && !machineIntentionallyDestroyed) {
+        const recovered = await attemptMetadataRecovery(
+          flyConfig,
+          this.ctx,
+          this.s,
+          createReconcileContext(this.s, this.env, 'start_recovery'),
+          options?.skipCooldown
         );
-      }
-    }
-
-    await this.persistProviderResult(
-      await this.provider().ensureStorage({
-        env: this.env,
-        state: this.s,
-        reason: 'start',
-      })
-    );
-
-    // Verify volume region matches cached flyRegion
-    let flyState = getFlyProviderState(this.s);
-    if (flyState.volumeId) {
-      try {
-        const volume = await fly.getVolume(flyConfig, flyState.volumeId);
-        if (volume.region !== flyState.region) {
-          doWarn(this.s, 'flyRegion drift detected', {
-            cachedRegion: flyState.region,
-            actualRegion: volume.region,
-          });
-          flyState = {
-            ...flyState,
-            region: volume.region,
-          };
-          await this.persistProviderResult({ providerState: flyState });
+        if (!recovered && !this.s.flyMachineId) {
+          throw new Error(
+            'Metadata recovery failed; aborting start to avoid creating a duplicate machine'
+          );
         }
-      } catch (err) {
-        if (fly.isFlyNotFound(err)) {
-          doWarn(this.s, 'Volume not found during region check, clearing');
-          await this.persistProviderResult({
-            providerState: {
+      }
+
+      await this.persistProviderResult(
+        await this.provider().ensureStorage({
+          env: this.env,
+          state: this.s,
+          reason: 'start',
+        })
+      );
+
+      // Verify volume region matches cached flyRegion
+      let flyState = getFlyProviderState(this.s);
+      if (flyState.volumeId) {
+        try {
+          const volume = await fly.getVolume(flyConfig, flyState.volumeId);
+          if (volume.region !== flyState.region) {
+            doWarn(this.s, 'flyRegion drift detected', {
+              cachedRegion: flyState.region,
+              actualRegion: volume.region,
+            });
+            flyState = {
               ...flyState,
-              volumeId: null,
-              region: null,
-            },
-          });
-          await this.persistProviderResult(
-            await this.provider().ensureStorage({
-              env: this.env,
-              state: this.s,
-              reason: 'start',
-            })
-          );
+              region: volume.region,
+            };
+            await this.persistProviderResult({ providerState: flyState });
+          }
+        } catch (err) {
+          if (fly.isFlyNotFound(err)) {
+            doWarn(this.s, 'Volume not found during region check, clearing');
+            await this.persistProviderResult({
+              providerState: {
+                ...flyState,
+                volumeId: null,
+                region: null,
+              },
+            });
+            await this.persistProviderResult(
+              await this.provider().ensureStorage({
+                env: this.env,
+                state: this.s,
+                reason: 'start',
+              })
+            );
+          }
         }
       }
-    }
 
-    // If running, verify machine is actually alive
-    if (this.s.status === 'running' && this.s.flyMachineId) {
-      try {
-        const machine = await fly.getMachine(flyConfig, this.s.flyMachineId);
-        if (machine.state === 'started') {
-          await reconcileMachineMount(
-            flyConfig,
-            this.ctx,
-            this.s,
-            machine,
-            createReconcileContext(this.s, this.env, 'start')
+      // If running, verify machine is actually alive
+      if (this.s.status === 'running' && this.s.flyMachineId) {
+        try {
+          const machine = await fly.getMachine(flyConfig, this.s.flyMachineId);
+          if (machine.state === 'started') {
+            await reconcileMachineMount(
+              flyConfig,
+              this.ctx,
+              this.s,
+              machine,
+              createReconcileContext(this.s, this.env, 'start')
+            );
+            console.log('[DO] Machine already running, mount verified');
+            await this.scheduleAlarm();
+            return { started: false };
+          }
+          console.log(
+            '[DO] Status is running but machine state is:',
+            machine.state,
+            '-- restarting'
           );
-          console.log('[DO] Machine already running, mount verified');
-          await this.scheduleAlarm();
-          return { started: false };
+        } catch (err) {
+          console.log('[DO] Failed to get machine state, will recreate:', err);
         }
-        console.log('[DO] Status is running but machine state is:', machine.state, '-- restarting');
-      } catch (err) {
-        console.log('[DO] Failed to get machine state, will recreate:', err);
       }
+    } else {
+      await this.persistProviderResult(
+        await this.provider().ensureStorage({
+          env: this.env,
+          state: this.s,
+          reason: 'start',
+        })
+      );
     }
 
     const { envVars, minSecretsVersion } = await buildUserEnvVars(this.env, this.ctx, this.s);
@@ -1194,7 +1277,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       devCreator: this.env.WORKER_ENV === 'development' ? (this.env.DEV_CREATOR ?? null) : null,
     };
     const runtimeSpec = buildRuntimeSpec(
-      resolveImageRef(this.s, this.env),
+      resolveRuntimeImageRef(this.s, this.env),
       envVars,
       this.s.machineSize,
       identity
@@ -1227,7 +1310,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     });
     await this.persistProviderResult(startResult);
 
-    if (this.s.flyMachineId) {
+    if (getRuntimeId(this.s)) {
       const healthy = await gateway.waitForHealthy(this.s, this.env);
       if (!healthy) {
         console.warn('[DO] start: gateway health probe timed out, proceeding with running status');
@@ -1274,7 +1357,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
    * Non-blocking start: immediately persists status='starting', schedules a fast
    * alarm, then fires start() in the background via waitUntil.
    * Used by provision() so the RPC call returns quickly instead of waiting for
-   * the full Fly startup sequence (which can take up to ~60 s).
+   * the full runtime startup sequence.
    */
   async startAsync(userId?: string): Promise<void> {
     await this.loadState();
@@ -1306,9 +1389,23 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         // Read from storage rather than this.s — waitUntil runs after the
         // originating request context completes and other handlers may have
         // mutated in-memory state in the interim.
-        const storedMachineId = await this.ctx.storage.get('flyMachineId');
-        const currentStatus = await this.ctx.storage.get('status');
-        if (!storedMachineId && currentStatus !== 'destroying') {
+        const storedEntries = await this.ctx.storage.get([
+          'providerState',
+          'flyMachineId',
+          'status',
+        ]);
+        const rawProviderState = storedEntries.get('providerState');
+        const parsedProviderState = ProviderStateSchema.safeParse(rawProviderState);
+        const storedProviderState: ProviderState | null = parsedProviderState.success
+          ? parsedProviderState.data
+          : null;
+        const storedFlyMachineId = storedEntries.get('flyMachineId');
+        const currentStatus = storedEntries.get('status');
+        const storedRuntimeId = getRuntimeId({
+          providerState: storedProviderState,
+          flyMachineId: typeof storedFlyMachineId === 'string' ? storedFlyMachineId : null,
+        });
+        if (!storedRuntimeId && currentStatus !== 'destroying') {
           // start() threw before persisting a machine ID. Reconcile cannot
           // distinguish this from "still in progress", so write the terminal
           // state explicitly to avoid the 5-min stuck window.
@@ -1358,7 +1455,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     const machineUptimeMs = this.s.lastStartedAt ? Date.now() - this.s.lastStartedAt : 0;
 
-    if (this.s.flyMachineId) {
+    if (getRuntimeId(this.s)) {
       try {
         await this.persistProviderResult(
           await this.provider().stopRuntime({
@@ -1404,9 +1501,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     }
 
     const machineUptimeMs = this.s.lastStartedAt ? Date.now() - this.s.lastStartedAt : 0;
+    const runtimeId = getRuntimeId(this.s);
+    const storageId = getStorageId(this.s);
 
-    this.s.pendingDestroyMachineId = this.s.flyMachineId;
-    this.s.pendingDestroyVolumeId = this.s.flyVolumeId;
+    this.s.pendingDestroyMachineId = runtimeId;
+    this.s.pendingDestroyVolumeId = storageId;
     this.s.status = 'destroying';
 
     await this.persist({
@@ -1437,10 +1536,14 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       }
     }
 
-    const flyConfig = getFlyConfig(this.env, this.s);
     const destroyRctx = createReconcileContext(this.s, this.env, 'destroy');
-    await tryDeleteMachine(flyConfig, this.ctx, this.s, destroyRctx);
-    await tryDeleteVolume(flyConfig, this.ctx, this.s, destroyRctx);
+    if (this.s.provider === 'fly') {
+      const flyConfig = getFlyConfig(this.env, this.s);
+      await tryDeleteMachine(flyConfig, this.ctx, this.s, destroyRctx);
+      await tryDeleteVolume(flyConfig, this.ctx, this.s, destroyRctx);
+    } else {
+      await this.retryNonFlyDestroy();
+    }
 
     // Capture identity before finalization wipes state
     const preDestroyUserId = this.s.userId;
@@ -1525,6 +1628,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     userId: string | null;
     sandboxId: string | null;
     orgId: string | null;
+    provider: ProviderId;
+    runtimeId: string | null;
+    storageId: string | null;
+    region: string | null;
     status: InstanceStatus | null;
     provisionedAt: number | null;
     lastStartedAt: number | null;
@@ -1554,6 +1661,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     if (
       this.s.status === 'running' &&
+      this.s.provider === 'fly' &&
       this.s.flyMachineId &&
       (this.s.lastLiveCheckAt === null ||
         Date.now() - this.s.lastLiveCheckAt >= LIVE_CHECK_THROTTLE_MS)
@@ -1566,6 +1674,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       userId: this.s.userId,
       sandboxId: this.s.sandboxId,
       orgId: this.s.orgId,
+      provider: this.s.provider,
+      runtimeId: getRuntimeId(this.s),
+      storageId: getStorageId(this.s),
+      region: getProviderRegion(this.s),
       status: this.s.status,
       provisionedAt: this.s.provisionedAt,
       lastStartedAt: this.s.lastStartedAt,
@@ -2194,7 +2306,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   }): Promise<{ success: boolean; error?: string }> {
     await this.loadState();
 
-    if (!this.s.flyMachineId) {
+    if (!getRuntimeId(this.s)) {
       return { success: false, error: 'No machine exists' };
     }
 
@@ -2222,6 +2334,13 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     });
 
     try {
+      if (this.s.provider !== 'fly' && options?.imageTag) {
+        return {
+          success: false,
+          error: `Provider ${this.s.provider} does not support image tag overrides`,
+        };
+      }
+
       if (options?.imageTag) {
         if (options.imageTag === 'latest') {
           const variant = 'default';
@@ -2246,10 +2365,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         });
       }
 
-      const flyConfig = getFlyConfig(this.env, this.s);
-
       // Backfill machineSize from live machine for legacy instances
-      if (this.s.machineSize === null && this.s.flyMachineId) {
+      if (this.s.provider === 'fly' && this.s.machineSize === null && this.s.flyMachineId) {
+        const flyConfig = getFlyConfig(this.env, this.s);
         const machine = await fly.getMachine(flyConfig, this.s.flyMachineId);
         if (machine.config?.guest) {
           const { cpus, memory_mb, cpu_kind } = machine.config.guest;
@@ -2306,7 +2424,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         return;
       }
 
-      if (!this.s.flyMachineId) {
+      if (!getRuntimeId(this.s)) {
         throw new Error('No machine exists');
       }
 
@@ -2359,7 +2477,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         devCreator: this.env.WORKER_ENV === 'development' ? (this.env.DEV_CREATOR ?? null) : null,
       };
       const runtimeSpec = buildRuntimeSpec(
-        resolveImageRef(this.s, this.env),
+        resolveRuntimeImageRef(this.s, this.env),
         envVars,
         this.s.machineSize,
         identity
@@ -2478,6 +2596,23 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     );
 
     try {
+      if (this.s.provider !== 'fly') {
+        if (this.s.status === 'destroying') {
+          await this.retryNonFlyDestroy();
+          const finalized = await finalizeDestroyIfComplete(
+            this.ctx,
+            this.s,
+            createReconcileContext(this.s, this.env, 'alarm_destroy'),
+            (userId, sandboxId) =>
+              markDestroyedInPostgresHelper(this.env, this.ctx, this.s, userId, sandboxId)
+          );
+          if (!finalized.finalized) {
+            await this.scheduleAlarm();
+          }
+        }
+        return;
+      }
+
       const flyConfig = getFlyConfig(this.env, this.s);
       const reconcileResult = await reconcileWithFly(
         flyConfig,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -31,7 +31,12 @@ import {
 import { resolveLatestVersion, resolveVersionByTag } from '../../lib/image-version';
 import { lookupCatalogVersion } from '../../lib/catalog-registration';
 import { ImageVariantSchema } from '../../schemas/image-version';
-import { LIVE_CHECK_THROTTLE_MS, OPENCLAW_BUILTIN_DEFAULT_MODEL } from '../../config';
+import {
+  LIVE_CHECK_THROTTLE_MS,
+  OPENCLAW_BUILTIN_DEFAULT_MODEL,
+  RESTARTING_TIMEOUT_MS,
+  STARTING_TIMEOUT_MS,
+} from '../../config';
 import {
   SECRET_CATALOG,
   FIELD_KEY_TO_ENV_VAR,
@@ -231,6 +236,150 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           error: toLoggable(err),
         });
       }
+    }
+  }
+
+  private async markStartFailedFromProvider(message: string): Promise<void> {
+    const now = Date.now();
+    this.s.status = 'stopped';
+    this.s.startingAt = null;
+    this.s.lastStoppedAt = now;
+    this.s.lastStartErrorMessage = message;
+    this.s.lastStartErrorAt = now;
+    await this.persist({
+      status: 'stopped',
+      startingAt: null,
+      lastStoppedAt: now,
+      lastStartErrorMessage: message,
+      lastStartErrorAt: now,
+    });
+  }
+
+  private async markRestartFailedFromProvider(message: string): Promise<void> {
+    const now = Date.now();
+    this.s.status = 'stopped';
+    this.s.startingAt = null;
+    this.s.restartingAt = null;
+    this.s.restartUpdateSent = false;
+    this.s.lastStoppedAt = now;
+    this.s.lastRestartErrorMessage = message;
+    this.s.lastRestartErrorAt = now;
+    await this.persist({
+      status: 'stopped',
+      startingAt: null,
+      restartingAt: null,
+      restartUpdateSent: false,
+      lastStoppedAt: now,
+      lastRestartErrorMessage: message,
+      lastRestartErrorAt: now,
+    });
+  }
+
+  private async markNonFlyRunningFromProvider(reason: 'start' | 'runtime'): Promise<void> {
+    const startingAt = this.s.startingAt;
+    this.s.status = 'running';
+    this.s.startingAt = null;
+    this.s.restartingAt = null;
+    this.s.restartUpdateSent = false;
+    if (this.s.lastStartedAt === null) {
+      this.s.lastStartedAt = Date.now();
+    }
+    this.s.healthCheckFailCount = 0;
+    this.s.lastStartErrorMessage = null;
+    this.s.lastStartErrorAt = null;
+    this.s.lastRestartErrorMessage = null;
+    this.s.lastRestartErrorAt = null;
+    await this.persist({
+      status: 'running',
+      startingAt: null,
+      restartingAt: null,
+      restartUpdateSent: false,
+      lastStartedAt: this.s.lastStartedAt,
+      healthCheckFailCount: 0,
+      lastStartErrorMessage: null,
+      lastStartErrorAt: null,
+      lastRestartErrorMessage: null,
+      lastRestartErrorAt: null,
+    });
+
+    if (reason === 'start') {
+      this.emitEvent({
+        event: 'instance.started',
+        status: 'running',
+        durationMs: startingAt ? Date.now() - startingAt : undefined,
+      });
+    }
+  }
+
+  private async reconcileNonFlyRuntimeFromAlarm(): Promise<void> {
+    if (this.s.provider === 'fly') {
+      throw new Error('reconcileNonFlyRuntimeFromAlarm should not be used for Fly providers');
+    }
+
+    if (!['starting', 'restarting', 'running'].includes(this.s.status ?? '')) {
+      return;
+    }
+
+    const result = await this.provider().inspectRuntime({
+      env: this.env,
+      state: this.s,
+    });
+    await this.persistProviderResult(result);
+    const runtimeState = result.observation?.runtimeState ?? 'missing';
+
+    if (runtimeState === 'running') {
+      if (this.s.status === 'restarting') {
+        await markRestartSuccessful(
+          this.ctx,
+          this.s,
+          createReconcileContext(this.s, this.env, 'alarm_non_fly')
+        );
+      } else if (this.s.status === 'starting') {
+        await this.markNonFlyRunningFromProvider('start');
+      }
+      await this.scheduleAlarm();
+      return;
+    }
+
+    if (this.s.status === 'starting') {
+      const timedOut =
+        this.s.startingAt !== null && Date.now() - this.s.startingAt > STARTING_TIMEOUT_MS;
+      if (timedOut || runtimeState === 'failed') {
+        const message = `Provider ${this.s.provider} runtime ${runtimeState} during start`;
+        await this.markStartFailedFromProvider(message);
+        this.emitProvisioningFailed('provider_runtime_not_running', message);
+        return;
+      }
+      await this.scheduleAlarm();
+      return;
+    }
+
+    if (this.s.status === 'restarting') {
+      const timedOut =
+        this.s.restartingAt !== null && Date.now() - this.s.restartingAt > RESTARTING_TIMEOUT_MS;
+      if (timedOut || runtimeState === 'failed' || runtimeState === 'missing') {
+        await this.markRestartFailedFromProvider(
+          `Provider ${this.s.provider} runtime ${runtimeState} during restart`
+        );
+        return;
+      }
+      await this.scheduleAlarm();
+      return;
+    }
+
+    if (this.s.status === 'running' && runtimeState !== 'starting') {
+      const now = Date.now();
+      this.s.status = 'stopped';
+      this.s.lastStoppedAt = now;
+      await this.persist({
+        status: 'stopped',
+        lastStoppedAt: now,
+      });
+      this.emitEvent({
+        event: 'instance.stopped',
+        status: 'stopped',
+        label: `provider_runtime_${runtimeState}`,
+      });
     }
   }
 
@@ -1405,31 +1554,49 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           ? parsedProviderState.data
           : null;
         const storedFlyMachineId = storedEntries.get('flyMachineId');
+        const storedFlyMachineIdValue =
+          typeof storedFlyMachineId === 'string' ? storedFlyMachineId : null;
         const currentStatus = storedEntries.get('status');
         const storedRuntimeId = getRuntimeId({
           providerState: storedProviderState,
-          flyMachineId: typeof storedFlyMachineId === 'string' ? storedFlyMachineId : null,
+          flyMachineId: storedFlyMachineIdValue,
         });
-        if (!storedRuntimeId && currentStatus !== 'destroying') {
+        const storedProviderId =
+          storedProviderState?.provider ?? (storedFlyMachineIdValue ? 'fly' : null);
+        let providerStillOwnsRunningRuntime = false;
+        if (currentStatus !== 'destroying' && storedProviderId === 'fly') {
+          providerStillOwnsRunningRuntime = Boolean(storedRuntimeId || storedFlyMachineIdValue);
+        } else if (storedProviderState && currentStatus !== 'destroying') {
+          try {
+            const inspected = await getProviderAdapter(this.env, {
+              provider: storedProviderState.provider,
+            }).inspectRuntime({
+              env: this.env,
+              state: {
+                ...this.s,
+                provider: storedProviderState.provider,
+                providerState: storedProviderState,
+                flyMachineId: storedFlyMachineIdValue,
+              },
+            });
+            providerStillOwnsRunningRuntime =
+              inspected.observation?.runtimeState === 'running' ||
+              inspected.observation?.runtimeState === 'starting';
+          } catch (inspectErr) {
+            doWarn(this.s, 'startAsync: failed to inspect runtime after start failure', {
+              error: toLoggable(inspectErr),
+            });
+          }
+        }
+
+        if (!providerStillOwnsRunningRuntime && currentStatus !== 'destroying') {
           // start() threw before persisting a machine ID. Reconcile cannot
           // distinguish this from "still in progress", so write the terminal
           // state explicitly to avoid the 5-min stuck window.
           // Skip if destroy() has taken ownership — writing 'stopped' would
           // clobber the 'destroying' state and strand cleanup.
-          const now = Date.now();
           const errorMessage = err instanceof Error ? err.message : String(err);
-          this.s.status = 'stopped';
-          this.s.startingAt = null;
-          this.s.lastStoppedAt = now;
-          this.s.lastStartErrorMessage = errorMessage;
-          this.s.lastStartErrorAt = now;
-          await this.persist({
-            status: 'stopped',
-            startingAt: null,
-            lastStoppedAt: now,
-            lastStartErrorMessage: errorMessage,
-            lastStartErrorAt: now,
-          });
+          await this.markStartFailedFromProvider(errorMessage);
           this.emitProvisioningFailed('no_machine_created', errorMessage);
         }
         // If storedMachineId exists the machine was created — reconcileStarting
@@ -1749,6 +1916,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     sandboxId: string | null;
     orgId: string | null;
     provider: ProviderId;
+    runtimeId: string | null;
+    storageId: string | null;
+    region: string | null;
     status: InstanceStatus | null;
     provisionedAt: number | null;
     lastStartedAt: number | null;
@@ -1800,6 +1970,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       sandboxId: this.s.sandboxId,
       orgId: this.s.orgId,
       provider: this.s.provider,
+      runtimeId: getRuntimeId(this.s),
+      storageId: getStorageId(this.s),
+      region: getProviderRegion(this.s),
       status: this.s.status,
       provisionedAt: this.s.provisionedAt,
       lastStartedAt: this.s.lastStartedAt,
@@ -2619,6 +2792,8 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           if (!finalized.finalized) {
             await this.scheduleAlarm();
           }
+        } else {
+          await this.reconcileNonFlyRuntimeFromAlarm();
         }
         return;
       }
@@ -2681,7 +2856,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         return;
       }
     } catch (err) {
-      doError(this.s, 'reconcileWithFly failed', {
+      doError(this.s, 'alarm reconcile failed', {
         error: toLoggable(err),
       });
     }

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -1636,6 +1636,8 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           })
         );
       } catch (err) {
+        // Non-Fly adapters own provider-specific "already gone" handling; this
+        // guard is for Fly APIs that can surface a machine 404 during stop.
         if (!fly.isFlyNotFound(err)) {
           throw err;
         }
@@ -2794,6 +2796,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
           }
         } else {
           await this.reconcileNonFlyRuntimeFromAlarm();
+        }
+        if (this.s.status) {
+          await this.scheduleAlarm();
         }
         return;
       }

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/kilo-cli-run.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/kilo-cli-run.ts
@@ -5,6 +5,7 @@ import {
   GatewayCommandResponseSchema,
 } from '../gateway-controller-types';
 import { callGatewayController, isErrorUnknownRoute } from './gateway';
+import { getRuntimeId } from './state';
 import type { InstanceMutableState } from './types';
 
 type KiloCliRunStartResponse = {
@@ -30,7 +31,7 @@ export async function startKiloCliRun(
   env: KiloClawEnv,
   prompt: string
 ): Promise<KiloCliRunStartResponse | null> {
-  if (state.status !== 'running' || !state.flyMachineId) {
+  if (state.status !== 'running' || !getRuntimeId(state)) {
     throw Object.assign(new Error('Instance is not running'), { status: 409 });
   }
 
@@ -56,7 +57,7 @@ export async function getKiloCliRunStatus(
   state: InstanceMutableState,
   env: KiloClawEnv
 ): Promise<KiloCliRunStatusResponse> {
-  if (state.status !== 'running' || !state.flyMachineId) {
+  if (state.status !== 'running' || !getRuntimeId(state)) {
     return {
       hasRun: false,
       status: null,
@@ -84,7 +85,7 @@ export async function cancelKiloCliRun(
   state: InstanceMutableState,
   env: KiloClawEnv
 ): Promise<{ ok: boolean }> {
-  if (state.status !== 'running' || !state.flyMachineId) {
+  if (state.status !== 'running' || !getRuntimeId(state)) {
     throw Object.assign(new Error('Instance is not running'), { status: 409 });
   }
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/pairing.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/pairing.ts
@@ -3,6 +3,7 @@ import type { KiloClawEnv } from '../../types';
 import * as fly from '../../fly/client';
 import type { InstanceMutableState } from './types';
 import { getFlyConfig } from './types';
+import { getRuntimeId } from './state';
 import { callGatewayController, isErrorUnknownRoute } from './gateway';
 import { doError, doWarn, toLoggable } from './log';
 import {
@@ -54,8 +55,7 @@ export async function listPairingRequests(
   env: KiloClawEnv,
   forceRefresh = false
 ): Promise<{ requests: PairingRequest[] }> {
-  const { flyMachineId } = state;
-  if (state.status !== 'running' || !flyMachineId) {
+  if (state.status !== 'running' || !getRuntimeId(state)) {
     return { requests: [] };
   }
 
@@ -78,6 +78,11 @@ export async function listPairingRequests(
       throw error;
     }
     // Controller predates this route — fall through to KV cache / fly exec
+  }
+
+  const { flyMachineId } = state;
+  if (!flyMachineId) {
+    return { requests: [] };
   }
 
   const cacheKey = makeCacheKey('pairing', state);
@@ -147,8 +152,7 @@ export async function approvePairingRequest(
   channel: string,
   code: string
 ): Promise<{ success: boolean; message: string }> {
-  const { flyMachineId } = state;
-  if (state.status !== 'running' || !flyMachineId) {
+  if (state.status !== 'running' || !getRuntimeId(state)) {
     return { success: false, message: 'Instance is not running' };
   }
 
@@ -180,6 +184,14 @@ export async function approvePairingRequest(
       throw error;
     }
     // Controller predates this route — fall through to fly exec
+  }
+
+  const { flyMachineId } = state;
+  if (!flyMachineId) {
+    return {
+      success: false,
+      message: 'Controller pairing route unavailable; redeploy required',
+    };
   }
 
   const flyConfig = getFlyConfig(env, state);
@@ -231,8 +243,7 @@ export async function listDevicePairingRequests(
   env: KiloClawEnv,
   forceRefresh = false
 ): Promise<{ requests: DevicePairingRequest[] }> {
-  const { flyMachineId } = state;
-  if (state.status !== 'running' || !flyMachineId) {
+  if (state.status !== 'running' || !getRuntimeId(state)) {
     return { requests: [] };
   }
 
@@ -255,6 +266,11 @@ export async function listDevicePairingRequests(
       throw error;
     }
     // Controller predates this route — fall through to KV cache / fly exec
+  }
+
+  const { flyMachineId } = state;
+  if (!flyMachineId) {
+    return { requests: [] };
   }
 
   const cacheKey = makeCacheKey('device-pairing', state);
@@ -322,8 +338,7 @@ export async function approveDevicePairingRequest(
   env: KiloClawEnv,
   requestId: string
 ): Promise<{ success: boolean; message: string }> {
-  const { flyMachineId } = state;
-  if (state.status !== 'running' || !flyMachineId) {
+  if (state.status !== 'running' || !getRuntimeId(state)) {
     return { success: false, message: 'Instance is not running' };
   }
 
@@ -352,6 +367,14 @@ export async function approveDevicePairingRequest(
       throw error;
     }
     // Controller predates this route — fall through to fly exec
+  }
+
+  const { flyMachineId } = state;
+  if (!flyMachineId) {
+    return {
+      success: false,
+      message: 'Controller pairing route unavailable; redeploy required',
+    };
   }
 
   const flyConfig = getFlyConfig(env, state);

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
@@ -12,7 +12,7 @@ import {
   storageUpdate,
   syncProviderStateForStorage,
 } from './state';
-import { buildUserEnvVars, resolveImageRef } from './config';
+import { buildUserEnvVars, resolveRuntimeImageRef } from './config';
 import * as gateway from './gateway';
 import * as flyMachines from './fly-machines';
 import { buildFlyMachineConfig } from './fly-machines';
@@ -403,7 +403,7 @@ export async function runUnexpectedStopRecoveryInBackground(
       devCreator: env.WORKER_ENV === 'development' ? (env.DEV_CREATOR ?? null) : null,
     };
     const runtimeSpec = buildRuntimeSpec(
-      resolveImageRef(state, env),
+      resolveRuntimeImageRef(state, env),
       envVars,
       state.machineSize,
       identity

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
@@ -393,7 +393,7 @@ export async function runUnexpectedStopRecoveryInBackground(
       await runtime.persist({ pendingRecoveryVolumeId: recoveryVolumeId });
     }
 
-    const { envVars, minSecretsVersion } = await buildUserEnvVars(env, ctx, state);
+    const { envVars, bootstrapEnv, minSecretsVersion } = await buildUserEnvVars(env, ctx, state);
     const identity = {
       userId: state.userId,
       sandboxId: state.sandboxId,
@@ -405,6 +405,7 @@ export async function runUnexpectedStopRecoveryInBackground(
     const runtimeSpec = buildRuntimeSpec(
       resolveRuntimeImageRef(state, env),
       envVars,
+      bootstrapEnv,
       state.machineSize,
       identity
     );

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { createMutableState } from './state';
-import { applyProviderState, getFlyProviderState, syncProviderStateForStorage } from './state';
+import {
+  applyProviderState,
+  getFlyProviderState,
+  getRuntimeId,
+  getStorageId,
+  syncProviderStateForStorage,
+} from './state';
 
 describe('provider state helpers', () => {
   it('hydrates legacy Fly fields from canonical providerState', () => {
@@ -108,6 +114,60 @@ describe('provider state helpers', () => {
       machineId: 'machine-1',
       volumeId: 'vol-1',
       region: 'ord',
+    });
+  });
+
+  it('clears legacy Fly fields when applying a non-Fly provider state', () => {
+    const state = createMutableState();
+    state.flyAppName = 'acct-old';
+    state.flyMachineId = 'machine-old';
+    state.flyVolumeId = 'vol-old';
+    state.flyRegion = 'ord';
+
+    applyProviderState(state, {
+      provider: 'docker-local',
+      containerName: 'kiloclaw-sandbox-1',
+      volumeName: 'kiloclaw-root-sandbox-1',
+      hostPort: 45001,
+    });
+
+    expect(state.flyAppName).toBeNull();
+    expect(state.flyMachineId).toBeNull();
+    expect(state.flyVolumeId).toBeNull();
+    expect(state.flyRegion).toBeNull();
+    expect(getRuntimeId(state)).toBe('kiloclaw-sandbox-1');
+    expect(getStorageId(state)).toBe('kiloclaw-root-sandbox-1');
+  });
+
+  it('clears legacy Fly fields in storage when writing non-Fly providerState', () => {
+    const state = createMutableState();
+    state.flyAppName = 'acct-old';
+    state.flyMachineId = 'machine-old';
+    state.flyVolumeId = 'vol-old';
+    state.flyRegion = 'ord';
+
+    const patch = syncProviderStateForStorage(state, {
+      provider: 'docker-local',
+      providerState: {
+        provider: 'docker-local',
+        containerName: 'kiloclaw-sandbox-1',
+        volumeName: 'kiloclaw-root-sandbox-1',
+        hostPort: 45001,
+      },
+    });
+
+    expect(patch).toEqual({
+      provider: 'docker-local',
+      providerState: {
+        provider: 'docker-local',
+        containerName: 'kiloclaw-sandbox-1',
+        volumeName: 'kiloclaw-root-sandbox-1',
+        hostPort: 45001,
+      },
+      flyAppName: null,
+      flyMachineId: null,
+      flyVolumeId: null,
+      flyRegion: null,
     });
   });
 });

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
@@ -3,6 +3,7 @@ import {
   type PersistedState,
   type ProviderState,
   type FlyProviderState,
+  type DockerLocalProviderState,
 } from '../../schemas/instance-config';
 import type { InstanceMutableState } from './types';
 
@@ -74,7 +75,63 @@ export function applyProviderState(
 
   if (providerState.provider === 'fly') {
     hydrateFlyLegacyFieldsFromProviderState(s);
+    return;
   }
+
+  s.flyAppName = null;
+  s.flyMachineId = null;
+  s.flyVolumeId = null;
+  s.flyRegion = null;
+}
+
+export function getDockerLocalProviderState(
+  source: Pick<InstanceMutableState, 'providerState'>
+): DockerLocalProviderState {
+  if (source.providerState?.provider === 'docker-local') {
+    return source.providerState;
+  }
+  return {
+    provider: 'docker-local',
+    containerName: null,
+    volumeName: null,
+    hostPort: null,
+  };
+}
+
+export function getRuntimeId(
+  source: Pick<InstanceMutableState, 'providerState' | 'flyMachineId'>
+): string | null {
+  if (source.providerState?.provider === 'fly') {
+    return source.providerState.machineId;
+  }
+  if (source.providerState?.provider === 'docker-local') {
+    return source.providerState.containerName;
+  }
+  return source.flyMachineId;
+}
+
+export function getStorageId(
+  source: Pick<InstanceMutableState, 'providerState' | 'flyVolumeId'>
+): string | null {
+  if (source.providerState?.provider === 'fly') {
+    return source.providerState.volumeId;
+  }
+  if (source.providerState?.provider === 'docker-local') {
+    return source.providerState.volumeName;
+  }
+  return source.flyVolumeId;
+}
+
+export function getProviderRegion(
+  source: Pick<InstanceMutableState, 'providerState' | 'flyRegion'>
+): string | null {
+  if (source.providerState?.provider === 'fly') {
+    return source.providerState.region;
+  }
+  if (source.providerState?.provider === 'docker-local') {
+    return null;
+  }
+  return source.flyRegion;
 }
 
 export function syncProviderStateForStorage(
@@ -93,8 +150,6 @@ export function syncProviderStateForStorage(
   // `providerState`; writes to legacy Fly fields should only happen alongside a
   // follow-up `persist()` call so this helper can mirror them.
   const nextProvider = patch.provider ?? s.provider;
-  if (nextProvider !== 'fly') return patch;
-
   const explicitProviderState = patch.providerState;
   if (explicitProviderState) {
     applyProviderState(s, explicitProviderState);
@@ -110,6 +165,29 @@ export function syncProviderStateForStorage(
     }
     return {
       ...patch,
+      provider: explicitProviderState.provider,
+      flyAppName: null,
+      flyMachineId: null,
+      flyVolumeId: null,
+      flyRegion: null,
+    };
+  }
+
+  if (nextProvider !== 'fly') return patch;
+
+  if ('provider' in patch && patch.provider && patch.provider !== 'fly') {
+    s.provider = patch.provider;
+    s.providerState = null;
+    s.flyAppName = null;
+    s.flyMachineId = null;
+    s.flyVolumeId = null;
+    s.flyRegion = null;
+    return {
+      ...patch,
+      flyAppName: null,
+      flyMachineId: null,
+      flyVolumeId: null,
+      flyRegion: null,
     };
   }
 
@@ -182,6 +260,8 @@ export async function loadState(ctx: DurableObjectState, s: InstanceMutableState
       } else {
         s.providerState = buildFlyProviderState(s);
       }
+    } else if (s.providerState) {
+      applyProviderState(s, s.providerState);
     }
     s.machineSize = d.machineSize;
     s.healthCheckFailCount = d.healthCheckFailCount;

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
@@ -175,22 +175,6 @@ export function syncProviderStateForStorage(
 
   if (nextProvider !== 'fly') return patch;
 
-  if ('provider' in patch && patch.provider && patch.provider !== 'fly') {
-    s.provider = patch.provider;
-    s.providerState = null;
-    s.flyAppName = null;
-    s.flyMachineId = null;
-    s.flyVolumeId = null;
-    s.flyRegion = null;
-    return {
-      ...patch,
-      flyAppName: null,
-      flyMachineId: null,
-      flyVolumeId: null,
-      flyRegion: null,
-    };
-  }
-
   const touchesFlyLegacyFields =
     'flyAppName' in patch ||
     'flyMachineId' in patch ||

--- a/services/kiloclaw/src/durable-objects/machine-config.ts
+++ b/services/kiloclaw/src/durable-objects/machine-config.ts
@@ -31,12 +31,14 @@ export type MachineIdentity = {
 export function buildRuntimeSpec(
   imageRef: string,
   envVars: Record<string, string>,
+  bootstrapEnv: Record<string, string>,
   machineSize: MachineSize | null,
   identity: MachineIdentity
 ): RuntimeSpec {
   return {
     imageRef,
     env: envVars,
+    bootstrapEnv,
     machineSize,
     rootMountPath: '/root',
     controllerPort: OPENCLAW_PORT,

--- a/services/kiloclaw/src/index.test.ts
+++ b/services/kiloclaw/src/index.test.ts
@@ -115,6 +115,8 @@ describe('proxy recovering state', () => {
         userId: 'user-1',
         sandboxId: 'sandbox-1',
         status: 'recovering',
+        provider: 'fly',
+        runtimeId: 'machine-1',
         flyMachineId: 'machine-1',
         flyAppName: 'test-app',
       }),
@@ -165,6 +167,8 @@ describe('proxy routing target usage', () => {
         userId: 'user-1',
         sandboxId: 'sandbox-1',
         status: 'running',
+        provider: 'fly',
+        runtimeId: 'machine-1',
         flyMachineId: 'machine-1',
         flyAppName: 'test-app',
       }),
@@ -224,6 +228,8 @@ describe('proxy routing target usage', () => {
         userId: 'user-1',
         sandboxId: 'sandbox-1',
         status: 'running',
+        provider: 'fly',
+        runtimeId: 'machine-1',
         flyMachineId: 'machine-1',
         flyAppName: 'test-app',
       }),
@@ -256,6 +262,43 @@ describe('proxy routing target usage', () => {
     });
   });
 
+  it('proxies to docker-local runtimes using the generic runtime id', async () => {
+    const instanceStub = {
+      getStatus: vi.fn().mockResolvedValue({
+        userId: 'user-1',
+        sandboxId: 'sandbox-1',
+        status: 'running',
+        provider: 'docker-local',
+        runtimeId: 'kiloclaw-sandbox-1',
+        flyMachineId: null,
+        flyAppName: null,
+      }),
+      getRoutingTarget: vi.fn().mockResolvedValue({
+        origin: 'http://127.0.0.1:45001',
+        headers: {},
+      }),
+    };
+    const fetchMock = vi.mocked(fetch) as FetchMock;
+    fetchMock.mockResolvedValue(new Response('ok', { status: 200 }));
+
+    const response = await worker.fetch(
+      new Request('https://example.com/i/550e8400-e29b-41d4-a716-446655440000/api/foo'),
+      {
+        NEXTAUTH_SECRET: 'nextauth-secret',
+        GATEWAY_TOKEN_SECRET: 'gateway-secret',
+        KILOCLAW_INSTANCE: {
+          idFromName: vi.fn().mockReturnValue('instance-id'),
+          get: vi.fn().mockReturnValue(instanceStub),
+        },
+      } as never,
+      { waitUntil: vi.fn() } as never
+    );
+
+    expect(response.status).toBe(200);
+    const { input } = getFetchCall(fetchMock);
+    expect(input).toBe('http://127.0.0.1:45001/api/foo');
+  });
+
   it('rebuilds HTTP retry auth with the refreshed authoritative sandbox id after crash recovery', async () => {
     const registryStub = {
       listInstances: vi.fn().mockResolvedValue([
@@ -275,6 +318,8 @@ describe('proxy routing target usage', () => {
           userId: 'user-1',
           sandboxId: 'sandbox-old',
           status: 'running',
+          provider: 'fly',
+          runtimeId: 'machine-old',
           flyMachineId: 'machine-old',
           flyAppName: 'test-app',
         })
@@ -282,6 +327,8 @@ describe('proxy routing target usage', () => {
           userId: 'user-1',
           sandboxId: 'sandbox-old',
           status: 'running',
+          provider: 'fly',
+          runtimeId: 'machine-old',
           flyMachineId: 'machine-old',
           flyAppName: 'test-app',
         })
@@ -289,6 +336,8 @@ describe('proxy routing target usage', () => {
           userId: 'user-1',
           sandboxId: 'sandbox-new',
           status: 'running',
+          provider: 'fly',
+          runtimeId: 'machine-new',
           flyMachineId: 'machine-new',
           flyAppName: 'test-app',
         })
@@ -296,6 +345,8 @@ describe('proxy routing target usage', () => {
           userId: 'user-1',
           sandboxId: 'sandbox-new',
           status: 'running',
+          provider: 'fly',
+          runtimeId: 'machine-new',
           flyMachineId: 'machine-new',
           flyAppName: 'test-app',
         }),
@@ -372,6 +423,8 @@ describe('proxy routing target usage', () => {
           userId: 'user-1',
           sandboxId: 'sandbox-old',
           status: 'running',
+          provider: 'fly',
+          runtimeId: 'machine-old',
           flyMachineId: 'machine-old',
           flyAppName: 'test-app',
         })
@@ -379,6 +432,8 @@ describe('proxy routing target usage', () => {
           userId: 'user-1',
           sandboxId: 'sandbox-old',
           status: 'running',
+          provider: 'fly',
+          runtimeId: 'machine-old',
           flyMachineId: 'machine-old',
           flyAppName: 'test-app',
         })
@@ -386,6 +441,8 @@ describe('proxy routing target usage', () => {
           userId: 'user-1',
           sandboxId: 'sandbox-new',
           status: 'running',
+          provider: 'fly',
+          runtimeId: 'machine-new',
           flyMachineId: 'machine-new',
           flyAppName: 'test-app',
         })
@@ -393,6 +450,8 @@ describe('proxy routing target usage', () => {
           userId: 'user-1',
           sandboxId: 'sandbox-new',
           status: 'running',
+          provider: 'fly',
+          runtimeId: 'machine-new',
           flyMachineId: 'machine-new',
           flyAppName: 'test-app',
         }),

--- a/services/kiloclaw/src/index.ts
+++ b/services/kiloclaw/src/index.ts
@@ -1,9 +1,9 @@
 /**
- * KiloClaw - Multi-tenant OpenClaw on Fly.io Machines
+ * KiloClaw - Multi-tenant OpenClaw runtimes
  *
- * Each authenticated user gets their own Fly Machine, managed by the
- * KiloClawInstance Durable Object. The catch-all proxy resolves the user's
- * flyMachineId from the DO and forwards HTTP/WebSocket traffic via Fly Proxy.
+ * Each authenticated user gets their own provider-backed runtime, managed by the
+ * KiloClawInstance Durable Object. The catch-all proxy resolves routing from the
+ * DO and forwards HTTP/WebSocket traffic through the active provider target.
  *
  * Auth model:
  * - User routes + catch-all proxy: JWT via authMiddleware (Bearer header or cookie)
@@ -117,7 +117,6 @@ function validateRequiredEnv(env: KiloClawEnv): string[] {
   const missing: string[] = [];
   if (!env.NEXTAUTH_SECRET) missing.push('NEXTAUTH_SECRET');
   if (!env.GATEWAY_TOKEN_SECRET) missing.push('GATEWAY_TOKEN_SECRET');
-  if (!env.FLY_API_TOKEN) missing.push('FLY_API_TOKEN');
   return missing;
 }
 
@@ -151,7 +150,6 @@ async function requireEnvVars(c: Context<AppEnv>, next: Next) {
     if (!c.env.HYPERDRIVE?.connectionString) missing.push('HYPERDRIVE');
     if (!c.env.NEXTAUTH_SECRET) missing.push('NEXTAUTH_SECRET');
     if (!c.env.GATEWAY_TOKEN_SECRET) missing.push('GATEWAY_TOKEN_SECRET');
-    if (!c.env.FLY_API_TOKEN) missing.push('FLY_API_TOKEN');
     if (missing.length > 0) {
       console.error('[CONFIG] Platform route missing bindings:', missing.join(', '));
       return c.json(
@@ -288,7 +286,7 @@ app.all('/i/:instanceId/*', async c => {
   if (status.status === 'recovering') {
     return c.json({ error: 'Instance is recovering from an unexpected stop' }, 409);
   }
-  if (!status.flyMachineId) {
+  if (!status.runtimeId) {
     return c.json({ error: 'Instance not provisioned' }, 404);
   }
   if (!status.sandboxId) {
@@ -317,8 +315,8 @@ app.all('/i/:instanceId/*', async c => {
     strippedPath,
     'instance:',
     instanceId,
-    'machine:',
-    status.flyMachineId
+    'runtime:',
+    status.runtimeId
   );
 
   const isWebSocketRequest = c.req.raw.headers.get('Upgrade')?.toLowerCase() === 'websocket';
@@ -538,8 +536,8 @@ async function attemptCrashRecovery(c: Context<AppEnv>): Promise<boolean> {
 }
 
 /**
- * Resolve the flyMachineId, flyAppName, sandboxId, and status for the current user from their DO.
- * Returns null machineId if the instance is destroying (blocks proxy during teardown).
+ * Resolve the active provider runtime id, sandboxId, and status for the current user from their DO.
+ * Returns null runtimeId if the instance is destroying (blocks proxy during teardown).
  * Routes through the user registry, which triggers lazy migration on first access.
  *
  * The returned sandboxId is the DO's authoritative value — it may differ from the
@@ -548,25 +546,25 @@ async function attemptCrashRecovery(c: Context<AppEnv>): Promise<boolean> {
  */
 async function resolveInstance(c: Context<AppEnv>): Promise<{
   stub: ReturnType<KiloClawEnv['KILOCLAW_INSTANCE']['get']> | null;
-  machineId: string | null;
+  runtimeId: string | null;
   sandboxId: string | null;
   status: string | null;
 }> {
   const resolved = await resolveRegistryEntry(c);
-  if (!resolved) return { stub: null, machineId: null, sandboxId: null, status: null };
+  if (!resolved) return { stub: null, runtimeId: null, sandboxId: null, status: null };
 
   const s = await resolved.stub.getStatus();
 
   if (s.status === 'destroying')
-    return { stub: resolved.stub, machineId: null, sandboxId: null, status: 'destroying' };
+    return { stub: resolved.stub, runtimeId: null, sandboxId: null, status: 'destroying' };
   if (s.status === 'restoring')
-    return { stub: resolved.stub, machineId: null, sandboxId: null, status: 'restoring' };
+    return { stub: resolved.stub, runtimeId: null, sandboxId: null, status: 'restoring' };
   if (s.status === 'recovering')
-    return { stub: resolved.stub, machineId: null, sandboxId: null, status: 'recovering' };
+    return { stub: resolved.stub, runtimeId: null, sandboxId: null, status: 'recovering' };
 
   return {
     stub: resolved.stub,
-    machineId: s.flyMachineId,
+    runtimeId: s.runtimeId,
     sandboxId: s.sandboxId,
     status: s.status,
   };
@@ -627,7 +625,7 @@ app.all('*', async c => {
             409
           );
         }
-        if (!instanceStatus.flyMachineId) {
+        if (!instanceStatus.runtimeId) {
           return c.json(
             { error: 'Instance not provisioned', hint: 'The instance has no running machine.' },
             404
@@ -645,8 +643,8 @@ app.all('*', async c => {
           console.log(
             '[PROXY] Cookie-routed to instance:',
             activeInstanceId,
-            'machine:',
-            instanceStatus.flyMachineId
+            'runtime:',
+            instanceStatus.runtimeId
           );
           const request = c.req.raw;
           const url = new URL(request.url);
@@ -783,7 +781,7 @@ app.all('*', async c => {
     // Cookie invalid/stale — fall through to default personal resolution
   }
 
-  const { stub, machineId, sandboxId, status } = await resolveInstance(c);
+  const { stub, runtimeId, sandboxId, status } = await resolveInstance(c);
   if (status === 'destroying') {
     return c.json(
       { error: 'Instance is being destroyed', hint: 'This instance is being torn down.' },
@@ -808,7 +806,7 @@ app.all('*', async c => {
       409
     );
   }
-  if (!machineId) {
+  if (!runtimeId) {
     return c.json(
       {
         error: 'Instance not provisioned',
@@ -836,7 +834,7 @@ app.all('*', async c => {
   }
   let targetUrl = routingTargetUrl(routingTarget, url.pathname, url.search);
 
-  console.log('[PROXY] Handling request:', url.pathname, 'machine:', machineId);
+  console.log('[PROXY] Handling request:', url.pathname, 'runtime:', runtimeId);
 
   const isWebSocketRequest = request.headers.get('Upgrade')?.toLowerCase() === 'websocket';
 
@@ -876,7 +874,7 @@ app.all('*', async c => {
         // Machine may have been recreated — refresh the instance routing header
         const refreshedInstance = await resolveInstance(c);
         if (
-          !refreshedInstance.machineId ||
+          !refreshedInstance.runtimeId ||
           !refreshedInstance.stub ||
           !refreshedInstance.sandboxId
         ) {
@@ -1042,7 +1040,7 @@ app.all('*', async c => {
     if (recovered) {
       // Machine may have been recreated — refresh the instance routing header
       const refreshedInstance = await resolveInstance(c);
-      if (!refreshedInstance.machineId || !refreshedInstance.stub || !refreshedInstance.sandboxId) {
+      if (!refreshedInstance.runtimeId || !refreshedInstance.stub || !refreshedInstance.sandboxId) {
         return c.json(
           { error: 'Instance not reachable after restart' },
           { status: 503, headers: { 'Retry-After': '5' } }

--- a/services/kiloclaw/src/providers/docker-local/index.test.ts
+++ b/services/kiloclaw/src/providers/docker-local/index.test.ts
@@ -91,6 +91,25 @@ describe('dockerLocalProviderAdapter', () => {
     });
   });
 
+  it('preserves a versioned Docker API base path', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(new Response('OK', { status: 200 }));
+
+    await dockerLocalProviderAdapter.ensureProvisioningResources({
+      env: {
+        WORKER_ENV: 'development',
+        DOCKER_LOCAL_API_BASE: 'http://127.0.0.1:23750/v1.44',
+        DOCKER_LOCAL_IMAGE: 'kiloclaw:local',
+        DOCKER_LOCAL_PORT_RANGE: '45000-45010',
+      } as never,
+      state: runtimeState(),
+      orgId: null,
+      machineSize: null,
+    });
+
+    expect(fetchInputUrl(fetchMock.mock.calls[0][0])).toBe('http://127.0.0.1:23750/v1.44/_ping');
+  });
+
   it('creates the Docker volume when storage is missing', async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock.mockResolvedValueOnce(new Response('', { status: 404 })).mockResolvedValueOnce(

--- a/services/kiloclaw/src/providers/docker-local/index.test.ts
+++ b/services/kiloclaw/src/providers/docker-local/index.test.ts
@@ -35,6 +35,17 @@ describe('dockerLocalProviderAdapter', () => {
     } as never;
   }
 
+  function runtimeStateWithProviderState(
+    providerState: Record<string, string | number | null>,
+    stateOverrides: Record<string, unknown> = {}
+  ) {
+    return {
+      ...(runtimeState() as unknown as Record<string, unknown>),
+      providerState,
+      ...stateOverrides,
+    } as never;
+  }
+
   function runtimeSpec() {
     return {
       imageRef: 'kiloclaw:local',
@@ -93,6 +104,10 @@ describe('dockerLocalProviderAdapter', () => {
   it('allocates a host port and creates/starts a container on first start', async () => {
     const fetchMock = vi.mocked(fetch);
     let createBody: Record<string, unknown> | null = null;
+    const events: string[] = [];
+    const onProviderResult = vi.fn(async () => {
+      events.push('persist');
+    });
     fetchMock.mockImplementation(async (input, init) => {
       const url = String(input);
       if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
@@ -111,9 +126,11 @@ describe('dockerLocalProviderAdapter', () => {
         });
       }
       if (url.endsWith('/containers/kiloclaw-sandbox-1/json')) {
+        events.push('inspect-container');
         return new Response('', { status: 404 });
       }
       if (url.includes('/containers/create?name=kiloclaw-sandbox-1')) {
+        events.push('create-container');
         createBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
         return new Response(JSON.stringify({ Id: 'container-1' }), {
           status: 201,
@@ -134,9 +151,24 @@ describe('dockerLocalProviderAdapter', () => {
         bootstrapEnv: {
           KILOCLAW_ENV_KEY: 'env-key-1',
         },
+        machineSize: {
+          cpu_kind: 'shared',
+          cpus: 2,
+          memory_mb: 4096,
+        },
       },
+      onProviderResult,
     });
 
+    expect(onProviderResult).toHaveBeenCalledWith({
+      providerState: {
+        provider: 'docker-local',
+        containerName: 'kiloclaw-sandbox-1',
+        volumeName: 'kiloclaw-root-sandbox-1',
+        hostPort: 45001,
+      },
+    });
+    expect(events).toEqual(['persist', 'inspect-container', 'create-container']);
     expect(result.providerState).toEqual({
       provider: 'docker-local',
       containerName: 'kiloclaw-sandbox-1',
@@ -147,6 +179,189 @@ describe('dockerLocalProviderAdapter', () => {
     expect(getContainerEnv(createBody)).toEqual(
       expect.arrayContaining(['FOO=bar', 'KILOCLAW_ENV_KEY=env-key-1'])
     );
+    expect(createBody).toMatchObject({
+      HostConfig: {
+        Binds: ['kiloclaw-root-sandbox-1:/root'],
+        Memory: 4096 * 1024 * 1024,
+        NanoCpus: 2_000_000_000,
+      },
+    });
+  });
+
+  it('recreates an existing stopped container so the current runtime spec is applied', async () => {
+    const fetchMock = vi.mocked(fetch);
+    const events: string[] = [];
+    let createBody: Record<string, unknown> | null = null;
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
+        return new Response(JSON.stringify({ Name: 'kiloclaw-root-sandbox-1' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/containers/kiloclaw-sandbox-1/json')) {
+        events.push('inspect-container');
+        return new Response(
+          JSON.stringify({
+            Id: 'container-1',
+            Name: '/kiloclaw-sandbox-1',
+            State: { Running: false, Status: 'exited' },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        );
+      }
+      if (url.endsWith('/containers/kiloclaw-sandbox-1?force=true')) {
+        events.push('remove-container');
+        return new Response(null, { status: 204 });
+      }
+      if (url.includes('/containers/create?name=kiloclaw-sandbox-1')) {
+        events.push('create-container');
+        createBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return new Response(JSON.stringify({ Id: 'container-2' }), {
+          status: 201,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/containers/kiloclaw-sandbox-1/start')) {
+        events.push('start-container');
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unhandled Docker API request: ${url}`);
+    });
+
+    const result = await dockerLocalProviderAdapter.startRuntime({
+      env: devEnv(),
+      state: runtimeStateWithProviderState({
+        provider: 'docker-local',
+        containerName: 'kiloclaw-sandbox-1',
+        volumeName: 'kiloclaw-root-sandbox-1',
+        hostPort: 45001,
+      }),
+      runtimeSpec: {
+        ...runtimeSpec(),
+        imageRef: 'kiloclaw:new',
+        env: { FOO: 'updated' },
+      },
+    });
+
+    expect(events).toEqual([
+      'inspect-container',
+      'remove-container',
+      'create-container',
+      'start-container',
+    ]);
+    expect(result.observation?.runtimeState).toBe('running');
+    expect(createBody).toMatchObject({ Image: 'kiloclaw:new' });
+    expect(getContainerEnv(createBody)).toEqual(expect.arrayContaining(['FOO=updated']));
+  });
+
+  it('recreates an existing running container during start from stopped state', async () => {
+    const fetchMock = vi.mocked(fetch);
+    const events: string[] = [];
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
+        return new Response(JSON.stringify({ Name: 'kiloclaw-root-sandbox-1' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/containers/kiloclaw-sandbox-1/json')) {
+        events.push('inspect-container');
+        return new Response(
+          JSON.stringify({
+            Id: 'container-1',
+            Name: '/kiloclaw-sandbox-1',
+            State: { Running: true, Status: 'running' },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        );
+      }
+      if (url.endsWith('/containers/kiloclaw-sandbox-1?force=true')) {
+        events.push('remove-container');
+        return new Response(null, { status: 204 });
+      }
+      if (url.includes('/containers/create?name=kiloclaw-sandbox-1')) {
+        events.push('create-container');
+        expect(JSON.parse(String(init?.body))).toMatchObject({ Image: 'kiloclaw:new' });
+        return new Response(JSON.stringify({ Id: 'container-2' }), {
+          status: 201,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/containers/kiloclaw-sandbox-1/start')) {
+        events.push('start-container');
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unhandled Docker API request: ${url}`);
+    });
+
+    await dockerLocalProviderAdapter.startRuntime({
+      env: devEnv(),
+      state: runtimeStateWithProviderState(
+        {
+          provider: 'docker-local',
+          containerName: 'kiloclaw-sandbox-1',
+          volumeName: 'kiloclaw-root-sandbox-1',
+          hostPort: 45001,
+        },
+        { status: 'stopped' }
+      ),
+      runtimeSpec: {
+        ...runtimeSpec(),
+        imageRef: 'kiloclaw:new',
+      },
+    });
+
+    expect(events).toEqual([
+      'inspect-container',
+      'remove-container',
+      'create-container',
+      'start-container',
+    ]);
+  });
+
+  it('inspects Docker container state as provider runtime state', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          Id: 'container-1',
+          Name: '/kiloclaw-sandbox-1',
+          State: { Running: true, Status: 'running' },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+
+    const result = await dockerLocalProviderAdapter.inspectRuntime({
+      env: devEnv(),
+      state: runtimeStateWithProviderState({
+        provider: 'docker-local',
+        containerName: 'kiloclaw-sandbox-1',
+        volumeName: 'kiloclaw-root-sandbox-1',
+        hostPort: 45001,
+      }),
+    });
+
+    expect(result.observation?.runtimeState).toBe('running');
+  });
+
+  it('reports missing when the Docker container is absent', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('', { status: 404 }));
+
+    const result = await dockerLocalProviderAdapter.inspectRuntime({
+      env: devEnv(),
+      state: runtimeStateWithProviderState({
+        provider: 'docker-local',
+        containerName: 'kiloclaw-sandbox-1',
+        volumeName: 'kiloclaw-root-sandbox-1',
+        hostPort: 45001,
+      }),
+    });
+
+    expect(result.observation?.runtimeState).toBe('missing');
   });
 
   it('returns a localhost routing target from the assigned host port', async () => {

--- a/services/kiloclaw/src/providers/docker-local/index.test.ts
+++ b/services/kiloclaw/src/providers/docker-local/index.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { dockerLocalProviderAdapter } from './index';
 
+function getContainerEnv(body: Record<string, unknown> | null): string[] {
+  const env = body?.Env;
+  if (!Array.isArray(env)) return [];
+  return env.filter((entry): entry is string => typeof entry === 'string');
+}
+
 describe('dockerLocalProviderAdapter', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn());
@@ -33,6 +39,7 @@ describe('dockerLocalProviderAdapter', () => {
     return {
       imageRef: 'kiloclaw:local',
       env: { FOO: 'bar' },
+      bootstrapEnv: {},
       machineSize: null,
       rootMountPath: '/root',
       controllerPort: 18789,
@@ -85,7 +92,8 @@ describe('dockerLocalProviderAdapter', () => {
 
   it('allocates a host port and creates/starts a container on first start', async () => {
     const fetchMock = vi.mocked(fetch);
-    fetchMock.mockImplementation(async input => {
+    let createBody: Record<string, unknown> | null = null;
+    fetchMock.mockImplementation(async (input, init) => {
       const url = String(input);
       if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
         return new Response('', { status: 404 });
@@ -106,6 +114,7 @@ describe('dockerLocalProviderAdapter', () => {
         return new Response('', { status: 404 });
       }
       if (url.includes('/containers/create?name=kiloclaw-sandbox-1')) {
+        createBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
         return new Response(JSON.stringify({ Id: 'container-1' }), {
           status: 201,
           headers: { 'content-type': 'application/json' },
@@ -120,7 +129,12 @@ describe('dockerLocalProviderAdapter', () => {
     const result = await dockerLocalProviderAdapter.startRuntime({
       env: devEnv(),
       state: runtimeState(),
-      runtimeSpec: runtimeSpec(),
+      runtimeSpec: {
+        ...runtimeSpec(),
+        bootstrapEnv: {
+          KILOCLAW_ENV_KEY: 'env-key-1',
+        },
+      },
     });
 
     expect(result.providerState).toEqual({
@@ -130,6 +144,9 @@ describe('dockerLocalProviderAdapter', () => {
       hostPort: 45001,
     });
     expect(result.observation?.runtimeState).toBe('running');
+    expect(getContainerEnv(createBody)).toEqual(
+      expect.arrayContaining(['FOO=bar', 'KILOCLAW_ENV_KEY=env-key-1'])
+    );
   });
 
   it('returns a localhost routing target from the assigned host port', async () => {

--- a/services/kiloclaw/src/providers/docker-local/index.test.ts
+++ b/services/kiloclaw/src/providers/docker-local/index.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dockerLocalProviderAdapter } from './index';
+
+describe('dockerLocalProviderAdapter', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function devEnv() {
+    return {
+      WORKER_ENV: 'development',
+      DOCKER_LOCAL_API_BASE: 'http://127.0.0.1:23750',
+      DOCKER_LOCAL_IMAGE: 'kiloclaw:local',
+      DOCKER_LOCAL_PORT_RANGE: '45000-45010',
+    } as never;
+  }
+
+  function runtimeState() {
+    return {
+      userId: 'user-1',
+      sandboxId: 'sandbox-1',
+      provider: 'docker-local',
+      providerState: null,
+      status: 'provisioned',
+    } as never;
+  }
+
+  function runtimeSpec() {
+    return {
+      imageRef: 'kiloclaw:local',
+      env: { FOO: 'bar' },
+      machineSize: null,
+      rootMountPath: '/root',
+      controllerPort: 18789,
+      controllerHealthCheckPath: '/_kilo/health',
+      metadata: { sandboxId: 'sandbox-1' },
+    } as const;
+  }
+
+  it('seeds deterministic names during provisioning resource setup', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(new Response('OK', { status: 200 }));
+
+    const result = await dockerLocalProviderAdapter.ensureProvisioningResources({
+      env: devEnv(),
+      state: runtimeState(),
+      orgId: null,
+      machineSize: null,
+    });
+
+    expect(result.providerState).toEqual({
+      provider: 'docker-local',
+      containerName: 'kiloclaw-sandbox-1',
+      volumeName: 'kiloclaw-root-sandbox-1',
+      hostPort: null,
+    });
+  });
+
+  it('creates the Docker volume when storage is missing', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 404 })).mockResolvedValueOnce(
+      new Response(JSON.stringify({ Name: 'kiloclaw-root-sandbox-1' }), {
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+    const result = await dockerLocalProviderAdapter.ensureStorage({
+      env: devEnv(),
+      state: runtimeState(),
+      reason: 'test',
+    });
+
+    expect(result.providerState).toEqual({
+      provider: 'docker-local',
+      containerName: 'kiloclaw-sandbox-1',
+      volumeName: 'kiloclaw-root-sandbox-1',
+      hostPort: null,
+    });
+  });
+
+  it('allocates a host port and creates/starts a container on first start', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(async input => {
+      const url = String(input);
+      if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
+        return new Response('', { status: 404 });
+      }
+      if (url.endsWith('/volumes/create')) {
+        return new Response(JSON.stringify({ Name: 'kiloclaw-root-sandbox-1' }), {
+          status: 201,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.includes('/containers/json?all=1')) {
+        return new Response(JSON.stringify([{ Ports: [{ PublicPort: 45000 }] }]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/containers/kiloclaw-sandbox-1/json')) {
+        return new Response('', { status: 404 });
+      }
+      if (url.includes('/containers/create?name=kiloclaw-sandbox-1')) {
+        return new Response(JSON.stringify({ Id: 'container-1' }), {
+          status: 201,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/containers/kiloclaw-sandbox-1/start')) {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unhandled Docker API request: ${url}`);
+    });
+
+    const result = await dockerLocalProviderAdapter.startRuntime({
+      env: devEnv(),
+      state: runtimeState(),
+      runtimeSpec: runtimeSpec(),
+    });
+
+    expect(result.providerState).toEqual({
+      provider: 'docker-local',
+      containerName: 'kiloclaw-sandbox-1',
+      volumeName: 'kiloclaw-root-sandbox-1',
+      hostPort: 45001,
+    });
+    expect(result.observation?.runtimeState).toBe('running');
+  });
+
+  it('returns a localhost routing target from the assigned host port', async () => {
+    const target = await dockerLocalProviderAdapter.getRoutingTarget({
+      env: devEnv(),
+      state: {
+        providerState: {
+          provider: 'docker-local',
+          containerName: 'kiloclaw-sandbox-1',
+          volumeName: 'kiloclaw-root-sandbox-1',
+          hostPort: 45001,
+        },
+      } as never,
+    });
+
+    expect(target).toEqual({
+      origin: 'http://127.0.0.1:45001',
+      headers: {},
+    });
+  });
+});

--- a/services/kiloclaw/src/providers/docker-local/index.test.ts
+++ b/services/kiloclaw/src/providers/docker-local/index.test.ts
@@ -7,6 +7,19 @@ function getContainerEnv(body: Record<string, unknown> | null): string[] {
   return env.filter((entry): entry is string => typeof entry === 'string');
 }
 
+function fetchInputUrl(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function requestJsonBody(init: RequestInit | undefined): Record<string, unknown> {
+  if (typeof init?.body !== 'string') {
+    throw new Error('Expected JSON string request body');
+  }
+  return JSON.parse(init.body) as Record<string, unknown>;
+}
+
 describe('dockerLocalProviderAdapter', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn());
@@ -109,7 +122,7 @@ describe('dockerLocalProviderAdapter', () => {
       events.push('persist');
     });
     fetchMock.mockImplementation(async (input, init) => {
-      const url = String(input);
+      const url = fetchInputUrl(input);
       if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
         return new Response('', { status: 404 });
       }
@@ -131,7 +144,7 @@ describe('dockerLocalProviderAdapter', () => {
       }
       if (url.includes('/containers/create?name=kiloclaw-sandbox-1')) {
         events.push('create-container');
-        createBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        createBody = requestJsonBody(init);
         return new Response(JSON.stringify({ Id: 'container-1' }), {
           status: 201,
           headers: { 'content-type': 'application/json' },
@@ -193,7 +206,7 @@ describe('dockerLocalProviderAdapter', () => {
     const events: string[] = [];
     let createBody: Record<string, unknown> | null = null;
     fetchMock.mockImplementation(async (input, init) => {
-      const url = String(input);
+      const url = fetchInputUrl(input);
       if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
         return new Response(JSON.stringify({ Name: 'kiloclaw-root-sandbox-1' }), {
           status: 200,
@@ -217,7 +230,7 @@ describe('dockerLocalProviderAdapter', () => {
       }
       if (url.includes('/containers/create?name=kiloclaw-sandbox-1')) {
         events.push('create-container');
-        createBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        createBody = requestJsonBody(init);
         return new Response(JSON.stringify({ Id: 'container-2' }), {
           status: 201,
           headers: { 'content-type': 'application/json' },
@@ -260,7 +273,7 @@ describe('dockerLocalProviderAdapter', () => {
     const fetchMock = vi.mocked(fetch);
     const events: string[] = [];
     fetchMock.mockImplementation(async (input, init) => {
-      const url = String(input);
+      const url = fetchInputUrl(input);
       if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
         return new Response(JSON.stringify({ Name: 'kiloclaw-root-sandbox-1' }), {
           status: 200,
@@ -284,7 +297,7 @@ describe('dockerLocalProviderAdapter', () => {
       }
       if (url.includes('/containers/create?name=kiloclaw-sandbox-1')) {
         events.push('create-container');
-        expect(JSON.parse(String(init?.body))).toMatchObject({ Image: 'kiloclaw:new' });
+        expect(requestJsonBody(init)).toMatchObject({ Image: 'kiloclaw:new' });
         return new Response(JSON.stringify({ Id: 'container-2' }), {
           status: 201,
           headers: { 'content-type': 'application/json' },

--- a/services/kiloclaw/src/providers/docker-local/index.ts
+++ b/services/kiloclaw/src/providers/docker-local/index.ts
@@ -97,13 +97,14 @@ function ensureDockerLocalConfigured(env: KiloClawEnv): string {
 
 async function dockerFetch(env: KiloClawEnv, path: string, init?: RequestInit): Promise<Response> {
   const base = ensureDockerLocalConfigured(env);
+  const url = `${base.replace(/\/+$/, '')}${path.startsWith('/') ? path : `/${path}`}`;
   const headers = new Headers(init?.headers);
   if (init?.body && !headers.has('content-type')) {
     headers.set('content-type', 'application/json');
   }
 
   try {
-    return await fetch(new URL(path, `${base}/`).toString(), {
+    return await fetch(url, {
       ...init,
       headers,
     });

--- a/services/kiloclaw/src/providers/docker-local/index.ts
+++ b/services/kiloclaw/src/providers/docker-local/index.ts
@@ -476,6 +476,8 @@ export const dockerLocalProviderAdapter: InstanceProviderAdapter = {
       await createContainer(env, state, providerState, runtimeSpec);
       await startContainer(env, containerName);
     }
+    // If Docker and the DO both report running, leave the dev container intact.
+    // Restart/redeploy is the explicit path that reapplies image/env/config changes.
 
     return {
       providerState,

--- a/services/kiloclaw/src/providers/docker-local/index.ts
+++ b/services/kiloclaw/src/providers/docker-local/index.ts
@@ -255,7 +255,10 @@ async function allocateHostPort(
 }
 
 function buildContainerEnv(runtimeSpec: RuntimeSpec): string[] {
-  return Object.entries(runtimeSpec.env).map(([key, value]) => `${key}=${value}`);
+  return Object.entries({
+    ...runtimeSpec.env,
+    ...runtimeSpec.bootstrapEnv,
+  }).map(([key, value]) => `${key}=${value}`);
 }
 
 function requireContainerConfig(providerState: DockerLocalProviderState): {

--- a/services/kiloclaw/src/providers/docker-local/index.ts
+++ b/services/kiloclaw/src/providers/docker-local/index.ts
@@ -1,0 +1,507 @@
+import type { DockerLocalProviderState } from '../../schemas/instance-config';
+import type { InstanceProviderAdapter } from '../types';
+import { getDockerLocalProviderState } from '../../durable-objects/kiloclaw-instance/state';
+import type { KiloClawEnv } from '../../types';
+import type { RuntimeSpec } from '../types';
+import type { InstanceMutableState } from '../../durable-objects/kiloclaw-instance/types';
+
+const DEFAULT_PORT_RANGE = '45000-45999';
+
+type DockerApiError = Error & { status: number };
+
+type DockerContainerSummary = {
+  Id?: string;
+  Names?: string[];
+  Ports?: Array<{ PublicPort?: number }>;
+};
+
+type DockerContainerInspect = {
+  Id: string;
+  Name: string;
+  State?: {
+    Running?: boolean;
+    Status?: string;
+  };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isDockerContainerInspect(value: unknown): value is DockerContainerInspect {
+  if (!isRecord(value)) return false;
+
+  const state = value.State;
+  if (state !== undefined && !isRecord(state)) return false;
+
+  return typeof value.Id === 'string' && typeof value.Name === 'string';
+}
+
+function isDockerContainerSummaryArray(value: unknown): value is DockerContainerSummary[] {
+  if (!Array.isArray(value)) return false;
+
+  return value.every(item => {
+    if (!isRecord(item)) return false;
+    if ('Id' in item && item.Id !== undefined && typeof item.Id !== 'string') return false;
+
+    const names = item.Names;
+    if (
+      names !== undefined &&
+      (!Array.isArray(names) || names.some(name => typeof name !== 'string'))
+    ) {
+      return false;
+    }
+
+    const ports = item.Ports;
+    if (
+      ports !== undefined &&
+      (!Array.isArray(ports) ||
+        ports.some(
+          port =>
+            !isRecord(port) ||
+            ('PublicPort' in port &&
+              port.PublicPort !== undefined &&
+              typeof port.PublicPort !== 'number')
+        ))
+    ) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+function dockerConfigError(message: string, status = 503): DockerApiError {
+  return Object.assign(new Error(message), { status });
+}
+
+function ensureDockerLocalConfigured(env: KiloClawEnv): string {
+  if (env.WORKER_ENV !== 'development') {
+    throw dockerConfigError('Provider docker-local is only available in development', 400);
+  }
+  if (!env.DOCKER_LOCAL_API_BASE) {
+    throw dockerConfigError('Provider docker-local is not configured for local Docker API');
+  }
+  return env.DOCKER_LOCAL_API_BASE;
+}
+
+async function dockerFetch(env: KiloClawEnv, path: string, init?: RequestInit): Promise<Response> {
+  const base = ensureDockerLocalConfigured(env);
+  const headers = new Headers(init?.headers);
+  if (init?.body && !headers.has('content-type')) {
+    headers.set('content-type', 'application/json');
+  }
+
+  try {
+    return await fetch(new URL(path, `${base}/`).toString(), {
+      ...init,
+      headers,
+    });
+  } catch (error) {
+    throw dockerConfigError(
+      `Provider docker-local cannot reach Docker API at ${base}: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+async function dockerRequest(
+  env: KiloClawEnv,
+  path: string,
+  init?: RequestInit,
+  expectedStatus: number[] = [200]
+): Promise<Response> {
+  const response = await dockerFetch(env, path, init);
+  if (!expectedStatus.includes(response.status)) {
+    const body = await response.text().catch(() => '');
+    throw dockerConfigError(
+      `Provider docker-local Docker API request failed: ${response.status}${body ? ` ${body}` : ''}`,
+      response.status
+    );
+  }
+  return response;
+}
+
+async function pingDocker(env: KiloClawEnv): Promise<void> {
+  await dockerRequest(env, '/_ping', undefined, [200]);
+}
+
+function buildContainerName(state: Pick<InstanceMutableState, 'sandboxId'>): string {
+  if (!state.sandboxId) {
+    throw dockerConfigError('Provider docker-local requires a sandboxId');
+  }
+  return `kiloclaw-${state.sandboxId}`;
+}
+
+function buildVolumeName(state: Pick<InstanceMutableState, 'sandboxId'>): string {
+  if (!state.sandboxId) {
+    throw dockerConfigError('Provider docker-local requires a sandboxId');
+  }
+  return `kiloclaw-root-${state.sandboxId}`;
+}
+
+function parsePortRange(env: KiloClawEnv): { start: number; end: number } {
+  const raw = env.DOCKER_LOCAL_PORT_RANGE ?? DEFAULT_PORT_RANGE;
+  const match = /^(\d+)-(\d+)$/.exec(raw);
+  if (!match) {
+    throw dockerConfigError('Provider docker-local has invalid DOCKER_LOCAL_PORT_RANGE');
+  }
+  const start = Number(match[1]);
+  const end = Number(match[2]);
+  if (!Number.isInteger(start) || !Number.isInteger(end) || start <= 0 || end < start) {
+    throw dockerConfigError('Provider docker-local has invalid DOCKER_LOCAL_PORT_RANGE');
+  }
+  return { start, end };
+}
+
+async function inspectVolume(env: KiloClawEnv, name: string): Promise<boolean> {
+  const response = await dockerFetch(env, `/volumes/${encodeURIComponent(name)}`, {
+    method: 'GET',
+  });
+  if (response.status === 404) return false;
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw dockerConfigError(
+      `Provider docker-local Docker API request failed: ${response.status}${body ? ` ${body}` : ''}`,
+      response.status
+    );
+  }
+  return true;
+}
+
+async function ensureVolume(env: KiloClawEnv, name: string): Promise<void> {
+  if (await inspectVolume(env, name)) return;
+  await dockerRequest(
+    env,
+    '/volumes/create',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        Name: name,
+        Labels: {
+          provider: 'docker-local',
+        },
+      }),
+    },
+    [201]
+  );
+}
+
+async function deleteVolume(env: KiloClawEnv, name: string): Promise<void> {
+  const response = await dockerFetch(env, `/volumes/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+  });
+  if (response.status === 404 || response.status === 204) return;
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw dockerConfigError(
+      `Provider docker-local Docker API request failed: ${response.status}${body ? ` ${body}` : ''}`,
+      response.status
+    );
+  }
+}
+
+async function inspectContainer(
+  env: KiloClawEnv,
+  containerName: string
+): Promise<DockerContainerInspect | null> {
+  const response = await dockerFetch(env, `/containers/${encodeURIComponent(containerName)}/json`, {
+    method: 'GET',
+  });
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw dockerConfigError(
+      `Provider docker-local Docker API request failed: ${response.status}${body ? ` ${body}` : ''}`,
+      response.status
+    );
+  }
+  const body: unknown = await response.json();
+  if (!isDockerContainerInspect(body)) {
+    throw dockerConfigError('Provider docker-local received an invalid container inspect payload');
+  }
+  return body;
+}
+
+async function listContainers(env: KiloClawEnv): Promise<DockerContainerSummary[]> {
+  const response = await dockerRequest(env, '/containers/json?all=1');
+  const body: unknown = await response.json();
+  if (!isDockerContainerSummaryArray(body)) {
+    throw dockerConfigError('Provider docker-local received an invalid container list payload');
+  }
+  return body;
+}
+
+async function allocateHostPort(
+  env: KiloClawEnv,
+  persistedHostPort: number | null
+): Promise<number> {
+  if (persistedHostPort) {
+    return persistedHostPort;
+  }
+  const { start, end } = parsePortRange(env);
+  const containers = await listContainers(env);
+  const used = new Set<number>();
+  for (const container of containers) {
+    for (const port of container.Ports ?? []) {
+      if (typeof port.PublicPort === 'number') {
+        used.add(port.PublicPort);
+      }
+    }
+  }
+  for (let port = start; port <= end; port++) {
+    if (!used.has(port)) return port;
+  }
+  throw dockerConfigError('Provider docker-local has no free ports in the configured range');
+}
+
+function buildContainerEnv(runtimeSpec: RuntimeSpec): string[] {
+  return Object.entries(runtimeSpec.env).map(([key, value]) => `${key}=${value}`);
+}
+
+function requireContainerConfig(providerState: DockerLocalProviderState): {
+  containerName: string;
+  volumeName: string;
+  hostPort: number;
+} {
+  if (!providerState.containerName || !providerState.volumeName || !providerState.hostPort) {
+    throw dockerConfigError('Provider docker-local is missing container configuration');
+  }
+
+  return {
+    containerName: providerState.containerName,
+    volumeName: providerState.volumeName,
+    hostPort: providerState.hostPort,
+  };
+}
+
+async function createContainer(
+  env: KiloClawEnv,
+  state: Pick<InstanceMutableState, 'sandboxId' | 'userId'>,
+  providerState: DockerLocalProviderState,
+  runtimeSpec: RuntimeSpec
+): Promise<void> {
+  const config = requireContainerConfig(providerState);
+  await dockerRequest(
+    env,
+    `/containers/create?name=${encodeURIComponent(config.containerName)}`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        Image: runtimeSpec.imageRef,
+        Env: buildContainerEnv(runtimeSpec),
+        ExposedPorts: {
+          [`${runtimeSpec.controllerPort}/tcp`]: {},
+        },
+        Labels: {
+          provider: 'docker-local',
+          sandboxId: state.sandboxId ?? '',
+          userId: state.userId ?? '',
+        },
+        HostConfig: {
+          Binds: [`${config.volumeName}:${runtimeSpec.rootMountPath}`],
+          PortBindings: {
+            [`${runtimeSpec.controllerPort}/tcp`]: [
+              {
+                HostIp: '127.0.0.1',
+                HostPort: String(config.hostPort),
+              },
+            ],
+          },
+          RestartPolicy: {
+            Name: 'no',
+          },
+        },
+      }),
+    },
+    [201]
+  );
+}
+
+async function startContainer(env: KiloClawEnv, containerName: string): Promise<void> {
+  await dockerRequest(
+    env,
+    `/containers/${encodeURIComponent(containerName)}/start`,
+    {
+      method: 'POST',
+    },
+    [204, 304]
+  );
+}
+
+async function stopContainer(env: KiloClawEnv, containerName: string): Promise<void> {
+  const response = await dockerFetch(env, `/containers/${encodeURIComponent(containerName)}/stop`, {
+    method: 'POST',
+  });
+  if (response.status === 404 || response.status === 304 || response.status === 204) return;
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw dockerConfigError(
+      `Provider docker-local Docker API request failed: ${response.status}${body ? ` ${body}` : ''}`,
+      response.status
+    );
+  }
+}
+
+async function removeContainer(env: KiloClawEnv, containerName: string): Promise<void> {
+  const response = await dockerFetch(
+    env,
+    `/containers/${encodeURIComponent(containerName)}?force=true`,
+    { method: 'DELETE' }
+  );
+  if (response.status === 404 || response.status === 204) return;
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw dockerConfigError(
+      `Provider docker-local Docker API request failed: ${response.status}${body ? ` ${body}` : ''}`,
+      response.status
+    );
+  }
+}
+
+function ensureNames(
+  state: Pick<InstanceMutableState, 'sandboxId'>,
+  providerState: DockerLocalProviderState
+): DockerLocalProviderState {
+  return {
+    provider: 'docker-local',
+    containerName: providerState.containerName ?? buildContainerName(state),
+    volumeName: providerState.volumeName ?? buildVolumeName(state),
+    hostPort: providerState.hostPort,
+  };
+}
+
+export const dockerLocalProviderAdapter: InstanceProviderAdapter = {
+  id: 'docker-local',
+  capabilities: {
+    volumeSnapshots: false,
+    candidateVolumes: false,
+    volumeReassociation: false,
+    snapshotRestore: false,
+    directMachineDestroy: false,
+  },
+
+  async getRoutingTarget({ state }) {
+    const providerState = getDockerLocalProviderState(state);
+    if (!providerState.hostPort) {
+      throw dockerConfigError('Provider docker-local has no assigned host port');
+    }
+    return {
+      origin: `http://127.0.0.1:${providerState.hostPort}`,
+      headers: {},
+    };
+  },
+
+  async ensureProvisioningResources({ env, state }) {
+    await pingDocker(env);
+    return {
+      providerState: ensureNames(state, getDockerLocalProviderState(state)),
+    };
+  },
+
+  async ensureStorage({ env, state }) {
+    const providerState = ensureNames(state, getDockerLocalProviderState(state));
+    if (!providerState.volumeName) {
+      throw dockerConfigError('Provider docker-local is missing a volume name');
+    }
+    await ensureVolume(env, providerState.volumeName);
+    return { providerState };
+  },
+
+  async startRuntime({ env, state, runtimeSpec }) {
+    let providerState = ensureNames(state, getDockerLocalProviderState(state));
+    if (!providerState.volumeName || !providerState.containerName) {
+      throw dockerConfigError('Provider docker-local is missing deterministic resource names');
+    }
+    const volumeName = providerState.volumeName;
+    const containerName = providerState.containerName;
+    await ensureVolume(env, volumeName);
+    providerState = {
+      ...providerState,
+      hostPort: await allocateHostPort(env, providerState.hostPort),
+    };
+
+    const existing = await inspectContainer(env, containerName);
+    if (!existing) {
+      await createContainer(env, state, providerState, runtimeSpec);
+      await startContainer(env, containerName);
+    } else if (!existing.State?.Running) {
+      await startContainer(env, containerName);
+    }
+
+    return {
+      providerState,
+      observation: {
+        runtimeState: 'running',
+      },
+    };
+  },
+
+  async stopRuntime({ env, state }) {
+    const providerState = ensureNames(state, getDockerLocalProviderState(state));
+    if (providerState.containerName) {
+      await stopContainer(env, providerState.containerName);
+    }
+    return {
+      providerState,
+      observation: {
+        runtimeState: 'stopped',
+      },
+    };
+  },
+
+  async restartRuntime({ env, state, runtimeSpec }) {
+    let providerState = ensureNames(state, getDockerLocalProviderState(state));
+    if (!providerState.volumeName || !providerState.containerName) {
+      throw dockerConfigError('Provider docker-local is missing deterministic resource names');
+    }
+    const volumeName = providerState.volumeName;
+    const containerName = providerState.containerName;
+    await ensureVolume(env, volumeName);
+    providerState = {
+      ...providerState,
+      hostPort: await allocateHostPort(env, providerState.hostPort),
+    };
+
+    await removeContainer(env, containerName);
+    await createContainer(env, state, providerState, runtimeSpec);
+    await startContainer(env, containerName);
+
+    return {
+      providerState,
+      observation: {
+        runtimeState: 'running',
+      },
+    };
+  },
+
+  async destroyRuntime({ env, state }) {
+    const providerState = ensureNames(state, getDockerLocalProviderState(state));
+    if (!providerState.containerName) {
+      return { providerState };
+    }
+
+    await removeContainer(env, providerState.containerName);
+    return {
+      providerState: {
+        ...providerState,
+        containerName: null,
+        hostPort: null,
+      },
+    };
+  },
+
+  async destroyStorage({ env, state }) {
+    const providerState = ensureNames(state, getDockerLocalProviderState(state));
+    if (!providerState.volumeName) {
+      return { providerState };
+    }
+
+    await deleteVolume(env, providerState.volumeName);
+    return {
+      providerState: {
+        ...providerState,
+        volumeName: null,
+      },
+    };
+  },
+};

--- a/services/kiloclaw/src/providers/docker-local/index.ts
+++ b/services/kiloclaw/src/providers/docker-local/index.ts
@@ -1,5 +1,5 @@
 import type { DockerLocalProviderState } from '../../schemas/instance-config';
-import type { InstanceProviderAdapter } from '../types';
+import type { InstanceProviderAdapter, ProviderResult } from '../types';
 import { getDockerLocalProviderState } from '../../durable-objects/kiloclaw-instance/state';
 import type { KiloClawEnv } from '../../types';
 import type { RuntimeSpec } from '../types';
@@ -22,6 +22,16 @@ type DockerContainerInspect = {
     Running?: boolean;
     Status?: string;
   };
+};
+
+type DockerHostConfig = {
+  Binds: string[];
+  PortBindings: Record<string, Array<{ HostIp: string; HostPort: string }>>;
+  RestartPolicy: {
+    Name: 'no';
+  };
+  Memory?: number;
+  NanoCpus?: number;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -261,6 +271,34 @@ function buildContainerEnv(runtimeSpec: RuntimeSpec): string[] {
   }).map(([key, value]) => `${key}=${value}`);
 }
 
+function buildHostConfig(config: {
+  volumeName: string;
+  hostPort: number;
+  runtimeSpec: RuntimeSpec;
+}): DockerHostConfig {
+  const { volumeName, hostPort, runtimeSpec } = config;
+  return {
+    Binds: [`${volumeName}:${runtimeSpec.rootMountPath}`],
+    PortBindings: {
+      [`${runtimeSpec.controllerPort}/tcp`]: [
+        {
+          HostIp: '127.0.0.1',
+          HostPort: String(hostPort),
+        },
+      ],
+    },
+    RestartPolicy: {
+      Name: 'no',
+    },
+    ...(runtimeSpec.machineSize
+      ? {
+          Memory: runtimeSpec.machineSize.memory_mb * 1024 * 1024,
+          NanoCpus: runtimeSpec.machineSize.cpus * 1_000_000_000,
+        }
+      : {}),
+  };
+}
+
 function requireContainerConfig(providerState: DockerLocalProviderState): {
   containerName: string;
   volumeName: string;
@@ -300,24 +338,25 @@ async function createContainer(
           sandboxId: state.sandboxId ?? '',
           userId: state.userId ?? '',
         },
-        HostConfig: {
-          Binds: [`${config.volumeName}:${runtimeSpec.rootMountPath}`],
-          PortBindings: {
-            [`${runtimeSpec.controllerPort}/tcp`]: [
-              {
-                HostIp: '127.0.0.1',
-                HostPort: String(config.hostPort),
-              },
-            ],
-          },
-          RestartPolicy: {
-            Name: 'no',
-          },
-        },
+        HostConfig: buildHostConfig({
+          volumeName: config.volumeName,
+          hostPort: config.hostPort,
+          runtimeSpec,
+        }),
       }),
     },
     [201]
   );
+}
+
+async function persistProviderState(
+  providerState: DockerLocalProviderState,
+  onProviderResult: ((result: ProviderResult) => Promise<void>) | undefined
+): Promise<void> {
+  if (!onProviderResult) {
+    throw dockerConfigError('Provider docker-local requires provider state persistence callback');
+  }
+  await onProviderResult({ providerState });
 }
 
 async function startContainer(env: KiloClawEnv, containerName: string): Promise<void> {
@@ -410,7 +449,7 @@ export const dockerLocalProviderAdapter: InstanceProviderAdapter = {
     return { providerState };
   },
 
-  async startRuntime({ env, state, runtimeSpec }) {
+  async startRuntime({ env, state, runtimeSpec, onProviderResult }) {
     let providerState = ensureNames(state, getDockerLocalProviderState(state));
     if (!providerState.volumeName || !providerState.containerName) {
       throw dockerConfigError('Provider docker-local is missing deterministic resource names');
@@ -418,16 +457,22 @@ export const dockerLocalProviderAdapter: InstanceProviderAdapter = {
     const volumeName = providerState.volumeName;
     const containerName = providerState.containerName;
     await ensureVolume(env, volumeName);
+    const previousHostPort = providerState.hostPort;
     providerState = {
       ...providerState,
       hostPort: await allocateHostPort(env, providerState.hostPort),
     };
+    if (providerState.hostPort !== previousHostPort) {
+      await persistProviderState(providerState, onProviderResult);
+    }
 
     const existing = await inspectContainer(env, containerName);
     if (!existing) {
       await createContainer(env, state, providerState, runtimeSpec);
       await startContainer(env, containerName);
-    } else if (!existing.State?.Running) {
+    } else if (!existing.State?.Running || state.status !== 'running') {
+      await removeContainer(env, containerName);
+      await createContainer(env, state, providerState, runtimeSpec);
       await startContainer(env, containerName);
     }
 
@@ -452,7 +497,7 @@ export const dockerLocalProviderAdapter: InstanceProviderAdapter = {
     };
   },
 
-  async restartRuntime({ env, state, runtimeSpec }) {
+  async restartRuntime({ env, state, runtimeSpec, onProviderResult }) {
     let providerState = ensureNames(state, getDockerLocalProviderState(state));
     if (!providerState.volumeName || !providerState.containerName) {
       throw dockerConfigError('Provider docker-local is missing deterministic resource names');
@@ -460,10 +505,14 @@ export const dockerLocalProviderAdapter: InstanceProviderAdapter = {
     const volumeName = providerState.volumeName;
     const containerName = providerState.containerName;
     await ensureVolume(env, volumeName);
+    const previousHostPort = providerState.hostPort;
     providerState = {
       ...providerState,
       hostPort: await allocateHostPort(env, providerState.hostPort),
     };
+    if (providerState.hostPort !== previousHostPort) {
+      await persistProviderState(providerState, onProviderResult);
+    }
 
     await removeContainer(env, containerName);
     await createContainer(env, state, providerState, runtimeSpec);
@@ -473,6 +522,26 @@ export const dockerLocalProviderAdapter: InstanceProviderAdapter = {
       providerState,
       observation: {
         runtimeState: 'running',
+      },
+    };
+  },
+
+  async inspectRuntime({ env, state }) {
+    const providerState = ensureNames(state, getDockerLocalProviderState(state));
+    if (!providerState.containerName) {
+      return {
+        providerState,
+        observation: {
+          runtimeState: 'missing',
+        },
+      };
+    }
+
+    const container = await inspectContainer(env, providerState.containerName);
+    return {
+      providerState,
+      observation: {
+        runtimeState: !container ? 'missing' : container.State?.Running ? 'running' : 'stopped',
       },
     };
   },

--- a/services/kiloclaw/src/providers/fly/index.ts
+++ b/services/kiloclaw/src/providers/fly/index.ts
@@ -256,6 +256,47 @@ export const flyProviderAdapter: InstanceProviderAdapter = {
     };
   },
 
+  async inspectRuntime({ env, state }) {
+    const providerState = getFlyProviderState(state);
+    if (!providerState.machineId) {
+      return {
+        providerState,
+        observation: {
+          runtimeState: 'missing',
+        },
+      };
+    }
+
+    const flyConfig = getFlyConfig(env, state);
+    try {
+      const machine = await fly.getMachine(flyConfig, providerState.machineId);
+      const runtimeState =
+        machine.state === 'started'
+          ? 'running'
+          : machine.state === 'starting'
+            ? 'starting'
+            : machine.state === 'stopped' || machine.state === 'suspended'
+              ? 'stopped'
+              : 'failed';
+      return {
+        providerState,
+        observation: {
+          runtimeState,
+        },
+      };
+    } catch (err) {
+      if (fly.isFlyNotFound(err)) {
+        return {
+          providerState,
+          observation: {
+            runtimeState: 'missing',
+          },
+        };
+      }
+      throw err;
+    }
+  },
+
   async destroyRuntime({ env, state }) {
     const providerState = getFlyProviderState(state);
     if (!providerState.machineId) {

--- a/services/kiloclaw/src/providers/fly/index.ts
+++ b/services/kiloclaw/src/providers/fly/index.ts
@@ -255,4 +255,37 @@ export const flyProviderAdapter: InstanceProviderAdapter = {
       },
     };
   },
+
+  async destroyRuntime({ env, state }) {
+    const providerState = getFlyProviderState(state);
+    if (!providerState.machineId) {
+      return { providerState };
+    }
+
+    const flyConfig = getFlyConfig(env, state);
+    await fly.destroyMachine(flyConfig, providerState.machineId);
+    return {
+      providerState: {
+        ...providerState,
+        machineId: null,
+      },
+    };
+  },
+
+  async destroyStorage({ env, state }) {
+    const providerState = getFlyProviderState(state);
+    if (!providerState.volumeId) {
+      return { providerState };
+    }
+
+    const flyConfig = getFlyConfig(env, state);
+    await fly.deleteVolume(flyConfig, providerState.volumeId);
+    return {
+      providerState: {
+        ...providerState,
+        volumeId: null,
+        region: null,
+      },
+    };
+  },
 };

--- a/services/kiloclaw/src/providers/index.test.ts
+++ b/services/kiloclaw/src/providers/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { assertAvailableProvider, getProviderAdapter, resolveDefaultProvider } from './index';
+
+describe('provider registry', () => {
+  it('resolves docker-local from the default provider env var', () => {
+    expect(resolveDefaultProvider({ KILOCLAW_DEFAULT_PROVIDER: 'docker-local' })).toBe(
+      'docker-local'
+    );
+  });
+
+  it('falls back to fly for invalid default-provider values', () => {
+    expect(resolveDefaultProvider({ KILOCLAW_DEFAULT_PROVIDER: 'bogus' })).toBe('fly');
+  });
+
+  it('allows docker-local in development', () => {
+    expect(() =>
+      assertAvailableProvider({ WORKER_ENV: 'development' } as never, 'docker-local')
+    ).not.toThrow();
+  });
+
+  it('rejects docker-local outside development', () => {
+    expect(() =>
+      assertAvailableProvider({ WORKER_ENV: 'production' } as never, 'docker-local')
+    ).toThrow('Provider docker-local is only available in development');
+  });
+
+  it('returns the docker-local adapter in development', () => {
+    const adapter = getProviderAdapter(
+      { WORKER_ENV: 'development', DOCKER_LOCAL_API_BASE: 'http://127.0.0.1:23750' } as never,
+      { provider: 'docker-local' }
+    );
+
+    expect(adapter.id).toBe('docker-local');
+  });
+});

--- a/services/kiloclaw/src/providers/index.ts
+++ b/services/kiloclaw/src/providers/index.ts
@@ -1,11 +1,12 @@
 import type { InstanceMutableState } from '../durable-objects/kiloclaw-instance/types';
-import type { ProviderId } from '../schemas/instance-config';
+import { ProviderIdSchema, type ProviderId } from '../schemas/instance-config';
 import type { KiloClawEnv } from '../types';
 import type { InstanceProviderAdapter } from './types';
 import { flyProviderAdapter } from './fly';
+import { dockerLocalProviderAdapter } from './docker-local';
 
 function notImplementedProviderError(
-  provider: Exclude<ProviderId, 'fly'>
+  provider: Exclude<ProviderId, 'fly' | 'docker-local'>
 ): Error & { status: number } {
   return Object.assign(new Error(`Provider ${provider} is not implemented yet`), {
     status: 501,
@@ -15,6 +16,7 @@ function notImplementedProviderError(
 export function assertImplementedProvider(provider: ProviderId): void {
   switch (provider) {
     case 'fly':
+    case 'docker-local':
       return;
     case 'northflank':
     case 'aws':
@@ -23,10 +25,41 @@ export function assertImplementedProvider(provider: ProviderId): void {
   }
 }
 
+function invalidProviderConfiguration(message: string, status = 400): Error & { status: number } {
+  return Object.assign(new Error(message), { status });
+}
+
+export function isDevelopmentWorker(env: Pick<KiloClawEnv, 'WORKER_ENV'>): boolean {
+  return env.WORKER_ENV === 'development';
+}
+
+export function assertAvailableProvider(env: KiloClawEnv, provider: ProviderId): void {
+  assertImplementedProvider(provider);
+  if (provider === 'docker-local' && !isDevelopmentWorker(env)) {
+    throw invalidProviderConfiguration('Provider docker-local is only available in development');
+  }
+}
+
+export function resolveDefaultProvider(
+  env: Pick<KiloClawEnv, 'KILOCLAW_DEFAULT_PROVIDER'>
+): ProviderId {
+  const parsed = ProviderIdSchema.safeParse(env.KILOCLAW_DEFAULT_PROVIDER);
+  return parsed.success ? parsed.data : 'fly';
+}
+
 export function getProviderAdapter(
-  _env: KiloClawEnv,
+  env: KiloClawEnv,
   state: Pick<InstanceMutableState, 'provider'>
 ): InstanceProviderAdapter {
-  assertImplementedProvider(state.provider);
-  return flyProviderAdapter;
+  assertAvailableProvider(env, state.provider);
+  switch (state.provider) {
+    case 'fly':
+      return flyProviderAdapter;
+    case 'docker-local':
+      return dockerLocalProviderAdapter;
+    case 'northflank':
+    case 'aws':
+    case 'k8s':
+      throw notImplementedProviderError(state.provider);
+  }
 }

--- a/services/kiloclaw/src/providers/index.ts
+++ b/services/kiloclaw/src/providers/index.ts
@@ -19,8 +19,6 @@ export function assertImplementedProvider(provider: ProviderId): void {
     case 'docker-local':
       return;
     case 'northflank':
-    case 'aws':
-    case 'k8s':
       throw notImplementedProviderError(provider);
   }
 }
@@ -58,8 +56,6 @@ export function getProviderAdapter(
     case 'docker-local':
       return dockerLocalProviderAdapter;
     case 'northflank':
-    case 'aws':
-    case 'k8s':
       throw notImplementedProviderError(state.provider);
   }
 }

--- a/services/kiloclaw/src/providers/types.ts
+++ b/services/kiloclaw/src/providers/types.ts
@@ -75,6 +75,10 @@ export type RestartRuntimeArgs = ProviderContext & {
   onProviderResult?: (result: ProviderResult) => Promise<void>;
 };
 
+export type DestroyRuntimeArgs = ProviderContext;
+
+export type DestroyStorageArgs = ProviderContext;
+
 export type InstanceProviderAdapter = {
   readonly id: ProviderId;
   readonly capabilities: ProviderCapabilities;
@@ -84,4 +88,6 @@ export type InstanceProviderAdapter = {
   startRuntime(args: StartRuntimeArgs): Promise<ProviderResult>;
   stopRuntime(args: StopRuntimeArgs): Promise<ProviderResult>;
   restartRuntime(args: RestartRuntimeArgs): Promise<ProviderResult>;
+  destroyRuntime(args: DestroyRuntimeArgs): Promise<ProviderResult>;
+  destroyStorage(args: DestroyStorageArgs): Promise<ProviderResult>;
 };

--- a/services/kiloclaw/src/providers/types.ts
+++ b/services/kiloclaw/src/providers/types.ts
@@ -40,7 +40,7 @@ export type RuntimeSpec = {
 };
 
 export type ProviderObservation = {
-  runtimeState?: 'starting' | 'running' | 'stopped' | 'failed';
+  runtimeState?: 'starting' | 'running' | 'stopped' | 'failed' | 'missing';
   machineSize?: MachineSize | null;
 };
 
@@ -89,6 +89,7 @@ export type InstanceProviderAdapter = {
   startRuntime(args: StartRuntimeArgs): Promise<ProviderResult>;
   stopRuntime(args: StopRuntimeArgs): Promise<ProviderResult>;
   restartRuntime(args: RestartRuntimeArgs): Promise<ProviderResult>;
+  inspectRuntime(args: ProviderContext): Promise<ProviderResult>;
   destroyRuntime(args: DestroyRuntimeArgs): Promise<ProviderResult>;
   destroyStorage(args: DestroyStorageArgs): Promise<ProviderResult>;
 };

--- a/services/kiloclaw/src/providers/types.ts
+++ b/services/kiloclaw/src/providers/types.ts
@@ -31,6 +31,7 @@ export type ProviderCapabilities = Record<ProviderCapability, boolean>;
 export type RuntimeSpec = {
   imageRef: string;
   env: Record<string, string>;
+  bootstrapEnv: Record<string, string>;
   machineSize: MachineSize | null;
   rootMountPath: '/root';
   controllerPort: number;

--- a/services/kiloclaw/src/routes/platform-destroy-fly-machine.test.ts
+++ b/services/kiloclaw/src/routes/platform-destroy-fly-machine.test.ts
@@ -226,7 +226,7 @@ describe('POST /destroy-fly-machine', () => {
   it('returns 400 when direct machine destroy is unsupported for the active provider', async () => {
     const { env, getProviderMetadata } = makeEnv();
     getProviderMetadata.mockResolvedValueOnce({
-      provider: 'k8s',
+      provider: 'northflank',
       capabilities: {
         volumeSnapshots: false,
         candidateVolumes: false,
@@ -245,7 +245,7 @@ describe('POST /destroy-fly-machine', () => {
 
     expect(resp.status).toBe(400);
     expect(await jsonBody(resp)).toEqual({
-      error: 'destroy-fly-machine is not supported for provider k8s',
+      error: 'destroy-fly-machine is not supported for provider northflank',
     });
     expect(fetchSpy).not.toHaveBeenCalled();
   });

--- a/services/kiloclaw/src/routes/platform-provider-capabilities.test.ts
+++ b/services/kiloclaw/src/routes/platform-provider-capabilities.test.ts
@@ -7,7 +7,7 @@ vi.mock('cloudflare:workers', () => ({
 }));
 
 type ProviderMetadata = {
-  provider: 'fly' | 'k8s';
+  provider: 'fly' | 'northflank';
   capabilities: {
     volumeSnapshots: boolean;
     candidateVolumes: boolean;
@@ -87,7 +87,7 @@ describe('platform provider capability gates', () => {
 
   it('rejects volume snapshot listing for unsupported providers', async () => {
     const { env, listVolumeSnapshots } = makeEnv({
-      provider: 'k8s',
+      provider: 'northflank',
       capabilities: {
         volumeSnapshots: false,
         candidateVolumes: false,
@@ -101,14 +101,14 @@ describe('platform provider capability gates', () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({
-      error: 'volume-snapshots is not supported for provider k8s',
+      error: 'volume-snapshots is not supported for provider northflank',
     });
     expect(listVolumeSnapshots).not.toHaveBeenCalled();
   });
 
   it('rejects candidate volume listing for unsupported providers', async () => {
     const { env, listCandidateVolumes } = makeEnv({
-      provider: 'k8s',
+      provider: 'northflank',
       capabilities: {
         volumeSnapshots: false,
         candidateVolumes: false,
@@ -122,14 +122,14 @@ describe('platform provider capability gates', () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({
-      error: 'candidate-volumes is not supported for provider k8s',
+      error: 'candidate-volumes is not supported for provider northflank',
     });
     expect(listCandidateVolumes).not.toHaveBeenCalled();
   });
 
   it('rejects volume reassociation for unsupported providers', async () => {
     const { env, reassociateVolume } = makeEnv({
-      provider: 'k8s',
+      provider: 'northflank',
       capabilities: {
         volumeSnapshots: false,
         candidateVolumes: false,
@@ -155,14 +155,14 @@ describe('platform provider capability gates', () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({
-      error: 'reassociate-volume is not supported for provider k8s',
+      error: 'reassociate-volume is not supported for provider northflank',
     });
     expect(reassociateVolume).not.toHaveBeenCalled();
   });
 
   it('rejects snapshot restore for unsupported providers', async () => {
     const { env, enqueueSnapshotRestore } = makeEnv({
-      provider: 'k8s',
+      provider: 'northflank',
       capabilities: {
         volumeSnapshots: false,
         candidateVolumes: false,
@@ -187,7 +187,7 @@ describe('platform provider capability gates', () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({
-      error: 'restore-volume-snapshot is not supported for provider k8s',
+      error: 'restore-volume-snapshot is not supported for provider northflank',
     });
     expect(enqueueSnapshotRestore).not.toHaveBeenCalled();
   });

--- a/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
+++ b/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
@@ -133,4 +133,42 @@ describe('sanitizeError: explicit provider support errors', () => {
     });
     expect(provision).not.toHaveBeenCalled();
   });
+
+  it('returns 400 for docker-local outside development', async () => {
+    const provision = vi.fn();
+    const env = {
+      WORKER_ENV: 'production',
+      KILOCLAW_INSTANCE: {
+        idFromName: (id: string) => id,
+        get: () => ({ provision }),
+      },
+      KILOCLAW_AE: { writeDataPoint: vi.fn() },
+      KV_CLAW_CACHE: {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        list: vi.fn().mockResolvedValue({ keys: [], list_complete: true }),
+        getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null }),
+      },
+    } as never;
+
+    const resp = await platform.request(
+      '/provision',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          userId: 'user-1',
+          provider: 'docker-local',
+        }),
+      },
+      env
+    );
+
+    expect(resp.status).toBe(400);
+    expect(await jsonBody(resp)).toEqual({
+      error: 'Provider docker-local is only available in development',
+    });
+    expect(provision).not.toHaveBeenCalled();
+  });
 });

--- a/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
+++ b/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
@@ -121,7 +121,7 @@ describe('sanitizeError: explicit provider support errors', () => {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
           userId: 'user-1',
-          provider: 'k8s',
+          provider: 'northflank',
         }),
       },
       env
@@ -129,7 +129,7 @@ describe('sanitizeError: explicit provider support errors', () => {
 
     expect(resp.status).toBe(501);
     expect(await jsonBody(resp)).toEqual({
-      error: 'Provider k8s is not implemented yet',
+      error: 'Provider northflank is not implemented yet',
     });
     expect(provision).not.toHaveBeenCalled();
   });

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -33,7 +33,7 @@ import { sandboxIdFromUserId } from '../auth/sandbox-id';
 import { writeEvent } from '../utils/analytics';
 import { deriveHttpEventName } from '../middleware/analytics';
 import { sendMessage } from '../stream-chat/client';
-import { assertImplementedProvider } from '../providers';
+import { assertAvailableProvider } from '../providers';
 import type { ProviderCapability } from '../providers/types';
 import { resolveDoKeyForUser } from '../lib/instance-routing';
 
@@ -479,7 +479,7 @@ platform.post('/provision', async c => {
   let provision;
   try {
     if (provider) {
-      assertImplementedProvider(provider);
+      assertAvailableProvider(c.env, provider);
     }
     provision = await withResolvedDORetry(
       c.env,

--- a/services/kiloclaw/src/schemas/instance-config.ts
+++ b/services/kiloclaw/src/schemas/instance-config.ts
@@ -56,7 +56,7 @@ export const CustomSecretMetaSchema = z.object({
 export type CustomSecretMeta = z.infer<typeof CustomSecretMetaSchema>;
 
 // Keep in sync with apps/web/src/lib/kiloclaw/types.ts KiloClawProviderId.
-export const ProviderIdSchema = z.enum(['fly', 'docker-local', 'northflank', 'aws', 'k8s']);
+export const ProviderIdSchema = z.enum(['fly', 'docker-local', 'northflank']);
 export type ProviderId = z.infer<typeof ProviderIdSchema>;
 
 export const FlyProviderStateSchema = z.object({

--- a/services/kiloclaw/src/schemas/instance-config.ts
+++ b/services/kiloclaw/src/schemas/instance-config.ts
@@ -55,6 +55,7 @@ export const CustomSecretMetaSchema = z.object({
 
 export type CustomSecretMeta = z.infer<typeof CustomSecretMetaSchema>;
 
+// Keep in sync with apps/web/src/lib/kiloclaw/types.ts KiloClawProviderId.
 export const ProviderIdSchema = z.enum(['fly', 'docker-local', 'northflank', 'aws', 'k8s']);
 export type ProviderId = z.infer<typeof ProviderIdSchema>;
 

--- a/services/kiloclaw/src/schemas/instance-config.ts
+++ b/services/kiloclaw/src/schemas/instance-config.ts
@@ -55,7 +55,7 @@ export const CustomSecretMetaSchema = z.object({
 
 export type CustomSecretMeta = z.infer<typeof CustomSecretMetaSchema>;
 
-export const ProviderIdSchema = z.enum(['fly', 'northflank', 'aws', 'k8s']);
+export const ProviderIdSchema = z.enum(['fly', 'docker-local', 'northflank', 'aws', 'k8s']);
 export type ProviderId = z.infer<typeof ProviderIdSchema>;
 
 export const FlyProviderStateSchema = z.object({
@@ -66,8 +66,19 @@ export const FlyProviderStateSchema = z.object({
   region: z.string().nullable().default(null),
 });
 
-export const ProviderStateSchema = FlyProviderStateSchema;
+export const DockerLocalProviderStateSchema = z.object({
+  provider: z.literal('docker-local'),
+  containerName: z.string().nullable().default(null),
+  volumeName: z.string().nullable().default(null),
+  hostPort: z.number().int().nullable().default(null),
+});
+
+export const ProviderStateSchema = z.discriminatedUnion('provider', [
+  FlyProviderStateSchema,
+  DockerLocalProviderStateSchema,
+]);
 export type FlyProviderState = z.infer<typeof FlyProviderStateSchema>;
+export type DockerLocalProviderState = z.infer<typeof DockerLocalProviderStateSchema>;
 export type ProviderState = z.infer<typeof ProviderStateSchema>;
 
 export const InstanceConfigSchema = z.object({

--- a/services/kiloclaw/src/types.ts
+++ b/services/kiloclaw/src/types.ts
@@ -24,6 +24,7 @@ export type KiloClawEnv = {
   INTERNAL_API_SECRET?: string;
   GATEWAY_TOKEN_SECRET?: string;
   WORKER_ENV?: string; // e.g. 'production' or 'development' -- for JWT env validation
+  KILOCLAW_DEFAULT_PROVIDER?: string;
 
   // KiloCode provider configuration
   KILOCODE_API_BASE_URL?: string;
@@ -45,6 +46,9 @@ export type KiloClawEnv = {
   FLY_IMAGE_TAG?: string;
   FLY_IMAGE_DIGEST?: string;
   OPENCLAW_VERSION?: string;
+  DOCKER_LOCAL_API_BASE?: string;
+  DOCKER_LOCAL_IMAGE?: string;
+  DOCKER_LOCAL_PORT_RANGE?: string;
 
   // Developer identity (development only, auto-populated by dev-start from `fly auth whoami`)
   DEV_CREATOR?: string;

--- a/services/kiloclaw/src/utils/env-encryption.ts
+++ b/services/kiloclaw/src/utils/env-encryption.ts
@@ -2,8 +2,9 @@
  * AES-256-GCM encryption for environment variable values.
  *
  * Used to encrypt sensitive env var values in the CF Worker before placing
- * them in Fly Machine config.env. Decrypted at boot by the controller's
- * bootstrap module using the KILOCLAW_ENV_KEY (stored as a Fly app secret).
+ * them in the provider runtime environment. Decrypted at boot by the
+ * controller's bootstrap module using KILOCLAW_ENV_KEY, which providers
+ * deliver either through a secret store or direct bootstrap env injection.
  *
  * Ciphertext format: "enc:v1:{base64(12-byte-iv + ciphertext + 16-byte-tag)}"
  */


### PR DESCRIPTION
## Summary

Adds `docker-local` as the first non-Fly provider demo while keeping `KiloClawInstance` as the single authority for lifecycle state. The goal is a simple local development path that can provision multiple KiloClaw runtimes through a local Docker API, while preserving existing Fly behavior and public platform routes. This branch introduces provider IDs/provider state, the docker-local adapter, provider-neutral runtime/storage routing metadata, provider runtime inspection for non-Fly alarm reconciliation, and admin/UI gates based on provider capabilities instead of Fly-only IDs where the action is provider-neutral.

It also decouples bootstrap env-key creation from Fly app creation, injects the same bootstrap/user env set across providers, and hardens docker-local lifecycle correctness around terminal start failures, durable host-port persistence, and existing-container spec reconciliation.

## Verification

- Provision and destroy instances
- Pair telegram
- Change default model
- Start/stop instance
- Restart gateway
- Concurrently running fly personal instance still works. 


If you wanna test this:

1. Add the following to your .dev.vars:

```
KILOCLAW_DEFAULT_PROVIDER=docker-local
DOCKER_LOCAL_API_BASE=http://127.0.0.1:23750
DOCKER_LOCAL_IMAGE=kiloclaw:local
DOCKER_LOCAL_PORT_RANGE=45000-45999
```
2. run `./scripts/build-local-image.sh`
3. expose the docker API some how e.g. `socat TCP-LISTEN:23750,bind=127.0.0.1,reuseaddr,fork UNIX-CONNECT:/var/run/docker.sock`
4. start kiloclaw worker
5. Deploy a new instance, basically instantly 😁 

## Visual Changes

N/A - UI changes are control gating and provider/runtime labels in the existing KiloClaw admin surfaces.

## Reviewer Notes

Fly remains the production/default provider. The start failure path intentionally preserves the old Fly invariant: once a Fly machine ID is durably persisted, the DO leaves the instance in `starting` and lets Fly alarm reconciliation decide instead of marking it `stopped` from the async catch handler.

The adapter seam is provider-neutral for lifecycle routing/results, but some internal Fly helper translation still exists under the Fly-only helper layer. 

Docker-local is development-only and expects a locally exposed Docker HTTP API.


## What doesn't work

openclaw doctor - we need to move that to executed via the controller rather than via fly exec