### PR TITLE
fix(cloud-agent): stop wrapper message id fallback

### DIFF
--- a/services/cloud-agent-next/src/execution/orchestrator.ts
+++ b/services/cloud-agent-next/src/execution/orchestrator.ts
@@ -161,7 +161,11 @@ export class ExecutionOrchestrator {
         condenseOnComplete: wrapper.condenseOnComplete,
         execution,
       });
-      logger.withFields({ inflightId: result.messageId }).info('Prompt sent to wrapper');
+      if (result.messageId) {
+        logger.withFields({ messageId: result.messageId }).info('Prompt sent to wrapper');
+      } else {
+        logger.info('Prompt sent to wrapper');
+      }
     } catch (error) {
       throw ExecutionError.wrapperStartFailed(
         `Failed to send prompt: ${error instanceof Error ? error.message : String(error)}`,

--- a/services/cloud-agent-next/src/kilo/wrapper-client.test.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-client.test.ts
@@ -229,6 +229,15 @@ describe('WrapperClient', () => {
       expect(result.messageId).toBe('msg_generated_1');
     });
 
+    it('allows prompt responses without messageId', async () => {
+      const session = createMockSession(createSuccessResponse({ status: 'sent' }));
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      const result = await client.prompt({ prompt: 'Hello, world!' });
+
+      expect(result.messageId).toBeUndefined();
+    });
+
     it('sends prompt text', async () => {
       const session = createMockSession(
         createSuccessResponse({ status: 'sent', messageId: 'msg_1' })

--- a/services/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -555,13 +555,13 @@ export class WrapperClient {
    * Send a prompt to the wrapper.
    * Opens connection if idle, tracks in inflight.
    */
-  async prompt(options: WrapperPromptOptions): Promise<{ messageId: string }> {
+  async prompt(options: WrapperPromptOptions): Promise<{ messageId?: string }> {
     const response = await this.request<{
       status: string;
-      messageId: string;
+      messageId?: string;
     }>('POST', '/job/prompt', options);
 
-    return { messageId: response.messageId };
+    return response.messageId !== undefined ? { messageId: response.messageId } : {};
   }
 
   // ---------------------------------------------------------------------------

--- a/services/cloud-agent-next/test/unit/wrapper/state.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/state.test.ts
@@ -87,30 +87,12 @@ describe('WrapperState', () => {
         expect(state.getLastError()).toBeNull();
       });
 
-      it('resets message counter on start', () => {
-        state.startJob(createJobContext({ executionId: 'exc_first' }));
-        state.nextMessageId(); // counter = 1
-        state.nextMessageId(); // counter = 2
-
-        // Clear job and start new one
-        state.clearJob();
-        state.startJob(createJobContext({ executionId: 'exc_second' }));
-
-        // Counter should be reset
-        const messageId = state.nextMessageId();
-        expect(messageId).toBe('msg_second_1');
-      });
-
       it('is idempotent for same executionId', () => {
         const context = createJobContext({ executionId: 'exc_same' });
         state.startJob(context);
-        state.nextMessageId(); // counter = 1
 
-        // Re-start with same executionId should not reset counter
         state.startJob(context);
 
-        // Counter should NOT be reset for idempotent call
-        // (This is the current behavior - idempotent returns early)
         expect(state.currentJob).toEqual(context);
       });
 
@@ -160,17 +142,6 @@ describe('WrapperState', () => {
         expect(state.isActive).toBe(false);
         expect(state.isIdle).toBe(true);
       });
-
-      it('resets message counter', () => {
-        state.startJob(createJobContext({ executionId: 'exc_test' }));
-        state.nextMessageId();
-        state.nextMessageId();
-
-        state.clearJob();
-        state.startJob(createJobContext({ executionId: 'exc_new' }));
-
-        expect(state.nextMessageId()).toBe('msg_new_1');
-      });
     });
   });
 
@@ -209,54 +180,6 @@ describe('WrapperState', () => {
       state.setActive(false);
       state.setActive(false);
       expect(state.isIdle).toBe(true);
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Message ID Generation
-  // -------------------------------------------------------------------------
-
-  describe('message ID generation', () => {
-    it('throws when no job context', () => {
-      expect(() => state.nextMessageId()).toThrow(/No job context/);
-    });
-
-    it('generates sequential IDs', () => {
-      state.startJob(createJobContext({ executionId: 'exc_test' }));
-
-      expect(state.nextMessageId()).toBe('msg_test_1');
-      expect(state.nextMessageId()).toBe('msg_test_2');
-      expect(state.nextMessageId()).toBe('msg_test_3');
-    });
-
-    it('strips exec_ prefix', () => {
-      state.startJob(createJobContext({ executionId: 'exec_abc123' }));
-
-      expect(state.nextMessageId()).toBe('msg_abc123_1');
-    });
-
-    it('strips execution_ prefix', () => {
-      state.startJob(createJobContext({ executionId: 'execution_def456' }));
-
-      expect(state.nextMessageId()).toBe('msg_def456_1');
-    });
-
-    it('strips msg_ prefix', () => {
-      state.startJob(createJobContext({ executionId: 'msg_ghi789' }));
-
-      expect(state.nextMessageId()).toBe('msg_ghi789_1');
-    });
-
-    it('strips exc_ prefix', () => {
-      state.startJob(createJobContext({ executionId: 'exc_ghi789' }));
-
-      expect(state.nextMessageId()).toBe('msg_ghi789_1');
-    });
-
-    it('handles executionId without prefix', () => {
-      state.startJob(createJobContext({ executionId: 'custom-id-123' }));
-
-      expect(state.nextMessageId()).toBe('msg_custom-id-123_1');
     });
   });
 

--- a/services/cloud-agent-next/wrapper/src/kilo-api.ts
+++ b/services/cloud-agent-next/wrapper/src/kilo-api.ts
@@ -120,7 +120,7 @@ export function createWrapperKiloClient(
       // Use v2 client — it supports `variant` (thinking effort); v1 SDK omits it.
       await v2Client.session.promptAsync({
         sessionID: opts.sessionId,
-        messageID: opts.messageId,
+        ...(opts.messageId !== undefined ? { messageID: opts.messageId } : {}),
         parts: textParts,
         ...(opts.variant ? { variant: opts.variant } : {}),
         ...(opts.model

--- a/services/cloud-agent-next/wrapper/src/server.ts
+++ b/services/cloud-agent-next/wrapper/src/server.ts
@@ -262,7 +262,7 @@ function createPromptHandler(config: ServerConfig, deps: ServerDependencies) {
     if (!body.prompt && !body.parts) {
       return errorResponse('INVALID_REQUEST', 'Either prompt or parts is required', 400);
     }
-    const messageId = body.messageId ?? state.nextMessageId();
+    const messageId = body.messageId;
 
     // Set per-turn config on the lifecycle manager
     deps.setPerTurnConfig({
@@ -300,7 +300,9 @@ function createPromptHandler(config: ServerConfig, deps: ServerDependencies) {
         system: body.system,
         tools: body.tools,
       });
-      logToFile(`job/prompt: sent messageId=${messageId}`);
+      logToFile(
+        messageId !== undefined ? `job/prompt: sent messageId=${messageId}` : 'job/prompt: sent'
+      );
     } catch (error) {
       state.setActive(false);
       const msg = error instanceof Error ? error.message : String(error);
@@ -308,7 +310,9 @@ function createPromptHandler(config: ServerConfig, deps: ServerDependencies) {
       return errorResponse('SEND_ERROR', `Failed to send prompt: ${msg}`, 500);
     }
 
-    return jsonResponse({ status: 'sent', messageId });
+    return jsonResponse(
+      messageId !== undefined ? { status: 'sent', messageId } : { status: 'sent' }
+    );
   };
 }
 

--- a/services/cloud-agent-next/wrapper/src/state.ts
+++ b/services/cloud-agent-next/wrapper/src/state.ts
@@ -59,9 +59,6 @@ export class WrapperState {
   private lastActivityAt = Date.now();
   private _lastError: LastError | null = null;
 
-  // Message counter for ID generation
-  private messageCounter = 0;
-
   // Last root-session assistant message ID (tracked from message.updated kilocode events)
   private _lastAssistantMessageId: string | null = null;
 
@@ -111,7 +108,6 @@ export class WrapperState {
     // Start new job
     this.job = context;
     this._lastError = null;
-    this.messageCounter = 0;
     this.updateActivity();
   }
 
@@ -123,7 +119,6 @@ export class WrapperState {
     this._logUploader = null;
     this.job = null;
     this._isActive = false;
-    this.messageCounter = 0;
     this._lastAssistantMessageId = null;
   }
 
@@ -268,24 +263,6 @@ export class WrapperState {
    */
   setLastAssistantMessageId(messageId: string): void {
     this._lastAssistantMessageId = messageId;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Message ID Generation
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Generate the next messageId for this job.
-   * Format: msg_<base-executionId>_<counter>
-   */
-  nextMessageId(): string {
-    if (!this.job) {
-      throw new Error('No job context - call startJob() first');
-    }
-    this.messageCounter++;
-    // Strip known prefixes if present
-    const base = this.job.executionId.replace(/^(exc_|exec_|execution_|msg_)/, '');
-    return `msg_${base}_${this.messageCounter}`;
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Stop the cloud-agent-next wrapper from generating fallback message IDs when callers omit `messageId`.
- Treat wrapper prompt responses as having an optional `messageId`, and only send `messageID` to Kilo when one was provided.
- Remove wrapper state/tests for the execution-derived message counter and add coverage for prompt responses without message IDs.

## Verification
- `git diff --check -- services/cloud-agent-next/wrapper/src/server.ts services/cloud-agent-next/wrapper/src/kilo-api.ts services/cloud-agent-next/wrapper/src/state.ts services/cloud-agent-next/src/kilo/wrapper-client.ts services/cloud-agent-next/src/kilo/wrapper-client.test.ts services/cloud-agent-next/src/execution/orchestrator.ts services/cloud-agent-next/test/unit/wrapper/state.test.ts` passed.
- `pnpm --filter cloud-agent-next typecheck` failed because local `node_modules` are missing; TypeScript could not resolve dependencies such as `vitest`, `@cloudflare/sandbox`, and `hono`.
- `pnpm --filter cloud-agent-next test -- test/unit/wrapper/state.test.ts src/kilo/wrapper-client.test.ts` failed because `vitest` is not installed/found in this checkout.
- Pre-push hook failed on unrelated local environment issues: `oxfmt --list-different .` flagged untracked report files and repository typecheck reported existing dependency/test-type errors; branch was pushed with `--no-verify` after explicit approval.

## Visual Changes
N/A

## Reviewer Notes
- Web UI callers still generate and pass the canonical 30-character `msg_...` IDs; callers that omit `messageId` now rely on Kilo/default behavior instead of wrapper-generated IDs.
- Untracked local files `cloudflare-do-timeout-report.md` and `reports/` were left untouched and are not included.