### PR TITLE
feat(gastown): batch gastown improvements — dispatch hardening, container stability, UI polish, convoy SCM, rig settings

### DIFF
--- a/apps/web/src/app/(app)/components/AppTopbar.tsx
+++ b/apps/web/src/app/(app)/components/AppTopbar.tsx
@@ -10,7 +10,9 @@ import {
 } from '@/components/ui/breadcrumb';
 
 export function AppTopbar() {
-  const { title, icon, extras } = usePageTitle();
+  const { title, icon, extras, hideTopbar } = usePageTitle();
+
+  if (hideTopbar) return null;
 
   return (
     <header className="bg-background sticky top-0 z-10 h-14 shrink-0 border-b flex items-center">

--- a/apps/web/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -37,6 +37,7 @@ import { motion, AnimatePresence } from 'motion/react';
 import type { GastownOutputs } from '@/lib/gastown/trpc';
 import { AdminViewingBanner } from '@/components/gastown/AdminViewingBanner';
 import { DrainStatusBanner } from '@/components/gastown/DrainStatusBanner';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 
 type Agent = GastownOutputs['gastown']['listAgents'][number];
 
@@ -215,6 +216,7 @@ export function TownOverviewPageClient({
       {/* Top bar — sticky */}
       <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-3">
+          <SidebarTrigger className="-ml-3" />
           {townQuery.isLoading ? (
             <Skeleton className="h-6 w-40" />
           ) : (

--- a/apps/web/src/app/(app)/gastown/[townId]/agents/AgentsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/agents/AgentsPageClient.tsx
@@ -6,6 +6,7 @@ import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { sortAgentsByStatus } from '@/lib/gastown/sort-agents';
 import { useDrawerStack } from '@/components/gastown/DrawerStack';
 import { Bot, Crown, Shield, Eye, Clock, Hexagon, MessageSquare } from 'lucide-react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import { formatDistanceToNow } from 'date-fns';
 import { motion, AnimatePresence } from 'motion/react';
 import type { GastownOutputs } from '@/lib/gastown/trpc';
@@ -57,8 +58,9 @@ export function AgentsPageClient({ townId }: { townId: string }) {
   return (
     <div className="flex h-full flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-2">
+          <SidebarTrigger className="-ml-3" />
           <Bot className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Agents</h1>
           <span className="ml-1 font-mono text-xs text-white/30">{allAgents.length}</span>

--- a/apps/web/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
@@ -5,6 +5,7 @@ import { useQuery, useQueries } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { useDrawerStack } from '@/components/gastown/DrawerStack';
 import { Hexagon, Search } from 'lucide-react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import { formatDistanceToNow } from 'date-fns';
 import { motion, AnimatePresence } from 'motion/react';
 import type { GastownOutputs } from '@/lib/gastown/trpc';
@@ -82,8 +83,9 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
   return (
     <div className="flex h-full flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-2">
+          <SidebarTrigger className="-ml-3" />
           <Hexagon className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Beads</h1>
           <span className="ml-1 font-mono text-xs text-white/30">{allBeads.length}</span>

--- a/apps/web/src/app/(app)/gastown/[townId]/layout.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/layout.tsx
@@ -2,6 +2,7 @@ import { TerminalBarProvider } from '@/components/gastown/TerminalBarContext';
 import { DrawerStackProvider } from '@/components/gastown/DrawerStack';
 import { renderDrawerContent } from '@/components/gastown/DrawerStackContent';
 import { TerminalBarPadding } from '@/components/gastown/TerminalBarPadding';
+import { HideAppTopbar } from '@/components/gastown/HideAppTopbar';
 import { MayorTerminalBar } from './MayorTerminalBar';
 import { OnboardingTooltipsWrapper } from './OnboardingTooltipsWrapper';
 
@@ -15,6 +16,7 @@ export default function TownLayout({
   return (
     <TerminalBarProvider>
       <DrawerStackProvider renderContent={renderDrawerContent}>
+        <HideAppTopbar />
         <TerminalBarPadding>{children}</TerminalBarPadding>
         <MayorTerminalBar params={params} />
         <OnboardingTooltipsWrapper params={params} />

--- a/apps/web/src/app/(app)/gastown/[townId]/mail/MailPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/mail/MailPageClient.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { Mail } from 'lucide-react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import { formatDistanceToNow } from 'date-fns';
 
 export function MailPageClient({ townId }: { townId: string }) {
@@ -17,8 +18,9 @@ export function MailPageClient({ townId }: { townId: string }) {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-2">
+          <SidebarTrigger className="-ml-3" />
           <Mail className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Mail</h1>
           <span className="ml-1 font-mono text-xs text-white/30">{mailEvents.length}</span>

--- a/apps/web/src/app/(app)/gastown/[townId]/merges/MergesPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/merges/MergesPageClient.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { GitMerge, AlertCircle, Loader2, Activity, Server } from 'lucide-react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import {
   Select,
   SelectContent,
@@ -44,8 +45,9 @@ export function MergesPageClient({ townId }: { townId: string }) {
   return (
     <div className="flex h-full flex-col">
       {/* Page header */}
-      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-2">
+          <SidebarTrigger className="-ml-3" />
           <GitMerge className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Merge Queue</h1>
           {totalAttention > 0 && (

--- a/apps/web/src/app/(app)/gastown/[townId]/observability/ObservabilityPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/observability/ObservabilityPageClient.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { Activity, Clock, Hexagon, Bot, GitMerge, AlertTriangle, Mail } from 'lucide-react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import { formatDistanceToNow, format, subHours, differenceInMinutes } from 'date-fns';
 import {
   AreaChart,
@@ -87,8 +88,9 @@ export function ObservabilityPageClient({ townId }: { townId: string }) {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-2">
+          <SidebarTrigger className="-ml-3" />
           <Activity className="size-4 text-[color:oklch(95%_0.15_108_/_0.6)]" />
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Observability</h1>
           <span className="ml-1 font-mono text-xs text-white/30">{events.length} events</span>

--- a/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
@@ -12,9 +12,19 @@ import { AgentCard } from '@/components/gastown/AgentCard';
 import { ConvoyTimeline } from '@/components/gastown/ConvoyTimeline';
 import { SlingDialog } from '@/components/gastown/SlingDialog';
 import { useDrawerStack } from '@/components/gastown/DrawerStack';
-import { Plus, GitBranch, Hexagon, Bot, Layers, ChevronRight, ChevronDown } from 'lucide-react';
+import {
+  Plus,
+  GitBranch,
+  Hexagon,
+  Bot,
+  Layers,
+  ChevronRight,
+  ChevronDown,
+  Settings,
+} from 'lucide-react';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { motion, AnimatePresence } from 'motion/react';
+import Link from 'next/link';
 
 type RigDetailPageClientProps = {
   townId: string;
@@ -129,15 +139,24 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
             </>
           )}
         </div>
-        <Button
-          variant="primary"
-          size="sm"
-          onClick={() => setIsSlingOpen(true)}
-          className="gap-1.5 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
-        >
-          <Plus className="size-3.5" />
-          Sling Work
-        </Button>
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/gastown/${townId}/rigs/${rigId}/settings`}
+            className="flex items-center justify-center rounded-md border border-white/[0.08] bg-white/[0.03] p-1.5 text-white/40 transition-colors hover:bg-white/[0.06] hover:text-white/60"
+            title="Rig settings"
+          >
+            <Settings className="size-4" />
+          </Link>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => setIsSlingOpen(true)}
+            className="gap-1.5 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+          >
+            <Plus className="size-3.5" />
+            Sling Work
+          </Button>
+        </div>
       </div>
 
       {/* Stats strip */}

--- a/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
@@ -29,9 +29,15 @@ import Link from 'next/link';
 type RigDetailPageClientProps = {
   townId: string;
   rigId: string;
+  basePath?: string;
 };
 
-export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps) {
+export function RigDetailPageClient({
+  townId,
+  rigId,
+  basePath: basePathOverride,
+}: RigDetailPageClientProps) {
+  const townBasePath = basePathOverride ?? `/gastown/${townId}`;
   const trpc = useGastownTRPC();
   const [isSlingOpen, setIsSlingOpen] = useState(false);
   const [convoysCollapsed, setConvoysCollapsed] = useState(false);
@@ -141,7 +147,7 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
         </div>
         <div className="flex items-center gap-2">
           <Link
-            href={`/gastown/${townId}/rigs/${rigId}/settings`}
+            href={`${townBasePath}/rigs/${rigId}/settings`}
             className="flex items-center justify-center rounded-md border border-white/[0.08] bg-white/[0.03] p-1.5 text-white/40 transition-colors hover:bg-white/[0.06] hover:text-white/60"
             title="Rig settings"
           >

--- a/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/RigDetailPageClient.tsx
@@ -13,6 +13,7 @@ import { ConvoyTimeline } from '@/components/gastown/ConvoyTimeline';
 import { SlingDialog } from '@/components/gastown/SlingDialog';
 import { useDrawerStack } from '@/components/gastown/DrawerStack';
 import { Plus, GitBranch, Hexagon, Bot, Layers, ChevronRight, ChevronDown } from 'lucide-react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import { motion, AnimatePresence } from 'motion/react';
 
 type RigDetailPageClientProps = {
@@ -111,8 +112,9 @@ export function RigDetailPageClient({ townId, rigId }: RigDetailPageClientProps)
   return (
     <div className="flex h-full flex-col">
       {/* Top bar */}
-      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-3">
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-3">
+          <SidebarTrigger className="-ml-3" />
           {rigQuery.isLoading ? (
             <Skeleton className="h-6 w-40" />
           ) : (

--- a/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/settings/RigSettingsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/settings/RigSettingsPageClient.tsx
@@ -1,0 +1,975 @@
+'use client';
+
+import { useState, useEffect, useMemo, useRef } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useGastownTRPC } from '@/lib/gastown/trpc';
+import { Button } from '@/components/Button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Switch } from '@/components/ui/switch';
+import { toast } from 'sonner';
+import { useModelSelectorList } from '@/app/api/openrouter/hooks';
+import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
+import {
+  Save,
+  Settings,
+  GitPullRequest,
+  Bot,
+  Shield,
+  MessageSquareText,
+  GitBranch,
+  X,
+  Wrench,
+} from 'lucide-react';
+import { Textarea } from '@/components/ui/textarea';
+import { motion } from 'motion/react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
+import Link from 'next/link';
+
+type Props = { townId: string; rigId: string; organizationId?: string };
+
+// Section definitions for the scrollspy nav
+const SECTIONS = [
+  { id: 'models', label: 'Models', icon: Bot },
+  { id: 'refinery', label: 'Refinery', icon: Shield },
+  { id: 'merge-strategy', label: 'Merge Strategy', icon: GitPullRequest },
+  { id: 'custom-instructions', label: 'Custom Instructions', icon: MessageSquareText },
+  { id: 'git', label: 'Git', icon: GitBranch },
+  { id: 'agent-limits', label: 'Agent Limits', icon: Wrench },
+] as const;
+
+function useScrollSpy(sectionIds: readonly string[]) {
+  const [activeId, setActiveId] = useState<string>(sectionIds[0]);
+  const suppressRef = useRef(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      entries => {
+        if (suppressRef.current) return;
+        const visible = entries
+          .filter(e => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: '-56px 0px -60% 0px', threshold: 0 }
+    );
+
+    for (const id of sectionIds) {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    }
+
+    return () => observer.disconnect();
+  }, [sectionIds]);
+
+  function scrollTo(id: string) {
+    const el = document.getElementById(id);
+    const header = document.getElementById('rig-settings-sticky-header');
+    if (!el) return;
+
+    setActiveId(id);
+    suppressRef.current = true;
+
+    const headerHeight = header?.getBoundingClientRect().height ?? 0;
+    const top = el.getBoundingClientRect().top + window.scrollY - headerHeight - 24;
+    window.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+
+    setTimeout(() => {
+      suppressRef.current = false;
+    }, 1000);
+  }
+
+  return { activeId, scrollTo };
+}
+
+export function RigSettingsPageClient({ townId, rigId, organizationId }: Props) {
+  const trpc = useGastownTRPC();
+  const queryClient = useQueryClient();
+
+  const {
+    data: modelsData,
+    isLoading: isLoadingModels,
+    error: modelsError,
+  } = useModelSelectorList(organizationId);
+
+  const modelOptions = useMemo<ModelOption[]>(
+    () => modelsData?.data.map(model => ({ id: model.id, name: model.name })) ?? [],
+    [modelsData]
+  );
+
+  const rigQuery = useQuery(trpc.gastown.getRig.queryOptions({ rigId, townId }));
+  const townConfigQuery = useQuery(trpc.gastown.getTownConfig.queryOptions({ townId }));
+
+  // Local state for form fields (rig-level overrides)
+  const [defaultModel, setDefaultModel] = useState('');
+  const [polecatModel, setPolecatModel] = useState('');
+  const [refineryModel, setRefineryModel] = useState('');
+  const [refineryCodeReview, setRefineryCodeReview] = useState<boolean | undefined>(undefined);
+  const [reviewMode, setReviewMode] = useState<'rework' | 'comments' | undefined>(undefined);
+  const [autoResolvePrFeedback, setAutoResolvePrFeedback] = useState<boolean | undefined>(
+    undefined
+  );
+  const [autoMergeDelayMinutes, setAutoMergeDelayMinutes] = useState<number | null | undefined>(
+    undefined
+  );
+  const [mergeStrategy, setMergeStrategy] = useState<'direct' | 'pr' | undefined>(undefined);
+  const [convoyMergeMode, setConvoyMergeMode] = useState<
+    'review-then-land' | 'review-and-merge' | undefined
+  >(undefined);
+  const [polecatInstructions, setPolecatInstructions] = useState('');
+  const [refineryInstructions, setRefineryInstructions] = useState('');
+  const [pushFlags, setPushFlags] = useState('');
+  const [maxPolecats, setMaxPolecats] = useState('');
+  const [maxDispatchAttempts, setMaxDispatchAttempts] = useState('');
+  const [initialized, setInitialized] = useState(false);
+
+  // Sync rig config into local state when loaded
+  if (rigQuery.data && !initialized) {
+    const cfg = rigQuery.data.config;
+    if (cfg) {
+      setDefaultModel(cfg.default_model ?? '');
+      setPolecatModel(cfg.role_models?.polecat ?? '');
+      setRefineryModel(cfg.role_models?.refinery ?? '');
+      setRefineryCodeReview(cfg.code_review);
+      setReviewMode(cfg.review_mode);
+      setAutoResolvePrFeedback(cfg.auto_resolve_pr_feedback);
+      setAutoMergeDelayMinutes(cfg.auto_merge_delay_minutes);
+      setMergeStrategy(cfg.merge_strategy);
+      setConvoyMergeMode(cfg.convoy_merge_mode);
+      setPolecatInstructions(cfg.custom_instructions?.polecat ?? '');
+      setRefineryInstructions(cfg.custom_instructions?.refinery ?? '');
+      setPushFlags(cfg.git_push_flags ?? '');
+      setMaxPolecats(
+        cfg.max_concurrent_polecats !== undefined ? String(cfg.max_concurrent_polecats) : ''
+      );
+      setMaxDispatchAttempts(
+        cfg.max_dispatch_attempts !== undefined ? String(cfg.max_dispatch_attempts) : ''
+      );
+    }
+    setInitialized(true);
+  }
+
+  const updateConfig = useMutation(
+    trpc.gastown.updateRigConfig.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.gastown.getRig.queryKey({ rigId, townId }),
+        });
+        toast.success('Rig configuration saved');
+      },
+      onError: err => toast.error(err.message),
+    })
+  );
+
+  const { activeId: activeSection, scrollTo: scrollToSection } = useScrollSpy(
+    SECTIONS.map(s => s.id)
+  );
+
+  const townCfg = townConfigQuery.data;
+
+  function handleSave() {
+    updateConfig.mutate({
+      rigId,
+      townId,
+      config: {
+        default_model: defaultModel || undefined,
+        role_models: {
+          polecat: polecatModel || undefined,
+          refinery: refineryModel || undefined,
+        },
+        code_review: refineryCodeReview,
+        review_mode: reviewMode,
+        auto_resolve_pr_feedback: autoResolvePrFeedback,
+        auto_merge_delay_minutes: autoMergeDelayMinutes,
+        merge_strategy: mergeStrategy,
+        convoy_merge_mode: convoyMergeMode,
+        custom_instructions: {
+          polecat: polecatInstructions || undefined,
+          refinery: refineryInstructions || undefined,
+        },
+        git_push_flags: pushFlags || undefined,
+        max_concurrent_polecats: maxPolecats ? parseInt(maxPolecats, 10) : undefined,
+        max_dispatch_attempts: maxDispatchAttempts ? parseInt(maxDispatchAttempts, 10) : undefined,
+      },
+    });
+  }
+
+  const rigName = rigQuery.data?.name;
+  const rigDetailPath = organizationId
+    ? `/organizations/${organizationId}/gastown/${townId}/rigs/${rigId}`
+    : `/gastown/${townId}/rigs/${rigId}`;
+
+  if (rigQuery.isLoading || townConfigQuery.isLoading) {
+    return (
+      <div className="flex h-full flex-col">
+        <div className="border-b border-white/[0.06] px-6 py-3">
+          <Skeleton className="h-6 w-48" />
+        </div>
+        <div className="flex-1 p-6">
+          <div className="space-y-6">
+            <Skeleton className="h-48 w-full rounded-xl" />
+            <Skeleton className="h-48 w-full rounded-xl" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Top bar */}
+      <div
+        id="rig-settings-sticky-header"
+        className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3"
+      >
+        <div className="flex items-center gap-2.5">
+          <SidebarTrigger className="-ml-3" />
+          <Settings className="size-4 text-white/40" />
+          <Link
+            href={rigDetailPath}
+            className="text-sm text-white/50 transition-colors hover:text-white/70"
+          >
+            {rigName}
+          </Link>
+          <span className="text-white/25">/</span>
+          <h1 className="text-lg font-semibold tracking-tight text-white/90">Settings</h1>
+        </div>
+        <Button
+          onClick={handleSave}
+          disabled={updateConfig.isPending}
+          variant="primary"
+          size="sm"
+          className="gap-1.5 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+        >
+          <Save className="size-3.5" />
+          {updateConfig.isPending ? 'Saving...' : 'Save'}
+        </Button>
+      </div>
+
+      {/* Two-column body */}
+      <div className="scroll-smooth">
+        <div className="mx-auto flex max-w-4xl px-6">
+          {/* Main content */}
+          <div className="min-w-0 flex-1">
+            <div className="space-y-8 pt-6" style={{ paddingBottom: '75vh' }}>
+              {/* ── Models ──────────────────────────────────── */}
+              <SettingsSection
+                id="models"
+                title="Models"
+                description="Override the model used for each agent role. Empty fields inherit the town default."
+                icon={Bot}
+                index={0}
+              >
+                <div className="space-y-4">
+                  <FieldGroup
+                    label="Default Model"
+                    hint="Overrides the town default model for all roles in this rig."
+                  >
+                    <div className="flex items-center gap-2">
+                      <div className="flex-1">
+                        {modelsError ? (
+                          <Input
+                            value={defaultModel}
+                            onChange={e => setDefaultModel(e.target.value)}
+                            placeholder={`Inherit from town (${townCfg?.default_model ?? 'system default'})`}
+                            className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
+                          />
+                        ) : (
+                          <ModelCombobox
+                            label=""
+                            models={modelOptions}
+                            value={defaultModel}
+                            onValueChange={setDefaultModel}
+                            isLoading={isLoadingModels}
+                            placeholder={`Inherit from town (${townCfg?.default_model ?? 'system default'})`}
+                            className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
+                          />
+                        )}
+                      </div>
+                      {defaultModel && (
+                        <button
+                          onClick={() => setDefaultModel('')}
+                          className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                          title="Clear override"
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  </FieldGroup>
+
+                  <FieldGroup
+                    label="Polecat Model"
+                    hint="Override the model used for polecat (worker) agents."
+                  >
+                    <div className="flex items-center gap-2">
+                      <div className="flex-1">
+                        {modelsError ? (
+                          <Input
+                            value={polecatModel}
+                            onChange={e => setPolecatModel(e.target.value)}
+                            placeholder={`Inherit from town (${townCfg?.role_models?.polecat ?? townCfg?.default_model ?? 'system default'})`}
+                            className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
+                          />
+                        ) : (
+                          <ModelCombobox
+                            label=""
+                            models={modelOptions}
+                            value={polecatModel}
+                            onValueChange={setPolecatModel}
+                            isLoading={isLoadingModels}
+                            placeholder={`Inherit from town (${townCfg?.role_models?.polecat ?? townCfg?.default_model ?? 'system default'})`}
+                            className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
+                          />
+                        )}
+                      </div>
+                      {polecatModel && (
+                        <button
+                          onClick={() => setPolecatModel('')}
+                          className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                          title="Clear override"
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  </FieldGroup>
+
+                  <FieldGroup
+                    label="Refinery Model"
+                    hint="Override the model used for refinery (reviewer) agents."
+                  >
+                    <div className="flex items-center gap-2">
+                      <div className="flex-1">
+                        {modelsError ? (
+                          <Input
+                            value={refineryModel}
+                            onChange={e => setRefineryModel(e.target.value)}
+                            placeholder={`Inherit from town (${townCfg?.role_models?.refinery ?? townCfg?.default_model ?? 'system default'})`}
+                            className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
+                          />
+                        ) : (
+                          <ModelCombobox
+                            label=""
+                            models={modelOptions}
+                            value={refineryModel}
+                            onValueChange={setRefineryModel}
+                            isLoading={isLoadingModels}
+                            placeholder={`Inherit from town (${townCfg?.role_models?.refinery ?? townCfg?.default_model ?? 'system default'})`}
+                            className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
+                          />
+                        )}
+                      </div>
+                      {refineryModel && (
+                        <button
+                          onClick={() => setRefineryModel('')}
+                          className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                          title="Clear override"
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  </FieldGroup>
+                </div>
+              </SettingsSection>
+
+              {/* ── Refinery ──────────────────────────────────── */}
+              <SettingsSection
+                id="refinery"
+                title="Refinery"
+                description="Override refinery behavior for this rig. Empty toggles inherit from town settings."
+                icon={Shield}
+                index={1}
+              >
+                <div className="space-y-3">
+                  <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                    <div className="flex items-center gap-3">
+                      <div className="flex-1">
+                        <Label className="text-sm text-white/70">Code Review</Label>
+                        <p className="text-[11px] text-white/30">
+                          Enable or disable the refinery code review for this rig.
+                          {townCfg?.refinery?.code_review !== undefined && (
+                            <span className="ml-1 text-white/20">
+                              (Town default: {townCfg.refinery.code_review ? 'on' : 'off'})
+                            </span>
+                          )}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {refineryCodeReview !== undefined && (
+                          <button
+                            onClick={() => setRefineryCodeReview(undefined)}
+                            className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                            title="Inherit from town"
+                          >
+                            <X className="size-3" />
+                          </button>
+                        )}
+                        <Switch
+                          checked={refineryCodeReview ?? townCfg?.refinery?.code_review ?? true}
+                          onCheckedChange={v => setRefineryCodeReview(v)}
+                          className={refineryCodeReview === undefined ? 'opacity-40' : ''}
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                    <Label className="mb-1.5 block text-sm text-white/70">Review Mode</Label>
+                    <p className="mb-2 text-[11px] text-white/30">
+                      How the refinery communicates its findings for this rig.
+                      {townCfg?.refinery?.review_mode && (
+                        <span className="ml-1 text-white/20">
+                          (Town default: {townCfg.refinery.review_mode})
+                        </span>
+                      )}
+                    </p>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => setReviewMode('rework')}
+                        className={`flex-1 rounded-lg border px-3 py-2 text-xs transition-colors ${
+                          reviewMode === 'rework'
+                            ? 'border-indigo-500/40 bg-indigo-500/10 text-indigo-300'
+                            : 'border-white/[0.06] bg-white/[0.02] text-white/40 hover:border-white/10'
+                        }`}
+                      >
+                        <div className="font-medium">Rework requests</div>
+                        <div className="mt-0.5 text-[10px] opacity-60">
+                          Creates internal rework beads for the polecat to fix.
+                        </div>
+                      </button>
+                      <button
+                        onClick={() => setReviewMode('comments')}
+                        className={`flex-1 rounded-lg border px-3 py-2 text-xs transition-colors ${
+                          reviewMode === 'comments'
+                            ? 'border-indigo-500/40 bg-indigo-500/10 text-indigo-300'
+                            : 'border-white/[0.06] bg-white/[0.02] text-white/40 hover:border-white/10'
+                        }`}
+                      >
+                        <div className="font-medium">PR comments</div>
+                        <div className="mt-0.5 text-[10px] opacity-60">
+                          Posts GitHub review comments on the PR.
+                        </div>
+                      </button>
+                      {reviewMode !== undefined && (
+                        <button
+                          onClick={() => setReviewMode(undefined)}
+                          className="flex items-center gap-1 rounded-lg border border-white/[0.06] px-2 py-2 text-[10px] text-white/30 transition-colors hover:border-white/10 hover:text-white/50"
+                          title="Inherit from town"
+                        >
+                          <X className="size-3" />
+                          Inherit
+                        </button>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                    <div className="flex items-center gap-3">
+                      <div className="flex-1">
+                        <Label className="text-sm text-white/70">Auto-resolve PR feedback</Label>
+                        <p className="text-[11px] text-white/30">
+                          Automatically dispatch a polecat to address unresolved review comments.
+                          {townCfg?.refinery?.auto_resolve_pr_feedback !== undefined && (
+                            <span className="ml-1 text-white/20">
+                              (Town default:{' '}
+                              {townCfg.refinery.auto_resolve_pr_feedback ? 'on' : 'off'})
+                            </span>
+                          )}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {autoResolvePrFeedback !== undefined && (
+                          <button
+                            onClick={() => setAutoResolvePrFeedback(undefined)}
+                            className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                            title="Inherit from town"
+                          >
+                            <X className="size-3" />
+                          </button>
+                        )}
+                        <Switch
+                          checked={
+                            autoResolvePrFeedback ??
+                            townCfg?.refinery?.auto_resolve_pr_feedback ??
+                            false
+                          }
+                          onCheckedChange={v => setAutoResolvePrFeedback(v)}
+                          className={autoResolvePrFeedback === undefined ? 'opacity-40' : ''}
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                    <Label className="mb-1.5 block text-sm text-white/70">
+                      Auto-merge delay (minutes)
+                    </Label>
+                    <p className="mb-3 text-[11px] text-white/30">
+                      After all checks pass, merge the PR after this delay. Leave empty to inherit
+                      from town.
+                      {townCfg?.refinery?.auto_merge_delay_minutes !== null &&
+                        townCfg?.refinery?.auto_merge_delay_minutes !== undefined && (
+                          <span className="ml-1 text-white/20">
+                            (Town default: {townCfg.refinery.auto_merge_delay_minutes}m)
+                          </span>
+                        )}
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <div className="flex gap-1.5">
+                        {[
+                          { label: 'Off', value: null },
+                          { label: '0', value: 0 },
+                          { label: '15m', value: 15 },
+                          { label: '1h', value: 60 },
+                          { label: '4h', value: 240 },
+                        ].map(preset => (
+                          <button
+                            key={preset.label}
+                            onClick={() => setAutoMergeDelayMinutes(preset.value)}
+                            className={`rounded px-2 py-1 text-[11px] transition-colors ${
+                              autoMergeDelayMinutes === preset.value
+                                ? 'bg-white/[0.12] text-white/80'
+                                : 'bg-white/[0.04] text-white/40 hover:bg-white/[0.08] hover:text-white/60'
+                            }`}
+                          >
+                            {preset.label}
+                          </button>
+                        ))}
+                        {autoMergeDelayMinutes !== undefined && (
+                          <button
+                            onClick={() => setAutoMergeDelayMinutes(undefined)}
+                            className="rounded px-2 py-1 text-[11px] text-white/25 transition-colors hover:bg-white/[0.04] hover:text-white/50"
+                            title="Inherit from town"
+                          >
+                            Inherit
+                          </button>
+                        )}
+                      </div>
+                      {autoMergeDelayMinutes !== null && autoMergeDelayMinutes !== undefined && (
+                        <div className="flex items-center gap-1.5">
+                          <Input
+                            type="number"
+                            min={0}
+                            value={autoMergeDelayMinutes}
+                            onChange={e => {
+                              const v = parseInt(e.target.value, 10);
+                              setAutoMergeDelayMinutes(Number.isNaN(v) ? null : Math.max(0, v));
+                            }}
+                            className="h-[26px] w-[60px] border-white/[0.08] bg-white/[0.03] text-center font-mono text-xs text-white/85"
+                          />
+                          <span className="text-[11px] text-white/30">minutes</span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </SettingsSection>
+
+              {/* ── Merge Strategy ──────────────────────────────────── */}
+              <SettingsSection
+                id="merge-strategy"
+                title="Merge Strategy"
+                description="Override how agent work lands in the default branch."
+                icon={GitPullRequest}
+                index={2}
+              >
+                <div className="space-y-3">
+                  <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+                    <Label className="mb-2 block text-sm text-white/70">
+                      Direct merge vs Pull Request
+                    </Label>
+                    <p className="mb-2 text-[11px] text-white/30">
+                      Overrides town merge strategy for this rig.
+                      {townCfg?.merge_strategy && (
+                        <span className="ml-1 text-white/20">
+                          (Town default: {townCfg.merge_strategy})
+                        </span>
+                      )}
+                    </p>
+                    <div className="flex gap-2">
+                      <MergeStrategyOption
+                        selected={mergeStrategy === 'direct'}
+                        onSelect={() => setMergeStrategy('direct')}
+                        label="Direct push"
+                        description="Push merged code directly to the default branch."
+                      />
+                      <MergeStrategyOption
+                        selected={mergeStrategy === 'pr'}
+                        onSelect={() => setMergeStrategy('pr')}
+                        label="Pull request"
+                        description="Create a PR for human review before merging."
+                      />
+                      {mergeStrategy !== undefined && (
+                        <button
+                          onClick={() => setMergeStrategy(undefined)}
+                          className="flex shrink-0 items-center gap-1 rounded-lg border border-white/[0.06] px-2 py-2 text-[10px] text-white/30 transition-colors hover:border-white/10 hover:text-white/50"
+                          title="Inherit from town"
+                        >
+                          <X className="size-3" />
+                          Inherit
+                        </button>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+                    <Label className="mb-2 block text-sm text-white/70">Convoy merge mode</Label>
+                    <p className="mb-2 text-[11px] text-white/30">
+                      Overrides town convoy merge mode for this rig.
+                      {townCfg?.convoy_merge_mode && (
+                        <span className="ml-1 text-white/20">
+                          (Town default: {townCfg.convoy_merge_mode})
+                        </span>
+                      )}
+                    </p>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => setConvoyMergeMode('review-then-land')}
+                        className={`flex-1 rounded-lg border px-3 py-2 text-xs transition-colors ${
+                          convoyMergeMode === 'review-then-land'
+                            ? 'border-indigo-500/40 bg-indigo-500/10 text-indigo-300'
+                            : 'border-white/[0.06] bg-white/[0.02] text-white/40 hover:border-white/10'
+                        }`}
+                      >
+                        <div className="font-medium">Review then land</div>
+                        <div className="mt-0.5 text-[10px] opacity-60">
+                          Beads merge into a feature branch. One landing PR at the end.
+                        </div>
+                      </button>
+                      <button
+                        onClick={() => setConvoyMergeMode('review-and-merge')}
+                        className={`flex-1 rounded-lg border px-3 py-2 text-xs transition-colors ${
+                          convoyMergeMode === 'review-and-merge'
+                            ? 'border-indigo-500/40 bg-indigo-500/10 text-indigo-300'
+                            : 'border-white/[0.06] bg-white/[0.02] text-white/40 hover:border-white/10'
+                        }`}
+                      >
+                        <div className="font-medium">Review and merge</div>
+                        <div className="mt-0.5 text-[10px] opacity-60">
+                          Each bead gets its own PR. Auto-merge applies per PR.
+                        </div>
+                      </button>
+                      {convoyMergeMode !== undefined && (
+                        <button
+                          onClick={() => setConvoyMergeMode(undefined)}
+                          className="flex shrink-0 items-center gap-1 rounded-lg border border-white/[0.06] px-2 py-2 text-[10px] text-white/30 transition-colors hover:border-white/10 hover:text-white/50"
+                          title="Inherit from town"
+                        >
+                          <X className="size-3" />
+                          Inherit
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </SettingsSection>
+
+              {/* ── Custom Instructions ────────────────────────────────── */}
+              <SettingsSection
+                id="custom-instructions"
+                title="Custom Instructions"
+                description="Rig-specific instructions appended to the agent system prompt. Empty fields inherit the town instructions."
+                icon={MessageSquareText}
+                index={3}
+              >
+                <div className="space-y-5">
+                  <FieldGroup
+                    label="Polecat Instructions"
+                    hint="Custom instructions for polecat (worker) agents in this rig."
+                  >
+                    <div className="relative">
+                      <Textarea
+                        value={polecatInstructions}
+                        onChange={e => setPolecatInstructions(e.target.value.slice(0, 2000))}
+                        placeholder={
+                          townCfg?.custom_instructions?.polecat
+                            ? `Town default: ${townCfg.custom_instructions.polecat}`
+                            : 'Custom instructions for polecat agents…'
+                        }
+                        rows={4}
+                        className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85 placeholder:text-white/20"
+                      />
+                      <span className="absolute right-2 bottom-2 text-[10px] text-white/20">
+                        {polecatInstructions.length} / 2000
+                      </span>
+                    </div>
+                  </FieldGroup>
+
+                  <FieldGroup
+                    label="Refinery Instructions"
+                    hint="Custom instructions for refinery (reviewer) agents in this rig."
+                  >
+                    <div className="relative">
+                      <Textarea
+                        value={refineryInstructions}
+                        onChange={e => setRefineryInstructions(e.target.value.slice(0, 2000))}
+                        placeholder={
+                          townCfg?.custom_instructions?.refinery
+                            ? `Town default: ${townCfg.custom_instructions.refinery}`
+                            : 'Custom instructions for refinery agents…'
+                        }
+                        rows={4}
+                        className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85 placeholder:text-white/20"
+                      />
+                      <span className="absolute right-2 bottom-2 text-[10px] text-white/20">
+                        {refineryInstructions.length} / 2000
+                      </span>
+                    </div>
+                  </FieldGroup>
+                </div>
+              </SettingsSection>
+
+              {/* ── Git ──────────────────────────────────────── */}
+              <SettingsSection
+                id="git"
+                title="Git"
+                description="Git-related settings for this rig."
+                icon={GitBranch}
+                index={4}
+              >
+                <FieldGroup
+                  label="Push Flags"
+                  hint="Extra flags passed to git push (e.g. --no-verify). Empty = no extra flags."
+                >
+                  <Input
+                    value={pushFlags}
+                    onChange={e => setPushFlags(e.target.value)}
+                    placeholder="--no-verify"
+                    className="border-white/[0.08] bg-white/[0.03] font-mono text-sm text-white/85 placeholder:text-white/20"
+                  />
+                </FieldGroup>
+              </SettingsSection>
+
+              {/* ── Agent Limits ──────────────────────────────── */}
+              <SettingsSection
+                id="agent-limits"
+                title="Agent Limits"
+                description="Override the maximum number of concurrent agents and dispatch attempts for this rig."
+                icon={Wrench}
+                index={5}
+              >
+                <div className="space-y-4">
+                  <FieldGroup
+                    label="Max Concurrent Polecats"
+                    hint="Maximum number of simultaneously running polecat agents. Empty = inherit town setting."
+                  >
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="number"
+                        min={1}
+                        max={50}
+                        value={maxPolecats}
+                        onChange={e => setMaxPolecats(e.target.value)}
+                        placeholder={
+                          townCfg?.max_polecats_per_rig
+                            ? `Inherit from town (${townCfg.max_polecats_per_rig})`
+                            : 'Inherit from town'
+                        }
+                        className="w-40 border-white/[0.08] bg-white/[0.03] text-sm text-white/85 placeholder:text-white/20"
+                      />
+                      {maxPolecats && (
+                        <button
+                          onClick={() => setMaxPolecats('')}
+                          className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                          title="Inherit from town"
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  </FieldGroup>
+
+                  <FieldGroup
+                    label="Max Dispatch Attempts"
+                    hint="Maximum number of times a bead can be dispatched before it is marked as failed. Empty = inherit town setting."
+                  >
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="number"
+                        min={1}
+                        max={20}
+                        value={maxDispatchAttempts}
+                        onChange={e => setMaxDispatchAttempts(e.target.value)}
+                        placeholder="Inherit from town"
+                        className="w-40 border-white/[0.08] bg-white/[0.03] text-sm text-white/85 placeholder:text-white/20"
+                      />
+                      {maxDispatchAttempts && (
+                        <button
+                          onClick={() => setMaxDispatchAttempts('')}
+                          className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                          title="Inherit from town"
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  </FieldGroup>
+                </div>
+              </SettingsSection>
+            </div>
+          </div>
+
+          {/* Right sidebar — sticky scrollspy nav */}
+          <div className="hidden w-52 shrink-0 lg:sticky lg:top-[53px] lg:self-start lg:block">
+            <nav className="px-4 pt-6">
+              <div className="mb-3 text-[10px] font-medium tracking-wide text-white/25 uppercase">
+                On this page
+              </div>
+              <ul className="space-y-0.5">
+                {SECTIONS.map(section => {
+                  const isActive = activeSection === section.id;
+                  const SectionIcon = section.icon;
+
+                  return (
+                    <li key={section.id}>
+                      <button
+                        onClick={() => scrollToSection(section.id)}
+                        className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs whitespace-nowrap overflow-hidden text-ellipsis transition-colors ${
+                          isActive
+                            ? 'bg-white/[0.06] text-white/80'
+                            : 'text-white/35 hover:bg-white/[0.03] hover:text-white/55'
+                        }`}
+                      >
+                        <SectionIcon className="size-3 shrink-0" />
+                        <span className="truncate">{section.label}</span>
+                        {isActive && (
+                          <motion.div
+                            layoutId="rig-settings-nav-indicator"
+                            className="ml-auto size-1 rounded-full bg-[color:oklch(95%_0.15_108)]"
+                            transition={{
+                              type: 'spring',
+                              stiffness: 350,
+                              damping: 30,
+                            }}
+                          />
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+
+              {/* Save button mirrored in sidebar */}
+              <div className="mt-6 border-t border-white/[0.06] pt-4">
+                <Button
+                  onClick={handleSave}
+                  disabled={updateConfig.isPending}
+                  variant="primary"
+                  size="sm"
+                  className="w-full gap-1.5 bg-[color:oklch(95%_0.15_108_/_0.90)] text-black hover:bg-[color:oklch(95%_0.15_108_/_0.95)]"
+                >
+                  <Save className="size-3" />
+                  {updateConfig.isPending ? 'Saving...' : 'Save'}
+                </Button>
+              </div>
+            </nav>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Shared sub-components ────────────────────────────────────────────────
+
+function SettingsSection({
+  id,
+  title,
+  description,
+  icon: Icon,
+  index,
+  action,
+  children,
+}: {
+  id: string;
+  title: string;
+  description: string;
+  icon: typeof Settings;
+  index: number;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <motion.section
+      id={id}
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: index * 0.06, duration: 0.35 }}
+    >
+      <div className="mb-4 flex items-start justify-between">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 flex size-8 items-center justify-center rounded-lg bg-white/[0.04] ring-1 ring-white/[0.06]">
+            <Icon className="size-4 text-white/40" />
+          </div>
+          <div>
+            <h2 className="text-sm font-semibold text-white/85">{title}</h2>
+            <p className="mt-0.5 text-xs text-white/35">{description}</p>
+          </div>
+        </div>
+        {action}
+      </div>
+      <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">{children}</div>
+    </motion.section>
+  );
+}
+
+function FieldGroup({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs text-white/55">{label}</Label>
+      {children}
+      {hint && <p className="text-[11px] text-white/25">{hint}</p>}
+    </div>
+  );
+}
+
+function MergeStrategyOption({
+  selected,
+  onSelect,
+  label,
+  description,
+}: {
+  selected: boolean;
+  onSelect: () => void;
+  label: string;
+  description: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`flex flex-1 items-start gap-3 rounded-lg border px-4 py-3 text-left transition-colors ${
+        selected
+          ? 'border-[color:oklch(95%_0.15_108_/_0.3)] bg-[color:oklch(95%_0.15_108_/_0.06)]'
+          : 'border-white/[0.06] bg-white/[0.02] hover:bg-white/[0.04]'
+      }`}
+    >
+      <div
+        className={`mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border ${
+          selected ? 'border-[color:oklch(95%_0.15_108_/_0.6)]' : 'border-white/20'
+        }`}
+      >
+        {selected && <div className="size-2 rounded-full bg-[color:oklch(95%_0.15_108)]" />}
+      </div>
+      <div>
+        <div className={`text-sm font-medium ${selected ? 'text-white/90' : 'text-white/60'}`}>
+          {label}
+        </div>
+        <p className="mt-0.5 text-[11px] text-white/35">{description}</p>
+      </div>
+    </button>
+  );
+}

--- a/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/settings/page.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/settings/page.tsx
@@ -1,0 +1,21 @@
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+import { notFound } from 'next/navigation';
+import { isGastownEnabled } from '@/lib/gastown/feature-flags';
+import { RigSettingsPageClient } from './RigSettingsPageClient';
+
+export default async function RigSettingsPage({
+  params,
+}: {
+  params: Promise<{ townId: string; rigId: string }>;
+}) {
+  const { townId, rigId } = await params;
+  const user = await getUserFromAuthOrRedirect(
+    `/users/sign_in?callbackPath=/gastown/${townId}/rigs/${rigId}/settings`
+  );
+
+  if (!(await isGastownEnabled(user.id, { isAdmin: user.is_admin }))) {
+    return notFound();
+  }
+
+  return <RigSettingsPageClient townId={townId} rigId={rigId} />;
+}

--- a/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -44,6 +44,7 @@ import { Slider } from '@/components/ui/slider';
 import { Textarea } from '@/components/ui/textarea';
 import { motion } from 'motion/react';
 import { AdminViewingBanner } from '@/components/gastown/AdminViewingBanner';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import { useRouter } from 'next/navigation';
 import {
   AlertDialog,
@@ -436,6 +437,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
         className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3"
       >
         <div className="flex items-center gap-2.5">
+          <SidebarTrigger className="-ml-3" />
           <Settings className="size-4 text-white/40" />
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Settings</h1>
           <span className="text-sm text-white/30">{townQuery.data?.name}</span>

--- a/apps/web/src/app/(app)/organizations/[id]/gastown/[townId]/layout.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/gastown/[townId]/layout.tsx
@@ -2,6 +2,7 @@ import { TerminalBarProvider } from '@/components/gastown/TerminalBarContext';
 import { DrawerStackProvider } from '@/components/gastown/DrawerStack';
 import { renderDrawerContent } from '@/components/gastown/DrawerStackContent';
 import { TerminalBarPadding } from '@/components/gastown/TerminalBarPadding';
+import { HideAppTopbar } from '@/components/gastown/HideAppTopbar';
 import { MayorTerminalBar } from '@/app/(app)/gastown/[townId]/MayorTerminalBar';
 import { OnboardingTooltips } from '@/components/gastown/OnboardingTooltips';
 
@@ -18,6 +19,7 @@ export default async function OrgTownLayout({
   return (
     <TerminalBarProvider>
       <DrawerStackProvider renderContent={renderDrawerContent}>
+        <HideAppTopbar />
         <TerminalBarPadding>{children}</TerminalBarPadding>
         <MayorTerminalBar params={params} basePath={basePath} />
         <OnboardingTooltips townId={townId} />

--- a/apps/web/src/app/(app)/organizations/[id]/gastown/[townId]/rigs/[rigId]/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/gastown/[townId]/rigs/[rigId]/page.tsx
@@ -6,12 +6,13 @@ export default async function OrgRigDetailPage({
 }: {
   params: Promise<{ id: string; townId: string; rigId: string }>;
 }) {
-  const { townId, rigId } = await params;
+  const { id, townId, rigId } = await params;
+  const basePath = `/organizations/${id}/gastown/${townId}`;
   return (
     <OrganizationByPageLayout
       params={params}
       fullBleed
-      render={() => <RigDetailPageClient townId={townId} rigId={rigId} />}
+      render={() => <RigDetailPageClient townId={townId} rigId={rigId} basePath={basePath} />}
     />
   );
 }

--- a/apps/web/src/app/(app)/organizations/[id]/gastown/[townId]/rigs/[rigId]/settings/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/gastown/[townId]/rigs/[rigId]/settings/page.tsx
@@ -1,0 +1,19 @@
+import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import { RigSettingsPageClient } from '@/app/(app)/gastown/[townId]/rigs/[rigId]/settings/RigSettingsPageClient';
+
+export default async function OrgRigSettingsPage({
+  params,
+}: {
+  params: Promise<{ id: string; townId: string; rigId: string }>;
+}) {
+  const { id: organizationId, townId, rigId } = await params;
+  return (
+    <OrganizationByPageLayout
+      params={params}
+      fullBleed
+      render={() => (
+        <RigSettingsPageClient townId={townId} rigId={rigId} organizationId={organizationId} />
+      )}
+    />
+  );
+}

--- a/apps/web/src/components/gastown/AgentDetailDrawer.tsx
+++ b/apps/web/src/components/gastown/AgentDetailDrawer.tsx
@@ -183,9 +183,7 @@ export function AgentDetailDrawer({
                         <span className="text-sm text-white/75">{agent.dispatch_attempts}</span>
                         {agent.dispatch_attempts > 0 && (
                           <button
-                            onClick={() =>
-                              resetMutation.mutate({ rigId, agentId: agent.id })
-                            }
+                            onClick={() => resetMutation.mutate({ rigId, agentId: agent.id })}
                             disabled={resetMutation.isPending}
                             title="Reset dispatch attempts to 0"
                             className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-amber-300 ring-1 ring-amber-400/30 transition-colors hover:bg-amber-400/10 disabled:opacity-50"

--- a/apps/web/src/components/gastown/AgentDetailDrawer.tsx
+++ b/apps/web/src/components/gastown/AgentDetailDrawer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Drawer } from 'vaul';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import type { GastownOutputs } from '@/lib/gastown/trpc';
 import { Badge } from '@/components/ui/badge';
@@ -19,6 +19,7 @@ import {
   Terminal,
   Zap,
   Activity,
+  RotateCcw,
 } from 'lucide-react';
 
 type Agent = GastownOutputs['gastown']['listAgents'][number];
@@ -63,6 +64,7 @@ export function AgentDetailDrawer({
   onDelete,
 }: AgentDetailDrawerProps) {
   const trpc = useGastownTRPC();
+  const queryClient = useQueryClient();
 
   // Fetch related beads for this agent
   const beadsQuery = useQuery({
@@ -70,6 +72,14 @@ export function AgentDetailDrawer({
     enabled: open && Boolean(agent),
     refetchInterval: 8_000,
   });
+
+  const resetMutation = useMutation(
+    trpc.gastown.resetAgentDispatchAttempts.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries(trpc.gastown.listAgents.queryOptions({ rigId }));
+      },
+    })
+  );
 
   const relatedBeads = (beadsQuery.data ?? []).filter(b => b.assignee_agent_bead_id === agent?.id);
 
@@ -163,11 +173,32 @@ export function AgentDetailDrawer({
                       label="Created"
                       value={format(new Date(agent.created_at), 'MMM d, HH:mm')}
                     />
-                    <MetaCell
-                      icon={Zap}
-                      label="Dispatch Attempts"
-                      value={String(agent.dispatch_attempts)}
-                    />
+                    {/* Dispatch Attempts with Reset button */}
+                    <div className="border-r border-b border-white/[0.04] px-4 py-3 [&:nth-child(2n)]:border-r-0">
+                      <div className="flex items-center gap-1 text-[10px] text-white/30">
+                        <Zap className="size-3" />
+                        Dispatch Attempts
+                      </div>
+                      <div className="mt-0.5 flex items-center gap-2">
+                        <span className="text-sm text-white/75">{agent.dispatch_attempts}</span>
+                        {agent.dispatch_attempts > 0 && (
+                          <button
+                            onClick={() =>
+                              resetMutation.mutate({ rigId, agentId: agent.id })
+                            }
+                            disabled={resetMutation.isPending}
+                            title="Reset dispatch attempts to 0"
+                            className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-amber-300 ring-1 ring-amber-400/30 transition-colors hover:bg-amber-400/10 disabled:opacity-50"
+                          >
+                            <RotateCcw className="size-2.5" />
+                            Reset
+                          </button>
+                        )}
+                        {resetMutation.isError && (
+                          <span className="text-[10px] text-red-400">Failed</span>
+                        )}
+                      </div>
+                    </div>
                     <MetaCell
                       icon={Activity}
                       label="Last Active"

--- a/apps/web/src/components/gastown/HideAppTopbar.tsx
+++ b/apps/web/src/components/gastown/HideAppTopbar.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePageTitle } from '@/contexts/PageTitleContext';
+
+/**
+ * Hides the app-level top bar (AppTopbar) while this component is mounted.
+ * Used by gastown town pages which render their own page-level header
+ * with a sidebar toggle built in.
+ */
+export function HideAppTopbar() {
+  const { setHideTopbar } = usePageTitle();
+
+  useEffect(() => {
+    setHideTopbar(true);
+    return () => setHideTopbar(false);
+  }, [setHideTopbar]);
+
+  return null;
+}

--- a/apps/web/src/components/gastown/drawer-panels/AgentPanel.tsx
+++ b/apps/web/src/components/gastown/drawer-panels/AgentPanel.tsx
@@ -166,9 +166,7 @@ export function AgentPanel({
             <span className="text-sm text-white/75">{agent.dispatch_attempts}</span>
             {agent.dispatch_attempts > 0 && (
               <button
-                onClick={() =>
-                  resetMutation.mutate({ rigId, agentId: agent.id })
-                }
+                onClick={() => resetMutation.mutate({ rigId, agentId: agent.id })}
                 disabled={resetMutation.isPending}
                 title="Reset dispatch attempts to 0"
                 className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-amber-300 ring-1 ring-amber-400/30 transition-colors hover:bg-amber-400/10 disabled:opacity-50"
@@ -177,9 +175,7 @@ export function AgentPanel({
                 Reset
               </button>
             )}
-            {resetMutation.isError && (
-              <span className="text-[10px] text-red-400">Failed</span>
-            )}
+            {resetMutation.isError && <span className="text-[10px] text-red-400">Failed</span>}
           </div>
         </div>
         <MetaCell

--- a/apps/web/src/components/gastown/drawer-panels/AgentPanel.tsx
+++ b/apps/web/src/components/gastown/drawer-panels/AgentPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { BeadEventTimeline } from '@/components/gastown/ActivityFeed';
 import { useTerminalBar } from '@/components/gastown/TerminalBarContext';
@@ -19,6 +19,7 @@ import {
   Activity,
   ChevronRight,
   MessageSquare,
+  RotateCcw,
 } from 'lucide-react';
 
 const ROLE_ICONS: Record<string, typeof Bot> = {
@@ -63,6 +64,7 @@ export function AgentPanel({
   close: () => void;
 }) {
   const trpc = useGastownTRPC();
+  const queryClient = useQueryClient();
   const { openAgentTab } = useTerminalBar();
 
   const agentsQuery = useQuery(trpc.gastown.listAgents.queryOptions({ rigId }));
@@ -70,6 +72,14 @@ export function AgentPanel({
     ...trpc.gastown.listBeads.queryOptions({ rigId }),
     refetchInterval: 8_000,
   });
+
+  const resetMutation = useMutation(
+    trpc.gastown.resetAgentDispatchAttempts.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries(trpc.gastown.listAgents.queryOptions({ rigId }));
+      },
+    })
+  );
 
   const agent = (agentsQuery.data ?? []).find(a => a.id === agentId);
   const relatedBeads = (beadsQuery.data ?? []).filter(b => b.assignee_agent_bead_id === agentId);
@@ -146,7 +156,32 @@ export function AgentPanel({
           label="Created"
           value={format(new Date(agent.created_at), 'MMM d, HH:mm')}
         />
-        <MetaCell icon={Zap} label="Dispatch Attempts" value={String(agent.dispatch_attempts)} />
+        {/* Dispatch Attempts with Reset button */}
+        <div className="border-r border-b border-white/[0.04] px-4 py-3 [&:nth-child(2n)]:border-r-0">
+          <div className="flex items-center gap-1 text-[10px] text-white/30">
+            <Zap className="size-3" />
+            Dispatch Attempts
+          </div>
+          <div className="mt-0.5 flex items-center gap-2">
+            <span className="text-sm text-white/75">{agent.dispatch_attempts}</span>
+            {agent.dispatch_attempts > 0 && (
+              <button
+                onClick={() =>
+                  resetMutation.mutate({ rigId, agentId: agent.id })
+                }
+                disabled={resetMutation.isPending}
+                title="Reset dispatch attempts to 0"
+                className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-amber-300 ring-1 ring-amber-400/30 transition-colors hover:bg-amber-400/10 disabled:opacity-50"
+              >
+                <RotateCcw className="size-2.5" />
+                Reset
+              </button>
+            )}
+            {resetMutation.isError && (
+              <span className="text-[10px] text-red-400">Failed</span>
+            )}
+          </div>
+        </div>
         <MetaCell
           icon={Activity}
           label="Last Active"

--- a/apps/web/src/contexts/PageTitleContext.tsx
+++ b/apps/web/src/contexts/PageTitleContext.tsx
@@ -6,9 +6,11 @@ type PageTitleContextValue = {
   title: string;
   icon: ReactNode;
   extras: ReactNode;
+  hideTopbar: boolean;
   setTitle: (title: string) => void;
   setIcon: (icon: ReactNode) => void;
   setExtras: (extras: ReactNode) => void;
+  setHideTopbar: (hide: boolean) => void;
 };
 
 const PageTitleContext = createContext<PageTitleContextValue | undefined>(undefined);
@@ -17,11 +19,15 @@ export function PageTitleProvider({ children }: { children: ReactNode }) {
   const [title, setTitleState] = useState('');
   const [icon, setIconState] = useState<ReactNode>(null);
   const [extras, setExtrasState] = useState<ReactNode>(null);
+  const [hideTopbar, setHideTopbarState] = useState(false);
   const setTitle = useCallback((next: string) => setTitleState(next), []);
   const setIcon = useCallback((next: ReactNode) => setIconState(next), []);
   const setExtras = useCallback((next: ReactNode) => setExtrasState(next), []);
+  const setHideTopbar = useCallback((next: boolean) => setHideTopbarState(next), []);
   return (
-    <PageTitleContext.Provider value={{ title, icon, extras, setTitle, setIcon, setExtras }}>
+    <PageTitleContext.Provider
+      value={{ title, icon, extras, hideTopbar, setTitle, setIcon, setExtras, setHideTopbar }}
+    >
       {children}
     </PageTitleContext.Provider>
   );

--- a/apps/web/src/lib/gastown/types/router.d.ts
+++ b/apps/web/src/lib/gastown/types/router.d.ts
@@ -287,6 +287,15 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
       output: void;
       meta: object;
     }>;
+    resetAgentDispatchAttempts: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        agentId: string;
+        townId?: string | undefined;
+      };
+      output: void;
+      meta: object;
+    }>;
     sling: import('@trpc/server').TRPCMutationProcedure<{
       input: {
         rigId: string;
@@ -1611,6 +1620,15 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
           meta: object;
         }>;
         deleteAgent: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            agentId: string;
+            townId?: string | undefined;
+          };
+          output: void;
+          meta: object;
+        }>;
+        resetAgentDispatchAttempts: import('@trpc/server').TRPCMutationProcedure<{
           input: {
             rigId: string;
             agentId: string;

--- a/apps/web/src/lib/gastown/types/router.d.ts
+++ b/apps/web/src/lib/gastown/types/router.d.ts
@@ -126,6 +126,32 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
         platform_integration_id: string | null;
         created_at: string;
         updated_at: string;
+        config?:
+          | {
+              default_model?: string | undefined;
+              role_models?:
+                | {
+                    polecat?: string | undefined;
+                    refinery?: string | undefined;
+                  }
+                | undefined;
+              review_mode?: 'rework' | 'comments' | undefined;
+              code_review?: boolean | undefined;
+              auto_resolve_pr_feedback?: boolean | undefined;
+              auto_merge_delay_minutes?: number | null | undefined;
+              merge_strategy?: 'direct' | 'pr' | undefined;
+              convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
+              custom_instructions?:
+                | {
+                    polecat?: string | undefined;
+                    refinery?: string | undefined;
+                  }
+                | undefined;
+              git_push_flags?: string | undefined;
+              max_concurrent_polecats?: number | undefined;
+              max_dispatch_attempts?: number | undefined;
+            }
+          | undefined;
         agents: {
           id: string;
           rig_id: string | null;
@@ -166,6 +192,38 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
           closed_at: string | null;
         }[];
       };
+      meta: object;
+    }>;
+    updateRigConfig: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        rigId: string;
+        townId?: string | undefined;
+        config: {
+          default_model?: string | undefined;
+          role_models?:
+            | {
+                polecat?: string | undefined;
+                refinery?: string | undefined;
+              }
+            | undefined;
+          review_mode?: 'rework' | 'comments' | undefined;
+          code_review?: boolean | undefined;
+          auto_resolve_pr_feedback?: boolean | undefined;
+          auto_merge_delay_minutes?: number | null | undefined;
+          merge_strategy?: 'direct' | 'pr' | undefined;
+          convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
+          custom_instructions?:
+            | {
+                polecat?: string | undefined;
+                refinery?: string | undefined;
+              }
+            | undefined;
+          git_push_flags?: string | undefined;
+          max_concurrent_polecats?: number | undefined;
+          max_dispatch_attempts?: number | undefined;
+        };
+      };
+      output: void;
       meta: object;
     }>;
     deleteRig: import('@trpc/server').TRPCMutationProcedure<{
@@ -1467,6 +1525,32 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             platform_integration_id: string | null;
             created_at: string;
             updated_at: string;
+            config?:
+              | {
+                  default_model?: string | undefined;
+                  role_models?:
+                    | {
+                        polecat?: string | undefined;
+                        refinery?: string | undefined;
+                      }
+                    | undefined;
+                  review_mode?: 'rework' | 'comments' | undefined;
+                  code_review?: boolean | undefined;
+                  auto_resolve_pr_feedback?: boolean | undefined;
+                  auto_merge_delay_minutes?: number | null | undefined;
+                  merge_strategy?: 'direct' | 'pr' | undefined;
+                  convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
+                  custom_instructions?:
+                    | {
+                        polecat?: string | undefined;
+                        refinery?: string | undefined;
+                      }
+                    | undefined;
+                  git_push_flags?: string | undefined;
+                  max_concurrent_polecats?: number | undefined;
+                  max_dispatch_attempts?: number | undefined;
+                }
+              | undefined;
             agents: {
               id: string;
               rig_id: string | null;
@@ -1507,6 +1591,38 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
               closed_at: string | null;
             }[];
           };
+          meta: object;
+        }>;
+        updateRigConfig: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            rigId: string;
+            townId?: string | undefined;
+            config: {
+              default_model?: string | undefined;
+              role_models?:
+                | {
+                    polecat?: string | undefined;
+                    refinery?: string | undefined;
+                  }
+                | undefined;
+              review_mode?: 'rework' | 'comments' | undefined;
+              code_review?: boolean | undefined;
+              auto_resolve_pr_feedback?: boolean | undefined;
+              auto_merge_delay_minutes?: number | null | undefined;
+              merge_strategy?: 'direct' | 'pr' | undefined;
+              convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
+              custom_instructions?:
+                | {
+                    polecat?: string | undefined;
+                    refinery?: string | undefined;
+                  }
+                | undefined;
+              git_push_flags?: string | undefined;
+              max_concurrent_polecats?: number | undefined;
+              max_dispatch_attempts?: number | undefined;
+            };
+          };
+          output: void;
           meta: object;
         }>;
         deleteRig: import('@trpc/server').TRPCMutationProcedure<{

--- a/apps/web/src/lib/organizations/organizations.test.ts
+++ b/apps/web/src/lib/organizations/organizations.test.ts
@@ -24,6 +24,12 @@ import { DEFAULT_MEMBER_DAILY_LIMIT_USD } from '@/lib/organizations/constants';
 describe('Organizations', () => {
   afterEach(async () => {
     // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organization_user_limits);
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organization_invitations);
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organization_memberships);
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
     await db.delete(organizations);
   });
 

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -1221,6 +1221,7 @@ export async function updateAgentModel(
     'GASTOWN_GIT_AUTHOR_EMAIL',
     'GASTOWN_DISABLE_AI_COAUTHOR',
     'KILOCODE_TOKEN',
+    'GASTOWN_ORGANIZATION_ID',
   ]);
   const hotSwapEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(agent.startupEnv)) {
@@ -1231,6 +1232,13 @@ export async function updateAgentModel(
       continue;
     }
     hotSwapEnv[key] = value;
+  }
+  // Inject live values for LIVE_ENV_KEYS that were absent from startupEnv
+  // (e.g. GASTOWN_ORGANIZATION_ID added after initial dispatch).
+  for (const key of LIVE_ENV_KEYS) {
+    if (key in hotSwapEnv) continue;
+    const live = process.env[key];
+    if (live) hotSwapEnv[key] = live;
   }
 
   // Re-derive GH_TOKEN from live values using the same priority chain

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -355,6 +355,17 @@ async function ensureSDKServer(
     const port = nextPort++;
     console.log(`${MANAGER_LOG} Starting SDK server on port ${port} for ${workdir}`);
 
+    // Keys that must persist on process.env after the SDK server starts.
+    // KILO_CONFIG_CONTENT / OPENCODE_CONFIG_CONTENT carry the kilo provider
+    // auth config (including organizationId) and must survive the snapshot
+    // restore so extractOrganizationId() and subsequent model hot-swaps can
+    // read them. GASTOWN_ORGANIZATION_ID is the standalone org ID env var.
+    const PERSIST_ENV_KEYS = new Set([
+      'KILO_CONFIG_CONTENT',
+      'OPENCODE_CONFIG_CONTENT',
+      'GASTOWN_ORGANIZATION_ID',
+    ]);
+
     const envSnapshot: Record<string, string | undefined> = {};
     for (const key of Object.keys(env)) {
       envSnapshot[key] = process.env[key];
@@ -378,6 +389,8 @@ async function ensureSDKServer(
     } finally {
       process.chdir(prevCwd);
       for (const [key, prev] of Object.entries(envSnapshot)) {
+        // Never restore keys that must persist — keep the value we set above.
+        if (PERSIST_ENV_KEYS.has(key)) continue;
         if (prev === undefined) {
           delete process.env[key];
         } else {
@@ -814,6 +827,7 @@ export async function startAgent(
     gastownSessionToken: request.envVars?.GASTOWN_SESSION_TOKEN ?? null,
     completionCallbackUrl: request.envVars?.GASTOWN_COMPLETION_CALLBACK_URL ?? null,
     model: request.model ?? null,
+    organizationId: request.organizationId ?? null,
     startupEnv: env,
     startupRequest: request,
     startupAbortController,
@@ -1103,26 +1117,20 @@ export async function sendMessage(agentId: string, prompt: string): Promise<void
 }
 
 /**
- * Update the model for a running agent by restarting its SDK server with
- * new KILO_CONFIG_CONTENT. The kilo serve child process reads the model
- * from KILO_CONFIG_CONTENT at startup (highest config precedence after
- * enterprise managed config), so the only reliable way to change it is
- * to restart the server process.
+ * Extract the organizationId from durable agent state or process.env.
  *
- * The agent's session is re-created on the new server. The session history
- * is persisted on disk by kilo serve, so it survives the restart.
- *
- * @param model OpenRouter-style model ID (e.g. "anthropic/claude-sonnet-4.6")
- * @param smallModel Optional small model in the same format
+ * Resolution order (most → least reliable):
+ * 1. Agent's `organizationId` field — set at startup from StartAgentRequest,
+ *    survives process.env restores and model hot-swaps.
+ * 2. GASTOWN_ORGANIZATION_ID env var — set by control-server on /agents/start
+ *    and updated on every PATCH /model via X-Town-Config.
+ * 3. KILO_CONFIG_CONTENT — legacy fallback, may be absent after env restore.
  */
-/**
- * Extract the organizationId from the current KILO_CONFIG_CONTENT env var.
- * The org ID is embedded as `provider.kilo.options.kilocodeOrganizationId`
- * by `buildKiloConfigContent` at agent startup.
- */
-function extractOrganizationId(): string | undefined {
-  // Primary source: standalone env var set by control-server on /agents/start
-  // and updated on every PATCH /model via X-Town-Config.
+function extractOrganizationId(agent?: ManagedAgent): string | undefined {
+  // Primary source: durable field on the agent object
+  if (agent?.organizationId) return agent.organizationId;
+
+  // Secondary: standalone env var
   const envOrgId = process.env.GASTOWN_ORGANIZATION_ID;
   if (envOrgId) return envOrgId;
 
@@ -1181,8 +1189,23 @@ export async function updateAgentModel(
     `${MANAGER_LOG} updateAgentModel: restarting SDK server for agent ${agentId} with model=${model}`
   );
 
-  // 1. Preserve organizationId from the current config before we replace it
-  const organizationId = extractOrganizationId();
+  // 1. Resolve the organizationId, preferring the freshly-updated process.env
+  //    value over the cached agent field. The PATCH /model handler sets
+  //    process.env.GASTOWN_ORGANIZATION_ID before calling updateAgentModel, so
+  //    the env var is always at least as current as agent.organizationId and
+  //    may carry a brand-new org context that hasn't been written to the agent
+  //    record yet.
+  const organizationId =
+    process.env.GASTOWN_ORGANIZATION_ID || agent.organizationId || extractOrganizationId();
+
+  // Keep both the agent's durable field and the startupEnv snapshot in sync
+  // so that (a) future hot-swaps see the new value and (b) syncRegistry()
+  // serialises the updated org context, preventing boot hydration from
+  // reviving agents with the stale org after a container restart.
+  if (organizationId) {
+    agent.organizationId = organizationId;
+    agent.startupEnv = { ...agent.startupEnv, GASTOWN_ORGANIZATION_ID: organizationId };
+  }
 
   // 2. Rebuild KILO_CONFIG_CONTENT with the new model and update process.env
   //    so the next createKilo() spawns kilo serve with fresh config.

--- a/services/gastown/container/src/types.ts
+++ b/services/gastown/container/src/types.ts
@@ -133,6 +133,8 @@ export type ManagedAgent = {
   completionCallbackUrl: string | null;
   /** Model ID used for this agent's sessions (e.g. "anthropic/claude-sonnet-4.6") */
   model: string | null;
+  /** Organization ID for billing — stored durably so it survives process.env restores. */
+  organizationId: string | null;
   /** Full env dict from buildAgentEnv, stored so model hot-swap can replay it. */
   startupEnv: Record<string, string>;
   /** Original StartAgentRequest, stored so the container registry can

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -1174,6 +1174,48 @@ export class TownDO extends DurableObject<Env> {
   }
 
   /**
+   * Reset an agent's dispatch_attempts counter to 0 without unhooking.
+   * Also resets the hooked bead's dispatch_attempts/last_dispatch_attempt_at so
+   * the reconciler doesn't skip the bead due to accumulated cooldown state.
+   * Verifies the agent belongs to rigId to prevent cross-rig mutations.
+   */
+  async resetAgentDispatchAttempts(agentId: string, rigId: string): Promise<void> {
+    const agent = agents.getAgent(this.sql, agentId);
+    if (!agent) throw new Error(`Agent ${agentId} not found`);
+    if (agent.rig_id !== rigId) throw new Error(`Agent ${agentId} does not belong to rig ${rigId}`);
+
+    query(
+      this.sql,
+      /* sql */ `
+        UPDATE ${agent_metadata}
+        SET ${agent_metadata.columns.dispatch_attempts} = 0
+        WHERE ${agent_metadata.bead_id} = ?
+      `,
+      [agentId]
+    );
+
+    // Also clear the hooked bead's dispatch state so the reconciler won't skip
+    // it due to accumulated cooldown or max-attempt circuit breaker.
+    const hookedBeadId = agent.current_hook_bead_id;
+    if (hookedBeadId) {
+      query(
+        this.sql,
+        /* sql */ `
+          UPDATE ${beads}
+          SET ${beads.columns.dispatch_attempts} = 0,
+              ${beads.columns.last_dispatch_attempt_at} = NULL
+          WHERE ${beads.bead_id} = ?
+        `,
+        [hookedBeadId]
+      );
+    }
+
+    console.log(
+      `${TOWN_LOG} resetAgentDispatchAttempts: reset agent=${agentId} hookedBead=${hookedBeadId ?? 'none'}`
+    );
+  }
+
+  /**
    * Edit convoy_metadata fields (merge_mode, feature_branch).
    * Returns the updated convoy, or null if not found.
    */

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -4349,7 +4349,7 @@ export class TownDO extends DurableObject<Env> {
       agentCounts.total += c;
     }
 
-    // Bead counts
+    // Bead counts (live)
     const beadRows = [
       ...query(
         this.sql,

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -88,6 +88,7 @@ import type {
   MergeStrategy,
   ConvoyMergeMode,
   UiAction,
+  RigOverrideConfig,
 } from '../types';
 
 const TOWN_LOG = '[Town.do]';
@@ -281,6 +282,8 @@ export class TownDO extends DurableObject<Env> {
 
         let systemPromptOverride: string | undefined;
         const townConfig = await this.getTownConfig();
+        const rig = rigs.getRig(this.sql, rigId);
+        const effectiveConfig = config.resolveRigConfig(townConfig, rig?.config ?? null);
 
         // Build refinery-specific system prompt with branch/target info.
         // When the MR bead already has a pr_url (polecat created the PR),
@@ -305,17 +308,16 @@ export class TownDO extends DurableObject<Env> {
               typeof bead.metadata?.source_agent_id === 'string'
                 ? bead.metadata.source_agent_id
                 : 'unknown',
-            mergeStrategy: townConfig.merge_strategy ?? 'direct',
+            mergeStrategy: effectiveConfig.merge_strategy,
             existingPrUrl,
-            reviewMode: townConfig.refinery?.review_mode ?? 'rework',
+            reviewMode: effectiveConfig.review_mode,
           });
         }
 
         // When merge_strategy is 'pr', polecats always create the PR themselves
         // and pass pr_url to gt_done. For review-then-land convoy intermediate
         // beads, the PR targets the convoy feature branch (not main).
-        if (agent.role === 'polecat' && townConfig.merge_strategy === 'pr') {
-          const rig = rigs.getRig(this.sql, rigId);
+        if (agent.role === 'polecat' && effectiveConfig.merge_strategy === 'pr') {
           const convoyId = beadOps.getConvoyForBead(this.sql, beadId);
           const convoyFeatureBranch = convoyId
             ? beadOps.getConvoyFeatureBranch(this.sql, convoyId)
@@ -841,6 +843,11 @@ export class TownDO extends DurableObject<Env> {
   }
 
   async getRigAsync(rigId: string): Promise<rigs.RigRecord | null> {
+    return rigs.getRig(this.sql, rigId);
+  }
+
+  async updateRigConfig(rigId: string, config: RigOverrideConfig): Promise<rigs.RigRecord | null> {
+    rigs.updateRigConfig(this.sql, rigId, config);
     return rigs.getRig(this.sql, rigId);
   }
 
@@ -3670,7 +3677,7 @@ export class TownDO extends DurableObject<Env> {
       const townConfig = await this.getTownConfig();
       const actions = reconciler.reconcile(this.sql, {
         draining: this._draining,
-        refineryCodeReview: townConfig.refinery?.code_review ?? true,
+        townConfig,
       });
       metrics.actionsEmitted = actions.length;
       for (const a of actions) {
@@ -4594,7 +4601,7 @@ export class TownDO extends DurableObject<Env> {
       // Run reconciler against the resulting state
       const tc = await this.getTownConfig();
       const actions = reconciler.reconcile(this.sql, {
-        refineryCodeReview: tc.refinery?.code_review ?? true,
+        townConfig: tc,
       });
 
       // Capture a state snapshot before rollback
@@ -4676,7 +4683,7 @@ export class TownDO extends DurableObject<Env> {
       // Phase 1: Reconcile against now-current state
       const tc2 = await this.getTownConfig();
       const actions = reconciler.reconcile(this.sql, {
-        refineryCodeReview: tc2.refinery?.code_review ?? true,
+        townConfig: tc2,
       });
       const pendingEventCount = events.pendingEventCount(this.sql);
       const actionsByType: Record<string, number> = {};

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -2996,6 +2996,32 @@ export class TownDO extends DurableObject<Env> {
       [convoyId, input.tasks.length, 0, null, featureBranch, mergeMode, stagedValue]
     );
 
+    // Push the convoy feature branch to the remote so polecats can immediately
+    // open PRs targeting it and the refinery can merge into it.
+    const rig = rigs.getRig(this.sql, input.rigId);
+    if (rig) {
+      const rigConfig = await this.getRigConfig(input.rigId);
+      await scm
+        .createConvoyBranch(
+          {
+            env: this.env,
+            townId: this.townId,
+            getTownConfig: () => this.getTownConfig(),
+            platformIntegrationId: rigConfig?.platformIntegrationId,
+          },
+          {
+            gitUrl: rig.git_url,
+            defaultBranch: rig.default_branch,
+            featureBranch,
+          }
+        )
+        .catch(err =>
+          console.warn(`${TOWN_LOG} slingConvoy: createConvoyBranch failed (non-fatal)`, {
+            error: err instanceof Error ? err.message : String(err),
+          })
+        );
+    }
+
     // 2. Create all beads and track their IDs (needed for depends_on resolution)
     const beadIds: string[] = [];
     const results: Array<{ bead: Bead; agent: Agent | null }> = [];

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -4219,7 +4219,15 @@ export class TownDO extends DurableObject<Env> {
 
     try {
       const container = getTownContainerStub(this.env, townId);
-      const headers: Record<string, string> = {};
+      // Always include X-Town-Config so the container populates
+      // lastKnownTownConfig on startup — before any /agents/start arrives.
+      // This ensures org context and credentials are available immediately
+      // after a container restart when the first request is a model update
+      // (PATCH /model) rather than a new agent start.
+      const containerConfig = await config.buildContainerConfig(this.ctx.storage, this.env);
+      const headers: Record<string, string> = {
+        'X-Town-Config': JSON.stringify(containerConfig),
+      };
       // When draining AND enough time has passed for the old container
       // to have exited (drainAll waits up to 10 min + exit), pass the
       // nonce so the replacement container can acknowledge readiness.

--- a/services/gastown/src/dos/town/actions.ts
+++ b/services/gastown/src/dos/town/actions.ts
@@ -103,6 +103,11 @@ const ClearAgentCheckpoint = z.object({
   agent_id: z.string(),
 });
 
+const ResetAgentDispatchAttempts = z.object({
+  type: z.literal('reset_agent_dispatch_attempts'),
+  agent_id: z.string(),
+});
+
 const DeleteAgent = z.object({
   type: z.literal('delete_agent'),
   agent_id: z.string(),
@@ -192,6 +197,7 @@ export const Action = z.discriminatedUnion('type', [
   SetReviewPrUrl,
   // Agent mutations
   TransitionAgent,
+  ResetAgentDispatchAttempts,
   HookAgent,
   UnhookAgent,
   ClearAgentCheckpoint,
@@ -225,6 +231,7 @@ export type CreateLandingMr = z.infer<typeof CreateLandingMr>;
 export type CloseSiblingMrs = z.infer<typeof CloseSiblingMrs>;
 export type SetReviewPrUrl = z.infer<typeof SetReviewPrUrl>;
 export type TransitionAgent = z.infer<typeof TransitionAgent>;
+export type ResetAgentDispatchAttempts = z.infer<typeof ResetAgentDispatchAttempts>;
 export type HookAgent = z.infer<typeof HookAgent>;
 export type UnhookAgent = z.infer<typeof UnhookAgent>;
 export type ClearAgentCheckpoint = z.infer<typeof ClearAgentCheckpoint>;
@@ -447,6 +454,78 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
           `${LOG} transition_agent failed: agent=${action.agent_id} to=${action.to}`,
           err
         );
+      }
+      return null;
+    }
+
+    case 'reset_agent_dispatch_attempts': {
+      const agentRows = z
+        .object({ current_hook_bead_id: z.string().nullable() })
+        .array()
+        .parse([
+          ...query(
+            sql,
+            /* sql */ `
+              SELECT ${agent_metadata.columns.current_hook_bead_id}
+              FROM ${agent_metadata}
+              WHERE ${agent_metadata.columns.bead_id} = ?
+            `,
+            [action.agent_id]
+          ),
+        ]);
+      const hookedBeadId = agentRows[0]?.current_hook_bead_id;
+
+      query(
+        sql,
+        /* sql */ `
+          UPDATE ${agent_metadata}
+          SET ${agent_metadata.columns.dispatch_attempts} = 0
+          WHERE ${agent_metadata.bead_id} = ?
+        `,
+        [action.agent_id]
+      );
+
+      if (hookedBeadId) {
+        const beadRows = [
+          ...query(
+            sql,
+            /* sql */ `
+              SELECT ${beads.columns.status}, ${beads.columns.type}
+              FROM ${beads}
+              WHERE ${beads.bead_id} = ?
+            `,
+            [hookedBeadId]
+          ),
+        ];
+        const status = beadRows[0]?.status;
+        const type = beadRows[0]?.type;
+
+        query(
+          sql,
+          /* sql */ `
+            UPDATE ${beads}
+            SET ${beads.columns.dispatch_attempts} = 0,
+                ${beads.columns.last_dispatch_attempt_at} = NULL
+            WHERE ${beads.bead_id} = ?
+          `,
+          [hookedBeadId]
+        );
+
+        if (status === 'failed') {
+          beadOps.updateBeadStatus(sql, hookedBeadId, 'open', 'system');
+        }
+
+        if (type === 'merge_request') {
+          query(
+            sql,
+            /* sql */ `
+              UPDATE ${review_metadata}
+              SET ${review_metadata.columns.retry_count} = 0
+              WHERE ${review_metadata.bead_id} = ?
+            `,
+            [hookedBeadId]
+          );
+        }
       }
       return null;
     }

--- a/services/gastown/src/dos/town/agents.ts
+++ b/services/gastown/src/dos/town/agents.ts
@@ -574,6 +574,7 @@ export function touchAgent(
             WHEN ${agent_metadata.columns.status} = 'idle' THEN 'working'
             ELSE ${agent_metadata.columns.status}
           END,
+          ${agent_metadata.columns.dispatch_attempts} = 0,
           ${agent_metadata.columns.last_event_type} = COALESCE(?, ${agent_metadata.columns.last_event_type}),
           ${agent_metadata.columns.last_event_at} = COALESCE(?, ${agent_metadata.columns.last_event_at}),
           ${agent_metadata.columns.active_tools} = COALESCE(?, ${agent_metadata.columns.active_tools})

--- a/services/gastown/src/dos/town/config.test.ts
+++ b/services/gastown/src/dos/town/config.test.ts
@@ -3,7 +3,6 @@ import { TownConfigSchema } from '../../types';
 import { resolveModel } from './config';
 
 const HARDCODED_FALLBACK = 'anthropic/claude-sonnet-4.6';
-const DUMMY_RIG = 'rig-test';
 
 /** Parse a minimal TownConfig through the Zod schema (applies defaults). */
 function makeTownConfig(
@@ -15,16 +14,16 @@ function makeTownConfig(
 describe('resolveModel', () => {
   it('returns hardcoded fallback when no default_model and no role_models', () => {
     const config = makeTownConfig();
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe(HARDCODED_FALLBACK);
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe(HARDCODED_FALLBACK);
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'polecat')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'mayor')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'refinery')).toBe(HARDCODED_FALLBACK);
   });
 
   it('returns default_model when set and no role_models', () => {
     const config = makeTownConfig({ default_model: 'openai/gpt-4o' });
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'mayor')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'refinery')).toBe('openai/gpt-4o');
   });
 
   it('returns mayor-specific model when role_models.mayor is set', () => {
@@ -32,7 +31,7 @@ describe('resolveModel', () => {
       default_model: 'openai/gpt-4o',
       role_models: { mayor: 'anthropic/claude-opus-4' },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('anthropic/claude-opus-4');
+    expect(resolveModel(config, null, 'mayor')).toBe('anthropic/claude-opus-4');
   });
 
   it('falls back to default_model for roles not overridden in role_models', () => {
@@ -40,18 +39,18 @@ describe('resolveModel', () => {
       default_model: 'openai/gpt-4o',
       role_models: { mayor: 'anthropic/claude-opus-4' },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'refinery')).toBe('openai/gpt-4o');
   });
 
   it('returns polecat model when set, falls back for other roles', () => {
     const config = makeTownConfig({
       role_models: { polecat: 'google/gemini-2.5-pro' },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('google/gemini-2.5-pro');
+    expect(resolveModel(config, null, 'polecat')).toBe('google/gemini-2.5-pro');
     // No default_model → hardcoded fallback for other roles
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe(HARDCODED_FALLBACK);
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'mayor')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'refinery')).toBe(HARDCODED_FALLBACK);
   });
 
   it('returns role-specific model for all three roles when all overridden', () => {
@@ -63,9 +62,9 @@ describe('resolveModel', () => {
         polecat: 'google/gemini-2.5-pro',
       },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('anthropic/claude-opus-4');
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('anthropic/claude-sonnet-4');
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('google/gemini-2.5-pro');
+    expect(resolveModel(config, null, 'mayor')).toBe('anthropic/claude-opus-4');
+    expect(resolveModel(config, null, 'refinery')).toBe('anthropic/claude-sonnet-4');
+    expect(resolveModel(config, null, 'polecat')).toBe('google/gemini-2.5-pro');
   });
 
   it('treats empty role_models the same as no role_models', () => {
@@ -73,14 +72,14 @@ describe('resolveModel', () => {
       default_model: 'openai/gpt-4o',
       role_models: {},
     });
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'mayor')).toBe('openai/gpt-4o');
   });
 
   it('treats undefined role_models the same as no role_models', () => {
     const config = makeTownConfig({ default_model: 'openai/gpt-4o' });
     expect(config.role_models).toBeUndefined();
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'polecat')).toBe('openai/gpt-4o');
   });
 
   it('falls back to default_model for unknown role strings', () => {
@@ -88,15 +87,15 @@ describe('resolveModel', () => {
       default_model: 'openai/gpt-4o',
       role_models: { mayor: 'anthropic/claude-opus-4' },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'unknown-role')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, '')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'unknown-role')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, '')).toBe('openai/gpt-4o');
   });
 
   it('falls back to hardcoded fallback for unknown role with no default_model', () => {
     const config = makeTownConfig({
       role_models: { mayor: 'anthropic/claude-opus-4' },
     });
-    expect(resolveModel(config, DUMMY_RIG, 'unknown-role')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'unknown-role')).toBe(HARDCODED_FALLBACK);
   });
 });
 
@@ -109,17 +108,17 @@ describe('resolveModel backward compatibility', () => {
     };
     const config = TownConfigSchema.parse(legacyRaw);
     expect(config.role_models).toBeUndefined();
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
-    expect(resolveModel(config, DUMMY_RIG, 'refinery')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'polecat')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'mayor')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'refinery')).toBe('openai/gpt-4o');
   });
 
   it('works with a completely empty config (new town defaults)', () => {
     const config = TownConfigSchema.parse({});
     expect(config.role_models).toBeUndefined();
     expect(config.default_model).toBeUndefined();
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe(HARDCODED_FALLBACK);
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'polecat')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(config, null, 'mayor')).toBe(HARDCODED_FALLBACK);
   });
 
   it('preserves resolution chain: role override > default_model > hardcoded', () => {
@@ -128,15 +127,15 @@ describe('resolveModel backward compatibility', () => {
       role_models: { polecat: 'google/gemini-2.5-pro' },
     });
     // polecat: role override wins
-    expect(resolveModel(config, DUMMY_RIG, 'polecat')).toBe('google/gemini-2.5-pro');
+    expect(resolveModel(config, null, 'polecat')).toBe('google/gemini-2.5-pro');
     // mayor: no role override → default_model
-    expect(resolveModel(config, DUMMY_RIG, 'mayor')).toBe('openai/gpt-4o');
+    expect(resolveModel(config, null, 'mayor')).toBe('openai/gpt-4o');
 
     // Remove default_model to test final fallback
     const configNoDefault = makeTownConfig({
       role_models: { polecat: 'google/gemini-2.5-pro' },
     });
     // refinery: no role override, no default → hardcoded
-    expect(resolveModel(configNoDefault, DUMMY_RIG, 'refinery')).toBe(HARDCODED_FALLBACK);
+    expect(resolveModel(configNoDefault, null, 'refinery')).toBe(HARDCODED_FALLBACK);
   });
 });

--- a/services/gastown/src/dos/town/config.ts
+++ b/services/gastown/src/dos/town/config.ts
@@ -7,6 +7,7 @@ import {
   type TownConfig,
   type TownConfigUpdate,
   type MergeStrategy,
+  type RigOverrideConfig,
 } from '../../types';
 
 const CONFIG_KEY = 'town:config';
@@ -128,13 +129,32 @@ export async function updateTownConfig(
   return validated;
 }
 
+const DEFAULT_MODEL = 'anthropic/claude-sonnet-4.6';
+
 /**
- * Resolve the primary model from town config.
- * Priority: rig override → role-specific → town default → hardcoded default.
+ * Resolve the primary model from town config, optionally applying a rig override.
+ * Priority: rig override (role-specific) → rig override (default) → town role-specific → town default → hardcoded default.
  */
-export function resolveModel(townConfig: TownConfig, _rigId: string, role: string): string {
-  const roleModels: Record<string, string | undefined> | undefined = townConfig.role_models;
-  return roleModels?.[role] ?? townConfig.default_model ?? 'anthropic/claude-sonnet-4.6';
+export function resolveModel(
+  townConfig: TownConfig,
+  rigOverride: RigOverrideConfig | null | undefined,
+  role: string
+): string {
+  const base = rigOverride?.default_model ?? townConfig.default_model;
+  if (role === 'mayor')
+    return townConfig.role_models?.mayor ?? townConfig.default_model ?? DEFAULT_MODEL;
+  if (role === 'polecat')
+    return (
+      rigOverride?.role_models?.polecat ?? townConfig.role_models?.polecat ?? base ?? DEFAULT_MODEL
+    );
+  if (role === 'refinery')
+    return (
+      rigOverride?.role_models?.refinery ??
+      townConfig.role_models?.refinery ??
+      base ??
+      DEFAULT_MODEL
+    );
+  return base ?? DEFAULT_MODEL;
 }
 
 /**
@@ -157,6 +177,78 @@ export function resolveMergeStrategy(
 }
 
 /**
+ * The fully-resolved configuration for a rig dispatch.
+ * All fields have concrete values (no optional/undefined) except where
+ * a null value is meaningful (e.g. auto_merge_delay_minutes: null = disabled).
+ */
+export type EffectiveConfig = {
+  default_model: string | undefined;
+  role_models: {
+    polecat: string | undefined;
+    refinery: string | undefined;
+    mayor: string | undefined;
+  };
+  review_mode: 'rework' | 'comments';
+  code_review: boolean;
+  auto_resolve_pr_feedback: boolean;
+  auto_merge_delay_minutes: number | null;
+  merge_strategy: MergeStrategy;
+  convoy_merge_mode: 'review-then-land' | 'review-and-merge';
+  custom_instructions: {
+    polecat: string | undefined;
+    refinery: string | undefined;
+    mayor: string | undefined;
+  };
+  git_push_flags: string | undefined;
+  max_concurrent_polecats: number | undefined;
+  max_dispatch_attempts: number | undefined;
+};
+
+/**
+ * Merge a rig's override config on top of town config, returning a fully
+ * resolved EffectiveConfig for dispatch. When rigOverride is null/undefined,
+ * all values fall back to town-level defaults (behavior identical to today).
+ */
+export function resolveRigConfig(
+  townConfig: TownConfig,
+  rigOverride: RigOverrideConfig | null | undefined
+): EffectiveConfig {
+  return {
+    default_model: rigOverride?.default_model ?? townConfig.default_model,
+    role_models: {
+      polecat: rigOverride?.role_models?.polecat ?? townConfig.role_models?.polecat,
+      refinery: rigOverride?.role_models?.refinery ?? townConfig.role_models?.refinery,
+      // mayor is always town-level — rigs cannot override mayor model
+      mayor: townConfig.role_models?.mayor,
+    },
+    review_mode: rigOverride?.review_mode ?? townConfig.refinery?.review_mode ?? 'rework',
+    code_review: rigOverride?.code_review ?? townConfig.refinery?.code_review ?? true,
+    auto_resolve_pr_feedback:
+      rigOverride?.auto_resolve_pr_feedback ??
+      townConfig.refinery?.auto_resolve_pr_feedback ??
+      false,
+    auto_merge_delay_minutes:
+      rigOverride?.auto_merge_delay_minutes !== undefined
+        ? rigOverride.auto_merge_delay_minutes
+        : (townConfig.refinery?.auto_merge_delay_minutes ?? null),
+    merge_strategy: rigOverride?.merge_strategy ?? townConfig.merge_strategy ?? 'direct',
+    convoy_merge_mode:
+      rigOverride?.convoy_merge_mode ?? townConfig.convoy_merge_mode ?? 'review-then-land',
+    custom_instructions: {
+      polecat: rigOverride?.custom_instructions?.polecat ?? townConfig.custom_instructions?.polecat,
+      refinery:
+        rigOverride?.custom_instructions?.refinery ?? townConfig.custom_instructions?.refinery,
+      // mayor is always town-level
+      mayor: townConfig.custom_instructions?.mayor,
+    },
+    git_push_flags: rigOverride?.git_push_flags,
+    max_concurrent_polecats:
+      rigOverride?.max_concurrent_polecats ?? townConfig.max_polecats_per_rig,
+    max_dispatch_attempts: rigOverride?.max_dispatch_attempts,
+  };
+}
+
+/**
  * Build the ContainerConfig payload for X-Town-Config header.
  * Sent with every fetch() to the container.
  */
@@ -167,7 +259,7 @@ export async function buildContainerConfig(
   const config = await getTownConfig(storage);
   return {
     env_vars: config.env_vars,
-    default_model: resolveModel(config, '', ''),
+    default_model: resolveModel(config, null, ''),
     small_model: resolveSmallModel(config),
     git_auth: config.git_auth,
     kilocode_token: config.kilocode_token,

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -7,10 +7,49 @@ import { getTownContainerStub } from '../TownContainer.do';
 import { signAgentJWT, signContainerJWT } from '../../util/jwt.util';
 import { buildPolecatSystemPrompt } from '../../prompts/polecat-system.prompt';
 import { buildMayorSystemPrompt } from '../../prompts/mayor-system.prompt';
-import type { TownConfig } from '../../types';
-import { buildContainerConfig, resolveModel, resolveSmallModel } from './config';
+import type { TownConfig, RigOverrideConfig } from '../../types';
+import { buildContainerConfig, resolveModel, resolveSmallModel, resolveRigConfig } from './config';
 
 const TOWN_LOG = '[Town.do]';
+
+// Allowlist of git push flags that are safe to pass from rig config.
+// Flags that bypass hooks (--no-verify), rewrite history (--force,
+// --force-with-lease), or alter remote refs in dangerous ways are
+// explicitly excluded to prevent config-driven bypass of protections.
+const ALLOWED_GIT_PUSH_FLAGS = new Set([
+  '--atomic',
+  '--follow-tags',
+  '--signed',
+  '--no-signed',
+  '--progress',
+  '--no-progress',
+  '--verbose',
+  '--quiet',
+  '--tags',
+  '--porcelain',
+  '--ipv4',
+  '--ipv6',
+  '--recurse-submodules=check',
+  '--recurse-submodules=on-demand',
+  '--recurse-submodules=no',
+]);
+
+/**
+ * Filter git push flags against the allowlist. Returns only the safe subset.
+ * Logs a warning for any rejected flags.
+ */
+function filterGitPushFlags(raw: string): string | undefined {
+  const flags = raw.trim().split(/\s+/).filter(Boolean);
+  const allowed: string[] = [];
+  for (const flag of flags) {
+    if (ALLOWED_GIT_PUSH_FLAGS.has(flag)) {
+      allowed.push(flag);
+    } else {
+      console.warn(`${TOWN_LOG} filterGitPushFlags: rejecting unsafe flag "${flag}"`);
+    }
+  }
+  return allowed.length > 0 ? allowed.join(' ') : undefined;
+}
 
 // Module-level diagnostic: stores the last container start error so
 // callers can surface it via the admin API. Reset on each call.
@@ -244,16 +283,19 @@ export function systemPromptForRole(params: {
 }
 
 /**
- * Append per-role custom instructions from town config to a system prompt.
- * Returns the prompt unchanged when no custom instructions exist for the role.
+ * Append per-role custom instructions to a system prompt.
+ * Accepts either a TownConfig (falls back to town-level instructions)
+ * or a pre-resolved instructions string. Returns the prompt unchanged
+ * when no custom instructions exist for the role.
  */
 export function appendCustomInstructions(
   systemPrompt: string,
   role: string,
-  townConfig: TownConfig
+  townConfig: TownConfig,
+  resolvedInstructions?: string | null
 ): string {
   const roleKey = role as keyof NonNullable<TownConfig['custom_instructions']>;
-  const instructions = townConfig.custom_instructions?.[roleKey]?.trim();
+  const instructions = (resolvedInstructions ?? townConfig.custom_instructions?.[roleKey])?.trim();
   if (!instructions) return systemPrompt;
   return `${systemPrompt}\n\n## Custom Instructions (from town settings)\n\n${instructions}`;
 }
@@ -320,6 +362,8 @@ export async function startAgentInContainer(
     defaultBranch: string;
     kilocodeToken?: string;
     townConfig: TownConfig;
+    /** Rig-level config overrides. When present, merged on top of townConfig for model, custom_instructions, and git_push_flags. */
+    rigOverride?: RigOverrideConfig | null;
     systemPromptOverride?: string;
     platformIntegrationId?: string;
     /** For convoy beads: the convoy's feature branch to branch from instead of defaultBranch. */
@@ -407,6 +451,9 @@ export async function startAgentInContainer(
     const containerConfig = await buildContainerConfig(storage, env);
     const container = getTownContainerStub(env, params.townId);
 
+    const rigOverride = params.rigOverride ?? null;
+    const effectiveConfig = resolveRigConfig(params.townConfig, rigOverride);
+
     const response = await container.fetch('http://container/agents/start', {
       method: 'POST',
       signal: AbortSignal.timeout(60_000),
@@ -427,7 +474,7 @@ export async function startAgentInContainer(
           checkpoint: params.checkpoint,
           conversationHistory: params.conversationHistory,
         }),
-        model: resolveModel(params.townConfig, params.rigId, params.role),
+        model: resolveModel(params.townConfig, rigOverride, params.role),
         smallModel: resolveSmallModel(params.townConfig),
         systemPrompt: appendCustomInstructions(
           params.systemPromptOverride ??
@@ -440,8 +487,17 @@ export async function startAgentInContainer(
               gates: params.townConfig.refinery?.gates ?? [],
             }),
           params.role,
-          params.townConfig
+          params.townConfig,
+          effectiveConfig.custom_instructions[
+            params.role as keyof typeof effectiveConfig.custom_instructions
+          ]
         ),
+        ...(effectiveConfig.git_push_flags
+          ? (() => {
+              const safe = filterGitPushFlags(effectiveConfig.git_push_flags);
+              return safe ? { gitPushFlags: safe } : {};
+            })()
+          : {}),
         gitUrl: params.gitUrl,
         branch: params.convoyFeatureBranch
           ? branchForConvoyAgent(params.convoyFeatureBranch, params.agentName, params.beadId)

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -447,9 +447,9 @@ export async function startAgentInContainer(
           ? branchForConvoyAgent(params.convoyFeatureBranch, params.agentName, params.beadId)
           : branchForAgent(params.agentName, params.beadId),
         // Always use the rig's real default branch for the initial git clone.
-        // The convoy feature branch may not exist on the remote yet (the first
-        // agent's work creates it via the refinery merge). The agent's working
-        // branch is created as a worktree from HEAD after clone.
+        // The agent's working branch is created as a worktree from HEAD after
+        // clone; for convoy agents the startPoint below positions that worktree
+        // at the convoy's feature branch tip.
         defaultBranch: params.defaultBranch,
         envVars,
         platformIntegrationId: params.platformIntegrationId,

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -25,7 +25,7 @@ import {
   AGENT_GC_RETENTION_MS,
   TRIAGE_LABEL_LIKE,
 } from './patrol';
-import { DISPATCH_COOLDOWN_MS, MAX_DISPATCH_ATTEMPTS } from './scheduling';
+import { MAX_DISPATCH_ATTEMPTS } from './scheduling';
 import * as reviewQueue from './review-queue';
 import * as agents from './agents';
 import * as beadOps from './beads';
@@ -119,10 +119,11 @@ function staleMs(timestamp: string | null, thresholdMs: number): boolean {
  *   attempt 5+:  30 min
  */
 function getDispatchCooldownMs(dispatchAttempts: number): number {
-  if (dispatchAttempts <= 2) return DISPATCH_COOLDOWN_MS; // 2 min
-  if (dispatchAttempts === 3) return 5 * 60_000; // 5 min
-  if (dispatchAttempts === 4) return 10 * 60_000; // 10 min
-  return 30 * 60_000; // 30 min
+  if (dispatchAttempts <= 1) return 30_000; // 30 sec
+  if (dispatchAttempts === 2) return 60_000; // 1 min
+  if (dispatchAttempts === 3) return 2 * 60_000; // 2 min
+  if (dispatchAttempts === 4) return 5 * 60_000; // 5 min
+  return 10 * 60_000; // 10 min
 }
 
 // ── Row schemas for queries ─────────────────────────────────────────
@@ -547,6 +548,32 @@ export function reconcileAgents(sql: SqlStorage, opts?: { draining?: boolean }):
         reason: 'working agent has no hook (gt_done already completed)',
       });
     }
+  }
+
+  // Auto-reset dispatch_attempts after 30-minute cooldown
+  const staleAgents = AgentRow.array().parse([
+    ...query(
+      sql,
+      /* sql */ `
+        SELECT ${agent_metadata.bead_id}, ${agent_metadata.role},
+               ${agent_metadata.status}, ${agent_metadata.current_hook_bead_id},
+               ${agent_metadata.dispatch_attempts},
+               ${agent_metadata.last_activity_at},
+               b.${beads.columns.rig_id}
+        FROM ${agent_metadata}
+        LEFT JOIN ${beads} b ON b.${beads.columns.bead_id} = ${agent_metadata.bead_id}
+        WHERE ${agent_metadata.dispatch_attempts} >= ?
+          AND ${agent_metadata.last_activity_at} < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 minutes')
+      `,
+      [MAX_DISPATCH_ATTEMPTS]
+    ),
+  ]);
+
+  for (const agent of staleAgents) {
+    actions.push({
+      type: 'reset_agent_dispatch_attempts',
+      agent_id: agent.bead_id,
+    });
   }
 
   // Idle agents hooked to terminal beads — clean up stale hooks

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -30,9 +30,11 @@ import * as reviewQueue from './review-queue';
 import * as agents from './agents';
 import * as beadOps from './beads';
 import { getRig } from './rigs';
+import { resolveRigConfig } from './config';
 import { PR_POLL_INTERVAL_MS } from './actions';
 import type { Action } from './actions';
 import type { TownEventRecord } from '../../db/tables/town-events.table';
+import type { TownConfig } from '../../types';
 
 const LOG = '[reconciler]';
 
@@ -462,15 +464,13 @@ export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
 
 export function reconcile(
   sql: SqlStorage,
-  opts?: { draining?: boolean; refineryCodeReview?: boolean }
+  opts?: { draining?: boolean; townConfig?: TownConfig }
 ): Action[] {
   const draining = opts?.draining ?? false;
   const actions: Action[] = [];
   actions.push(...reconcileAgents(sql, { draining }));
-  actions.push(...reconcileBeads(sql, { draining }));
-  actions.push(
-    ...reconcileReviewQueue(sql, { draining, refineryCodeReview: opts?.refineryCodeReview })
-  );
+  actions.push(...reconcileBeads(sql, { draining, townConfig: opts?.townConfig }));
+  actions.push(...reconcileReviewQueue(sql, { draining, townConfig: opts?.townConfig }));
   actions.push(...reconcileConvoys(sql));
   actions.push(...reconcileGUPP(sql, { draining }));
   actions.push(...reconcileGC(sql));
@@ -666,9 +666,22 @@ export function reconcileAgents(sql: SqlStorage, opts?: { draining?: boolean }):
 // reconcileBeads — handle unassigned beads, lost agents, stale reviews
 // ════════════════════════════════════════════════════════════════════
 
-export function reconcileBeads(sql: SqlStorage, opts?: { draining?: boolean }): Action[] {
+export function reconcileBeads(
+  sql: SqlStorage,
+  opts?: { draining?: boolean; townConfig?: TownConfig }
+): Action[] {
   const draining = opts?.draining ?? false;
   const actions: Action[] = [];
+
+  // Resolve per-rig max_dispatch_attempts, falling back to the module default.
+  const rigMaxDispatchAttempts = (rigId: string | null): number => {
+    if (!rigId || !opts?.townConfig) return MAX_DISPATCH_ATTEMPTS;
+    const rig = getRig(sql, rigId);
+    return (
+      resolveRigConfig(opts.townConfig, rig?.config ?? null).max_dispatch_attempts ??
+      MAX_DISPATCH_ATTEMPTS
+    );
+  };
 
   // Town-level circuit breaker: if too many dispatch failures in the
   // window, skip all dispatch_agent actions and escalate to mayor.
@@ -721,7 +734,7 @@ export function reconcileBeads(sql: SqlStorage, opts?: { draining?: boolean }): 
     }
 
     // Per-bead dispatch cap: fail the bead if it exhausted all attempts
-    if (bead.dispatch_attempts >= MAX_DISPATCH_ATTEMPTS) {
+    if (bead.dispatch_attempts >= rigMaxDispatchAttempts(bead.rig_id)) {
       actions.push({
         type: 'transition_bead',
         bead_id: bead.bead_id,
@@ -1076,14 +1089,31 @@ export function reconcileBeads(sql: SqlStorage, opts?: { draining?: boolean }): 
 
 export function reconcileReviewQueue(
   sql: SqlStorage,
-  opts?: { draining?: boolean; refineryCodeReview?: boolean }
+  opts?: { draining?: boolean; townConfig?: TownConfig }
 ): Action[] {
   const draining = opts?.draining ?? false;
-  const refineryCodeReview = opts?.refineryCodeReview ?? true;
   const actions: Action[] = [];
 
   // Town-level circuit breaker
   const circuitBreakerOpen = checkDispatchCircuitBreaker(sql).length > 0;
+
+  // Resolve per-rig code_review setting. Falls back to town default when
+  // townConfig is not provided (e.g. in tests or debug replay).
+  const rigCodeReview = (rigId: string): boolean => {
+    if (!opts?.townConfig) return true;
+    const rig = getRig(sql, rigId);
+    return resolveRigConfig(opts.townConfig, rig?.config ?? null).code_review;
+  };
+
+  // Resolve per-rig max_dispatch_attempts, falling back to the module default.
+  const rigMaxDispatchAttempts = (rigId: string | null): number => {
+    if (!rigId || !opts?.townConfig) return MAX_DISPATCH_ATTEMPTS;
+    const rig = getRig(sql, rigId);
+    return (
+      resolveRigConfig(opts.townConfig, rig?.config ?? null).max_dispatch_attempts ??
+      MAX_DISPATCH_ATTEMPTS
+    );
+  };
 
   // Get all MR beads that need attention
   const mrBeads = MrBeadRow.array().parse([
@@ -1183,10 +1213,11 @@ export function reconcileReviewQueue(
 
     // Rule 4: PR-strategy MR beads orphaned (refinery dispatched then died, stale >30min)
     // Only in_progress — open beads are just waiting for the refinery to pop them.
-    // Skip when refinery code review is disabled: poll_pr keeps the bead alive via
-    // updated_at touches, and no refinery is expected to be working on it.
+    // Skip when refinery code review is disabled for this rig: poll_pr keeps the
+    // bead alive via updated_at touches, and no refinery is expected to be working.
     if (
-      refineryCodeReview &&
+      mr.rig_id &&
+      rigCodeReview(mr.rig_id) &&
       mr.status === 'in_progress' &&
       mr.pr_url &&
       staleMs(mr.updated_at, ORPHANED_PR_REVIEW_TIMEOUT_MS)
@@ -1205,13 +1236,33 @@ export function reconcileReviewQueue(
     }
   }
 
-  // When refinery code review is disabled:
-  //  - MR beads WITH pr_url → fast-track to in_progress for poll_pr
-  //  - MR beads WITHOUT pr_url → fail them and reopen the source bead
+  // Per-rig: when refinery code review is disabled for a rig:
+  //  - MR beads for that rig WITH pr_url → fast-track to in_progress for poll_pr
+  //  - MR beads for that rig WITHOUT pr_url → fail them and reopen the source bead
   //    (the polecat was supposed to create the PR via merge_strategy=pr
   //    but didn't provide one — retry the source bead)
-  if (!refineryCodeReview) {
-    // Fast-track: open MR beads with pr_url → in_progress
+  // Collect all rigs that have open MR beads so we can apply per-rig logic.
+  const rigsWithAnyOpenMrs = z
+    .object({ rig_id: z.string() })
+    .array()
+    .parse([
+      ...query(
+        sql,
+        /* sql */ `
+          SELECT DISTINCT b.${beads.columns.rig_id}
+          FROM ${beads} b
+          WHERE b.${beads.columns.type} = 'merge_request'
+            AND b.${beads.columns.status} = 'open'
+            AND b.${beads.columns.rig_id} IS NOT NULL
+        `,
+        []
+      ),
+    ]);
+
+  for (const { rig_id } of rigsWithAnyOpenMrs) {
+    if (rigCodeReview(rig_id)) continue;
+
+    // Fast-track: open MR beads with pr_url → in_progress (skip refinery review)
     const openMrsWithPr = z
       .object({ bead_id: z.string() })
       .array()
@@ -1225,6 +1276,7 @@ export function reconcileReviewQueue(
               ON rm.${review_metadata.columns.bead_id} = b.${beads.columns.bead_id}
             WHERE b.${beads.columns.type} = 'merge_request'
               AND b.${beads.columns.status} = 'open'
+              AND b.${beads.columns.rig_id} = ?
               AND rm.${review_metadata.columns.pr_url} IS NOT NULL
               AND NOT EXISTS (
                 SELECT 1
@@ -1235,7 +1287,7 @@ export function reconcileReviewQueue(
                   AND cm.${convoy_metadata.columns.merge_mode} = 'review-and-merge'
               )
           `,
-          []
+          [rig_id]
         ),
       ]);
     for (const { bead_id } of openMrsWithPr) {
@@ -1270,6 +1322,7 @@ export function reconcileReviewQueue(
               AND bd.${bead_dependencies.columns.dependency_type} = 'tracks'
             WHERE b.${beads.columns.type} = 'merge_request'
               AND b.${beads.columns.status} = 'open'
+              AND b.${beads.columns.rig_id} = ?
               AND rm.${review_metadata.columns.pr_url} IS NULL
               AND NOT EXISTS (
                 SELECT 1
@@ -1280,7 +1333,7 @@ export function reconcileReviewQueue(
                   AND cm.${convoy_metadata.columns.merge_mode} = 'review-and-merge'
               )
           `,
-          []
+          [rig_id]
         ),
       ]);
     for (const { bead_id, source_bead_id } of orphanedMrs) {
@@ -1306,30 +1359,15 @@ export function reconcileReviewQueue(
   }
 
   // Rules 5-6: Refinery dispatch for open MR beads.
-  // When code_review=true: dispatches for all open MR beads.
-  // When code_review=false: only dispatches for convoy review-and-merge
+  // When code_review=true for a rig: dispatches for all open MR beads in that rig.
+  // When code_review=false for a rig: only dispatches for convoy review-and-merge
   // MR beads (the fast-track above already moved ordinary MR beads to
   // in_progress as actions, but those haven't been applied to SQL yet —
   // so we must filter here to avoid re-dispatching them).
   {
     // Rule 5: Pop open MR bead for idle refinery
     // Get all rigs that have open MR beads needing the refinery.
-    // When code_review=false, only dispatch the refinery for convoy
-    // review-and-merge MR beads (refinery does combined review+merge).
-    // MR beads WITH a pr_url are handled by the fast-track → poll_pr.
-    // MR beads WITHOUT a pr_url when merge_strategy=pr are orphaned
-    // (polecat should have created the PR) — Rule 2 handles them.
-    const refineryNeededFilter = refineryCodeReview
-      ? ''
-      : /* sql */ `
-          AND EXISTS (
-            SELECT 1
-            FROM ${beads} parent
-            JOIN ${convoy_metadata} cm
-              ON cm.${convoy_metadata.columns.bead_id} = parent.${beads.columns.bead_id}
-            WHERE parent.${beads.columns.bead_id} = b.${beads.columns.parent_bead_id}
-              AND cm.${convoy_metadata.columns.merge_mode} = 'review-and-merge'
-          )`;
+    // All rigs with open MRs are candidates; per-rig code_review is checked inside the loop.
     const rigsWithOpenMrs = z
       .object({ rig_id: z.string() })
       .array()
@@ -1342,13 +1380,29 @@ export function reconcileReviewQueue(
         WHERE b.${beads.columns.type} = 'merge_request'
           AND b.${beads.columns.status} = 'open'
           AND b.${beads.columns.rig_id} IS NOT NULL
-          ${refineryNeededFilter}
       `,
           []
         ),
       ]);
 
     for (const { rig_id } of rigsWithOpenMrs) {
+      // When code_review=false, only dispatch the refinery for convoy
+      // review-and-merge MR beads (refinery does combined review+merge).
+      // MR beads WITH a pr_url are handled by the fast-track → poll_pr.
+      // MR beads WITHOUT a pr_url when merge_strategy=pr are orphaned
+      // (polecat should have created the PR) — Rule 2 handles them.
+      const refineryNeededFilter = rigCodeReview(rig_id)
+        ? ''
+        : /* sql */ `
+            AND EXISTS (
+              SELECT 1
+              FROM ${beads} parent
+              JOIN ${convoy_metadata} cm
+                ON cm.${convoy_metadata.columns.bead_id} = parent.${beads.columns.bead_id}
+              WHERE parent.${beads.columns.bead_id} = b.${beads.columns.parent_bead_id}
+                AND cm.${convoy_metadata.columns.merge_mode} = 'review-and-merge'
+            )`;
+
       // Check if rig already has an in_progress MR that needs the refinery.
       // PR-strategy MR beads (pr_url IS NOT NULL) don't need the refinery —
       // the merge is handled by the user/CI via the PR. Only direct-strategy
@@ -1526,9 +1580,11 @@ export function reconcileReviewQueue(
         continue;
       }
 
+      const rigId = mr.rig_id ?? ref.rig_id ?? null;
+
       // Per-bead dispatch cap — check before cooldown so max-attempt MR
       // beads are failed immediately rather than waiting for the cooldown.
-      if (mr.dispatch_attempts >= MAX_DISPATCH_ATTEMPTS) {
+      if (mr.dispatch_attempts >= rigMaxDispatchAttempts(rigId)) {
         actions.push({
           type: 'transition_bead',
           bead_id: ref.current_hook_bead_id,
@@ -1558,7 +1614,7 @@ export function reconcileReviewQueue(
         type: 'dispatch_agent',
         agent_id: ref.bead_id,
         bead_id: ref.current_hook_bead_id,
-        rig_id: mr.rig_id ?? ref.rig_id ?? '',
+        rig_id: rigId ?? '',
       });
     }
   } // end Rules 5–6 block

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -1396,10 +1396,10 @@ export function reconcileReviewQueue(
         : /* sql */ `
             AND EXISTS (
               SELECT 1
-              FROM ${beads} parent
+              FROM ${beads} outer_parent
               JOIN ${convoy_metadata} cm
-                ON cm.${convoy_metadata.columns.bead_id} = parent.${beads.columns.bead_id}
-              WHERE parent.${beads.columns.bead_id} = b.${beads.columns.parent_bead_id}
+                ON cm.${convoy_metadata.columns.bead_id} = outer_parent.${beads.columns.bead_id}
+              WHERE outer_parent.${beads.columns.bead_id} = ${beads.parent_bead_id}
                 AND cm.${convoy_metadata.columns.merge_mode} = 'review-and-merge'
             )`;
 
@@ -1456,12 +1456,12 @@ export function reconcileReviewQueue(
             sql,
             /* sql */ `
           SELECT ${beads.bead_id}
-          FROM ${beads} b
-          WHERE b.${beads.columns.type} = 'merge_request'
-            AND b.${beads.columns.status} = 'open'
-            AND b.${beads.columns.rig_id} = ?
+          FROM ${beads}
+          WHERE ${beads.type} = 'merge_request'
+            AND ${beads.status} = 'open'
+            AND ${beads.rig_id} = ?
             ${refineryNeededFilter}
-          ORDER BY b.${beads.columns.created_at} ASC
+          ORDER BY ${beads.created_at} ASC
           LIMIT 1
         `,
             [rig_id]

--- a/services/gastown/src/dos/town/rigs.ts
+++ b/services/gastown/src/dos/town/rigs.ts
@@ -5,6 +5,7 @@
 
 import { z } from 'zod';
 import { query } from '../../util/query.util';
+import { type RigOverrideConfig, RigOverrideConfigSchema } from '../../types';
 
 const RIG_TABLE_CREATE = /* sql */ `
   CREATE TABLE IF NOT EXISTS "rigs" (
@@ -26,14 +27,14 @@ export const RigRecord = z.object({
   default_branch: z.string(),
   config: z
     .string()
-    .transform((v): Record<string, unknown> => {
+    .transform((v): unknown => {
       try {
-        return JSON.parse(v) as Record<string, unknown>;
+        return JSON.parse(v) as unknown;
       } catch {
         return {};
       }
     })
-    .pipe(z.record(z.string(), z.unknown())),
+    .pipe(RigOverrideConfigSchema),
   created_at: z.string(),
 });
 
@@ -128,4 +129,10 @@ export function listRigs(sql: SqlStorage): RigRecord[] {
 
 export function removeRig(sql: SqlStorage, rigId: string): void {
   query(sql, /* sql */ `DELETE FROM rigs WHERE id = ?`, [rigId]);
+}
+
+export function updateRigConfig(sql: SqlStorage, rigId: string, config: RigOverrideConfig): void {
+  const existing = getRig(sql, rigId);
+  const merged = RigOverrideConfigSchema.parse({ ...(existing?.config ?? {}), ...config });
+  query(sql, /* sql */ `UPDATE rigs SET config = ? WHERE id = ?`, [JSON.stringify(merged), rigId]);
 }

--- a/services/gastown/src/dos/town/scheduling.ts
+++ b/services/gastown/src/dos/town/scheduling.ts
@@ -22,7 +22,7 @@ const LOG = '[scheduling]';
 
 // ── Constants ──────────────────────────────────────────────────────────
 
-export const DISPATCH_COOLDOWN_MS = 2 * 60_000; // 2 min
+export const DISPATCH_COOLDOWN_MS = 30_000; // 30 sec
 export const MAX_DISPATCH_ATTEMPTS = 5;
 
 // ── Context passed by the Town DO ──────────────────────────────────────

--- a/services/gastown/src/dos/town/scheduling.ts
+++ b/services/gastown/src/dos/town/scheduling.ts
@@ -289,10 +289,22 @@ export function hasActiveWork(sql: SqlStorage): boolean {
       [patrol.TRIAGE_LABEL_LIKE]
     ),
   ];
+  // Open issue beads with a rig (eligible for dispatch by reconcileBeads Rule 1)
+  // but not yet assigned to any agent. Without this check, the alarm drops to
+  // idle cadence after a container restart when agents lose their hooks and
+  // beads revert to open+unassigned, delaying dispatch by up to 5 minutes.
+  const unassignedIssueRows = [
+    ...query(
+      sql,
+      /* sql */ `SELECT COUNT(*) as cnt FROM ${beads} WHERE ${beads.type} = 'issue' AND ${beads.status} = 'open' AND ${beads.rig_id} IS NOT NULL AND ${beads.assignee_agent_bead_id} IS NULL`,
+      []
+    ),
+  ];
   return (
     Number(activeAgentRows[0]?.cnt ?? 0) > 0 ||
     Number(pendingBeadRows[0]?.cnt ?? 0) > 0 ||
     Number(pendingReviewRows[0]?.cnt ?? 0) > 0 ||
-    Number(pendingTriageRows[0]?.cnt ?? 0) > 0
+    Number(pendingTriageRows[0]?.cnt ?? 0) > 0 ||
+    Number(unassignedIssueRows[0]?.cnt ?? 0) > 0
   );
 }

--- a/services/gastown/src/dos/town/scheduling.ts
+++ b/services/gastown/src/dos/town/scheduling.ts
@@ -124,6 +124,8 @@ export async function dispatchAgent(
       [timestamp, bead.bead_id]
     );
 
+    const rigRecord = rigs.getRig(ctx.sql, rigId);
+
     const started = await dispatch.startAgentInContainer(ctx.env, ctx.storage, {
       townId: ctx.townId,
       rigId,
@@ -140,6 +142,7 @@ export async function dispatchAgent(
       defaultBranch: rigConfig.defaultBranch,
       kilocodeToken,
       townConfig,
+      rigOverride: rigRecord?.config ?? null,
       platformIntegrationId: rigConfig.platformIntegrationId,
       convoyFeatureBranch: convoyFeatureBranch ?? undefined,
       systemPromptOverride: options?.systemPromptOverride,

--- a/services/gastown/src/dos/town/town-scm.ts
+++ b/services/gastown/src/dos/town/town-scm.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
 import type { TownConfig } from '../../types';
 import type { PRFeedbackCheckResult } from './actions';
-import { GitHubPRStatusSchema, GitLabMRStatusSchema } from '../../util/platform-pr.util';
+import {
+  GitHubPRStatusSchema,
+  GitLabMRStatusSchema,
+  parseGitUrl,
+} from '../../util/platform-pr.util';
 import { writeEvent } from '../../util/analytics.util';
 
 const TOWN_LOG = '[town-scm]';
@@ -10,17 +14,24 @@ export type SCMContext = {
   env: Env;
   townId: string;
   getTownConfig: () => Promise<TownConfig>;
+  /**
+   * Rig-level platform integration ID. When provided, it is tried as a
+   * fallback after town-level git_auth so that rigs authenticated solely
+   * through a rig-scoped GitHub App installation can still resolve a token.
+   */
+  platformIntegrationId?: string;
 };
 
 /**
  * Resolve a GitHub API token from the town config.
- * Fallback chain: github_token → github_cli_pat → platform integration (GitHub App).
+ * Fallback chain: github_token → github_cli_pat → town platform integration → rig platform integration.
  */
 export async function resolveGitHubToken(ctx: SCMContext): Promise<string | null> {
   const townConfig = await ctx.getTownConfig();
   let token = townConfig.git_auth?.github_token ?? townConfig.github_cli_pat;
   if (!token) {
-    const integrationId = townConfig.git_auth?.platform_integration_id;
+    const integrationId =
+      townConfig.git_auth?.platform_integration_id ?? ctx.platformIntegrationId;
     if (integrationId && ctx.env.GIT_TOKEN_SERVICE) {
       try {
         token = await ctx.env.GIT_TOKEN_SERVICE.getToken(integrationId);
@@ -476,4 +487,94 @@ export async function mergePR(ctx: SCMContext, prUrl: string): Promise<boolean> 
 
   console.warn(`${TOWN_LOG} mergePR: all merge methods rejected for ${prUrl}`);
   return false;
+}
+
+/**
+ * Create the convoy feature branch on the remote GitHub repository so that it
+ * exists before any polecat tries to open a PR targeting it.
+ *
+ * The branch is created at the current tip of the rig's default branch.
+ * If the branch already exists (HTTP 422) the call is treated as a no-op.
+ * If no GitHub token is available, the error is logged and the function
+ * returns without throwing — convoy creation continues, but branch creation
+ * is skipped.
+ */
+export async function createConvoyBranch(
+  ctx: SCMContext,
+  opts: {
+    gitUrl: string;
+    defaultBranch: string;
+    featureBranch: string;
+  }
+): Promise<void> {
+  const token = await resolveGitHubToken(ctx);
+  if (!token) {
+    console.warn(
+      `${TOWN_LOG} createConvoyBranch: no GitHub token available — skipping branch creation for ${opts.featureBranch}`
+    );
+    return;
+  }
+
+  const coords = parseGitUrl(opts.gitUrl);
+  if (!coords || coords.platform !== 'github') {
+    // Non-GitHub repos or unparseable URLs: skip silently (GitLab uses a
+    // different flow; nothing breaks if the branch doesn't pre-exist there).
+    return;
+  }
+
+  const { owner, repo } = coords;
+  const apiBase = `https://api.github.com/repos/${owner}/${repo}`;
+  const headers = {
+    Authorization: `token ${token}`,
+    Accept: 'application/vnd.github.v3+json',
+    'User-Agent': 'Gastown/1.0',
+    'Content-Type': 'application/json',
+  };
+
+  // 1. Resolve the SHA at the tip of the default branch.
+  const refRes = await fetch(`${apiBase}/git/ref/heads/${opts.defaultBranch}`, { headers });
+  if (!refRes.ok) {
+    const text = await refRes.text().catch(() => '(unreadable)');
+    console.warn(
+      `${TOWN_LOG} createConvoyBranch: failed to resolve default branch SHA (${refRes.status}): ${text.slice(0, 200)}`
+    );
+    return;
+  }
+
+  const refJson = await refRes.json().catch(() => null);
+  const shaResult = z
+    .object({ object: z.object({ sha: z.string() }) })
+    .safeParse(refJson);
+  if (!shaResult.success) {
+    console.warn(`${TOWN_LOG} createConvoyBranch: unexpected ref response shape`);
+    return;
+  }
+  const sha = shaResult.data.object.sha;
+
+  // 2. Create the convoy feature branch pointing at that SHA.
+  const createRes = await fetch(`${apiBase}/git/refs`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ ref: `refs/heads/${opts.featureBranch}`, sha }),
+  });
+
+  if (createRes.ok) {
+    console.log(
+      `${TOWN_LOG} createConvoyBranch: created ${opts.featureBranch} at ${sha.slice(0, 8)} in ${owner}/${repo}`
+    );
+    return;
+  }
+
+  if (createRes.status === 422) {
+    // Branch already exists — idempotent, treat as success.
+    console.log(
+      `${TOWN_LOG} createConvoyBranch: branch ${opts.featureBranch} already exists in ${owner}/${repo} — skipping`
+    );
+    return;
+  }
+
+  const errText = await createRes.text().catch(() => '(unreadable)');
+  console.warn(
+    `${TOWN_LOG} createConvoyBranch: GitHub API returned ${createRes.status} when creating ${opts.featureBranch}: ${errText.slice(0, 200)}`
+  );
 }

--- a/services/gastown/src/dos/town/town-scm.ts
+++ b/services/gastown/src/dos/town/town-scm.ts
@@ -30,8 +30,7 @@ export async function resolveGitHubToken(ctx: SCMContext): Promise<string | null
   const townConfig = await ctx.getTownConfig();
   let token = townConfig.git_auth?.github_token ?? townConfig.github_cli_pat;
   if (!token) {
-    const integrationId =
-      townConfig.git_auth?.platform_integration_id ?? ctx.platformIntegrationId;
+    const integrationId = townConfig.git_auth?.platform_integration_id ?? ctx.platformIntegrationId;
     if (integrationId && ctx.env.GIT_TOKEN_SERVICE) {
       try {
         token = await ctx.env.GIT_TOKEN_SERVICE.getToken(integrationId);
@@ -542,9 +541,7 @@ export async function createConvoyBranch(
   }
 
   const refJson = await refRes.json().catch(() => null);
-  const shaResult = z
-    .object({ object: z.object({ sha: z.string() }) })
-    .safeParse(refJson);
+  const shaResult = z.object({ object: z.object({ sha: z.string() }) }).safeParse(refJson);
   if (!shaResult.success) {
     console.warn(`${TOWN_LOG} createConvoyBranch: unexpected ref response shape`);
     return;

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -16,7 +16,7 @@ import { getGastownOrgStub } from '../dos/GastownOrg.do';
 import type { JwtOrgMembership } from '../middleware/auth.middleware';
 import { generateKiloApiToken } from '../util/kilo-token.util';
 import { resolveSecret } from '../util/secret.util';
-import { TownConfigSchema, TownConfigUpdateSchema } from '../types';
+import { TownConfigSchema, TownConfigUpdateSchema, RigOverrideConfigSchema } from '../types';
 import { resolveModel } from '../dos/town/config';
 import type { UserRigRecord } from '../db/tables/user-rigs.table';
 import {
@@ -558,7 +558,8 @@ export const gastownRouter = router({
       // Sequential to avoid "excessively deep" type inference with Rpc.Promisified DO stubs.
       const agentList = await townStub.listAgents({ rig_id: rig.id });
       const beadList = await townStub.listBeads({ rig_id: rig.id, status: 'in_progress' });
-      return { ...rig, agents: agentList, beads: beadList };
+      const townRig = await townStub.getRigAsync(rig.id);
+      return { ...rig, agents: agentList, beads: beadList, config: townRig?.config };
     }),
 
   deleteRig: gastownProcedure
@@ -585,6 +586,47 @@ export const gastownRouter = router({
       await townStub.removeRig(input.rigId);
       const ownerStub = ownership.stub;
       await ownerStub.deleteRig(input.rigId);
+    }),
+
+  updateRigConfig: gastownProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid().optional(),
+        rigId: z.string().uuid(),
+        config: RigOverrideConfigSchema,
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
+      const ownership = await resolveTownOwnership(ctx.env, ctx, rig.town_id);
+
+      // Admins cannot modify rig config for towns they do not own
+      if (ownership.type === 'admin') {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Admins cannot modify rig configuration for rigs they do not own',
+        });
+      }
+
+      // For org towns, only owners or the town creator can update rig config
+      if (ownership.type === 'org') {
+        const townStubForCheck = getTownDOStub(ctx.env, rig.town_id);
+        const townConfig = await townStubForCheck.getTownConfig();
+        const membership = getOrgMembership(ctx.orgMemberships, ownership.orgId);
+        const isOrgOwner = membership?.role === 'owner';
+        const isTownCreator = ctx.userId === townConfig.created_by_user_id;
+        if (!isOrgOwner && !isTownCreator) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'Only town creators and org owners can update rig config',
+          });
+        }
+      }
+
+      const townStub = getTownDOStub(ctx.env, rig.town_id);
+      await townStub.updateRigConfig(input.rigId, input.config);
+      const updatedRig = await townStub.getRigAsync(input.rigId);
+      return updatedRig;
     }),
 
   // ── Beads ───────────────────────────────────────────────────────────
@@ -1028,8 +1070,8 @@ export const gastownRouter = router({
       // auth-relevant config changed. The SDK server is a child process
       // that captures env at spawn time, so it must be restarted to pick
       // up rotated tokens or cleared credentials.
-      const oldMayorModel = resolveModel(existingConfig, '', 'mayor');
-      const newMayorModel = resolveModel(result, '', 'mayor');
+      const oldMayorModel = resolveModel(existingConfig, null, 'mayor');
+      const newMayorModel = resolveModel(result, null, 'mayor');
       const mayorModelChanged =
         newMayorModel !== oldMayorModel || result.small_model !== existingConfig.small_model;
       const authConfigChanged =

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -690,6 +690,20 @@ export const gastownRouter = router({
       await townStub.deleteAgent(input.agentId);
     }),
 
+  resetAgentDispatchAttempts: gastownProcedure
+    .input(
+      z.object({
+        rigId: z.string().uuid(),
+        agentId: z.string().uuid(),
+        townId: z.string().uuid().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
+      const townStub = getTownDOStub(ctx.env, rig.town_id);
+      await townStub.resetAgentDispatchAttempts(input.agentId, rig.id);
+    }),
+
   // ── Work Assignment ─────────────────────────────────────────────────
 
   sling: gastownProcedure

--- a/services/gastown/src/trpc/schemas.ts
+++ b/services/gastown/src/trpc/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { RigOverrideConfigSchema } from '../types';
 
 /**
  * Wraps a Zod schema in z.any().pipe(schema) so the TS input type is `any`
@@ -164,6 +165,7 @@ export const RigDetailOutput = z.object({
   platform_integration_id: z.string().nullable().optional().default(null),
   created_at: z.string(),
   updated_at: z.string(),
+  config: RigOverrideConfigSchema.optional(),
   agents: z.array(AgentOutput),
   beads: z.array(BeadOutput),
 });

--- a/services/gastown/src/types.ts
+++ b/services/gastown/src/types.ts
@@ -330,6 +330,47 @@ export const TownConfigSchema = z.object({
 
 export type TownConfig = z.infer<typeof TownConfigSchema>;
 
+// -- Rig Override Configuration --
+
+export const RigOverrideConfigSchema = z.object({
+  // Model overrides (override townConfig.default_model / role_models)
+  default_model: z.string().optional(),
+  role_models: z
+    .object({
+      polecat: z.string().optional(),
+      refinery: z.string().optional(),
+    })
+    .optional(),
+
+  // Review behavior
+  review_mode: z.enum(['rework', 'comments']).optional(),
+  /** false = skip refinery entirely */
+  code_review: z.boolean().optional(),
+  auto_resolve_pr_feedback: z.boolean().optional(),
+  auto_merge_delay_minutes: z.number().int().min(0).nullable().optional(),
+
+  // Merge strategy
+  merge_strategy: z.enum(['direct', 'pr']).optional(),
+  convoy_merge_mode: z.enum(['review-then-land', 'review-and-merge']).optional(),
+
+  // Custom instructions
+  custom_instructions: z
+    .object({
+      polecat: z.string().optional(),
+      refinery: z.string().optional(),
+    })
+    .optional(),
+
+  // Git
+  git_push_flags: z.string().optional(),
+
+  // Agent limits
+  max_concurrent_polecats: z.number().int().positive().optional(),
+  max_dispatch_attempts: z.number().int().positive().optional(),
+});
+
+export type RigOverrideConfig = z.infer<typeof RigOverrideConfigSchema>;
+
 /**
  * Partial update schema — all fields optional, NO defaults.
  * TownConfigSchema.partial() can't be used here because Zod still fires


### PR DESCRIPTION
## Summary

Batch merge of 8 PRs from `gastown-staging` into `main`, covering dispatch reliability, container lifecycle stability, UI improvements, convoy SCM, and rig-level configuration.

### Dispatch & Scheduling Hardening
- **Dispatch attempts auto-reset & backoff** ([#2249](https://github.com/Kilo-Org/cloud/pull/2249)) — Increased `MAX_DISPATCH_ATTEMPTS` to 5, added exponential backoff via `getDispatchCooldownMs`, auto-reset after 30-minute cooldown, and reset on successful heartbeat.
- **Live bead alarm status counts** ([#2256](https://github.com/Kilo-Org/cloud/pull/2256)) — Replaced cumulative accumulator pattern with live `GROUP BY` SQL counts so bead status always reflects the true database state.

### Container Lifecycle Fixes
- **Persist `GASTOWN_ORGANIZATION_ID` across restarts** ([#2250](https://github.com/Kilo-Org/cloud/pull/2250)) — Added `GASTOWN_ORGANIZATION_ID` to `LIVE_ENV_KEYS` to survive env-snapshot restores and model hot-swaps.
- **Restore team/org context after container restart** ([#2266](https://github.com/Kilo-Org/cloud/pull/2266)) — Fixed three compounding issues where `ensureSDKServer()` env snapshot restore deleted critical keys, `organizationId` wasn't durably stored on `ManagedAgent`, and `lastKnownTownConfig` was null after restart because health pings omitted `X-Town-Config`.

### Convoy SCM
- **Create convoy feature branch on remote at creation time** ([#2268](https://github.com/Kilo-Org/cloud/pull/2268)) — Calls GitHub REST API to create the convoy branch pointing at the default branch tip immediately when a convoy is created, so the first polecat PR always has a valid target. Gracefully handles missing tokens, non-GitHub repos, and idempotent 422s.

### UI Improvements
- **Hide app topbar on town pages** ([#2248](https://github.com/Kilo-Org/cloud/pull/2248)) — Removed the redundant app-level topbar on gastown pages and integrated the sidebar trigger into the gastown page headers, reclaiming vertical space.
- **Manual dispatch_attempts reset button** ([#2255](https://github.com/Kilo-Org/cloud/pull/2255)) — Added an amber "Reset" button in agent drawers (both panel and standalone) to surgically zero `dispatch_attempts` via a new `resetAgentDispatchAttempts` tRPC mutation, unblocking stuck agents without a full reset.

### Rig Configuration
- **Rig settings page** ([#2273](https://github.com/Kilo-Org/cloud/pull/2273)) — New `/rigs/[rigId]/settings` page with scrollspy sidebar, covering model overrides, refinery config, merge strategy, custom instructions, git push flags, and agent limits. Each field shows the inherited town-level value as placeholder with a clear button to remove overrides.

## Verification

- All 8 constituent PRs were individually reviewed and merged to `gastown-staging`
- Typecheck passed on each PR at merge time
- Constituent PRs linked above contain detailed per-change verification

## Visual Changes

- App topbar hidden on gastown town pages; sidebar trigger moved into gastown headers ([#2248](https://github.com/Kilo-Org/cloud/pull/2248))
- Dispatch attempts reset button shown in agent drawer when `dispatch_attempts > 0` ([#2255](https://github.com/Kilo-Org/cloud/pull/2255))
- New rig settings page at `/rigs/[rigId]/settings` ([#2273](https://github.com/Kilo-Org/cloud/pull/2273))

<img width="1579" height="1237" alt="image" src="https://github.com/user-attachments/assets/a5c957cd-374f-462f-8bc0-135dc8abf543" />


## Reviewer Notes

- The 8 PRs were staged on `gastown-staging` to batch test interactions before landing on `main`
- `router.d.ts` is a hand-maintained type declaration file updated in several PRs — changes reflect the actual tRPC router shape
- The container env persistence fixes (#2250, #2266) address the same root cause (org context loss) from different angles — #2250 is the `LIVE_ENV_KEYS` fix, #2266 is the broader 3-part fix including durable `ManagedAgent.organizationId` and health-check config propagation