### PR TITLE
fix(kiloclaw): add env.dev to prevent wrangler OAuth prompt on local dev start

### DIFF
--- a/services/kiloclaw/package.json
+++ b/services/kiloclaw/package.json
@@ -8,8 +8,8 @@
   "type": "module",
   "scripts": {
     "deploy": "wrangler deploy",
-    "start": "wrangler dev",
-    "dev": "wrangler dev",
+    "start": "wrangler dev --env dev",
+    "dev": "wrangler dev --env dev",
     "types": "wrangler types",
     "typecheck": "tsgo --noEmit",
     "lint": "pnpm -w exec oxlint --config .oxlintrc.json services/kiloclaw/src",

--- a/services/kiloclaw/wrangler.jsonc
+++ b/services/kiloclaw/wrangler.jsonc
@@ -192,7 +192,6 @@
         "WORKER_ENV": "development",
         "NEXT_PUBLIC_POSTHOG_KEY": "phc_GK2Pxl0HPj5ZPfwhLRjXrtdz8eD7e9MKnXiFrOqnB6z",
       },
-
     },
   },
 }

--- a/services/kiloclaw/wrangler.jsonc
+++ b/services/kiloclaw/wrangler.jsonc
@@ -133,4 +133,66 @@
   // FLY_API_TOKEN,
   // NEXTAUTH_SECRET, INTERNAL_API_SECRET, GATEWAY_TOKEN_SECRET,
   // AGENT_ENV_VARS_PRIVATE_KEY
+
+  "env": {
+    "dev": {
+      "durable_objects": {
+        "bindings": [
+          { "class_name": "KiloClawInstance", "name": "KILOCLAW_INSTANCE" },
+          { "class_name": "KiloClawApp", "name": "KILOCLAW_APP" },
+          { "class_name": "KiloClawRegistry", "name": "KILOCLAW_REGISTRY" },
+        ],
+      },
+      "kv_namespaces": [
+        {
+          "binding": "KV_CLAW_CACHE",
+          "id": "1f406d747ead4a5896b750c1000973e0",
+        },
+      ],
+      "analytics_engine_datasets": [
+        { "binding": "KILOCLAW_AE", "dataset": "kiloclaw_events" },
+        {
+          "binding": "KILOCLAW_CONTROLLER_AE",
+          "dataset": "kiloclaw_controller_telemetry",
+        },
+      ],
+      "queues": {
+        "producers": [
+          { "queue": "kiloclaw-snapshot-restore", "binding": "SNAPSHOT_RESTORE_QUEUE" },
+        ],
+        "consumers": [
+          {
+            "queue": "kiloclaw-snapshot-restore",
+            "max_batch_size": 1,
+            "max_batch_timeout": 5,
+            "max_retries": 2,
+            "max_concurrency": 2,
+            "dead_letter_queue": "kiloclaw-snapshot-restore-dlq",
+          },
+        ],
+      },
+      "hyperdrive": [
+        {
+          "binding": "HYPERDRIVE",
+          "id": "624ec80650dd414199349f4e217ddb10",
+          "localConnectionString": "postgres://postgres:postgres@localhost:5432/postgres",
+        },
+      ],
+      "vars": {
+        "FLY_APP_NAME": "kiloclaw-machines",
+        "FLY_REGISTRY_APP": "kiloclaw-machines",
+        "FLY_ORG_SLUG": "kilo-679",
+        "FLY_IMAGE_TAG": "latest",
+        "FLY_REGION": "eu,us",
+        "BACKEND_API_URL": "https://app.kilo.ai",
+        "OPENCLAW_ALLOWED_ORIGINS": "https://claw.kilosessions.ai,https://kilo.ai,https://www.kilo.ai",
+        "KILOCLAW_CHECKIN_URL": "https://claw.kilosessions.ai/api/controller/checkin",
+        "REQUIRE_PROXY_TOKEN": "true",
+        "PROACTIVE_REFRESH_THRESHOLD_HOURS": "72",
+        "WORKER_ENV": "development",
+        "NEXT_PUBLIC_POSTHOG_KEY": "phc_GK2Pxl0HPj5ZPfwhLRjXrtdz8eD7e9MKnXiFrOqnB6z",
+      },
+
+    },
+  },
 }


### PR DESCRIPTION
## Motivation

Since #2205 landed, `wrangler dev` for kiloclaw opens a browser OAuth flow against the Cloudflare Pipelines API and then crashes because the redirect port is already in use. This is the bug Remon and Florian reported on April 9.

The cause is that wrangler, when it sees a `pipelines` binding in the top-level config, attempts to authenticate against Cloudflare to simulate that binding locally. The earlier attempt to fix this used an `env.dev` override with an empty `pipelines` array, but wrangler `env` overrides only apply when you pass `--env` explicitly. Plain `wrangler dev` always reads the top-level config.

## Implementation

The fix follows the `env.dev` pattern already established by `cloud-agent` and `cloud-agent-next`: add a named `env.dev` environment to `wrangler.jsonc` and switch the `dev` and `start` scripts to `wrangler dev --env dev`.

`env.dev` redeclares all bindings that wrangler does not inherit across named environments: `durable_objects`, `kv_namespaces`, `analytics_engine_datasets`, `queues`, `hyperdrive`, and `vars`. Pipeline bindings are intentionally absent. Pipelines have no local simulation in wrangler, so declaring them in `env.dev` would route `.send()` calls to the real Cloudflare Pipelines API. Both bindings are typed as optional in `KiloClawEnv` and the write paths in `analytics.ts` and `controller.ts` are guarded with `if` checks, so they no-op when the bindings are absent.

The `name` override is omitted from `env.dev` so that `kiloclaw-billing` and `gmail-push`, which bind to `service: "kiloclaw"` by name, continue to resolve correctly in local dev.

A wrangler warning about pipelines not being inherited by `env.dev` remains. It is cosmetic — the worker starts correctly and no OAuth flow is triggered.

## Testing

`pnpm --filter kiloclaw typecheck` passes. Verified locally: `pnpm dev` in `services/kiloclaw` starts the worker on port 8795 with no browser window opening.

## Notes

`KV_CLAW_CACHE` in `env.dev` reuses the production namespace ID because no separate dev namespace exists. Reads and writes during local dev hit real production cache entries, which is the same behaviour as before this PR.