### PR TITLE
feat(mobile): send SKAN and AdAttributionKit postback copies to AppsFlyer

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -26,6 +26,10 @@ const config: ExpoConfig = {
     usesAppleSignIn: true,
     infoPlist: {
       ITSAppUsesNonExemptEncryption: false,
+      NSAdvertisingAttributionReportEndpoint: 'https://appsflyer-skadnetwork.com/',
+      AdAttributionKit: {
+        PostbackCopyURL: 'https://appsflyer-skadnetwork.com/',
+      },
       NSMicrophoneUsageDescription:
         'Allow $(PRODUCT_NAME) to access your microphone to record audio messages.',
       NSPhotoLibraryUsageDescription:


### PR DESCRIPTION
## Summary
- Adds `NSAdvertisingAttributionReportEndpoint` and `AdAttributionKit.PostbackCopyURL` Info.plist keys pointing to `https://appsflyer-skadnetwork.com/`
- Apple will forward SKAdNetwork and AdAttributionKit postback copies to AppsFlyer for marketing attribution reporting

## Test plan
- [ ] Verify new keys appear in the built Info.plist (`expo prebuild --clean` then check `ios/KiloClaw/Info.plist`)
- [ ] Confirm no runtime regressions on iOS