### PR TITLE
fix(auth): strip GitHub iss param to fix OAuth login

### DIFF
--- a/apps/web/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/src/app/api/auth/[...nextauth]/route.ts
@@ -16,8 +16,8 @@ function stripGitHubIssParam(request: NextRequest): NextRequest {
   return request;
 }
 
-async function handler(request: NextRequest) {
-  return nextAuthHttpHandler(stripGitHubIssParam(request));
+async function handler(request: NextRequest, context: unknown) {
+  return nextAuthHttpHandler(stripGitHubIssParam(request), context);
 }
 
 export { handler as GET, handler as POST };

--- a/apps/web/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,23 @@
 import { nextAuthHttpHandler } from '@/lib/user.server';
+import { NextRequest } from 'next/server';
 
-export { nextAuthHttpHandler as GET, nextAuthHttpHandler as POST };
+// GitHub recently started appending `&iss=https://github.com/login/oauth` to
+// their OAuth callback URL (per RFC 9207). NextAuth v4's openid-client sees
+// the `iss` param and tries to validate it, but GithubProvider has no issuer
+// configured (it's plain OAuth, not OIDC), causing the error: "issuer must be
+// configured on the issuer". Stripping the param before NextAuth processes it
+// fixes the issue without reducing security — we already validate `state`.
+function stripGitHubIssParam(request: NextRequest): NextRequest {
+  const url = request.nextUrl.clone();
+  if (url.pathname.includes('/callback/github') && url.searchParams.has('iss')) {
+    url.searchParams.delete('iss');
+    return new NextRequest(url, request);
+  }
+  return request;
+}
+
+async function handler(request: NextRequest) {
+  return nextAuthHttpHandler(stripGitHubIssParam(request));
+}
+
+export { handler as GET, handler as POST };


### PR DESCRIPTION
## Summary

- GitHub recently started appending `&iss=https://github.com/login/oauth` to OAuth callback URLs ([RFC 9207](https://datatracker.ietf.org/doc/html/rfc9207))
- NextAuth v4's `openid-client` sees the `iss` param and tries to validate the issuer, but `GithubProvider` has no issuer configured (plain OAuth, not OIDC)
- **All GitHub logins have been failing since 2026-04-09 ~19:21 UTC** with `"issuer must be configured on the issuer"`
- Fix: strip the `iss` query param from GitHub callbacks before NextAuth processes them. This doesn't reduce security — we already validate `state` for CSRF protection

## Test plan

- [x] Typecheck passes
- [ ] Verify GitHub login works on Vercel preview
- [ ] Verify Google/Apple/other OAuth providers still work (unaffected paths)