### PR TITLE
fix(email): update clawInstanceReady email with value copy and free tier clarity

### DIFF
--- a/apps/web/src/emails/clawInstanceReady.html
+++ b/apps/web/src/emails/clawInstanceReady.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Instance Ready</title>
+    <title>Your KiloClaw instance is live</title>
   </head>
   <body
     style="
@@ -35,7 +35,7 @@
                     font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                   "
                 >
-                  Your Instance Is Ready
+                  Your KiloClaw instance is live
                 </h1>
               </td>
             </tr>
@@ -46,19 +46,75 @@
                   style="
                     margin: 0 0 16px;
                     font-size: 14px;
-                    line-height: 20px;
+                    line-height: 22px;
                     color: #9ca3af;
                     font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                   "
                 >
-                  Your KiloClaw instance has finished setting up and is
-                  <strong style="color: #d1d5db">ready to use</strong>. You can now connect and
-                  start working.
+                  Your KiloClaw instance is now ready to use.
                 </p>
-                <!-- CTA Button -->
+                <p
+                  style="
+                    margin: 0 0 24px;
+                    font-size: 14px;
+                    line-height: 22px;
+                    color: #9ca3af;
+                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                  "
+                >
+                  KiloClaw isn't a chatbot. It's an assistant that acts on your behalf, even when
+                  you're not around. Connect your email, calendar, and other tools — then ask it to
+                  take care of things for you.
+                </p>
+
+                <!-- Free tier block -->
+                <table
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  style="
+                    background-color: #1a1a1a;
+                    border: 1px solid #3a3a3a;
+                    border-radius: 6px;
+                    margin-bottom: 28px;
+                  "
+                >
+                  <tr>
+                    <td style="padding: 20px 24px">
+                      <p
+                        style="
+                          margin: 0 0 6px;
+                          font-size: 11px;
+                          font-weight: 700;
+                          color: #f4e452;
+                          letter-spacing: 0.08em;
+                          text-transform: uppercase;
+                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                        "
+                      >
+                        What's free and for how long
+                      </p>
+                      <p
+                        style="
+                          margin: 0;
+                          font-size: 13px;
+                          line-height: 21px;
+                          color: #9ca3af;
+                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                        "
+                      >
+                        Your KiloClaw hosting is free for 7 days. For the first 6 hours we also
+                        cover AI inference costs — no setup needed. After that, inference is at
+                        cost: you pick the model, you pay only what the AI provider charges us.
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+
+                <!-- Primary CTA -->
                 <table width="100%" cellpadding="0" cellspacing="0">
                   <tr>
-                    <td align="center" style="padding: 10px 0 20px">
+                    <td align="center" style="padding: 0 0 12px">
                       <a
                         href="{{ claw_url }}"
                         style="
@@ -77,19 +133,45 @@
                       </a>
                     </td>
                   </tr>
+                  <!-- Secondary CTA -->
+                  <tr>
+                    <td align="center" style="padding: 0 0 20px">
+                      <a
+                        href="https://kilo.ai/kiloclaw/get-started"
+                        style="
+                          display: inline-block;
+                          padding: 12px 32px;
+                          background-color: transparent;
+                          color: #f4e452;
+                          text-decoration: none;
+                          border-radius: 6px;
+                          border: 1px solid #f4e452;
+                          font-size: 14px;
+                          font-weight: 700;
+                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                        "
+                      >
+                        Free onboarding session
+                      </a>
+                    </td>
+                  </tr>
+                  <!-- Docs link -->
+                  <tr>
+                    <td align="center" style="padding: 0 0 10px">
+                      <a
+                        href="https://kilo.ai/docs/kiloclaw/overview"
+                        style="
+                          font-size: 13px;
+                          color: #f4e452;
+                          text-decoration: underline;
+                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                        "
+                      >
+                        Read the documentation
+                      </a>
+                    </td>
+                  </tr>
                 </table>
-                <p
-                  style="
-                    margin: 0;
-                    font-size: 14px;
-                    line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-                  "
-                >
-                  If you have any questions, please don't hesitate to reply to this email. We are
-                  here to help!
-                </p>
               </td>
             </tr>
             <!-- Sign-off -->
@@ -98,6 +180,17 @@
                 <p
                   style="
                     margin: 20px 0 0;
+                    font-size: 14px;
+                    line-height: 20px;
+                    color: #9ca3af;
+                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                  "
+                >
+                  If you have any questions, reply to this email — we're here to help.
+                </p>
+                <p
+                  style="
+                    margin: 16px 0 0;
                     font-size: 14px;
                     line-height: 20px;
                     color: #9ca3af;

--- a/apps/web/src/routers/admin/email-testing-router.ts
+++ b/apps/web/src/routers/admin/email-testing-router.ts
@@ -87,6 +87,7 @@ function fixtureTemplateVars(template: TemplateName): Record<string, string | Ra
     case 'clawTrialEndingSoon':
       return { days_remaining: '5', claw_url: `${NEXTAUTH_URL}/claw` };
     case 'clawTrialExpiresTomorrow':
+    case 'clawInstanceReady':
     case 'clawInstanceDestroyed':
       return { claw_url: `${NEXTAUTH_URL}/claw` };
     case 'clawSuspendedTrial':


### PR DESCRIPTION
## Summary

- Rewrites the `clawInstanceReady` transactional email with more descriptive copy explaining what KiloClaw is and what users can do with it
- Adds a free tier clarity block explaining the 7-day free hosting and 6-hour inference coverage
- Adds a secondary CTA for the free onboarding session and a documentation link
- Fixes a missing fixture case for `clawInstanceReady` in the admin email testing router (was previously throwing on preview)

## Verification

- `pnpm typecheck` — no errors
- `pnpm format` — auto-formatted, passes `format:check`
- Previewed via `/admin/email-testing` → `clawInstanceReady`

## Visual Changes
<img width="1234" height="1496" alt="image (1)" src="https://github.com/user-attachments/assets/24868517-dc2e-4c84-9c80-1b51c2016ec4" />

N/A — email-only change, preview available in admin panel.

## Reviewer Notes

No new template variables introduced — `{{ claw_url }}` and `{{ year }}` unchanged. No updates needed to `email.ts`, `AGENTS.md`, or the instance-ready route.