### PR TITLE
feat(kiloclaw): add listAllInstances tRPC procedure

### DIFF
--- a/apps/web/src/lib/kiloclaw/instance-registry.ts
+++ b/apps/web/src/lib/kiloclaw/instance-registry.ts
@@ -272,9 +272,14 @@ export async function getActiveOrgInstance(
 /**
  * List all active instances for a user across all contexts (personal + orgs).
  * Used by the mobile "all claws" screen.
+ *
+ * Rows are ordered by created_at ASC so the oldest (canonical) row per context
+ * comes first. We then deduplicate: for personal instances and for each org,
+ * only the oldest row is kept — matching the semantics of getActiveInstance /
+ * getActiveOrgInstance which use LIMIT 1 + ORDER BY created_at.
  */
 export async function listAllActiveInstances(userId: string): Promise<ActiveKiloClawInstance[]> {
-  return db
+  const rows = await db
     .select({
       id: kiloclaw_instances.id,
       userId: kiloclaw_instances.user_id,
@@ -285,6 +290,17 @@ export async function listAllActiveInstances(userId: string): Promise<ActiveKilo
     .from(kiloclaw_instances)
     .where(and(eq(kiloclaw_instances.user_id, userId), isNull(kiloclaw_instances.destroyed_at)))
     .orderBy(kiloclaw_instances.created_at);
+
+  // Deduplicate: keep only the oldest row per context (personal = null orgId,
+  // org = specific orgId). Race conditions in ensureActiveInstance can leave
+  // orphan personal rows; getActiveInstance already handles this with LIMIT 1.
+  const seen = new Set<string>();
+  return rows.filter(row => {
+    const key = row.organizationId ?? 'personal';
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 /**

--- a/apps/web/src/lib/kiloclaw/instance-registry.ts
+++ b/apps/web/src/lib/kiloclaw/instance-registry.ts
@@ -283,9 +283,7 @@ export async function listAllActiveInstances(userId: string): Promise<ActiveKilo
       name: kiloclaw_instances.name,
     })
     .from(kiloclaw_instances)
-    .where(
-      and(eq(kiloclaw_instances.user_id, userId), isNull(kiloclaw_instances.destroyed_at))
-    )
+    .where(and(eq(kiloclaw_instances.user_id, userId), isNull(kiloclaw_instances.destroyed_at)))
     .orderBy(kiloclaw_instances.created_at);
 }
 

--- a/apps/web/src/lib/kiloclaw/instance-registry.ts
+++ b/apps/web/src/lib/kiloclaw/instance-registry.ts
@@ -270,6 +270,26 @@ export async function getActiveOrgInstance(
 }
 
 /**
+ * List all active instances for a user across all contexts (personal + orgs).
+ * Used by the mobile "all claws" screen.
+ */
+export async function listAllActiveInstances(userId: string): Promise<ActiveKiloClawInstance[]> {
+  return db
+    .select({
+      id: kiloclaw_instances.id,
+      userId: kiloclaw_instances.user_id,
+      sandboxId: kiloclaw_instances.sandbox_id,
+      organizationId: kiloclaw_instances.organization_id,
+      name: kiloclaw_instances.name,
+    })
+    .from(kiloclaw_instances)
+    .where(
+      and(eq(kiloclaw_instances.user_id, userId), isNull(kiloclaw_instances.destroyed_at))
+    )
+    .orderBy(kiloclaw_instances.created_at);
+}
+
+/**
  * List all active instances for an organization (all users).
  */
 export async function listActiveOrgInstances(orgId: string): Promise<ActiveKiloClawInstance[]> {

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -32,6 +32,7 @@ import {
   kiloclaw_cli_runs,
   cloud_agent_webhook_triggers,
   credit_transactions,
+  organizations,
 } from '@kilocode/db/schema';
 import { and, eq, ne, desc, isNotNull, isNull, inArray, sql, like, or } from 'drizzle-orm';
 import { deleteWorkerTrigger } from '@/lib/webhook-agent/webhook-agent-client';
@@ -40,6 +41,7 @@ import type { KiloClawDashboardStatus, KiloCodeConfigResponse } from '@/lib/kilo
 import {
   ensureActiveInstance,
   getActiveInstance,
+  listAllActiveInstances,
   markActiveInstanceDestroyed,
   markInstanceDestroyedById,
   renameInstance,
@@ -1430,6 +1432,57 @@ export const kiloclawRouter = createTRPCRouter({
   latestVersion: baseProcedure.query(async () => {
     const client = new KiloClawInternalClient();
     return client.getLatestVersion();
+  }),
+
+  /**
+   * List all active KiloClaw instances for the user across all contexts
+   * (personal + every org they belong to). Returns lightweight metadata
+   * with live status for each instance.
+   */
+  listAllInstances: baseProcedure.query(async ({ ctx }) => {
+    const instances = await listAllActiveInstances(ctx.user.id);
+    if (instances.length === 0) return [];
+
+    // Build org name map for instances that belong to organizations
+    const orgIds = [
+      ...new Set(instances.map(i => i.organizationId).filter((id): id is string => id !== null)),
+    ];
+    const orgNameMap = new Map<string, string>();
+    if (orgIds.length > 0) {
+      const orgs = await db
+        .select({ id: organizations.id, name: organizations.name })
+        .from(organizations)
+        .where(inArray(organizations.id, orgIds));
+      for (const org of orgs) {
+        orgNameMap.set(org.id, org.name);
+      }
+    }
+
+    // Fetch live status from each instance's worker in parallel
+    const client = new KiloClawInternalClient();
+    const results = await Promise.all(
+      instances.map(async (instance) => {
+        let status: string | null = null;
+        try {
+          const workerStatus = await client.getStatus(ctx.user.id, workerInstanceId(instance));
+          status = workerStatus.status;
+        } catch {
+          // Worker unreachable — show as null (unknown)
+        }
+        return {
+          id: instance.id,
+          sandboxId: instance.sandboxId,
+          name: instance.name,
+          organizationId: instance.organizationId,
+          organizationName: instance.organizationId
+            ? (orgNameMap.get(instance.organizationId) ?? null)
+            : null,
+          status,
+        };
+      })
+    );
+
+    return results;
   }),
 
   getStatus: baseProcedure.query(async ({ ctx }) => {

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -1461,7 +1461,7 @@ export const kiloclawRouter = createTRPCRouter({
     // Fetch live status from each instance's worker in parallel
     const client = new KiloClawInternalClient();
     const results = await Promise.all(
-      instances.map(async (instance) => {
+      instances.map(async instance => {
         let status: string | null = null;
         try {
           const workerStatus = await client.getStatus(ctx.user.id, workerInstanceId(instance));


### PR DESCRIPTION
## Summary
- New `listAllActiveInstances(userId)` function in instance-registry that queries all active instances for a user across personal and org contexts
- New `listAllInstances` tRPC procedure on the kiloclaw router that returns all instances with live status from workers and org names for display
- Supports the mobile app's upcoming context removal (see dependent PR)

## Test plan
- [ ] Verify the endpoint returns personal + org instances for a user with both
- [ ] Verify status is fetched in parallel from workers
- [ ] Verify org names are resolved correctly
- [ ] Verify empty array is returned for users with no instances