### PR TITLE
feat(email): add complementary inference ended transactional email for KiloClaw

### DIFF
--- a/apps/web/src/app/api/internal/kiloclaw/billing-side-effects/route.ts
+++ b/apps/web/src/app/api/internal/kiloclaw/billing-side-effects/route.ts
@@ -29,6 +29,7 @@ const billingTemplateNames = [
   'clawEarlybirdEndingSoon',
   'clawEarlybirdExpiresTomorrow',
   'clawCreditRenewalFailed',
+  'clawComplementaryInferenceEnded',
 ] as const;
 
 type BillingSideEffectLogFields = BillingCorrelationContext & {

--- a/apps/web/src/emails/AGENTS.md
+++ b/apps/web/src/emails/AGENTS.md
@@ -70,5 +70,6 @@ Every template must include this branding footer below the card:
 | `clawDestructionWarning.html`       | `destruction_date`, `claw_url`, `year`                                                                                     | `27`                       |
 | `clawInstanceDestroyed.html`        | `claw_url`, `year`                                                                                                         | `28`                       |
 | `clawEarlybirdEndingSoon.html`      | `days_remaining`, `expiry_date`, `claw_url`, `year`                                                                        | `29`                       |
-| `clawEarlybirdExpiresTomorrow.html` | `expiry_date`, `claw_url`, `year`                                                                                          | `30`                       |
-| `accountDeletionRequest.html`       | `email`, `year`                                                                                                            | —                          |
+| `clawEarlybirdExpiresTomorrow.html`        | `expiry_date`, `claw_url`, `year`                                                                                   | `30`                       |
+| `clawComplementaryInferenceEnded.html`     | `claw_url`, `credits_url`, `free_model_name`, `year`                                                                | —                          |
+| `accountDeletionRequest.html`              | `email`, `year`                                                                                                     | —                          |

--- a/apps/web/src/emails/AGENTS.md
+++ b/apps/web/src/emails/AGENTS.md
@@ -48,28 +48,28 @@ Every template must include this branding footer below the card:
 
 ## Template Variables
 
-| Template file                       | Variables                                                                                                                  | Customer.io ID (crosswalk) |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| `orgSubscription.html`              | `seats`, `organization_url`, `invoices_url`, `year`                                                                        | `10`                       |
-| `orgRenewed.html`                   | `seats`, `invoices_url`, `year`                                                                                            | `11`                       |
-| `orgCancelled.html`                 | `invoices_url`, `year`                                                                                                     | `12`                       |
-| `orgSSOUserJoined.html`             | `new_user_email`, `organization_url`, `year`                                                                               | `13`                       |
-| `orgInvitation.html`                | `organization_name`, `inviter_name`, `accept_invite_url`, `year`                                                           | `6`                        |
-| `magicLink.html`                    | `magic_link_url`, `email`, `expires_in`, `year`                                                                            | `14`                       |
-| `balanceAlert.html`                 | `minimum_balance`, `organization_url`, `year`                                                                              | `16`                       |
-| `autoTopUpFailed.html`              | `reason`, `credits_url`, `year`                                                                                            | `17`                       |
-| `ossInviteNewUser.html`             | `tier_name`, `seats`, `seat_value`, `credits_section`, `accept_invite_url`, `integrations_url`, `code_reviews_url`, `year` | `18`                       |
-| `ossInviteExistingUser.html`        | `tier_name`, `seats`, `seat_value`, `credits_section`, `organization_url`, `integrations_url`, `code_reviews_url`, `year`  | `19`                       |
-| `ossExistingOrgProvisioned.html`    | `tier_name`, `seats`, `seat_value`, `credits_section`, `organization_url`, `integrations_url`, `code_reviews_url`, `year`  | `20`                       |
-| `deployFailed.html`                 | `deployment_name`, `deployment_url`, `repository`, `year`                                                                  | `21`                       |
-| `clawTrialEndingSoon.html`          | `days_remaining`, `claw_url`, `year`                                                                                       | `22`                       |
-| `clawTrialExpiresTomorrow.html`     | `claw_url`, `year`                                                                                                         | `23`                       |
-| `clawSuspendedTrial.html`           | `destruction_date`, `claw_url`, `year`                                                                                     | `24`                       |
-| `clawSuspendedSubscription.html`    | `destruction_date`, `claw_url`, `year`                                                                                     | `25`                       |
-| `clawSuspendedPayment.html`         | `destruction_date`, `claw_url`, `year`                                                                                     | `26`                       |
-| `clawDestructionWarning.html`       | `destruction_date`, `claw_url`, `year`                                                                                     | `27`                       |
-| `clawInstanceDestroyed.html`        | `claw_url`, `year`                                                                                                         | `28`                       |
-| `clawEarlybirdEndingSoon.html`      | `days_remaining`, `expiry_date`, `claw_url`, `year`                                                                        | `29`                       |
-| `clawEarlybirdExpiresTomorrow.html`        | `expiry_date`, `claw_url`, `year`                                                                                   | `30`                       |
-| `clawComplementaryInferenceEnded.html`     | `claw_url`, `credits_url`, `free_model_name`, `year`                                                                | —                          |
-| `accountDeletionRequest.html`              | `email`, `year`                                                                                                     | —                          |
+| Template file                          | Variables                                                                                                                  | Customer.io ID (crosswalk) |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `orgSubscription.html`                 | `seats`, `organization_url`, `invoices_url`, `year`                                                                        | `10`                       |
+| `orgRenewed.html`                      | `seats`, `invoices_url`, `year`                                                                                            | `11`                       |
+| `orgCancelled.html`                    | `invoices_url`, `year`                                                                                                     | `12`                       |
+| `orgSSOUserJoined.html`                | `new_user_email`, `organization_url`, `year`                                                                               | `13`                       |
+| `orgInvitation.html`                   | `organization_name`, `inviter_name`, `accept_invite_url`, `year`                                                           | `6`                        |
+| `magicLink.html`                       | `magic_link_url`, `email`, `expires_in`, `year`                                                                            | `14`                       |
+| `balanceAlert.html`                    | `minimum_balance`, `organization_url`, `year`                                                                              | `16`                       |
+| `autoTopUpFailed.html`                 | `reason`, `credits_url`, `year`                                                                                            | `17`                       |
+| `ossInviteNewUser.html`                | `tier_name`, `seats`, `seat_value`, `credits_section`, `accept_invite_url`, `integrations_url`, `code_reviews_url`, `year` | `18`                       |
+| `ossInviteExistingUser.html`           | `tier_name`, `seats`, `seat_value`, `credits_section`, `organization_url`, `integrations_url`, `code_reviews_url`, `year`  | `19`                       |
+| `ossExistingOrgProvisioned.html`       | `tier_name`, `seats`, `seat_value`, `credits_section`, `organization_url`, `integrations_url`, `code_reviews_url`, `year`  | `20`                       |
+| `deployFailed.html`                    | `deployment_name`, `deployment_url`, `repository`, `year`                                                                  | `21`                       |
+| `clawTrialEndingSoon.html`             | `days_remaining`, `claw_url`, `year`                                                                                       | `22`                       |
+| `clawTrialExpiresTomorrow.html`        | `claw_url`, `year`                                                                                                         | `23`                       |
+| `clawSuspendedTrial.html`              | `destruction_date`, `claw_url`, `year`                                                                                     | `24`                       |
+| `clawSuspendedSubscription.html`       | `destruction_date`, `claw_url`, `year`                                                                                     | `25`                       |
+| `clawSuspendedPayment.html`            | `destruction_date`, `claw_url`, `year`                                                                                     | `26`                       |
+| `clawDestructionWarning.html`          | `destruction_date`, `claw_url`, `year`                                                                                     | `27`                       |
+| `clawInstanceDestroyed.html`           | `claw_url`, `year`                                                                                                         | `28`                       |
+| `clawEarlybirdEndingSoon.html`         | `days_remaining`, `expiry_date`, `claw_url`, `year`                                                                        | `29`                       |
+| `clawEarlybirdExpiresTomorrow.html`    | `expiry_date`, `claw_url`, `year`                                                                                          | `30`                       |
+| `clawComplementaryInferenceEnded.html` | `claw_url`, `credits_url`, `free_model_name`, `year`                                                                       | —                          |
+| `accountDeletionRequest.html`          | `email`, `year`                                                                                                            | —                          |

--- a/apps/web/src/emails/clawComplementaryInferenceEnded.html
+++ b/apps/web/src/emails/clawComplementaryInferenceEnded.html
@@ -129,7 +129,7 @@
                       >
                         Switch to
                         <span style="color: #d1d5db">{{ free_model_name }}</span>
-                        in your KiloClaw settings for limited free inference.
+                        in your KiloClaw settings for free models with limited intelligence.
                       </p>
                     </td>
                   </tr>

--- a/apps/web/src/emails/clawComplementaryInferenceEnded.html
+++ b/apps/web/src/emails/clawComplementaryInferenceEnded.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Your Free Inference Period Has Ended</title>
+  </head>
+  <body
+    style="
+      margin: 0;
+      padding: 0;
+      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+      background-color: #1a1a1a;
+      color: #d1d5db;
+    "
+  >
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+      <tr>
+        <td align="center" style="padding: 40px 20px">
+          <table
+            width="600"
+            cellpadding="0"
+            cellspacing="0"
+            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
+          >
+            <!-- Header -->
+            <tr>
+              <td style="padding: 40px 40px 20px">
+                <h1
+                  style="
+                    margin: 0;
+                    font-size: 24px;
+                    font-weight: 700;
+                    color: #f4e452;
+                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                  "
+                >
+                  Your Free Inference Period Has Ended
+                </h1>
+              </td>
+            </tr>
+            <!-- Body -->
+            <tr>
+              <td style="padding: 0 40px 30px">
+                <p
+                  style="
+                    margin: 0 0 16px;
+                    font-size: 14px;
+                    line-height: 22px;
+                    color: #9ca3af;
+                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                  "
+                >
+                  The 6 hours of complimentary AI usage included with your KiloClaw trial have now
+                  ended. Your KiloClaw is still running so no worries.
+                </p>
+                <p
+                  style="
+                    margin: 0 0 24px;
+                    font-size: 14px;
+                    line-height: 22px;
+                    color: #9ca3af;
+                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                  "
+                >
+                  You have two ways to keep going:
+                </p>
+
+                <!-- Options block -->
+                <table
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  style="
+                    background-color: #1a1a1a;
+                    border: 1px solid #3a3a3a;
+                    border-radius: 6px;
+                    margin-bottom: 28px;
+                  "
+                >
+                  <tr>
+                    <td style="padding: 20px 24px">
+                      <p
+                        style="
+                          margin: 0 0 6px;
+                          font-size: 11px;
+                          font-weight: 700;
+                          color: #f4e452;
+                          letter-spacing: 0.08em;
+                          text-transform: uppercase;
+                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                        "
+                      >
+                        Option 1 — Add Credits
+                      </p>
+                      <p
+                        style="
+                          margin: 0 0 16px;
+                          font-size: 13px;
+                          line-height: 21px;
+                          color: #9ca3af;
+                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                        "
+                      >
+                        Add credits to continue using any model. You pay only what the AI provider
+                        charges — no markup.
+                      </p>
+                      <p
+                        style="
+                          margin: 0 0 6px;
+                          font-size: 11px;
+                          font-weight: 700;
+                          color: #f4e452;
+                          letter-spacing: 0.08em;
+                          text-transform: uppercase;
+                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                        "
+                      >
+                        Option 2 — Use the Free Model
+                      </p>
+                      <p
+                        style="
+                          margin: 0;
+                          font-size: 13px;
+                          line-height: 21px;
+                          color: #9ca3af;
+                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                        "
+                      >
+                         Switch to
+                        <span style="color: #d1d5db">{{ free_model_name }}</span>
+                         in your KiloClaw settings for limited free inference.
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+
+                <!-- Primary CTA -->
+                <table width="100%" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td align="center" style="padding: 0 0 12px">
+                      <a
+                        href="{{ credits_url }}"
+                        style="
+                          display: inline-block;
+                          padding: 14px 32px;
+                          background-color: #f4e452;
+                          color: #6b7280;
+                          text-decoration: none;
+                          border-radius: 6px;
+                          font-size: 16px;
+                          font-weight: 700;
+                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                        "
+                      >
+                        Add Credits
+                      </a>
+                    </td>
+                  </tr>
+                  <!-- Secondary CTA -->
+                  <tr>
+                    <td align="center" style="padding: 0 0 20px">
+                      <a
+                        href="{{ claw_url }}"
+                        style="
+                          display: inline-block;
+                          padding: 12px 32px;
+                          background-color: transparent;
+                          color: #f4e452;
+                          text-decoration: none;
+                          border-radius: 6px;
+                          border: 1px solid #f4e452;
+                          font-size: 14px;
+                          font-weight: 700;
+                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                        "
+                      >
+                        Open KiloClaw
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <!-- Sign-off -->
+            <tr>
+              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+                <p
+                  style="
+                    margin: 20px 0 0;
+                    font-size: 14px;
+                    line-height: 20px;
+                    color: #9ca3af;
+                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                  "
+                >
+                  If you have any questions, reply to this email — we're here to help.
+                </p>
+                <p
+                  style="
+                    margin: 16px 0 0;
+                    font-size: 14px;
+                    line-height: 20px;
+                    color: #9ca3af;
+                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                  "
+                >
+                  — The Kilo Team
+                </p>
+              </td>
+            </tr>
+          </table>
+          <!-- Branding Footer -->
+          <table width="600" cellpadding="0" cellspacing="0">
+            <tr>
+              <td align="center" style="padding: 30px 20px">
+                <p
+                  style="
+                    margin: 0;
+                    font-size: 12px;
+                    color: #6b7280;
+                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                  "
+                >
+                  © {{ year }} Kilo Code, LLC<br />455 Market St, Ste 1940 PMB 993504<br />San
+                  Francisco, CA 94105, USA
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/apps/web/src/emails/clawComplementaryInferenceEnded.html
+++ b/apps/web/src/emails/clawComplementaryInferenceEnded.html
@@ -127,9 +127,9 @@
                           font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                         "
                       >
-                         Switch to
+                        Switch to
                         <span style="color: #d1d5db">{{ free_model_name }}</span>
-                         in your KiloClaw settings for limited free inference.
+                        in your KiloClaw settings for limited free inference.
                       </p>
                     </td>
                   </tr>

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -31,6 +31,7 @@ export const subjects = {
   clawEarlybirdExpiresTomorrow: 'Your KiloClaw Earlybird Access Expires Tomorrow',
   clawInstanceReady: 'Your KiloClaw Instance Is Ready',
   clawCreditRenewalFailed: 'Action Required: KiloClaw Hosting Renewal Failed',
+  clawComplementaryInferenceEnded: 'Your Free AI Inference Period Has Ended',
   accountDeletionRequest: 'Kilo: Account Deletion Request Received',
 } as const;
 

--- a/apps/web/src/routers/admin/email-testing-router.ts
+++ b/apps/web/src/routers/admin/email-testing-router.ts
@@ -107,6 +107,12 @@ function fixtureTemplateVars(template: TemplateName): Record<string, string | Ra
       return { expiry_date: '2026-09-26', claw_url: `${NEXTAUTH_URL}/claw` };
     case 'clawCreditRenewalFailed':
       return { claw_url: `${NEXTAUTH_URL}/claw` };
+    case 'clawComplementaryInferenceEnded':
+      return {
+        claw_url: `${NEXTAUTH_URL}/claw`,
+        credits_url: `${NEXTAUTH_URL}/credits`,
+        free_model_name: 'Kilo Auto Free',
+      };
   }
   throw new Error(`Unknown template: ${template}`);
 }

--- a/services/kiloclaw-billing/src/index.test.ts
+++ b/services/kiloclaw-billing/src/index.test.ts
@@ -77,6 +77,7 @@ describe('kiloclaw billing worker handler', () => {
       sweep3_instance_destruction: 0,
       sweep4_past_due_cleanup: 0,
       sweep5_intro_schedules_repaired: 0,
+      complementary_inference_ended_emails: 0,
       emails_sent: 0,
       emails_skipped: 0,
       errors: 0,
@@ -153,7 +154,7 @@ describe('kiloclaw billing worker handler', () => {
     const message = {
       body: {
         runId: '11111111-1111-4111-8111-111111111111',
-        sweep: 'earlybird_warning',
+        sweep: 'complementary_inference_ended',
       },
       attempts: 1,
       ack: vi.fn(),
@@ -177,7 +178,7 @@ describe('kiloclaw billing worker handler', () => {
         billingFlow: 'kiloclaw_lifecycle',
         billingComponent: 'worker',
         billingRunId: '11111111-1111-4111-8111-111111111111',
-        billingSweep: 'earlybird_warning',
+        billingSweep: 'complementary_inference_ended',
         billingAttempt: 1,
       })
     );

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -49,7 +49,8 @@ type TemplateName =
   | 'clawTrialExpiresTomorrow'
   | 'clawEarlybirdEndingSoon'
   | 'clawEarlybirdExpiresTomorrow'
-  | 'clawCreditRenewalFailed';
+  | 'clawCreditRenewalFailed'
+  | 'clawComplementaryInferenceEnded';
 
 type SendResult =
   | { sent: true }
@@ -70,6 +71,7 @@ type BillingSummary = {
   sweep3_instance_destruction: number;
   sweep4_past_due_cleanup: number;
   sweep5_intro_schedules_repaired: number;
+  complementary_inference_ended_emails: number;
   emails_sent: number;
   emails_skipped: number;
   errors: number;
@@ -210,6 +212,7 @@ function createSummary(): BillingSummary {
     sweep3_instance_destruction: 0,
     sweep4_past_due_cleanup: 0,
     sweep5_intro_schedules_repaired: 0,
+    complementary_inference_ended_emails: 0,
     emails_sent: 0,
     emails_skipped: 0,
     errors: 0,
@@ -1774,6 +1777,89 @@ async function runEarlybirdWarningSweep(
   }
 }
 
+const COMPLEMENTARY_INFERENCE_WINDOW_MS = 6 * 60 * 60 * 1000;
+
+async function runComplementaryInferenceEndedSweep(
+  database: WorkerDb,
+  env: BillingWorkerEnv,
+  context: SweepExecutionContext,
+  summary: BillingSummary
+): Promise<void> {
+  const clawUrl = buildClawUrl(env);
+  const creditsUrl = `${env.KILOCODE_BACKEND_BASE_URL}/credits`;
+  const windowCutoff = new Date(Date.now() - COMPLEMENTARY_INFERENCE_WINDOW_MS).toISOString();
+
+  // Find users whose "instance ready" email was sent more than 6 hours ago,
+  // whose instance is not destroyed, who have never purchased credits,
+  // and who have not already received this notification.
+  //
+  // The email_type for the "instance ready" log is `claw_instance_ready:{sandboxId}`.
+  // We extract the sandbox_id by joining against kiloclaw_instances.
+  const rows = await database
+    .select({
+      user_id: kilocode_users.id,
+      email: kilocode_users.google_user_email,
+      sandbox_id: kiloclaw_instances.sandbox_id,
+    })
+    .from(kiloclaw_email_log)
+    .innerJoin(kilocode_users, eq(kiloclaw_email_log.user_id, kilocode_users.id))
+    .innerJoin(
+      kiloclaw_instances,
+      and(
+        eq(kiloclaw_instances.user_id, kiloclaw_email_log.user_id),
+        sql`${kiloclaw_email_log.email_type} = 'claw_instance_ready:' || ${kiloclaw_instances.sandbox_id}`
+      )
+    )
+    .where(
+      and(
+        sql`${kiloclaw_email_log.email_type} LIKE 'claw_instance_ready:%'`,
+        lte(kiloclaw_email_log.sent_at, windowCutoff),
+        isNull(kiloclaw_instances.destroyed_at),
+        // Not already sent the complementary inference ended email for this instance
+        sql`NOT EXISTS (
+          SELECT 1 FROM ${kiloclaw_email_log} AS sent_check
+          WHERE sent_check.user_id = ${kiloclaw_email_log.user_id}
+            AND sent_check.email_type = 'claw_complementary_inference_ended:' || ${kiloclaw_instances.sandbox_id}
+        )`,
+        // Never purchased credits (is_free = false, no org_id = personal purchase)
+        sql`NOT EXISTS (
+          SELECT 1 FROM ${credit_transactions}
+          WHERE ${credit_transactions.kilo_user_id} = ${kilocode_users.id}
+            AND ${credit_transactions.is_free} = false
+            AND ${credit_transactions.organization_id} IS NULL
+        )`
+      )
+    );
+
+  for (const row of rows) {
+    try {
+      const sent = await trySendEmail(
+        database,
+        env,
+        context,
+        row.user_id,
+        row.email,
+        `claw_complementary_inference_ended:${row.sandbox_id}`,
+        'clawComplementaryInferenceEnded',
+        {
+          claw_url: clawUrl,
+          credits_url: creditsUrl,
+          free_model_name: 'Kilo Auto Free',
+        },
+        summary
+      );
+
+      if (sent) summary.complementary_inference_ended_emails++;
+    } catch (error) {
+      summary.errors++;
+      log('error', 'Complementary inference ended sweep failed for user', {
+        userId: row.user_id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
 export async function runSweep(
   env: BillingWorkerEnv,
   message: BillingSweepMessage,
@@ -1830,6 +1916,9 @@ export async function runSweep(
             break;
           case 'earlybird_warning':
             await runEarlybirdWarningSweep(database, env, context, summary);
+            break;
+          case 'complementary_inference_ended':
+            await runComplementaryInferenceEndedSweep(database, env, context, summary);
             break;
         }
 

--- a/services/kiloclaw-billing/src/types.ts
+++ b/services/kiloclaw-billing/src/types.ts
@@ -9,6 +9,7 @@ export const BILLING_SWEEP_ORDER = [
   'destruction_warning',
   'trial_warning',
   'earlybird_warning',
+  'complementary_inference_ended',
 ] as const;
 
 export const BILLING_QUEUE_MAX_RETRIES = 3;


### PR DESCRIPTION
## Summary

- Adds a new transactional email (`clawComplementaryInferenceEnded`) sent to KiloClaw users 6 hours after their instance becomes ready, informing them that the complimentary AI inference period has ended
- Only sent to users who have never purchased credits (skipped for paying users who already understand the credit system)
- Adds a new `complementary_inference_ended` billing lifecycle sweep to the kiloclaw-billing worker, wired into the existing sweep chain as the final step

## Verification

- `pnpm typecheck` — passes clean across all packages
- `pnpm --filter kiloclaw-billing test` — all 15 tests pass
- Template is previewable via the admin email testing panel at `/admin/email-testing`

## Visual Changes
<img width="624" height="754" alt="image" src="https://github.com/user-attachments/assets/169695e3-b9f5-4eda-9635-9bd2d806daa8" />

## Reviewer Notes

- The sweep triggers by querying `kiloclaw_email_log` for `claw_instance_ready:{sandboxId}` entries older than 6 hours, then LEFT JOINs to confirm no `claw_complementary_inference_ended:{sandboxId}` entry exists yet and that the instance is not destroyed
- Credit check uses `credit_transactions` (`is_free = false AND organization_id IS NULL`) — consistent with the existing `hasUserEverPaid()` helper in `creditTransactions.ts`
- Fully idempotent via the `kiloclaw_email_log` unique index on `(user_id, email_type)`