### PR TITLE
feat(gastown): add town ID copy badge and Debug settings section

### DIFF
--- a/apps/web/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -29,6 +29,7 @@ import {
   ChevronDown,
   Layers,
   MessageSquare,
+  Copy,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
@@ -228,6 +229,17 @@ export function TownOverviewPageClient({
             <span className="size-1.5 rounded-full bg-emerald-400" />
             Live
           </span>
+          <button
+            onClick={() => {
+              void navigator.clipboard.writeText(townId);
+              toast.success('Copied town ID');
+            }}
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-xs text-white/30 hover:bg-white/[0.06] hover:text-white/60 transition-colors"
+            title={townId}
+          >
+            <Copy className="size-3" />
+            {townId.slice(0, 8)}…
+          </button>
         </div>
         <Button
           variant="primary"

--- a/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -33,6 +33,8 @@ import {
   Key,
   MessageSquareText,
   X,
+  Bug,
+  Copy,
 } from 'lucide-react';
 import {
   Accordion,
@@ -75,6 +77,7 @@ const SECTIONS = [
   { id: 'refinery', label: 'Refinery', icon: Shield },
   { id: 'container', label: 'Container', icon: Container },
   { id: 'custom-instructions', label: 'Custom Instructions', icon: MessageSquareText },
+  { id: 'debug', label: 'Debug', icon: Bug },
   { id: 'danger-zone', label: 'Danger Zone', icon: Trash2 },
 ] as const;
 
@@ -177,6 +180,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
   const townQuery = useQuery(trpc.gastown.getTown.queryOptions({ townId }));
   const configQuery = useQuery(trpc.gastown.getTownConfig.queryOptions({ townId }));
   const adminAccessQuery = useQuery(trpc.gastown.checkAdminAccess.queryOptions({ townId }));
+  const rigsQuery = useQuery(trpc.gastown.listRigs.queryOptions({ townId }));
 
   // Admin viewing another user's town → force read-only
   const isAdminViewing = adminAccessQuery.data?.isAdminViewing ?? false;
@@ -386,6 +390,74 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
         },
       },
     });
+  }
+
+  function handleCopyDebugInfo() {
+    const cfg = configQuery.data;
+    const debugInfo = {
+      town_id: townId,
+      user_id: currentUser?.id ?? null,
+      organization_id: organizationId ?? cfg?.organization_id ?? null,
+
+      rigs: (rigsQuery.data ?? []).map(r => ({
+        id: r.id,
+        name: r.name,
+        git_url: r.git_url,
+        default_branch: r.default_branch,
+      })),
+
+      settings: cfg
+        ? {
+            default_model: cfg.default_model ?? null,
+            small_model: cfg.small_model ?? null,
+            role_models: {
+              mayor: cfg.role_models?.mayor ?? null,
+              refinery: cfg.role_models?.refinery ?? null,
+              polecat: cfg.role_models?.polecat ?? null,
+            },
+
+            max_polecats_per_rig: cfg.max_polecats_per_rig ?? null,
+
+            github_token_set: !!(cfg.git_auth?.github_token),
+            gitlab_token_set: !!(cfg.git_auth?.gitlab_token),
+            gitlab_instance_url: cfg.git_auth?.gitlab_instance_url || null,
+            github_cli_pat_set: !!(cfg.github_cli_pat),
+            git_author_name: cfg.git_author_name || null,
+            // git_author_email intentionally omitted (PII)
+            disable_ai_coauthor: cfg.disable_ai_coauthor ?? false,
+
+            env_var_keys: Object.keys(cfg.env_vars ?? {}),
+
+            merge_strategy: cfg.merge_strategy ?? 'direct',
+            convoy_merge_mode: cfg.convoy_merge_mode ?? 'review-then-land',
+            staged_convoys_default: cfg.staged_convoys_default ?? false,
+
+            refinery: {
+              code_review: cfg.refinery?.code_review ?? true,
+              auto_merge: cfg.refinery?.auto_merge ?? true,
+              review_mode: cfg.refinery?.review_mode ?? 'rework',
+              auto_resolve_pr_feedback: cfg.refinery?.auto_resolve_pr_feedback ?? false,
+              auto_merge_delay_minutes: cfg.refinery?.auto_merge_delay_minutes ?? null,
+              gates: cfg.refinery?.gates ?? [],
+            },
+
+            custom_instructions: {
+              mayor_set: !!(cfg.custom_instructions?.mayor),
+              polecat_set: !!(cfg.custom_instructions?.polecat),
+              refinery_set: !!(cfg.custom_instructions?.refinery),
+            },
+
+            alarm_interval_active: cfg.alarm_interval_active ?? null,
+            alarm_interval_idle: cfg.alarm_interval_idle ?? null,
+          }
+        : null,
+
+      generated_at: new Date().toISOString(),
+      url: window.location.href,
+    };
+
+    void navigator.clipboard.writeText(JSON.stringify(debugInfo, null, 2));
+    toast.success('Debug info copied to clipboard');
   }
 
   function addEnvVar() {
@@ -1147,13 +1219,38 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
                 </div>
               </SettingsSection>
 
+              {/* ── Debug ──────────────────────────────────────────── */}
+              <SettingsSection
+                id="debug"
+                title="Debug"
+                description="Copy diagnostic information to share with support. No sensitive data is included."
+                icon={Bug}
+                index={11}
+              >
+                <div className="space-y-3">
+                  <p className="text-xs text-white/40">
+                    Copies a JSON snapshot of your town configuration for troubleshooting. API
+                    tokens, email addresses, and custom instruction contents are excluded.
+                  </p>
+                  <Button
+                    onClick={handleCopyDebugInfo}
+                    variant="secondary"
+                    size="sm"
+                    className="gap-2"
+                  >
+                    <Copy className="size-3.5" />
+                    Copy debug info
+                  </Button>
+                </div>
+              </SettingsSection>
+
               {/* ── Danger Zone ──────────────────────────────────────── */}
               <SettingsSection
                 id="danger-zone"
                 title="Danger Zone"
                 description="Irreversible actions for this town."
                 icon={Trash2}
-                index={11}
+                index={12}
               >
                 <div className="space-y-3">
                   <div className="flex items-center justify-between rounded-lg border border-red-500/20 bg-red-500/5 px-4 py-3">

--- a/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -399,12 +399,25 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
       user_id: currentUser?.id ?? null,
       organization_id: organizationId ?? cfg?.organization_id ?? null,
 
-      rigs: (rigsQuery.data ?? []).map(r => ({
-        id: r.id,
-        name: r.name,
-        git_url: r.git_url,
-        default_branch: r.default_branch,
-      })),
+      rigs: (rigsQuery.data ?? []).map(r => {
+        let git_url_sanitized: string | null = null;
+        if (r.git_url) {
+          try {
+            const u = new URL(r.git_url);
+            u.username = '';
+            u.password = '';
+            git_url_sanitized = u.toString();
+          } catch {
+            // not a parseable URL — omit entirely to avoid leaking anything
+          }
+        }
+        return {
+          id: r.id,
+          name: r.name,
+          git_url: git_url_sanitized,
+          default_branch: r.default_branch,
+        };
+      }),
 
       settings: cfg
         ? {
@@ -422,8 +435,8 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
             gitlab_token_set: !!(cfg.git_auth?.gitlab_token),
             gitlab_instance_url: cfg.git_auth?.gitlab_instance_url || null,
             github_cli_pat_set: !!(cfg.github_cli_pat),
-            git_author_name: cfg.git_author_name || null,
-            // git_author_email intentionally omitted (PII)
+            git_author_name_set: !!(cfg.git_author_name),
+            // git_author_name and git_author_email intentionally omitted (PII)
             disable_ai_coauthor: cfg.disable_ai_coauthor ?? false,
 
             env_var_keys: Object.keys(cfg.env_vars ?? {}),


### PR DESCRIPTION
## Summary
- Adds a subtle copyable town ID badge in the sticky top bar of the Overview page; clicking it copies the full UUID and shows a toast
- Adds a \"Debug\" section to Town Settings (before Danger Zone in both sidebar nav and scrollable content) with a \"Copy debug info\" button that serializes a JSON snapshot of the town config — tokens and email omitted, env var keys only, custom instruction presence only

## Verification
- TypeScript compiles cleanly (`pnpm typecheck`)
- Both changes reviewed manually in source; SECTIONS array updated, `index` props updated (debug=11, danger-zone=12), `rigsQuery` already present, `toast` from `sonner` used consistently

## Visual Changes
N/A

## Reviewer Notes
- No PII in the debug JSON output (emails, tokens are boolean `_set` fields; env var keys only; custom instruction content omitted)
- `git_author_email` is intentionally excluded from debug info per the GDPR rule