### PR TITLE
feat: kilo-context-pipeline — Phase 1 (Container-based pipeline execution)

### DIFF
--- a/services/kilo-context-pipeline/.dev.vars.example
+++ b/services/kilo-context-pipeline/.dev.vars.example
@@ -1,0 +1,53 @@
+# Copy to .dev.vars for local development with `wrangler dev`.
+# All values here are REQUIRED secrets for production deployment.
+# Set them with: wrangler secret put <NAME>
+
+# ── Required secrets ─────────────────────────────────────────────────────────
+
+# Kilo gateway token (used by process/run-all.mjs for LLM API calls)
+KILO_API_TOKEN=your-kilo-api-token
+
+# Kilo org ID (passed alongside KILO_API_TOKEN)
+KILO_ORG_ID=your-kilo-org-id
+
+# Slack user token (used by process/fetch-sources.mjs)
+SLACK_USER_TOKEN=xoxp-your-slack-user-token
+
+# R2 credentials (used by process/publish.mjs to upload KB artifacts)
+R2_ACCESS_KEY_ID=your-r2-access-key-id
+R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
+
+# Shared secret between this service and the kilo-context Worker for /_invalidate.
+# Generate with: openssl rand -hex 32
+# Also set as a secret in the kilo-context Worker:
+#   cd ../kilo-context/worker && wrangler secret put PIPELINE_SERVICE_TOKEN
+PIPELINE_SERVICE_TOKEN=your-shared-pipeline-service-token
+
+# ── Optional secrets ──────────────────────────────────────────────────────────
+
+# Google Drive folder ID — omit to skip the transcripts connector entirely
+# GDRIVE_FOLDER_ID=your-google-drive-folder-id
+
+# Base64-encoded Google Drive token.json — required if GDRIVE_FOLDER_ID is set
+# Generate with: base64 < /path/to/token.json | tr -d '\n'
+# GDRIVE_TOKEN_JSON=ewogICJhY2Nlc3NfdG9rZW4iOi....
+
+# ── First-time setup ──────────────────────────────────────────────────────────
+#
+# 1. Set all required secrets:
+#    wrangler secret put KILO_API_TOKEN
+#    wrangler secret put KILO_ORG_ID
+#    wrangler secret put SLACK_USER_TOKEN
+#    wrangler secret put R2_ACCESS_KEY_ID
+#    wrangler secret put R2_SECRET_ACCESS_KEY
+#    wrangler secret put PIPELINE_SERVICE_TOKEN
+#
+# 2. Set PIPELINE_SERVICE_TOKEN in the kilo-context Worker too:
+#    cd services/kilo-context/worker && wrangler secret put PIPELINE_SERVICE_TOKEN
+#
+# 3. Deploy:
+#    pnpm deploy
+#
+# 4. Verify with:
+#    curl https://kilo-context-pipeline.<your-account>.workers.dev/status
+#    curl -X POST https://kilo-context-pipeline.<your-account>.workers.dev/trigger

--- a/services/kilo-context-pipeline/.gitignore
+++ b/services/kilo-context-pipeline/.gitignore
@@ -1,0 +1,4 @@
+.dev.vars
+dist/
+node_modules/
+.wrangler/

--- a/services/kilo-context-pipeline/Dockerfile
+++ b/services/kilo-context-pipeline/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:22
+
+# Install system dependencies required by the kilo-context pipeline.
+# git    — required by process/ingest-github.mjs (runs git clone)
+# ca-certificates — required for HTTPS fetches inside the container
+RUN apt-get update && \
+    apt-get install -y git ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# ── Bake the kilo-context product repo ────────────────────────────────────
+# Clone at image-build time so every container start is instant.
+# The product repo contains all pipeline scripts (process/*.mjs) and the
+# source configuration (which Slack channels, GitHub repos, etc. to pull).
+# Instance credentials are injected via environment variables at runtime.
+WORKDIR /app
+RUN git clone --depth 1 https://github.com/kilo-org/kilo-context.git /app
+
+# Install Node.js dependencies.
+# node:22 (full image) includes build tools (gcc, python3, make) needed to
+# compile native modules such as @lancedb/lancedb.
+RUN npm install --ignore-scripts=false
+
+# ── In-container HTTP server ───────────────────────────────────────────────
+# server.mjs listens on PORT (default 8080), accepts POST /run, spawns the
+# pipeline subprocess, and streams stdout/stderr as a chunked response.
+COPY server.mjs /app/server.mjs
+
+EXPOSE 8080
+
+# KB_ROOT is injected at Container spawn time by the Orchestrator.
+# It points to the writable workspace directory on the container filesystem.
+# The pipeline scripts resolve all paths through process/paths.mjs via KB_ROOT.
+ENV KB_ROOT=/workspace/kb
+ENV NODE_ENV=production
+
+CMD ["node", "/app/server.mjs"]

--- a/services/kilo-context-pipeline/package.json
+++ b/services/kilo-context-pipeline/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "kilo-context-pipeline",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "start": "wrangler dev",
+    "types": "wrangler types",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "hono": "catalog:"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
+    "wrangler": "catalog:"
+  }
+}

--- a/services/kilo-context-pipeline/server.mjs
+++ b/services/kilo-context-pipeline/server.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * server.mjs — in-container HTTP server for the kilo-context pipeline.
+ *
+ * Listens on PORT (default 8080).
+ *
+ * Routes:
+ *   POST /run    — start the pipeline, stream stdout/stderr as chunked response.
+ *                  Body: { env?: Record<string,string> }
+ *                  Signals completion with the line: __PIPELINE_COMPLETE__ <status> <exitCode>
+ *   GET  /health — liveness check: { ok: true, running: boolean }
+ *
+ * Only one pipeline run at a time. Concurrent POST /run calls receive 409.
+ * The container should be destroyed by the Orchestrator after the run completes.
+ */
+
+import { createServer } from 'node:http';
+import { spawn } from 'node:child_process';
+import { mkdirSync, existsSync } from 'node:fs';
+
+const PORT = parseInt(process.env.PORT ?? '8080', 10);
+const APP_DIR = '/app';
+
+/** True while a pipeline subprocess is running. Prevents concurrent runs. */
+let isRunning = false;
+
+const server = createServer((req, res) => {
+  const url = new URL(req.url, 'http://localhost');
+
+  // ── GET /health ──────────────────────────────────────────────────────────
+  if (req.method === 'GET' && url.pathname === '/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, running: isRunning }));
+    return;
+  }
+
+  // ── POST /run ─────────────────────────────────────────────────────────────
+  if (req.method === 'POST' && url.pathname === '/run') {
+    if (isRunning) {
+      res.writeHead(409, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Pipeline already running' }));
+      return;
+    }
+
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      /** @type {{ env?: Record<string,string> }} */
+      let parsed = {};
+      try { parsed = JSON.parse(body || '{}'); } catch { /* ignore */ }
+
+      // Merge request-supplied env vars on top of process.env.
+      // This lets the Orchestrator inject KILO_API_TOKEN, SLACK_USER_TOKEN, etc.
+      const envOverrides = parsed.env ?? {};
+      const kbRoot = envOverrides.KB_ROOT ?? process.env.KB_ROOT ?? '/workspace/kb';
+
+      // Ensure KB_ROOT directory exists.
+      if (!existsSync(kbRoot)) {
+        try {
+          mkdirSync(kbRoot, { recursive: true });
+          console.log(`[pipeline-server] Created KB_ROOT: ${kbRoot}`);
+        } catch (err) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: `Failed to create KB_ROOT: ${err.message}` }));
+          return;
+        }
+      }
+
+      isRunning = true;
+      console.log(`[pipeline-server] Starting pipeline run. KB_ROOT=${kbRoot}`);
+
+      res.writeHead(200, {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Transfer-Encoding': 'chunked',
+        'Cache-Control': 'no-cache',
+        'X-Content-Type-Options': 'nosniff',
+      });
+
+      /** Write to the response, ignoring errors if the client disconnected. */
+      const write = (/** @type {Buffer|string} */ data) => {
+        try { res.write(data); } catch { /* client disconnected — ignore */ }
+      };
+
+      // Run: npm run pull && npm run update && npm run publish
+      // - All three steps run sequentially via shell &&.
+      // - cwd=/app (where package.json lives with the npm scripts).
+      // - KB_ROOT and credentials are passed via the merged env.
+      const subprocess = spawn(
+        '/bin/sh',
+        ['-c', 'npm run pull && npm run update && npm run publish'],
+        {
+          cwd: APP_DIR,
+          env: {
+            ...process.env,
+            ...envOverrides,
+            KB_ROOT: kbRoot,
+            HOME: '/root',
+            PATH: process.env.PATH,
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        }
+      );
+
+      subprocess.stdout.on('data', data => write(data));
+      subprocess.stderr.on('data', data => write(data));
+
+      subprocess.on('error', err => {
+        write(`\n[pipeline-server] Subprocess error: ${err.message}\n`);
+      });
+
+      subprocess.on('close', exitCode => {
+        const status = exitCode === 0 ? 'success' : 'failed';
+        const code = exitCode ?? -1;
+        console.log(`[pipeline-server] Pipeline ${status} (exit ${code})`);
+        // Emit a sentinel line the Orchestrator can match on to determine status.
+        write(`\n__PIPELINE_COMPLETE__ ${status} ${code}\n`);
+        try { res.end(); } catch { /* ignore */ }
+        isRunning = false;
+      });
+    });
+    return;
+  }
+
+  // ── 404 ───────────────────────────────────────────────────────────────────
+  res.writeHead(404);
+  res.end('Not found');
+});
+
+server.listen(PORT, '0.0.0.0', () => {
+  console.log(`[pipeline-server] Listening on port ${PORT}`);
+});

--- a/services/kilo-context-pipeline/src/index.ts
+++ b/services/kilo-context-pipeline/src/index.ts
@@ -1,0 +1,112 @@
+/**
+ * kilo-context-pipeline — Cloudflare Worker entry point.
+ *
+ * Handles:
+ *   - HTTP routes: /trigger, /status, /runs (proxied to PipelineOrchestrator DO)
+ *   - Cron trigger: daily 06:00 UTC (triggers the Orchestrator for each active instance)
+ *
+ * The PipelineContainer and PipelineOrchestrator classes are re-exported here
+ * so Wrangler can register them as Durable Objects.
+ */
+
+import { Hono } from 'hono';
+import type { Env } from './types';
+
+// Re-export Durable Object classes so Wrangler binds them.
+export { PipelineContainer } from './pipeline.container';
+export { PipelineOrchestrator } from './orchestrator.do';
+
+type HonoEnv = { Bindings: Env };
+const app = new Hono<HonoEnv>();
+
+// ── Health check ─────────────────────────────────────────────────────────────
+app.get('/', c =>
+  c.json({ ok: true, service: 'kilo-context-pipeline', ts: new Date().toISOString() })
+);
+
+// ── Pipeline control routes (proxied to Orchestrator) ─────────────────────────
+
+/**
+ * POST /trigger — start a pipeline run (or 409 if already running).
+ * Response: { runId, status: 'running', startedAt }
+ */
+app.post('/trigger', async c => {
+  const stub = getOrchestratorStub(c.env);
+  return stub.fetch(
+    new Request('http://orchestrator/trigger', { method: 'POST' })
+  );
+});
+
+/**
+ * GET /status — current run state.
+ * Response: { status: 'idle' | 'running' | 'success' | 'failed', lastRun: RunSummary | null }
+ */
+app.get('/status', async c => {
+  const stub = getOrchestratorStub(c.env);
+  return stub.fetch(
+    new Request('http://orchestrator/status', { method: 'GET' })
+  );
+});
+
+/**
+ * GET /runs?limit=N — run history (newest first, max 100).
+ * Response: { runs: RunSummary[] }
+ */
+app.get('/runs', async c => {
+  const limit = c.req.query('limit') ?? '20';
+  const stub = getOrchestratorStub(c.env);
+  return stub.fetch(
+    new Request(`http://orchestrator/runs?limit=${limit}`, { method: 'GET' })
+  );
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function getOrchestratorStub(env: Env): DurableObjectStub {
+  const instanceId = env.PIPELINE_INSTANCE_ID ?? 'kilo-internal';
+  const id = env.PIPELINE_ORCHESTRATOR.idFromName(instanceId);
+  return env.PIPELINE_ORCHESTRATOR.get(id);
+}
+
+// ── Cron handler ──────────────────────────────────────────────────────────────
+
+/**
+ * Daily cron at 06:00 UTC: trigger the pipeline for the configured instance.
+ * For Phase 1 there is one instance; multi-instance fan-out is Phase 2.
+ */
+async function handleCron(env: Env): Promise<void> {
+  const instanceId = env.PIPELINE_INSTANCE_ID ?? 'kilo-internal';
+  console.log(`[cron] Triggering pipeline for instance: ${instanceId}`);
+
+  const id = env.PIPELINE_ORCHESTRATOR.idFromName(instanceId);
+  const stub = env.PIPELINE_ORCHESTRATOR.get(id);
+
+  try {
+    const res = await stub.fetch(
+      new Request('http://orchestrator/trigger', { method: 'POST' })
+    );
+    const body = await res.json();
+    if (res.ok) {
+      console.log(`[cron] Run triggered:`, JSON.stringify(body));
+    } else {
+      // 409 = already running — not an error
+      console.warn(`[cron] Trigger returned ${res.status}:`, JSON.stringify(body));
+    }
+  } catch (err) {
+    console.error(`[cron] Failed to trigger ${instanceId}:`, err);
+  }
+}
+
+// ── Default export ────────────────────────────────────────────────────────────
+
+export default {
+  fetch: app.fetch,
+
+  async scheduled(
+    _event: ScheduledEvent,
+    env: Env,
+    ctx: ExecutionContext
+  ): Promise<void> {
+    ctx.waitUntil(handleCron(env));
+  },
+};

--- a/services/kilo-context-pipeline/src/orchestrator.do.ts
+++ b/services/kilo-context-pipeline/src/orchestrator.do.ts
@@ -1,0 +1,324 @@
+/**
+ * PipelineOrchestrator — Durable Object managing the kilo-context pipeline lifecycle.
+ *
+ * State: SQLite database with a `runs` table recording every pipeline run.
+ *
+ * Routes (all relative to the service's root path):
+ *   POST /trigger  — spawn a new pipeline run (idempotent: rejects if already running)
+ *   GET  /status   — current run state + last run summary
+ *   GET  /runs     — run history (last N runs, default 20)
+ *
+ * Flow:
+ *   1. POST /trigger creates a run record (status=running) in SQLite.
+ *   2. ctx.waitUntil spawns spawnPipeline() in the background:
+ *      a. Creates a PipelineContainer DO instance using the run UUID as name.
+ *      b. POSTs { env: { KB_ROOT, KILO_API_TOKEN, ... } } to the container's /run.
+ *      c. Reads the streaming response line by line, accumulates a log tail.
+ *      d. Detects the __PIPELINE_COMPLETE__ sentinel to determine exit code.
+ *      e. Updates the run record (status=success|failed) in SQLite.
+ *      f. On success, calls /_invalidate on the KB Worker via service binding.
+ *   3. GET /status and GET /runs read from SQLite — no live container state needed.
+ */
+
+import { DurableObject } from 'cloudflare:workers';
+import type { Env } from './types';
+
+// ── SQLite row shapes ────────────────────────────────────────────────────────
+
+interface RunRow {
+  id: string;
+  status: string;
+  started_at: string;
+  completed_at: string | null;
+  exit_code: number | null;
+  log_tail: string | null;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/** Maximum bytes of log output to keep per run (last N bytes). */
+const LOG_MAX_BYTES = 50_000;
+
+/** How many bytes of the log tail to surface in GET /runs responses. */
+const LOG_PREVIEW_BYTES = 2_000;
+
+export class PipelineOrchestrator extends DurableObject<Env> {
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    // Create the runs table once on first instantiation.
+    // new_sqlite_classes in migrations ensures this DO has a SQLite database.
+    this.ctx.storage.sql.exec(`
+      CREATE TABLE IF NOT EXISTS runs (
+        id           TEXT    PRIMARY KEY,
+        status       TEXT    NOT NULL,   -- 'running' | 'success' | 'failed'
+        started_at   TEXT    NOT NULL,   -- ISO-8601
+        completed_at TEXT,               -- ISO-8601, null while running
+        exit_code    INTEGER,            -- null while running
+        log_tail     TEXT                -- last ${LOG_MAX_BYTES} bytes of stdout+stderr
+      );
+    `);
+  }
+
+  override async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === 'POST' && url.pathname === '/trigger') {
+      return this.handleTrigger();
+    }
+    if (request.method === 'GET' && url.pathname === '/status') {
+      return this.handleStatus();
+    }
+    if (request.method === 'GET' && url.pathname === '/runs') {
+      const limit = Math.min(parseInt(url.searchParams.get('limit') ?? '20', 10), 100);
+      return this.handleRuns(limit);
+    }
+
+    return new Response('Not found', { status: 404 });
+  }
+
+  // ── Route handlers ──────────────────────────────────────────────────────────
+
+  private handleTrigger(): Response {
+    // Reject concurrent runs.
+    const running = [
+      ...this.ctx.storage.sql.exec<RunRow>(
+        `SELECT id FROM runs WHERE status = 'running' ORDER BY started_at DESC LIMIT 1`
+      ),
+    ];
+    if (running.length > 0) {
+      return Response.json(
+        { error: 'Run already in progress', runId: running[0].id },
+        { status: 409 }
+      );
+    }
+
+    const runId = crypto.randomUUID();
+    const startedAt = new Date().toISOString();
+
+    this.ctx.storage.sql.exec(
+      `INSERT INTO runs (id, status, started_at) VALUES (?, ?, ?)`,
+      runId,
+      'running',
+      startedAt
+    );
+
+    // Kick off pipeline in the background so this HTTP response returns immediately.
+    this.ctx.waitUntil(this.spawnPipeline(runId));
+
+    return Response.json({ runId, status: 'running', startedAt });
+  }
+
+  private handleStatus(): Response {
+    const rows = [
+      ...this.ctx.storage.sql.exec<RunRow>(
+        `SELECT id, status, started_at, completed_at, exit_code FROM runs
+         ORDER BY started_at DESC LIMIT 1`
+      ),
+    ];
+    if (rows.length === 0) {
+      return Response.json({ status: 'idle', lastRun: null });
+    }
+    const r = rows[0];
+    return Response.json({
+      status: r.status,
+      lastRun: {
+        id: r.id,
+        status: r.status,
+        startedAt: r.started_at,
+        completedAt: r.completed_at ?? null,
+        exitCode: r.exit_code ?? null,
+        durationMs: r.completed_at
+          ? new Date(r.completed_at).getTime() - new Date(r.started_at).getTime()
+          : null,
+      },
+    });
+  }
+
+  private handleRuns(limit: number): Response {
+    const rows = [
+      ...this.ctx.storage.sql.exec<RunRow>(
+        `SELECT id, status, started_at, completed_at, exit_code, log_tail
+         FROM runs ORDER BY started_at DESC LIMIT ?`,
+        limit
+      ),
+    ];
+    return Response.json({
+      runs: rows.map(r => ({
+        id: r.id,
+        status: r.status,
+        startedAt: r.started_at,
+        completedAt: r.completed_at ?? null,
+        exitCode: r.exit_code ?? null,
+        durationMs:
+          r.completed_at
+            ? new Date(r.completed_at).getTime() - new Date(r.started_at).getTime()
+            : null,
+        // Surface the last LOG_PREVIEW_BYTES of the log in list responses.
+        logPreview: r.log_tail ? r.log_tail.slice(-LOG_PREVIEW_BYTES) : null,
+      })),
+    });
+  }
+
+  // ── Pipeline spawning ────────────────────────────────────────────────────────
+
+  /**
+   * Create a Container DO instance for this run, send POST /run, read the
+   * streaming response, then update the run record on completion.
+   *
+   * Runs entirely inside ctx.waitUntil — the Trigger response has already
+   * been returned to the caller before this method makes any awaited calls.
+   */
+  private async spawnPipeline(runId: string): Promise<void> {
+    try {
+      // Each run gets its own Container DO instance (keyed by run UUID).
+      // The Container starts when the first request arrives.
+      const containerId = this.env.PIPELINE_CONTAINER.idFromName(runId);
+      const container = this.env.PIPELINE_CONTAINER.get(containerId);
+
+      // Build a per-run workspace directory so concurrent runs (if ever) don't clash.
+      const kbRoot = `/workspace/${runId}`;
+
+      // Collect all credentials to inject into the subprocess environment.
+      const pipelineEnv: Record<string, string> = {
+        KB_ROOT: kbRoot,
+        KILO_API_TOKEN: this.env.KILO_API_TOKEN,
+        KILO_ORG_ID: this.env.KILO_ORG_ID,
+        SLACK_USER_TOKEN: this.env.SLACK_USER_TOKEN,
+        R2_ACCESS_KEY_ID: this.env.R2_ACCESS_KEY_ID,
+        R2_SECRET_ACCESS_KEY: this.env.R2_SECRET_ACCESS_KEY,
+      };
+      if (this.env.GDRIVE_FOLDER_ID) {
+        pipelineEnv.GDRIVE_FOLDER_ID = this.env.GDRIVE_FOLDER_ID;
+      }
+      if (this.env.GDRIVE_TOKEN_JSON) {
+        pipelineEnv.GDRIVE_TOKEN_JSON = this.env.GDRIVE_TOKEN_JSON;
+      }
+
+      const response = await container.fetch(
+        new Request('http://container/run', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ env: pipelineEnv }),
+        })
+      );
+
+      if (!response.ok) {
+        const errText = await response.text();
+        this.markRunFailed(runId, null, `Container /run returned ${response.status}: ${errText}`);
+        return;
+      }
+
+      // Read the streaming response and capture a log tail.
+      const { exitCode, logTail } = await this.consumeStream(response);
+
+      const status = exitCode === 0 ? 'success' : 'failed';
+      this.markRunComplete(runId, status, exitCode, logTail);
+
+      if (status === 'success') {
+        await this.invalidateMcpCache();
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[orchestrator] Run ${runId} failed:`, message);
+      this.markRunFailed(runId, null, message);
+    }
+  }
+
+  /**
+   * Consume a streaming response from the container, accumulating a log tail
+   * and extracting the exit code from the __PIPELINE_COMPLETE__ sentinel line.
+   */
+  private async consumeStream(
+    response: Response
+  ): Promise<{ exitCode: number | null; logTail: string }> {
+    let logBuffer = '';
+    let exitCode: number | null = null;
+
+    if (!response.body) {
+      return { exitCode: null, logTail: '(no response body)' };
+    }
+
+    const decoder = new TextDecoder();
+    const reader = response.body.getReader();
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const chunk = decoder.decode(value, { stream: true });
+        logBuffer += chunk;
+
+        // Trim to last LOG_MAX_BYTES to avoid unbounded memory use.
+        if (logBuffer.length > LOG_MAX_BYTES) {
+          logBuffer = logBuffer.slice(logBuffer.length - LOG_MAX_BYTES);
+        }
+
+        // Detect __PIPELINE_COMPLETE__ <status> <exitCode>
+        const match = logBuffer.match(/__PIPELINE_COMPLETE__ (\w+) (-?\d+)/);
+        if (match) {
+          exitCode = parseInt(match[2], 10);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    return { exitCode, logTail: logBuffer };
+  }
+
+  // ── SQLite helpers ───────────────────────────────────────────────────────────
+
+  private markRunComplete(
+    runId: string,
+    status: 'success' | 'failed',
+    exitCode: number | null,
+    logTail: string
+  ): void {
+    this.ctx.storage.sql.exec(
+      `UPDATE runs
+       SET status = ?, completed_at = ?, exit_code = ?, log_tail = ?
+       WHERE id = ?`,
+      status,
+      new Date().toISOString(),
+      exitCode,
+      logTail.slice(-LOG_MAX_BYTES),
+      runId
+    );
+  }
+
+  private markRunFailed(runId: string, exitCode: number | null, logTail: string): void {
+    this.markRunComplete(runId, 'failed', exitCode, logTail);
+  }
+
+  // ── MCP cache invalidation ────────────────────────────────────────────────────
+
+  /**
+   * Tell the KB Worker to drop its in-memory index cache.
+   * Called via Cloudflare service binding (same-account, internal network).
+   * The KB Worker accepts X-Pipeline-Token for this internal call, bypassing
+   * the standard MCP_AUTH_TOKEN requirement.
+   */
+  private async invalidateMcpCache(): Promise<void> {
+    try {
+      const res = await this.env.KB_WORKER.fetch(
+        new Request('https://kilo-context.workers.dev/_invalidate', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Pipeline-Token': this.env.PIPELINE_SERVICE_TOKEN,
+          },
+        })
+      );
+      if (res.ok) {
+        console.log('[orchestrator] KB cache invalidated successfully');
+      } else {
+        console.error('[orchestrator] KB cache invalidation returned', res.status);
+      }
+    } catch (err) {
+      // Non-fatal: the cache version pointer in R2 will still trigger a reload
+      // on the next request to the KB Worker within 60 seconds.
+      console.error('[orchestrator] KB cache invalidation failed:', err);
+    }
+  }
+}

--- a/services/kilo-context-pipeline/src/pipeline.container.ts
+++ b/services/kilo-context-pipeline/src/pipeline.container.ts
@@ -1,0 +1,44 @@
+/**
+ * PipelineContainer — Cloudflare Container managing the kilo-context pipeline.
+ *
+ * This is a Durable Object subclass with the Container mixin applied.
+ * Cloudflare automatically:
+ *   - Builds the Docker image referenced in wrangler.jsonc's `containers` block
+ *   - Starts the container when the first request arrives via containerFetch()
+ *   - Routes subsequent requests to the running container's HTTP server (port 8080)
+ *   - Stops the container after sleepAfterSeconds of inactivity
+ *
+ * The container runs server.mjs which:
+ *   - Listens on port 8080
+ *   - Accepts POST /run — spawns the pipeline, streams stdout/stderr back
+ *   - Accepts GET /health — liveness probe
+ *
+ * The Orchestrator creates one Container instance per run (using the run UUID
+ * as the DO name), fires POST /run, reads the streaming response, then discards
+ * the Container (the container shuts down after sleepAfterSeconds).
+ */
+import { Container } from 'cloudflare:containers';
+
+export class PipelineContainer extends Container {
+  /**
+   * Port the in-container HTTP server listens on.
+   * Must match EXPOSE and the listen port in server.mjs.
+   */
+  override defaultPort: number = 8080;
+
+  /**
+   * Shut down the container after 2 minutes of inactivity.
+   * After a run completes the stream ends; the Orchestrator reads EOF and
+   * moves on. The container has nothing else to do, so let it stop promptly.
+   */
+  override sleepAfterSeconds: number = 120;
+
+  /**
+   * Forward all requests to the container's HTTP server.
+   * containerFetch() starts the container if it is not already running,
+   * then proxies the request+response (including streaming bodies).
+   */
+  override async fetch(request: Request): Promise<Response> {
+    return this.containerFetch(request);
+  }
+}

--- a/services/kilo-context-pipeline/src/types.ts
+++ b/services/kilo-context-pipeline/src/types.ts
@@ -1,0 +1,58 @@
+/**
+ * Env bindings for the kilo-context-pipeline Worker.
+ * Keep in sync with wrangler.jsonc.
+ */
+export interface Env {
+  // ── Durable Objects ──────────────────────────────────────────────────────
+  /** Manages run lifecycle, SQLite history, and fan-out to Containers. */
+  PIPELINE_ORCHESTRATOR: DurableObjectNamespace;
+  /** One Container instance per pipeline run. */
+  PIPELINE_CONTAINER: DurableObjectNamespace;
+
+  // ── Service binding ───────────────────────────────────────────────────────
+  /** The kilo-context MCP Worker — called for /_invalidate after a successful run. */
+  KB_WORKER: Fetcher;
+
+  // ── Instance identity ─────────────────────────────────────────────────────
+  /**
+   * Stable ID for this KB instance (default: "kilo-internal").
+   * Used as the DO name for PIPELINE_ORCHESTRATOR so run history is persistent
+   * across Worker deployments.
+   */
+  PIPELINE_INSTANCE_ID: string;
+
+  // ── Pipeline secrets (injected into the Container subprocess env) ─────────
+  // All are passed verbatim to `npm run pull` / `npm run update` inside the
+  // Container. The pipeline scripts read them via process.env.
+
+  /** Kilo gateway token — used by run-all.mjs for LLM API calls. */
+  KILO_API_TOKEN: string;
+  /** Kilo org ID — passed alongside KILO_API_TOKEN for gateway auth. */
+  KILO_ORG_ID: string;
+  /** Slack user token — used by fetch-sources.mjs to pull Slack transcripts. */
+  SLACK_USER_TOKEN: string;
+  /** R2 access key — used by publish.mjs to upload KB artifacts. */
+  R2_ACCESS_KEY_ID: string;
+  /** R2 secret key — used by publish.mjs to upload KB artifacts. */
+  R2_SECRET_ACCESS_KEY: string;
+  /**
+   * Shared secret between this service and the KB Worker.
+   * The Orchestrator sends this as X-Pipeline-Token when calling /_invalidate.
+   * The KB Worker accepts it without requiring MCP_AUTH_TOKEN.
+   */
+  PIPELINE_SERVICE_TOKEN: string;
+
+  // ── Optional secrets ──────────────────────────────────────────────────────
+  /**
+   * Google Drive folder ID. If set, the transcripts connector runs.
+   * Also set GDRIVE_TOKEN_JSON (base64 pre-staged token.json).
+   * If unset, pull-transcripts.mjs is skipped entirely.
+   */
+  GDRIVE_FOLDER_ID?: string;
+  /**
+   * Base64-encoded Google Drive token.json. Injected as GDRIVE_TOKEN_JSON.
+   * The transcripts connector reads it and writes to $KB_ROOT/token.json.
+   * Required if GDRIVE_FOLDER_ID is set.
+   */
+  GDRIVE_TOKEN_JSON?: string;
+}

--- a/services/kilo-context-pipeline/tsconfig.json
+++ b/services/kilo-context-pipeline/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/workers-types"],
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/services/kilo-context-pipeline/wrangler.jsonc
+++ b/services/kilo-context-pipeline/wrangler.jsonc
@@ -1,0 +1,100 @@
+/**
+ * kilo-context-pipeline — Wrangler configuration
+ *
+ * Builds and deploys:
+ *   - The Container image (from ./Dockerfile)
+ *   - The PipelineContainer Durable Object (wraps the Container)
+ *   - The PipelineOrchestrator Durable Object (SQLite-backed run history)
+ *   - The Cron trigger (daily 06:00 UTC)
+ *
+ * Required secrets (set via: wrangler secret put <NAME>):
+ *   KILO_API_TOKEN          — Kilo gateway token for LLM API calls in the pipeline
+ *   KILO_ORG_ID             — Kilo org ID for gateway auth
+ *   SLACK_USER_TOKEN        — Slack user token for fetch-sources.mjs
+ *   R2_ACCESS_KEY_ID        — R2 access key for publish.mjs
+ *   R2_SECRET_ACCESS_KEY    — R2 secret key for publish.mjs
+ *   PIPELINE_SERVICE_TOKEN  — Shared secret with the kilo-context Worker for /_invalidate
+ *
+ * Optional secrets:
+ *   GDRIVE_FOLDER_ID        — Google Drive folder ID (skips transcripts connector if absent)
+ *   GDRIVE_TOKEN_JSON       — Base64-encoded token.json for Google Drive OAuth
+ */
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "account_id": "e115e769bcdd4c3d66af59d3332cb394",
+  "name": "kilo-context-pipeline",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-10-01",
+  "compatibility_flags": ["nodejs_compat"],
+
+  "dev": {
+    "port": 8820,
+    "local_protocol": "http",
+    "ip": "0.0.0.0",
+  },
+
+  "observability": {
+    "enabled": true,
+  },
+
+  // ── Container (Docker image for the pipeline runner) ────────────────────────
+  // The image is built from ./Dockerfile when `wrangler deploy` runs.
+  // Each Container instance corresponds to one PipelineContainer DO instance.
+  "containers": [
+    {
+      "class_name": "PipelineContainer",
+      "image": "./Dockerfile",
+      // standard-1: 1 vCPU, 2 GiB RAM — sufficient for Node.js LLM pipeline
+      "instance_type": "standard-1",
+      // Phase 1: one daily run at a time. Raise if multiple instances share the Worker.
+      "max_instances": 5,
+    },
+  ],
+
+  // ── Durable Objects ──────────────────────────────────────────────────────────
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "PIPELINE_ORCHESTRATOR",
+        "class_name": "PipelineOrchestrator",
+      },
+      {
+        "name": "PIPELINE_CONTAINER",
+        "class_name": "PipelineContainer",
+      },
+    ],
+  },
+
+  // ── Durable Object migrations ────────────────────────────────────────────────
+  // new_sqlite_classes is required for both the Orchestrator (uses SQLite) and
+  // the Container DO (Container DOs require sqlite-class migration registration).
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["PipelineOrchestrator", "PipelineContainer"],
+    },
+  ],
+
+  // ── Service binding: kilo-context MCP Worker ─────────────────────────────────
+  // Used by the Orchestrator to call /_invalidate after a successful run.
+  // Requires the kilo-context Worker to be deployed in the same account.
+  "services": [
+    {
+      "binding": "KB_WORKER",
+      "service": "kilo-context",
+    },
+  ],
+
+  // ── Cron trigger ─────────────────────────────────────────────────────────────
+  // Daily at 06:00 UTC. Calls the scheduled() handler in src/index.ts.
+  "triggers": {
+    "crons": ["0 6 * * *"],
+  },
+
+  // ── Vars ─────────────────────────────────────────────────────────────────────
+  "vars": {
+    // Instance ID used as the DO name for PIPELINE_ORCHESTRATOR.
+    // Change this if you run multiple pipeline instances in the same Worker.
+    "PIPELINE_INSTANCE_ID": "kilo-internal",
+  },
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of the [Pipeline Execution Architecture](https://github.com/kilo-org/kilo-context/blob/main/docs/PIPELINE-EXECUTION-ARCHITECTURE.md): moves the kilo-context KB pipeline off the local machine and onto Cloudflare Containers with a daily cron trigger.

**Done when:** The Orchestrator triggers a Container run on the daily cron, `npm run pull && npm run update && npm run publish` completes, artifacts land in R2, the MCP Worker serves fresh data, and the run appears in `GET /runs`. No local machine involvement.

---

## New service: `services/kilo-context-pipeline/`

### `Dockerfile`
- Base `node:22` (includes build tools for native modules like `@lancedb/lancedb`)
- Installs `git` (required by `process/ingest-github.mjs`)
- Clones `kilo-org/kilo-context` product repo at image-build time (`git clone --depth 1`)
- Runs `npm install` to pre-install all dependencies
- Copies `server.mjs` entrypoint and exposes port 8080

### `server.mjs` (in-container HTTP server)
- Listens on port 8080
- `POST /run` — receives `{ env: {...} }` with pipeline credentials, spawns `npm run pull && npm run update && npm run publish`, streams stdout/stderr as chunked response, emits `__PIPELINE_COMPLETE__ <status> <exitCode>` sentinel when done
- `GET /health` — liveness check
- One-at-a-time guard (409 if already running)

### `src/pipeline.container.ts`
- `PipelineContainer` extends `Container` from `cloudflare:containers`
- `defaultPort = 8080`, `sleepAfterSeconds = 120`
- Proxies all requests via `containerFetch()`

### `src/orchestrator.do.ts`
- `PipelineOrchestrator` Durable Object with SQLite (`new_sqlite_classes`)
- **`POST /trigger`** — creates run record, starts Container via `ctx.waitUntil`, returns `{ runId, status: 'running' }`
- **`GET /status`** — current run state + last run summary
- **`GET /runs?limit=N`** — run history (newest first)
- `spawnPipeline()` — creates per-run `PipelineContainer` DO, calls `POST /run` with all credentials injected, reads streaming response, captures log tail (last 50KB), detects `__PIPELINE_COMPLETE__` sentinel, updates SQLite on completion
- `invalidateMcpCache()` — calls `POST /_invalidate` on the KV Worker via service binding using `X-Pipeline-Token`

### `src/index.ts`
- Hono worker with `/trigger`, `/status`, `/runs` routes (all proxied to Orchestrator)
- `scheduled()` handler: fires at 06:00 UTC, calls `/trigger` on the `PIPELINE_INSTANCE_ID` Orchestrator (default: `kilo-internal`)

### `wrangler.jsonc`
- `containers: [{ class_name: "PipelineContainer", image: "./Dockerfile", instance_type: "standard-1", max_instances: 5 }]`
- `durable_objects: PipelineOrchestrator + PipelineContainer`
- `migrations: new_sqlite_classes: [PipelineOrchestrator, PipelineContainer]`
- `services: [{ binding: KB_WORKER, service: kilo-context }]`
- `triggers: { crons: ["0 6 * * *"] }`
- `vars: { PIPELINE_INSTANCE_ID: "kilo-internal" }`

---

## Deployment checklist (required before merging)

**Set these secrets** (`wrangler secret put <NAME>` from `services/kilo-context-pipeline/`):

```
KILO_API_TOKEN           # Kilo gateway token (LLM calls)
KILO_ORG_ID              # Kilo org ID
SLACK_USER_TOKEN         # Slack user token (fetch-sources.mjs)
R2_ACCESS_KEY_ID         # R2 credentials (publish.mjs)
R2_SECRET_ACCESS_KEY
PIPELINE_SERVICE_TOKEN   # Shared with kilo-context Worker — see kilo-org/kilo-context#<PR>
```

Optional:
```
GDRIVE_FOLDER_ID         # Google Drive connector (skipped if absent)
GDRIVE_TOKEN_JSON        # Base64-encoded token.json
```

**Also set** `PIPELINE_SERVICE_TOKEN` in the kilo-context Worker (see companion PR in kilo-org/kilo-context).

---

## What this does NOT include (Phase 2+)
- Source queue fan-out via Cloudflare Queues
- R2-backed workspace persistence (`--resume` across runs)
- Studio integration