### PR TITLE
Fix(kiloclaw) model discovery timeouts

### DIFF
--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -46,7 +46,20 @@ RUN npm install -g pnpm
 
 # Install OpenClaw
 # Pin to specific version for reproducible builds
+# Patch: bump model discovery timeout from 5s to 60s — shared-cpu machines
+# under boot load routinely need 27-35s for the first TLS+fetch to complete.
+# Remove this sed patch once openclaw exposes a configurable timeout.
 RUN npm install -g openclaw@2026.4.5 \
+    && OC_DIST=/usr/local/lib/node_modules/openclaw/dist \
+    && PM_FILE=$(find "$OC_DIST" -name 'provider-models-*.js' | head -1) \
+    && if [ -z "$PM_FILE" ]; then echo "ERROR: provider-models-*.js not found in openclaw dist" >&2; exit 1; fi \
+    && BEFORE=$(grep -c 'DISCOVERY_TIMEOUT_MS = 5e3' "$PM_FILE") \
+    && if [ "$BEFORE" -ne 1 ]; then echo "ERROR: expected exactly 1 occurrence of DISCOVERY_TIMEOUT_MS = 5e3, found $BEFORE — openclaw may have changed" >&2; exit 1; fi \
+    && sed -i 's/DISCOVERY_TIMEOUT_MS = 5e3/DISCOVERY_TIMEOUT_MS = 60e3/' "$PM_FILE" \
+    && AFTER=$(grep -c 'DISCOVERY_TIMEOUT_MS = 60e3' "$PM_FILE") \
+    && if [ "$AFTER" -ne 1 ]; then echo "ERROR: sed patch failed — expected 1 occurrence of 60e3, found $AFTER" >&2; exit 1; fi \
+    && if grep -q 'DISCOVERY_TIMEOUT_MS = 5e3' "$PM_FILE"; then echo "ERROR: old 5e3 value still present after patch" >&2; exit 1; fi \
+    && echo "OK: patched DISCOVERY_TIMEOUT_MS 5e3 -> 60e3 in $(basename $PM_FILE)" \
     && openclaw --version
 
 # Install ClawHub CLI


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

During Docker build, change the const `DISCOVERY_TIMEOUT_MS` in OpenClaw from 5 seconds to 60 seconds.
This is accomplished using sed against the minified js file. 
OpenClaw does not expose `DISCOVERY_TIMEOUT_MS` as a configurable setting, instead its defined as a const. 

During testing, we found the models discovery to take upwards of 30 seconds due to initial provision, boot, onboard CPU contention issues. This provides a longer timeout, allowing for it to complete before the first OpenClaw attempt at using a model.

## Verification

- linting
- Docker build and test locally

## Visual Changes

N/A

## Reviewer Notes

The file is plain text JavaScript (minified, but still just text). sed -i reads the entire file into memory, performs the string substitution, and writes a completely new file. The output file is simply a few bytes longer. There are no fixed offsets, pointer tables, or binary structure to corrupt.

This would be dangerous with:
- ELF binaries — fixed offsets, section headers, symbol tables
- Wasm — binary format with length-prefixed sections
- Java .class files — constant pool with byte offsets
- Source maps — column mappings would be off (but you're not shipping source maps here)

But for a .js file — even a minified one — it's just a UTF-8 text stream that the Node runtime parses fresh each time. Replacing 5e3 (3 chars) with 60e3 (4 chars) just shifts everything after it by one byte in the new file. No pointers, no offsets, nothing breaks.