### PR TITLE
fix(dev): Move Stripe webhook from KiloClaw to Core service group

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -84,6 +84,8 @@ pnpm add -g vercel
 
 ### Stripe CLI (optional, for payment testing)
 
+Install it to enable local Stripe webhook forwarding. `pnpm dev:start` skips the Stripe forwarder when the CLI is not installed.
+
 ```bash
 brew install stripe/stripe-cli/stripe
 ```
@@ -182,7 +184,7 @@ pnpm drizzle:verify-bootstrap
 pnpm dev:start
 ```
 
-This launches a tmux dashboard with the Next.js app, local infrastructure, and the Stripe webhook forwarder. The web app will be available at http://localhost:3000.
+This launches a tmux dashboard with the Next.js app and local infrastructure. When the Stripe CLI is installed, it also starts the Stripe webhook forwarder. The web app will be available at http://localhost:3000.
 
 To stop all services:
 
@@ -229,13 +231,11 @@ All tests should pass against the local PostgreSQL database.
 
 To test Stripe integration locally:
 
-1. Log in to Stripe CLI: `stripe login`
-2. Start the webhook forwarder: `pnpm stripe`
-3. Copy the webhook signing secret from the CLI output
-4. Add it to `.env.development.local`:
-   ```
-   STRIPE_WEBHOOK_SECRET="whsec_..."
-   ```
+1. Install and log in to Stripe CLI: `stripe login`
+2. Start local development: `pnpm dev:start`
+3. The dev launcher starts the webhook forwarder and writes `STRIPE_WEBHOOK_SECRET` to `apps/web/.env.development.local`.
+
+If the Stripe CLI is not installed, `pnpm dev:start` skips webhook forwarding. To run only the webhook forwarder manually, use `pnpm --filter web stripe`.
 
 ## Database Schema Changes
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -182,7 +182,7 @@ pnpm drizzle:verify-bootstrap
 pnpm dev:start
 ```
 
-This launches a tmux dashboard with the Next.js app and related services. The web app will be available at http://localhost:3000.
+This launches a tmux dashboard with the Next.js app, local infrastructure, and the Stripe webhook forwarder. The web app will be available at http://localhost:3000.
 
 To stop all services:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -146,7 +146,7 @@ You need to re-run this every time you pull new migrations from the repository.
 pnpm dev:start
 ```
 
-This launches a tmux dashboard with the Next.js app and related services. The web app will be available at http://localhost:3000.
+This launches a tmux dashboard with the Next.js app, local infrastructure, and the Stripe webhook forwarder. The web app will be available at http://localhost:3000.
 
 To stop all services:
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
     "dev:prod-db": "USE_PRODUCTION_DB=true bash ../../scripts/dev.sh",
     "build": "next build",
     "start": "next start",
-    "stripe": "stripe listen --forward-to http://localhost:$(cat ../../.dev-port 2>/dev/null || echo 3000)/api/stripe/webhook",
+    "stripe": "stripe listen --forward-to http://localhost:${STRIPE_FORWARD_PORT:-$(cat ../../.dev-port 2>/dev/null || echo 3000)}/api/stripe/webhook",
     "lint": "pnpm -w exec oxlint --config .oxlintrc.json apps/web/src",
     "format": "pnpm -w exec oxfmt .",
     "format:check": "pnpm -w exec oxfmt --list-different .",

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -306,10 +306,14 @@ async function insertPersonalSubscriptionFixture(params: PersonalSubscriptionFix
   });
 }
 
-async function seedDeliveredImpactSignupEvent(userId: string, email: string) {
+async function seedDeliveredImpactSignupEvent(
+  userId: string,
+  email: string,
+  conversionDate = new Date()
+) {
   const { recordAffiliateAttributionAndQueueParentEvent } = await import('@/lib/affiliate-events');
   const { recordImpactAffiliateTouch } = await import('@/lib/impact-referral');
-  const eventDate = new Date('2026-04-09T10:00:00.000Z');
+  const eventDate = new Date(conversionDate.getTime() - 10 * 60_000);
 
   const parentEvent = await recordAffiliateAttributionAndQueueParentEvent({
     userId,
@@ -332,7 +336,7 @@ async function seedDeliveredImpactSignupEvent(userId: string, email: string) {
       utmTerm: null,
       utmContent: null,
       touchedAt: eventDate,
-      expiresAt: new Date('2026-05-09T10:00:00.000Z'),
+      expiresAt: new Date(conversionDate.getTime() + 30 * 86_400_000),
     },
   });
 
@@ -2795,7 +2799,8 @@ describe('handleKiloClawInvoicePaid affiliate events', () => {
   });
 
   it('enqueues sale affiliate events for delivered attributed users', async () => {
-    await seedDeliveredImpactSignupEvent(user.id, user.google_user_email);
+    const paidAt = new Date('2026-04-09T10:00:00.000Z');
+    await seedDeliveredImpactSignupEvent(user.id, user.google_user_email, paidAt);
 
     const [instance] = await db
       .insert(kiloclaw_instances)
@@ -2852,7 +2857,7 @@ describe('handleKiloClawInvoicePaid affiliate events', () => {
           ],
         },
         status_transitions: {
-          paid_at: Math.floor(new Date('2026-04-09T10:00:00.000Z').getTime() / 1000),
+          paid_at: Math.floor(paidAt.getTime() / 1000),
         },
       } as unknown as Stripe.Invoice,
     });

--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -134,7 +134,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
   // Always start core (always-on) groups; additional targets are merged in
   const coreServices = resolveGroups(getAlwaysOnGroupIds());
   const extraServices = targets.length === 0 ? [] : resolveTargets(targets);
-  const serviceNames = topologicalSort([...new Set([...coreServices, ...extraServices])]);
+  let serviceNames = topologicalSort([...new Set([...coreServices, ...extraServices])]);
 
   // --- Check for socat when kiloclaw-docker-tcp is requested ---
   if (serviceNames.includes('kiloclaw-docker-tcp')) {
@@ -143,6 +143,17 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
     } catch {
       console.error('socat is not installed. Install it with: brew install socat');
       process.exit(1);
+    }
+  }
+
+  // --- Skip Stripe webhook forwarding when the optional Stripe CLI is absent ---
+  if (serviceNames.includes('stripe')) {
+    try {
+      execSync('stripe --version', { stdio: 'ignore' });
+    } catch {
+      console.warn('⚠ stripe CLI not found on PATH — skipping Stripe webhook forwarder.');
+      console.warn('  Install it with: brew install stripe/stripe-cli/stripe');
+      serviceNames = serviceNames.filter(name => name !== 'stripe');
     }
   }
 
@@ -177,11 +188,15 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
   }
 
   // --- Create tmux session ---
-  // Pass KILO_PORT_OFFSET into the session environment so panes see it even
-  // when an existing tmux server (from a sibling worktree) is running with a
-  // different offset. Without this, new windows inherit the server env, not
-  // ours, and services bind to base ports — causing conflicts.
-  createSession(sessionName, { KILO_PORT_OFFSET: String(portOffset) });
+  // Pass critical port env into the session so panes see it even when an
+  // existing tmux server (from a sibling worktree) is running with different
+  // values. Without this, new windows inherit the server env, not ours, and
+  // services can bind to the wrong ports.
+  const sessionEnv: Record<string, string> = { KILO_PORT_OFFSET: String(portOffset) };
+  if (process.env.PORT !== undefined && process.env.PORT !== '') {
+    sessionEnv.PORT = String(getService('nextjs').port);
+  }
+  createSession(sessionName, sessionEnv);
 
   // --- Start each service in its own tmux window ---
   const SIDEBAR_WIDTH = 40;

--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -187,7 +187,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
   const SIDEBAR_WIDTH = 40;
 
   // --- Start capture services first (tunnel, stripe) and wait for output ---
-  const captureServiceSet = new Set(['kiloclaw-tunnel', 'kiloclaw-stripe', 'app-builder-tunnel']);
+  const captureServiceSet = new Set(['kiloclaw-tunnel', 'stripe', 'app-builder-tunnel']);
   const captureServices = serviceNames.filter(n => captureServiceSet.has(n));
   const otherServices = serviceNames.filter(n => !captureServiceSet.has(n));
   const startedServices: string[] = [];
@@ -205,7 +205,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
       oldMtimes.set('checkin', readEnvMtime(tunnelEnvPath));
       oldMtimes.set('kilochat', readEnvMtime(tunnelEnvPath));
     }
-    if (captureServices.includes('kiloclaw-stripe')) {
+    if (captureServices.includes('stripe')) {
       const stripeEnvPath = path.join(repoRoot, 'apps/web/.env.development.local');
       oldValues.set('stripe', readEnvValue(stripeEnvPath, 'STRIPE_WEBHOOK_SECRET'));
       oldMtimes.set('stripe', readEnvMtime(stripeEnvPath));
@@ -275,7 +275,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
       );
     }
 
-    if (captureServices.includes('kiloclaw-stripe')) {
+    if (captureServices.includes('stripe')) {
       waits.push(
         waitForEnvValueChange(
           path.join(repoRoot, 'apps/web/.env.development.local'),
@@ -287,7 +287,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
           if (ready) {
             console.log('  Stripe webhook secret captured');
           } else {
-            console.warn('  Stripe secret not captured after 30s - check kiloclaw-stripe window');
+            console.warn('  Stripe secret not captured after 30s - check stripe window');
           }
         })
       );

--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -156,7 +156,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
   const SIDEBAR_WIDTH = 40;
 
   // --- Start capture services first (tunnel, stripe) and wait for output ---
-  const captureServiceSet = new Set(['kiloclaw-tunnel', 'kiloclaw-stripe', 'app-builder-tunnel']);
+  const captureServiceSet = new Set(['kiloclaw-tunnel', 'stripe', 'app-builder-tunnel']);
   const captureServices = serviceNames.filter(n => captureServiceSet.has(n));
   const otherServices = serviceNames.filter(n => !captureServiceSet.has(n));
   const startedServices: string[] = [];
@@ -170,7 +170,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
       oldValues.set('tunnel', readEnvValue(tunnelEnvPath, 'KILOCODE_API_BASE_URL'));
       oldMtimes.set('tunnel', readEnvMtime(tunnelEnvPath));
     }
-    if (captureServices.includes('kiloclaw-stripe')) {
+    if (captureServices.includes('stripe')) {
       const stripeEnvPath = path.join(repoRoot, 'apps/web/.env.development.local');
       oldValues.set('stripe', readEnvValue(stripeEnvPath, 'STRIPE_WEBHOOK_SECRET'));
       oldMtimes.set('stripe', readEnvMtime(stripeEnvPath));
@@ -211,7 +211,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
       );
     }
 
-    if (captureServices.includes('kiloclaw-stripe')) {
+    if (captureServices.includes('stripe')) {
       waits.push(
         waitForEnvValueChange(
           path.join(repoRoot, 'apps/web/.env.development.local'),
@@ -223,7 +223,7 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
           if (ready) {
             console.log('  Stripe webhook secret captured');
           } else {
-            console.warn('  Stripe secret not captured after 30s - check kiloclaw-stripe window');
+            console.warn('  Stripe secret not captured after 30s - check stripe window');
           }
         })
       );

--- a/dev/local/scripts/start-stripe.ts
+++ b/dev/local/scripts/start-stripe.ts
@@ -78,7 +78,10 @@ async function main(): Promise<void> {
 
   console.log(`Starting Stripe webhook listener for http://localhost:${forwardPort}...`);
 
-  let secretPattern: RegExp | null = /whsec_[a-zA-Z0-9]+/;
+  const secretPattern = /whsec_[a-zA-Z0-9]+/;
+  const secretRedactionPattern = /whsec_[a-zA-Z0-9]+/g;
+  let secretCaptured = false;
+  let outputBuffer = '';
 
   const child = spawn('pnpm', ['--filter', 'web', 'run', 'stripe'], {
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -86,19 +89,37 @@ async function main(): Promise<void> {
     env: { ...process.env, STRIPE_FORWARD_PORT: String(forwardPort) },
   });
 
-  function handleOutput(data: Buffer) {
-    process.stdout.write(data);
+  function processOutput(text: string): void {
+    const match = secretCaptured ? null : text.match(secretPattern);
+    if (match) {
+      const secret = match[0];
+      updateEnvValue(envFilePath, 'STRIPE_WEBHOOK_SECRET', `"${secret}"`);
+      secretCaptured = true;
+    }
 
-    if (!secretPattern) return;
-    const match = data.toString().match(secretPattern);
-    if (!match) return;
+    process.stdout.write(text.replace(secretRedactionPattern, '[redacted]'));
 
-    const secret = match[0];
-    updateEnvValue(envFilePath, 'STRIPE_WEBHOOK_SECRET', `"${secret}"`);
+    if (match) {
+      console.log('\nSet STRIPE_WEBHOOK_SECRET in apps/web/.env.development.local');
+    }
+  }
 
-    console.log('\nSet STRIPE_WEBHOOK_SECRET in apps/web/.env.development.local');
+  function flushOutputBuffer(): void {
+    if (outputBuffer === '') return;
+    processOutput(outputBuffer);
+    outputBuffer = '';
+  }
 
-    secretPattern = null;
+  function handleOutput(data: Buffer): void {
+    outputBuffer += data.toString();
+
+    let newlineIndex = outputBuffer.indexOf('\n');
+    while (newlineIndex !== -1) {
+      const line = outputBuffer.slice(0, newlineIndex + 1);
+      outputBuffer = outputBuffer.slice(newlineIndex + 1);
+      processOutput(line);
+      newlineIndex = outputBuffer.indexOf('\n');
+    }
   }
 
   child.stdout.on('data', handleOutput);
@@ -109,6 +130,7 @@ async function main(): Promise<void> {
   }
 
   child.on('close', code => {
+    flushOutputBuffer();
     process.exit(code ?? 1);
   });
 }

--- a/dev/local/scripts/start-stripe.ts
+++ b/dev/local/scripts/start-stripe.ts
@@ -1,5 +1,6 @@
 import { spawn, spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
+import * as net from 'node:net';
 import * as path from 'node:path';
 
 const repoRoot = path.resolve(import.meta.dirname, '../../..');
@@ -23,45 +24,96 @@ function updateEnvValue(filePath: string, key: string, value: string): void {
   fs.writeFileSync(filePath, content);
 }
 
-if (spawnSync('stripe', ['--version'], { stdio: 'ignore' }).error) {
-  console.error(
-    'stripe CLI not found on PATH. Install it:\n  https://docs.stripe.com/stripe-cli#install\n  brew install stripe/stripe-cli/stripe'
-  );
+function parseTargetPort(value: string | undefined): number {
+  if (value === undefined) return 3000;
+
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid Next.js target port: ${value}`);
+  }
+
+  return port;
+}
+
+function findAvailablePort(port: number, retries: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+
+    server.once('error', error => {
+      if ('code' in error && error.code === 'EADDRINUSE') {
+        const nextPort = retries > 0 ? port + 1 : 0;
+        const nextRetries = retries > 0 ? retries - 1 : 0;
+        findAvailablePort(nextPort, nextRetries).then(resolve, reject);
+        return;
+      }
+
+      reject(error);
+    });
+
+    server.once('listening', () => {
+      const address = server.address();
+      if (address === null || typeof address === 'string') {
+        server.close(() => reject(new Error(`Could not resolve available port from ${port}`)));
+        return;
+      }
+
+      const assignedPort = address.port;
+      server.close(() => resolve(assignedPort));
+    });
+
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+async function main(): Promise<void> {
+  if (spawnSync('stripe', ['--version'], { stdio: 'ignore' }).error) {
+    console.error(
+      'stripe CLI not found on PATH. Install it:\n  https://docs.stripe.com/stripe-cli#install\n  brew install stripe/stripe-cli/stripe'
+    );
+    process.exit(1);
+  }
+
+  const targetPort = parseTargetPort(process.argv[2]);
+  const forwardPort = await findAvailablePort(targetPort, 10);
+
+  console.log(`Starting Stripe webhook listener for http://localhost:${forwardPort}...`);
+
+  let secretPattern: RegExp | null = /whsec_[a-zA-Z0-9]+/;
+
+  const child = spawn('pnpm', ['--filter', 'web', 'run', 'stripe'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    cwd: repoRoot,
+    env: { ...process.env, STRIPE_FORWARD_PORT: String(forwardPort) },
+  });
+
+  function handleOutput(data: Buffer) {
+    process.stdout.write(data);
+
+    if (!secretPattern) return;
+    const match = data.toString().match(secretPattern);
+    if (!match) return;
+
+    const secret = match[0];
+    updateEnvValue(envFilePath, 'STRIPE_WEBHOOK_SECRET', `"${secret}"`);
+
+    console.log('\nSet STRIPE_WEBHOOK_SECRET in apps/web/.env.development.local');
+
+    secretPattern = null;
+  }
+
+  child.stdout.on('data', handleOutput);
+  child.stderr.on('data', handleOutput);
+
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.on(signal, () => child.kill(signal));
+  }
+
+  child.on('close', code => {
+    process.exit(code ?? 1);
+  });
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : String(error));
   process.exit(1);
-}
-
-console.log('Starting Stripe webhook listener...');
-
-let secretPattern: RegExp | null = /whsec_[a-zA-Z0-9]+/;
-
-const child = spawn('pnpm', ['--filter', 'web', 'run', 'stripe'], {
-  stdio: ['ignore', 'pipe', 'pipe'],
-  cwd: repoRoot,
-});
-
-function handleOutput(data: Buffer) {
-  process.stdout.write(data);
-
-  if (!secretPattern) return;
-  const match = data.toString().match(secretPattern);
-  if (!match) return;
-
-  const secret = match[0];
-  updateEnvValue(envFilePath, 'STRIPE_WEBHOOK_SECRET', `"${secret}"`);
-
-  console.log('\nSet STRIPE_WEBHOOK_SECRET in apps/web/.env.development.local');
-
-  // Only capture once
-  secretPattern = null;
-}
-
-child.stdout.on('data', handleOutput);
-child.stderr.on('data', handleOutput);
-
-for (const signal of ['SIGINT', 'SIGTERM'] as const) {
-  process.on(signal, () => child.kill(signal));
-}
-
-child.on('close', code => {
-  process.exit(code ?? 1);
 });

--- a/dev/local/services.ts
+++ b/dev/local/services.ts
@@ -377,13 +377,14 @@ function buildServiceDefs(): ServiceDef[] {
     }
 
     if (name === 'stripe') {
+      const nextjsPort = 3000 + portOffset;
       defs.push({
         name,
         type: 'process',
         dir: '.',
         port: 0,
         dependsOn: meta.dependsOn,
-        command: ['tsx', 'dev/local/scripts/start-stripe.ts'],
+        command: ['tsx', 'dev/local/scripts/start-stripe.ts', String(nextjsPort)],
         group: meta.group,
       });
       continue;

--- a/dev/local/services.ts
+++ b/dev/local/services.ts
@@ -65,9 +65,10 @@ type ServiceMeta = {
 
 const serviceMeta: Record<string, ServiceMeta> = {
   // core
-  nextjs: { group: 'core', dependsOn: ['postgres', 'redis'] },
+  nextjs: { group: 'core', dependsOn: ['postgres', 'redis', 'stripe'] },
   postgres: { group: 'core', dependsOn: [] },
   redis: { group: 'core', dependsOn: [] },
+  stripe: { group: 'core', dependsOn: [] },
   // cloud-agent
   'cloud-agent-next': {
     group: 'cloud-agent',
@@ -135,7 +136,6 @@ const serviceMeta: Record<string, ServiceMeta> = {
   },
   // kiloclaw
   'kiloclaw-tunnel': { group: 'kiloclaw', dependsOn: [] },
-  'kiloclaw-stripe': { group: 'kiloclaw', dependsOn: [] },
   'kiloclaw-docker-tcp': { group: 'kiloclaw', dependsOn: [] },
   notifications: {
     group: 'kiloclaw',
@@ -376,7 +376,7 @@ function buildServiceDefs(): ServiceDef[] {
       continue;
     }
 
-    if (name === 'kiloclaw-stripe') {
+    if (name === 'stripe') {
       defs.push({
         name,
         type: 'process',

--- a/dev/local/services.ts
+++ b/dev/local/services.ts
@@ -223,6 +223,20 @@ function getPortOffset(): number {
 
 export const portOffset = getPortOffset();
 
+function getNextjsTargetPort(): number {
+  const explicit = process.env.PORT;
+  if (explicit === undefined || explicit === '') return 3000 + portOffset;
+
+  const port = Number(explicit);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid PORT: ${explicit}`);
+  }
+
+  return port;
+}
+
+const nextjsTargetPort = getNextjsTargetPort();
+
 // ---------------------------------------------------------------------------
 // Wrangler config discovery
 // ---------------------------------------------------------------------------
@@ -306,7 +320,7 @@ function buildServiceDefs(): ServiceDef[] {
         name,
         type: 'nextjs',
         dir: 'apps/web',
-        port: 3000 + portOffset,
+        port: nextjsTargetPort,
         dependsOn: meta.dependsOn,
         command: ['pnpm', 'run', 'dev'],
         group: meta.group,
@@ -355,7 +369,6 @@ function buildServiceDefs(): ServiceDef[] {
     }
 
     if (name === 'kiloclaw-tunnel') {
-      const nextjsPort = 3000 + portOffset;
       const kiloclawPort = readWranglerPort(path.join(repoRoot, 'services/kiloclaw')) + portOffset;
       const kiloChatPort = readWranglerPort(path.join(repoRoot, 'services/kilo-chat')) + portOffset;
       defs.push({
@@ -367,7 +380,7 @@ function buildServiceDefs(): ServiceDef[] {
         command: [
           'tsx',
           'dev/local/scripts/start-tunnel.ts',
-          String(nextjsPort),
+          String(nextjsTargetPort),
           String(kiloclawPort),
           String(kiloChatPort),
         ],
@@ -377,14 +390,13 @@ function buildServiceDefs(): ServiceDef[] {
     }
 
     if (name === 'stripe') {
-      const nextjsPort = 3000 + portOffset;
       defs.push({
         name,
         type: 'process',
         dir: '.',
         port: 0,
         dependsOn: meta.dependsOn,
-        command: ['tsx', 'dev/local/scripts/start-stripe.ts', String(nextjsPort)],
+        command: ['tsx', 'dev/local/scripts/start-stripe.ts', String(nextjsTargetPort)],
         group: meta.group,
       });
       continue;

--- a/dev/local/services.ts
+++ b/dev/local/services.ts
@@ -186,6 +186,20 @@ function getPortOffset(): number {
 
 export const portOffset = getPortOffset();
 
+function getNextjsTargetPort(): number {
+  const explicit = process.env.PORT;
+  if (explicit === undefined || explicit === '') return 3000 + portOffset;
+
+  const port = Number(explicit);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid PORT: ${explicit}`);
+  }
+
+  return port;
+}
+
+const nextjsTargetPort = getNextjsTargetPort();
+
 // ---------------------------------------------------------------------------
 // Wrangler config discovery
 // ---------------------------------------------------------------------------
@@ -257,7 +271,7 @@ function buildServiceDefs(): ServiceDef[] {
         name,
         type: 'nextjs',
         dir: 'apps/web',
-        port: 3000 + portOffset,
+        port: nextjsTargetPort,
         dependsOn: meta.dependsOn,
         command: ['pnpm', 'run', 'dev'],
         group: meta.group,
@@ -292,28 +306,26 @@ function buildServiceDefs(): ServiceDef[] {
     }
 
     if (name === 'kiloclaw-tunnel') {
-      const nextjsPort = 3000 + portOffset;
       defs.push({
         name,
         type: 'process',
         dir: '.',
         port: 0,
         dependsOn: meta.dependsOn,
-        command: ['tsx', 'dev/local/scripts/start-tunnel.ts', String(nextjsPort)],
+        command: ['tsx', 'dev/local/scripts/start-tunnel.ts', String(nextjsTargetPort)],
         group: meta.group,
       });
       continue;
     }
 
     if (name === 'stripe') {
-      const nextjsPort = 3000 + portOffset;
       defs.push({
         name,
         type: 'process',
         dir: '.',
         port: 0,
         dependsOn: meta.dependsOn,
-        command: ['tsx', 'dev/local/scripts/start-stripe.ts', String(nextjsPort)],
+        command: ['tsx', 'dev/local/scripts/start-stripe.ts', String(nextjsTargetPort)],
         group: meta.group,
       });
       continue;

--- a/dev/local/services.ts
+++ b/dev/local/services.ts
@@ -306,13 +306,14 @@ function buildServiceDefs(): ServiceDef[] {
     }
 
     if (name === 'stripe') {
+      const nextjsPort = 3000 + portOffset;
       defs.push({
         name,
         type: 'process',
         dir: '.',
         port: 0,
         dependsOn: meta.dependsOn,
-        command: ['tsx', 'dev/local/scripts/start-stripe.ts'],
+        command: ['tsx', 'dev/local/scripts/start-stripe.ts', String(nextjsPort)],
         group: meta.group,
       });
       continue;

--- a/dev/local/services.ts
+++ b/dev/local/services.ts
@@ -53,9 +53,10 @@ type ServiceMeta = {
 
 const serviceMeta: Record<string, ServiceMeta> = {
   // core
-  nextjs: { group: 'core', dependsOn: ['postgres', 'redis'] },
+  nextjs: { group: 'core', dependsOn: ['postgres', 'redis', 'stripe'] },
   postgres: { group: 'core', dependsOn: [] },
   redis: { group: 'core', dependsOn: [] },
+  stripe: { group: 'core', dependsOn: [] },
   // cloud-agent
   'cloud-agent-next': {
     group: 'cloud-agent',
@@ -122,7 +123,6 @@ const serviceMeta: Record<string, ServiceMeta> = {
   },
   // kiloclaw
   'kiloclaw-tunnel': { group: 'kiloclaw', dependsOn: [] },
-  'kiloclaw-stripe': { group: 'kiloclaw', dependsOn: [] },
   kiloclaw: {
     group: 'kiloclaw',
     dependsOn: ['postgres', 'kiloclaw-tunnel'],
@@ -305,7 +305,7 @@ function buildServiceDefs(): ServiceDef[] {
       continue;
     }
 
-    if (name === 'kiloclaw-stripe') {
+    if (name === 'stripe') {
       defs.push({
         name,
         type: 'process',

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -44,4 +44,4 @@ done
 
 export PORT
 export NEXTAUTH_URL="${NEXTAUTH_URL:-${APP_URL_OVERRIDE:-http://localhost:$PORT}}"
-exec npx next dev -p "$PORT" "$@"
+exec next dev -p "$PORT" "$@"


### PR DESCRIPTION
## Summary

Local development now starts Stripe webhook forwarding early when the Stripe CLI is available and skips it gracefully when unavailable, so default startup works for developers without payment tooling.

- Treat the Stripe webhook forwarder as a core local service named `stripe`.
- Start capture services before the rest of the tmux dashboard and wait for the Stripe webhook secret when Stripe forwarding is active.
- Resolve the target Next.js port and pass it to the Stripe listener so worktree offsets, explicit `PORT`, and auto-incremented ports forward correctly.
- Propagate explicit `PORT` into tmux sessions so Next.js, Stripe forwarding, and tunnels agree on the app port.
- Skip the Stripe service with a warning when the Stripe CLI is not installed.
- Redact Stripe webhook signing secrets before writing forwarder output to tmux panes or logs.
- Update local development docs to describe optional Stripe CLI behavior.
- Stabilize Impact affiliate test fixtures so CI does not fail after the seeded tracking touch expires.

## Verification

- `pnpm format:changed`
- `pnpm typecheck`
- `git diff --check`
- `pnpm test -- apps/web/src/routers/kiloclaw-billing-router.test.ts --runTestsByPath --testNamePattern "affiliate events"`
- Normal `git push origin fix/dev-stripe-startup` was attempted; pre-push checks passed, then the remote rejected the push as non-fast-forward because the branch was rebased.
- `git push --force-with-lease origin fix/dev-stripe-startup` completed successfully after approval; pre-push checks passed.
- Latest `git push origin fix/dev-stripe-startup` completed successfully; pre-push checks passed.

## Visual Changes

N/A

## Reviewer Notes

- The branch was rebased on `origin/main`; the existing PR branch was updated with `git push --force-with-lease` after approval.
- Developers without Stripe CLI will still get the Next.js app and local infrastructure. They will not get local Stripe webhook forwarding until they install and log in to Stripe CLI.
- `whsec_...` values are captured into `apps/web/.env.development.local` but redacted from terminal/log output.
- The affiliate test change keeps the seed touch valid relative to the conversion timestamp; it does not change production affiliate behavior.
