### PR TITLE
fix(kiloclaw-billing): gate inference ended emails

### DIFF
--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -38,7 +38,6 @@ function createMockDb(selectResults: unknown[][], options?: { txInsertRowCounts?
   const txDeletes: unknown[] = [];
   const inserts: Array<Record<string, unknown>> = [];
   const txInserts: Array<Record<string, unknown>> = [];
-  const wheres: unknown[] = [];
   const txInsertRowCounts = [...(options?.txInsertRowCounts ?? [])];
   const nextSelectResult = () => createSelectResult(selectResults.shift() ?? []);
   const createSelectBuilder = (): SelectBuilder => {
@@ -46,10 +45,7 @@ function createMockDb(selectResults: unknown[][], options?: { txInsertRowCounts?
       from: vi.fn(() => builder),
       innerJoin: vi.fn(() => builder),
       leftJoin: vi.fn(() => builder),
-      where: vi.fn(whereArg => {
-        wheres.push(whereArg);
-        return nextSelectResult();
-      }),
+      where: vi.fn(() => nextSelectResult()),
       limit: vi.fn(async () => selectResults.shift() ?? []),
     };
     return builder;
@@ -127,17 +123,7 @@ function createMockDb(selectResults: unknown[][], options?: { txInsertRowCounts?
     txDeletes,
     inserts,
     txInserts,
-    wheres,
   };
-}
-
-function containsValue(value: unknown, expected: string, seen = new WeakSet<object>()): boolean {
-  if (value === expected) return true;
-  if (typeof value !== 'object' || value === null) return false;
-  if (seen.has(value)) return false;
-  seen.add(value);
-  if (Array.isArray(value)) return value.some(item => containsValue(item, expected, seen));
-  return Object.values(value).some(item => containsValue(item, expected, seen));
 }
 
 function createEnv(fetchImpl: BillingWorkerEnv['KILOCLAW']['fetch']): BillingWorkerEnv {
@@ -741,73 +727,5 @@ describe('credit renewal sweep affiliate tracking', () => {
         },
       },
     ]);
-  });
-});
-
-describe('complementary inference ended sweep', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockGetWorkerDb.mockReset();
-    vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.spyOn(console, 'error').mockImplementation(() => undefined);
-  });
-
-  it('filters instance-ready email eligibility at the rollout cutoff', async () => {
-    const { db, inserts, wheres } = createMockDb([
-      [
-        {
-          user_id: 'user-after',
-          email: 'after@example.com',
-          sandbox_id: 'ki_after',
-        },
-      ],
-    ]);
-    mockGetWorkerDb.mockReturnValue(db);
-    const fetch = vi.fn(
-      async (_request: RequestInfo | URL, _init?: RequestInit) =>
-        new Response(JSON.stringify({ sent: true }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        })
-    );
-    vi.spyOn(globalThis, 'fetch').mockImplementation(fetch);
-
-    const summary = await runSweep(
-      createEnv(vi.fn()),
-      {
-        runId: 'edededed-eded-4ded-8ded-edededededed',
-        sweep: 'complementary_inference_ended',
-      },
-      1
-    );
-
-    expect(summary.complementary_inference_ended_emails).toBe(1);
-    expect(summary.emails_sent).toBe(1);
-    expect(summary.errors).toBe(0);
-    expect(wheres.some(whereArg => containsValue(whereArg, '2026-04-10T00:00:00.000Z'))).toBe(true);
-    expect(inserts).toEqual([
-      {
-        user_id: 'user-after',
-        email_type: 'claw_complementary_inference_ended:ki_after',
-      },
-    ]);
-    expect(fetch).toHaveBeenCalledTimes(1);
-    const request = fetch.mock.calls[0]?.[1];
-    const body = JSON.parse(typeof request?.body === 'string' ? request.body : '{}') as {
-      action: string;
-      input: Record<string, unknown>;
-    };
-    expect(body).toEqual({
-      action: 'send_email',
-      input: {
-        to: 'after@example.com',
-        templateName: 'clawComplementaryInferenceEnded',
-        templateVars: {
-          claw_url: 'https://app.kilo.ai/claw',
-          credits_url: 'https://app.kilo.ai/credits',
-          free_model_name: 'Kilo Auto Free',
-        },
-      },
-    });
   });
 });

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -38,6 +38,7 @@ function createMockDb(selectResults: unknown[][], options?: { txInsertRowCounts?
   const txDeletes: unknown[] = [];
   const inserts: Array<Record<string, unknown>> = [];
   const txInserts: Array<Record<string, unknown>> = [];
+  const wheres: unknown[] = [];
   const txInsertRowCounts = [...(options?.txInsertRowCounts ?? [])];
   const nextSelectResult = () => createSelectResult(selectResults.shift() ?? []);
   const createSelectBuilder = (): SelectBuilder => {
@@ -45,7 +46,10 @@ function createMockDb(selectResults: unknown[][], options?: { txInsertRowCounts?
       from: vi.fn(() => builder),
       innerJoin: vi.fn(() => builder),
       leftJoin: vi.fn(() => builder),
-      where: vi.fn(() => nextSelectResult()),
+      where: vi.fn(whereArg => {
+        wheres.push(whereArg);
+        return nextSelectResult();
+      }),
       limit: vi.fn(async () => selectResults.shift() ?? []),
     };
     return builder;
@@ -123,7 +127,17 @@ function createMockDb(selectResults: unknown[][], options?: { txInsertRowCounts?
     txDeletes,
     inserts,
     txInserts,
+    wheres,
   };
+}
+
+function containsValue(value: unknown, expected: string, seen = new WeakSet<object>()): boolean {
+  if (value === expected) return true;
+  if (typeof value !== 'object' || value === null) return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+  if (Array.isArray(value)) return value.some(item => containsValue(item, expected, seen));
+  return Object.values(value).some(item => containsValue(item, expected, seen));
 }
 
 function createEnv(fetchImpl: BillingWorkerEnv['KILOCLAW']['fetch']): BillingWorkerEnv {
@@ -738,26 +752,13 @@ describe('complementary inference ended sweep', () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
   });
 
-  it('only emails users whose instance-ready email was sent after the rollout cutoff', async () => {
-    const { db, inserts } = createMockDb([
+  it('filters instance-ready email eligibility at the rollout cutoff', async () => {
+    const { db, inserts, wheres } = createMockDb([
       [
-        {
-          user_id: 'user-before',
-          email: 'before@example.com',
-          sandbox_id: 'ki_before',
-          instance_ready_sent_at: '2026-04-09T23:59:59.999Z',
-        },
-        {
-          user_id: 'user-at-cutoff',
-          email: 'at-cutoff@example.com',
-          sandbox_id: 'ki_at_cutoff',
-          instance_ready_sent_at: '2026-04-10T00:00:00.000Z',
-        },
         {
           user_id: 'user-after',
           email: 'after@example.com',
           sandbox_id: 'ki_after',
-          instance_ready_sent_at: '2026-04-10T00:00:00.001Z',
         },
       ],
     ]);
@@ -783,6 +784,7 @@ describe('complementary inference ended sweep', () => {
     expect(summary.complementary_inference_ended_emails).toBe(1);
     expect(summary.emails_sent).toBe(1);
     expect(summary.errors).toBe(0);
+    expect(wheres.some(whereArg => containsValue(whereArg, '2026-04-10T00:00:00.000Z'))).toBe(true);
     expect(inserts).toEqual([
       {
         user_id: 'user-after',

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -729,3 +729,83 @@ describe('credit renewal sweep affiliate tracking', () => {
     ]);
   });
 });
+
+describe('complementary inference ended sweep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetWorkerDb.mockReset();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  it('only emails users whose instance-ready email was sent after the rollout cutoff', async () => {
+    const { db, inserts } = createMockDb([
+      [
+        {
+          user_id: 'user-before',
+          email: 'before@example.com',
+          sandbox_id: 'ki_before',
+          instance_ready_sent_at: '2026-04-09T23:59:59.999Z',
+        },
+        {
+          user_id: 'user-at-cutoff',
+          email: 'at-cutoff@example.com',
+          sandbox_id: 'ki_at_cutoff',
+          instance_ready_sent_at: '2026-04-10T00:00:00.000Z',
+        },
+        {
+          user_id: 'user-after',
+          email: 'after@example.com',
+          sandbox_id: 'ki_after',
+          instance_ready_sent_at: '2026-04-10T00:00:00.001Z',
+        },
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi.fn(
+      async (_request: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(JSON.stringify({ sent: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+    );
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fetch);
+
+    const summary = await runSweep(
+      createEnv(vi.fn()),
+      {
+        runId: 'edededed-eded-4ded-8ded-edededededed',
+        sweep: 'complementary_inference_ended',
+      },
+      1
+    );
+
+    expect(summary.complementary_inference_ended_emails).toBe(1);
+    expect(summary.emails_sent).toBe(1);
+    expect(summary.errors).toBe(0);
+    expect(inserts).toEqual([
+      {
+        user_id: 'user-after',
+        email_type: 'claw_complementary_inference_ended:ki_after',
+      },
+    ]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const request = fetch.mock.calls[0]?.[1];
+    const body = JSON.parse(typeof request?.body === 'string' ? request.body : '{}') as {
+      action: string;
+      input: Record<string, unknown>;
+    };
+    expect(body).toEqual({
+      action: 'send_email',
+      input: {
+        to: 'after@example.com',
+        templateName: 'clawComplementaryInferenceEnded',
+        templateVars: {
+          claw_url: 'https://app.kilo.ai/claw',
+          credits_url: 'https://app.kilo.ai/credits',
+          free_model_name: 'Kilo Auto Free',
+        },
+      },
+    });
+  });
+});

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -1779,14 +1779,6 @@ async function runEarlybirdWarningSweep(
 
 const COMPLEMENTARY_INFERENCE_WINDOW_MS = 6 * 60 * 60 * 1000;
 const COMPLEMENTARY_INFERENCE_INSTANCE_READY_CUTOFF_ISO = '2026-04-10T00:00:00.000Z';
-const COMPLEMENTARY_INFERENCE_INSTANCE_READY_CUTOFF_MS = Date.parse(
-  COMPLEMENTARY_INFERENCE_INSTANCE_READY_CUTOFF_ISO
-);
-
-function wasInstanceReadyEmailSentAfterComplementaryInferenceCutoff(sentAt: string): boolean {
-  const sentAtMs = Date.parse(sentAt);
-  return Number.isFinite(sentAtMs) && sentAtMs > COMPLEMENTARY_INFERENCE_INSTANCE_READY_CUTOFF_MS;
-}
 
 async function runComplementaryInferenceEndedSweep(
   database: WorkerDb,
@@ -1809,7 +1801,6 @@ async function runComplementaryInferenceEndedSweep(
       user_id: kilocode_users.id,
       email: kilocode_users.google_user_email,
       sandbox_id: kiloclaw_instances.sandbox_id,
-      instance_ready_sent_at: kiloclaw_email_log.sent_at,
     })
     .from(kiloclaw_email_log)
     .innerJoin(kilocode_users, eq(kiloclaw_email_log.user_id, kilocode_users.id))
@@ -1844,10 +1835,6 @@ async function runComplementaryInferenceEndedSweep(
 
   for (const row of rows) {
     try {
-      if (!wasInstanceReadyEmailSentAfterComplementaryInferenceCutoff(row.instance_ready_sent_at)) {
-        continue;
-      }
-
       const sent = await trySendEmail(
         database,
         env,

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, inArray, isNotNull, isNull, lt, lte, sql } from 'drizzle-orm';
+import { and, eq, gt, gte, inArray, isNotNull, isNull, lt, lte, sql } from 'drizzle-orm';
 import { addMonths, format } from 'date-fns';
 
 import type { WorkerDb } from '@kilocode/db';
@@ -1778,6 +1778,15 @@ async function runEarlybirdWarningSweep(
 }
 
 const COMPLEMENTARY_INFERENCE_WINDOW_MS = 6 * 60 * 60 * 1000;
+const COMPLEMENTARY_INFERENCE_INSTANCE_READY_CUTOFF_ISO = '2026-04-10T00:00:00.000Z';
+const COMPLEMENTARY_INFERENCE_INSTANCE_READY_CUTOFF_MS = Date.parse(
+  COMPLEMENTARY_INFERENCE_INSTANCE_READY_CUTOFF_ISO
+);
+
+function wasInstanceReadyEmailSentAfterComplementaryInferenceCutoff(sentAt: string): boolean {
+  const sentAtMs = Date.parse(sentAt);
+  return Number.isFinite(sentAtMs) && sentAtMs > COMPLEMENTARY_INFERENCE_INSTANCE_READY_CUTOFF_MS;
+}
 
 async function runComplementaryInferenceEndedSweep(
   database: WorkerDb,
@@ -1789,9 +1798,9 @@ async function runComplementaryInferenceEndedSweep(
   const creditsUrl = `${env.KILOCODE_BACKEND_BASE_URL}/credits`;
   const windowCutoff = new Date(Date.now() - COMPLEMENTARY_INFERENCE_WINDOW_MS).toISOString();
 
-  // Find users whose "instance ready" email was sent more than 6 hours ago,
-  // whose instance is not destroyed, who have never purchased credits,
-  // and who have not already received this notification.
+  // Find users whose "instance ready" email was sent more than 6 hours ago
+  // after the rollout cutoff, whose instance is not destroyed, who have never
+  // purchased credits, and who have not already received this notification.
   //
   // The email_type for the "instance ready" log is `claw_instance_ready:{sandboxId}`.
   // We extract the sandbox_id by joining against kiloclaw_instances.
@@ -1800,6 +1809,7 @@ async function runComplementaryInferenceEndedSweep(
       user_id: kilocode_users.id,
       email: kilocode_users.google_user_email,
       sandbox_id: kiloclaw_instances.sandbox_id,
+      instance_ready_sent_at: kiloclaw_email_log.sent_at,
     })
     .from(kiloclaw_email_log)
     .innerJoin(kilocode_users, eq(kiloclaw_email_log.user_id, kilocode_users.id))
@@ -1813,6 +1823,7 @@ async function runComplementaryInferenceEndedSweep(
     .where(
       and(
         sql`${kiloclaw_email_log.email_type} LIKE 'claw_instance_ready:%'`,
+        gt(kiloclaw_email_log.sent_at, COMPLEMENTARY_INFERENCE_INSTANCE_READY_CUTOFF_ISO),
         lte(kiloclaw_email_log.sent_at, windowCutoff),
         isNull(kiloclaw_instances.destroyed_at),
         // Not already sent the complementary inference ended email for this instance
@@ -1833,6 +1844,10 @@ async function runComplementaryInferenceEndedSweep(
 
   for (const row of rows) {
     try {
+      if (!wasInstanceReadyEmailSentAfterComplementaryInferenceCutoff(row.instance_ready_sent_at)) {
+        continue;
+      }
+
       const sent = await trySendEmail(
         database,
         env,


### PR DESCRIPTION
## Summary

- The complimentary inference ended email should only reach users who first received the KiloClaw instance-ready email after the rollout cutoff.
- Users with older instance-ready emails could otherwise receive a new lifecycle notification for a period that predates the PR that introduced it.
- The sweep now requires the matching instance-ready email log to be strictly after `2026-04-10T00:00:00.000Z` while preserving the existing six-hour delay, destroyed-instance, duplicate-email, and credit-purchase guards.

## Verification

- [x] Spec alignment: reviewed KiloClaw billing lifecycle notification rules and preserved email idempotency behavior.
- [x] Tests verified: `pnpm --filter kiloclaw-billing test -- src/lifecycle.test.ts` passed with 15 tests.
- [ ] Add any additional manual verification details.

## Visual Changes

N/A

## Reviewer Notes

<details>
<summary>Code Reviewer Notes</summary>

- The database query adds a strict `sent_at > 2026-04-10T00:00:00.000Z` predicate on the `claw_instance_ready:*` email log.
- Eligibility is owned by the SQL predicate; there is no second in-loop cutoff guard.
- No dedicated cutoff test was added because asserting Drizzle query internals was more brittle than useful for this one-line eligibility predicate.

</details>