### PR TITLE
fix(kiloclaw): install all missing openclaw@2026.4.5 channel deps

### DIFF
--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -49,7 +49,21 @@ RUN npm install -g pnpm
 # Patch: bump model discovery timeout from 5s to 60s — shared-cpu machines
 # under boot load routinely need 27-35s for the first TLS+fetch to complete.
 # Remove this sed patch once openclaw exposes a configurable timeout.
-RUN npm install -g @buape/carbon@0.14.0
+# Workaround: openclaw@2026.4.5 is missing bundled channel plugin runtime deps
+# that were removed in the "move bundled extension deps to plugin packages" refactor
+# and re-added in openclaw@2026.4.9 via "mirror bundled channel deps at root (#63065)".
+# Install them globally so openclaw can resolve them at runtime.
+# Remove this block when upgrading to openclaw >= 2026.4.9.
+RUN npm install -g \
+    @buape/carbon@0.14.0 \
+    @grammyjs/runner@^2.0.3 \
+    @grammyjs/transformer-throttler@^1.2.1 \
+    @larksuiteoapi/node-sdk@^1.60.0 \
+    @slack/bolt@^4.6.0 \
+    @slack/web-api@^7.15.0 \
+    grammy@^1.42.0 \
+    https-proxy-agent@^9.0.0 \
+    opusscript@^0.1.1
 RUN npm install -g openclaw@2026.4.5 \
     && OC_DIST=/usr/local/lib/node_modules/openclaw/dist \
     && PM_FILE=$(find "$OC_DIST" -name 'provider-models-*.js' | head -1) \

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -49,6 +49,7 @@ RUN npm install -g pnpm
 # Patch: bump model discovery timeout from 5s to 60s — shared-cpu machines
 # under boot load routinely need 27-35s for the first TLS+fetch to complete.
 # Remove this sed patch once openclaw exposes a configurable timeout.
+RUN npm install -g @buape/carbon@0.14.0
 RUN npm install -g openclaw@2026.4.5 \
     && OC_DIST=/usr/local/lib/node_modules/openclaw/dist \
     && PM_FILE=$(find "$OC_DIST" -name 'provider-models-*.js' | head -1) \


### PR DESCRIPTION
## Summary

OpenClaw 2026.4.5 is missing 9 bundled channel plugin runtime dependencies that were removed in upstream commit `d7018aaf` ("move bundled extension deps to plugin packages") and re-added in `44c7c894` ("mirror bundled channel deps at root #63065"), which shipped in 2026.4.9. This caused `Cannot find module '@buape/carbon'` errors at runtime (and likely similar failures for Telegram/Grammy, Slack, Lark, and Discord voice channels).

This PR pre-installs all 9 missing packages globally in the Dockerfile before the openclaw install, with a comment documenting the root cause and when to remove the workaround (upgrade to openclaw >= 2026.4.9).

## Verification

- [x] Traced the dependency through openclaw git history — confirmed removed in refactor, re-added in 2026.4.9
- [x] Verified `kiloclaw-customizer` plugin has no relation to `@buape/carbon`
- [x] Cross-referenced `npm view openclaw@2026.4.5 dependencies` vs `openclaw@2026.4.9 dependencies` to confirm the missing set
- [ ] Docker image build (pending CI)

## Visual Changes

N/A

## Reviewer Notes

- This is a temporary workaround. The clean fix is bumping to `openclaw >= 2026.4.9`, but that may require validating other changes in that release.
- Only the packages from the green `+` lines in the upstream diff are included — packages that were already in 2026.4.5's dependency list (e.g., `ajv`, `chalk`, `hono`) are not duplicated.