### PR TITLE
Feat(kiloclaw) admin machine resize

### DIFF
--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1494,7 +1494,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
       'performance-2x': { cpus: 2, memory_mb: 4096, cpu_kind: 'performance' },
     };
     const machineSize = sizeMap[selectedMachineSize];
-    if (!machineSize || !data) return;
+    if (!machineSize || !data || !userId) return;
 
     try {
       // Step 1: Stop if running — retry up to 3 times since Fly can be slow

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1180,7 +1180,9 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
   const [resizeMachineDialogOpen, setResizeMachineDialogOpen] = useState(false);
   const [selectedMachineSize, setSelectedMachineSize] = useState<string>('shared-cpu-2x');
   const [resizeConfirmText, setResizeConfirmText] = useState('');
-  const [resizePhase, setResizePhase] = useState<'idle' | 'stopping' | 'resizing' | 'starting' | 'waiting' | 'done' | 'error'>('idle');
+  const [resizePhase, setResizePhase] = useState<
+    'idle' | 'stopping' | 'resizing' | 'starting' | 'waiting' | 'done' | 'error'
+  >('idle');
   const [resizeError, setResizeError] = useState<string | null>(null);
   const [awaitingRestartCompletion, setAwaitingRestartCompletion] = useState(false);
   const [restoreSnapshotDialogOpen, setRestoreSnapshotDialogOpen] = useState(false);
@@ -1460,10 +1462,12 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     trpc.admin.kiloclawInstances.resizeMachine.mutationOptions()
   );
 
-  const isResizingMachine = resizePhase !== 'idle' && resizePhase !== 'done' && resizePhase !== 'error';
+  const isResizingMachine =
+    resizePhase !== 'idle' && resizePhase !== 'done' && resizePhase !== 'error';
 
   // Poll status during resize phases
-  const resizePolling = resizePhase === 'stopping' || resizePhase === 'starting' || resizePhase === 'waiting';
+  const resizePolling =
+    resizePhase === 'stopping' || resizePhase === 'starting' || resizePhase === 'waiting';
   useQuery({
     queryKey: ['machine-resize-poll', userId, instanceId, resizePolling],
     queryFn: async () => {
@@ -1487,7 +1491,10 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     setResizeConfirmText('');
     setResizeError(null);
 
-    const sizeMap: Record<string, { cpus: number; memory_mb: number; cpu_kind: 'shared' | 'performance' }> = {
+    const sizeMap: Record<
+      string,
+      { cpus: number; memory_mb: number; cpu_kind: 'shared' | 'performance' }
+    > = {
       'shared-cpu-2x': { cpus: 2, memory_mb: 3072, cpu_kind: 'shared' },
       'shared-cpu-4x': { cpus: 4, memory_mb: 3072, cpu_kind: 'shared' },
       'performance-1x': { cpus: 1, memory_mb: 3072, cpu_kind: 'performance' },
@@ -1995,7 +2002,9 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                         {data.workerStatus.machineSize.memory_mb}MB
                       </code>
                     ) : (
-                      <span className="text-muted-foreground text-sm">default (shared-cpu-2x, 3072MB)</span>
+                      <span className="text-muted-foreground text-sm">
+                        default (shared-cpu-2x, 3072MB)
+                      </span>
                     )}
                   </DetailField>
                 </div>
@@ -2313,9 +2322,10 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                   disabled={machineActionPending || isResizingMachine}
                   onClick={() => {
                     const ms = data?.workerStatus?.machineSize;
-                    const key = ms?.cpu_kind === 'performance'
-                      ? `performance-${ms.cpus}x`
-                      : `shared-cpu-${ms?.cpus ?? 2}x`;
+                    const key =
+                      ms?.cpu_kind === 'performance'
+                        ? `performance-${ms.cpus}x`
+                        : `shared-cpu-${ms?.cpus ?? 2}x`;
                     setSelectedMachineSize(key);
                     setResizeMachineDialogOpen(true);
                   }}
@@ -2430,7 +2440,13 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                                 : ''
                           }
                         >
-                          {step === 'stopping' ? 'Stop' : step === 'resizing' ? 'Resize' : step === 'starting' ? 'Start' : 'Health check'}
+                          {step === 'stopping'
+                            ? 'Stop'
+                            : step === 'resizing'
+                              ? 'Resize'
+                              : step === 'starting'
+                                ? 'Start'
+                                : 'Health check'}
                         </span>
                       </span>
                     ))}
@@ -2453,9 +2469,16 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                 <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600" />
                 <div>
                   <p className="text-sm font-medium text-green-600">Machine resize complete</p>
-                  <p className="text-muted-foreground text-xs">Machine is running with the new size.</p>
+                  <p className="text-muted-foreground text-xs">
+                    Machine is running with the new size.
+                  </p>
                 </div>
-                <Button variant="outline" size="sm" className="ml-auto" onClick={() => setResizePhase('idle')}>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="ml-auto"
+                  onClick={() => setResizePhase('idle')}
+                >
                   Dismiss
                 </Button>
               </div>
@@ -2472,7 +2495,15 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                   <p className="text-sm font-medium text-red-600">Machine resize failed</p>
                   <p className="text-muted-foreground text-xs">{resizeError}</p>
                 </div>
-                <Button variant="outline" size="sm" className="ml-auto" onClick={() => { setResizePhase('idle'); setResizeError(null); }}>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="ml-auto"
+                  onClick={() => {
+                    setResizePhase('idle');
+                    setResizeError(null);
+                  }}
+                >
                   Dismiss
                 </Button>
               </div>
@@ -2496,8 +2527,8 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                 Resize Machine
               </DialogTitle>
               <DialogDescription className="pt-3">
-                This will stop the machine, update its CPU/memory spec, and restart it.
-                The user will be disconnected during the restart.
+                This will stop the machine, update its CPU/memory spec, and restart it. The user
+                will be disconnected during the restart.
                 <span className="text-foreground mt-2 block font-medium">
                   User: {data?.user_email ?? data?.user_id}
                 </span>

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -50,6 +50,7 @@ import {
   RotateCcw,
   RotateCw,
   ArrowUpCircle,
+  ArrowUpDown,
   RefreshCw,
   Pin,
   Stethoscope,
@@ -1176,6 +1177,11 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
   const [doctorDialogOpen, setDoctorDialogOpen] = useState(false);
   const [restoreConfigDialogOpen, setRestoreConfigDialogOpen] = useState(false);
   const [destroyMachineDialogOpen, setDestroyMachineDialogOpen] = useState(false);
+  const [resizeMachineDialogOpen, setResizeMachineDialogOpen] = useState(false);
+  const [selectedMachineSize, setSelectedMachineSize] = useState<string>('shared-cpu-2x');
+  const [resizeConfirmText, setResizeConfirmText] = useState('');
+  const [resizePhase, setResizePhase] = useState<'idle' | 'stopping' | 'resizing' | 'starting' | 'waiting' | 'done' | 'error'>('idle');
+  const [resizeError, setResizeError] = useState<string | null>(null);
   const [awaitingRestartCompletion, setAwaitingRestartCompletion] = useState(false);
   const [restoreSnapshotDialogOpen, setRestoreSnapshotDialogOpen] = useState(false);
   const [restoreSnapshotId, setRestoreSnapshotId] = useState<string | null>(null);
@@ -1449,6 +1455,85 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
       },
     })
   );
+
+  const { mutateAsync: resizeMachineMutation } = useMutation(
+    trpc.admin.kiloclawInstances.resizeMachine.mutationOptions()
+  );
+
+  const isResizingMachine = resizePhase !== 'idle' && resizePhase !== 'done' && resizePhase !== 'error';
+
+  // Poll status during resize phases
+  const resizePolling = resizePhase === 'stopping' || resizePhase === 'starting' || resizePhase === 'waiting';
+  useQuery({
+    queryKey: ['machine-resize-poll', userId, instanceId, resizePolling],
+    queryFn: async () => {
+      invalidateMachineQueries();
+      return { ts: Date.now() };
+    },
+    enabled: resizePolling,
+    refetchInterval: resizePolling ? 3000 : false,
+  });
+
+  // Advance resize phase when machine reaches running
+  const currentStatus = data?.workerStatus?.status;
+  useEffect(() => {
+    if (resizePhase === 'waiting' && currentStatus === 'running') {
+      setResizePhase('done');
+    }
+  }, [resizePhase, currentStatus]);
+
+  const handleResize = async () => {
+    setResizeMachineDialogOpen(false);
+    setResizeConfirmText('');
+    setResizeError(null);
+
+    const sizeMap: Record<string, { cpus: number; memory_mb: number; cpu_kind: 'shared' | 'performance' }> = {
+      'shared-cpu-2x': { cpus: 2, memory_mb: 3072, cpu_kind: 'shared' },
+      'shared-cpu-4x': { cpus: 4, memory_mb: 3072, cpu_kind: 'shared' },
+      'performance-1x': { cpus: 1, memory_mb: 3072, cpu_kind: 'performance' },
+      'performance-2x': { cpus: 2, memory_mb: 4096, cpu_kind: 'performance' },
+    };
+    const machineSize = sizeMap[selectedMachineSize];
+    if (!machineSize || !data) return;
+
+    try {
+      // Step 1: Stop if running — retry up to 3 times since Fly can be slow
+      if (currentStatus !== 'stopped') {
+        setResizePhase('stopping');
+        let stopped = false;
+        for (let attempt = 0; attempt < 3 && !stopped; attempt++) {
+          try {
+            await machineStop({ userId, instanceId });
+            stopped = true;
+          } catch {
+            // Stop timed out — wait and check if it actually stopped
+            await new Promise(resolve => setTimeout(resolve, 10_000));
+            // Re-fetch status to check
+            await queryClient.invalidateQueries({
+              queryKey: trpc.admin.kiloclawInstances.get.queryKey(),
+            });
+          }
+        }
+        // Final wait to let status propagate
+        await new Promise(resolve => setTimeout(resolve, 5000));
+      }
+
+      // Step 2: Update DO state
+      setResizePhase('resizing');
+      await resizeMachineMutation({ userId, instanceId: data.id, machineSize });
+
+      // Step 3: Start with new size
+      setResizePhase('starting');
+      await machineStart({ userId, instanceId });
+
+      // Step 4: Wait for running
+      setResizePhase('waiting');
+    } catch (err) {
+      setResizePhase('error');
+      setResizeError(err instanceof Error ? err.message : 'An unknown error occurred');
+      toast.error(`Resize failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    }
+  };
 
   // Reset the destroyed success state when the machine ID changes (e.g. new machine created)
   const flyMachineId = data?.workerStatus?.flyMachineId;
@@ -1901,6 +1986,21 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                 </div>
 
                 <div className="flex items-center gap-2">
+                  <Server className="text-muted-foreground h-4 w-4 shrink-0" />
+                  <DetailField label="Machine Size">
+                    {data.workerStatus.machineSize ? (
+                      <code className="text-sm">
+                        {data.workerStatus.machineSize.cpu_kind ?? 'shared'}-cpu-
+                        {data.workerStatus.machineSize.cpus}x,{' '}
+                        {data.workerStatus.machineSize.memory_mb}MB
+                      </code>
+                    ) : (
+                      <span className="text-muted-foreground text-sm">default (shared-cpu-2x, 3072MB)</span>
+                    )}
+                  </DetailField>
+                </div>
+
+                <div className="flex items-center gap-2">
                   <HardDrive className="text-muted-foreground h-4 w-4 shrink-0" />
                   <DetailField label="Fly Volume ID">
                     <code className="text-sm">{data.workerStatus.flyVolumeId ?? '—'}</code>
@@ -2148,7 +2248,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <CardTitle>Machine Controls</CardTitle>
-                  <CardDescription>Start or stop the Fly machine</CardDescription>
+                  <CardDescription>Start, stop, resize, or destroy the Fly machine</CardDescription>
                 </div>
                 <StatusBadge status={data.workerStatus?.status ?? null} />
               </div>
@@ -2206,6 +2306,22 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                     <ArrowUpCircle className="mr-1 h-4 w-4" />
                   )}
                   Upgrade to Latest
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={machineActionPending || isResizingMachine}
+                  onClick={() => {
+                    const ms = data?.workerStatus?.machineSize;
+                    const key = ms?.cpu_kind === 'performance'
+                      ? `performance-${ms.cpus}x`
+                      : `shared-cpu-${ms?.cpus ?? 2}x`;
+                    setSelectedMachineSize(key);
+                    setResizeMachineDialogOpen(true);
+                  }}
+                >
+                  <ArrowUpDown className="mr-1 h-4 w-4" />
+                  Resize Machine
                 </Button>
                 <Button
                   size="sm"
@@ -2281,6 +2397,167 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
               >
                 {isDestroyingFlyMachine && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}
                 Destroy Machine
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        {/* Resize Machine Progress */}
+        {isResizingMachine && (
+          <Card className="border-orange-500/50">
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-3 rounded border p-4">
+                <Loader2 className="h-5 w-5 shrink-0 animate-spin text-orange-500" />
+                <div className="space-y-1">
+                  <p className="text-sm font-medium">
+                    {resizePhase === 'stopping' && 'Stopping machine...'}
+                    {resizePhase === 'resizing' && 'Updating machine size...'}
+                    {resizePhase === 'starting' && 'Starting machine with new size...'}
+                    {resizePhase === 'waiting' && 'Waiting for machine to be ready...'}
+                  </p>
+                  <div className="text-muted-foreground flex items-center gap-2 text-xs">
+                    {(['stopping', 'resizing', 'starting', 'waiting'] as const).map((step, i) => (
+                      <span key={step} className="flex items-center gap-1">
+                        {i > 0 && <span className="text-muted-foreground/50">&rarr;</span>}
+                        <span
+                          className={
+                            resizePhase === step
+                              ? 'font-medium text-orange-500'
+                              : (['stopping', 'resizing', 'starting', 'waiting'] as const).indexOf(
+                                    resizePhase as typeof step
+                                  ) > i
+                                ? 'text-foreground'
+                                : ''
+                          }
+                        >
+                          {step === 'stopping' ? 'Stop' : step === 'resizing' ? 'Resize' : step === 'starting' ? 'Start' : 'Health check'}
+                        </span>
+                      </span>
+                    ))}
+                  </div>
+                  {currentStatus && (
+                    <p className="text-muted-foreground text-xs">
+                      Machine status: <StatusBadge status={currentStatus} />
+                    </p>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {resizePhase === 'done' && (
+          <Card className="border-green-500/50">
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-3 rounded border border-green-600/30 bg-green-600/5 p-4">
+                <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600" />
+                <div>
+                  <p className="text-sm font-medium text-green-600">Machine resize complete</p>
+                  <p className="text-muted-foreground text-xs">Machine is running with the new size.</p>
+                </div>
+                <Button variant="outline" size="sm" className="ml-auto" onClick={() => setResizePhase('idle')}>
+                  Dismiss
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {resizePhase === 'error' && (
+          <Card className="border-destructive/50">
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-3 rounded border border-red-600/30 bg-red-600/5 p-4">
+                <AlertTriangle className="h-5 w-5 shrink-0 text-red-600" />
+                <div>
+                  <p className="text-sm font-medium text-red-600">Machine resize failed</p>
+                  <p className="text-muted-foreground text-xs">{resizeError}</p>
+                </div>
+                <Button variant="outline" size="sm" className="ml-auto" onClick={() => { setResizePhase('idle'); setResizeError(null); }}>
+                  Dismiss
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Resize Machine Dialog */}
+        <Dialog
+          open={resizeMachineDialogOpen}
+          onOpenChange={open => {
+            if (isResizingMachine) return;
+            setResizeMachineDialogOpen(open);
+            if (!open) setResizeConfirmText('');
+          }}
+        >
+          <DialogContent className="sm:max-w-[425px]">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2 text-orange-500">
+                <AlertTriangle className="h-5 w-5" />
+                Resize Machine
+              </DialogTitle>
+              <DialogDescription className="pt-3">
+                This will stop the machine, update its CPU/memory spec, and restart it.
+                The user will be disconnected during the restart.
+                <span className="text-foreground mt-2 block font-medium">
+                  User: {data?.user_email ?? data?.user_id}
+                </span>
+                {data?.workerStatus?.machineSize ? (
+                  <span className="mt-2 block text-sm">
+                    Current:{' '}
+                    <code className="text-xs">
+                      {data.workerStatus.machineSize.cpu_kind ?? 'shared'}-cpu-
+                      {data.workerStatus.machineSize.cpus}x,{' '}
+                      {data.workerStatus.machineSize.memory_mb}MB
+                    </code>
+                  </span>
+                ) : (
+                  <span className="text-muted-foreground mt-2 block text-sm">
+                    Current: default (shared-cpu-2x, 3072MB)
+                  </span>
+                )}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4 py-4">
+              <div>
+                <label className="text-sm font-medium">New size</label>
+                <select
+                  className="bg-background border-input mt-1 w-full rounded-md border px-3 py-2 text-sm"
+                  value={selectedMachineSize}
+                  onChange={e => setSelectedMachineSize(e.target.value)}
+                  disabled={isResizingMachine}
+                >
+                  <option value="shared-cpu-2x">shared-cpu-2x, 3GB (~$20/mo)</option>
+                  <option value="shared-cpu-4x">shared-cpu-4x, 3GB (~$24/mo)</option>
+                  <option value="performance-1x">performance-1x, 3GB (~$47/mo)</option>
+                  <option value="performance-2x">performance-2x, 4GB (~$85/mo)</option>
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium">
+                  Type <code className="text-destructive text-xs">RESIZE</code> to confirm
+                </label>
+                <input
+                  type="text"
+                  className="bg-background border-input mt-1 w-full rounded-md border px-3 py-2 text-sm"
+                  value={resizeConfirmText}
+                  onChange={e => setResizeConfirmText(e.target.value)}
+                  placeholder="RESIZE"
+                  disabled={isResizingMachine}
+                />
+              </div>
+            </div>
+            <DialogFooter className="gap-2 sm:gap-0">
+              <DialogClose asChild>
+                <Button variant="secondary" disabled={isResizingMachine}>
+                  Cancel
+                </Button>
+              </DialogClose>
+              <Button
+                variant="destructive"
+                disabled={isResizingMachine || resizeConfirmText !== 'RESIZE'}
+                onClick={() => void handleResize()}
+              >
+                Confirm Resize
               </Button>
             </DialogFooter>
           </DialogContent>

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1178,7 +1178,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
   const [restoreConfigDialogOpen, setRestoreConfigDialogOpen] = useState(false);
   const [destroyMachineDialogOpen, setDestroyMachineDialogOpen] = useState(false);
   const [resizeMachineDialogOpen, setResizeMachineDialogOpen] = useState(false);
-  const [selectedMachineSize, setSelectedMachineSize] = useState<string>('shared-cpu-2x');
+  const [selectedMachineSize, setSelectedMachineSize] = useState<string>('performance-1x');
   const [resizeConfirmText, setResizeConfirmText] = useState('');
   const [resizePhase, setResizePhase] = useState<
     'idle' | 'stopping' | 'resizing' | 'starting' | 'waiting' | 'done' | 'error'
@@ -1520,6 +1520,11 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
               queryKey: trpc.admin.kiloclawInstances.get.queryKey(),
             });
           }
+        }
+        if (!stopped) {
+          throw new Error(
+            'Failed to stop the machine after 3 attempts. Please try again or stop it manually first.'
+          );
         }
         // Final wait to let status propagate
         await new Promise(resolve => setTimeout(resolve, 5000));
@@ -2003,7 +2008,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                       </code>
                     ) : (
                       <span className="text-muted-foreground text-sm">
-                        default (shared-cpu-2x, 3072MB)
+                        default (performance-1x, 3072MB)
                       </span>
                     )}
                   </DetailField>
@@ -2322,10 +2327,11 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                   disabled={machineActionPending || isResizingMachine}
                   onClick={() => {
                     const ms = data?.workerStatus?.machineSize;
-                    const key =
-                      ms?.cpu_kind === 'performance'
+                    const key = ms
+                      ? ms.cpu_kind === 'performance'
                         ? `performance-${ms.cpus}x`
-                        : `shared-cpu-${ms?.cpus ?? 2}x`;
+                        : `shared-cpu-${ms.cpus}x`
+                      : 'performance-1x';
                     setSelectedMachineSize(key);
                     setResizeMachineDialogOpen(true);
                   }}
@@ -2543,7 +2549,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                   </span>
                 ) : (
                   <span className="text-muted-foreground mt-2 block text-sm">
-                    Current: default (shared-cpu-2x, 3072MB)
+                    Current: default (performance-1x, 3072MB)
                   </span>
                 )}
               </DialogDescription>

--- a/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -34,6 +34,7 @@ import type {
   GmailNotificationsResponse,
   CandidateVolumesResponse,
   ReassociateVolumeResponse,
+  ResizeMachineResponse,
   RestoreVolumeSnapshotResponse,
   CleanupRecoveryPreviousVolumeResponse,
   RegionsResponse,
@@ -703,6 +704,22 @@ export class KiloClawInternalClient {
       {
         method: 'POST',
         body: JSON.stringify({ userId, newVolumeId, reason }),
+      },
+      { userId }
+    );
+  }
+
+  async resizeMachine(
+    userId: string,
+    machineSize: { cpus: number; memory_mb: number; cpu_kind?: 'shared' | 'performance' },
+    instanceId?: string
+  ): Promise<ResizeMachineResponse> {
+    const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
+    return this.request(
+      `/api/platform/resize-machine${params}`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ userId, machineSize }),
       },
       { userId }
     );

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -373,6 +373,12 @@ export type ReassociateVolumeResponse = {
   newRegion: string;
 };
 
+/** Response from POST /api/platform/resize-machine */
+export type ResizeMachineResponse = {
+  previousSize: { cpus: number; memory_mb: number; cpu_kind?: string } | null;
+  newSize: { cpus: number; memory_mb: number; cpu_kind?: string };
+};
+
 /** Response from GET /api/platform/regions */
 export type RegionsResponse = {
   regions: string[];

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -27,6 +27,7 @@ import type {
   VolumeSnapshot,
   CandidateVolumesResponse,
   ReassociateVolumeResponse,
+  ResizeMachineResponse,
   RestoreVolumeSnapshotResponse,
 } from '@/lib/kiloclaw/types';
 import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
@@ -1129,6 +1130,55 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       } catch (err) {
         console.error('Failed to reassociate volume for user:', input.userId, err);
         throwKiloclawAdminError(err, 'Failed to reassociate volume');
+      }
+    }),
+
+  resizeMachine: adminProcedure
+    .input(
+      z.object({
+        userId: z.string().min(1),
+        instanceId: z.string().uuid().optional(),
+        machineSize: z.object({
+          cpus: z.number().int().min(1).max(8),
+          memory_mb: z.number().int().min(256).max(16384),
+          cpu_kind: z.enum(['shared', 'performance']).optional(),
+        }),
+      })
+    )
+    .mutation(async ({ input, ctx }): Promise<ResizeMachineResponse> => {
+      console.log(
+        `[admin-kiloclaw] Machine resize triggered by admin ${ctx.user.id} (${ctx.user.google_user_email}) for user ${input.userId}: ${JSON.stringify(input.machineSize)}`
+      );
+      try {
+        const instance = await resolveInstance(input.userId, input.instanceId);
+        const client = new KiloClawInternalClient();
+        const result = await client.resizeMachine(
+          input.userId,
+          input.machineSize,
+          workerInstanceId(instance)
+        );
+
+        try {
+          await createKiloClawAdminAuditLog({
+            action: 'kiloclaw.machine.resize',
+            actor_id: ctx.user.id,
+            actor_email: ctx.user.google_user_email,
+            actor_name: ctx.user.google_user_name,
+            target_user_id: input.userId,
+            message: `Machine resized: ${JSON.stringify(result.previousSize)} → ${JSON.stringify(result.newSize)}`,
+            metadata: {
+              previousSize: result.previousSize,
+              newSize: result.newSize,
+            },
+          });
+        } catch (auditErr) {
+          console.error('Failed to write audit log for machine resize:', auditErr);
+        }
+
+        return result;
+      } catch (err) {
+        console.error('Failed to resize machine for user:', input.userId, err);
+        throwKiloclawAdminError(err, 'Failed to resize machine');
       }
     }),
 

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -198,6 +198,7 @@ export const KiloClawAdminAuditAction = z.enum([
   'kiloclaw.config.restore',
   'kiloclaw.doctor.run',
   'kiloclaw.machine.destroy_fly',
+  'kiloclaw.machine.resize',
   'kiloclaw.subscription.bulk_trial_grant',
   'kiloclaw.subscription.admin_cancel',
 ]);

--- a/services/kiloclaw/src/config.ts
+++ b/services/kiloclaw/src/config.ts
@@ -36,11 +36,11 @@ export const KILOCLAW_AUTH_COOKIE_MAX_AGE = 60 * 60 * 24;
 /** API key max age for gateway credentials minted by the worker */
 export const KILOCODE_API_KEY_EXPIRY_SECONDS = 30 * 24 * 60 * 60;
 
-/** Default Fly Machine guest spec (shared-cpu-2x, 3GB) */
+/** Default Fly Machine guest spec (performance-1x, 3GB) */
 export const DEFAULT_MACHINE_GUEST = {
-  cpus: 2,
+  cpus: 1,
   memory_mb: 3072,
-  cpu_kind: 'shared' as const,
+  cpu_kind: 'performance' as const,
 };
 
 /** Default Fly Volume size in GB */

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -6945,6 +6945,97 @@ describe('reassociateVolume', () => {
 });
 
 // ============================================================================
+// resizeMachine
+// ============================================================================
+
+describe('resizeMachine', () => {
+  it('rejects when instance is not provisioned', async () => {
+    const { instance } = createInstance();
+    await expect(
+      instance.resizeMachine({ cpus: 4, memory_mb: 3072, cpu_kind: 'shared' })
+    ).rejects.toThrow('Instance is not provisioned');
+  });
+
+  it('rejects when instance is being destroyed', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, { status: 'destroying' });
+
+    await expect(
+      instance.resizeMachine({ cpus: 4, memory_mb: 3072, cpu_kind: 'shared' })
+    ).rejects.toThrow('Cannot resize: instance is being destroyed');
+  });
+
+  it('rejects when instance is restoring', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, { status: 'restoring' });
+
+    await expect(
+      instance.resizeMachine({ cpus: 4, memory_mb: 3072, cpu_kind: 'shared' })
+    ).rejects.toThrow('Cannot resize: instance is restoring from snapshot');
+  });
+
+  it('rejects when instance is recovering', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, { status: 'recovering' });
+
+    await expect(
+      instance.resizeMachine({ cpus: 4, memory_mb: 3072, cpu_kind: 'shared' })
+    ).rejects.toThrow('Cannot resize: instance is recovering');
+  });
+
+  it('persists new machine size and returns previous', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, {
+      machineSize: { cpus: 2, memory_mb: 3072, cpu_kind: 'shared' },
+    });
+
+    const result = await instance.resizeMachine({ cpus: 4, memory_mb: 3072, cpu_kind: 'shared' });
+
+    expect(result.previousSize).toEqual({ cpus: 2, memory_mb: 3072, cpu_kind: 'shared' });
+    expect(result.newSize).toEqual({ cpus: 4, memory_mb: 3072, cpu_kind: 'shared' });
+    const stored = storage._store.get('machineSize') as { cpus: number; memory_mb: number };
+    expect(stored.cpus).toBe(4);
+    expect(stored.memory_mb).toBe(3072);
+  });
+
+  it('returns null previousSize when no prior size set', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage);
+
+    const result = await instance.resizeMachine({
+      cpus: 1,
+      memory_mb: 3072,
+      cpu_kind: 'performance',
+    });
+
+    expect(result.previousSize).toBeNull();
+    expect(result.newSize).toEqual({ cpus: 1, memory_mb: 3072, cpu_kind: 'performance' });
+  });
+
+  it('allows resize when instance is running', async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage);
+
+    const result = await instance.resizeMachine({ cpus: 4, memory_mb: 3072, cpu_kind: 'shared' });
+
+    expect(result.newSize.cpus).toBe(4);
+  });
+
+  it('allows resize when instance is stopped', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, { status: 'stopped' });
+
+    const result = await instance.resizeMachine({
+      cpus: 2,
+      memory_mb: 4096,
+      cpu_kind: 'performance',
+    });
+
+    expect(result.newSize).toEqual({ cpus: 2, memory_mb: 4096, cpu_kind: 'performance' });
+  });
+});
+
+// ============================================================================
 // updateExecPreset
 // ============================================================================
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -3532,7 +3532,7 @@ describe('start: 412 insufficient resources recovery', () => {
     const regions412Call = (flyClient.createVolumeWithFallback as Mock).mock.calls[0];
     expect(regions412Call[1]).toEqual(
       expect.objectContaining({
-        compute: expect.objectContaining({ cpus: 2, memory_mb: 3072 }) as unknown,
+        compute: expect.objectContaining({ cpus: 1, memory_mb: 3072 }) as unknown,
       })
     );
     // Regions are passed in configured order, and deprioritize is a no-op here
@@ -3587,7 +3587,7 @@ describe('start: 412 insufficient resources recovery', () => {
     expect(regionsForkCall[1]).toEqual(
       expect.objectContaining({
         source_volume_id: 'vol-1',
-        compute: expect.objectContaining({ cpus: 2, memory_mb: 3072 }) as unknown,
+        compute: expect.objectContaining({ cpus: 1, memory_mb: 3072 }) as unknown,
       })
     );
     const forkCreateVolumeCall = (flyClient.createVolumeWithFallback as Mock).mock
@@ -3655,7 +3655,7 @@ describe('start: 412 insufficient resources recovery', () => {
     expect(regionsUpdateCall[1]).toEqual(
       expect.objectContaining({
         source_volume_id: 'vol-1',
-        compute: expect.objectContaining({ cpus: 2, memory_mb: 3072 }) as unknown,
+        compute: expect.objectContaining({ cpus: 1, memory_mb: 3072 }) as unknown,
       })
     );
     const updateForkCreateVolumeCall = (flyClient.createVolumeWithFallback as Mock).mock

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -1890,6 +1890,40 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     };
   }
 
+  // ── Machine resize (admin) ─────────────────────────────────────────
+
+  async resizeMachine(newSize: MachineSize): Promise<{
+    previousSize: MachineSize | null;
+    newSize: MachineSize;
+  }> {
+    await this.loadState();
+
+    if (!this.s.userId) {
+      throw new Error('Instance is not provisioned');
+    }
+    if (this.s.status === 'destroying') {
+      throw new Error('Cannot resize: instance is being destroyed');
+    }
+    if (this.s.status === 'restoring') {
+      throw new Error('Cannot resize: instance is restoring from snapshot');
+    }
+    if (this.s.status === 'recovering') {
+      throw new Error('Cannot resize: instance is recovering from an unexpected stop');
+    }
+
+    const previousSize = this.s.machineSize;
+
+    this.s.machineSize = newSize;
+    await this.persist({ machineSize: newSize });
+
+    console.log(
+      `[admin-machine-resize] userId=${this.s.userId} ` +
+        `previous=${JSON.stringify(previousSize)} new=${JSON.stringify(newSize)}`
+    );
+
+    return { previousSize, newSize };
+  }
+
   // ── Snapshot restore (admin) ───────────────────────────────────────
 
   /**

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -16,6 +16,7 @@ import {
   GoogleCredentialsSchema,
   SecretsPatchSchema,
   InstanceIdParam,
+  MachineSizeSchema,
 } from '../schemas/instance-config';
 import {
   ImageVersionEntrySchema,
@@ -1989,6 +1990,35 @@ platform.post('/reassociate-volume', async c => {
     return c.json(response);
   } catch (err) {
     const { message, status } = sanitizeError(err, 'reassociate-volume');
+    return jsonError(message, status);
+  }
+});
+
+// POST /api/platform/resize-machine
+// Updates the machine size for an instance. Takes effect on next start/restart.
+const ResizeMachineSchema = z.object({
+  userId: z.string().min(1),
+  machineSize: MachineSizeSchema,
+});
+
+platform.post('/resize-machine', async c => {
+  const result = await parseBody(c, ResizeMachineSchema);
+  if ('error' in result) return result.error;
+
+  const iidResult = parseInstanceIdQuery(c);
+  if ('error' in iidResult) return iidResult.error;
+
+  try {
+    const response = await withResolvedDORetry(
+      c.env,
+      result.data.userId,
+      iidResult.instanceId,
+      stub => stub.resizeMachine(result.data.machineSize),
+      'resizeMachine'
+    );
+    return c.json(response);
+  } catch (err) {
+    const { message, status } = sanitizeError(err, 'resize-machine');
     return jsonError(message, status);
   }
 });

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -333,6 +333,7 @@ const SAFE_ERROR_PREFIXES = [
   'Volume ', // reassociate: volume not found / bad state
   'Cannot restore: ', // snapshot restore: bad state
   'Cannot destroy: ', // destroy while restoring
+  'Cannot resize: ', // resize during destroying/restoring/recovering
   'Cannot retry recovery', // force-retry-recovery guard messages
   'Stream Chat sendMessage failed', // sendMessage HTTP errors
   'Stream Chat is not set up', // no Stream Chat on this instance

--- a/services/kiloclaw/src/schemas/instance-config.ts
+++ b/services/kiloclaw/src/schemas/instance-config.ts
@@ -16,7 +16,7 @@ export const EncryptedEnvelopeSchema = z.object({
   version: z.literal(1),
 });
 
-const MachineSizeSchema = z.object({
+export const MachineSizeSchema = z.object({
   cpus: z.number().int().min(1).max(8),
   memory_mb: z.number().int().min(256).max(16384),
   cpu_kind: z.enum(['shared', 'performance']).optional(),


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary
Add admin machine resize capability to KiloClaw. Operators can change an instance's CPU/memory spec from the admin panel with a full stop → resize → start flow.                        
                                                                      
**Changes across 9 files:**                                                     
- **DO layer**: New `resizeMachine()` method with state validation guards (rejects during destroying/restoring/recovering)
- **Worker route**: `POST /api/platform/resize-machine` using exported `MachineSizeSchema`                                
- **Web app**: Internal client method, tRPC mutation with audit logging, admin UI with confirmation dialog
- **Admin UI**: Resize button on machine card, current size displayed on instance page, typed "RESIZE" confirmation,progress indicators (Stop → Resize → Start → Health check), done/error states, retry logic for Fly stop timeouts (3 attempts with 10s delays)                                                                                                 
- **Schema**: Added `kiloclaw.machine.resize` to audit action enum (text column, no migration needed)
- **Presets:** shared-cpu-2x (3GB), shared-cpu-4x (3GB), performance-1x (3GB), performance-2x (4GB)     
**NOTE: performance-2x requires 4GB**

## Verification
- [x] `pnpm --filter kiloclaw typecheck` — passes                                                                         
- [x] `pnpm --filter kiloclaw test` — 1250 tests pass (8 new for resizeMachine)                                           
- [x] `pnpm --filter kiloclaw lint` — 0 warnings, 0 errors                                                                
- [x] `pnpm --filter kiloclaw format:check` — passes                                                                      
- [x] Manual test: resized dev instance via admin UI, confirmed stop → resize → start flow                                
- [x] Manual test: verified `fly machine list --json` shows updated guest spec after resize

## Visual Changes

  | Before | After |                                                                                                        
  | ------ | ----- |                                                                                                        
  | Machine card: Start/Stop/Destroy buttons only | Machine card: + Resize button with ArrowUpDown icon |                   
  | No machine size shown | Machine size displayed (e.g. `shared-cpu-2x, 3072MB`) |                                         
  | N/A | Resize dialog: current size, preset picker, type RESIZE to confirm |                                              
  | N/A | Progress card: Stop → Resize → Start → Health check with live status |   

## Reviewer Notes
- The resize updates DO persisted state (`machineSize`). The next `start()` picks it up via `guestFromSize()`. The reconcile loop also backfills from the live Fly machine, so manual `fly machine update` changes are preserved.            
- Resize does NOT require the instance to be stopped first — the UI handles the stop/start orchestration. The DO method itself allows resize in any non-destructive state (running, stopped, provisioned).                                        - The stop step retries 3 times with 10s waits because Fly's `waitForState(stopped)` regularly times out on shared cpu machines under load.                                                                                                      
- performance-2x uses 4GB (not 3GB) because Fly requires minimum 2GB per vCPU for performance machines.