### PR TITLE
fix(gastown): prevent triage batch bead dispatch loop with wrong system prompt

### DIFF
--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -4075,6 +4075,9 @@ export class TownDO extends DurableObject<Env> {
     const systemPrompt = buildTriageSystemPrompt(pendingRequests);
 
     // Only now create the synthetic bead — preconditions are verified.
+    // Set rig_id so that if Rule 3 resets this bead to 'open' after a
+    // dispatch timeout, Rule 1 of the reconciler can pick it up and
+    // re-dispatch it (with the correct triage system prompt via Option B).
     const triageBead = beadOps.createBead(this.sql, {
       type: 'issue',
       title: `Triage batch: ${pendingCount} request(s)`,
@@ -4082,6 +4085,7 @@ export class TownDO extends DurableObject<Env> {
       priority: 'high',
       labels: [patrol.TRIAGE_BATCH_LABEL],
       created_by: 'patrol',
+      rig_id: rigId,
     });
 
     const triageAgent = agents.getOrCreateAgent(this.sql, 'polecat', rigId, this.townId);

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -343,6 +343,17 @@ export class TownDO extends DurableObject<Env> {
           });
         }
 
+        // Option B (defense-in-depth): If the reconciler re-dispatches an
+        // open triage batch bead (gt:triage, created_by='patrol') — e.g.
+        // because Option A's in_progress transition was somehow bypassed —
+        // inject the triage system prompt so the polecat gets the correct
+        // tools and instructions instead of the generic polecat prompt.
+        if (bead.labels.includes(patrol.TRIAGE_BATCH_LABEL) && bead.created_by === 'patrol') {
+          const pendingRequests = patrol.listPendingTriageRequests(this.sql);
+          const { buildTriageSystemPrompt } = await import('../prompts/triage-system.prompt');
+          systemPromptOverride = buildTriageSystemPrompt(pendingRequests);
+        }
+
         return scheduling.dispatchAgent(schedulingCtx, agent, bead, {
           systemPromptOverride,
         });
@@ -4075,6 +4086,14 @@ export class TownDO extends DurableObject<Env> {
 
     const triageAgent = agents.getOrCreateAgent(this.sql, 'polecat', rigId, this.townId);
     agents.hookBead(this.sql, triageAgent.id, triageBead.bead_id);
+
+    // Option A: Immediately mark the triage batch bead as in_progress so
+    // the reconciler's Rule 2 (idle agent + open hooked bead → dispatch_agent)
+    // does not re-fire on the next tick if the container start fails. Rule 3
+    // (stale in_progress bead + no working agent + 5-min timeout) will reset
+    // it back to open if the dispatch fails, allowing a clean retry via
+    // maybeDispatchTriageAgent with the correct triage system prompt.
+    beadOps.updateBeadStatus(this.sql, triageBead.bead_id, 'in_progress', triageAgent.id);
 
     const started = await dispatch.startAgentInContainer(this.env, this.ctx.storage, {
       townId: this.townId,


### PR DESCRIPTION
## Summary

- **Option A**: Mark the triage batch bead (`gt:triage`, `created_by='patrol'`) as `in_progress` immediately after `hookBead()` in `maybeDispatchTriageAgent()`, before awaiting `startAgentInContainer()`. This prevents the reconciler's Rule 2 (idle agent + open hooked bead → `dispatch_agent`) from re-dispatching the bead on the next tick with the generic polecat system prompt when container start fails. Rule 3 (stale `in_progress` bead + no working agent + 5-min timeout) resets it back to `open` on failure, allowing `maybeDispatchTriageAgent` to pick it up again with the correct triage system prompt.
- **Option B (defense-in-depth)**: In `applyActionCtx.dispatchAgent`, detect triage batch beads (`gt:triage` label + `created_by='patrol'`) and inject the triage system prompt via `buildTriageSystemPrompt()`. This ensures even if Rule 2 somehow fires against an open triage batch bead, the polecat receives the correct prompt and tools.

Fixes #1958.

## Verification

- Code review: both changes are minimal, targeted, and follow existing patterns (`beadOps.updateBeadStatus` for Option A, dynamic import of `buildTriageSystemPrompt` matching the existing `maybeDispatchTriageAgent` pattern for Option B).
- Option A: bead goes `in_progress` before the async network call, preventing Rule 2 re-fire.
- Option B: guard fires only when `bead.labels.includes(patrol.TRIAGE_BATCH_LABEL) && bead.created_by === 'patrol'` — safe predicate, no false positives for regular polecat beads.

## Visual Changes

N/A

## Reviewer Notes

- `scheduling.dispatchAgent` already has its own `updateBeadStatus(..., 'in_progress', ...)` guard (lines 88-96 of `scheduling.ts`) that no-ops when the bead is already `in_progress`, so Option A's pre-transition is safe and idempotent through Option B's path.
- The `lightweight: true` flag for triage dispatches is only set in the direct `startAgentInContainer` call path (`maybeDispatchTriageAgent`); Option B goes through `scheduling.dispatchAgent` which doesn't support `lightweight`. This is acceptable — Option B is a fallback for an edge case and the missing `lightweight` flag is a minor inefficiency, not a correctness issue.