### PR TITLE
fix(email): strip promotional content from transactional KiloClaw emails

### DIFF
--- a/apps/web/src/emails/AGENTS.md
+++ b/apps/web/src/emails/AGENTS.md
@@ -21,6 +21,15 @@ All templates use the Kilo brand design system:
 | Footer / secondary text | `#6b7280`                                             |
 | Section divider         | `1px solid #3a3a3a`                                   |
 
+## Content Guidelines
+
+All templates in this directory are **transactional** emails sent via `app.kilocode.ai`. Keep content factual and account-status focused:
+
+- State what changed and what the user needs to know.
+- A single CTA linking to the relevant page in the app is appropriate.
+- Do **not** include sales copy, upsell blocks, pricing language, or secondary CTAs promoting features or plans.
+- The footer company name is **Kilo Code, Inc** — never "LLC".
+
 ## Footer
 
 Every template must include this branding footer below the card:
@@ -38,7 +47,7 @@ Every template must include this branding footer below the card:
           font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
         "
       >
-        © {{ year }} Kilo Code, LLC<br />455 Market St, Ste 1940 PMB 993504<br />San Francisco, CA
+        © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San Francisco, CA
         94105, USA
       </p>
     </td>
@@ -71,5 +80,5 @@ Every template must include this branding footer below the card:
 | `clawInstanceDestroyed.html`           | `claw_url`, `year`                                                                                                         | `28`                       |
 | `clawEarlybirdEndingSoon.html`         | `days_remaining`, `expiry_date`, `claw_url`, `year`                                                                        | `29`                       |
 | `clawEarlybirdExpiresTomorrow.html`    | `expiry_date`, `claw_url`, `year`                                                                                          | `30`                       |
-| `clawComplementaryInferenceEnded.html` | `claw_url`, `credits_url`, `free_model_name`, `year`                                                                       | —                          |
+| `clawComplementaryInferenceEnded.html` | `claw_url`, `year`                                                                                                         | —                          |
 | `accountDeletionRequest.html`          | `email`, `year`                                                                                                            | —                          |

--- a/apps/web/src/emails/clawComplementaryInferenceEnded.html
+++ b/apps/web/src/emails/clawComplementaryInferenceEnded.html
@@ -52,7 +52,8 @@
                   "
                 >
                   The 6 hours of complimentary AI usage included with your KiloClaw trial have now
-                  ended. Your KiloClaw instance is still running.
+                  ended. Your instance is still running. AI model requests will use credits from
+                  your account balance going forward.
                 </p>
                 <!-- CTA -->
                 <table width="100%" cellpadding="0" cellspacing="0">

--- a/apps/web/src/emails/clawComplementaryInferenceEnded.html
+++ b/apps/web/src/emails/clawComplementaryInferenceEnded.html
@@ -52,95 +52,14 @@
                   "
                 >
                   The 6 hours of complimentary AI usage included with your KiloClaw trial have now
-                  ended. Your KiloClaw is still running so no worries.
+                  ended. Your KiloClaw instance is still running.
                 </p>
-                <p
-                  style="
-                    margin: 0 0 24px;
-                    font-size: 14px;
-                    line-height: 22px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-                  "
-                >
-                  You have two ways to keep going:
-                </p>
-
-                <!-- Options block -->
-                <table
-                  width="100%"
-                  cellpadding="0"
-                  cellspacing="0"
-                  style="
-                    background-color: #1a1a1a;
-                    border: 1px solid #3a3a3a;
-                    border-radius: 6px;
-                    margin-bottom: 28px;
-                  "
-                >
-                  <tr>
-                    <td style="padding: 20px 24px">
-                      <p
-                        style="
-                          margin: 0 0 6px;
-                          font-size: 11px;
-                          font-weight: 700;
-                          color: #f4e452;
-                          letter-spacing: 0.08em;
-                          text-transform: uppercase;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-                        "
-                      >
-                        Option 1 — Add Credits
-                      </p>
-                      <p
-                        style="
-                          margin: 0 0 16px;
-                          font-size: 13px;
-                          line-height: 21px;
-                          color: #9ca3af;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-                        "
-                      >
-                        Add credits to continue using any model. You pay only what the AI provider
-                        charges — no markup.
-                      </p>
-                      <p
-                        style="
-                          margin: 0 0 6px;
-                          font-size: 11px;
-                          font-weight: 700;
-                          color: #f4e452;
-                          letter-spacing: 0.08em;
-                          text-transform: uppercase;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-                        "
-                      >
-                        Option 2 — Use the Free Model
-                      </p>
-                      <p
-                        style="
-                          margin: 0;
-                          font-size: 13px;
-                          line-height: 21px;
-                          color: #9ca3af;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-                        "
-                      >
-                        Switch to
-                        <span style="color: #d1d5db">{{ free_model_name }}</span>
-                        in your KiloClaw settings for free models with limited intelligence.
-                      </p>
-                    </td>
-                  </tr>
-                </table>
-
-                <!-- Primary CTA -->
+                <!-- CTA -->
                 <table width="100%" cellpadding="0" cellspacing="0">
                   <tr>
-                    <td align="center" style="padding: 0 0 12px">
+                    <td align="center" style="padding: 10px 0 20px">
                       <a
-                        href="{{ credits_url }}"
+                        href="{{ claw_url }}"
                         style="
                           display: inline-block;
                           padding: 14px 32px;
@@ -149,28 +68,6 @@
                           text-decoration: none;
                           border-radius: 6px;
                           font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-                        "
-                      >
-                        Add Credits
-                      </a>
-                    </td>
-                  </tr>
-                  <!-- Secondary CTA -->
-                  <tr>
-                    <td align="center" style="padding: 0 0 20px">
-                      <a
-                        href="{{ claw_url }}"
-                        style="
-                          display: inline-block;
-                          padding: 12px 32px;
-                          background-color: transparent;
-                          color: #f4e452;
-                          text-decoration: none;
-                          border-radius: 6px;
-                          border: 1px solid #f4e452;
-                          font-size: 14px;
                           font-weight: 700;
                           font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                         "
@@ -222,7 +119,7 @@
                     font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                   "
                 >
-                  © {{ year }} Kilo Code, LLC<br />455 Market St, Ste 1940 PMB 993504<br />San
+                  © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San
                   Francisco, CA 94105, USA
                 </p>
               </td>

--- a/apps/web/src/emails/clawCreditRenewalFailed.html
+++ b/apps/web/src/emails/clawCreditRenewalFailed.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hosting Renewal Failed</title>
+  </head>
+  <body
+    style="
+      margin: 0;
+      padding: 0;
+      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+      background-color: #1a1a1a;
+      color: #d1d5db;
+    "
+  >
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+      <tr>
+        <td align="center" style="padding: 40px 20px">
+          <table
+            width="600"
+            cellpadding="0"
+            cellspacing="0"
+            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
+          >
+            <!-- Header -->
+            <tr>
+              <td style="padding: 40px 40px 20px">
+                <h1
+                  style="
+                    margin: 0;
+                    font-size: 24px;
+                    font-weight: 700;
+                    color: #f4e452;
+                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                  "
+                >
+                  Hosting Renewal Failed
+                </h1>
+              </td>
+            </tr>
+            <!-- Body -->
+            <tr>
+              <td style="padding: 0 40px 30px">
+                <p
+                  style="
+                    margin: 0 0 16px;
+                    font-size: 14px;
+                    line-height: 20px;
+                    color: #9ca3af;
+                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                  "
+                >
+                  Your KiloClaw hosting renewal failed because your account does not have enough
+                  credits. Add credits to your account to keep your instance running.
+                </p>
+                <!-- CTA Button -->
+                <table width="100%" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td align="center" style="padding: 10px 0 20px">
+                      <a
+                        href="{{ claw_url }}"
+                        style="
+                          display: inline-block;
+                          padding: 14px 32px;
+                          background-color: #f4e452;
+                          color: #6b7280;
+                          text-decoration: none;
+                          border-radius: 6px;
+                          font-size: 16px;
+                          font-weight: 700;
+                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                        "
+                      >
+                        Manage Your Instance
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+                <p
+                  style="
+                    margin: 0;
+                    font-size: 14px;
+                    line-height: 20px;
+                    color: #9ca3af;
+                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                  "
+                >
+                  If you have any questions, please don't hesitate to reply to this email. We are
+                  here to help!
+                </p>
+              </td>
+            </tr>
+            <!-- Sign-off -->
+            <tr>
+              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+                <p
+                  style="
+                    margin: 20px 0 0;
+                    font-size: 14px;
+                    line-height: 20px;
+                    color: #9ca3af;
+                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                  "
+                >
+                  — The Kilo Team
+                </p>
+              </td>
+            </tr>
+          </table>
+          <!-- Branding Footer -->
+          <table width="600" cellpadding="0" cellspacing="0">
+            <tr>
+              <td align="center" style="padding: 30px 20px">
+                <p
+                  style="
+                    margin: 0;
+                    font-size: 12px;
+                    color: #6b7280;
+                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                  "
+                >
+                  © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San
+                  Francisco, CA 94105, USA
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/apps/web/src/emails/clawDestructionWarning.html
+++ b/apps/web/src/emails/clawDestructionWarning.html
@@ -53,8 +53,7 @@
                 >
                   Your KiloClaw instance is scheduled for permanent deletion on
                   <strong style="color: #d1d5db">{{ destruction_date }}</strong>. This cannot be
-                  undone. All data associated with your instance will be lost. Subscribe now to
-                  prevent deletion.
+                  undone. All data associated with your instance will be lost.
                 </p>
                 <!-- CTA Button -->
                 <table width="100%" cellpadding="0" cellspacing="0">
@@ -74,7 +73,7 @@
                           font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                         "
                       >
-                        Subscribe Now
+                        Manage Your Instance
                       </a>
                     </td>
                   </tr>

--- a/apps/web/src/emails/clawEarlybirdEndingSoon.html
+++ b/apps/web/src/emails/clawEarlybirdEndingSoon.html
@@ -53,8 +53,8 @@
                 >
                   Your KiloClaw earlybird access ends in
                   <strong style="color: #d1d5db">{{ days_remaining }} days</strong> on
-                  <strong style="color: #d1d5db">{{ expiry_date }}</strong>. Choose a subscription
-                  plan to keep your instance running after your earlybird access expires.
+                  <strong style="color: #d1d5db">{{ expiry_date }}</strong>. After it expires, your
+                  instance will continue running only if you have an active subscription.
                 </p>
                 <!-- CTA Button -->
                 <table width="100%" cellpadding="0" cellspacing="0">
@@ -74,7 +74,7 @@
                           font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                         "
                       >
-                        Choose a Plan
+                        Manage Your Instance
                       </a>
                     </td>
                   </tr>

--- a/apps/web/src/emails/clawEarlybirdExpiresTomorrow.html
+++ b/apps/web/src/emails/clawEarlybirdExpiresTomorrow.html
@@ -53,8 +53,7 @@
                 >
                   Your KiloClaw earlybird access expires tomorrow on
                   <strong style="color: #d1d5db">{{ expiry_date }}</strong>. After it ends, your
-                  instance will remain running only if you have an active subscription. Choose a
-                  plan now to avoid any disruption.
+                  instance will continue running only if you have an active subscription.
                 </p>
                 <!-- CTA Button -->
                 <table width="100%" cellpadding="0" cellspacing="0">
@@ -74,7 +73,7 @@
                           font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                         "
                       >
-                        Choose a Plan
+                        Manage Your Instance
                       </a>
                     </td>
                   </tr>

--- a/apps/web/src/emails/clawInstanceDestroyed.html
+++ b/apps/web/src/emails/clawInstanceDestroyed.html
@@ -52,8 +52,7 @@
                   "
                 >
                   Your KiloClaw instance has been permanently deleted. All associated data has been
-                  removed and cannot be recovered. You can provision a new instance at any time by
-                  subscribing to a KiloClaw plan.
+                  removed and cannot be recovered.
                 </p>
                 <!-- CTA Button -->
                 <table width="100%" cellpadding="0" cellspacing="0">
@@ -73,7 +72,7 @@
                           font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                         "
                       >
-                        Get Started Again
+                        Go to KiloClaw
                       </a>
                     </td>
                   </tr>

--- a/apps/web/src/emails/clawInstanceReady.html
+++ b/apps/web/src/emails/clawInstanceReady.html
@@ -53,68 +53,10 @@
                 >
                   Your KiloClaw instance is now ready to use.
                 </p>
-                <p
-                  style="
-                    margin: 0 0 24px;
-                    font-size: 14px;
-                    line-height: 22px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-                  "
-                >
-                  KiloClaw isn't a chatbot. It's an assistant that acts on your behalf, even when
-                  you're not around. Connect your email, calendar, and other tools — then ask it to
-                  take care of things for you.
-                </p>
-
-                <!-- Free tier block -->
-                <table
-                  width="100%"
-                  cellpadding="0"
-                  cellspacing="0"
-                  style="
-                    background-color: #1a1a1a;
-                    border: 1px solid #3a3a3a;
-                    border-radius: 6px;
-                    margin-bottom: 28px;
-                  "
-                >
-                  <tr>
-                    <td style="padding: 20px 24px">
-                      <p
-                        style="
-                          margin: 0 0 6px;
-                          font-size: 11px;
-                          font-weight: 700;
-                          color: #f4e452;
-                          letter-spacing: 0.08em;
-                          text-transform: uppercase;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-                        "
-                      >
-                        What's free and for how long
-                      </p>
-                      <p
-                        style="
-                          margin: 0;
-                          font-size: 13px;
-                          line-height: 21px;
-                          color: #9ca3af;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-                        "
-                      >
-                        Your KiloClaw hosting is free for 7 days. For the first 6 hours we also
-                        cover AI inference costs — no setup needed. After that, inference is at
-                        cost: you pick the model, you pay only what the AI provider charges us.
-                      </p>
-                    </td>
-                  </tr>
-                </table>
-
-                <!-- Primary CTA -->
+                <!-- CTA -->
                 <table width="100%" cellpadding="0" cellspacing="0">
                   <tr>
-                    <td align="center" style="padding: 0 0 12px">
+                    <td align="center" style="padding: 10px 0 20px">
                       <a
                         href="{{ claw_url }}"
                         style="
@@ -130,44 +72,6 @@
                         "
                       >
                         Open KiloClaw
-                      </a>
-                    </td>
-                  </tr>
-                  <!-- Secondary CTA -->
-                  <tr>
-                    <td align="center" style="padding: 0 0 20px">
-                      <a
-                        href="https://kilo.ai/kiloclaw/get-started"
-                        style="
-                          display: inline-block;
-                          padding: 12px 32px;
-                          background-color: transparent;
-                          color: #f4e452;
-                          text-decoration: none;
-                          border-radius: 6px;
-                          border: 1px solid #f4e452;
-                          font-size: 14px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-                        "
-                      >
-                        Free onboarding session
-                      </a>
-                    </td>
-                  </tr>
-                  <!-- Docs link -->
-                  <tr>
-                    <td align="center" style="padding: 0 0 10px">
-                      <a
-                        href="https://kilo.ai/docs/kiloclaw/overview"
-                        style="
-                          font-size: 13px;
-                          color: #f4e452;
-                          text-decoration: underline;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-                        "
-                      >
-                        Read the documentation
                       </a>
                     </td>
                   </tr>

--- a/apps/web/src/emails/clawInstanceReady.html
+++ b/apps/web/src/emails/clawInstanceReady.html
@@ -51,7 +51,9 @@
                     font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                   "
                 >
-                  Your KiloClaw instance is now ready to use.
+                  Your KiloClaw instance is now ready to use. Your KiloClaw hosting is free for 7
+                  days. For the first 6 hours we also cover AI usage costs. After that, inference is
+                  at cost: you pick the model, you pay only what the AI provider charges us.
                 </p>
                 <!-- CTA -->
                 <table width="100%" cellpadding="0" cellspacing="0">

--- a/apps/web/src/emails/clawInstanceReady.html
+++ b/apps/web/src/emails/clawInstanceReady.html
@@ -51,8 +51,8 @@
                     font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                   "
                 >
-                  Your KiloClaw instance is now ready to use. Your KiloClaw hosting is free for 7
-                  days. For the first 6 hours we also cover AI usage costs. After that, inference is
+                  Your KiloClaw instance is now ready to use. Hosting is free for 7
+                  days and AI inference is for the first 6 hours. After that, inference is
                   at cost: you pick the model, you pay only what the AI provider charges us.
                 </p>
                 <!-- CTA -->

--- a/apps/web/src/emails/clawSuspendedSubscription.html
+++ b/apps/web/src/emails/clawSuspendedSubscription.html
@@ -51,9 +51,8 @@
                     font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                   "
                 >
-                  Your KiloClaw subscription has ended and your instance has been stopped.
-                  Resubscribe within 7 days to restore access and keep your data. If no action is
-                  taken, your instance will be permanently deleted on
+                  Your KiloClaw subscription has ended and your instance has been stopped. If no
+                  action is taken, your instance will be permanently deleted on
                   <strong style="color: #d1d5db">{{ destruction_date }}</strong>.
                 </p>
                 <!-- CTA Button -->
@@ -74,7 +73,7 @@
                           font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                         "
                       >
-                        Resubscribe
+                        Manage Your Instance
                       </a>
                     </td>
                   </tr>

--- a/apps/web/src/emails/clawSuspendedTrial.html
+++ b/apps/web/src/emails/clawSuspendedTrial.html
@@ -51,9 +51,8 @@
                     font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                   "
                 >
-                  Your free KiloClaw trial has ended and your instance has been stopped. Subscribe
-                  within 7 days to keep your instance and all its data. If no action is taken, your
-                  instance will be permanently deleted on
+                  Your free KiloClaw trial has ended and your instance has been stopped. If no
+                  action is taken, your instance will be permanently deleted on
                   <strong style="color: #d1d5db">{{ destruction_date }}</strong>.
                 </p>
                 <!-- CTA Button -->
@@ -74,7 +73,7 @@
                           font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                         "
                       >
-                        Subscribe Now
+                        Manage Your Instance
                       </a>
                     </td>
                   </tr>

--- a/apps/web/src/emails/clawTrialEndingSoon.html
+++ b/apps/web/src/emails/clawTrialEndingSoon.html
@@ -52,8 +52,8 @@
                   "
                 >
                   Your free KiloClaw trial ends in
-                  <strong style="color: #d1d5db">{{ days_remaining }} days</strong>. Subscribe now
-                  to keep your instance running and avoid losing your data.
+                  <strong style="color: #d1d5db">{{ days_remaining }} days</strong>. After it ends,
+                  your instance will be stopped and scheduled for deletion in 7 days.
                 </p>
                 <!-- CTA Button -->
                 <table width="100%" cellpadding="0" cellspacing="0">
@@ -73,7 +73,7 @@
                           font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                         "
                       >
-                        Subscribe Now
+                        Manage Your Instance
                       </a>
                     </td>
                   </tr>

--- a/apps/web/src/emails/clawTrialExpiresTomorrow.html
+++ b/apps/web/src/emails/clawTrialExpiresTomorrow.html
@@ -52,7 +52,7 @@
                   "
                 >
                   Your free KiloClaw trial expires tomorrow. After it ends, your instance will be
-                  stopped and scheduled for deletion in 7 days. Subscribe now to keep it running.
+                  stopped and scheduled for deletion in 7 days.
                 </p>
                 <!-- CTA Button -->
                 <table width="100%" cellpadding="0" cellspacing="0">
@@ -72,7 +72,7 @@
                           font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                         "
                       >
-                        Subscribe Now
+                        Manage Your Instance
                       </a>
                     </td>
                   </tr>

--- a/apps/web/src/routers/admin/email-testing-router.ts
+++ b/apps/web/src/routers/admin/email-testing-router.ts
@@ -110,6 +110,8 @@ function fixtureTemplateVars(template: TemplateName): Record<string, string | Ra
       return { claw_url: `${NEXTAUTH_URL}/claw` };
     case 'clawComplementaryInferenceEnded':
       return { claw_url: `${NEXTAUTH_URL}/claw` };
+    case 'accountDeletionRequest':
+      return { email: 'user@example.com' };
   }
   throw new Error(`Unknown template: ${template}`);
 }

--- a/apps/web/src/routers/admin/email-testing-router.ts
+++ b/apps/web/src/routers/admin/email-testing-router.ts
@@ -109,11 +109,7 @@ function fixtureTemplateVars(template: TemplateName): Record<string, string | Ra
     case 'clawCreditRenewalFailed':
       return { claw_url: `${NEXTAUTH_URL}/claw` };
     case 'clawComplementaryInferenceEnded':
-      return {
-        claw_url: `${NEXTAUTH_URL}/claw`,
-        credits_url: `${NEXTAUTH_URL}/credits`,
-        free_model_name: 'Kilo Auto Free',
-      };
+      return { claw_url: `${NEXTAUTH_URL}/claw` };
   }
   throw new Error(`Unknown template: ${template}`);
 }

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -1787,7 +1787,6 @@ async function runComplementaryInferenceEndedSweep(
   summary: BillingSummary
 ): Promise<void> {
   const clawUrl = buildClawUrl(env);
-  const creditsUrl = `${env.KILOCODE_BACKEND_BASE_URL}/credits`;
   const windowCutoff = new Date(Date.now() - COMPLEMENTARY_INFERENCE_WINDOW_MS).toISOString();
 
   // Find users whose "instance ready" email was sent more than 6 hours ago
@@ -1843,11 +1842,7 @@ async function runComplementaryInferenceEndedSweep(
         row.email,
         `claw_complementary_inference_ended:${row.sandbox_id}`,
         'clawComplementaryInferenceEnded',
-        {
-          claw_url: clawUrl,
-          credits_url: creditsUrl,
-          free_model_name: 'Kilo Auto Free',
-        },
+        { claw_url: clawUrl },
         summary
       );
 


### PR DESCRIPTION
## Summary

Several KiloClaw email templates on `app.kilocode.ai` had drifted to include sales copy — upsell blocks, \"Subscribe Now\" / \"Add Credits\" / \"Choose a Plan\" CTAs, product-pitch paragraphs, and secondary onboarding CTAs. This is the transactional sending domain and promotional content in these emails harms deliverability for all email (including magic links and payment notices) by training ESP classifiers to route mail from this domain to spam.

Changes per template:
- **clawInstanceReady**: remove product pitch para, free-tier promo block, \"Free onboarding session\" + docs secondary CTAs
- **clawComplementaryInferenceEnded**: remove \"Option 1 — Add Credits\" / \"Option 2 — Use Free Model\" sales block; simplify to single neutral CTA; fix footer LLC→Inc; drop now-unused `credits_url` and `free_model_name` template vars from lifecycle.ts and email-testing-router.ts
- **clawTrialEndingSoon/Tomorrow**: remove \"Subscribe Now\" CTA and \"Subscribe now to keep it running\" copy
- **clawSuspendedTrial/Subscription**: remove \"Subscribe within 7 days\" / \"Resubscribe within 7 days\" sales copy; change CTAs to \"Manage Your Instance\"
- **clawDestructionWarning**: remove \"Subscribe now to prevent deletion\" copy
- **clawEarlybirdEndingSoon/Tomorrow**: remove \"Choose a Plan\" CTA and \"Choose a subscription plan\" copy
- **clawInstanceDestroyed**: remove \"subscribing to a KiloClaw plan\" re-engagement copy; change \"Get Started Again\" to \"Go to KiloClaw\"
- **AGENTS.md**: add Content Guidelines section making the transactional-only requirement and the correct footer company name (Kilo Code, Inc) explicit

## Verification

- `pnpm typecheck` passes on touched files; pre-existing errors in the repo are unrelated to this change
- Reviewed all 11 affected templates manually

## Visual Changes

N/A — email template content changes only

## Reviewer Notes

The OSS invite templates (`ossInviteNewUser`, `ossInviteExistingUser`, `ossExistingOrgProvisioned`) were reviewed and left unchanged — their tier/seat/credit content is informational (describing what the recipient has been granted), not promotional copy.