### PR TITLE
feat(gastown): add resolveRigConfig() helpers and wire into dispatch path

### DIFF
--- a/services/gastown/src/dos/town/config.test.ts
+++ b/services/gastown/src/dos/town/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { TownConfigSchema } from '../../types';
-import { resolveModel } from './config';
+import { resolveModel, resolveRigConfig } from './config';
 
 const HARDCODED_FALLBACK = 'anthropic/claude-sonnet-4.6';
 
@@ -137,5 +137,133 @@ describe('resolveModel backward compatibility', () => {
     });
     // refinery: no role override, no default → hardcoded
     expect(resolveModel(configNoDefault, null, 'refinery')).toBe(HARDCODED_FALLBACK);
+  });
+});
+
+describe('resolveRigConfig', () => {
+  it('falls back entirely to town config when rigOverride is null', () => {
+    const town = TownConfigSchema.parse({
+      default_model: 'openai/gpt-4o',
+      merge_strategy: 'pr',
+      refinery: { review_mode: 'comments', code_review: false },
+      custom_instructions: { polecat: 'town polecat', mayor: 'town mayor' },
+    });
+    const effective = resolveRigConfig(town, null);
+    expect(effective.default_model).toBe('openai/gpt-4o');
+    expect(effective.merge_strategy).toBe('pr');
+    expect(effective.review_mode).toBe('comments');
+    expect(effective.code_review).toBe(false);
+    expect(effective.custom_instructions.polecat).toBe('town polecat');
+    // mayor is always town-level
+    expect(effective.custom_instructions.mayor).toBe('town mayor');
+  });
+
+  it('falls back entirely to town config when rigOverride is undefined', () => {
+    const town = TownConfigSchema.parse({ default_model: 'openai/gpt-4o' });
+    const effective = resolveRigConfig(town, undefined);
+    expect(effective.default_model).toBe('openai/gpt-4o');
+    expect(effective.merge_strategy).toBe('direct');
+    expect(effective.review_mode).toBe('rework');
+    expect(effective.code_review).toBe(true);
+  });
+
+  it('rig override takes precedence over town config for model', () => {
+    const town = TownConfigSchema.parse({ default_model: 'openai/gpt-4o' });
+    const effective = resolveRigConfig(town, { default_model: 'google/gemini-2.5-pro' });
+    expect(effective.default_model).toBe('google/gemini-2.5-pro');
+  });
+
+  it('rig role_models override town role_models', () => {
+    const town = TownConfigSchema.parse({
+      role_models: { polecat: 'openai/gpt-4o', refinery: 'openai/gpt-4o-mini' },
+    });
+    const effective = resolveRigConfig(town, {
+      role_models: { polecat: 'google/gemini-2.5-pro' },
+    });
+    expect(effective.role_models.polecat).toBe('google/gemini-2.5-pro');
+    // refinery falls back to town when rig doesn't override
+    expect(effective.role_models.refinery).toBe('openai/gpt-4o-mini');
+  });
+
+  it('mayor model is always from town config, never rig override', () => {
+    const town = TownConfigSchema.parse({
+      role_models: { mayor: 'anthropic/claude-opus-4' },
+    });
+    // Even if rigOverride had a mayor field, it would not affect this —
+    // the function always reads townConfig.role_models?.mayor for mayor.
+    const effective = resolveRigConfig(town, { default_model: 'google/gemini-2.5-pro' });
+    expect(effective.role_models.mayor).toBe('anthropic/claude-opus-4');
+  });
+
+  it('rig merge_strategy overrides town merge_strategy', () => {
+    const town = TownConfigSchema.parse({ merge_strategy: 'direct' });
+    const effective = resolveRigConfig(town, { merge_strategy: 'pr' });
+    expect(effective.merge_strategy).toBe('pr');
+  });
+
+  it('rig review_mode overrides town refinery.review_mode', () => {
+    const town = TownConfigSchema.parse({ refinery: { review_mode: 'rework' } });
+    const effective = resolveRigConfig(town, { review_mode: 'comments' });
+    expect(effective.review_mode).toBe('comments');
+  });
+
+  it('rig code_review=false skips refinery for that rig only', () => {
+    const town = TownConfigSchema.parse({ refinery: { code_review: true } });
+    const effective = resolveRigConfig(town, { code_review: false });
+    expect(effective.code_review).toBe(false);
+  });
+
+  it('rig custom_instructions.polecat overrides town, mayor stays town-level', () => {
+    const town = TownConfigSchema.parse({
+      custom_instructions: { polecat: 'town polecat', mayor: 'town mayor' },
+    });
+    const effective = resolveRigConfig(town, {
+      custom_instructions: { polecat: 'rig polecat' },
+    });
+    expect(effective.custom_instructions.polecat).toBe('rig polecat');
+    expect(effective.custom_instructions.mayor).toBe('town mayor');
+  });
+
+  it('rig git_push_flags are passed through', () => {
+    const town = TownConfigSchema.parse({});
+    const effective = resolveRigConfig(town, { git_push_flags: '--atomic' });
+    expect(effective.git_push_flags).toBe('--atomic');
+  });
+
+  it('git_push_flags is undefined when not set on rig', () => {
+    const town = TownConfigSchema.parse({});
+    const effective = resolveRigConfig(town, null);
+    expect(effective.git_push_flags).toBeUndefined();
+  });
+
+  it('auto_merge_delay_minutes: null from rig overrides town default', () => {
+    const town = TownConfigSchema.parse({
+      refinery: { auto_merge_delay_minutes: 30 },
+    });
+    const effective = resolveRigConfig(town, { auto_merge_delay_minutes: null });
+    expect(effective.auto_merge_delay_minutes).toBeNull();
+  });
+
+  it('max_concurrent_polecats falls back to townConfig.max_polecats_per_rig', () => {
+    const town = TownConfigSchema.parse({ max_polecats_per_rig: 3 });
+    const effective = resolveRigConfig(town, null);
+    expect(effective.max_concurrent_polecats).toBe(3);
+  });
+
+  it('rig max_concurrent_polecats overrides town', () => {
+    const town = TownConfigSchema.parse({ max_polecats_per_rig: 3 });
+    const effective = resolveRigConfig(town, { max_concurrent_polecats: 1 });
+    expect(effective.max_concurrent_polecats).toBe(1);
+  });
+
+  it('produces stable defaults when both town and rig are empty', () => {
+    const town = TownConfigSchema.parse({});
+    const effective = resolveRigConfig(town, null);
+    expect(effective.merge_strategy).toBe('direct');
+    expect(effective.convoy_merge_mode).toBe('review-then-land');
+    expect(effective.review_mode).toBe('rework');
+    expect(effective.code_review).toBe(true);
+    expect(effective.auto_resolve_pr_feedback).toBe(false);
+    expect(effective.auto_merge_delay_minutes).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Adds `resolveRigConfig()` utility to `services/gastown/src/dos/town/config.ts` that merges rig-level override config on top of town config, returning an `EffectiveConfig` for dispatch
- Adds `EffectiveConfig` type capturing all rig-resolved fields: model, review settings, merge strategy, custom instructions, git push flags, and agent limits
- Updates `resolveModel()` to accept `RigOverrideConfig | null | undefined` instead of ignoring `_rigId` — applies rig-specific model overrides with correct priority chain (rig role-specific → rig default → town role-specific → town default → hardcoded fallback)
- Wires `rigOverride` into `startAgentInContainer()` in `container-dispatch.ts` — dispatches rig-overridden `model`, `custom_instructions`, and `git_push_flags` (with allowlist filtering for safety)
- Updates `scheduling.ts` `dispatchAgent()` to load the rig SQLite record and pass `rig.config` as `rigOverride`
- Updates `Town.do.ts` `applyActionCtx.dispatchAgent` to use `resolveRigConfig()` for `merge_strategy` and `review_mode` rig-scoped decisions
- When rig has no overrides, all values fall back to town config — no behavior change for existing rigs
- Adds comprehensive unit tests for `resolveRigConfig()` covering all override fields and fallback paths

## Verification

- TypeScript compiles cleanly
- Unit tests cover: rig model override, role_models precedence, mayor always town-level, merge_strategy, review_mode, code_review, custom_instructions, git_push_flags, auto_merge_delay_minutes null override, max_concurrent_polecats fallback, and stable defaults

## Visual Changes

N/A — internal dispatch logic only

## Reviewer Notes

The core implementation (`resolveRigConfig`, `EffectiveConfig`, updated `resolveModel`, and all call-site wiring) was already merged into `gastown-staging` as part of PR #2280. This PR contributes the unit tests for `resolveRigConfig()` that exercise the rig-override precedence rules.