### PR TITLE
chore(gastown): remove dead code from patrol/scheduling/review-queue (#1403)

### DIFF
--- a/services/gastown/container/src/completion-reporter.ts
+++ b/services/gastown/container/src/completion-reporter.ts
@@ -1,8 +1,7 @@
 /**
- * Reports agent completion/failure back to the Rig DO via the Gastown
- * worker API. This closes the bead and unhooks the agent, preventing
- * the infinite retry loop where witnessPatrol resets the agent to idle
- * and schedulePendingWork re-dispatches it.
+ * Reports agent completion/failure back to the Gastown worker API.
+ * This closes the bead and unhooks the agent so the reconciler does not
+ * re-dispatch it.
  */
 
 import type { ManagedAgent } from './types';

--- a/services/gastown/container/src/control-server.ts
+++ b/services/gastown/container/src/control-server.ts
@@ -471,9 +471,9 @@ app.post('/repos/setup', async c => {
 
 // POST /git/merge
 // Deterministic merge of a polecat branch into the target branch.
-// Called by the Rig DO's processReviewQueue → startMergeInContainer.
-// Runs the merge synchronously and reports the result back to the Rig DO
-// via a callback to the completeReview endpoint.
+// Called by the TownDO's startMergeInContainer.
+// Runs the merge synchronously and reports the result back via a callback
+// to the completeReview endpoint.
 app.post('/git/merge', async c => {
   const body: unknown = await c.req.json().catch(() => null);
   const parsed = MergeRequest.safeParse(body);
@@ -539,7 +539,7 @@ app.post('/git/merge', async c => {
     }
   };
 
-  // Fire and forget — the Rig DO will time out stuck entries via recoverStuckReviews
+  // Fire and forget — the TownDO will time out stuck entries via its alarm loop
   doMerge().catch(err => {
     console.error(`Merge failed for entry ${req.entryId}:`, err);
   });

--- a/services/gastown/src/dos/town/patrol.ts
+++ b/services/gastown/src/dos/town/patrol.ts
@@ -17,8 +17,6 @@ const LOG = '[patrol]';
 
 // ── Thresholds ──────────────────────────────────────────────────────
 
-/** First GUPP warning (existing behavior) */
-export const GUPP_WARN_MS = 30 * 60_000; // 30 min
 /** Escalate to mayor after second threshold */
 export const GUPP_ESCALATE_MS = 60 * 60_000; // 1h
 /** Force-stop agent after third threshold */


### PR DESCRIPTION
## Summary

- **`popReviewQueue` was already gone**: Confirmed no instances of `popReviewQueue` remain anywhere in the codebase — it was removed in a prior pass.
- **Removed unused `GUPP_WARN_MS` export** from `patrol.ts`: this constant was exported but never referenced outside the file. The other threshold constants (`GUPP_ESCALATE_MS`, `GUPP_FORCE_STOP_MS`, `AGENT_GC_RETENTION_MS`) are actively used.
- **Updated stale comments** in `container/src/completion-reporter.ts` and `container/src/control-server.ts` that referenced removed functions (`witnessPatrol`, `schedulePendingWork`, `processReviewQueue`, `recoverStuckReviews`). Comments now describe the current reconciler/TownDO alarm-based architecture.

## Verification

- Searched entire `services/gastown/` tree for `popReviewQueue`, `feedStrandedConvoys`, `rehookOrphanedBeads`, `schedulePendingWork`, `recoverStuckReviews`, `witnessPatrol`, `processReviewQueue` — only the updated comment locations were found, now fixed.
- Verified `GUPP_WARN_MS` has zero callers anywhere in the repo before removing.
- All other `patrol.ts`, `scheduling.ts`, and `review-queue.ts` exports confirmed to have active callers.

## Visual Changes

N/A

## Reviewer Notes

The test describe blocks in `rig-alarm.test.ts` and `rig-do.test.ts` use `witnessPatrol` as a suite name — these are descriptive test labels for patrol behavior (which still runs internally via alarms), not dead code references, so they were left unchanged.