### PR TITLE
fix(security-agent): make finding upserts race-safe when toggling agent enabled

### DIFF
--- a/apps/web/src/components/security-agent/SecurityAgentContext.tsx
+++ b/apps/web/src/components/security-agent/SecurityAgentContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useState, useCallback, useMemo } from 'react';
+import { createContext, useContext, useState, useCallback, useMemo, useRef } from 'react';
 import { useTRPC } from '@/lib/trpc/utils';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -121,6 +121,7 @@ export function SecurityAgentProvider({ organizationId, children }: SecurityAgen
 
   const [startingAnalysisIds, setStartingAnalysisIds] = useState<Set<string>>(new Set());
   const [gitHubError, setGitHubError] = useState<string | null>(null);
+  const toggleEnabledInFlightRef = useRef(false);
 
   // Permission status query
   const { data: permissionData, isLoading: isLoadingPermission } = useQuery(
@@ -216,6 +217,9 @@ export function SecurityAgentProvider({ organizationId, children }: SecurityAgen
       },
       onError: error => {
         toast.error('Failed to toggle Security Agent', { description: error.message });
+      },
+      onSettled: () => {
+        toggleEnabledInFlightRef.current = false;
       },
     })
   );
@@ -329,6 +333,9 @@ export function SecurityAgentProvider({ organizationId, children }: SecurityAgen
       },
       onError: error => {
         toast.error('Failed to toggle Security Agent', { description: error.message });
+      },
+      onSettled: () => {
+        toggleEnabledInFlightRef.current = false;
       },
     })
   );
@@ -472,10 +479,15 @@ export function SecurityAgentProvider({ organizationId, children }: SecurityAgen
         selectedRepositoryIds: number[];
       }
     ) => {
+      if (toggleEnabledInFlightRef.current) return;
+      toggleEnabledInFlightRef.current = true;
+
       if (isOrg && organizationId) {
         orgSetEnabledMutate({ organizationId, isEnabled: enabled, ...repositorySelection });
-      } else {
+      } else if (!isOrg) {
         personalSetEnabledMutate({ isEnabled: enabled, ...repositorySelection });
+      } else {
+        toggleEnabledInFlightRef.current = false;
       }
     },
     [isOrg, organizationId, orgSetEnabledMutate, personalSetEnabledMutate]

--- a/apps/web/src/components/security-agent/SecurityAgentPageClient.tsx
+++ b/apps/web/src/components/security-agent/SecurityAgentPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -56,6 +56,7 @@ export function SecurityAgentPageClient({ organizationId }: SecurityAgentPageCli
   const [dismissDialogOpen, setDismissDialogOpen] = useState(false);
   const [startingAnalysisIds, setStartingAnalysisIds] = useState<Set<string>>(new Set());
   const [gitHubError, setGitHubError] = useState<string | null>(null);
+  const toggleEnabledInFlightRef = useRef(false);
   const [sortBy, setSortBy] = useState<'severity_desc' | 'severity_asc' | 'sla_due_at_asc'>(
     'severity_desc'
   );
@@ -223,6 +224,9 @@ export function SecurityAgentPageClient({ organizationId }: SecurityAgentPageCli
       onError: error => {
         toast.error('Failed to toggle Security Agent', { description: error.message });
       },
+      onSettled: () => {
+        toggleEnabledInFlightRef.current = false;
+      },
     })
   );
 
@@ -291,6 +295,9 @@ export function SecurityAgentPageClient({ organizationId }: SecurityAgentPageCli
       },
       onError: error => {
         toast.error('Failed to toggle Security Agent', { description: error.message });
+      },
+      onSettled: () => {
+        toggleEnabledInFlightRef.current = false;
       },
     })
   );
@@ -525,6 +532,9 @@ export function SecurityAgentPageClient({ organizationId }: SecurityAgentPageCli
         selectedRepositoryIds: number[];
       }
     ) => {
+      if (toggleEnabledInFlightRef.current) return;
+      toggleEnabledInFlightRef.current = true;
+
       if (isOrg && organizationId) {
         orgSetEnabledMutate({
           organizationId,
@@ -538,6 +548,8 @@ export function SecurityAgentPageClient({ organizationId }: SecurityAgentPageCli
           repositorySelectionMode: repositorySelection.repositorySelectionMode,
           selectedRepositoryIds: repositorySelection.selectedRepositoryIds,
         });
+      } else {
+        toggleEnabledInFlightRef.current = false;
       }
     },
     [isOrg, organizationId, orgSetEnabledMutate, personalSetEnabledMutate]

--- a/apps/web/src/lib/security-agent/db/security-findings.test.ts
+++ b/apps/web/src/lib/security-agent/db/security-findings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { db } from '@/lib/drizzle';
+import { db, pool } from '@/lib/drizzle';
 import { security_findings, agent_configs } from '@kilocode/db/schema';
 import { eq, and } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
@@ -183,6 +183,72 @@ describe('upsertSecurityFinding', () => {
       );
 
     expect(rows).toHaveLength(1);
+  });
+
+  it('does not let a stale first-insert racer overwrite the winner', async () => {
+    const user = await insertTestUser();
+    const owner: SecurityReviewOwner = { userId: user.id };
+    const repo = 'test-org/stale-first-insert-race-repo';
+    const sourceId = '13';
+    const client = await pool.connect();
+
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `INSERT INTO security_findings (
+          owned_by_user_id,
+          repo_full_name,
+          source,
+          source_id,
+          severity,
+          package_name,
+          package_ecosystem,
+          title,
+          status,
+          fixed_at,
+          raw_data
+        ) VALUES ($1, $2, 'dependabot', $3, 'critical', 'lodash', 'npm', 'Prototype Pollution in lodash', 'fixed', $4, $5::jsonb)`,
+        [
+          user.id,
+          repo,
+          sourceId,
+          '2026-01-16T00:00:00.000Z',
+          JSON.stringify({ ...rawDependabotAlertFixture, state: 'fixed' }),
+        ]
+      );
+
+      const staleUpsert = upsertSecurityFinding({
+        ...makeFinding({ source_id: sourceId, status: 'open', severity: 'high' }),
+        owner,
+        repoFullName: repo,
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 50));
+      await client.query('COMMIT');
+
+      const result = await staleUpsert;
+
+      expect(result.wasInserted).toBe(false);
+      expect(result.previousStatus).toBe('fixed');
+      expect(result.effectiveStatus).toBe('fixed');
+
+      const [row] = await db
+        .select()
+        .from(security_findings)
+        .where(
+          and(
+            eq(security_findings.repo_full_name, repo),
+            eq(security_findings.source, 'dependabot'),
+            eq(security_findings.source_id, sourceId)
+          )
+        );
+
+      expect(row.status).toBe('fixed');
+      expect(row.severity).toBe('critical');
+    } finally {
+      await client.query('ROLLBACK').catch(() => undefined);
+      client.release();
+    }
   });
 
   it('preserves superseded status fields while refreshing sync metadata', async () => {

--- a/apps/web/src/lib/security-agent/db/security-findings.test.ts
+++ b/apps/web/src/lib/security-agent/db/security-findings.test.ts
@@ -137,6 +137,95 @@ describe('upsertSecurityFinding', () => {
     expect(row.severity).toBe('critical');
   });
 
+  it('returns the same row for concurrent first upserts on the same source key', async () => {
+    const user = await insertTestUser();
+    const owner: SecurityReviewOwner = { userId: user.id };
+    const repo = 'test-org/concurrent-upsert-repo';
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        upsertSecurityFinding({
+          ...makeFinding({ source_id: '11' }),
+          owner,
+          repoFullName: repo,
+        })
+      )
+    );
+
+    const insertedResults = results.filter(result => result.wasInserted);
+    const updatedResults = results.filter(result => !result.wasInserted);
+
+    expect(new Set(results.map(result => result.findingId)).size).toBe(1);
+    expect(insertedResults).toHaveLength(1);
+    expect(insertedResults[0]?.previousStatus).toBeNull();
+    expect(updatedResults.map(result => result.previousStatus)).toEqual([
+      'open',
+      'open',
+      'open',
+      'open',
+    ]);
+    expect(updatedResults.map(result => result.effectiveStatus)).toEqual([
+      'open',
+      'open',
+      'open',
+      'open',
+    ]);
+
+    const rows = await db
+      .select()
+      .from(security_findings)
+      .where(
+        and(
+          eq(security_findings.repo_full_name, repo),
+          eq(security_findings.source, 'dependabot'),
+          eq(security_findings.source_id, '11')
+        )
+      );
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it('preserves superseded status fields while refreshing sync metadata', async () => {
+    const user = await insertTestUser();
+    const owner: SecurityReviewOwner = { userId: user.id };
+    const repo = 'test-org/superseded-preserve-repo';
+
+    const first = await upsertSecurityFinding({
+      ...makeFinding({ source_id: '12' }),
+      owner,
+      repoFullName: repo,
+    });
+
+    await db
+      .update(security_findings)
+      .set({
+        status: 'ignored',
+        ignored_reason: `superseded:${first.findingId}`,
+        ignored_by: 'system',
+      })
+      .where(eq(security_findings.id, first.findingId));
+
+    const second = await upsertSecurityFinding({
+      ...makeFinding({ source_id: '12', status: 'open', severity: 'critical' }),
+      owner,
+      repoFullName: repo,
+    });
+
+    expect(second.wasInserted).toBe(false);
+    expect(second.previousStatus).toBe('ignored');
+    expect(second.effectiveStatus).toBe('ignored');
+
+    const [row] = await db
+      .select()
+      .from(security_findings)
+      .where(eq(security_findings.id, first.findingId));
+
+    expect(row.status).toBe('ignored');
+    expect(row.ignored_reason).toBe(`superseded:${first.findingId}`);
+    expect(row.ignored_by).toBe('system');
+    expect(row.severity).toBe('critical');
+  });
+
   it('uses repo_full_name + source + source_id as the unique key', async () => {
     const user = await insertTestUser();
     const owner: SecurityReviewOwner = { userId: user.id };

--- a/apps/web/src/lib/security-agent/db/security-findings.ts
+++ b/apps/web/src/lib/security-agent/db/security-findings.ts
@@ -104,56 +104,14 @@ export async function upsertSecurityFinding(
     }>(sql`
       WITH existing_match AS (
         SELECT ${security_findings.id} AS id,
-               ${security_findings.status} AS previous_status,
-               ${security_findings.ignored_reason} AS ignored_reason,
-               ${security_findings.ignored_by} AS ignored_by,
-               ${security_findings.created_at} AS created_at
+               ${security_findings.status} AS previous_status
         FROM ${security_findings}
         WHERE ${security_findings.repo_full_name} = ${params.repoFullName}
           AND ${security_findings.source} = ${params.source}
           AND ${security_findings.source_id} = ${params.source_id}
         FOR UPDATE
       ),
-      updated AS (
-        UPDATE ${security_findings}
-        SET
-          ${sql.identifier(security_findings.severity.name)} = ${params.severity},
-          ${sql.identifier(security_findings.ghsa_id.name)} = ${params.ghsa_id},
-          ${sql.identifier(security_findings.cve_id.name)} = ${params.cve_id},
-          ${sql.identifier(security_findings.vulnerable_version_range.name)} = ${params.vulnerable_version_range},
-          ${sql.identifier(security_findings.patched_version.name)} = ${params.patched_version},
-          ${sql.identifier(security_findings.title.name)} = ${params.title},
-          ${sql.identifier(security_findings.description.name)} = ${params.description},
-          ${sql.identifier(security_findings.status.name)} = CASE
-            WHEN existing_match.ignored_reason LIKE 'superseded:%' THEN existing_match.previous_status
-            ELSE ${params.status}
-          END,
-          ${sql.identifier(security_findings.ignored_reason.name)} = CASE
-            WHEN existing_match.ignored_reason LIKE 'superseded:%' THEN existing_match.ignored_reason
-            ELSE ${params.ignored_reason}
-          END,
-          ${sql.identifier(security_findings.ignored_by.name)} = CASE
-            WHEN existing_match.ignored_reason LIKE 'superseded:%' THEN existing_match.ignored_by
-            ELSE ${params.ignored_by}
-          END,
-          ${sql.identifier(security_findings.fixed_at.name)} = ${params.fixed_at},
-          ${sql.identifier(security_findings.sla_due_at.name)} = ${params.slaDueAt?.toISOString() || null},
-          ${sql.identifier(security_findings.dependabot_html_url.name)} = ${params.dependabot_html_url},
-          ${sql.identifier(security_findings.raw_data.name)} = ${params.raw_data},
-          ${sql.identifier(security_findings.cwe_ids.name)} = ${sql.param(params.cwe_ids)}::text[],
-          ${sql.identifier(security_findings.cvss_score.name)} = ${params.cvss_score?.toString() || null},
-          ${sql.identifier(security_findings.dependency_scope.name)} = ${params.dependency_scope},
-          ${sql.identifier(security_findings.last_synced_at.name)} = now(),
-          ${sql.identifier(security_findings.updated_at.name)} = now()
-        FROM existing_match
-        WHERE ${security_findings.id} = existing_match.id
-        RETURNING
-          ${security_findings.id} AS id,
-          existing_match.previous_status AS previous_status,
-          ${security_findings.status} AS effective_status,
-          ${security_findings.created_at} AS created_at
-      ),
-      inserted AS (
+      upserted AS (
         INSERT INTO ${security_findings} (
           ${sql.identifier(security_findings.owned_by_organization_id.name)},
           ${sql.identifier(security_findings.owned_by_user_id.name)},
@@ -211,45 +169,58 @@ export async function upsertSecurityFinding(
           ${sql.param(params.cwe_ids)}::text[],
           ${params.cvss_score?.toString() || null},
           ${params.dependency_scope}
-        WHERE NOT EXISTS (SELECT 1 FROM updated)
-        ON CONFLICT (${sql.identifier(security_findings.repo_full_name.name)}, ${sql.identifier(security_findings.source.name)}, ${sql.identifier(security_findings.source_id.name)}) DO NOTHING
-        RETURNING ${security_findings.id} AS id,
-          NULL::text AS previous_status,
-          ${security_findings.status} AS effective_status,
-          ${security_findings.created_at} AS created_at
-      ),
-      -- fallback: concurrent insert race — previous_status reflects the current row state
-      -- (written by the concurrent winner), not the true pre-update value. This means
-      -- syncAutoAnalysisQueueForFinding may misidentify a status transition during races.
-      -- Acceptable because the concurrent winner's sync call will have the correct value.
-      fallback AS (
-        SELECT
+        FROM (SELECT 1) AS input
+        LEFT JOIN existing_match ON true
+        ON CONFLICT (${sql.identifier(security_findings.repo_full_name.name)}, ${sql.identifier(security_findings.source.name)}, ${sql.identifier(security_findings.source_id.name)}) DO UPDATE
+        SET
+          ${sql.identifier(security_findings.severity.name)} = EXCLUDED.${sql.identifier(security_findings.severity.name)},
+          ${sql.identifier(security_findings.ghsa_id.name)} = EXCLUDED.${sql.identifier(security_findings.ghsa_id.name)},
+          ${sql.identifier(security_findings.cve_id.name)} = EXCLUDED.${sql.identifier(security_findings.cve_id.name)},
+          ${sql.identifier(security_findings.vulnerable_version_range.name)} = EXCLUDED.${sql.identifier(security_findings.vulnerable_version_range.name)},
+          ${sql.identifier(security_findings.patched_version.name)} = EXCLUDED.${sql.identifier(security_findings.patched_version.name)},
+          ${sql.identifier(security_findings.title.name)} = EXCLUDED.${sql.identifier(security_findings.title.name)},
+          ${sql.identifier(security_findings.description.name)} = EXCLUDED.${sql.identifier(security_findings.description.name)},
+          ${sql.identifier(security_findings.status.name)} = CASE
+            WHEN ${security_findings.ignored_reason} LIKE 'superseded:%' THEN ${security_findings.status}
+            ELSE EXCLUDED.${sql.identifier(security_findings.status.name)}
+          END,
+          ${sql.identifier(security_findings.ignored_reason.name)} = CASE
+            WHEN ${security_findings.ignored_reason} LIKE 'superseded:%' THEN ${security_findings.ignored_reason}
+            ELSE EXCLUDED.${sql.identifier(security_findings.ignored_reason.name)}
+          END,
+          ${sql.identifier(security_findings.ignored_by.name)} = CASE
+            WHEN ${security_findings.ignored_reason} LIKE 'superseded:%' THEN ${security_findings.ignored_by}
+            ELSE EXCLUDED.${sql.identifier(security_findings.ignored_by.name)}
+          END,
+          ${sql.identifier(security_findings.fixed_at.name)} = EXCLUDED.${sql.identifier(security_findings.fixed_at.name)},
+          ${sql.identifier(security_findings.sla_due_at.name)} = EXCLUDED.${sql.identifier(security_findings.sla_due_at.name)},
+          ${sql.identifier(security_findings.dependabot_html_url.name)} = EXCLUDED.${sql.identifier(security_findings.dependabot_html_url.name)},
+          ${sql.identifier(security_findings.raw_data.name)} = EXCLUDED.${sql.identifier(security_findings.raw_data.name)},
+          ${sql.identifier(security_findings.cwe_ids.name)} = EXCLUDED.${sql.identifier(security_findings.cwe_ids.name)},
+          ${sql.identifier(security_findings.cvss_score.name)} = EXCLUDED.${sql.identifier(security_findings.cvss_score.name)},
+          ${sql.identifier(security_findings.dependency_scope.name)} = EXCLUDED.${sql.identifier(security_findings.dependency_scope.name)},
+          ${sql.identifier(security_findings.last_synced_at.name)} = now(),
+          ${sql.identifier(security_findings.updated_at.name)} = now()
+        RETURNING
           ${security_findings.id} AS id,
-          ${security_findings.status} AS previous_status,
+          (xmax = 0) AS was_inserted,
           ${security_findings.status} AS effective_status,
           ${security_findings.created_at} AS created_at
-        FROM ${security_findings}
-        WHERE ${security_findings.repo_full_name} = ${params.repoFullName}
-          AND ${security_findings.source} = ${params.source}
-          AND ${security_findings.source_id} = ${params.source_id}
-          AND NOT EXISTS (SELECT 1 FROM updated)
-          AND NOT EXISTS (SELECT 1 FROM inserted)
-        LIMIT 1
-      ),
-      chosen AS (
-        SELECT id, false AS was_inserted, previous_status, effective_status, created_at FROM updated
-        UNION ALL
-        SELECT id, true AS was_inserted, previous_status, effective_status, created_at FROM inserted
-        UNION ALL
-        SELECT id, false AS was_inserted, previous_status, effective_status, created_at FROM fallback
       )
       SELECT
-        chosen.id AS "findingId",
-        chosen.was_inserted AS "wasInserted",
-        chosen.previous_status AS "previousStatus",
-        chosen.effective_status AS "effectiveStatus",
-        chosen.created_at AS "findingCreatedAt"
-      FROM chosen
+        upserted.id AS "findingId",
+        upserted.was_inserted AS "wasInserted",
+        -- If the conflict row was inserted after this statement snapshot, existing_match
+        -- is empty. Use the persisted status so duplicate initial syncs do not look like
+        -- a fresh transition; the concurrent inserter reports the actual insert.
+        CASE
+          WHEN upserted.was_inserted THEN NULL::text
+          ELSE COALESCE(existing_match.previous_status, upserted.effective_status)
+        END AS "previousStatus",
+        upserted.effective_status AS "effectiveStatus",
+        upserted.created_at AS "findingCreatedAt"
+      FROM upserted
+      LEFT JOIN existing_match ON existing_match.id = upserted.id
       LIMIT 1
     `);
 

--- a/apps/web/src/lib/security-agent/db/security-findings.ts
+++ b/apps/web/src/lib/security-agent/db/security-findings.ts
@@ -201,6 +201,8 @@ export async function upsertSecurityFinding(
           ${sql.identifier(security_findings.dependency_scope.name)} = EXCLUDED.${sql.identifier(security_findings.dependency_scope.name)},
           ${sql.identifier(security_findings.last_synced_at.name)} = now(),
           ${sql.identifier(security_findings.updated_at.name)} = now()
+        -- Avoid stale first-insert racers rewriting the concurrent winner.
+        WHERE EXISTS (SELECT 1 FROM existing_match)
         RETURNING
           ${security_findings.id} AS id,
           (xmax = 0) AS was_inserted,
@@ -224,7 +226,30 @@ export async function upsertSecurityFinding(
       LIMIT 1
     `);
 
-    const finding = rows[0];
+    let finding = rows[0];
+    if (!finding) {
+      const fallback = await db.execute<{
+        findingId: string;
+        wasInserted: boolean;
+        previousStatus: SecurityFindingStatus;
+        effectiveStatus: SecurityFindingStatus;
+        findingCreatedAt: string;
+      }>(sql`
+        SELECT
+          ${security_findings.id} AS "findingId",
+          false AS "wasInserted",
+          ${security_findings.status} AS "previousStatus",
+          ${security_findings.status} AS "effectiveStatus",
+          ${security_findings.created_at} AS "findingCreatedAt"
+        FROM ${security_findings}
+        WHERE ${security_findings.repo_full_name} = ${params.repoFullName}
+          AND ${security_findings.source} = ${params.source}
+          AND ${security_findings.source_id} = ${params.source_id}
+        LIMIT 1
+      `);
+      finding = fallback.rows[0];
+    }
+
     if (!finding) {
       throw new Error('Failed to upsert security finding');
     }


### PR DESCRIPTION
## Summary

### Why this change
A user could trigger duplicate requests from the UI which resulted in a race condition for the upsert statement.

### How this is addressed
- Made Security Agent finding upserts deterministic under concurrent first inserts by returning the committed row instead of throwing on empty same-statement snapshots.
- Add a synchronous client-side in-flight guard to reduce duplicate enable/disable mutations from rapid UI events.

## Verification
- `pnpm --filter web test -- src/lib/security-agent/db/security-findings.test.ts` — passed, 19 tests.
- `pnpm --filter web test -- src/lib/security-agent/services/sync-service.test.ts` — passed, 3 tests.

## Visual Changes
N/A

## Reviewer Notes
<details>
   <summary>Code review notes</summary>

- The SQL intentionally updates only conflicts visible to the statement snapshot; conflicts from concurrent first inserts fall through to a second-statement read to avoid stale overwrites.
- Owner/repo-level cross-instance sync locking is still deferred; the persistence path is race-safe and duplicate UI submissions are reduced.

</details>