### PR TITLE
fix(kiloclaw): skip destroyed instance deletion warnings

### DIFF
--- a/apps/web/src/app/api/internal/kiloclaw/billing-side-effects/route.test.ts
+++ b/apps/web/src/app/api/internal/kiloclaw/billing-side-effects/route.test.ts
@@ -95,6 +95,8 @@ describe('POST /api/internal/kiloclaw/billing-side-effects', () => {
             templateVars: {
               claw_url: 'https://app.kilo.ai/claw',
             },
+            userId: 'user-123',
+            instanceId: 'instance-456',
           },
         },
         {
@@ -118,6 +120,8 @@ describe('POST /api/internal/kiloclaw/billing-side-effects', () => {
         event: 'downstream_action',
         outcome: 'started',
         action: 'send_email',
+        userId: 'user-123',
+        instanceId: 'instance-456',
         templateName: 'clawCreditRenewalFailed',
       })
     );
@@ -129,6 +133,8 @@ describe('POST /api/internal/kiloclaw/billing-side-effects', () => {
         event: 'downstream_action',
         outcome: 'completed',
         action: 'send_email',
+        userId: 'user-123',
+        instanceId: 'instance-456',
         templateName: 'clawCreditRenewalFailed',
         statusCode: 200,
       })

--- a/apps/web/src/app/api/internal/kiloclaw/billing-side-effects/route.ts
+++ b/apps/web/src/app/api/internal/kiloclaw/billing-side-effects/route.ts
@@ -40,6 +40,7 @@ type BillingSideEffectLogFields = BillingCorrelationContext & {
   action?: string;
   durationMs?: number;
   userId?: string;
+  instanceId?: string;
   stripeSubscriptionId?: string;
   templateName?: (typeof billingTemplateNames)[number];
   statusCode?: number;
@@ -88,6 +89,8 @@ const BodySchema = z.discriminatedUnion('action', [
       templateName: z.enum(billingTemplateNames),
       templateVars: z.record(z.string(), z.string()),
       subjectOverride: z.string().min(1).optional(),
+      userId: z.string().min(1).optional(),
+      instanceId: z.string().min(1).optional(),
     }),
   }),
   z.object({
@@ -146,12 +149,17 @@ const BodySchema = z.discriminatedUnion('action', [
 
 function getActionLogFields(body: z.infer<typeof BodySchema>): {
   userId?: string;
+  instanceId?: string;
   stripeSubscriptionId?: string;
   templateName?: (typeof billingTemplateNames)[number];
 } {
   switch (body.action) {
     case 'send_email':
-      return { templateName: body.input.templateName };
+      return {
+        userId: body.input.userId,
+        instanceId: body.input.instanceId,
+        templateName: body.input.templateName,
+      };
     case 'trigger_user_auto_top_up':
       return { userId: body.input.user.id };
     case 'ensure_auto_intro_schedule':

--- a/apps/web/src/emails/clawDestructionWarning.html
+++ b/apps/web/src/emails/clawDestructionWarning.html
@@ -51,9 +51,11 @@
                     font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
                   "
                 >
-                  Your KiloClaw instance is scheduled for permanent deletion on
+                  Your KiloClaw instance
+                  <strong style="color: #d1d5db">{{ instance_label }}</strong>
+                  is scheduled for permanent deletion on
                   <strong style="color: #d1d5db">{{ destruction_date }}</strong>. This cannot be
-                  undone. All data associated with your instance will be lost.
+                  undone. All data associated with this instance will be lost.
                 </p>
                 <!-- CTA Button -->
                 <table width="100%" cellpadding="0" cellspacing="0">

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -1059,6 +1059,16 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     // Post-destroy cleanup: best-effort DB tidying that must not report
     // failure after a successful destroy.
     try {
+      await db
+        .update(kiloclaw_subscriptions)
+        .set({ destruction_deadline: null })
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.user_id, instance.user_id),
+            eq(kiloclaw_subscriptions.instance_id, instance.id)
+          )
+        );
+
       // Clear lifecycle emails so they can fire again if the user re-provisions.
       const resettableEmailTypes = [
         'claw_suspended_trial',

--- a/apps/web/src/routers/admin/email-testing-router.ts
+++ b/apps/web/src/routers/admin/email-testing-router.ts
@@ -101,6 +101,8 @@ function fixtureTemplateVars(template: TemplateName): Record<string, string | Ra
       return {
         destruction_date: formatDate(new Date(Date.now() + 2 * 86_400_000)),
         claw_url: `${NEXTAUTH_URL}/claw`,
+        instance_label: 'Research Claw',
+        instance_id_short: '11111111',
       };
     case 'clawEarlybirdEndingSoon':
       return { days_remaining: '14', expiry_date: '2026-09-26', claw_url: `${NEXTAUTH_URL}/claw` };

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -22,6 +22,7 @@ import {
   kiloclaw_version_pins,
   kiloclaw_image_catalog,
   kiloclaw_cli_runs,
+  kiloclaw_subscriptions,
 } from '@kilocode/db/schema';
 import { and, eq, desc, sql } from 'drizzle-orm';
 import type { KiloClawDashboardStatus, KiloCodeConfigResponse } from '@/lib/kiloclaw/types';
@@ -448,14 +449,27 @@ export const organizationKiloclawRouter = createTRPCRouter({
     const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
     const destroyedRow = await markActiveInstanceDestroyed(ctx.user.id, instance.id);
     const client = new KiloClawInternalClient();
+    let result: Awaited<ReturnType<KiloClawInternalClient['destroy']>>;
     try {
-      return await client.destroy(ctx.user.id, workerInstanceId(instance));
+      result = await client.destroy(ctx.user.id, workerInstanceId(instance));
     } catch (error) {
       if (destroyedRow) {
         await restoreDestroyedInstance(destroyedRow.id);
       }
       throw error;
     }
+
+    await db
+      .update(kiloclaw_subscriptions)
+      .set({ destruction_deadline: null })
+      .where(
+        and(
+          eq(kiloclaw_subscriptions.user_id, ctx.user.id),
+          eq(kiloclaw_subscriptions.instance_id, instance.id)
+        )
+      );
+
+    return result;
   }),
 
   // ── Config ────────────────────────────────────────────────────

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -459,15 +459,19 @@ export const organizationKiloclawRouter = createTRPCRouter({
       throw error;
     }
 
-    await db
-      .update(kiloclaw_subscriptions)
-      .set({ destruction_deadline: null })
-      .where(
-        and(
-          eq(kiloclaw_subscriptions.user_id, ctx.user.id),
-          eq(kiloclaw_subscriptions.instance_id, instance.id)
-        )
-      );
+    try {
+      await db
+        .update(kiloclaw_subscriptions)
+        .set({ destruction_deadline: null })
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.user_id, ctx.user.id),
+            eq(kiloclaw_subscriptions.instance_id, instance.id)
+          )
+        );
+    } catch (cleanupError) {
+      console.error('[organization-kiloclaw] Post-destroy cleanup failed:', cleanupError);
+    }
 
     return result;
   }),

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -31,13 +31,18 @@ function createSelectResult<T>(rows: T[]): SelectResult<T> {
   return result;
 }
 
-function createMockDb(selectResults: unknown[][], options?: { txInsertRowCounts?: number[] }) {
+function createMockDb(
+  selectResults: unknown[][],
+  options?: { insertRowCounts?: number[]; txInsertRowCounts?: number[] }
+) {
   const updates: Array<Record<string, unknown>> = [];
   const txUpdates: Array<Record<string, unknown>> = [];
   const deletes: unknown[] = [];
   const txDeletes: unknown[] = [];
   const inserts: Array<Record<string, unknown>> = [];
   const txInserts: Array<Record<string, unknown>> = [];
+  const selectBuilders: SelectBuilder[] = [];
+  const insertRowCounts = [...(options?.insertRowCounts ?? [])];
   const txInsertRowCounts = [...(options?.txInsertRowCounts ?? [])];
   const nextSelectResult = () => createSelectResult(selectResults.shift() ?? []);
   const createSelectBuilder = (): SelectBuilder => {
@@ -48,6 +53,7 @@ function createMockDb(selectResults: unknown[][], options?: { txInsertRowCounts?
       where: vi.fn(() => nextSelectResult()),
       limit: vi.fn(async () => selectResults.shift() ?? []),
     };
+    selectBuilders.push(builder);
     return builder;
   };
   const select = vi.fn(() => createSelectBuilder());
@@ -63,7 +69,7 @@ function createMockDb(selectResults: unknown[][], options?: { txInsertRowCounts?
     values: vi.fn((values: Record<string, unknown>) => {
       inserts.push(values);
       return {
-        onConflictDoNothing: vi.fn(async () => ({ rowCount: 1 })),
+        onConflictDoNothing: vi.fn(async () => ({ rowCount: insertRowCounts.shift() ?? 1 })),
       };
     }),
   }));
@@ -123,6 +129,7 @@ function createMockDb(selectResults: unknown[][], options?: { txInsertRowCounts?
     txDeletes,
     inserts,
     txInserts,
+    selectBuilders,
   };
 }
 
@@ -300,6 +307,177 @@ describe('interrupted auto-resume sweep', () => {
         auto_resume_attempt_count: 0,
       },
     ]);
+  });
+});
+
+describe('destruction warning sweep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetWorkerDb.mockReset();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ sent: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+    );
+  });
+
+  it('sends destruction warning for suspended subscriptions with non-destroyed instances', async () => {
+    const instanceId = '11111111-1111-4111-8111-111111111111';
+    const destructionDeadline = '2099-04-15T10:00:00.000Z';
+    const { db, inserts, selectBuilders } = createMockDb([
+      [
+        {
+          user_id: 'user-1',
+          email: 'user-1@example.com',
+          destruction_deadline: destructionDeadline,
+          instance_id: instanceId,
+          instance_name: 'Research Claw',
+          instance_destroyed_at: null,
+          plan: 'commit',
+        },
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+
+    const summary = await runSweep(
+      createEnv(vi.fn()),
+      {
+        runId: '13131313-1313-4313-8313-131313131313',
+        sweep: 'destruction_warning',
+      },
+      1
+    );
+
+    expect(summary.errors).toBe(0);
+    expect(summary.destruction_warnings).toBe(1);
+    expect(summary.emails_sent).toBe(1);
+    expect(selectBuilders[0]?.innerJoin).toHaveBeenCalledTimes(2);
+    expect(selectBuilders[0]?.leftJoin).not.toHaveBeenCalled();
+    expect(inserts).toEqual([{ user_id: 'user-1', email_type: 'claw_destruction_warning' }]);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    const body = JSON.parse(typeof init?.body === 'string' ? init.body : '{}') as {
+      action: string;
+      input: Record<string, unknown>;
+    };
+    expect(body).toEqual({
+      action: 'send_email',
+      input: {
+        to: 'user-1@example.com',
+        templateName: 'clawDestructionWarning',
+        templateVars: {
+          destruction_date: 'April 15, 2099',
+          claw_url: 'https://app.kilo.ai/claw',
+          instance_label: 'Research Claw',
+          instance_id_short: '11111111',
+        },
+        userId: 'user-1',
+        instanceId,
+      },
+    });
+  });
+
+  it('does not send destruction warning when joined instance is destroyed', async () => {
+    const { db, inserts } = createMockDb([
+      [
+        {
+          user_id: 'user-1',
+          email: 'user-1@example.com',
+          destruction_deadline: '2099-04-15T10:00:00.000Z',
+          instance_id: '11111111-1111-4111-8111-111111111111',
+          instance_name: 'Destroyed Claw',
+          instance_destroyed_at: '2099-04-13T10:00:00.000Z',
+          plan: 'trial',
+        },
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+
+    const summary = await runSweep(
+      createEnv(vi.fn()),
+      {
+        runId: '14141414-1414-4414-8414-141414141414',
+        sweep: 'destruction_warning',
+      },
+      1
+    );
+
+    expect(summary.errors).toBe(0);
+    expect(summary.destruction_warnings).toBe(0);
+    expect(summary.emails_sent).toBe(0);
+    expect(inserts).toHaveLength(0);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not create warning log for destroyed instances without a prior warning row', async () => {
+    const { db, inserts } = createMockDb([
+      [
+        {
+          user_id: 'user-1',
+          email: 'user-1@example.com',
+          destruction_deadline: '2099-04-15T10:00:00.000Z',
+          instance_id: '22222222-2222-4222-8222-222222222222',
+          instance_name: null,
+          instance_destroyed_at: '2099-04-13T10:00:00.000Z',
+          plan: 'standard',
+        },
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+
+    const summary = await runSweep(
+      createEnv(vi.fn()),
+      {
+        runId: '15151515-1515-4515-8515-151515151515',
+        sweep: 'destruction_warning',
+      },
+      1
+    );
+
+    expect(summary.destruction_warnings).toBe(0);
+    expect(summary.emails_skipped).toBe(0);
+    expect(inserts).toHaveLength(0);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('counts destruction warnings only when an email is actually sent', async () => {
+    const { db, inserts } = createMockDb(
+      [
+        [
+          {
+            user_id: 'user-1',
+            email: 'user-1@example.com',
+            destruction_deadline: '2099-04-15T10:00:00.000Z',
+            instance_id: '33333333-3333-4333-8333-333333333333',
+            instance_name: null,
+            instance_destroyed_at: null,
+            plan: 'standard',
+          },
+        ],
+      ],
+      { insertRowCounts: [0] }
+    );
+    mockGetWorkerDb.mockReturnValue(db);
+
+    const summary = await runSweep(
+      createEnv(vi.fn()),
+      {
+        runId: '16161616-1616-4616-8616-161616161616',
+        sweep: 'destruction_warning',
+      },
+      1
+    );
+
+    expect(summary.destruction_warnings).toBe(0);
+    expect(summary.emails_sent).toBe(0);
+    expect(summary.emails_skipped).toBe(1);
+    expect(inserts).toEqual([{ user_id: 'user-1', email_type: 'claw_destruction_warning' }]);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });
 

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -105,6 +105,8 @@ type EmailActionInput = {
   templateName: TemplateName;
   templateVars: Record<string, string>;
   subjectOverride?: string;
+  userId?: string;
+  instanceId?: string;
 };
 
 type UserForAutoTopUp = {
@@ -255,6 +257,22 @@ function getKiloClawAffiliateItemSku(env: BillingWorkerEnv, plan: 'commit' | 'st
 
 function formatDateForEmail(date: Date): string {
   return format(date, 'MMMM d, yyyy');
+}
+
+function shortInstanceId(instanceId: string): string {
+  return instanceId.slice(0, 8);
+}
+
+function formatInstanceLabel(params: {
+  instanceName: string | null;
+  instanceId: string;
+  plan: KiloClawPlan;
+}): string {
+  const trimmedName = params.instanceName?.trim();
+  if (trimmedName) return trimmedName;
+
+  const shortId = shortInstanceId(params.instanceId);
+  return shortId || params.plan;
 }
 
 function workerInstanceId(
@@ -578,7 +596,8 @@ async function trySendEmail(
   templateName: TemplateName,
   templateVars: Record<string, string>,
   summary: BillingSummary,
-  subjectOverride?: string
+  subjectOverride?: string,
+  entityFields: BillingEntityFields = {}
 ): Promise<boolean> {
   const result = await database
     .insert(kiloclaw_email_log)
@@ -591,6 +610,7 @@ async function trySendEmail(
   }
 
   try {
+    const emailEntityFields = { ...entityFields, userId };
     const emailResult = await callBillingSideEffect(
       env,
       context,
@@ -601,9 +621,11 @@ async function trySendEmail(
           templateName,
           templateVars,
           subjectOverride,
+          userId: emailEntityFields.userId,
+          instanceId: emailEntityFields.instanceId,
         },
       },
-      { userId }
+      emailEntityFields
     );
 
     if (!emailResult.sent) {
@@ -1585,20 +1607,27 @@ async function runDestructionWarningSweep(
       user_id: kiloclaw_subscriptions.user_id,
       email: kilocode_users.google_user_email,
       destruction_deadline: kiloclaw_subscriptions.destruction_deadline,
+      instance_id: kiloclaw_instances.id,
+      instance_name: kiloclaw_instances.name,
+      instance_destroyed_at: kiloclaw_instances.destroyed_at,
+      plan: kiloclaw_subscriptions.plan,
     })
     .from(kiloclaw_subscriptions)
     .innerJoin(kilocode_users, eq(kiloclaw_subscriptions.user_id, kilocode_users.id))
+    .innerJoin(kiloclaw_instances, eq(kiloclaw_subscriptions.instance_id, kiloclaw_instances.id))
     .where(
       and(
         gte(kiloclaw_subscriptions.destruction_deadline, advisoryNow),
         lte(kiloclaw_subscriptions.destruction_deadline, twoDaysFromNow),
-        isNotNull(kiloclaw_subscriptions.suspended_at)
+        isNotNull(kiloclaw_subscriptions.suspended_at),
+        isNull(kiloclaw_instances.destroyed_at)
       )
     );
 
   for (const row of destructionWarningRows) {
     try {
-      if (!row.destruction_deadline) continue;
+      if (!row.destruction_deadline || row.instance_destroyed_at) continue;
+      const instanceIdShort = shortInstanceId(row.instance_id);
       const sent = await trySendEmail(
         database,
         env,
@@ -1610,8 +1639,16 @@ async function runDestructionWarningSweep(
         {
           destruction_date: formatDateForEmail(new Date(row.destruction_deadline)),
           claw_url: clawUrl,
+          instance_label: formatInstanceLabel({
+            instanceName: row.instance_name,
+            instanceId: row.instance_id,
+            plan: row.plan,
+          }),
+          instance_id_short: instanceIdShort,
         },
-        summary
+        summary,
+        undefined,
+        { instanceId: row.instance_id }
       );
       if (sent) summary.destruction_warnings++;
     } catch (error) {


### PR DESCRIPTION
## Summary

A user could received a KiloClaw deletion-warning email for an inactive canceled trial row even if they had an active subscription. The stale row still had `suspended_at` and `destruction_deadline`, but its associated instance was already destroyed.

The lifecycle sweep only looked at subscription deadline state and did not verify that there was actually still an undestroyed instance to delete.

The chosen fix is to make destruction warnings instance-backed. The sweep now joins `kiloclaw_subscriptions` to `kiloclaw_instances` and only sends when the joined instance has `destroyed_at IS NULL`.

The email now names the affected instance, using the instance name when present and a short instance ID fallback. This makes future warnings easier for users and support to interpret as we move to multiple instances.

## Verification

Local testing to make sure only valid use cases receive email notification.

## Visual Changes

N/A

## Reviewer Notes

<details>
<summary>Code Reviewer Notes</summary>

- `runDestructionWarningSweep` uses an `innerJoin` to `kiloclaw_instances` and `destroyed_at IS NULL`, which also skips null `instance_id` rows.
- `trySendEmail` forwards optional `userId` and `instanceId` metadata to side-effect logs without logging recipient emails.
- Email idempotency remains keyed by `kiloclaw_email_log`; destroyed rows should not insert warning rows.
- Successful user/admin/org destroy flows clear `destruction_deadline`; personal destroy already had equivalent cleanup.
- Tests cover actual sends, destroyed-instance skips, missing-prior-log skips, and summary counts.

</details>