### PR TITLE
fix(headers): add security headers

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -149,7 +149,7 @@ const nextConfig = {
           },
           {
             key: 'Permissions-Policy',
-            value: 'geolocation=(), camera=(), microphone=()',
+            value: 'geolocation=(self), camera=(), microphone=()',
           },
           {
             key: 'Cross-Origin-Resource-Policy',

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -27,6 +27,7 @@ const monorepoRoot = resolve(import.meta.dirname, '../..');
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  poweredByHeader: false,
 
   // Both values MUST be set to the monorepo root and kept in sync.
   // `vercel build` sets NEXT_PRIVATE_OUTPUT_TRACE_ROOT to the project dir (apps/web)
@@ -137,6 +138,26 @@ const nextConfig = {
           {
             key: 'Cross-Origin-Opener-Policy',
             value: 'same-origin',
+          },
+          {
+            key: 'X-XSS-Protection',
+            value: '0',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'geolocation=(), camera=(), microphone=()',
+          },
+          {
+            key: 'Cross-Origin-Resource-Policy',
+            value: 'same-origin',
+          },
+          {
+            key: 'Cross-Origin-Embedder-Policy-Report-Only',
+            value: 'require-corp',
           },
         ],
       },


### PR DESCRIPTION
## Summary

Code-related pentest L1 security-header finding is addressed without broad product rewrites.

### L1: Missing security headers

- Disabled Next's powered-by header and added XSS filter disablement, referrer policy, permissions policy, CORP, and COEP report-only headers while preserving existing HSTS, COOP, X-Frame-Options, and nosniff headers.
- Kept `Cross-Origin-Embedder-Policy` in report-only mode to avoid breaking third-party scripts/assets that do not emit compatible CORS/CORP headers.
- Set `X-XSS-Protection: 0` rather than enabling deprecated browser XSS filters.
- Mitigated rollout risk by allowing same-origin browser geolocation (`geolocation=(self)`) so KiloClaw weather/location setup keeps working while camera and microphone remain disabled.

## Verification

- Local dev environment verification
- `pnpm format`

## Visual Changes

N/A

## Reviewer Notes

- Header changes are centralized in `apps/web/next.config.mjs`.
- `poweredByHeader: false` removes the framework disclosure header.
- Existing HSTS, COOP, X-Frame-Options, and `X-Content-Type-Options: nosniff` behavior is preserved.
- COEP is `Cross-Origin-Embedder-Policy-Report-Only` for compatibility with Stripe/Stytch/Impact/GTM/PostHog/Turnstile resources.
- Permissions policy allows same-origin geolocation but disables camera and microphone.
- Rollout watchpoints: geolocation prompt behavior, browser console resource-policy errors, PostHog event volume, OAuth/Stripe return flows.