### PR TITLE
fix(mobile): clear chat badge when app returns to foreground

### DIFF
--- a/apps/mobile/src/components/kiloclaw/chat.tsx
+++ b/apps/mobile/src/components/kiloclaw/chat.tsx
@@ -61,9 +61,20 @@ export function KiloClawChat({
         }
       });
 
+      // Also clear when the app returns to the foreground while this chat is focused.
+      // Notifications received in the background do not fire the listener above, and
+      // useFocusEffect does not re-run on app resume (focus is a navigation concept,
+      // not an app-state one), so without this the badge stays stuck after backgrounding.
+      const appStateSubscription = AppState.addEventListener('change', nextAppState => {
+        if (nextAppState === 'active') {
+          markChatRead({ channelId: instanceId });
+        }
+      });
+
       return () => {
         setActiveChatInstance(null);
         subscription.remove();
+        appStateSubscription.remove();
       };
     }, [instanceId, markChatRead])
   );


### PR DESCRIPTION
## Summary

Fixes a bug where the push-notification badge count stays stuck after the user receives a notification while the app is backgrounded on the chat screen.

### Repro

1. Open a chat.
2. Send a message.
3. Background the app.
4. Agent replies → OS badge shows 1.
5. Foreground the app (chat screen is still focused).
6. Expected: badge clears to 0.
7. Actual: badge stays at 1 until you navigate away and back.

### Root cause

`markChatRead` only had two triggers:
- `useFocusEffect` — fires on **navigation** focus change, not on app-state change.
- `addNotificationReceivedListener` — fires only when a notification arrives while the app is foregrounded.

A notification received while backgrounded hits neither, and the subsequent foreground doesn't re-run `useFocusEffect` because navigation focus never changed. Both the server row and OS badge stay at 1.

### Fix

Register an `AppState` listener inside `useFocusEffect`. On `active` transition it calls `markChatRead` for the focused chat. The listener is scoped to focus — it's added when the chat gains focus and removed on blur/unmount, so it only fires for the chat the user is actually on.

## Test plan

- [ ] Background app on chat screen → receive notification → foreground → badge clears to 0
- [ ] Receive notification for a different chat while on this chat → badge reflects unread from other chat after foreground
- [ ] Navigate away from chat → listener unregistered (no stray `markChatRead` calls)
- [ ] `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused` all pass