### PR TITLE
fix(claw): clarify trial messaging — no automatic charges on expiry

### DIFF
--- a/apps/web/src/app/(app)/claw/components/SubscriptionTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SubscriptionTab.tsx
@@ -44,8 +44,8 @@ export function SubscriptionTab() {
             <p className="text-foreground text-sm font-medium">No active subscription</p>
             <p className="text-muted-foreground mt-1 text-sm">
               {trialDays != null
-                ? `Your free trial has ${trialDays} ${trialDays === 1 ? 'day' : 'days'} remaining. Subscribe to keep your instance running.`
-                : 'Subscribe to a hosting plan to keep your instance running.'}
+                ? `Your free trial has ${trialDays} ${trialDays === 1 ? 'day' : 'days'} remaining. You won't be charged automatically — subscribe to keep your instance running.`
+                : "Subscribe to a hosting plan to keep your instance running. You won't be charged automatically."}
             </p>
           </div>
           <Button variant="primary" onClick={() => setShowPlanDialog(true)}>

--- a/apps/web/src/app/(app)/claw/components/billing/BillingBanner.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/BillingBanner.tsx
@@ -96,14 +96,14 @@ function getBannerContent(state: ClawBannerState, billing: ClawBillingStatus) {
     case 'trial_ending_very_soon':
       return {
         title: `Free Trial Ending Very Soon — ${pluralizeDays(billing.trial?.daysRemaining)} left`,
-        message: 'Your KiloClaw will be stopped when the trial ends. Subscribe to keep it running.',
+        message: "Your KiloClaw will be stopped when the trial ends. You won't be charged automatically — subscribe to keep it running.",
         cta: 'Subscribe Now',
         action: 'subscribe' as const,
       };
     case 'trial_expires_today':
       return {
         title: 'Free Trial Ends Today',
-        message: 'Your KiloClaw will be stopped at the end of today. Subscribe now.',
+        message: "Your KiloClaw will be stopped at the end of today. You won't be charged automatically — subscribe now to keep it running.",
         cta: 'Subscribe Now',
         action: 'subscribe' as const,
       };

--- a/apps/web/src/app/(app)/claw/components/billing/BillingBanner.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/BillingBanner.tsx
@@ -96,14 +96,16 @@ function getBannerContent(state: ClawBannerState, billing: ClawBillingStatus) {
     case 'trial_ending_very_soon':
       return {
         title: `Free Trial Ending Very Soon — ${pluralizeDays(billing.trial?.daysRemaining)} left`,
-        message: "Your KiloClaw will be stopped when the trial ends. You won't be charged automatically — subscribe to keep it running.",
+        message:
+          "Your KiloClaw will be stopped when the trial ends. You won't be charged automatically — subscribe to keep it running.",
         cta: 'Subscribe Now',
         action: 'subscribe' as const,
       };
     case 'trial_expires_today':
       return {
         title: 'Free Trial Ends Today',
-        message: "Your KiloClaw will be stopped at the end of today. You won't be charged automatically — subscribe now to keep it running.",
+        message:
+          "Your KiloClaw will be stopped at the end of today. You won't be charged automatically — subscribe now to keep it running.",
         cta: 'Subscribe Now',
         action: 'subscribe' as const,
       };

--- a/apps/web/src/emails/clawTrialExpiresTomorrow.html
+++ b/apps/web/src/emails/clawTrialExpiresTomorrow.html
@@ -52,7 +52,8 @@
                   "
                 >
                   Your free KiloClaw trial expires tomorrow. After it ends, your instance will be
-                  stopped and scheduled for deletion in 7 days.
+                  stopped and scheduled for deletion in 7 days. You won't be charged automatically,
+                  but you can subscribe to keep your instance running.
                 </p>
                 <!-- CTA Button -->
                 <table width="100%" cellpadding="0" cellspacing="0">


### PR DESCRIPTION
## Summary

- Updated trial banner messages in `BillingBanner.tsx` (`trial_ending_very_soon` and `trial_expires_today` states) to explicitly state users won't be charged automatically when their trial ends
- Updated trial messages in `SubscriptionTab.tsx` (both active trial and expired trial states) with the same reassurance
- Updated the "trial expires tomorrow" email body (`clawTrialExpiresTomorrow.html`) to append the no-auto-charge clarification

The goal is to reduce user anxiety at the most urgent trial touchpoints: KiloClaw simply stops when the trial ends — there are no automatic charges.

## Verification

- `pnpm typecheck` — no new errors introduced by these changes
- `pnpm lint` — clean (also fixed a pre-existing missing dependency that caused lint failures after the latest `main` pull)
- `pnpm format` — applied formatter to `BillingBanner.tsx` where line length triggered reformatting

## Visual Changes

N/A — text-only changes to existing UI strings and an HTML email template.

<img width="619" height="505" alt="image" src="https://github.com/user-attachments/assets/c8fb8c8e-b3df-41de-82e0-35377140d40a" />

## Reviewer Notes

Only string content changed — no logic, component structure, or API changes. The three files touched are the highest-urgency trial touchpoints identified in the plan.