### PR TITLE
fix(claw): show session banner on all pages

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawChangelogPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawChangelogPage.tsx
@@ -4,6 +4,7 @@ import { Sparkles } from 'lucide-react';
 import { SetPageTitle } from '@/components/SetPageTitle';
 import { Card, CardContent } from '@/components/ui/card';
 import { ChangelogTab } from './ChangelogTab';
+import { ClawConfigServiceBannerWithStatus } from './ClawConfigServiceBanner';
 import { BillingWrapper } from './billing/BillingWrapper';
 
 function ChangelogCard() {
@@ -17,7 +18,12 @@ function ChangelogCard() {
 }
 
 export function ClawChangelogPage({ organizationId }: { organizationId?: string }) {
-  const content = <ChangelogCard />;
+  const content = (
+    <>
+      <ClawConfigServiceBannerWithStatus organizationId={organizationId} />
+      <ChangelogCard />
+    </>
+  );
 
   return (
     <div className="container m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">

--- a/apps/web/src/app/(app)/claw/components/ClawChatPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawChatPage.tsx
@@ -7,6 +7,7 @@ import { useKiloClawStatus } from '@/hooks/useKiloClaw';
 import { useOrgKiloClawStatus } from '@/hooks/useOrgKiloClaw';
 import { ClawContextProvider } from './ClawContext';
 import { ChatTab } from './ChatTab';
+import { ClawConfigServiceBanner } from './ClawConfigServiceBanner';
 import { BillingWrapper } from './billing/BillingWrapper';
 import { SetPageTitle } from '@/components/SetPageTitle';
 import { Card, CardContent } from '@/components/ui/card';
@@ -57,11 +58,14 @@ function ClawChatWithStatus({ organizationId }: { organizationId?: string }) {
 
   const isRunning = status.status === 'running';
   const chatContent = (
-    <Card>
-      <CardContent className="p-5">
-        <ChatTab enabled={isRunning} />
-      </CardContent>
-    </Card>
+    <>
+      <ClawConfigServiceBanner status={status} />
+      <Card>
+        <CardContent className="p-5">
+          <ChatTab enabled={isRunning} />
+        </CardContent>
+      </Card>
+    </>
   );
 
   // Personal context uses BillingWrapper for access-lock dialogs/banners.

--- a/apps/web/src/app/(app)/claw/components/ClawConfigServiceBanner.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawConfigServiceBanner.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { Zap } from 'lucide-react';
+import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
+import { useKiloClawStatus } from '@/hooks/useKiloClaw';
+import { useOrgKiloClawStatus } from '@/hooks/useOrgKiloClaw';
+import { cn } from '@/lib/utils';
+
+const CONFIG_SERVICE_URL = 'https://kilo.ai/kiloclaw/config-service';
+const CONFIG_SERVICE_NUDGE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+function shouldShowConfigServiceBanner(status: KiloClawDashboardStatus | null | undefined) {
+  const provisionedAt = status?.provisionedAt;
+  return (
+    provisionedAt !== null &&
+    provisionedAt !== undefined &&
+    Date.now() - provisionedAt < CONFIG_SERVICE_NUDGE_WINDOW_MS
+  );
+}
+
+export function ClawConfigServiceBanner({
+  status,
+  className,
+}: {
+  status: KiloClawDashboardStatus | null | undefined;
+  className?: string;
+}) {
+  if (!shouldShowConfigServiceBanner(status)) return null;
+
+  return (
+    <div
+      className={cn(
+        'border-violet-500/30 bg-violet-500/10 flex flex-col gap-3 rounded-xl border p-4 sm:flex-row sm:items-center sm:justify-between',
+        className
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <Zap className="text-violet-400 mt-0.5 h-5 w-5 shrink-0" />
+        <div>
+          <p className="text-violet-400 text-sm font-semibold">
+            Go from inbox chaos to an AI executive assistant - in one hour.
+          </p>
+          <p className="text-muted-foreground mt-0.5 text-sm">
+            A KiloClaw expert configures your email, calendar, and messaging live on a call.
+            Includes <b>2 months free</b> hosting.
+          </p>
+        </div>
+      </div>
+      <a
+        href={CONFIG_SERVICE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="bg-violet-500 text-white hover:bg-violet-500/90 inline-flex shrink-0 items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors"
+      >
+        Book your session
+      </a>
+    </div>
+  );
+}
+
+function PersonalClawConfigServiceBannerWithStatus({ className }: { className?: string }) {
+  const { data: status } = useKiloClawStatus();
+  return <ClawConfigServiceBanner status={status} className={className} />;
+}
+
+function OrgClawConfigServiceBannerWithStatus({
+  organizationId,
+  className,
+}: {
+  organizationId: string;
+  className?: string;
+}) {
+  const { data: status } = useOrgKiloClawStatus(organizationId);
+  return <ClawConfigServiceBanner status={status} className={className} />;
+}
+
+export function ClawConfigServiceBannerWithStatus({
+  organizationId,
+  className,
+}: {
+  organizationId?: string;
+  className?: string;
+}) {
+  if (organizationId) {
+    return (
+      <OrgClawConfigServiceBannerWithStatus organizationId={organizationId} className={className} />
+    );
+  }
+
+  return <PersonalClawConfigServiceBannerWithStatus className={className} />;
+}

--- a/apps/web/src/app/(app)/claw/components/ClawInstanceOverview.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawInstanceOverview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { TriangleAlert, Zap } from 'lucide-react';
+import { TriangleAlert } from 'lucide-react';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { useKiloClawGatewayStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { useOrgKiloClawGatewayStatus, useOrgKiloClawMutations } from '@/hooks/useOrgKiloClaw';
@@ -33,11 +33,6 @@ export function ClawInstanceOverview({ status }: { status: KiloClawDashboardStat
 
   const { data: isServiceDegraded } = useClawServiceDegraded();
 
-  const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
-  const instanceYoung =
-    status.provisionedAt !== null && Date.now() - status.provisionedAt < SEVEN_DAYS_MS;
-  const configServiceNudgeVisible = instanceYoung;
-
   return (
     <>
       {isServiceDegraded && (
@@ -58,31 +53,6 @@ export function ClawInstanceOverview({ status }: { status: KiloClawDashboardStat
             </span>
           </AlertDescription>
         </Alert>
-      )}
-
-      {configServiceNudgeVisible && !organizationId && (
-        <div className="border-violet-500/30 bg-violet-500/10 flex flex-col gap-3 rounded-xl border p-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-start gap-3">
-            <Zap className="text-violet-400 mt-0.5 h-5 w-5 shrink-0" />
-            <div>
-              <p className="text-violet-400 text-sm font-semibold">
-                Go from inbox chaos to an AI executive assistant - in one hour.
-              </p>
-              <p className="text-muted-foreground mt-0.5 text-sm">
-                A KiloClaw expert configures your email, calendar, and messaging live on a call.
-                Includes <b>2 months free</b> hosting.
-              </p>
-            </div>
-          </div>
-          <a
-            href="https://kilo.ai/kiloclaw/config-service"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="bg-violet-500 text-white hover:bg-violet-500/90 inline-flex shrink-0 items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors"
-          >
-            Book your session
-          </a>
-        </div>
       )}
 
       <Card>

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -17,6 +17,7 @@ import { BotIdentityStep } from './BotIdentityStep';
 import { ChannelPairingStep } from './ChannelPairingStep';
 import { ChannelSelectionStepView } from './ChannelSelectionStep';
 import { ClawContextProvider, useClawContext } from './ClawContext';
+import { ClawConfigServiceBanner } from './ClawConfigServiceBanner';
 import { ClawHeader } from './ClawHeader';
 import { CreateInstanceCard } from './CreateInstanceCard';
 import { PermissionStep } from './PermissionStep';
@@ -172,6 +173,8 @@ function ClawOnboardingFlowInner({
           </AlertDescription>
         </Alert>
       )}
+
+      <ClawConfigServiceBanner status={status} />
 
       <MaybeBillingWrapper skip={!!organizationId} hideBanners>
         {mode === 'post-provisioning' ? (

--- a/apps/web/src/app/(app)/claw/components/ClawSettingsPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawSettingsPage.tsx
@@ -8,6 +8,7 @@ import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { useKiloClawStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { useOrgKiloClawStatus, useOrgKiloClawMutations } from '@/hooks/useOrgKiloClaw';
 import { ClawContextProvider, useClawContext } from './ClawContext';
+import { ClawConfigServiceBanner } from './ClawConfigServiceBanner';
 import { ClawInstanceOverview } from './ClawInstanceOverview';
 import { SettingsTab } from './SettingsTab';
 import { BillingWrapper } from './billing/BillingWrapper';
@@ -137,6 +138,7 @@ function ClawSettingsWithStatus({
   if (!status || status.status === null) return null;
   const settingsContent = (
     <div className="flex flex-col gap-6">
+      <ClawConfigServiceBanner status={status} />
       <ClawInstanceOverview status={status} />
       <ClawSettingsInner status={status} organizationName={organizationName} />
     </div>

--- a/apps/web/src/app/(app)/claw/components/ClawSubscriptionPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawSubscriptionPage.tsx
@@ -4,6 +4,7 @@ import { CreditCard } from 'lucide-react';
 import { SetPageTitle } from '@/components/SetPageTitle';
 import { Card, CardContent } from '@/components/ui/card';
 import { BillingWrapper } from './billing/BillingWrapper';
+import { ClawConfigServiceBannerWithStatus } from './ClawConfigServiceBanner';
 import { SubscriptionTab } from './SubscriptionTab';
 
 export function ClawSubscriptionPage() {
@@ -14,6 +15,7 @@ export function ClawSubscriptionPage() {
         icon={<CreditCard className="text-muted-foreground h-4 w-4" />}
       />
       <BillingWrapper>
+        <ClawConfigServiceBannerWithStatus />
         <Card>
           <CardContent className="p-5">
             <SubscriptionTab />

--- a/apps/web/src/app/(app)/claw/components/index.ts
+++ b/apps/web/src/app/(app)/claw/components/index.ts
@@ -2,6 +2,10 @@ export { OpenClawButton } from './OpenClawButton';
 export { ClawInstanceOverview } from './ClawInstanceOverview';
 export { ClawOnboardingFlow } from './ClawOnboardingFlow';
 export type { ClawOnboardingMode } from './ClawOnboardingFlow';
+export {
+  ClawConfigServiceBanner,
+  ClawConfigServiceBannerWithStatus,
+} from './ClawConfigServiceBanner';
 export { ClawHeader } from './ClawHeader';
 export { ClawChatPage } from './ClawChatPage';
 export { ClawSettingsPage } from './ClawSettingsPage';

--- a/apps/web/src/app/(app)/claw/earlybird/page.tsx
+++ b/apps/web/src/app/(app)/claw/earlybird/page.tsx
@@ -4,10 +4,12 @@ import { PageLayout } from '@/components/PageLayout';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
+import { ClawConfigServiceBannerWithStatus } from '../components/ClawConfigServiceBanner';
 
 export default function EarlybirdPage() {
   return (
     <PageLayout title="">
+      <ClawConfigServiceBannerWithStatus className="mx-auto w-full max-w-[1140px]" />
       <div className="flex justify-center pt-8">
         <Card className="group border-brand-primary/20 relative max-w-2xl overflow-hidden">
           <div className="bg-brand-primary/10 absolute top-0 right-0 h-40 w-40 translate-x-10 -translate-y-10 rounded-full blur-2xl" />

--- a/apps/web/src/app/(app)/claw/kilo-cli-run/[id]/page.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-cli-run/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { useKiloCliRunStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { SetPageTitle } from '@/components/SetPageTitle';
 import KiloCrabIcon from '@/components/KiloCrabIcon';
+import { ClawConfigServiceBannerWithStatus } from '../../components/ClawConfigServiceBanner';
 
 /** Strip ANSI escape codes so raw terminal output renders in a browser <pre>. */
 function stripAnsi(raw: string): string {
@@ -79,6 +80,8 @@ export default function KiloCliRunPage() {
           Back to Dashboard
         </Button>
       </div>
+
+      <ClawConfigServiceBannerWithStatus />
 
       <div className="space-y-4">
         <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- Extracts the KiloClaw config service CTA into a reusable banner component.
- Shows the session banner across KiloClaw pages for newly provisioned personal and organization instances.
- Keeps the existing seven-day visibility window and booking CTA behavior.

## Visual Changes

<img width="3217" height="1034" alt="CleanShot 2026-04-13 at 13 57 33@2x" src="https://github.com/user-attachments/assets/caaf078d-f50e-4046-84e6-13da1c2f1f59" />
