### PR TITLE
Allow having .wrangler folders symlinked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ yarn-error.log*
 
 # platform-specific
 .vercel
-.wrangler/
+.wrangler
 /.superset
 supabase/.temp
 


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

I previously had a worktree setup script that copied the `.wrangler` folder for each service. However, this proved problematic because I kept losing valuable state across different worktrees (mainly the kiloclaw instance information, stored in durable objects). So, instead, I'm now using symlinks for the wrangler folders to ensure they stay in sync across worktrees.

## Verification

- `.wrangler` folders no longer show up as changed in new worktrees
- I can access the same kiloclaw instance across multiple worktrees
