### PR TITLE
fix(privacy): scrub magic link URLs

### DIFF
--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Disallow: /users/sign_in
+Disallow: /auth/verify-magic-link

--- a/apps/web/src/app/auth/verify-magic-link/page.tsx
+++ b/apps/web/src/app/auth/verify-magic-link/page.tsx
@@ -11,17 +11,14 @@ function VerifyMagicLinkContent() {
 
   useEffect(() => {
     const token = searchParams.get('token');
-    const email = searchParams.get('email');
     const callbackUrl = searchParams.get('callbackUrl') || '/users/after-sign-in';
 
-    if (!token || !email) {
+    if (!token) {
       window.location.href = '/users/sign_in?error=INVALID_VERIFICATION';
       return;
     }
 
-    // Sign in using the email provider with the token
     signIn('email', {
-      email,
       token,
       callbackUrl,
       redirect: true,

--- a/apps/web/src/components/PostHogProvider.tsx
+++ b/apps/web/src/components/PostHogProvider.tsx
@@ -5,7 +5,7 @@ import { PostHogProvider as PHProvider, usePostHog } from 'posthog-js/react';
 import { useSession } from 'next-auth/react';
 import { Suspense, useEffect, useRef } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
-import { sanitizeAnalyticsUrl } from '@/lib/sanitize-analytics-url';
+import { sanitizeAnalyticsUrl, sanitizeAnalyticsUrlValue } from '@/lib/sanitize-analytics-url';
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
@@ -26,6 +26,18 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       disable_web_experiments: false,
       capture_pageview: false, // We capture pageviews manually
       capture_pageleave: true, // Enable pageleave capture
+      before_send: event => {
+        if (!event?.properties) return event;
+        return {
+          ...event,
+          properties: {
+            ...event.properties,
+            $current_url: sanitizeAnalyticsUrlValue(event.properties.$current_url),
+            $referrer: sanitizeAnalyticsUrlValue(event.properties.$referrer),
+            $referring_domain: sanitizeAnalyticsUrlValue(event.properties.$referring_domain),
+          },
+        };
+      },
       loaded: function (ph) {
         if (!isProduction) {
           // Opt out of capturing in non-production environments

--- a/apps/web/src/components/PostHogProvider.tsx
+++ b/apps/web/src/components/PostHogProvider.tsx
@@ -5,6 +5,7 @@ import { PostHogProvider as PHProvider, usePostHog } from 'posthog-js/react';
 import { useSession } from 'next-auth/react';
 import { Suspense, useEffect, useRef } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
+import { sanitizeAnalyticsUrl } from '@/lib/sanitize-analytics-url';
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
@@ -69,11 +70,7 @@ function PostHogPageView() {
 
   useEffect(() => {
     if (pathname && posthog) {
-      let url = window.origin + pathname;
-      const search = searchParams.toString();
-      if (search) {
-        url += '?' + search;
-      }
+      const url = sanitizeAnalyticsUrl(window.origin, pathname, searchParams.toString());
       posthog.capture('$pageview', { $current_url: url });
     }
   }, [pathname, searchParams, posthog]);

--- a/apps/web/src/lib/auth/magic-link-tokens.test.ts
+++ b/apps/web/src/lib/auth/magic-link-tokens.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
-import { createMagicLinkToken, verifyAndConsumeMagicLinkToken } from './magic-link-tokens';
+import {
+  createMagicLinkToken,
+  getMagicLinkUrl,
+  verifyAndConsumeMagicLinkToken,
+} from './magic-link-tokens';
 import { db } from '@/lib/drizzle';
 import { sql } from 'drizzle-orm';
 
@@ -50,6 +54,18 @@ describe('Magic Link Tokens', () => {
 
       expect(token1.plaintext_token).not.toBe(token2.plaintext_token);
       expect(token1.token_hash).not.toBe(token2.token_hash);
+    });
+  });
+
+  describe('getMagicLinkUrl', () => {
+    it('does not include email addresses in magic link URLs', async () => {
+      const token = await createMagicLinkToken(testEmail);
+      const url = new URL(getMagicLinkUrl(token));
+
+      expect(url.pathname).toBe('/auth/verify-magic-link');
+      expect(url.searchParams.get('token')).toBe(token.plaintext_token);
+      expect(url.searchParams.has('email')).toBe(false);
+      expect(url.toString()).not.toContain(encodeURIComponent(testEmail));
     });
   });
 

--- a/apps/web/src/lib/auth/magic-link-tokens.ts
+++ b/apps/web/src/lib/auth/magic-link-tokens.ts
@@ -85,12 +85,11 @@ export async function verifyAndConsumeMagicLinkToken(
 }
 
 export function getMagicLinkUrl(
-  { plaintext_token, email }: MagicLinkTokenWithPlaintext,
+  { plaintext_token }: MagicLinkTokenWithPlaintext,
   callbackUrl?: string
 ): string {
   const url = new URL(`${NEXTAUTH_URL}/auth/verify-magic-link`);
   url.searchParams.set('token', plaintext_token);
-  url.searchParams.set('email', email);
   if (callbackUrl) {
     url.searchParams.set('callbackUrl', callbackUrl);
   }

--- a/apps/web/src/lib/auth/redirect-urls.test.ts
+++ b/apps/web/src/lib/auth/redirect-urls.test.ts
@@ -1,0 +1,24 @@
+import { authFailureRedirectUrl, ssoSignInRedirectUrl } from '@/lib/auth/redirect-urls';
+
+describe('auth redirect URLs', () => {
+  it('does not include email addresses on auth failure redirects', () => {
+    const url = authFailureRedirectUrl('BLOCKED', false);
+
+    expect(url).toBe('/users/sign_in?error=BLOCKED');
+    expect(new URL(url, 'https://app.kilo.ai').searchParams.has('email')).toBe(false);
+  });
+
+  it('does not include email addresses on account-linking failure redirects', () => {
+    const url = authFailureRedirectUrl('DIFFERENT-OAUTH', true);
+
+    expect(url).toBe('/connected-accounts?error=DIFFERENT-OAUTH');
+    expect(new URL(url, 'https://app.kilo.ai').searchParams.has('email')).toBe(false);
+  });
+
+  it('does not include email addresses on SSO enforcement redirects', () => {
+    const url = ssoSignInRedirectUrl('example.com');
+
+    expect(url).toBe('/users/sign_in?domain=example.com');
+    expect(new URL(url, 'https://app.kilo.ai').searchParams.has('email')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/auth/redirect-urls.ts
+++ b/apps/web/src/lib/auth/redirect-urls.ts
@@ -1,0 +1,10 @@
+import { SSO_SIGNIN_PATH, type AuthErrorType } from '@/lib/auth/constants';
+
+export function authFailureRedirectUrl(error: AuthErrorType, isAccountLinking: boolean): string {
+  const baseUrl = isAccountLinking ? '/connected-accounts' : '/users/sign_in';
+  return `${baseUrl}?${new URLSearchParams({ error }).toString()}`;
+}
+
+export function ssoSignInRedirectUrl(domain: string): string {
+  return `${SSO_SIGNIN_PATH}?${new URLSearchParams({ domain }).toString()}`;
+}

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -187,7 +187,7 @@ export async function sendMagicLinkEmail(
     templateVars: {
       magic_link_url: getMagicLinkUrl(magicLink, callbackUrl),
       email: magicLink.email,
-      expires_in: '24 hours',
+      expires_in: '30 minutes',
       expires_at: new Date(magicLink.expires_at).toISOString(),
       app_url: NEXTAUTH_URL,
     },

--- a/apps/web/src/lib/sanitize-analytics-url.test.ts
+++ b/apps/web/src/lib/sanitize-analytics-url.test.ts
@@ -1,0 +1,29 @@
+import { sanitizeAnalyticsUrl } from '@/lib/sanitize-analytics-url';
+
+describe('sanitizeAnalyticsUrl', () => {
+  it('drops all query params from magic link verification URLs', () => {
+    expect(
+      sanitizeAnalyticsUrl(
+        'https://app.kilo.ai',
+        '/auth/verify-magic-link',
+        'token=secret&email=user%40example.com&callbackUrl=%2Fprofile'
+      )
+    ).toBe('https://app.kilo.ai/auth/verify-magic-link');
+  });
+
+  it('removes sensitive query params from other URLs', () => {
+    expect(
+      sanitizeAnalyticsUrl(
+        'https://app.kilo.ai',
+        '/users/sign_in',
+        'email=user%40example.com&state=secret&foo=bar&Token=abc'
+      )
+    ).toBe('https://app.kilo.ai/users/sign_in?foo=bar');
+  });
+
+  it('preserves non-sensitive query params', () => {
+    expect(sanitizeAnalyticsUrl('https://app.kilo.ai', '/credits', 'tab=usage&page=2')).toBe(
+      'https://app.kilo.ai/credits?tab=usage&page=2'
+    );
+  });
+});

--- a/apps/web/src/lib/sanitize-analytics-url.test.ts
+++ b/apps/web/src/lib/sanitize-analytics-url.test.ts
@@ -1,4 +1,4 @@
-import { sanitizeAnalyticsUrl } from '@/lib/sanitize-analytics-url';
+import { sanitizeAnalyticsUrl, sanitizeAnalyticsUrlValue } from '@/lib/sanitize-analytics-url';
 
 describe('sanitizeAnalyticsUrl', () => {
   it('drops all query params from magic link verification URLs', () => {
@@ -25,5 +25,18 @@ describe('sanitizeAnalyticsUrl', () => {
     expect(sanitizeAnalyticsUrl('https://app.kilo.ai', '/credits', 'tab=usage&page=2')).toBe(
       'https://app.kilo.ai/credits?tab=usage&page=2'
     );
+  });
+
+  it('sanitizes full analytics URL property values', () => {
+    expect(
+      sanitizeAnalyticsUrlValue(
+        'https://app.kilo.ai/users/sign_in?email=user%40example.com&state=secret&foo=bar'
+      )
+    ).toBe('https://app.kilo.ai/users/sign_in?foo=bar');
+  });
+
+  it('leaves non-URL property values unchanged', () => {
+    expect(sanitizeAnalyticsUrlValue('not a url')).toBe('not a url');
+    expect(sanitizeAnalyticsUrlValue(null)).toBeNull();
   });
 });

--- a/apps/web/src/lib/sanitize-analytics-url.ts
+++ b/apps/web/src/lib/sanitize-analytics-url.ts
@@ -1,11 +1,7 @@
 const SENSITIVE_QUERY_PARAMS = new Set(['callbackurl', 'code', 'email', 'state', 'token']);
 const SENSITIVE_PATHS = new Set(['/auth/verify-magic-link']);
 
-export function sanitizeAnalyticsUrl(
-  origin: string,
-  pathname: string,
-  searchParams: string
-): string {
+function sanitizeUrlParts(origin: string, pathname: string, searchParams: string): string {
   const baseUrl = `${origin}${pathname}`;
   if (SENSITIVE_PATHS.has(pathname) || !searchParams) {
     return baseUrl;
@@ -20,4 +16,28 @@ export function sanitizeAnalyticsUrl(
 
   const sanitizedSearch = sanitizedParams.toString();
   return sanitizedSearch ? `${baseUrl}?${sanitizedSearch}` : baseUrl;
+}
+
+export function sanitizeAnalyticsUrl(
+  origin: string,
+  pathname: string,
+  searchParams: string
+): string {
+  return sanitizeUrlParts(origin, pathname, searchParams);
+}
+
+export function sanitizeAnalyticsUrlValue(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+
+  if (!value.startsWith('http://') && !value.startsWith('https://') && !value.startsWith('/')) {
+    return value;
+  }
+
+  try {
+    const baseOrigin = typeof window === 'undefined' ? 'http://localhost' : window.origin;
+    const url = new URL(value, baseOrigin);
+    return sanitizeUrlParts(url.origin, url.pathname, url.searchParams.toString());
+  } catch {
+    return value;
+  }
 }

--- a/apps/web/src/lib/sanitize-analytics-url.ts
+++ b/apps/web/src/lib/sanitize-analytics-url.ts
@@ -1,7 +1,11 @@
 const SENSITIVE_QUERY_PARAMS = new Set(['callbackurl', 'code', 'email', 'state', 'token']);
 const SENSITIVE_PATHS = new Set(['/auth/verify-magic-link']);
 
-export function sanitizeAnalyticsUrl(origin: string, pathname: string, searchParams: string): string {
+export function sanitizeAnalyticsUrl(
+  origin: string,
+  pathname: string,
+  searchParams: string
+): string {
   const baseUrl = `${origin}${pathname}`;
   if (SENSITIVE_PATHS.has(pathname) || !searchParams) {
     return baseUrl;

--- a/apps/web/src/lib/sanitize-analytics-url.ts
+++ b/apps/web/src/lib/sanitize-analytics-url.ts
@@ -1,0 +1,19 @@
+const SENSITIVE_QUERY_PARAMS = new Set(['callbackurl', 'code', 'email', 'state', 'token']);
+const SENSITIVE_PATHS = new Set(['/auth/verify-magic-link']);
+
+export function sanitizeAnalyticsUrl(origin: string, pathname: string, searchParams: string): string {
+  const baseUrl = `${origin}${pathname}`;
+  if (SENSITIVE_PATHS.has(pathname) || !searchParams) {
+    return baseUrl;
+  }
+
+  const sanitizedParams = new URLSearchParams();
+  new URLSearchParams(searchParams).forEach((value, key) => {
+    if (!SENSITIVE_QUERY_PARAMS.has(key.toLowerCase())) {
+      sanitizedParams.append(key, value);
+    }
+  });
+
+  const sanitizedSearch = sanitizedParams.toString();
+  return sanitizedSearch ? `${baseUrl}?${sanitizedSearch}` : baseUrl;
+}

--- a/apps/web/src/lib/user.server.ts
+++ b/apps/web/src/lib/user.server.ts
@@ -50,7 +50,8 @@ import { linkAccountToExistingUser } from '@/lib/user';
 import type { FailureResult } from '@/lib/maybe-result';
 import { failureResult, whenOk } from '@/lib/maybe-result';
 import type { AuthErrorType } from '@/lib/auth/constants';
-import { hosted_domain_specials, SSO_SIGNIN_PATH } from '@/lib/auth/constants';
+import { hosted_domain_specials } from '@/lib/auth/constants';
+import { authFailureRedirectUrl, ssoSignInRedirectUrl } from '@/lib/auth/redirect-urls';
 import { isValidCallbackPath } from '@/lib/getSignInCallbackUrl';
 import {
   GITHUB_CLIENT_ID,
@@ -578,24 +579,20 @@ const authOptions: NextAuthOptions = {
       let isAccountLinking: boolean | null = null;
       let linkingSession: AccountLinkingSession | null = null;
       const redirectContext = await getSignInRedirectContext();
-      const redirectUrlForCode = (error: AuthErrorType, email?: string): string => {
-        const params = new URLSearchParams({ error });
-        if (email) {
-          params.set('email', email);
+      const redirectUrlForCode = (error: AuthErrorType): string => {
+        const redirectUrl = new URL(
+          authFailureRedirectUrl(error, Boolean(isAccountLinking)),
+          'http://localhost'
+        );
+        if (!isAccountLinking) {
+          if (redirectContext.callbackPath) {
+            redirectUrl.searchParams.set('callbackPath', redirectContext.callbackPath);
+          }
+          if (redirectContext.signup) {
+            redirectUrl.searchParams.set('signup', 'true');
+          }
         }
-        if (isAccountLinking) {
-          return `/connected-accounts?${params.toString()}`;
-        }
-        // Preserve the original sign-in context so an error bounce (e.g. BLOCKED,
-        // USER-NOT-FOUND, DIFFERENT-OAUTH) doesn't strand a mobile device-auth
-        // flow on a plain sign-in page without the code or signup mode.
-        if (redirectContext.callbackPath) {
-          params.set('callbackPath', redirectContext.callbackPath);
-        }
-        if (redirectContext.signup) {
-          params.set('signup', 'true');
-        }
-        return `/users/sign_in?${params.toString()}`;
+        return `${redirectUrl.pathname}?${redirectUrl.searchParams.toString()}`;
       };
       try {
         if (!account) return `TRAP: No account found`;
@@ -620,7 +617,7 @@ const authOptions: NextAuthOptions = {
         const domain = getLowerDomainFromEmail(accountInfo.google_user_email);
 
         if (!domain) {
-          return redirectUrlForCode('USER-NOT-FOUND', accountInfo.google_user_email);
+          return redirectUrlForCode('USER-NOT-FOUND');
         }
 
         if (await isEmailBlacklistedByDomainAsync(accountInfo.google_user_email)) {
@@ -629,7 +626,7 @@ const authOptions: NextAuthOptions = {
             accountInfo
           );
 
-          return redirectUrlForCode(`BLOCKED`, accountInfo.google_user_email);
+          return redirectUrlForCode(`BLOCKED`);
         }
 
         let domainToCheck = domain;
@@ -639,7 +636,7 @@ const authOptions: NextAuthOptions = {
 
         // Block new signups from blocked TLDs (existing users can still sign in)
         if (!existingUser && isBlockedTLD(accountInfo.google_user_email)) {
-          return redirectUrlForCode(`BLOCKED`, accountInfo.google_user_email);
+          return redirectUrlForCode(`BLOCKED`);
         }
 
         if (existingUser) {
@@ -660,11 +657,7 @@ const authOptions: NextAuthOptions = {
             (await doesOrgWithSSODomainExist(domainToCheck));
 
           if (redir) {
-            // Include email in redirect so it can be auto-filled on SSO sign-in page
-            const emailParam = accountInfo.google_user_email
-              ? `&email=${encodeURIComponent(accountInfo.google_user_email)}`
-              : '';
-            return SSO_SIGNIN_PATH + `?domain=${encodeURIComponent(domainToCheck)}${emailParam}`; // redirect to SSO sign-in page
+            return ssoSignInRedirectUrl(domainToCheck);
           }
         }
 
@@ -752,7 +745,7 @@ const authOptions: NextAuthOptions = {
               }
             );
           }
-          return redirectUrlForCode(result.error, accountInfo.google_user_email);
+          return redirectUrlForCode(result.error);
         }
 
         if (result.user.blocked_reason) {

--- a/apps/web/src/lib/user.server.ts
+++ b/apps/web/src/lib/user.server.ts
@@ -521,24 +521,23 @@ const authOptions: NextAuthOptions = {
       id: 'email',
       name: 'Email',
       credentials: {
-        email: { label: 'Email', type: 'email' },
         token: { label: 'Token', type: 'text' },
       },
       async authorize(credentials) {
-        if (!credentials?.email || !credentials?.token) {
+        if (!credentials?.token) {
           return null;
         }
 
         const tokenData = await verifyAndConsumeMagicLinkToken(credentials.token);
 
-        if (!tokenData || tokenData.email !== credentials.email) {
+        if (!tokenData) {
           return null;
         }
 
         return {
-          id: `email-${credentials.email}`,
-          email: credentials.email,
-          name: credentials.email.split('@')[0],
+          id: `email-${tokenData.email}`,
+          email: tokenData.email,
+          name: tokenData.email.split('@')[0],
           image: '',
         };
       },

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -7,11 +7,18 @@ import { withKiloEditorCookie } from './middleware/withKiloEditorCookie';
 function baseProxy(request: NextRequestWithAuth) {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-pathname', request.nextUrl.pathname);
-  return NextResponse.next({
+  const response = NextResponse.next({
     request: {
       headers: requestHeaders,
     },
   });
+
+  if (request.nextUrl.pathname === '/auth/verify-magic-link') {
+    response.headers.set('Cache-Control', 'no-store');
+    response.headers.set('X-Robots-Tag', 'noindex, noarchive, nofollow');
+  }
+
+  return response;
 }
 
 export const proxy = withBlockedClients(


### PR DESCRIPTION
## Summary

Pentest L2 identified archived Wayback Machine URLs where magic-link verification links exposed both login tokens and user email addresses in the query string. This PR keeps the existing magic-link token model but removes email PII from generated verification URLs and reduces future leakage paths.

### L2: Magic-link URL privacy

- Removed the `email` query parameter from generated magic-link URLs. The token already maps to the email in `magic_link_tokens`, so the credentials provider verifies the token and derives the email from the consumed token row.
- Auth failure redirects and SSO-enforcement redirects no longer append `email=`.
- Preserves same-browser prefill through existing `signin_hint` localStorage behavior instead of server-generated email query strings.
- PostHog manual pageviews sanitize sensitive query params (`token`, `email`, `callbackUrl`, `code`, `state`) and drop all query params for `/auth/verify-magic-link`.
- Mitigated remaining analytics leakage by adding a PostHog `before_send` sanitizer for default event URL properties (`$current_url`, `$referrer`, `$referring_domain`), covering pageleave/autocapture-style events in addition to manual pageviews.
- Added `Disallow: /auth/verify-magic-link` to `robots.txt` and sets `Cache-Control: no-store` plus `X-Robots-Tag: noindex, noarchive, nofollow` on the verification route.
- Fixed magic-link email copy to say links expire in `30 minutes`, matching token default.

## Verification

- `pnpm --filter web exec jest src/lib/sanitize-analytics-url.test.ts --runInBand`
- `pnpm format`

## Visual Changes

N/A

## Reviewer Notes

- Magic-link URLs still contain the one-time plaintext token because the email recipient needs it to authenticate, but they no longer include the user's email address.
- Existing old links with `email=` remain accepted because the extra query param is ignored.
- Rollback caveat: email-less links generated after this deploy may fail under old code until token expiry (`30 minutes`).
- Existing archived URLs from the pentest report still require separate operational removal requests with archive.org.
- Rollout watchpoints: `/api/auth/callback/email` errors, `/auth/verify-magic-link` failures, magic-link request-to-consumption rate, SSO-domain sign-in completion, PostHog `$current_url` values containing `token=` or `email=`.