### PR TITLE
fix(gastown): propagate custom env_vars to running containers on settings save

### DIFF
--- a/services/gastown/container/src/control-server.ts
+++ b/services/gastown/container/src/control-server.ts
@@ -43,6 +43,9 @@ const TownConfigHeader = z.record(z.string(), z.unknown());
 // Used as a fallback by code that runs outside a request context (e.g. background tasks).
 let lastKnownTownConfig: Record<string, unknown> | null = null;
 
+// Track which custom env var keys were applied last sync so removed keys can be cleared.
+let lastAppliedEnvVarKeys = new Set<string>();
+
 /** Get the latest town config delivered via X-Town-Config header. */
 export function getCurrentTownConfig(): Record<string, unknown> | null {
   return lastKnownTownConfig;
@@ -102,6 +105,24 @@ function syncTownConfigToProcessEnv(): void {
   } else {
     delete process.env.GASTOWN_ORGANIZATION_ID;
   }
+
+  // Apply custom env_vars from the town config. Infra keys above always take
+  // precedence — custom keys are applied after so they cannot override them.
+  const rawEnvVars = cfg.env_vars;
+  const customEnvVars: Record<string, string> =
+    rawEnvVars !== null && typeof rawEnvVars === 'object' && !Array.isArray(rawEnvVars)
+      ? (rawEnvVars as Record<string, string>)
+      : {};
+  const newCustomKeys = new Set(Object.keys(customEnvVars));
+  // Remove keys that were present in the previous sync but are gone now.
+  for (const key of lastAppliedEnvVarKeys) {
+    if (!newCustomKeys.has(key)) delete process.env[key];
+  }
+  // Apply current custom env vars.
+  for (const [key, value] of Object.entries(customEnvVars)) {
+    process.env[key] = String(value);
+  }
+  lastAppliedEnvVarKeys = newCustomKeys;
 }
 
 export const app = new Hono();

--- a/services/gastown/container/src/control-server.ts
+++ b/services/gastown/container/src/control-server.ts
@@ -46,9 +46,34 @@ let lastKnownTownConfig: Record<string, unknown> | null = null;
 // Track which custom env var keys were applied last sync so removed keys can be cleared.
 let lastAppliedEnvVarKeys = new Set<string>();
 
+// Env keys managed by the control plane that custom env_vars must never override.
+// If a custom key collides with a reserved key, the infra value wins and the
+// custom value is silently ignored — matching the !(key in env) guard in buildAgentEnv.
+const RESERVED_ENV_KEYS = new Set([
+  'KILOCODE_TOKEN',
+  'GIT_TOKEN',
+  'GITHUB_TOKEN',
+  'GITLAB_TOKEN',
+  'GITLAB_INSTANCE_URL',
+  'GITHUB_CLI_PAT',
+  'GH_TOKEN',
+  'GASTOWN_GIT_AUTHOR_NAME',
+  'GASTOWN_GIT_AUTHOR_EMAIL',
+  'GASTOWN_DISABLE_AI_COAUTHOR',
+  'GASTOWN_ORGANIZATION_ID',
+  'GASTOWN_CONTAINER_TOKEN',
+  'GASTOWN_SESSION_TOKEN',
+  'GASTOWN_API_URL',
+]);
+
 /** Get the latest town config delivered via X-Town-Config header. */
 export function getCurrentTownConfig(): Record<string, unknown> | null {
   return lastKnownTownConfig;
+}
+
+/** Get the set of custom env var keys applied in the last sync. */
+export function getLastAppliedEnvVarKeys(): Set<string> {
+  return lastAppliedEnvVarKeys;
 }
 
 /**
@@ -106,8 +131,9 @@ function syncTownConfigToProcessEnv(): void {
     delete process.env.GASTOWN_ORGANIZATION_ID;
   }
 
-  // Apply custom env_vars from the town config. Infra keys above always take
-  // precedence — custom keys are applied after so they cannot override them.
+  // Apply custom env_vars from the town config. Reserved infra keys are
+  // skipped so the control-plane values always take precedence — matching the
+  // !(key in env) guard in buildAgentEnv.
   const rawEnvVars = cfg.env_vars;
   const customEnvVars: Record<string, string> =
     rawEnvVars !== null && typeof rawEnvVars === 'object' && !Array.isArray(rawEnvVars)
@@ -115,11 +141,13 @@ function syncTownConfigToProcessEnv(): void {
       : {};
   const newCustomKeys = new Set(Object.keys(customEnvVars));
   // Remove keys that were present in the previous sync but are gone now.
+  // Skip reserved keys — deleting those would wipe a control-plane value.
   for (const key of lastAppliedEnvVarKeys) {
-    if (!newCustomKeys.has(key)) delete process.env[key];
+    if (!newCustomKeys.has(key) && !RESERVED_ENV_KEYS.has(key)) delete process.env[key];
   }
-  // Apply current custom env vars.
+  // Apply current custom env vars, skipping reserved keys.
   for (const [key, value] of Object.entries(customEnvVars)) {
+    if (RESERVED_ENV_KEYS.has(key)) continue;
     process.env[key] = String(value);
   }
   lastAppliedEnvVarKeys = newCustomKeys;

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -12,7 +12,7 @@ import * as fs from 'node:fs/promises';
 import type { ManagedAgent, StartAgentRequest } from './types';
 import { reportAgentCompleted, reportMayorWaiting } from './completion-reporter';
 import { buildKiloConfigContent } from './agent-runner';
-import { getCurrentTownConfig } from './control-server';
+import { getCurrentTownConfig, getLastAppliedEnvVarKeys } from './control-server';
 import { log } from './logger';
 
 const MANAGER_LOG = '[process-manager]';
@@ -1271,14 +1271,24 @@ export async function updateAgentModel(
   // populated from process.env above), so custom vars cannot override.
   const freshConfig = getCurrentTownConfig();
   const freshEnvVars = freshConfig?.env_vars;
+  const freshCustomKeySet = new Set<string>();
   if (freshEnvVars !== null && typeof freshEnvVars === 'object' && !Array.isArray(freshEnvVars)) {
     for (const [key, value] of Object.entries(freshEnvVars as Record<string, unknown>)) {
       if (LIVE_ENV_KEYS.has(key)) continue;
+      freshCustomKeySet.add(key);
       if (value !== undefined && value !== null) {
         hotSwapEnv[key] = String(value);
       } else {
         delete hotSwapEnv[key];
       }
+    }
+  }
+  // Remove stale custom env vars — keys that were applied in a previous
+  // sync but are no longer in the town config. Without this, startupEnv
+  // keeps carrying deleted custom keys through every hot-swap.
+  for (const key of getLastAppliedEnvVarKeys()) {
+    if (!freshCustomKeySet.has(key) && !LIVE_ENV_KEYS.has(key)) {
+      delete hotSwapEnv[key];
     }
   }
 

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -12,6 +12,7 @@ import * as fs from 'node:fs/promises';
 import type { ManagedAgent, StartAgentRequest } from './types';
 import { reportAgentCompleted, reportMayorWaiting } from './completion-reporter';
 import { buildKiloConfigContent } from './agent-runner';
+import { getCurrentTownConfig } from './control-server';
 import { log } from './logger';
 
 const MANAGER_LOG = '[process-manager]';
@@ -1262,6 +1263,23 @@ export async function updateAgentModel(
     if (key in hotSwapEnv) continue;
     const live = process.env[key];
     if (live) hotSwapEnv[key] = live;
+  }
+
+  // Overlay custom env_vars from the town config so hot-swap picks up
+  // values that were added/changed after the initial dispatch. Infra
+  // keys in LIVE_ENV_KEYS always take precedence (they were already
+  // populated from process.env above), so custom vars cannot override.
+  const freshConfig = getCurrentTownConfig();
+  const freshEnvVars = freshConfig?.env_vars;
+  if (freshEnvVars !== null && typeof freshEnvVars === 'object' && !Array.isArray(freshEnvVars)) {
+    for (const [key, value] of Object.entries(freshEnvVars as Record<string, unknown>)) {
+      if (LIVE_ENV_KEYS.has(key)) continue;
+      if (value !== undefined && value !== null) {
+        hotSwapEnv[key] = String(value);
+      } else {
+        delete hotSwapEnv[key];
+      }
+    }
   }
 
   // Re-derive GH_TOKEN from live values using the same priority chain

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -797,6 +797,32 @@ export class TownDO extends DurableObject<Env> {
       }
     }
 
+    // Persist custom env_vars to DO storage so they survive container restarts.
+    // Compare against the previously-persisted set of keys to clear removed ones.
+    const CUSTOM_ENV_KEYS_STORAGE_KEY = 'container:custom_env_var_keys';
+    const prevCustomKeys: string[] =
+      (await this.ctx.storage.get<string[]>(CUSTOM_ENV_KEYS_STORAGE_KEY)) ?? [];
+    const newCustomKeys = Object.keys(townConfig.env_vars);
+    const newCustomKeySet = new Set(newCustomKeys);
+
+    for (const key of prevCustomKeys) {
+      if (!newCustomKeySet.has(key)) {
+        try {
+          await container.deleteEnvVar(key);
+        } catch (err) {
+          console.warn(`[Town.do] syncConfigToContainer: delete custom ${key} failed:`, err);
+        }
+      }
+    }
+    for (const [key, value] of Object.entries(townConfig.env_vars)) {
+      try {
+        await container.setEnvVar(key, value);
+      } catch (err) {
+        console.warn(`[Town.do] syncConfigToContainer: set custom ${key} failed:`, err);
+      }
+    }
+    await this.ctx.storage.put(CUSTOM_ENV_KEYS_STORAGE_KEY, newCustomKeys);
+
     // Phase 2: Push to the running container's process.env via the
     // /sync-config endpoint. The X-Town-Config header delivers the
     // full config; the endpoint applies CONFIG_ENV_MAP to process.env.

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -799,10 +799,29 @@ export class TownDO extends DurableObject<Env> {
 
     // Persist custom env_vars to DO storage so they survive container restarts.
     // Compare against the previously-persisted set of keys to clear removed ones.
+    // Reserved infra keys are never overwritten or deleted — infra values always win.
+    const RESERVED_ENV_KEYS = new Set([
+      'KILOCODE_TOKEN',
+      'GIT_TOKEN',
+      'GITHUB_TOKEN',
+      'GITLAB_TOKEN',
+      'GITLAB_INSTANCE_URL',
+      'GITHUB_CLI_PAT',
+      'GH_TOKEN',
+      'GASTOWN_GIT_AUTHOR_NAME',
+      'GASTOWN_GIT_AUTHOR_EMAIL',
+      'GASTOWN_DISABLE_AI_COAUTHOR',
+      'GASTOWN_ORGANIZATION_ID',
+      'GASTOWN_CONTAINER_TOKEN',
+      'GASTOWN_SESSION_TOKEN',
+      'GASTOWN_API_URL',
+    ]);
     const CUSTOM_ENV_KEYS_STORAGE_KEY = 'container:custom_env_var_keys';
     const prevCustomKeys: string[] =
       (await this.ctx.storage.get<string[]>(CUSTOM_ENV_KEYS_STORAGE_KEY)) ?? [];
-    const newCustomKeys = Object.keys(townConfig.env_vars);
+    const newCustomKeys = Object.keys(townConfig.env_vars).filter(
+      key => !RESERVED_ENV_KEYS.has(key)
+    );
     const newCustomKeySet = new Set(newCustomKeys);
 
     for (const key of prevCustomKeys) {
@@ -815,6 +834,7 @@ export class TownDO extends DurableObject<Env> {
       }
     }
     for (const [key, value] of Object.entries(townConfig.env_vars)) {
+      if (RESERVED_ENV_KEYS.has(key)) continue;
       try {
         await container.setEnvVar(key, value);
       } catch (err) {

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -825,6 +825,7 @@ export class TownDO extends DurableObject<Env> {
     const newCustomKeySet = new Set(newCustomKeys);
 
     for (const key of prevCustomKeys) {
+      if (RESERVED_ENV_KEYS.has(key)) continue;
       if (!newCustomKeySet.has(key)) {
         try {
           await container.deleteEnvVar(key);


### PR DESCRIPTION
## Summary

Custom environment variables set in town settings (`env_vars`) were not reaching already-running container processes until a restart + re-dispatch. Three gaps fixed:

1. **`syncTownConfigToProcessEnv()`** (control-server.ts) — now iterates `env_vars` from the town config and writes each to `process.env`. Tracks previously-applied keys in a module-level `Set` so removed keys are deleted from `process.env`.

2. **`syncConfigToContainer()`** (Town.do.ts) — now persists custom `env_vars` to `TownContainerDO` storage via `container.setEnvVar()`/`deleteEnvVar()` so they survive container restarts. Previously-persisted custom keys are tracked in DO storage (`container:custom_env_var_keys`) and cleaned up on removal.

3. **`updateAgentModel()` hot-swap** (process-manager.ts) — now overlays fresh custom `env_vars` from `getCurrentTownConfig()` over the stale `startupEnv` snapshot. Infra keys in `LIVE_ENV_KEYS` always take precedence over custom vars with the same name.

## Verification

- Code review against acceptance criteria in the issue
- All three gaps verified present in original code and fixed in this diff
- Infra key precedence maintained: `LIVE_ENV_KEYS` values from `process.env` override custom env_vars; custom vars skip keys that are in `LIVE_ENV_KEYS`

## Visual Changes

N/A

## Reviewer Notes

- The `lastAppliedEnvVarKeys` Set in control-server.ts is module-level state — it resets on container restart, which is fine since `process.env` also resets.
- The `CUSTOM_ENV_KEYS_STORAGE_KEY` in Town.do.ts uses DO durable storage so it persists across restarts.
- Custom env var keys that collide with infra keys (GIT_TOKEN, KILOCODE_TOKEN, etc.) are silently skipped in the hot-swap overlay to maintain infra precedence.