### PR TITLE
fix(claw): use authoritative created flag to fix orphaned instance rows

### DIFF
--- a/apps/web/src/lib/kiloclaw/instance-registry.ts
+++ b/apps/web/src/lib/kiloclaw/instance-registry.ts
@@ -13,6 +13,12 @@ export type ActiveKiloClawInstance = {
   name: string | null;
 };
 
+export type EnsureActiveInstanceResult = {
+  instance: ActiveKiloClawInstance;
+  /** True when this call inserted a new row (not returned an existing one). */
+  created: boolean;
+};
+
 /**
  * Returns true if this instance row uses the instance-keyed identity scheme
  * (ki_ sandboxId prefix, DO keyed by instanceId). Legacy rows have
@@ -64,7 +70,7 @@ type EnsureActiveInstanceOpts = {
 export async function ensureActiveInstance(
   userId: string,
   opts?: EnsureActiveInstanceOpts
-): Promise<ActiveKiloClawInstance> {
+): Promise<EnsureActiveInstanceResult> {
   const selectFields = {
     id: kiloclaw_instances.id,
     userId: kiloclaw_instances.user_id,
@@ -93,7 +99,7 @@ export async function ensureActiveInstance(
       throw new Error('Failed to create org instance row');
     }
 
-    return row;
+    return { instance: row, created: true };
   }
 
   // Personal flow: return existing active row if present.
@@ -103,7 +109,7 @@ export async function ensureActiveInstance(
   // orphan (no DO created for it). The window is milliseconds on a user-
   // initiated action already deduplicated by the frontend's useMutation.
   const existing = await getActiveInstance(userId);
-  if (existing) return existing;
+  if (existing) return { instance: existing, created: false };
 
   // No active row — create a new instance-keyed row.
   // sandboxId = sandboxIdFromInstanceId(uuid) ensures DB and DO identity match.
@@ -123,7 +129,7 @@ export async function ensureActiveInstance(
     throw new Error('Failed to create personal instance row');
   }
 
-  return row;
+  return { instance: row, created: true };
 }
 
 /**

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -503,11 +503,12 @@ function sanitizeKiloCodeConfigResponse(
 
 async function provisionInstance(
   user: Parameters<typeof generateApiToken>[0],
-  input: z.infer<typeof updateConfigSchema>
+  input: z.infer<typeof updateConfigSchema>,
+  /** Snapshot of the active row taken *before* ensureProvisionAccess, which may
+   *  itself create a row. Passing the snapshot in lets us correctly detect
+   *  whether the row was created as part of this provisioning attempt. */
+  preExistingRow: ActiveKiloClawInstance | null
 ) {
-  // Remember which row existed before so we can detect whether
-  // ensureActiveInstance created a new one for this attempt.
-  const preExistingRow = await getActiveInstance(user.id);
   const instanceRow = await ensureActiveInstance(user.id);
   const rowIsNew = !preExistingRow || preExistingRow.id !== instanceRow.id;
 
@@ -1738,8 +1739,12 @@ export const kiloclawRouter = createTRPCRouter({
 
   // Explicit lifecycle APIs
   provision: baseProcedure.input(updateConfigSchema).mutation(async ({ ctx, input }) => {
+    // Snapshot the active row *before* ensureProvisionAccess, which may create
+    // one. provisionInstance uses this to detect whether the row is new so it
+    // can clean up on failure.
+    const preExistingRow = await getActiveInstance(ctx.user.id);
     await ensureProvisionAccess(ctx.user.id, ctx.user.google_user_email);
-    return provisionInstance(ctx.user, input);
+    return provisionInstance(ctx.user, input, preExistingRow);
   }),
 
   patchConfig: clawAccessProcedure
@@ -1751,8 +1756,9 @@ export const kiloclawRouter = createTRPCRouter({
   // Backward-compatible alias — uses the same trial-bootstrap flow as provision
   // so first-time callers can create a trial row (clawAccessProcedure would reject them).
   updateConfig: baseProcedure.input(updateConfigSchema).mutation(async ({ ctx, input }) => {
+    const preExistingRow = await getActiveInstance(ctx.user.id);
     await ensureProvisionAccess(ctx.user.id, ctx.user.google_user_email);
-    return provisionInstance(ctx.user, input);
+    return provisionInstance(ctx.user, input, preExistingRow);
   }),
 
   updateKiloCodeConfig: clawAccessProcedure

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -504,20 +504,17 @@ function sanitizeKiloCodeConfigResponse(
 async function provisionInstance(
   user: Parameters<typeof generateApiToken>[0],
   input: z.infer<typeof updateConfigSchema>,
-  /** Whether ensureProvisionAccess (or an earlier step in this request)
-   *  created the instance row. This is combined with the created flag
-   *  from ensureActiveInstance below — either source means this request
-   *  owns the row and should clean it up on failure. */
-  instanceCreatedByAccessCheck: boolean
+  /** The exact row ID that ensureProvisionAccess created (if any).
+   *  Null when the access check returned an existing row or skipped
+   *  row creation (earlybird path). */
+  instanceIdCreatedByAccessCheck: string | null
 ) {
-  const { instance: instanceRow, created: instanceCreatedHere } = await ensureActiveInstance(
-    user.id
-  );
-  // The row was created by this request if either ensureProvisionAccess
-  // or the ensureActiveInstance call above inserted it. The earlybird
-  // path skips ensureActiveInstance in the access check, so the row may
-  // be created here instead.
-  const rowIsOwnedByThisRequest = instanceCreatedByAccessCheck || instanceCreatedHere;
+  const { instance: instanceRow, created: createdHere } = await ensureActiveInstance(user.id);
+  // Track the exact row ID this request created. Under concurrent
+  // provisions, two requests may each create a row but then converge on
+  // the oldest one via getActiveInstance. Only clean up instanceRow if
+  // it's the same row this request actually inserted.
+  const createdRowId = instanceIdCreatedByAccessCheck ?? (createdHere ? instanceRow.id : null);
 
   const encryptedSecrets = input.secrets
     ? Object.fromEntries(
@@ -555,10 +552,11 @@ async function provisionInstance(
       workerInstanceId(instanceRow) ? { instanceId: instanceRow.id } : undefined
     );
   } catch (error) {
-    // Only clean up the exact row this request created. The flag comes
-    // from ensureActiveInstance calls that actually inserted — not a
-    // racy before/after snapshot.
-    if (rowIsOwnedByThisRequest) {
+    // Only clean up if this request created the row AND it's the row
+    // we actually tried to provision. Under concurrent inserts, the
+    // row we created may differ from instanceRow (which converges on
+    // the oldest active row). Never destroy a row another request owns.
+    if (createdRowId && createdRowId === instanceRow.id) {
       await markInstanceDestroyedById(instanceRow.id).catch(cleanupErr => {
         console.error(
           '[kiloclaw] Failed to clean up instance row after provision error:',
@@ -668,7 +666,7 @@ async function fetchKiloClawServiceDegraded(): Promise<boolean> {
 async function ensureProvisionAccess(
   userId: string,
   userEmail: string
-): Promise<{ instanceCreated: boolean }> {
+): Promise<{ createdInstanceId: string | null }> {
   // Check earlybird before anything else — active earlybird grants access,
   // expired earlybird must not fall through to the trial bootstrap.
   const [earlybird] = await db
@@ -678,7 +676,7 @@ async function ensureProvisionAccess(
     .limit(1);
   if (earlybird) {
     if (new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE) > new Date()) {
-      return { instanceCreated: false };
+      return { createdInstanceId: null };
     }
     // Expired earlybird — fall through to subscription check, but must not
     // auto-create a trial (spec: user must manually subscribe).
@@ -687,7 +685,8 @@ async function ensureProvisionAccess(
   // Ensure the instance row exists so we can check/link subscriptions.
   // ensureActiveInstance is idempotent; the subsequent call in provisionInstance
   // will be a no-op.
-  const { instance, created: instanceCreated } = await ensureActiveInstance(userId);
+  const { instance, created } = await ensureActiveInstance(userId);
+  const createdInstanceId = created ? instance.id : null;
 
   // Adopt any orphaned subscription (instance_id = NULL) onto this instance
   // before checking access.  This covers the case where a user destroyed their
@@ -758,7 +757,7 @@ async function ensureProvisionAccess(
         });
       });
     }
-    return { instanceCreated };
+    return { createdInstanceId };
   }
 
   // Access check: check the subscription on this specific instance.
@@ -789,7 +788,7 @@ async function ensureProvisionAccess(
         !!instanceSub.trial_ends_at &&
         new Date(instanceSub.trial_ends_at) > new Date());
 
-    if (hasAccess) return { instanceCreated };
+    if (hasAccess) return { createdInstanceId };
   }
 
   throw new TRPCError({
@@ -1752,11 +1751,11 @@ export const kiloclawRouter = createTRPCRouter({
 
   // Explicit lifecycle APIs
   provision: baseProcedure.input(updateConfigSchema).mutation(async ({ ctx, input }) => {
-    const { instanceCreated } = await ensureProvisionAccess(
+    const { createdInstanceId } = await ensureProvisionAccess(
       ctx.user.id,
       ctx.user.google_user_email
     );
-    return provisionInstance(ctx.user, input, instanceCreated);
+    return provisionInstance(ctx.user, input, createdInstanceId);
   }),
 
   patchConfig: clawAccessProcedure
@@ -1768,11 +1767,11 @@ export const kiloclawRouter = createTRPCRouter({
   // Backward-compatible alias — uses the same trial-bootstrap flow as provision
   // so first-time callers can create a trial row (clawAccessProcedure would reject them).
   updateConfig: baseProcedure.input(updateConfigSchema).mutation(async ({ ctx, input }) => {
-    const { instanceCreated } = await ensureProvisionAccess(
+    const { createdInstanceId } = await ensureProvisionAccess(
       ctx.user.id,
       ctx.user.google_user_email
     );
-    return provisionInstance(ctx.user, input, instanceCreated);
+    return provisionInstance(ctx.user, input, createdInstanceId);
   }),
 
   updateKiloCodeConfig: clawAccessProcedure

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -505,13 +505,18 @@ async function provisionInstance(
   user: Parameters<typeof generateApiToken>[0],
   input: z.infer<typeof updateConfigSchema>,
   /** Whether ensureProvisionAccess (or an earlier step in this request)
-   *  created the instance row. When true and the DO provision fails, the
-   *  row is cleaned up. This is authoritative — it comes from the
-   *  ensureActiveInstance call that actually inserted, not from a
-   *  before/after snapshot that races with concurrent requests. */
-  instanceCreatedByThisRequest: boolean
+   *  created the instance row. This is combined with the created flag
+   *  from ensureActiveInstance below — either source means this request
+   *  owns the row and should clean it up on failure. */
+  instanceCreatedByAccessCheck: boolean
 ) {
-  const { instance: instanceRow } = await ensureActiveInstance(user.id);
+  const { instance: instanceRow, created: instanceCreatedHere } =
+    await ensureActiveInstance(user.id);
+  // The row was created by this request if either ensureProvisionAccess
+  // or the ensureActiveInstance call above inserted it. The earlybird
+  // path skips ensureActiveInstance in the access check, so the row may
+  // be created here instead.
+  const rowIsOwnedByThisRequest = instanceCreatedByAccessCheck || instanceCreatedHere;
 
   const encryptedSecrets = input.secrets
     ? Object.fromEntries(
@@ -549,10 +554,10 @@ async function provisionInstance(
       workerInstanceId(instanceRow) ? { instanceId: instanceRow.id } : undefined
     );
   } catch (error) {
-    // Only clean up the exact row this request created. The
-    // instanceCreatedByThisRequest flag comes from the ensureActiveInstance
-    // call that actually inserted — not a racy before/after snapshot.
-    if (instanceCreatedByThisRequest) {
+    // Only clean up the exact row this request created. The flag comes
+    // from ensureActiveInstance calls that actually inserted — not a
+    // racy before/after snapshot.
+    if (rowIsOwnedByThisRequest) {
       await markInstanceDestroyedById(instanceRow.id).catch(cleanupErr => {
         console.error(
           '[kiloclaw] Failed to clean up instance row after provision error:',

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -510,8 +510,9 @@ async function provisionInstance(
    *  owns the row and should clean it up on failure. */
   instanceCreatedByAccessCheck: boolean
 ) {
-  const { instance: instanceRow, created: instanceCreatedHere } =
-    await ensureActiveInstance(user.id);
+  const { instance: instanceRow, created: instanceCreatedHere } = await ensureActiveInstance(
+    user.id
+  );
   // The row was created by this request if either ensureProvisionAccess
   // or the ensureActiveInstance call above inserted it. The earlybird
   // path skips ensureActiveInstance in the access check, so the row may

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -194,9 +194,9 @@ async function getOrCreateInstanceForBilling(userId: string): Promise<ActiveKilo
     return active;
   }
 
-  const newInstance = await ensureActiveInstance(userId);
-  await adoptOrphanedSubscription(userId, newInstance.id);
-  return newInstance;
+  const { instance } = await ensureActiveInstance(userId);
+  await adoptOrphanedSubscription(userId, instance.id);
+  return instance;
 }
 
 type PersonalBillingInstanceRow = {
@@ -504,13 +504,14 @@ function sanitizeKiloCodeConfigResponse(
 async function provisionInstance(
   user: Parameters<typeof generateApiToken>[0],
   input: z.infer<typeof updateConfigSchema>,
-  /** Snapshot of the active row taken *before* ensureProvisionAccess, which may
-   *  itself create a row. Passing the snapshot in lets us correctly detect
-   *  whether the row was created as part of this provisioning attempt. */
-  preExistingRow: ActiveKiloClawInstance | null
+  /** Whether ensureProvisionAccess (or an earlier step in this request)
+   *  created the instance row. When true and the DO provision fails, the
+   *  row is cleaned up. This is authoritative — it comes from the
+   *  ensureActiveInstance call that actually inserted, not from a
+   *  before/after snapshot that races with concurrent requests. */
+  instanceCreatedByThisRequest: boolean
 ) {
-  const instanceRow = await ensureActiveInstance(user.id);
-  const rowIsNew = !preExistingRow || preExistingRow.id !== instanceRow.id;
+  const { instance: instanceRow } = await ensureActiveInstance(user.id);
 
   const encryptedSecrets = input.secrets
     ? Object.fromEntries(
@@ -548,9 +549,10 @@ async function provisionInstance(
       workerInstanceId(instanceRow) ? { instanceId: instanceRow.id } : undefined
     );
   } catch (error) {
-    // Only clean up the exact row this attempt created. Target by primary
-    // key so a concurrent request's row is never affected.
-    if (rowIsNew) {
+    // Only clean up the exact row this request created. The
+    // instanceCreatedByThisRequest flag comes from the ensureActiveInstance
+    // call that actually inserted — not a racy before/after snapshot.
+    if (instanceCreatedByThisRequest) {
       await markInstanceDestroyedById(instanceRow.id).catch(cleanupErr => {
         console.error(
           '[kiloclaw] Failed to clean up instance row after provision error:',
@@ -657,7 +659,10 @@ async function fetchKiloClawServiceDegraded(): Promise<boolean> {
  * Earlybird is checked first so earlybird purchasers never get an accidental
  * trial row, and expired earlybird users cannot regain access by provisioning.
  */
-async function ensureProvisionAccess(userId: string, userEmail: string): Promise<void> {
+async function ensureProvisionAccess(
+  userId: string,
+  userEmail: string
+): Promise<{ instanceCreated: boolean }> {
   // Check earlybird before anything else — active earlybird grants access,
   // expired earlybird must not fall through to the trial bootstrap.
   const [earlybird] = await db
@@ -666,7 +671,9 @@ async function ensureProvisionAccess(userId: string, userEmail: string): Promise
     .where(eq(kiloclaw_earlybird_purchases.user_id, userId))
     .limit(1);
   if (earlybird) {
-    if (new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE) > new Date()) return;
+    if (new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE) > new Date()) {
+      return { instanceCreated: false };
+    }
     // Expired earlybird — fall through to subscription check, but must not
     // auto-create a trial (spec: user must manually subscribe).
   }
@@ -674,7 +681,7 @@ async function ensureProvisionAccess(userId: string, userEmail: string): Promise
   // Ensure the instance row exists so we can check/link subscriptions.
   // ensureActiveInstance is idempotent; the subsequent call in provisionInstance
   // will be a no-op.
-  const instance = await ensureActiveInstance(userId);
+  const { instance, created: instanceCreated } = await ensureActiveInstance(userId);
 
   // Adopt any orphaned subscription (instance_id = NULL) onto this instance
   // before checking access.  This covers the case where a user destroyed their
@@ -745,7 +752,7 @@ async function ensureProvisionAccess(userId: string, userEmail: string): Promise
         });
       });
     }
-    return;
+    return { instanceCreated };
   }
 
   // Access check: check the subscription on this specific instance.
@@ -776,7 +783,7 @@ async function ensureProvisionAccess(userId: string, userEmail: string): Promise
         !!instanceSub.trial_ends_at &&
         new Date(instanceSub.trial_ends_at) > new Date());
 
-    if (hasAccess) return;
+    if (hasAccess) return { instanceCreated };
   }
 
   throw new TRPCError({
@@ -1739,12 +1746,11 @@ export const kiloclawRouter = createTRPCRouter({
 
   // Explicit lifecycle APIs
   provision: baseProcedure.input(updateConfigSchema).mutation(async ({ ctx, input }) => {
-    // Snapshot the active row *before* ensureProvisionAccess, which may create
-    // one. provisionInstance uses this to detect whether the row is new so it
-    // can clean up on failure.
-    const preExistingRow = await getActiveInstance(ctx.user.id);
-    await ensureProvisionAccess(ctx.user.id, ctx.user.google_user_email);
-    return provisionInstance(ctx.user, input, preExistingRow);
+    const { instanceCreated } = await ensureProvisionAccess(
+      ctx.user.id,
+      ctx.user.google_user_email
+    );
+    return provisionInstance(ctx.user, input, instanceCreated);
   }),
 
   patchConfig: clawAccessProcedure
@@ -1756,9 +1762,11 @@ export const kiloclawRouter = createTRPCRouter({
   // Backward-compatible alias — uses the same trial-bootstrap flow as provision
   // so first-time callers can create a trial row (clawAccessProcedure would reject them).
   updateConfig: baseProcedure.input(updateConfigSchema).mutation(async ({ ctx, input }) => {
-    const preExistingRow = await getActiveInstance(ctx.user.id);
-    await ensureProvisionAccess(ctx.user.id, ctx.user.google_user_email);
-    return provisionInstance(ctx.user, input, preExistingRow);
+    const { instanceCreated } = await ensureProvisionAccess(
+      ctx.user.id,
+      ctx.user.google_user_email
+    );
+    return provisionInstance(ctx.user, input, instanceCreated);
   }),
 
   updateKiloCodeConfig: clawAccessProcedure

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -327,7 +327,9 @@ export const organizationKiloclawRouter = createTRPCRouter({
         });
       }
 
-      const instanceRow = await ensureActiveInstance(ctx.user.id, { orgId: input.organizationId });
+      const { instance: instanceRow } = await ensureActiveInstance(ctx.user.id, {
+        orgId: input.organizationId,
+      });
 
       const encryptedSecrets = input.secrets
         ? Object.fromEntries(
@@ -376,6 +378,7 @@ export const organizationKiloclawRouter = createTRPCRouter({
 
         return result;
       } catch (error) {
+        // Org provision always creates a new row, so always clean up on failure.
         await markInstanceDestroyedById(instanceRow.id).catch(cleanupErr => {
           console.error(
             '[kiloclaw-org] Failed to clean up instance row after provision error:',


### PR DESCRIPTION
## Summary

- Fixes orphaned `kiloclaw_instances` rows (active DB row with no backing Durable Object) caused by multiple code paths that create rows without cleaning them up on failure.
- **Bug 1 — Provision failure:** `ensureProvisionAccess` creates a row via `ensureActiveInstance`, then `provisionInstance` snapshots via `getActiveInstance` — but sees the row as pre-existing, so `rowIsNew` is false. When the DO provision fails, cleanup is skipped.
- **Bug 2 — Concurrent provisions:** A boolean `created` flag doesn't identify *which* row was created. Two concurrent requests can converge on the same row, and a failing request destroys the other's successfully provisioned row.
- **Bug 3 — Access denial after row creation:** `ensureProvisionAccess` creates a row at line 692, then throws FORBIDDEN at line 798 (expired trial, no valid subscription). `provisionInstance` never runs, so the cleanup logic never executes. The row is orphaned.

### Fixes

| Bug | Fix |
|-----|-----|
| Provision failure | Track exact row ID from `ensureActiveInstance`'s `created` flag, not a before/after snapshot |
| Concurrent provisions | Only clean up when `createdRowId === instanceRow.id` — never destroy a row another request converged on |
| Access denial | `ensureProvisionAccess` now destroys the row it created before throwing FORBIDDEN |

### Files changed

| File | Change |
|------|--------|
| `apps/web/src/lib/kiloclaw/instance-registry.ts` | `ensureActiveInstance` returns `{ instance, created }` instead of bare instance |
| `apps/web/src/routers/kiloclaw-router.ts` | `ensureProvisionAccess` returns `{ createdInstanceId }`, cleans up on access denial; `provisionInstance` uses exact row ID match for cleanup |
| `apps/web/src/routers/organizations/organization-kiloclaw-router.ts` | Destructure new return type |

## Verification

- `pnpm --filter web typecheck` passes
- `pnpm --filter kiloclaw typecheck` passes
- `pnpm format` clean

## Visual Changes

N/A

## Reviewer Notes

- Bug 3 (access denial) is likely the most common source of orphans in production — it affects every user with an expired trial who visits `/claw/new` and clicks provision. The row is created during `ensureProvisionAccess` but the FORBIDDEN throw prevents `provisionInstance` from ever running.
- The earlybird path returns `createdInstanceId: null` (skips `ensureActiveInstance`), so `provisionInstance`'s own `ensureActiveInstance` call fills in the `createdRowId` when it creates the row.
- Org provision path always creates a new row, cleanup behavior unchanged.