### PR TITLE
feat(gastown): batch gastown improvements — deleteAgent terminal state fix, landing MR loop fix, env var propagation, container tooling, triage dispatch, dead code cleanup, UI polish

### DIFF
--- a/apps/web/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/TownOverviewPageClient.tsx
@@ -29,6 +29,7 @@ import {
   ChevronDown,
   Layers,
   MessageSquare,
+  Copy,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
@@ -228,6 +229,17 @@ export function TownOverviewPageClient({
             <span className="size-1.5 rounded-full bg-emerald-400" />
             Live
           </span>
+          <button
+            onClick={() => {
+              void navigator.clipboard.writeText(townId);
+              toast.success('Copied town ID');
+            }}
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-xs text-white/30 hover:bg-white/[0.06] hover:text-white/60 transition-colors"
+            title={townId}
+          >
+            <Copy className="size-3" />
+            {townId.slice(0, 8)}…
+          </button>
         </div>
         <Button
           variant="primary"

--- a/apps/web/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
@@ -167,8 +167,9 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
     if (!deleteConfirm) return;
 
     if (deleteConfirm.kind === 'selected') {
-      const { ids, rigId } = deleteConfirm;
+      const { ids } = deleteConfirm;
       for (const id of ids) {
+        const rigId = beadRigMap.get(id) ?? '';
         deleteBeadMutation.mutate({ rigId, beadId: id, townId });
       }
     } else {
@@ -248,9 +249,7 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
             className="overflow-hidden"
           >
             <div className="flex items-center gap-3 border-b border-white/[0.06] bg-red-500/[0.04] px-6 py-2">
-              <span className="text-xs text-white/50">
-                {selectedIds.size} selected
-              </span>
+              <span className="text-xs text-white/50">{selectedIds.size} selected</span>
               <button
                 onClick={handleDeleteSelected}
                 className="flex items-center gap-1.5 rounded-md bg-red-500/10 px-2.5 py-1.5 text-xs font-medium text-red-400 transition-colors hover:bg-red-500/20"
@@ -361,7 +360,12 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
       </div>
 
       {/* Delete confirmation dialog */}
-      <Dialog open={!!deleteConfirm} onOpenChange={open => { if (!open) setDeleteConfirm(null); }}>
+      <Dialog
+        open={!!deleteConfirm}
+        onOpenChange={open => {
+          if (!open) setDeleteConfirm(null);
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>

--- a/apps/web/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
@@ -1,14 +1,23 @@
 'use client';
 
-import { useState, useMemo } from 'react';
-import { useQuery, useQueries } from '@tanstack/react-query';
+import { useState, useMemo, useCallback } from 'react';
+import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { useDrawerStack } from '@/components/gastown/DrawerStack';
-import { Hexagon, Search } from 'lucide-react';
+import { Hexagon, Search, Trash2, X } from 'lucide-react';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { formatDistanceToNow } from 'date-fns';
 import { motion, AnimatePresence } from 'motion/react';
 import type { GastownOutputs } from '@/lib/gastown/trpc';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
 
 type Bead = GastownOutputs['gastown']['listBeads'][number];
 
@@ -23,11 +32,18 @@ const STATUS_DOT: Record<string, string> = {
   failed: 'bg-red-400',
 };
 
+type DeleteConfirm =
+  | { kind: 'selected'; ids: string[]; rigId: string }
+  | { kind: 'all-failed'; count: number; rigIds: string[] };
+
 export function BeadsPageClient({ townId }: BeadsPageClientProps) {
   const trpc = useGastownTRPC();
+  const queryClient = useQueryClient();
   const { open: openDrawer } = useDrawerStack();
   const [statusFilter, setStatusFilter] = useState<string | null>(null);
   const [search, setSearch] = useState('');
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [deleteConfirm, setDeleteConfirm] = useState<DeleteConfirm | null>(null);
 
   const rigsQuery = useQuery(trpc.gastown.listRigs.queryOptions({ townId }));
   const rigs = rigsQuery.data ?? [];
@@ -78,7 +94,91 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
     return counts;
   }, [allBeads]);
 
+  const failedBeads = useMemo(() => allBeads.filter(b => b.status === 'failed'), [allBeads]);
+
   const isLoading = rigsQuery.isLoading || rigBeadQueries.some(q => q.isLoading);
+
+  const invalidateBeads = useCallback(() => {
+    for (const rig of rigs) {
+      void queryClient.invalidateQueries(trpc.gastown.listBeads.queryFilter({ rigId: rig.id }));
+    }
+  }, [queryClient, rigs, trpc.gastown.listBeads]);
+
+  const deleteBeadMutation = useMutation(
+    trpc.gastown.deleteBead.mutationOptions({
+      onSuccess: () => {
+        invalidateBeads();
+        setSelectedIds(new Set());
+        setDeleteConfirm(null);
+      },
+    })
+  );
+
+  const isDeleting = deleteBeadMutation.isPending;
+
+  // Build a map from bead_id -> rigId for lookups
+  const beadRigMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const bead of allBeads) {
+      map.set(bead.bead_id, bead.rigId);
+    }
+    return map;
+  }, [allBeads]);
+
+  const allFilteredSelected =
+    filteredBeads.length > 0 && filteredBeads.every(b => selectedIds.has(b.bead_id));
+
+  const toggleSelectAll = () => {
+    if (allFilteredSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(filteredBeads.map(b => b.bead_id)));
+    }
+  };
+
+  const toggleSelect = (beadId: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(beadId)) {
+        next.delete(beadId);
+      } else {
+        next.add(beadId);
+      }
+      return next;
+    });
+  };
+
+  const handleDeleteSelected = () => {
+    if (selectedIds.size === 0) return;
+    // Group by rigId — pick the first rig for simplicity (all selected beads share the same rig
+    // in most cases; if mixed, we use the first one and the mutation handles array input)
+    const selectedArr = [...selectedIds];
+    const firstRigId = beadRigMap.get(selectedArr[0] ?? '') ?? '';
+    setDeleteConfirm({ kind: 'selected', ids: selectedArr, rigId: firstRigId });
+  };
+
+  const handleDeleteAllFailed = () => {
+    if (failedBeads.length === 0) return;
+    const rigIds = [...new Set(failedBeads.map(b => b.rigId))];
+    setDeleteConfirm({ kind: 'all-failed', count: failedBeads.length, rigIds });
+  };
+
+  const handleConfirmDelete = () => {
+    if (!deleteConfirm) return;
+
+    if (deleteConfirm.kind === 'selected') {
+      const { ids, rigId } = deleteConfirm;
+      deleteBeadMutation.mutate({ rigId, beadId: ids, townId });
+    } else {
+      // Delete all failed beads — collect all IDs and bulk-delete via the array endpoint.
+      // Using the first rig's ID for ownership verification; the town DO deletes by IDs.
+      const { rigIds } = deleteConfirm;
+      const firstRigId = rigIds[0];
+      if (!firstRigId) return;
+      const failedIds = failedBeads.map(b => b.bead_id);
+      deleteBeadMutation.mutate({ rigId: firstRigId, beadId: failedIds, townId });
+    }
+  };
 
   return (
     <div className="flex h-full flex-col">
@@ -90,6 +190,17 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Beads</h1>
           <span className="ml-1 font-mono text-xs text-white/30">{allBeads.length}</span>
         </div>
+
+        {/* Delete all failed shortcut */}
+        {failedBeads.length > 0 && (
+          <button
+            onClick={handleDeleteAllFailed}
+            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-red-400/70 transition-colors hover:bg-red-500/10 hover:text-red-400"
+          >
+            <Trash2 className="size-3" />
+            Delete all failed ({failedBeads.length})
+          </button>
+        )}
       </div>
 
       {/* Filter bar */}
@@ -127,6 +238,39 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
         </div>
       </div>
 
+      {/* Bulk action bar */}
+      <AnimatePresence>
+        {selectedIds.size > 0 && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="overflow-hidden"
+          >
+            <div className="flex items-center gap-3 border-b border-white/[0.06] bg-red-500/[0.04] px-6 py-2">
+              <span className="text-xs text-white/50">
+                {selectedIds.size} selected
+              </span>
+              <button
+                onClick={handleDeleteSelected}
+                className="flex items-center gap-1.5 rounded-md bg-red-500/10 px-2.5 py-1.5 text-xs font-medium text-red-400 transition-colors hover:bg-red-500/20"
+              >
+                <Trash2 className="size-3" />
+                Delete selected
+              </button>
+              <button
+                onClick={() => setSelectedIds(new Set())}
+                className="flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-white/30 transition-colors hover:text-white/50"
+              >
+                <X className="size-3" />
+                Clear
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       {/* Bead list */}
       <div className="flex-1 overflow-y-auto">
         {isLoading && (
@@ -153,6 +297,20 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
           </div>
         )}
 
+        {/* Select-all header row */}
+        {!isLoading && filteredBeads.length > 0 && (
+          <div className="flex items-center gap-3 border-b border-white/[0.04] px-6 py-1.5">
+            <input
+              type="checkbox"
+              checked={allFilteredSelected}
+              onChange={toggleSelectAll}
+              className="size-3.5 cursor-pointer accent-[oklch(95%_0.15_108)]"
+              aria-label="Select all beads"
+            />
+            <span className="text-[10px] text-white/20">Select all ({filteredBeads.length})</span>
+          </div>
+        )}
+
         <AnimatePresence mode="popLayout">
           {filteredBeads.map((bead, i) => (
             <motion.div
@@ -161,16 +319,28 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ delay: Math.min(i * 0.02, 0.3), duration: 0.15 }}
-              onClick={() => {
-                const rigId = (bead as Bead & { rigId: string }).rigId;
-                openDrawer({ type: 'bead', beadId: bead.bead_id, rigId });
-              }}
-              className="group flex cursor-pointer items-center gap-3 border-b border-white/[0.04] px-6 py-2.5 transition-colors hover:bg-white/[0.02]"
+              className={`group flex cursor-pointer items-center gap-3 border-b border-white/[0.04] px-6 py-2.5 transition-colors hover:bg-white/[0.02] ${
+                selectedIds.has(bead.bead_id) ? 'bg-white/[0.03]' : ''
+              }`}
             >
+              {/* Checkbox — stop propagation so clicking it doesn't open drawer */}
+              <input
+                type="checkbox"
+                checked={selectedIds.has(bead.bead_id)}
+                onChange={() => toggleSelect(bead.bead_id)}
+                onClick={e => e.stopPropagation()}
+                className="size-3.5 shrink-0 cursor-pointer accent-[oklch(95%_0.15_108)]"
+                aria-label={`Select bead ${bead.bead_id}`}
+              />
               <span
                 className={`size-2 shrink-0 rounded-full ${STATUS_DOT[bead.status] ?? 'bg-white/20'}`}
               />
-              <div className="min-w-0 flex-1">
+              <div
+                className="min-w-0 flex-1"
+                onClick={() => {
+                  openDrawer({ type: 'bead', beadId: bead.bead_id, rigId: bead.rigId });
+                }}
+              >
                 <div className="flex items-center gap-2">
                   <span className="truncate text-sm text-white/80">{bead.title}</span>
                   <span className="shrink-0 rounded bg-white/[0.04] px-1.5 py-0.5 text-[9px] font-medium text-white/30">
@@ -180,7 +350,7 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
                 <div className="mt-0.5 flex items-center gap-2 text-[10px] text-white/30">
                   <span className="font-mono">{bead.bead_id.slice(0, 8)}</span>
                   <span className="text-white/15">|</span>
-                  <span>{(bead as Bead & { rigName: string }).rigName}</span>
+                  <span>{bead.rigName}</span>
                   <span className="text-white/15">|</span>
                   <span>{formatDistanceToNow(new Date(bead.created_at), { addSuffix: true })}</span>
                 </div>
@@ -190,6 +360,30 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
           ))}
         </AnimatePresence>
       </div>
+
+      {/* Delete confirmation dialog */}
+      <Dialog open={!!deleteConfirm} onOpenChange={open => { if (!open) setDeleteConfirm(null); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {deleteConfirm?.kind === 'all-failed' ? 'Delete all failed beads' : 'Delete beads'}
+            </DialogTitle>
+            <DialogDescription>
+              {deleteConfirm?.kind === 'all-failed'
+                ? `Delete ${deleteConfirm.count} failed bead${deleteConfirm.count === 1 ? '' : 's'}? This cannot be undone.`
+                : `Delete ${deleteConfirm?.ids.length ?? 0} selected bead${(deleteConfirm?.ids.length ?? 0) === 1 ? '' : 's'}? This cannot be undone.`}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteConfirm(null)} disabled={isDeleting}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmDelete} disabled={isDeleting}>
+              {isDeleting ? 'Deleting…' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Drawers are rendered by the layout-level DrawerStackProvider */}
     </div>

--- a/apps/web/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
@@ -168,15 +168,14 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
 
     if (deleteConfirm.kind === 'selected') {
       const { ids, rigId } = deleteConfirm;
-      deleteBeadMutation.mutate({ rigId, beadId: ids, townId });
+      for (const id of ids) {
+        deleteBeadMutation.mutate({ rigId, beadId: id, townId });
+      }
     } else {
-      // Delete all failed beads — collect all IDs and bulk-delete via the array endpoint.
-      // Using the first rig's ID for ownership verification; the town DO deletes by IDs.
-      const { rigIds } = deleteConfirm;
-      const firstRigId = rigIds[0];
-      if (!firstRigId) return;
-      const failedIds = failedBeads.map(b => b.bead_id);
-      deleteBeadMutation.mutate({ rigId: firstRigId, beadId: failedIds, townId });
+      // Delete all failed beads one by one (no bulk endpoint).
+      for (const bead of failedBeads) {
+        deleteBeadMutation.mutate({ rigId: bead.rigId, beadId: bead.bead_id, townId });
+      }
     }
   };
 

--- a/apps/web/src/app/(app)/gastown/[townId]/merges/NeedsAttention.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/merges/NeedsAttention.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, Fragment } from 'react';
+import { useState, useMemo, Fragment, useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
@@ -15,7 +15,9 @@ import {
   Eye,
   GitBranch,
   GitMerge,
+  Loader2,
   RefreshCw,
+  X,
   XCircle,
   CheckCircle2,
   Clock,
@@ -113,6 +115,8 @@ export function NeedsAttention({
 }) {
   const session = useSession();
   const isAdmin = session?.data?.isAdmin ?? false;
+  const trpc = useGastownTRPC();
+  const queryClient = useQueryClient();
   const totalCount = data.openPRs.length + data.failedReviews.length + data.stalePRs.length;
 
   // Tag each item with its category for rendering
@@ -139,6 +143,39 @@ export function NeedsAttention({
     return map;
   }, [allItems]);
 
+  const failedItems = useMemo(
+    () => allItems.filter(({ category }) => category === 'failed').map(({ item }) => item),
+    [allItems]
+  );
+
+  const [isDismissingAll, setIsDismissingAll] = useState(false);
+  const updateBeadMutation = useMutation(trpc.gastown.updateBead.mutationOptions({}));
+
+  const dismissAllFailed = useCallback(async () => {
+    if (failedItems.length === 0) return;
+    setIsDismissingAll(true);
+    try {
+      await Promise.all(
+        failedItems.map(item =>
+          updateBeadMutation.mutateAsync({
+            rigId: item.mrBead.rig_id ?? '',
+            beadId: item.mrBead.bead_id,
+            status: 'closed',
+          })
+        )
+      );
+      void queryClient.invalidateQueries({
+        queryKey: trpc.gastown.getMergeQueueData.queryKey({ townId }),
+      });
+      toast.success(`Dismissed ${failedItems.length} failed ${failedItems.length === 1 ? 'bead' : 'beads'}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      toast.error(`Failed to dismiss all: ${message}`);
+    } finally {
+      setIsDismissingAll(false);
+    }
+  }, [failedItems, updateBeadMutation, queryClient, trpc, townId]);
+
   if (totalCount === 0) {
     return (
       <div className="rounded-xl border border-dashed border-white/10 p-6 text-center">
@@ -150,6 +187,24 @@ export function NeedsAttention({
 
   return (
     <div className="space-y-3">
+      {/* Dismiss all failed button */}
+      {failedItems.length > 0 && (
+        <div className="flex justify-end">
+          <button
+            onClick={() => void dismissAllFailed()}
+            disabled={isDismissingAll}
+            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs text-red-400/60 transition-colors hover:bg-red-500/10 hover:text-red-400 disabled:pointer-events-none disabled:opacity-40"
+          >
+            {isDismissingAll ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <X className="size-3" />
+            )}
+            Dismiss all failed ({failedItems.length})
+          </button>
+        </div>
+      )}
+
       {/* Convoy groups */}
       <AnimatePresence initial={false}>
         {convoyGroups.map(group => (
@@ -335,6 +390,18 @@ function AttentionItemRow({
     })
   );
 
+  const dismissMutation = useMutation(
+    trpc.gastown.updateBead.mutationOptions({
+      onSuccess: () => {
+        invalidateMergeQueue();
+        toast.success('Bead dismissed');
+      },
+      onError: (err: { message: string }) => {
+        toast.error(`Failed to dismiss: ${err.message}`);
+      },
+    })
+  );
+
   // Fail bead mutation: use adminForceFailBead
   const failMutation = useMutation(
     trpc.gastown.adminForceFailBead.mutationOptions({
@@ -349,7 +416,7 @@ function AttentionItemRow({
     })
   );
 
-  const isPending = retryMutation.isPending || failMutation.isPending;
+  const isPending = retryMutation.isPending || failMutation.isPending || dismissMutation.isPending;
 
   const handleConfirm = () => {
     if (!confirmAction) return;
@@ -388,13 +455,12 @@ function AttentionItemRow({
             </span>
             <button
               onClick={() => {
-                if (item.sourceBead) {
-                  openDrawer({
-                    type: 'bead',
-                    beadId: item.sourceBead.bead_id,
-                    rigId,
-                  });
-                }
+                const beadToOpen = item.sourceBead ?? item.mrBead;
+                openDrawer({
+                  type: 'bead',
+                  beadId: beadToOpen.bead_id,
+                  rigId,
+                });
               }}
               className="min-w-0 truncate text-sm text-white/75 transition-colors hover:text-white/90"
               title={sourceBeadTitle}
@@ -446,29 +512,45 @@ function AttentionItemRow({
             </a>
           )}
           {category === 'failed' && (
-            <button
-              onClick={() =>
-                setConfirmAction({
-                  beadId: item.mrBead.bead_id,
-                  title: sourceBeadTitle,
-                  action: 'retry',
-                })
-              }
-              className="rounded-md p-1.5 text-white/30 transition-colors hover:bg-white/[0.06] hover:text-white/60"
-              title="Retry Review"
-            >
-              <RefreshCw className="size-3.5" />
-            </button>
+            <>
+              <button
+                onClick={() =>
+                  setConfirmAction({
+                    beadId: item.mrBead.bead_id,
+                    title: sourceBeadTitle,
+                    action: 'retry',
+                  })
+                }
+                disabled={isPending}
+                className="rounded-md p-1.5 text-white/30 transition-colors hover:bg-white/[0.06] hover:text-white/60 disabled:pointer-events-none disabled:opacity-40"
+                title="Retry Review"
+              >
+                <RefreshCw className="size-3.5" />
+              </button>
+              <button
+                onClick={() =>
+                  dismissMutation.mutate({
+                    rigId,
+                    beadId: item.mrBead.bead_id,
+                    status: 'closed',
+                  })
+                }
+                disabled={isPending}
+                className="rounded-md p-1.5 text-white/30 transition-colors hover:bg-white/[0.06] hover:text-white/60 disabled:pointer-events-none disabled:opacity-40"
+                title="Dismiss"
+              >
+                <X className="size-3.5" />
+              </button>
+            </>
           )}
           <button
             onClick={() => {
-              if (item.sourceBead) {
-                openDrawer({
-                  type: 'bead',
-                  beadId: item.sourceBead.bead_id,
-                  rigId,
-                });
-              }
+              const beadToOpen = item.sourceBead ?? item.mrBead;
+              openDrawer({
+                type: 'bead',
+                beadId: beadToOpen.bead_id,
+                rigId,
+              });
             }}
             className="rounded-md p-1.5 text-white/30 transition-colors hover:bg-white/[0.06] hover:text-white/60"
             title="View Bead"

--- a/apps/web/src/app/(app)/gastown/[townId]/merges/NeedsAttention.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/merges/NeedsAttention.tsx
@@ -167,7 +167,9 @@ export function NeedsAttention({
       void queryClient.invalidateQueries({
         queryKey: trpc.gastown.getMergeQueueData.queryKey({ townId }),
       });
-      toast.success(`Dismissed ${failedItems.length} failed ${failedItems.length === 1 ? 'bead' : 'beads'}`);
+      toast.success(
+        `Dismissed ${failedItems.length} failed ${failedItems.length === 1 ? 'bead' : 'beads'}`
+      );
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Unknown error';
       toast.error(`Failed to dismiss all: ${message}`);

--- a/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/settings/RigSettingsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/rigs/[rigId]/settings/RigSettingsPageClient.tsx
@@ -112,6 +112,9 @@ export function RigSettingsPageClient({ townId, rigId, organizationId }: Props) 
   const [autoResolvePrFeedback, setAutoResolvePrFeedback] = useState<boolean | undefined>(
     undefined
   );
+  const [autoResolveMergeConflicts, setAutoResolveMergeConflicts] = useState<boolean | undefined>(
+    undefined
+  );
   const [autoMergeDelayMinutes, setAutoMergeDelayMinutes] = useState<number | null | undefined>(
     undefined
   );
@@ -136,6 +139,7 @@ export function RigSettingsPageClient({ townId, rigId, organizationId }: Props) 
       setRefineryCodeReview(cfg.code_review);
       setReviewMode(cfg.review_mode);
       setAutoResolvePrFeedback(cfg.auto_resolve_pr_feedback);
+      setAutoResolveMergeConflicts(cfg.auto_resolve_merge_conflicts);
       setAutoMergeDelayMinutes(cfg.auto_merge_delay_minutes);
       setMergeStrategy(cfg.merge_strategy);
       setConvoyMergeMode(cfg.convoy_merge_mode);
@@ -183,6 +187,7 @@ export function RigSettingsPageClient({ townId, rigId, organizationId }: Props) 
         code_review: refineryCodeReview,
         review_mode: reviewMode,
         auto_resolve_pr_feedback: autoResolvePrFeedback,
+        auto_resolve_merge_conflicts: autoResolveMergeConflicts,
         auto_merge_delay_minutes: autoMergeDelayMinutes,
         merge_strategy: mergeStrategy,
         convoy_merge_mode: convoyMergeMode,
@@ -500,6 +505,46 @@ export function RigSettingsPageClient({ townId, rigId, organizationId }: Props) 
                           }
                           onCheckedChange={v => setAutoResolvePrFeedback(v)}
                           className={autoResolvePrFeedback === undefined ? 'opacity-40' : ''}
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                    <div className="flex items-center gap-3">
+                      <div className="flex-1">
+                        <Label className="text-sm text-white/70">
+                          Auto-resolve merge conflicts
+                        </Label>
+                        <p className="text-[11px] text-white/30">
+                          When a PR has merge conflicts, automatically dispatch an agent to rebase
+                          and resolve them.
+                          {townCfg?.refinery?.auto_resolve_merge_conflicts !== undefined && (
+                            <span className="ml-1 text-white/20">
+                              (Town default:{' '}
+                              {townCfg.refinery.auto_resolve_merge_conflicts ? 'on' : 'off'})
+                            </span>
+                          )}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {autoResolveMergeConflicts !== undefined && (
+                          <button
+                            onClick={() => setAutoResolveMergeConflicts(undefined)}
+                            className="rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+                            title="Inherit from town"
+                          >
+                            <X className="size-3" />
+                          </button>
+                        )}
+                        <Switch
+                          checked={
+                            autoResolveMergeConflicts ??
+                            townCfg?.refinery?.auto_resolve_merge_conflicts ??
+                            true
+                          }
+                          onCheckedChange={v => setAutoResolveMergeConflicts(v)}
+                          className={autoResolveMergeConflicts === undefined ? 'opacity-40' : ''}
                         />
                       </div>
                     </div>

--- a/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -33,6 +33,8 @@ import {
   Key,
   MessageSquareText,
   X,
+  Bug,
+  Copy,
 } from 'lucide-react';
 import {
   Accordion,
@@ -75,6 +77,7 @@ const SECTIONS = [
   { id: 'refinery', label: 'Refinery', icon: Shield },
   { id: 'container', label: 'Container', icon: Container },
   { id: 'custom-instructions', label: 'Custom Instructions', icon: MessageSquareText },
+  { id: 'debug', label: 'Debug', icon: Bug },
   { id: 'danger-zone', label: 'Danger Zone', icon: Trash2 },
 ] as const;
 
@@ -177,6 +180,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
   const townQuery = useQuery(trpc.gastown.getTown.queryOptions({ townId }));
   const configQuery = useQuery(trpc.gastown.getTownConfig.queryOptions({ townId }));
   const adminAccessQuery = useQuery(trpc.gastown.checkAdminAccess.queryOptions({ townId }));
+  const rigsQuery = useQuery(trpc.gastown.listRigs.queryOptions({ townId }));
 
   // Admin viewing another user's town → force read-only
   const isAdminViewing = adminAccessQuery.data?.isAdminViewing ?? false;
@@ -386,6 +390,87 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
         },
       },
     });
+  }
+
+  function handleCopyDebugInfo() {
+    const cfg = configQuery.data;
+    const debugInfo = {
+      town_id: townId,
+      user_id: currentUser?.id ?? null,
+      organization_id: organizationId ?? cfg?.organization_id ?? null,
+
+      rigs: (rigsQuery.data ?? []).map(r => {
+        let git_url_sanitized: string | null = null;
+        if (r.git_url) {
+          try {
+            const u = new URL(r.git_url);
+            u.username = '';
+            u.password = '';
+            git_url_sanitized = u.toString();
+          } catch {
+            // not a parseable URL — omit entirely to avoid leaking anything
+          }
+        }
+        return {
+          id: r.id,
+          name: r.name,
+          git_url: git_url_sanitized,
+          default_branch: r.default_branch,
+        };
+      }),
+
+      settings: cfg
+        ? {
+            default_model: cfg.default_model ?? null,
+            small_model: cfg.small_model ?? null,
+            role_models: {
+              mayor: cfg.role_models?.mayor ?? null,
+              refinery: cfg.role_models?.refinery ?? null,
+              polecat: cfg.role_models?.polecat ?? null,
+            },
+
+            max_polecats_per_rig: cfg.max_polecats_per_rig ?? null,
+
+            github_token_set: !!(cfg.git_auth?.github_token),
+            gitlab_token_set: !!(cfg.git_auth?.gitlab_token),
+            gitlab_instance_url: cfg.git_auth?.gitlab_instance_url || null,
+            github_cli_pat_set: !!(cfg.github_cli_pat),
+            git_author_name_set: !!(cfg.git_author_name),
+            // git_author_name and git_author_email intentionally omitted (PII)
+            disable_ai_coauthor: cfg.disable_ai_coauthor ?? false,
+
+            env_var_keys: Object.keys(cfg.env_vars ?? {}),
+
+            merge_strategy: cfg.merge_strategy ?? 'direct',
+            convoy_merge_mode: cfg.convoy_merge_mode ?? 'review-then-land',
+            staged_convoys_default: cfg.staged_convoys_default ?? false,
+
+            refinery: {
+              code_review: cfg.refinery?.code_review ?? true,
+              auto_merge: cfg.refinery?.auto_merge ?? true,
+              review_mode: cfg.refinery?.review_mode ?? 'rework',
+              auto_resolve_pr_feedback: cfg.refinery?.auto_resolve_pr_feedback ?? false,
+              auto_merge_delay_minutes: cfg.refinery?.auto_merge_delay_minutes ?? null,
+              gates: cfg.refinery?.gates ?? [],
+            },
+
+            custom_instructions: {
+              mayor_set: !!(cfg.custom_instructions?.mayor),
+              polecat_set: !!(cfg.custom_instructions?.polecat),
+              refinery_set: !!(cfg.custom_instructions?.refinery),
+            },
+
+            alarm_interval_active: cfg.alarm_interval_active ?? null,
+            alarm_interval_idle: cfg.alarm_interval_idle ?? null,
+          }
+        : null,
+
+      generated_at: new Date().toISOString(),
+      url: window.location.href,
+    };
+
+    void navigator.clipboard.writeText(JSON.stringify(debugInfo, null, 2));
+    toast.success('Debug info copied to clipboard');
   }
 
   function addEnvVar() {
@@ -1147,13 +1232,38 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
                 </div>
               </SettingsSection>
 
+              {/* ── Debug ──────────────────────────────────────────── */}
+              <SettingsSection
+                id="debug"
+                title="Debug"
+                description="Copy diagnostic information to share with support. No sensitive data is included."
+                icon={Bug}
+                index={11}
+              >
+                <div className="space-y-3">
+                  <p className="text-xs text-white/40">
+                    Copies a JSON snapshot of your town configuration for troubleshooting. API
+                    tokens, email addresses, and custom instruction contents are excluded.
+                  </p>
+                  <Button
+                    onClick={handleCopyDebugInfo}
+                    variant="secondary"
+                    size="sm"
+                    className="gap-2"
+                  >
+                    <Copy className="size-3.5" />
+                    Copy debug info
+                  </Button>
+                </div>
+              </SettingsSection>
+
               {/* ── Danger Zone ──────────────────────────────────────── */}
               <SettingsSection
                 id="danger-zone"
                 title="Danger Zone"
                 description="Irreversible actions for this town."
                 icon={Trash2}
-                index={11}
+                index={12}
               >
                 <div className="space-y-3">
                   <div className="flex items-center justify-between rounded-lg border border-red-500/20 bg-red-500/5 px-4 py-3">

--- a/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -279,6 +279,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
   const [refineryCodeReview, setRefineryCodeReview] = useState(true);
   const [reviewMode, setReviewMode] = useState<'rework' | 'comments'>('rework');
   const [autoResolvePrFeedback, setAutoResolvePrFeedback] = useState(false);
+  const [autoResolveMergeConflicts, setAutoResolveMergeConflicts] = useState(true);
   const [autoMergeDelayMinutes, setAutoMergeDelayMinutes] = useState<number | null>(null);
   const [mergeStrategy, setMergeStrategy] = useState<'direct' | 'pr'>('direct');
   const [stagedConvoysDefault, setStagedConvoysDefault] = useState(false);
@@ -315,6 +316,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
     setRefineryCodeReview(cfg.refinery?.code_review ?? true);
     setReviewMode(cfg.refinery?.review_mode === 'comments' ? 'comments' : 'rework');
     setAutoResolvePrFeedback(cfg.refinery?.auto_resolve_pr_feedback ?? false);
+    setAutoResolveMergeConflicts(cfg.refinery?.auto_resolve_merge_conflicts ?? true);
     setAutoMergeDelayMinutes(cfg.refinery?.auto_merge_delay_minutes ?? null);
     setMergeStrategy(cfg.merge_strategy === 'pr' ? 'pr' : 'direct');
     setStagedConvoysDefault(cfg.staged_convoys_default ?? false);
@@ -380,6 +382,7 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
           review_mode: reviewMode,
           require_clean_merge: true,
           auto_resolve_pr_feedback: autoResolvePrFeedback,
+          auto_resolve_merge_conflicts: autoResolveMergeConflicts,
           auto_merge_delay_minutes: autoMergeDelayMinutes,
         },
         convoy_merge_mode: convoyMergeMode,
@@ -1071,6 +1074,20 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
                   <Switch
                     checked={autoResolvePrFeedback}
                     onCheckedChange={setAutoResolvePrFeedback}
+                  />
+                </div>
+
+                <div className="mt-3 flex items-center gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                  <div className="flex-1">
+                    <Label className="text-sm text-white/70">Auto-resolve merge conflicts</Label>
+                    <p className="text-[11px] text-white/30">
+                      When a PR has merge conflicts, automatically dispatch an agent to rebase and
+                      resolve them.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={autoResolveMergeConflicts}
+                    onCheckedChange={setAutoResolveMergeConflicts}
                   />
                 </div>
 

--- a/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/settings/TownSettingsPageClient.tsx
@@ -434,11 +434,11 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
 
             max_polecats_per_rig: cfg.max_polecats_per_rig ?? null,
 
-            github_token_set: !!(cfg.git_auth?.github_token),
-            gitlab_token_set: !!(cfg.git_auth?.gitlab_token),
+            github_token_set: !!cfg.git_auth?.github_token,
+            gitlab_token_set: !!cfg.git_auth?.gitlab_token,
             gitlab_instance_url: cfg.git_auth?.gitlab_instance_url || null,
-            github_cli_pat_set: !!(cfg.github_cli_pat),
-            git_author_name_set: !!(cfg.git_author_name),
+            github_cli_pat_set: !!cfg.github_cli_pat,
+            git_author_name_set: !!cfg.git_author_name,
             // git_author_name and git_author_email intentionally omitted (PII)
             disable_ai_coauthor: cfg.disable_ai_coauthor ?? false,
 
@@ -458,9 +458,9 @@ export function TownSettingsPageClient({ townId, readOnly = false, organizationI
             },
 
             custom_instructions: {
-              mayor_set: !!(cfg.custom_instructions?.mayor),
-              polecat_set: !!(cfg.custom_instructions?.polecat),
-              refinery_set: !!(cfg.custom_instructions?.refinery),
+              mayor_set: !!cfg.custom_instructions?.mayor,
+              polecat_set: !!cfg.custom_instructions?.polecat,
+              refinery_set: !!cfg.custom_instructions?.refinery,
             },
 
             alarm_interval_active: cfg.alarm_interval_active ?? null,

--- a/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepModel.tsx
+++ b/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepModel.tsx
@@ -1,9 +1,16 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { motion } from 'motion/react';
+import { X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
 import { useOnboarding } from './OnboardingContext';
 import { PRESETS } from './onboarding.domain';
@@ -171,15 +178,11 @@ const ROLES = [
 
 function ModelRolePickers({
   models,
-  isCustom,
-  onUpdate,
   modelOptions,
   isLoadingModels,
   modelsError,
 }: {
   models: { mayor: string; refinery: string; polecat: string };
-  isCustom: boolean;
-  onUpdate: (models: { mayor?: string; refinery?: string; polecat?: string }) => void;
   modelOptions: ModelOption[];
   isLoadingModels: boolean;
   modelsError: string | undefined;
@@ -202,23 +205,107 @@ function ModelRolePickers({
               label=""
               models={modelOptions}
               value={models[key]}
-              onValueChange={value => onUpdate({ ...models, [key]: value })}
+              onValueChange={() => {}}
               isLoading={isLoadingModels}
               error={modelsError}
               placeholder="Select a model"
-              disabled={!isCustom}
-              className={cn(
-                'border-white/[0.08] bg-white/[0.03] text-sm text-white/85',
-                !isCustom && 'opacity-70'
-              )}
+              disabled
+              className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85 opacity-70"
             />
           </div>
         ))}
-        {!isCustom && (
-          <p className="text-center text-[10px] text-white/20">
-            Select &ldquo;Custom&rdquo; to change models
-          </p>
-        )}
+        <p className="text-center text-[10px] text-white/20">
+          Select &ldquo;Custom&rdquo; to change models
+        </p>
+      </div>
+    </motion.div>
+  );
+}
+
+function CustomModelPicker({
+  customDefault,
+  setCustomDefault,
+  customMayor,
+  setCustomMayor,
+  customRefinery,
+  setCustomRefinery,
+  customPolecat,
+  setCustomPolecat,
+  modelOptions,
+  isLoadingModels,
+}: {
+  customDefault: string;
+  setCustomDefault: (v: string) => void;
+  customMayor: string;
+  setCustomMayor: (v: string) => void;
+  customRefinery: string;
+  setCustomRefinery: (v: string) => void;
+  customPolecat: string;
+  setCustomPolecat: (v: string) => void;
+  modelOptions: ModelOption[];
+  isLoadingModels: boolean;
+}) {
+  const roleRows: [string, string, (v: string) => void][] = [
+    ['Mayor', customMayor, setCustomMayor],
+    ['Refinery', customRefinery, setCustomRefinery],
+    ['Polecat', customPolecat, setCustomPolecat],
+  ];
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, height: 0 }}
+      animate={{ opacity: 1, height: 'auto' }}
+      transition={{ duration: 0.2 }}
+      className="mt-4 overflow-hidden"
+    >
+      <div className="space-y-3 rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
+        {/* Primary default model */}
+        <div>
+          <label className="mb-1 block text-xs text-white/50">Default Model</label>
+          <ModelCombobox
+            label=""
+            models={modelOptions}
+            value={customDefault}
+            onValueChange={setCustomDefault}
+            isLoading={isLoadingModels}
+            placeholder="Select a model"
+            className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
+          />
+        </div>
+
+        {/* Per-role overrides — collapsible */}
+        <Accordion type="single" collapsible>
+          <AccordionItem value="roles" className="border-white/[0.06]">
+            <AccordionTrigger className="py-2 text-xs text-white/50 hover:text-white/70 hover:no-underline">
+              Override by role (optional)
+            </AccordionTrigger>
+            <AccordionContent className="space-y-2 pb-1 pt-1">
+              {roleRows.map(([label, value, setValue]) => (
+                <div key={label} className="flex items-center gap-2">
+                  <span className="w-16 shrink-0 text-xs text-white/40">{label}</span>
+                  <ModelCombobox
+                    label=""
+                    models={modelOptions}
+                    value={value}
+                    onValueChange={setValue}
+                    isLoading={isLoadingModels}
+                    placeholder="Use default"
+                    className="flex-1 border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
+                  />
+                  {value && (
+                    <button
+                      type="button"
+                      onClick={() => setValue('')}
+                      className="shrink-0 text-white/30 hover:text-white/60"
+                    >
+                      <X className="size-3" />
+                    </button>
+                  )}
+                </div>
+              ))}
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       </div>
     </motion.div>
   );
@@ -226,6 +313,11 @@ function ModelRolePickers({
 
 export function OnboardingStepModel() {
   const { state, setModelPreset, setCustomModels } = useOnboarding();
+
+  const [customDefault, setCustomDefault] = useState(state.customModels.defaultModel ?? '');
+  const [customMayor, setCustomMayor] = useState(state.customModels.mayor ?? '');
+  const [customRefinery, setCustomRefinery] = useState(state.customModels.refinery ?? '');
+  const [customPolecat, setCustomPolecat] = useState(state.customModels.polecat ?? '');
 
   // Fetch available models for the Custom picker (no org context during onboarding)
   const {
@@ -239,15 +331,8 @@ export function OnboardingStepModel() {
     [modelsData]
   );
 
-  // Resolve current models for display: preset values or custom overrides
-  const currentModels = useMemo(() => {
-    if (state.modelPreset === 'custom') {
-      return {
-        mayor: state.customModels.mayor ?? 'kilo-auto/balanced',
-        refinery: state.customModels.refinery ?? 'kilo-auto/balanced',
-        polecat: state.customModels.polecat ?? 'kilo-auto/balanced',
-      };
-    }
+  // Resolve current models for display in the read-only preset role picker
+  const currentPresetModels = useMemo(() => {
     const preset = PRESETS.find(p => p.key === state.modelPreset);
     if (preset) return preset.models;
     return {
@@ -255,7 +340,7 @@ export function OnboardingStepModel() {
       refinery: 'kilo-auto/balanced',
       polecat: 'kilo-auto/balanced',
     };
-  }, [state.modelPreset, state.customModels]);
+  }, [state.modelPreset]);
 
   const isCustom = state.modelPreset === 'custom';
 
@@ -263,8 +348,25 @@ export function OnboardingStepModel() {
     setModelPreset(preset);
   }
 
-  function handleCustomUpdate(models: { mayor?: string; refinery?: string; polecat?: string }) {
-    setCustomModels(models);
+  // Sync custom model state up to context whenever any field changes
+  function handleSetCustomDefault(value: string) {
+    setCustomDefault(value);
+    setCustomModels({ defaultModel: value, mayor: customMayor, refinery: customRefinery, polecat: customPolecat });
+  }
+
+  function handleSetCustomMayor(value: string) {
+    setCustomMayor(value);
+    setCustomModels({ defaultModel: customDefault, mayor: value, refinery: customRefinery, polecat: customPolecat });
+  }
+
+  function handleSetCustomRefinery(value: string) {
+    setCustomRefinery(value);
+    setCustomModels({ defaultModel: customDefault, mayor: customMayor, refinery: value, polecat: customPolecat });
+  }
+
+  function handleSetCustomPolecat(value: string) {
+    setCustomPolecat(value);
+    setCustomModels({ defaultModel: customDefault, mayor: customMayor, refinery: customRefinery, polecat: value });
   }
 
   return (
@@ -292,15 +394,31 @@ export function OnboardingStepModel() {
           <CustomCard isSelected={isCustom} onSelect={() => handlePresetSelect('custom')} />
         </div>
 
-        {/* Always-visible model role pickers */}
-        <ModelRolePickers
-          models={currentModels}
-          isCustom={isCustom}
-          onUpdate={handleCustomUpdate}
-          modelOptions={modelOptions}
-          isLoadingModels={isLoadingModels}
-          modelsError={modelsError?.message}
-        />
+        {/* Preset model role pickers (read-only) — shown when a preset is active */}
+        {!isCustom && (
+          <ModelRolePickers
+            models={currentPresetModels}
+            modelOptions={modelOptions}
+            isLoadingModels={isLoadingModels}
+            modelsError={modelsError?.message}
+          />
+        )}
+
+        {/* Custom model picker — shown when custom is selected */}
+        {isCustom && (
+          <CustomModelPicker
+            customDefault={customDefault}
+            setCustomDefault={handleSetCustomDefault}
+            customMayor={customMayor}
+            setCustomMayor={handleSetCustomMayor}
+            customRefinery={customRefinery}
+            setCustomRefinery={handleSetCustomRefinery}
+            customPolecat={customPolecat}
+            setCustomPolecat={handleSetCustomPolecat}
+            modelOptions={modelOptions}
+            isLoadingModels={isLoadingModels}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepModel.tsx
+++ b/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepModel.tsx
@@ -351,22 +351,42 @@ export function OnboardingStepModel() {
   // Sync custom model state up to context whenever any field changes
   function handleSetCustomDefault(value: string) {
     setCustomDefault(value);
-    setCustomModels({ defaultModel: value, mayor: customMayor, refinery: customRefinery, polecat: customPolecat });
+    setCustomModels({
+      defaultModel: value,
+      mayor: customMayor,
+      refinery: customRefinery,
+      polecat: customPolecat,
+    });
   }
 
   function handleSetCustomMayor(value: string) {
     setCustomMayor(value);
-    setCustomModels({ defaultModel: customDefault, mayor: value, refinery: customRefinery, polecat: customPolecat });
+    setCustomModels({
+      defaultModel: customDefault,
+      mayor: value,
+      refinery: customRefinery,
+      polecat: customPolecat,
+    });
   }
 
   function handleSetCustomRefinery(value: string) {
     setCustomRefinery(value);
-    setCustomModels({ defaultModel: customDefault, mayor: customMayor, refinery: value, polecat: customPolecat });
+    setCustomModels({
+      defaultModel: customDefault,
+      mayor: customMayor,
+      refinery: value,
+      polecat: customPolecat,
+    });
   }
 
   function handleSetCustomPolecat(value: string) {
     setCustomPolecat(value);
-    setCustomModels({ defaultModel: customDefault, mayor: customMayor, refinery: customRefinery, polecat: value });
+    setCustomModels({
+      defaultModel: customDefault,
+      mayor: customMayor,
+      refinery: customRefinery,
+      polecat: value,
+    });
   }
 
   return (

--- a/apps/web/src/app/(app)/gastown/onboarding/onboarding.domain.ts
+++ b/apps/web/src/app/(app)/gastown/onboarding/onboarding.domain.ts
@@ -43,9 +43,11 @@ export function resolveGitUrlFromRepo(
 export type ModelPreset = 'frontier' | 'balanced' | 'cost-effective' | 'free' | 'custom';
 
 export type CustomModels = {
+  defaultModel?: string;
   mayor?: string;
   refinery?: string;
   polecat?: string;
+  smallModel?: string;
 };
 
 export type PresetConfig = {
@@ -110,14 +112,16 @@ export const PRESETS: PresetConfig[] = [
 /** Derive the config shape stored in OnboardingState from a preset. */
 export function presetToConfig(preset: ModelPreset, customModels: CustomModels) {
   if (preset === 'custom') {
-    const mayorModel = customModels.mayor ?? 'kilo-auto/balanced';
+    const fallback = 'kilo-auto/balanced';
+    const defaultModel = customModels.defaultModel || fallback;
     return {
-      default_model: mayorModel,
+      default_model: defaultModel,
       role_models: {
-        mayor: mayorModel,
-        refinery: customModels.refinery ?? 'kilo-auto/balanced',
-        polecat: customModels.polecat ?? 'kilo-auto/balanced',
+        mayor: customModels.mayor || defaultModel,
+        refinery: customModels.refinery || defaultModel,
+        polecat: customModels.polecat || defaultModel,
       },
+      small_model: customModels.smallModel || undefined,
     };
   }
 
@@ -133,10 +137,21 @@ export function presetToConfig(preset: ModelPreset, customModels: CustomModels) 
   if (refinery !== mayor) role_models.refinery = refinery;
   if (polecat !== mayor) role_models.polecat = polecat;
 
-  return {
+  const config: {
+    default_model: string;
+    role_models: Record<string, string>;
+    small_model?: string;
+  } = {
     default_model: mayor,
     role_models,
   };
+
+  // When the free preset is selected, also set small_model to the same free model
+  if (mayor === 'kilo-auto/free') {
+    config.small_model = 'kilo-auto/free';
+  }
+
+  return config;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/app/(app)/gastown/onboarding/onboarding.test.ts
+++ b/apps/web/src/app/(app)/gastown/onboarding/onboarding.test.ts
@@ -194,6 +194,7 @@ describe('presetToConfig', () => {
 
   test('returns custom config with provided models', () => {
     const config = presetToConfig('custom', {
+      defaultModel: 'openai/gpt-4.1',
       mayor: 'openai/gpt-4.1',
       refinery: 'anthropic/claude-opus-4',
       polecat: 'openai/gpt-4.1-mini',
@@ -216,9 +217,19 @@ describe('presetToConfig', () => {
     });
   });
 
-  test('uses kilo-auto/balanced for partially-specified custom models', () => {
-    const config = presetToConfig('custom', { mayor: 'openai/gpt-4.1' });
+  test('uses defaultModel as fallback for unset role overrides', () => {
+    const config = presetToConfig('custom', { defaultModel: 'openai/gpt-4.1', mayor: 'openai/gpt-4.1' });
     expect(config.default_model).toBe('openai/gpt-4.1');
+    expect(config.role_models).toEqual({
+      mayor: 'openai/gpt-4.1',
+      refinery: 'openai/gpt-4.1',
+      polecat: 'openai/gpt-4.1',
+    });
+  });
+
+  test('uses kilo-auto/balanced for default_model when no defaultModel specified', () => {
+    const config = presetToConfig('custom', { mayor: 'openai/gpt-4.1' });
+    expect(config.default_model).toBe('kilo-auto/balanced');
     expect(config.role_models).toEqual({
       mayor: 'openai/gpt-4.1',
       refinery: 'kilo-auto/balanced',

--- a/apps/web/src/app/(app)/gastown/onboarding/onboarding.test.ts
+++ b/apps/web/src/app/(app)/gastown/onboarding/onboarding.test.ts
@@ -218,7 +218,10 @@ describe('presetToConfig', () => {
   });
 
   test('uses defaultModel as fallback for unset role overrides', () => {
-    const config = presetToConfig('custom', { defaultModel: 'openai/gpt-4.1', mayor: 'openai/gpt-4.1' });
+    const config = presetToConfig('custom', {
+      defaultModel: 'openai/gpt-4.1',
+      mayor: 'openai/gpt-4.1',
+    });
     expect(config.default_model).toBe('openai/gpt-4.1');
     expect(config.role_models).toEqual({
       mayor: 'openai/gpt-4.1',

--- a/apps/web/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
+++ b/apps/web/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
@@ -22,8 +22,10 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
 import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
+import { Trash2 } from 'lucide-react';
 
 const beadStatuses = ['open', 'in_progress', 'closed', 'failed'] as const;
 type BeadStatus = (typeof beadStatuses)[number];
@@ -46,11 +48,10 @@ const STATUS_COLORS: Record<BeadStatus, string> = {
   failed: 'bg-red-500/10 text-red-400 border-red-500/20',
 };
 
-type ConfirmAction = {
-  type: 'close' | 'fail';
-  beadId: string;
-  title: string;
-};
+type ConfirmAction =
+  | { type: 'close' | 'fail'; beadId: string; title: string }
+  | { type: 'bulk-delete'; beadIds: string[] }
+  | { type: 'delete-all-failed'; count: number };
 
 export function BeadsTab({ townId }: { townId: string }) {
   const trpc = useTRPC();
@@ -59,6 +60,7 @@ export function BeadsTab({ townId }: { townId: string }) {
   const [statusFilter, setStatusFilter] = useState<BeadStatus | 'all'>('all');
   const [typeFilter, setTypeFilter] = useState<BeadType | 'all'>('all');
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   const beadsQuery = useQuery(
     trpc.admin.gastown.listBeads.queryOptions({
@@ -68,10 +70,14 @@ export function BeadsTab({ townId }: { townId: string }) {
     })
   );
 
+  const invalidateBeads = () => {
+    void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
+  };
+
   const forceCloseMutation = useMutation(
     trpc.admin.gastown.forceCloseBead.mutationOptions({
       onSuccess: () => {
-        void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
+        invalidateBeads();
         setConfirmAction(null);
         toast.success('Bead closed successfully');
       },
@@ -84,7 +90,7 @@ export function BeadsTab({ townId }: { townId: string }) {
   const forceFailMutation = useMutation(
     trpc.admin.gastown.forceFailBead.mutationOptions({
       onSuccess: () => {
-        void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
+        invalidateBeads();
         setConfirmAction(null);
         toast.success('Bead marked as failed');
       },
@@ -94,17 +100,104 @@ export function BeadsTab({ townId }: { townId: string }) {
     })
   );
 
+  const bulkDeleteMutation = useMutation(
+    trpc.admin.gastown.bulkDeleteBeads.mutationOptions({
+      onSuccess: data => {
+        invalidateBeads();
+        setConfirmAction(null);
+        setSelectedIds(new Set());
+        toast.success(`Deleted ${data.deleted} bead${data.deleted === 1 ? '' : 's'}`);
+      },
+      onError: err => {
+        toast.error(`Failed to delete beads: ${err.message}`);
+      },
+    })
+  );
+
+  const deleteByStatusMutation = useMutation(
+    trpc.admin.gastown.deleteBeadsByStatus.mutationOptions({
+      onSuccess: data => {
+        invalidateBeads();
+        setConfirmAction(null);
+        setSelectedIds(new Set());
+        toast.success(`Deleted ${data.deleted} bead${data.deleted === 1 ? '' : 's'}`);
+      },
+      onError: err => {
+        toast.error(`Failed to delete beads: ${err.message}`);
+      },
+    })
+  );
+
   const handleConfirm = () => {
     if (!confirmAction) return;
     if (confirmAction.type === 'close') {
       forceCloseMutation.mutate({ townId, beadId: confirmAction.beadId });
-    } else {
+    } else if (confirmAction.type === 'fail') {
       forceFailMutation.mutate({ townId, beadId: confirmAction.beadId });
+    } else if (confirmAction.type === 'bulk-delete') {
+      bulkDeleteMutation.mutate({ townId, beadIds: confirmAction.beadIds });
+    } else {
+      deleteByStatusMutation.mutate({ townId, status: 'failed', type: typeFilter === 'all' ? undefined : typeFilter });
     }
   };
 
   const beads = beadsQuery.data ?? [];
-  const isPending = forceCloseMutation.isPending || forceFailMutation.isPending;
+  const failedCount = beads.filter(b => b.status === 'failed').length;
+
+  const allSelected = beads.length > 0 && beads.every(b => selectedIds.has(b.bead_id));
+
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(beads.map(b => b.bead_id)));
+    }
+  };
+
+  const toggleSelect = (beadId: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(beadId)) {
+        next.delete(beadId);
+      } else {
+        next.add(beadId);
+      }
+      return next;
+    });
+  };
+
+  const isPending =
+    forceCloseMutation.isPending ||
+    forceFailMutation.isPending ||
+    bulkDeleteMutation.isPending ||
+    deleteByStatusMutation.isPending;
+
+  const confirmDialogTitle = () => {
+    if (!confirmAction) return '';
+    if (confirmAction.type === 'close') return 'Force Close Bead';
+    if (confirmAction.type === 'fail') return 'Force Fail Bead';
+    if (confirmAction.type === 'bulk-delete') return 'Delete Beads';
+    return 'Delete All Failed Beads';
+  };
+
+  const confirmDialogDescription = () => {
+    if (!confirmAction) return '';
+    if (confirmAction.type === 'close') {
+      return `This will force-close bead ${confirmAction.beadId.slice(0, 8)}…${confirmAction.title ? ` (${confirmAction.title})` : ''}. This action is logged in the audit trail.`;
+    }
+    if (confirmAction.type === 'fail') {
+      return `This will force-fail bead ${confirmAction.beadId.slice(0, 8)}…${confirmAction.title ? ` (${confirmAction.title})` : ''}. This action is logged in the audit trail.`;
+    }
+    if (confirmAction.type === 'bulk-delete') {
+      return `Delete ${confirmAction.beadIds.length} selected bead${confirmAction.beadIds.length === 1 ? '' : 's'}? This cannot be undone.`;
+    }
+    return `Delete ${confirmAction.count} failed bead${confirmAction.count === 1 ? '' : 's'}? This cannot be undone.`;
+  };
+
+  const isDestructiveConfirm =
+    confirmAction?.type === 'fail' ||
+    confirmAction?.type === 'bulk-delete' ||
+    confirmAction?.type === 'delete-all-failed';
 
   return (
     <Card>
@@ -112,6 +205,19 @@ export function BeadsTab({ townId }: { townId: string }) {
         <div className="flex items-center justify-between">
           <CardTitle>Beads</CardTitle>
           <div className="flex gap-2">
+            {/* Delete all failed shortcut */}
+            {failedCount > 0 && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-8 border-red-500/30 text-xs text-red-400 hover:bg-red-500/10"
+                onClick={() => setConfirmAction({ type: 'delete-all-failed', count: failedCount })}
+              >
+                <Trash2 className="mr-1 size-3" />
+                Delete all failed ({failedCount})
+              </Button>
+            )}
+
             <Select
               value={statusFilter}
               onValueChange={v => {
@@ -154,6 +260,32 @@ export function BeadsTab({ townId }: { townId: string }) {
             </Select>
           </div>
         </div>
+
+        {/* Bulk action bar */}
+        {selectedIds.size > 0 && (
+          <div className="mt-2 flex items-center gap-3 rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2">
+            <span className="text-sm text-muted-foreground">{selectedIds.size} selected</span>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 border-red-500/30 text-xs text-red-400 hover:bg-red-500/10"
+              onClick={() =>
+                setConfirmAction({ type: 'bulk-delete', beadIds: [...selectedIds] })
+              }
+            >
+              <Trash2 className="mr-1 size-3" />
+              Delete selected
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 text-xs"
+              onClick={() => setSelectedIds(new Set())}
+            >
+              Clear
+            </Button>
+          </div>
+        )}
       </CardHeader>
       <CardContent>
         {beadsQuery.isLoading && (
@@ -174,6 +306,13 @@ export function BeadsTab({ townId }: { townId: string }) {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b">
+                  <th className="pb-2 pr-2">
+                    <Checkbox
+                      checked={allSelected}
+                      onCheckedChange={toggleSelectAll}
+                      aria-label="Select all beads"
+                    />
+                  </th>
                   <th className="text-muted-foreground pb-2 text-left font-medium">Bead</th>
                   <th className="text-muted-foreground pb-2 text-left font-medium">Type</th>
                   <th className="text-muted-foreground pb-2 text-left font-medium">Status</th>
@@ -185,6 +324,13 @@ export function BeadsTab({ townId }: { townId: string }) {
               <tbody>
                 {beads.map(bead => (
                   <tr key={bead.bead_id} className="hover:bg-muted/40 border-b transition-colors">
+                    <td className="py-2 pr-2">
+                      <Checkbox
+                        checked={selectedIds.has(bead.bead_id)}
+                        onCheckedChange={() => toggleSelect(bead.bead_id)}
+                        aria-label={`Select bead ${bead.bead_id}`}
+                      />
+                    </td>
                     <td className="py-2 pr-4">
                       <Link
                         href={`/admin/gastown/towns/${townId}/beads/${bead.bead_id}`}
@@ -262,22 +408,15 @@ export function BeadsTab({ townId }: { townId: string }) {
       <Dialog open={!!confirmAction} onOpenChange={() => setConfirmAction(null)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>
-              {confirmAction?.type === 'close' ? 'Force Close Bead' : 'Force Fail Bead'}
-            </DialogTitle>
-            <DialogDescription>
-              This will {confirmAction?.type === 'close' ? 'force-close' : 'force-fail'} bead{' '}
-              <span className="font-mono">{confirmAction?.beadId.slice(0, 8)}…</span>
-              {confirmAction?.title ? ` (${confirmAction.title})` : ''}. This action is logged in
-              the audit trail.
-            </DialogDescription>
+            <DialogTitle>{confirmDialogTitle()}</DialogTitle>
+            <DialogDescription>{confirmDialogDescription()}</DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmAction(null)} disabled={isPending}>
               Cancel
             </Button>
             <Button
-              variant={confirmAction?.type === 'fail' ? 'destructive' : 'default'}
+              variant={isDestructiveConfirm ? 'destructive' : 'default'}
               onClick={handleConfirm}
               disabled={isPending}
             >
@@ -285,7 +424,9 @@ export function BeadsTab({ townId }: { townId: string }) {
                 ? 'Processing…'
                 : confirmAction?.type === 'close'
                   ? 'Force Close'
-                  : 'Force Fail'}
+                  : confirmAction?.type === 'fail'
+                    ? 'Force Fail'
+                    : 'Delete'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
+++ b/apps/web/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
@@ -137,7 +137,11 @@ export function BeadsTab({ townId }: { townId: string }) {
     } else if (confirmAction.type === 'bulk-delete') {
       bulkDeleteMutation.mutate({ townId, beadIds: confirmAction.beadIds });
     } else {
-      deleteByStatusMutation.mutate({ townId, status: 'failed', type: typeFilter === 'all' ? undefined : typeFilter });
+      deleteByStatusMutation.mutate({
+        townId,
+        status: 'failed',
+        type: typeFilter === 'all' ? undefined : typeFilter,
+      });
     }
   };
 
@@ -272,9 +276,7 @@ export function BeadsTab({ townId }: { townId: string }) {
               size="sm"
               variant="outline"
               className="h-7 border-red-500/30 text-xs text-red-400 hover:bg-red-500/10"
-              onClick={() =>
-                setConfirmAction({ type: 'bulk-delete', beadIds: [...selectedIds] })
-              }
+              onClick={() => setConfirmAction({ type: 'bulk-delete', beadIds: [...selectedIds] })}
             >
               <Trash2 className="mr-1 size-3" />
               Delete selected

--- a/apps/web/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
+++ b/apps/web/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
@@ -191,7 +191,10 @@ export function BeadsTab({ townId }: { townId: string }) {
     if (confirmAction.type === 'bulk-delete') {
       return `Delete ${confirmAction.beadIds.length} selected bead${confirmAction.beadIds.length === 1 ? '' : 's'}? This cannot be undone.`;
     }
-    return `Delete ${confirmAction.count} failed bead${confirmAction.count === 1 ? '' : 's'}? This cannot be undone.`;
+    if (confirmAction.type === 'delete-all-failed') {
+      return `Delete ${confirmAction.count} failed bead${confirmAction.count === 1 ? '' : 's'}? This cannot be undone.`;
+    }
+    return '';
   };
 
   const isDestructiveConfirm =

--- a/apps/web/src/lib/gastown/types/router.d.ts
+++ b/apps/web/src/lib/gastown/types/router.d.ts
@@ -138,6 +138,7 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
               review_mode?: 'rework' | 'comments' | undefined;
               code_review?: boolean | undefined;
               auto_resolve_pr_feedback?: boolean | undefined;
+              auto_resolve_merge_conflicts?: boolean | undefined;
               auto_merge_delay_minutes?: number | null | undefined;
               merge_strategy?: 'direct' | 'pr' | undefined;
               convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
@@ -209,6 +210,7 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
           review_mode?: 'rework' | 'comments' | undefined;
           code_review?: boolean | undefined;
           auto_resolve_pr_feedback?: boolean | undefined;
+          auto_resolve_merge_conflicts?: boolean | undefined;
           auto_merge_delay_minutes?: number | null | undefined;
           merge_strategy?: 'direct' | 'pr' | undefined;
           convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
@@ -555,6 +557,7 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
               code_review: boolean;
               review_mode: 'comments' | 'rework';
               auto_resolve_pr_feedback: boolean;
+              auto_resolve_merge_conflicts: boolean;
               auto_merge_delay_minutes: number | null;
             }
           | undefined;
@@ -619,6 +622,7 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
                 code_review?: boolean | undefined;
                 review_mode?: 'comments' | 'rework' | undefined;
                 auto_resolve_pr_feedback?: boolean | undefined;
+                auto_resolve_merge_conflicts?: boolean | undefined;
                 auto_merge_delay_minutes?: number | null | undefined;
               }
             | undefined;
@@ -677,6 +681,7 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
               code_review: boolean;
               review_mode: 'comments' | 'rework';
               auto_resolve_pr_feedback: boolean;
+              auto_resolve_merge_conflicts: boolean;
               auto_merge_delay_minutes: number | null;
             }
           | undefined;
@@ -1537,6 +1542,7 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
                   review_mode?: 'rework' | 'comments' | undefined;
                   code_review?: boolean | undefined;
                   auto_resolve_pr_feedback?: boolean | undefined;
+                  auto_resolve_merge_conflicts?: boolean | undefined;
                   auto_merge_delay_minutes?: number | null | undefined;
                   merge_strategy?: 'direct' | 'pr' | undefined;
                   convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
@@ -1608,6 +1614,7 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
               review_mode?: 'rework' | 'comments' | undefined;
               code_review?: boolean | undefined;
               auto_resolve_pr_feedback?: boolean | undefined;
+              auto_resolve_merge_conflicts?: boolean | undefined;
               auto_merge_delay_minutes?: number | null | undefined;
               merge_strategy?: 'direct' | 'pr' | undefined;
               convoy_merge_mode?: 'review-then-land' | 'review-and-merge' | undefined;
@@ -1954,6 +1961,7 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
                   code_review: boolean;
                   review_mode: 'comments' | 'rework';
                   auto_resolve_pr_feedback: boolean;
+                  auto_resolve_merge_conflicts: boolean;
                   auto_merge_delay_minutes: number | null;
                 }
               | undefined;
@@ -2018,6 +2026,7 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
                     code_review?: boolean | undefined;
                     review_mode?: 'comments' | 'rework' | undefined;
                     auto_resolve_pr_feedback?: boolean | undefined;
+                    auto_resolve_merge_conflicts?: boolean | undefined;
                     auto_merge_delay_minutes?: number | null | undefined;
                   }
                 | undefined;
@@ -2076,6 +2085,7 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
                   code_review: boolean;
                   review_mode: 'comments' | 'rework';
                   auto_resolve_pr_feedback: boolean;
+                  auto_resolve_merge_conflicts: boolean;
                   auto_merge_delay_minutes: number | null;
                 }
               | undefined;

--- a/apps/web/src/routers/admin/gastown-router.ts
+++ b/apps/web/src/routers/admin/gastown-router.ts
@@ -755,6 +755,40 @@ export const adminGastownRouter = createTRPCRouter({
       );
     }),
 
+  bulkDeleteBeads: adminProcedure
+    .input(z.object({ townId: z.string().uuid(), beadIds: z.array(z.string().uuid()) }))
+    .output(z.object({ deleted: z.number() }))
+    .mutation(async ({ input, ctx }) => {
+      const result = await gastownTrpcMutate(
+        ctx.user,
+        'gastown.adminBulkDeleteBeads',
+        { townId: input.townId, beadIds: input.beadIds },
+        z.object({ deleted: z.number() })
+      );
+      return result ?? { deleted: 0 };
+    }),
+
+  deleteBeadsByStatus: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        status: z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']),
+        type: z
+          .enum(['issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent'])
+          .optional(),
+      })
+    )
+    .output(z.object({ deleted: z.number() }))
+    .mutation(async ({ input, ctx }) => {
+      const result = await gastownTrpcMutate(
+        ctx.user,
+        'gastown.adminDeleteBeadsByStatus',
+        { townId: input.townId, status: input.status, type: input.type },
+        z.object({ deleted: z.number() })
+      );
+      return result ?? { deleted: 0 };
+    }),
+
   /** Force-retry a stalled review queue entry. Not yet implemented on the worker. */
   forceRetryReview: adminProcedure
     .input(z.object({ townId: z.string().uuid(), entryId: z.string().uuid() }))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1555,11 +1555,11 @@ importers:
   services/gastown/container:
     dependencies:
       '@kilocode/plugin':
-        specifier: 7.2.7
-        version: 7.2.7
+        specifier: 7.2.14
+        version: 7.2.14
       '@kilocode/sdk':
-        specifier: 7.2.7
-        version: 7.2.7
+        specifier: 7.2.14
+        version: 7.2.14
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -4158,8 +4158,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  '@kilocode/plugin@7.2.7':
-    resolution: {integrity: sha512-m4fHQlrUjuZTEABtOUIoHfUW3ejPpF8Jv2VhkFYVKJmuerltQBBFb4udrN97GJHMyoLL3nzJ6bNZkg3Czv8Z3g==}
+  '@kilocode/plugin@7.2.14':
+    resolution: {integrity: sha512-mS+WA9HZIBH2qQ9ARA+v0q4MdQTSdfOvKbe4AOSkjP+P5hVA70OM/UVM9DVcvmjSOxU+wuUxmOy+j/EQIrgFmw==}
     peerDependencies:
       '@opentui/core': '>=0.1.97'
       '@opentui/solid': '>=0.1.97'
@@ -4172,8 +4172,8 @@ packages:
   '@kilocode/sdk@7.1.23':
     resolution: {integrity: sha512-moSKXqpwE+ozVbNE1aYIUb5Kd7fesOicRUn90WiMlp+8lRhqQc6ZTTIaIB9ZzD7Dak//4bSuo++bb+Jtw3U4Fg==}
 
-  '@kilocode/sdk@7.2.7':
-    resolution: {integrity: sha512-710n8PQ3QfmTwEdzOW2p7ur79rF9IBJk6nGsUu1hp8o/66RTkpVYC0EB7DKNfJ1NzTWmUqmhJZGWq4suCfADKQ==}
+  '@kilocode/sdk@7.2.14':
+    resolution: {integrity: sha512-Naz83lFrsbavuDp6UwxRuglOaSNvRBsZfcRNvb7RpWYAwbuJP0dBdhpXj6uO3ta5qxeQ2JzxKNC9Ffz+LCLLDg==}
 
   '@lottiefiles/dotlottie-react@0.17.15':
     resolution: {integrity: sha512-4wYAjsJhM28eUvJ/gT3KRM6fcyT7EM9n7PDrP71LaBTacc6bSN43qFTSJc1Li3QxUiraz23p0Q8EJBzXo8DsRw==}
@@ -17671,14 +17671,14 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
 
-  '@kilocode/plugin@7.2.7':
+  '@kilocode/plugin@7.2.14':
     dependencies:
-      '@kilocode/sdk': 7.2.7
+      '@kilocode/sdk': 7.2.14
       zod: 4.1.8
 
   '@kilocode/sdk@7.1.23': {}
 
-  '@kilocode/sdk@7.2.7':
+  '@kilocode/sdk@7.2.14':
     dependencies:
       cross-spawn: 7.0.6
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,7 @@ overrides:
   hono: ^4.12.7
   undici@^6: ^6.24.1
   lightningcss: 1.30.1
+  axios: '>=1.15.0 <2'
 
 patchedDependencies:
   '@gorhom/bottom-sheet@5.1.8':
@@ -135,6 +136,9 @@ importers:
 
   apps/mobile:
     dependencies:
+      '@expo/react-native-action-sheet':
+        specifier: ^4.1.1
+        version: 4.1.1(@types/react@19.2.14)(react@19.2.0)
       '@kilocode/trpc':
         specifier: workspace:*
         version: link:../../packages/trpc
@@ -192,6 +196,9 @@ importers:
       expo-constants:
         specifier: ~55.0.12
         version: 55.0.12(expo@55.0.12)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(typescript@5.9.3)
+      expo-crypto:
+        specifier: ~55.0.14
+        version: 55.0.14(expo@55.0.12)
       expo-dev-client:
         specifier: ~55.0.23
         version: 55.0.23(expo@55.0.12)(typescript@5.9.3)
@@ -243,6 +250,9 @@ importers:
       expo-web-browser:
         specifier: ~55.0.13
         version: 55.0.13(expo@55.0.12)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))
+      jotai:
+        specifier: ^2.18.1
+        version: 2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.0)
       lucide-react-native:
         specifier: ^1.7.0
         version: 1.7.0(react-native-svg@15.15.3(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -435,8 +445,8 @@ importers:
         specifier: ^2.0.35
         version: 2.0.35(zod@4.3.6)
       '@anthropic-ai/sdk':
-        specifier: ^0.78.0
-        version: 0.78.0(zod@4.3.6)
+        specifier: ^0.90.0
+        version: 0.90.0(zod@4.3.6)
       '@aws-sdk/client-s3':
         specifier: ^3.1009.0
         version: 3.1009.0
@@ -728,6 +738,9 @@ importers:
       recharts:
         specifier: ^3.8.0
         version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(redux@5.0.1)
+      redis:
+        specifier: ^5.11.0
+        version: 5.11.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -752,6 +765,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      tldts:
+        specifier: ^7.0.28
+        version: 7.0.28
       uuid:
         specifier: 11.1.0
         version: 11.1.0
@@ -1189,8 +1205,8 @@ importers:
   services/cloud-agent-next:
     dependencies:
       '@cloudflare/sandbox':
-        specifier: 0.7.13
-        version: 0.7.13(@xterm/xterm@6.0.0)
+        specifier: 0.8.9
+        version: 0.8.9(@xterm/xterm@6.0.0)
       '@hono/trpc-server':
         specifier: ^0.4.2
         version: 0.4.2(@trpc/server@11.13.0(typescript@5.9.3))(hono@4.12.8)
@@ -1229,8 +1245,8 @@ importers:
         version: 4.3.6
     devDependencies:
       '@cloudflare/containers':
-        specifier: 0.1.1
-        version: 0.1.1
+        specifier: 0.3.0
+        version: 0.3.0
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.12.21
         version: 0.12.21(@cloudflare/workers-types@4.20260313.1)(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(vitest@3.2.4)
@@ -1262,8 +1278,8 @@ importers:
   services/cloud-agent-next/wrapper:
     dependencies:
       '@kilocode/sdk':
-        specifier: 7.1.17
-        version: 7.1.17
+        specifier: 7.1.23
+        version: 7.1.23
     devDependencies:
       '@types/bun':
         specifier: latest
@@ -1733,6 +1749,34 @@ importers:
         specifier: 'catalog:'
         version: 4.73.0(@cloudflare/workers-types@4.20260313.1)
 
+  services/kiloclaw-inbound-email:
+    dependencies:
+      '@kilocode/db':
+        specifier: workspace:*
+        version: link:../../packages/db
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
+      node-html-markdown:
+        specifier: ^2.0.0
+        version: 2.0.0
+      postal-mime:
+        specifier: ^2.7.4
+        version: 2.7.4
+    devDependencies:
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260319.1
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      wrangler:
+        specifier: 'catalog:'
+        version: 4.73.0(@cloudflare/workers-types@4.20260313.1)
+
   services/notifications:
     dependencies:
       '@kilocode/db':
@@ -2032,8 +2076,8 @@ packages:
       '@faker-js/faker': ^7.0.0 || ^8.0.0 || ^9.0.0
       zod: ^3.21.4
 
-  '@anthropic-ai/sdk@0.78.0':
-    resolution: {integrity: sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==}
+  '@anthropic-ai/sdk@0.90.0':
+    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2967,6 +3011,9 @@ packages:
   '@cloudflare/containers@0.1.1':
     resolution: {integrity: sha512-YTdobRTnTlUOUPMFemufH367A9Z8pDfZ+UboYMLbGpO0VlvEXZDiioSmXPQMHld2vRtkL31mcRii3bcbQU6fdw==}
 
+  '@cloudflare/containers@0.3.0':
+    resolution: {integrity: sha512-8HM1NgXThWCTk7SH28QFxqMNLJwl6RrMkj3qd0KvDA59BALsn3mZXNDT94i1JaGZnP4Bc8sPGs1u9UAl/mVUVg==}
+
   '@cloudflare/kv-asset-handler@0.4.0':
     resolution: {integrity: sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==}
     engines: {node: '>=18.0.0'}
@@ -2999,6 +3046,20 @@ packages:
 
   '@cloudflare/sandbox@0.7.13':
     resolution: {integrity: sha512-HVbg6nUqudsUPGMKznyG4gPgYVdEH6nt2NYgKmCJzUJeXixoWDiqCVsJpmCzNueHg/2HX982A6EhQgIUol6jzQ==}
+    peerDependencies:
+      '@openai/agents': ^0.3.3
+      '@opencode-ai/sdk': ^1.1.40
+      '@xterm/xterm': '>=5.0.0'
+    peerDependenciesMeta:
+      '@openai/agents':
+        optional: true
+      '@opencode-ai/sdk':
+        optional: true
+      '@xterm/xterm':
+        optional: true
+
+  '@cloudflare/sandbox@0.8.9':
+    resolution: {integrity: sha512-4lmMo96fOVck9lcmjJAJYRf2NNspcoGy8pNuEdBTary3WWuFeXBQLmzuid4ay5i6aGu2AeRegPSmjD+Z1K6qJw==}
     peerDependencies:
       '@openai/agents': ^0.3.3
       '@opencode-ai/sdk': ^1.1.40
@@ -3475,6 +3536,11 @@ packages:
     resolution: {integrity: sha512-3a0vS6dHhVEs8B9Sqz6OIdCZ52S7SWuvLxNTQ+LE66g8OJ5b8xW6kGSCK0Z2bWBFoYfAbZzitLaBi8oBKOVqkw==}
     peerDependencies:
       expo: '*'
+
+  '@expo/react-native-action-sheet@4.1.1':
+    resolution: {integrity: sha512-4KRaba2vhqDRR7ObBj6nrD5uJw8ePoNHdIOMETTpgGTX7StUbrF4j/sfrP1YUyaPEa1P8FXdwG6pB+2WtrJd1A==}
+    peerDependencies:
+      react: '>=18.0.0'
 
   '@expo/require-utils@55.0.3':
     resolution: {integrity: sha512-TS1m5tW45q4zoaTlt6DwmdYHxvFTIxoLrTHKOFrIirHIqIXnHCzpceg8wumiBi+ZXSaGY2gobTbfv+WVhJY6Fw==}
@@ -4074,8 +4140,8 @@ packages:
       '@opentui/solid':
         optional: true
 
-  '@kilocode/sdk@7.1.17':
-    resolution: {integrity: sha512-OMe11pt8m72rUIOrgUn9OEwSl+KlQzOlGD3zDyFutHqxylqXOr0/9IfYtAP5F5fUWYCtYE7SJbXcEbWvIyVhTg==}
+  '@kilocode/sdk@7.1.23':
+    resolution: {integrity: sha512-moSKXqpwE+ozVbNE1aYIUb5Kd7fesOicRUn90WiMlp+8lRhqQc6ZTTIaIB9ZzD7Dak//4bSuo++bb+Jtw3U4Fg==}
 
   '@kilocode/sdk@7.2.14':
     resolution: {integrity: sha512-Naz83lFrsbavuDp6UwxRuglOaSNvRBsZfcRNvb7RpWYAwbuJP0dBdhpXj6uO3ta5qxeQ2JzxKNC9Ffz+LCLLDg==}
@@ -7374,6 +7440,11 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/hoist-non-react-statics@3.3.7':
+    resolution: {integrity: sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==}
+    peerDependencies:
+      '@types/react': '*'
+
   '@types/html-minifier-terser@6.1.0':
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
 
@@ -8151,8 +8222,8 @@ packages:
   aws4fetch@1.0.20:
     resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
 
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -9687,6 +9758,11 @@ packages:
     peerDependencies:
       expo: '*'
       react-native: '*'
+
+  expo-crypto@55.0.14:
+    resolution: {integrity: sha512-TfAADBGZNNv9OOmdKFJCz54wDj87ufxtzQNSY+Roycpm8e5tuCnDIL7EjqUOmNTGH99Jj8ftPGFt4KGG2Ii2fg==}
+    peerDependencies:
+      expo: '*'
 
   expo-dev-client@55.0.23:
     resolution: {integrity: sha512-Gy5H2kwQkGU97LFqylc6zcUMUl8uP5EYsRcM6lqzp/Ag9w27QuwtibznxTyctEdzap5Z2+kEnrlYj/eRDn8MWQ==}
@@ -11971,6 +12047,13 @@ packages:
     resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
     engines: {node: '>= 6.13.0'}
 
+  node-html-markdown@2.0.0:
+    resolution: {integrity: sha512-DqUC3GGP7pwSYxS93SwHoP+qCw78xcMP6C6H2DuC8rPD2AweJRjBzQb5SdXpKtDlqAQ7hVotJcfhgU7hU5Gthw==}
+    engines: {node: '>=20.0.0'}
+
+  node-html-parser@6.1.13:
+    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
+
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -12402,6 +12485,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss-loader@8.2.1:
     resolution: {integrity: sha512-k98jtRzthjj3f76MYTs9JTpRqV1RaaMhEU0Lpw9OTmQZQdppg4B30VZ74BojuBHt3F4KyubHJoXCMUeM8Bqeow==}
     engines: {node: '>= 18.12.0'}
@@ -12571,6 +12657,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   public-encrypt@4.0.3:
     resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
@@ -13852,6 +13942,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -14777,7 +14874,7 @@ snapshots:
       randexp: 0.5.3
       zod: 4.3.6
 
-  '@anthropic-ai/sdk@0.78.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.90.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -16274,6 +16371,8 @@ snapshots:
 
   '@cloudflare/containers@0.1.1': {}
 
+  '@cloudflare/containers@0.3.0': {}
+
   '@cloudflare/kv-asset-handler@0.4.0':
     dependencies:
       mime: 3.0.0
@@ -16291,6 +16390,13 @@ snapshots:
   '@cloudflare/sandbox@0.7.13(@xterm/xterm@6.0.0)':
     dependencies:
       '@cloudflare/containers': 0.1.1
+      aws4fetch: 1.0.20
+    optionalDependencies:
+      '@xterm/xterm': 6.0.0
+
+  '@cloudflare/sandbox@0.8.9(@xterm/xterm@6.0.0)':
+    dependencies:
+      '@cloudflare/containers': 0.3.0
       aws4fetch: 1.0.20
     optionalDependencies:
       '@xterm/xterm': 6.0.0
@@ -16875,6 +16981,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  '@expo/react-native-action-sheet@4.1.1(@types/react@19.2.14)(react@19.2.0)':
+    dependencies:
+      '@types/hoist-non-react-statics': 3.3.7(@types/react@19.2.14)
+      hoist-non-react-statics: 3.3.2
+      react: 19.2.0
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@expo/require-utils@55.0.3(typescript@5.9.3)':
     dependencies:
@@ -17558,7 +17672,7 @@ snapshots:
       '@kilocode/sdk': 7.2.14
       zod: 4.1.8
 
-  '@kilocode/sdk@7.1.17': {}
+  '@kilocode/sdk@7.1.23': {}
 
   '@kilocode/sdk@7.2.14':
     dependencies:
@@ -20132,7 +20246,7 @@ snapshots:
       '@slack/types': 2.20.1
       '@types/node': 25.5.0
       '@types/retry': 0.12.0
-      axios: 1.13.6
+      axios: 1.15.0
       eventemitter3: 5.0.4
       form-data: 4.0.5
       is-electron: 2.2.2
@@ -21429,6 +21543,11 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+      hoist-non-react-statics: 3.3.2
+
   '@types/html-minifier-terser@6.1.0': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
@@ -22228,11 +22347,11 @@ snapshots:
 
   aws4fetch@1.0.20: {}
 
-  axios@1.13.6:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -23861,6 +23980,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  expo-crypto@55.0.14(expo@55.0.12):
+    dependencies:
+      expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.11)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
   expo-dev-client@55.0.23(expo@55.0.12)(typescript@5.9.3):
     dependencies:
@@ -25899,6 +26022,13 @@ snapshots:
       idb-keyval: 6.2.2
       jotai: 2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.4)
 
+  jotai@2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.0):
+    optionalDependencies:
+      '@babel/core': 7.29.0
+      '@babel/template': 7.28.6
+      '@types/react': 19.2.14
+      react: 19.2.0
+
   jotai@2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.4):
     optionalDependencies:
       '@babel/core': 7.29.0
@@ -26235,7 +26365,7 @@ snapshots:
 
   mailgun.js@12.7.1:
     dependencies:
-      axios: 1.13.6
+      axios: 1.15.0
       base-64: 1.0.0
       url-join: 4.0.1
     transitivePeerDependencies:
@@ -27114,6 +27244,15 @@ snapshots:
 
   node-forge@1.3.3: {}
 
+  node-html-markdown@2.0.0:
+    dependencies:
+      node-html-parser: 6.1.13
+
+  node-html-parser@6.1.13:
+    dependencies:
+      css-select: 5.2.2
+      he: 1.2.0
+
   node-int64@0.4.0: {}
 
   node-polyfill-webpack-plugin@2.0.1(webpack@5.105.4(esbuild@0.27.4)):
@@ -27655,6 +27794,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss-loader@8.2.1(postcss@8.5.8)(typescript@5.9.3)(webpack@5.105.4(esbuild@0.27.4)):
     dependencies:
       cosmiconfig: 9.0.1(typescript@5.9.3)
@@ -27861,6 +28002,8 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-from-env@1.1.0: {}
+
+  proxy-from-env@2.1.0: {}
 
   public-encrypt@4.0.3:
     dependencies:
@@ -29204,7 +29347,7 @@ snapshots:
     dependencies:
       '@types/jsonwebtoken': 9.0.10
       '@types/ws': 8.18.1
-      axios: 1.13.6
+      axios: 1.15.0
       base64-js: 1.5.1
       form-data: 4.0.5
       isomorphic-ws: 5.0.0(ws@8.19.0)
@@ -29519,6 +29662,12 @@ snapshots:
   tinyrainbow@3.1.0: {}
 
   tinyspy@4.0.4: {}
+
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
 
   tmpl@1.0.5: {}
 
@@ -30201,7 +30350,7 @@ snapshots:
 
   wait-on@7.2.0:
     dependencies:
-      axios: 1.13.6
+      axios: 1.15.0
       joi: 17.13.3
       lodash: 4.17.23
       minimist: 1.2.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,25 +366,25 @@ importers:
         version: 3.14.0(@faker-js/faker@10.3.0)(zod@4.3.6)
       '@chromatic-com/storybook':
         specifier: ^4.1.3
-        version: 4.1.3(@chromatic-com/playwright@0.12.8(@playwright/test@1.58.2)(@types/react@19.2.14)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 4.1.3(@chromatic-com/playwright@0.12.8(@playwright/test@1.58.2)(@types/react@19.2.14)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@faker-js/faker':
         specifier: ^10.3.0
         version: 10.3.0
       '@storybook/addon-docs':
         specifier: ^9.1.20
-        version: 9.1.20(@types/react@19.2.14)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 9.1.20(@types/react@19.2.14)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@storybook/addon-links':
         specifier: ^9.1.20
-        version: 9.1.20(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 9.1.20(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@storybook/addon-themes':
         specifier: ^9.1.20
-        version: 9.1.20(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 9.1.20(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@storybook/nextjs':
         specifier: ^9.1.20
-        version: 9.1.20(patch_hash=e1857649664eed8f87877c352d277c90d4af5a58d0ad931105f033c8c08165c1)(esbuild@0.27.4)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.4(esbuild@0.27.4))
+        version: 9.1.20(patch_hash=e1857649664eed8f87877c352d277c90d4af5a58d0ad931105f033c8c08165c1)(esbuild@0.27.4)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.4(esbuild@0.27.4))
       '@storybook/test-runner':
         specifier: ^0.23.0
-        version: 0.23.0(@types/node@25.6.0)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 0.23.0(@types/node@25.5.0)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.2.2)
@@ -399,7 +399,7 @@ importers:
         version: 7.0.0-dev.20260319.1
       chromatic:
         specifier: ^13.3.5
-        version: 13.3.5(@chromatic-com/playwright@0.12.8(@playwright/test@1.58.2)(@types/react@19.2.14)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 13.3.5(@chromatic-com/playwright@0.12.8(@playwright/test@1.58.2)(@types/react@19.2.14)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
@@ -417,7 +417,7 @@ importers:
         version: 3.0.5
       storybook:
         specifier: ^9.1.17
-        version: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.2
@@ -669,7 +669,7 @@ importers:
         version: 14.25.1
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       event-source-polyfill:
         specifier: ^1.0.31
         version: 1.0.31
@@ -877,7 +877,7 @@ importers:
     dependencies:
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       pg:
         specifier: ^8.20.0
         version: 8.20.0
@@ -933,7 +933,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/trpc:
     dependencies:
@@ -948,10 +948,10 @@ importers:
         version: 8.9.0
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       stripe:
         specifier: 'catalog:'
-        version: 19.3.0(@types/node@25.6.0)
+        version: 19.3.0(@types/node@25.5.0)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -964,7 +964,7 @@ importers:
         version: link:../encryption
       '@sentry/nextjs':
         specifier: ^10.43.0
-        version: 10.43.0(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.105.4)
+        version: 10.43.0(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260319.1
@@ -1004,7 +1004,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ~3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.6.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   services/ai-attribution:
     dependencies:
@@ -1013,7 +1013,7 @@ importers:
         version: link:../../packages/worker-utils
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -1035,7 +1035,7 @@ importers:
         version: 0.31.9
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.6.0)
+        version: 29.7.0(@types/node@25.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1056,7 +1056,7 @@ importers:
         version: 8.0.3
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       jsonwebtoken:
         specifier: 'catalog:'
         version: 9.0.3
@@ -1170,7 +1170,7 @@ importers:
         version: 11.13.0(typescript@5.9.3)
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       jsonwebtoken:
         specifier: 'catalog:'
         version: 9.0.3
@@ -1237,7 +1237,7 @@ importers:
         version: 11.13.0(typescript@5.9.3)
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -1293,7 +1293,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.12
+        version: 1.3.11
       '@types/node':
         specifier: ^20.19.37
         version: 20.19.37
@@ -1308,7 +1308,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.12
+        version: 1.3.11
       '@types/node':
         specifier: ^20.19.37
         version: 20.19.37
@@ -1471,7 +1471,7 @@ importers:
         version: 7.0.0-dev.20260319.1
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
+        version: 30.3.0(@types/node@24.12.0)(esbuild-register@3.6.0(esbuild@0.27.4))
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1501,7 +1501,7 @@ importers:
         version: 11.13.0(typescript@5.9.3)
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -1555,11 +1555,11 @@ importers:
   services/gastown/container:
     dependencies:
       '@kilocode/plugin':
-        specifier: 7.1.23
-        version: 7.1.23
+        specifier: 7.2.7
+        version: 7.2.7
       '@kilocode/sdk':
-        specifier: 7.1.23
-        version: 7.1.23
+        specifier: 7.2.7
+        version: 7.2.7
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -1575,7 +1575,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.6.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   services/git-token-service:
     dependencies:
@@ -1587,7 +1587,7 @@ importers:
         version: 8.2.0
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1625,7 +1625,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ~3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.6.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       wrangler:
         specifier: 'catalog:'
         version: 4.73.0(@cloudflare/workers-types@4.20260313.1)
@@ -1689,7 +1689,7 @@ importers:
         version: link:../../packages/worker-utils
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -1735,7 +1735,7 @@ importers:
         version: 4.1.0
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       jose:
         specifier: 'catalog:'
         version: 6.2.1
@@ -1769,7 +1769,7 @@ importers:
         version: link:../../packages/db
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       node-html-markdown:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1785,7 +1785,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       wrangler:
         specifier: 'catalog:'
         version: 4.73.0(@cloudflare/workers-types@4.20260313.1)
@@ -1800,7 +1800,7 @@ importers:
         version: link:../../packages/worker-utils
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       expo-server-sdk:
         specifier: ^6.1.0
         version: 6.1.0(patch_hash=7850520582b5b394397b35d1ea195192fe78589d8a6a748fe15177b818c4ed0b)
@@ -1843,7 +1843,7 @@ importers:
         version: link:../../packages/worker-utils
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -1880,7 +1880,7 @@ importers:
         version: link:../../packages/db
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       workers-tagged-logger:
         specifier: 'catalog:'
         version: 1.0.0
@@ -1911,7 +1911,7 @@ importers:
         version: link:../../packages/db
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1942,7 +1942,7 @@ importers:
         version: 0.0.22
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -1994,7 +1994,7 @@ importers:
         version: 10.0.1
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0)
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -4158,11 +4158,22 @@ packages:
       react: '*'
       react-native: '*'
 
-  '@kilocode/plugin@7.1.23':
-    resolution: {integrity: sha512-sFI0rlgQg3mzYP05/gg09IE1mN4QyAXyOlJjM36CFoVKi1bPYz/dqEqr6ddmMNmB577A4gDu0D07hr0pGIFrBA==}
+  '@kilocode/plugin@7.2.7':
+    resolution: {integrity: sha512-m4fHQlrUjuZTEABtOUIoHfUW3ejPpF8Jv2VhkFYVKJmuerltQBBFb4udrN97GJHMyoLL3nzJ6bNZkg3Czv8Z3g==}
+    peerDependencies:
+      '@opentui/core': '>=0.1.97'
+      '@opentui/solid': '>=0.1.97'
+    peerDependenciesMeta:
+      '@opentui/core':
+        optional: true
+      '@opentui/solid':
+        optional: true
 
   '@kilocode/sdk@7.1.23':
     resolution: {integrity: sha512-moSKXqpwE+ozVbNE1aYIUb5Kd7fesOicRUn90WiMlp+8lRhqQc6ZTTIaIB9ZzD7Dak//4bSuo++bb+Jtw3U4Fg==}
+
+  '@kilocode/sdk@7.2.7':
+    resolution: {integrity: sha512-710n8PQ3QfmTwEdzOW2p7ur79rF9IBJk6nGsUu1hp8o/66RTkpVYC0EB7DKNfJ1NzTWmUqmhJZGWq4suCfADKQ==}
 
   '@lottiefiles/dotlottie-react@0.17.15':
     resolution: {integrity: sha512-4wYAjsJhM28eUvJ/gT3KRM6fcyT7EM9n7PDrP71LaBTacc6bSN43qFTSJc1Li3QxUiraz23p0Q8EJBzXo8DsRw==}
@@ -7291,9 +7302,6 @@ packages:
   '@types/bun@1.3.11':
     resolution: {integrity: sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==}
 
-  '@types/bun@1.3.12':
-    resolution: {integrity: sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A==}
-
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -7415,9 +7423,6 @@ packages:
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
-
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -8453,9 +8458,6 @@ packages:
 
   bun-types@1.3.11:
     resolution: {integrity: sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==}
-
-  bun-types@1.3.12:
-    resolution: {integrity: sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -12934,10 +12936,6 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
-  react@19.2.5:
-    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
-    engines: {node: '>=0.10.0'}
-
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
@@ -14115,9 +14113,6 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   undici@6.24.1:
     resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
@@ -16323,16 +16318,16 @@ snapshots:
       - vite
       - webpack-cli
 
-  '@chromatic-com/playwright@0.12.8(@playwright/test@1.58.2)(@types/react@19.2.14)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@chromatic-com/playwright@0.12.8(@playwright/test@1.58.2)(@types/react@19.2.14)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@chromaui/rrweb-snapshot': 2.0.0-alpha.18-noAbsolute
       '@playwright/test': 1.58.2
       '@segment/analytics-node': 2.1.3
-      '@storybook/addon-essentials': 8.5.8(@types/react@19.2.14)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/addon-essentials': 8.5.8(@types/react@19.2.14)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@storybook/csf': 0.1.13
-      '@storybook/manager-api': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      '@storybook/server-webpack5': 8.5.8(esbuild@0.27.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/manager-api': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/server-webpack5': 8.5.8(esbuild@0.27.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@rspack/core'
@@ -16352,13 +16347,13 @@ snapshots:
       - webpack-cli
     optional: true
 
-  '@chromatic-com/storybook@4.1.3(@chromatic-com/playwright@0.12.8(@playwright/test@1.58.2)(@types/react@19.2.14)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@chromatic-com/storybook@4.1.3(@chromatic-com/playwright@0.12.8(@playwright/test@1.58.2)(@types/react@19.2.14)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@neoconfetti/react': 1.0.0
-      chromatic: 13.3.5(@chromatic-com/playwright@0.12.8(@playwright/test@1.58.2)(@types/react@19.2.14)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      chromatic: 13.3.5(@chromatic-com/playwright@0.12.8(@playwright/test@1.58.2)(@types/react@19.2.14)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       filesize: 10.1.6
       jsonfile: 6.2.0
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       strip-ansi: 7.2.0
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
@@ -16457,7 +16452,7 @@ snapshots:
       devalue: 5.6.4
       miniflare: 4.20250906.0
       semver: 7.7.4
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.6.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       wrangler: 4.35.0(@cloudflare/workers-types@4.20260313.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -17304,7 +17299,7 @@ snapshots:
   '@jest/console@30.3.0':
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
       chalk: 4.1.2
       jest-message-util: 30.3.0
       jest-util: 30.3.0
@@ -17439,7 +17434,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
       '@sinonjs/fake-timers': 15.1.1
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
@@ -17466,7 +17461,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
       jest-regex-util: 30.0.1
 
   '@jest/reporters@29.7.0':
@@ -17506,7 +17501,7 @@ snapshots:
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -17676,12 +17671,16 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
 
-  '@kilocode/plugin@7.1.23':
+  '@kilocode/plugin@7.2.7':
     dependencies:
-      '@kilocode/sdk': 7.1.23
+      '@kilocode/sdk': 7.2.7
       zod: 4.1.8
 
   '@kilocode/sdk@7.1.23': {}
+
+  '@kilocode/sdk@7.2.7':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@lottiefiles/dotlottie-react@0.17.15(react@19.2.4)':
     dependencies:
@@ -19969,7 +19968,7 @@ snapshots:
       - supports-color
       - webpack
 
-  '@sentry/nextjs@10.43.0(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.105.4)':
+  '@sentry/nextjs@10.43.0(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -19979,10 +19978,10 @@ snapshots:
       '@sentry/core': 10.43.0
       '@sentry/node': 10.43.0
       '@sentry/opentelemetry': 10.43.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)
-      '@sentry/react': 10.43.0(react@19.2.5)
+      '@sentry/react': 10.43.0(react@19.2.4)
       '@sentry/vercel-edge': 10.43.0
       '@sentry/webpack-plugin': 5.1.1(webpack@5.105.4)
-      next: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -20080,12 +20079,6 @@ snapshots:
       '@sentry/browser': 10.43.0
       '@sentry/core': 10.43.0
       react: 19.2.4
-
-  '@sentry/react@10.43.0(react@19.2.5)':
-    dependencies:
-      '@sentry/browser': 10.43.0
-      '@sentry/core': 10.43.0
-      react: 19.2.5
 
   '@sentry/types@10.37.0':
     dependencies:
@@ -20517,13 +20510,13 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-actions@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/addon-actions@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@storybook/global': 5.0.0
       '@types/uuid': 9.0.8
       dequal: 2.0.3
       polished: 4.3.1
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       uuid: 9.0.1
     optional: true
 
@@ -20536,11 +20529,11 @@ snapshots:
       storybook: 9.1.20
       uuid: 9.0.1
 
-  '@storybook/addon-backgrounds@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/addon-backgrounds@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@storybook/global': 5.0.0
       memoizerific: 1.11.3
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ts-dedent: 2.2.0
     optional: true
 
@@ -20551,11 +20544,11 @@ snapshots:
       storybook: 9.1.20
       ts-dedent: 2.2.0
 
-  '@storybook/addon-controls@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/addon-controls@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@storybook/global': 5.0.0
       dequal: 2.0.3
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ts-dedent: 2.2.0
     optional: true
 
@@ -20566,15 +20559,15 @@ snapshots:
       storybook: 9.1.20
       ts-dedent: 2.2.0
 
-  '@storybook/addon-docs@8.5.8(@types/react@19.2.14)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/addon-docs@8.5.8(@types/react@19.2.14)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@storybook/blocks': 8.5.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      '@storybook/csf-plugin': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      '@storybook/react-dom-shim': 8.5.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/blocks': 8.5.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/csf-plugin': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/react-dom-shim': 8.5.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -20593,31 +20586,31 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-docs@9.1.20(@types/react@19.2.14)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/addon-docs@9.1.20(@types/react@19.2.14)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@storybook/icons': 1.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-essentials@8.5.8(@types/react@19.2.14)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/addon-essentials@8.5.8(@types/react@19.2.14)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      '@storybook/addon-actions': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      '@storybook/addon-backgrounds': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      '@storybook/addon-controls': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      '@storybook/addon-docs': 8.5.8(@types/react@19.2.14)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      '@storybook/addon-highlight': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      '@storybook/addon-measure': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      '@storybook/addon-outline': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      '@storybook/addon-toolbars': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      '@storybook/addon-viewport': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/addon-actions': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/addon-backgrounds': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/addon-controls': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/addon-docs': 8.5.8(@types/react@19.2.14)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/addon-highlight': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/addon-measure': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/addon-outline': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/addon-toolbars': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/addon-viewport': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -20639,10 +20632,10 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-highlight@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/addon-highlight@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optional: true
 
   '@storybook/addon-highlight@8.5.8(storybook@9.1.20)':
@@ -20650,17 +20643,17 @@ snapshots:
       '@storybook/global': 5.0.0
       storybook: 9.1.20
 
-  '@storybook/addon-links@9.1.20(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/addon-links@9.1.20(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
       react: 19.2.4
 
-  '@storybook/addon-measure@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/addon-measure@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       tiny-invariant: 1.3.3
     optional: true
 
@@ -20670,10 +20663,10 @@ snapshots:
       storybook: 9.1.20
       tiny-invariant: 1.3.3
 
-  '@storybook/addon-outline@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/addon-outline@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ts-dedent: 2.2.0
     optional: true
 
@@ -20683,24 +20676,24 @@ snapshots:
       storybook: 9.1.20
       ts-dedent: 2.2.0
 
-  '@storybook/addon-themes@9.1.20(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/addon-themes@9.1.20(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ts-dedent: 2.2.0
 
-  '@storybook/addon-toolbars@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/addon-toolbars@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optional: true
 
   '@storybook/addon-toolbars@8.5.8(storybook@9.1.20)':
     dependencies:
       storybook: 9.1.20
 
-  '@storybook/addon-viewport@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/addon-viewport@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       memoizerific: 1.11.3
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optional: true
 
   '@storybook/addon-viewport@8.5.8(storybook@9.1.20)':
@@ -20708,11 +20701,11 @@ snapshots:
       memoizerific: 1.11.3
       storybook: 9.1.20
 
-  '@storybook/blocks@8.5.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/blocks@8.5.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@storybook/csf': 0.1.12
       '@storybook/icons': 1.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 19.2.4
@@ -20765,9 +20758,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/builder-webpack5@8.5.8(esbuild@0.27.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
+  '@storybook/builder-webpack5@8.5.8(esbuild@0.27.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
     dependencies:
-      '@storybook/core-webpack': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/core-webpack': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@types/semver': 7.7.1
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -20781,7 +20774,7 @@ snapshots:
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.7.4
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       style-loader: 3.3.4(webpack@5.105.4(esbuild@0.27.4))
       terser-webpack-plugin: 5.4.0(esbuild@0.27.4)(webpack@5.105.4(esbuild@0.27.4))
       ts-dedent: 2.2.0
@@ -20802,9 +20795,9 @@ snapshots:
       - webpack-cli
     optional: true
 
-  '@storybook/builder-webpack5@9.1.20(esbuild@0.27.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
+  '@storybook/builder-webpack5@9.1.20(esbuild@0.27.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
     dependencies:
-      '@storybook/core-webpack': 9.1.20(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/core-webpack': 9.1.20(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
       css-loader: 6.11.0(webpack@5.105.4(esbuild@0.27.4))
@@ -20812,7 +20805,7 @@ snapshots:
       fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.105.4(esbuild@0.27.4))
       html-webpack-plugin: 5.6.6(webpack@5.105.4(esbuild@0.27.4))
       magic-string: 0.30.21
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       style-loader: 3.3.4(webpack@5.105.4(esbuild@0.27.4))
       terser-webpack-plugin: 5.4.0(esbuild@0.27.4)(webpack@5.105.4(esbuild@0.27.4))
       ts-dedent: 2.2.0
@@ -20829,18 +20822,18 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/components@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/components@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optional: true
 
   '@storybook/components@8.5.8(storybook@9.1.20)':
     dependencies:
       storybook: 9.1.20
 
-  '@storybook/core-webpack@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/core-webpack@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ts-dedent: 2.2.0
     optional: true
 
@@ -20849,14 +20842,14 @@ snapshots:
       storybook: 9.1.20
       ts-dedent: 2.2.0
 
-  '@storybook/core-webpack@9.1.20(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/core-webpack@9.1.20(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/csf-plugin@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       unplugin: 1.16.1
     optional: true
 
@@ -20865,9 +20858,9 @@ snapshots:
       storybook: 9.1.20
       unplugin: 1.16.1
 
-  '@storybook/csf-plugin@9.1.20(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/csf-plugin@9.1.20(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       unplugin: 1.16.1
 
   '@storybook/csf@0.1.12':
@@ -20885,16 +20878,16 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/manager-api@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/manager-api@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optional: true
 
   '@storybook/manager-api@8.5.8(storybook@9.1.20)':
     dependencies:
       storybook: 9.1.20
 
-  '@storybook/nextjs@9.1.20(patch_hash=e1857649664eed8f87877c352d277c90d4af5a58d0ad931105f033c8c08165c1)(esbuild@0.27.4)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.4(esbuild@0.27.4))':
+  '@storybook/nextjs@9.1.20(patch_hash=e1857649664eed8f87877c352d277c90d4af5a58d0ad931105f033c8c08165c1)(esbuild@0.27.4)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.4(esbuild@0.27.4))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
@@ -20910,9 +20903,9 @@ snapshots:
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.105.4(esbuild@0.27.4))
-      '@storybook/builder-webpack5': 9.1.20(esbuild@0.27.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
-      '@storybook/preset-react-webpack': 9.1.20(esbuild@0.27.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
-      '@storybook/react': 9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
+      '@storybook/builder-webpack5': 9.1.20(esbuild@0.27.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 9.1.20(esbuild@0.27.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
+      '@storybook/react': 9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
       '@types/semver': 7.7.1
       babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.105.4(esbuild@0.27.4))
       css-loader: 6.11.0(webpack@5.105.4(esbuild@0.27.4))
@@ -20928,7 +20921,7 @@ snapshots:
       resolve-url-loader: 5.0.0
       sass-loader: 16.0.7(webpack@5.105.4(esbuild@0.27.4))
       semver: 7.7.4
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       style-loader: 3.3.4(webpack@5.105.4(esbuild@0.27.4))
       styled-jsx: 5.1.7(@babel/core@7.29.0)(react@19.2.4)
       tsconfig-paths: 4.2.0
@@ -20954,9 +20947,9 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@9.1.20(esbuild@0.27.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
+  '@storybook/preset-react-webpack@9.1.20(esbuild@0.27.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
     dependencies:
-      '@storybook/core-webpack': 9.1.20(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/core-webpack': 9.1.20(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.105.4(esbuild@0.27.4))
       '@types/semver': 7.7.1
       find-up: 7.0.0
@@ -20966,7 +20959,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       resolve: 1.22.11
       semver: 7.7.4
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       tsconfig-paths: 4.2.0
       webpack: 5.105.4(esbuild@0.27.4)
     optionalDependencies:
@@ -20978,13 +20971,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/preset-server-webpack@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/preset-server-webpack@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      '@storybook/core-webpack': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/core-webpack': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@storybook/global': 5.0.0
-      '@storybook/server': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/server': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       safe-identifier: 0.4.2
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ts-dedent: 2.2.0
       yaml-loader: 0.8.1
     optional: true
@@ -20999,9 +20992,9 @@ snapshots:
       ts-dedent: 2.2.0
       yaml-loader: 0.8.1
 
-  '@storybook/preview-api@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/preview-api@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optional: true
 
   '@storybook/preview-api@8.5.8(storybook@9.1.20)':
@@ -21022,11 +21015,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@8.5.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/react-dom-shim@8.5.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optional: true
 
   '@storybook/react-dom-shim@8.5.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20)':
@@ -21035,19 +21028,19 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       storybook: 9.1.20
 
-  '@storybook/react-dom-shim@9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/react-dom-shim@9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
-  '@storybook/react@9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
+  '@storybook/react@9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
       typescript: 5.9.3
 
@@ -21065,12 +21058,12 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/server-webpack5@8.5.8(esbuild@0.27.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
+  '@storybook/server-webpack5@8.5.8(esbuild@0.27.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
     dependencies:
-      '@storybook/builder-webpack5': 8.5.8(esbuild@0.27.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
-      '@storybook/preset-server-webpack': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      '@storybook/server': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/builder-webpack5': 8.5.8(esbuild@0.27.4)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
+      '@storybook/preset-server-webpack': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/server': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -21080,15 +21073,15 @@ snapshots:
       - webpack-cli
     optional: true
 
-  '@storybook/server@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/server@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      '@storybook/components': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/components': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@storybook/csf': 0.1.12
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      '@storybook/preview-api': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      '@storybook/theming': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/manager-api': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/preview-api': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/theming': 8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ts-dedent: 2.2.0
       yaml: 2.8.2
     optional: true
@@ -21105,7 +21098,7 @@ snapshots:
       ts-dedent: 2.2.0
       yaml: 2.8.2
 
-  '@storybook/test-runner@0.23.0(@types/node@25.6.0)(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/test-runner@0.23.0(@types/node@25.5.0)(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -21115,17 +21108,17 @@ snapshots:
       '@swc/core': 1.15.18
       '@swc/jest': 0.2.39(@swc/core@1.15.18)
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@25.6.0)
+      jest: 29.7.0(@types/node@25.5.0)
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
-      jest-playwright-preset: 4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@25.6.0))
+      jest-playwright-preset: 4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@25.5.0))
       jest-runner: 29.7.0
       jest-serializer-html: 7.1.0
-      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@25.6.0))
+      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@25.5.0))
       nyc: 15.1.0
       playwright: 1.58.2
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - '@swc/helpers'
       - '@types/node'
@@ -21135,9 +21128,9 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@storybook/theming@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/theming@8.5.8(storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      storybook: 9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optional: true
 
   '@storybook/theming@8.5.8(storybook@9.1.20)':
@@ -21391,10 +21384,6 @@ snapshots:
     dependencies:
       bun-types: 1.3.11
 
-  '@types/bun@1.3.12':
-    dependencies:
-      bun-types: 1.3.12
-
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -21402,7 +21391,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
 
   '@types/d3-array@3.2.2': {}
 
@@ -21512,7 +21501,7 @@ snapshots:
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
 
   '@types/node@20.19.37':
     dependencies:
@@ -21526,10 +21515,6 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@types/node@25.6.0':
-    dependencies:
-      undici-types: 7.19.2
-
   '@types/parse-json@4.0.2': {}
 
   '@types/pg-pool@2.0.7':
@@ -21538,7 +21523,7 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -21574,7 +21559,7 @@ snapshots:
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -21589,7 +21574,7 @@ snapshots:
 
   '@types/wait-on@5.3.4':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.5.0
 
   '@types/ws@8.18.1':
     dependencies:
@@ -21817,12 +21802,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-
   '@vitest/mocker@3.2.4(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -21839,14 +21818,6 @@ snapshots:
     optionalDependencies:
       vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@3.2.4(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-
   '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.0
@@ -21855,13 +21826,13 @@ snapshots:
     optionalDependencies:
       vite: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -22684,10 +22655,6 @@ snapshots:
     dependencies:
       '@types/node': 25.5.0
 
-  bun-types@1.3.12:
-    dependencies:
-      '@types/node': 20.19.37
-
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -22794,13 +22761,13 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  chromatic@13.3.5(@chromatic-com/playwright@0.12.8(@playwright/test@1.58.2)(@types/react@19.2.14)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))):
+  chromatic@13.3.5(@chromatic-com/playwright@0.12.8(@playwright/test@1.58.2)(@types/react@19.2.14)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))):
     optionalDependencies:
-      '@chromatic-com/playwright': 0.12.8(@playwright/test@1.58.2)(@types/react@19.2.14)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@chromatic-com/playwright': 0.12.8(@playwright/test@1.58.2)(@types/react@19.2.14)(esbuild@0.27.4)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.5.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -22811,7 +22778,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.5.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -23097,13 +23064,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@25.6.0):
+  create-jest@29.7.0(@types/node@25.5.0):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.6.0)
+      jest-config: 29.7.0(@types/node@25.5.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -23551,12 +23518,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.12)(pg@8.20.0):
+  drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260313.1
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.18.0
-      bun-types: 1.3.12
+      bun-types: 1.3.11
       pg: 8.20.0
 
   dset@3.1.4: {}
@@ -25242,7 +25209,7 @@ snapshots:
       '@jest/expect': 30.3.0
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -25281,16 +25248,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@25.6.0):
+  jest-cli@29.7.0(@types/node@25.5.0):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.6.0)
+      create-jest: 29.7.0(@types/node@25.5.0)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.6.0)
+      jest-config: 29.7.0(@types/node@25.5.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -25309,25 +25276,6 @@ snapshots:
       exit-x: 0.2.2
       import-local: 3.2.0
       jest-config: 30.3.0(@types/node@24.12.0)(esbuild-register@3.6.0(esbuild@0.27.4))
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest-cli@30.3.0(esbuild-register@3.6.0(esbuild@0.27.4)):
-    dependencies:
-      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -25398,36 +25346,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@25.6.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 13.0.6
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.6.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
   jest-config@30.3.0(@types/node@24.12.0)(esbuild-register@3.6.0(esbuild@0.27.4)):
     dependencies:
       '@babel/core': 7.29.0
@@ -25492,37 +25410,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.3.0(esbuild-register@3.6.0(esbuild@0.27.4)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 13.0.6
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      esbuild-register: 3.6.0(esbuild@0.27.4)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
   jest-diff@29.7.0:
     dependencies:
       chalk: 4.1.2
@@ -25575,7 +25462,7 @@ snapshots:
       '@jest/environment': 30.3.0
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
       jest-validate: 30.3.0
@@ -25601,7 +25488,7 @@ snapshots:
   jest-haste-map@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -25680,10 +25567,10 @@ snapshots:
       '@types/node': 25.5.0
       jest-util: 30.3.0
 
-  jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@25.6.0)):
+  jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@25.5.0)):
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@25.6.0)
+      jest: 29.7.0(@types/node@25.5.0)
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -25794,7 +25681,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -25850,7 +25737,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -25935,7 +25822,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -25959,11 +25846,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.3.0
 
-  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@25.6.0)):
+  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@25.5.0)):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 5.6.2
-      jest: 29.7.0(@types/node@25.6.0)
+      jest: 29.7.0(@types/node@25.5.0)
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -25985,7 +25872,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -25994,7 +25881,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.5.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -26007,7 +25894,7 @@ snapshots:
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.3.0
       merge-stream: 2.0.0
@@ -26025,12 +25912,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@25.6.0):
+  jest@29.7.0(@types/node@25.5.0):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.6.0)
+      jest-cli: 29.7.0(@types/node@25.5.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -26043,19 +25930,6 @@ snapshots:
       '@jest/types': 30.3.0
       import-local: 3.2.0
       jest-cli: 30.3.0(@types/node@24.12.0)(esbuild-register@3.6.0(esbuild@0.27.4))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.3.0(esbuild-register@3.6.0(esbuild@0.27.4)):
-    dependencies:
-      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -27302,33 +27176,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.5))(react@19.2.5):
-    dependencies:
-      '@next/env': 16.1.6
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.8
-      caniuse-lite: 1.0.30001779
-      postcss: 8.4.31
-      react: 19.2.5
-      react-dom: 19.2.4(react@19.2.5)
-      styled-jsx: 5.1.6(react@19.2.5)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.1.6
-      '@next/swc-darwin-x64': 16.1.6
-      '@next/swc-linux-arm64-gnu': 16.1.6
-      '@next/swc-linux-arm64-musl': 16.1.6
-      '@next/swc-linux-x64-gnu': 16.1.6
-      '@next/swc-linux-x64-musl': 16.1.6
-      '@next/swc-win32-arm64-msvc': 16.1.6
-      '@next/swc-win32-x64-msvc': 16.1.6
-      '@opentelemetry/api': 1.9.0
-      '@playwright/test': 1.58.2
-      babel-plugin-react-compiler: 1.0.0
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
@@ -28099,7 +27946,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 24.12.0
+      '@types/node': 25.5.0
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -28221,11 +28068,6 @@ snapshots:
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
-      scheduler: 0.27.0
-
-  react-dom@19.2.4(react@19.2.5):
-    dependencies:
-      react: 19.2.5
       scheduler: 0.27.0
 
   react-dropzone@14.4.1(react@19.2.4):
@@ -28552,8 +28394,6 @@ snapshots:
   react@19.2.0: {}
 
   react@19.2.4: {}
-
-  react@19.2.5: {}
 
   readable-stream@2.3.8:
     dependencies:
@@ -29325,7 +29165,7 @@ snapshots:
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.27.4
@@ -29341,13 +29181,13 @@ snapshots:
       - utf-8-validate
       - vite
 
-  storybook@9.1.20(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  storybook@9.1.20(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.27.4
@@ -29598,11 +29438,11 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.0
 
-  stripe@19.3.0(@types/node@25.6.0):
+  stripe@19.3.0(@types/node@25.5.0):
     dependencies:
       qs: 6.15.0
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.5.0
 
   strnum@2.2.0: {}
 
@@ -29630,11 +29470,6 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@babel/core': 7.29.0
-
-  styled-jsx@5.1.6(react@19.2.5):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.5
 
   styled-jsx@5.1.7(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
@@ -29970,8 +29805,6 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici-types@7.19.2: {}
-
   undici@6.24.1: {}
 
   undici@7.18.2: {}
@@ -30284,28 +30117,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@oxc-project/runtime': 0.115.0
@@ -30333,23 +30144,6 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.5.0
-      esbuild: 0.27.4
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      terser: 5.46.0
-      tsx: 4.21.0
-      yaml: 2.8.2
-
-  vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      '@oxc-project/runtime': 0.115.0
-      lightningcss: 1.30.1
-      picomatch: 4.0.3
-      postcss: 8.5.8
-      rolldown: 1.0.0-rc.9
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.6.0
       esbuild: 0.27.4
       fsevents: 2.3.3
       jiti: 2.6.1
@@ -30445,50 +30239,6 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.6.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 25.6.0
-      '@vitest/ui': 3.2.4(vitest@3.2.4)
-    transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.1.0
@@ -30528,10 +30278,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -30548,11 +30298,11 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.0(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 25.6.0
+      '@types/node': 25.5.0
     transitivePeerDependencies:
       - '@vitejs/devtools'
       - esbuild

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,7 +83,6 @@ overrides:
   hono: ^4.12.7
   undici@^6: ^6.24.1
   lightningcss: 1.30.1
-  axios: '>=1.15.0 <2'
 
 patchedDependencies:
   '@gorhom/bottom-sheet@5.1.8':
@@ -136,9 +135,6 @@ importers:
 
   apps/mobile:
     dependencies:
-      '@expo/react-native-action-sheet':
-        specifier: ^4.1.1
-        version: 4.1.1(@types/react@19.2.14)(react@19.2.0)
       '@kilocode/trpc':
         specifier: workspace:*
         version: link:../../packages/trpc
@@ -196,9 +192,6 @@ importers:
       expo-constants:
         specifier: ~55.0.12
         version: 55.0.12(expo@55.0.12)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(typescript@5.9.3)
-      expo-crypto:
-        specifier: ~55.0.14
-        version: 55.0.14(expo@55.0.12)
       expo-dev-client:
         specifier: ~55.0.23
         version: 55.0.23(expo@55.0.12)(typescript@5.9.3)
@@ -250,9 +243,6 @@ importers:
       expo-web-browser:
         specifier: ~55.0.13
         version: 55.0.13(expo@55.0.12)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))
-      jotai:
-        specifier: ^2.18.1
-        version: 2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.0)
       lucide-react-native:
         specifier: ^1.7.0
         version: 1.7.0(react-native-svg@15.15.3(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -445,8 +435,8 @@ importers:
         specifier: ^2.0.35
         version: 2.0.35(zod@4.3.6)
       '@anthropic-ai/sdk':
-        specifier: ^0.90.0
-        version: 0.90.0(zod@4.3.6)
+        specifier: ^0.78.0
+        version: 0.78.0(zod@4.3.6)
       '@aws-sdk/client-s3':
         specifier: ^3.1009.0
         version: 3.1009.0
@@ -738,9 +728,6 @@ importers:
       recharts:
         specifier: ^3.8.0
         version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(redux@5.0.1)
-      redis:
-        specifier: ^5.11.0
-        version: 5.11.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -765,9 +752,6 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
-      tldts:
-        specifier: ^7.0.28
-        version: 7.0.28
       uuid:
         specifier: 11.1.0
         version: 11.1.0
@@ -1205,8 +1189,8 @@ importers:
   services/cloud-agent-next:
     dependencies:
       '@cloudflare/sandbox':
-        specifier: 0.8.9
-        version: 0.8.9(@xterm/xterm@6.0.0)
+        specifier: 0.7.13
+        version: 0.7.13(@xterm/xterm@6.0.0)
       '@hono/trpc-server':
         specifier: ^0.4.2
         version: 0.4.2(@trpc/server@11.13.0(typescript@5.9.3))(hono@4.12.8)
@@ -1245,8 +1229,8 @@ importers:
         version: 4.3.6
     devDependencies:
       '@cloudflare/containers':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.1.1
+        version: 0.1.1
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.12.21
         version: 0.12.21(@cloudflare/workers-types@4.20260313.1)(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(vitest@3.2.4)
@@ -1278,8 +1262,8 @@ importers:
   services/cloud-agent-next/wrapper:
     dependencies:
       '@kilocode/sdk':
-        specifier: 7.1.23
-        version: 7.1.23
+        specifier: 7.1.17
+        version: 7.1.17
     devDependencies:
       '@types/bun':
         specifier: latest
@@ -1461,7 +1445,7 @@ importers:
         version: 7.0.0-dev.20260319.1
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@24.12.0)(esbuild-register@3.6.0(esbuild@0.27.4))
+        version: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1545,11 +1529,11 @@ importers:
   services/gastown/container:
     dependencies:
       '@kilocode/plugin':
-        specifier: 7.1.23
-        version: 7.1.23
+        specifier: 7.2.7
+        version: 7.2.7
       '@kilocode/sdk':
-        specifier: 7.1.23
-        version: 7.1.23
+        specifier: 7.2.7
+        version: 7.2.7
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -1745,34 +1729,6 @@ importers:
       vitest:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      wrangler:
-        specifier: 'catalog:'
-        version: 4.73.0(@cloudflare/workers-types@4.20260313.1)
-
-  services/kiloclaw-inbound-email:
-    dependencies:
-      '@kilocode/db':
-        specifier: workspace:*
-        version: link:../../packages/db
-      drizzle-orm:
-        specifier: 'catalog:'
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(bun-types@1.3.11)(pg@8.20.0)
-      node-html-markdown:
-        specifier: ^2.0.0
-        version: 2.0.0
-      postal-mime:
-        specifier: ^2.7.4
-        version: 2.7.4
-    devDependencies:
-      '@typescript/native-preview':
-        specifier: 'catalog:'
-        version: 7.0.0-dev.20260319.1
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
-      vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       wrangler:
         specifier: 'catalog:'
         version: 4.73.0(@cloudflare/workers-types@4.20260313.1)
@@ -2076,8 +2032,8 @@ packages:
       '@faker-js/faker': ^7.0.0 || ^8.0.0 || ^9.0.0
       zod: ^3.21.4
 
-  '@anthropic-ai/sdk@0.90.0':
-    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
+  '@anthropic-ai/sdk@0.78.0':
+    resolution: {integrity: sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -3011,9 +2967,6 @@ packages:
   '@cloudflare/containers@0.1.1':
     resolution: {integrity: sha512-YTdobRTnTlUOUPMFemufH367A9Z8pDfZ+UboYMLbGpO0VlvEXZDiioSmXPQMHld2vRtkL31mcRii3bcbQU6fdw==}
 
-  '@cloudflare/containers@0.3.0':
-    resolution: {integrity: sha512-8HM1NgXThWCTk7SH28QFxqMNLJwl6RrMkj3qd0KvDA59BALsn3mZXNDT94i1JaGZnP4Bc8sPGs1u9UAl/mVUVg==}
-
   '@cloudflare/kv-asset-handler@0.4.0':
     resolution: {integrity: sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==}
     engines: {node: '>=18.0.0'}
@@ -3046,20 +2999,6 @@ packages:
 
   '@cloudflare/sandbox@0.7.13':
     resolution: {integrity: sha512-HVbg6nUqudsUPGMKznyG4gPgYVdEH6nt2NYgKmCJzUJeXixoWDiqCVsJpmCzNueHg/2HX982A6EhQgIUol6jzQ==}
-    peerDependencies:
-      '@openai/agents': ^0.3.3
-      '@opencode-ai/sdk': ^1.1.40
-      '@xterm/xterm': '>=5.0.0'
-    peerDependenciesMeta:
-      '@openai/agents':
-        optional: true
-      '@opencode-ai/sdk':
-        optional: true
-      '@xterm/xterm':
-        optional: true
-
-  '@cloudflare/sandbox@0.8.9':
-    resolution: {integrity: sha512-4lmMo96fOVck9lcmjJAJYRf2NNspcoGy8pNuEdBTary3WWuFeXBQLmzuid4ay5i6aGu2AeRegPSmjD+Z1K6qJw==}
     peerDependencies:
       '@openai/agents': ^0.3.3
       '@opencode-ai/sdk': ^1.1.40
@@ -3536,11 +3475,6 @@ packages:
     resolution: {integrity: sha512-3a0vS6dHhVEs8B9Sqz6OIdCZ52S7SWuvLxNTQ+LE66g8OJ5b8xW6kGSCK0Z2bWBFoYfAbZzitLaBi8oBKOVqkw==}
     peerDependencies:
       expo: '*'
-
-  '@expo/react-native-action-sheet@4.1.1':
-    resolution: {integrity: sha512-4KRaba2vhqDRR7ObBj6nrD5uJw8ePoNHdIOMETTpgGTX7StUbrF4j/sfrP1YUyaPEa1P8FXdwG6pB+2WtrJd1A==}
-    peerDependencies:
-      react: '>=18.0.0'
 
   '@expo/require-utils@55.0.3':
     resolution: {integrity: sha512-TS1m5tW45q4zoaTlt6DwmdYHxvFTIxoLrTHKOFrIirHIqIXnHCzpceg8wumiBi+ZXSaGY2gobTbfv+WVhJY6Fw==}
@@ -4129,11 +4063,22 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@kilocode/plugin@7.1.23':
-    resolution: {integrity: sha512-sFI0rlgQg3mzYP05/gg09IE1mN4QyAXyOlJjM36CFoVKi1bPYz/dqEqr6ddmMNmB577A4gDu0D07hr0pGIFrBA==}
+  '@kilocode/plugin@7.2.7':
+    resolution: {integrity: sha512-m4fHQlrUjuZTEABtOUIoHfUW3ejPpF8Jv2VhkFYVKJmuerltQBBFb4udrN97GJHMyoLL3nzJ6bNZkg3Czv8Z3g==}
+    peerDependencies:
+      '@opentui/core': '>=0.1.97'
+      '@opentui/solid': '>=0.1.97'
+    peerDependenciesMeta:
+      '@opentui/core':
+        optional: true
+      '@opentui/solid':
+        optional: true
 
-  '@kilocode/sdk@7.1.23':
-    resolution: {integrity: sha512-moSKXqpwE+ozVbNE1aYIUb5Kd7fesOicRUn90WiMlp+8lRhqQc6ZTTIaIB9ZzD7Dak//4bSuo++bb+Jtw3U4Fg==}
+  '@kilocode/sdk@7.1.17':
+    resolution: {integrity: sha512-OMe11pt8m72rUIOrgUn9OEwSl+KlQzOlGD3zDyFutHqxylqXOr0/9IfYtAP5F5fUWYCtYE7SJbXcEbWvIyVhTg==}
+
+  '@kilocode/sdk@7.2.7':
+    resolution: {integrity: sha512-710n8PQ3QfmTwEdzOW2p7ur79rF9IBJk6nGsUu1hp8o/66RTkpVYC0EB7DKNfJ1NzTWmUqmhJZGWq4suCfADKQ==}
 
   '@lottiefiles/dotlottie-react@0.17.15':
     resolution: {integrity: sha512-4wYAjsJhM28eUvJ/gT3KRM6fcyT7EM9n7PDrP71LaBTacc6bSN43qFTSJc1Li3QxUiraz23p0Q8EJBzXo8DsRw==}
@@ -7429,11 +7374,6 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
-  '@types/hoist-non-react-statics@3.3.7':
-    resolution: {integrity: sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==}
-    peerDependencies:
-      '@types/react': '*'
-
   '@types/html-minifier-terser@6.1.0':
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
 
@@ -8211,8 +8151,8 @@ packages:
   aws4fetch@1.0.20:
     resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -9747,11 +9687,6 @@ packages:
     peerDependencies:
       expo: '*'
       react-native: '*'
-
-  expo-crypto@55.0.14:
-    resolution: {integrity: sha512-TfAADBGZNNv9OOmdKFJCz54wDj87ufxtzQNSY+Roycpm8e5tuCnDIL7EjqUOmNTGH99Jj8ftPGFt4KGG2Ii2fg==}
-    peerDependencies:
-      expo: '*'
 
   expo-dev-client@55.0.23:
     resolution: {integrity: sha512-Gy5H2kwQkGU97LFqylc6zcUMUl8uP5EYsRcM6lqzp/Ag9w27QuwtibznxTyctEdzap5Z2+kEnrlYj/eRDn8MWQ==}
@@ -12036,13 +11971,6 @@ packages:
     resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
     engines: {node: '>= 6.13.0'}
 
-  node-html-markdown@2.0.0:
-    resolution: {integrity: sha512-DqUC3GGP7pwSYxS93SwHoP+qCw78xcMP6C6H2DuC8rPD2AweJRjBzQb5SdXpKtDlqAQ7hVotJcfhgU7hU5Gthw==}
-    engines: {node: '>=20.0.0'}
-
-  node-html-parser@6.1.13:
-    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
-
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -12474,9 +12402,6 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postal-mime@2.7.4:
-    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
-
   postcss-loader@8.2.1:
     resolution: {integrity: sha512-k98jtRzthjj3f76MYTs9JTpRqV1RaaMhEU0Lpw9OTmQZQdppg4B30VZ74BojuBHt3F4KyubHJoXCMUeM8Bqeow==}
     engines: {node: '>= 18.12.0'}
@@ -12646,10 +12571,6 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
 
   public-encrypt@4.0.3:
     resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
@@ -13931,13 +13852,6 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@7.0.28:
-    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
-
-  tldts@7.0.28:
-    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
-    hasBin: true
-
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -14863,7 +14777,7 @@ snapshots:
       randexp: 0.5.3
       zod: 4.3.6
 
-  '@anthropic-ai/sdk@0.90.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.78.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -16360,8 +16274,6 @@ snapshots:
 
   '@cloudflare/containers@0.1.1': {}
 
-  '@cloudflare/containers@0.3.0': {}
-
   '@cloudflare/kv-asset-handler@0.4.0':
     dependencies:
       mime: 3.0.0
@@ -16379,13 +16291,6 @@ snapshots:
   '@cloudflare/sandbox@0.7.13(@xterm/xterm@6.0.0)':
     dependencies:
       '@cloudflare/containers': 0.1.1
-      aws4fetch: 1.0.20
-    optionalDependencies:
-      '@xterm/xterm': 6.0.0
-
-  '@cloudflare/sandbox@0.8.9(@xterm/xterm@6.0.0)':
-    dependencies:
-      '@cloudflare/containers': 0.3.0
       aws4fetch: 1.0.20
     optionalDependencies:
       '@xterm/xterm': 6.0.0
@@ -16970,14 +16875,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  '@expo/react-native-action-sheet@4.1.1(@types/react@19.2.14)(react@19.2.0)':
-    dependencies:
-      '@types/hoist-non-react-statics': 3.3.7(@types/react@19.2.14)
-      hoist-non-react-statics: 3.3.2
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
 
   '@expo/require-utils@55.0.3(typescript@5.9.3)':
     dependencies:
@@ -17656,12 +17553,16 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kilocode/plugin@7.1.23':
+  '@kilocode/plugin@7.2.7':
     dependencies:
-      '@kilocode/sdk': 7.1.23
+      '@kilocode/sdk': 7.2.7
       zod: 4.1.8
 
-  '@kilocode/sdk@7.1.23': {}
+  '@kilocode/sdk@7.1.17': {}
+
+  '@kilocode/sdk@7.2.7':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@lottiefiles/dotlottie-react@0.17.15(react@19.2.4)':
     dependencies:
@@ -20231,7 +20132,7 @@ snapshots:
       '@slack/types': 2.20.1
       '@types/node': 25.5.0
       '@types/retry': 0.12.0
-      axios: 1.15.0
+      axios: 1.13.6
       eventemitter3: 5.0.4
       form-data: 4.0.5
       is-electron: 2.2.2
@@ -21528,11 +21429,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14)':
-    dependencies:
-      '@types/react': 19.2.14
-      hoist-non-react-statics: 3.3.2
-
   '@types/html-minifier-terser@6.1.0': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
@@ -21958,7 +21854,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -22332,11 +22228,11 @@ snapshots:
 
   aws4fetch@1.0.20: {}
 
-  axios@1.15.0:
+  axios@1.13.6:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
-      proxy-from-env: 2.1.0
+      proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
 
@@ -23966,10 +23862,6 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-crypto@55.0.14(expo@55.0.12):
-    dependencies:
-      expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.11)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-
   expo-dev-client@55.0.23(expo@55.0.12)(typescript@5.9.3):
     dependencies:
       expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.11)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
@@ -25332,6 +25224,25 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-cli@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4)):
+    dependencies:
+      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
+      '@jest/test-result': 30.3.0
+      '@jest/types': 30.3.0
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
   jest-config@29.7.0(@types/node@24.12.0):
     dependencies:
       '@babel/core': 7.29.0
@@ -25983,6 +25894,19 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4)):
+    dependencies:
+      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
+      '@jest/types': 30.3.0
+      import-local: 3.2.0
+      jest-cli: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
   jimp-compact@0.16.1: {}
 
   jiti@2.6.1: {}
@@ -26006,13 +25930,6 @@ snapshots:
       '@rocicorp/resolver': 1.0.2
       idb-keyval: 6.2.2
       jotai: 2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.4)
-
-  jotai@2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.0):
-    optionalDependencies:
-      '@babel/core': 7.29.0
-      '@babel/template': 7.28.6
-      '@types/react': 19.2.14
-      react: 19.2.0
 
   jotai@2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.4):
     optionalDependencies:
@@ -26350,7 +26267,7 @@ snapshots:
 
   mailgun.js@12.7.1:
     dependencies:
-      axios: 1.15.0
+      axios: 1.13.6
       base-64: 1.0.0
       url-join: 4.0.1
     transitivePeerDependencies:
@@ -27229,15 +27146,6 @@ snapshots:
 
   node-forge@1.3.3: {}
 
-  node-html-markdown@2.0.0:
-    dependencies:
-      node-html-parser: 6.1.13
-
-  node-html-parser@6.1.13:
-    dependencies:
-      css-select: 5.2.2
-      he: 1.2.0
-
   node-int64@0.4.0: {}
 
   node-polyfill-webpack-plugin@2.0.1(webpack@5.105.4(esbuild@0.27.4)):
@@ -27779,8 +27687,6 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postal-mime@2.7.4: {}
-
   postcss-loader@8.2.1(postcss@8.5.8)(typescript@5.9.3)(webpack@5.105.4(esbuild@0.27.4)):
     dependencies:
       cosmiconfig: 9.0.1(typescript@5.9.3)
@@ -27987,8 +27893,6 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-from-env@1.1.0: {}
-
-  proxy-from-env@2.1.0: {}
 
   public-encrypt@4.0.3:
     dependencies:
@@ -29332,7 +29236,7 @@ snapshots:
     dependencies:
       '@types/jsonwebtoken': 9.0.10
       '@types/ws': 8.18.1
-      axios: 1.15.0
+      axios: 1.13.6
       base64-js: 1.5.1
       form-data: 4.0.5
       isomorphic-ws: 5.0.0(ws@8.19.0)
@@ -29647,12 +29551,6 @@ snapshots:
   tinyrainbow@3.1.0: {}
 
   tinyspy@4.0.4: {}
-
-  tldts-core@7.0.28: {}
-
-  tldts@7.0.28:
-    dependencies:
-      tldts-core: 7.0.28
 
   tmpl@1.0.5: {}
 
@@ -30335,7 +30233,7 @@ snapshots:
 
   wait-on@7.2.0:
     dependencies:
-      axios: 1.15.0
+      axios: 1.13.6
       joi: 17.13.3
       lodash: 4.17.23
       minimist: 1.2.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1445,7 +1445,7 @@ importers:
         version: 7.0.0-dev.20260319.1
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))
+        version: 30.3.0(@types/node@24.12.0)(esbuild-register@3.6.0(esbuild@0.27.4))
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1529,11 +1529,11 @@ importers:
   services/gastown/container:
     dependencies:
       '@kilocode/plugin':
-        specifier: 7.2.7
-        version: 7.2.7
+        specifier: 7.2.14
+        version: 7.2.14
       '@kilocode/sdk':
-        specifier: 7.2.7
-        version: 7.2.7
+        specifier: 7.2.14
+        version: 7.2.14
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -4063,8 +4063,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@kilocode/plugin@7.2.7':
-    resolution: {integrity: sha512-m4fHQlrUjuZTEABtOUIoHfUW3ejPpF8Jv2VhkFYVKJmuerltQBBFb4udrN97GJHMyoLL3nzJ6bNZkg3Czv8Z3g==}
+  '@kilocode/plugin@7.2.14':
+    resolution: {integrity: sha512-mS+WA9HZIBH2qQ9ARA+v0q4MdQTSdfOvKbe4AOSkjP+P5hVA70OM/UVM9DVcvmjSOxU+wuUxmOy+j/EQIrgFmw==}
     peerDependencies:
       '@opentui/core': '>=0.1.97'
       '@opentui/solid': '>=0.1.97'
@@ -4077,8 +4077,8 @@ packages:
   '@kilocode/sdk@7.1.17':
     resolution: {integrity: sha512-OMe11pt8m72rUIOrgUn9OEwSl+KlQzOlGD3zDyFutHqxylqXOr0/9IfYtAP5F5fUWYCtYE7SJbXcEbWvIyVhTg==}
 
-  '@kilocode/sdk@7.2.7':
-    resolution: {integrity: sha512-710n8PQ3QfmTwEdzOW2p7ur79rF9IBJk6nGsUu1hp8o/66RTkpVYC0EB7DKNfJ1NzTWmUqmhJZGWq4suCfADKQ==}
+  '@kilocode/sdk@7.2.14':
+    resolution: {integrity: sha512-Naz83lFrsbavuDp6UwxRuglOaSNvRBsZfcRNvb7RpWYAwbuJP0dBdhpXj6uO3ta5qxeQ2JzxKNC9Ffz+LCLLDg==}
 
   '@lottiefiles/dotlottie-react@0.17.15':
     resolution: {integrity: sha512-4wYAjsJhM28eUvJ/gT3KRM6fcyT7EM9n7PDrP71LaBTacc6bSN43qFTSJc1Li3QxUiraz23p0Q8EJBzXo8DsRw==}
@@ -17553,14 +17553,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kilocode/plugin@7.2.7':
+  '@kilocode/plugin@7.2.14':
     dependencies:
-      '@kilocode/sdk': 7.2.7
+      '@kilocode/sdk': 7.2.14
       zod: 4.1.8
 
   '@kilocode/sdk@7.1.17': {}
 
-  '@kilocode/sdk@7.2.7':
+  '@kilocode/sdk@7.2.14':
     dependencies:
       cross-spawn: 7.0.6
 
@@ -21854,7 +21854,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -25224,25 +25224,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4)):
-    dependencies:
-      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   jest-config@29.7.0(@types/node@24.12.0):
     dependencies:
       '@babel/core': 7.29.0
@@ -25887,19 +25868,6 @@ snapshots:
       '@jest/types': 30.3.0
       import-local: 3.2.0
       jest-cli: 30.3.0(@types/node@24.12.0)(esbuild-register@3.6.0(esbuild@0.27.4))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4)):
-    dependencies:
-      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros

--- a/services/gastown/container/Dockerfile
+++ b/services/gastown/container/Dockerfile
@@ -4,7 +4,7 @@ FROM oven/bun:1-slim
 # Package categories:
 #   version control: git, git-lfs
 #   network/download: curl, wget, ca-certificates, gnupg, unzip
-#   build toolchain: build-essential, autoconf
+#   build toolchain: build-essential, autoconf, cmake, pkg-config
 #   search tools: ripgrep, jq
 #   compression: bzip2, zstd
 #   SSL/crypto: libssl-dev, libffi-dev
@@ -27,6 +27,8 @@ RUN apt-get update && \
       unzip \
       build-essential \
       autoconf \
+      cmake \
+      pkg-config \
       ripgrep \
       jq \
       bzip2 \

--- a/services/gastown/container/Dockerfile
+++ b/services/gastown/container/Dockerfile
@@ -16,6 +16,7 @@ FROM oven/bun:1-slim
 #   C++ stdlib: libc++1
 #   math: libgmp-dev
 #   timezone data: tzdata
+#   Java: default-jdk
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git \
@@ -49,6 +50,7 @@ RUN apt-get update && \
       libc++1 \
       libgmp-dev \
       tzdata \
+      default-jdk \
     && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/services/gastown/container/Dockerfile
+++ b/services/gastown/container/Dockerfile
@@ -72,7 +72,7 @@ RUN git lfs install --system
 # Install both glibc and musl variants — the CLI's binary resolver may
 # pick either depending on the detected libc.
 # Also install pnpm — many projects use it as their package manager.
-RUN npm install -g @kilocode/cli @kilocode/cli-linux-x64 @kilocode/cli-linux-x64-musl @kilocode/plugin pnpm && \
+RUN npm install -g @kilocode/cli@7.2.7 @kilocode/cli-linux-x64@7.2.7 @kilocode/cli-linux-x64-musl@7.2.7 @kilocode/plugin@7.2.7 pnpm && \
     ln -s "$(which kilo)" /usr/local/bin/opencode
 
 # Create non-root user for defense-in-depth

--- a/services/gastown/container/Dockerfile
+++ b/services/gastown/container/Dockerfile
@@ -72,7 +72,7 @@ RUN git lfs install --system
 # Install both glibc and musl variants — the CLI's binary resolver may
 # pick either depending on the detected libc.
 # Also install pnpm — many projects use it as their package manager.
-RUN npm install -g @kilocode/cli@7.2.7 @kilocode/cli-linux-x64@7.2.7 @kilocode/cli-linux-x64-musl@7.2.7 @kilocode/plugin@7.2.7 pnpm && \
+RUN npm install -g @kilocode/cli@7.2.14 @kilocode/cli-linux-x64@7.2.14 @kilocode/cli-linux-x64-musl@7.2.14 @kilocode/plugin@7.2.14 pnpm && \
     ln -s "$(which kilo)" /usr/local/bin/opencode
 
 # Create non-root user for defense-in-depth

--- a/services/gastown/container/Dockerfile.dev
+++ b/services/gastown/container/Dockerfile.dev
@@ -4,7 +4,7 @@ FROM --platform=linux/arm64 oven/bun:1-slim
 # Package categories:
 #   version control: git, git-lfs
 #   network/download: curl, wget, ca-certificates, gnupg, unzip
-#   build toolchain: build-essential, autoconf
+#   build toolchain: build-essential, autoconf, cmake, pkg-config
 #   search tools: ripgrep, jq
 #   compression: bzip2, zstd
 #   SSL/crypto: libssl-dev, libffi-dev
@@ -27,6 +27,8 @@ RUN apt-get update && \
       unzip \
       build-essential \
       autoconf \
+      cmake \
+      pkg-config \
       ripgrep \
       jq \
       bzip2 \

--- a/services/gastown/container/Dockerfile.dev
+++ b/services/gastown/container/Dockerfile.dev
@@ -16,6 +16,7 @@ FROM --platform=linux/arm64 oven/bun:1-slim
 #   C++ stdlib: libc++1
 #   math: libgmp-dev
 #   timezone data: tzdata
+#   Java: default-jdk
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git \
@@ -49,6 +50,7 @@ RUN apt-get update && \
       libc++1 \
       libgmp-dev \
       tzdata \
+      default-jdk \
     && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/services/gastown/container/Dockerfile.dev
+++ b/services/gastown/container/Dockerfile.dev
@@ -71,7 +71,7 @@ RUN git lfs install --system
 # pick either depending on the detected libc. bun:1-slim is Debian (glibc)
 # but the resolver sometimes misdetects; installing both is safe.
 # Also install pnpm — many projects use it as their package manager.
-RUN npm install -g @kilocode/cli @kilocode/cli-linux-arm64 @kilocode/cli-linux-arm64-musl pnpm && \
+RUN npm install -g @kilocode/cli@7.2.7 @kilocode/cli-linux-arm64@7.2.7 @kilocode/cli-linux-arm64-musl@7.2.7 @kilocode/plugin@7.2.7 pnpm && \
     ln -s "$(which kilo)" /usr/local/bin/opencode
 
 # Create non-root user for defense-in-depth

--- a/services/gastown/container/Dockerfile.dev
+++ b/services/gastown/container/Dockerfile.dev
@@ -71,7 +71,7 @@ RUN git lfs install --system
 # pick either depending on the detected libc. bun:1-slim is Debian (glibc)
 # but the resolver sometimes misdetects; installing both is safe.
 # Also install pnpm — many projects use it as their package manager.
-RUN npm install -g @kilocode/cli@7.2.7 @kilocode/cli-linux-arm64@7.2.7 @kilocode/cli-linux-arm64-musl@7.2.7 @kilocode/plugin@7.2.7 pnpm && \
+RUN npm install -g @kilocode/cli@7.2.14 @kilocode/cli-linux-arm64@7.2.14 @kilocode/cli-linux-arm64-musl@7.2.14 @kilocode/plugin@7.2.14 pnpm && \
     ln -s "$(which kilo)" /usr/local/bin/opencode
 
 # Create non-root user for defense-in-depth

--- a/services/gastown/container/package.json
+++ b/services/gastown/container/package.json
@@ -12,8 +12,8 @@
     "lint": "pnpm -w exec oxlint --config .oxlintrc.json services/gastown/container/src"
   },
   "dependencies": {
-    "@kilocode/plugin": "7.1.23",
-    "@kilocode/sdk": "7.1.23",
+    "@kilocode/plugin": "7.2.7",
+    "@kilocode/sdk": "7.2.7",
     "hono": "catalog:",
     "zod": "catalog:"
   },

--- a/services/gastown/container/package.json
+++ b/services/gastown/container/package.json
@@ -12,8 +12,8 @@
     "lint": "pnpm -w exec oxlint --config .oxlintrc.json services/gastown/container/src"
   },
   "dependencies": {
-    "@kilocode/plugin": "7.2.7",
-    "@kilocode/sdk": "7.2.7",
+    "@kilocode/plugin": "7.2.14",
+    "@kilocode/sdk": "7.2.14",
     "hono": "catalog:",
     "zod": "catalog:"
   },

--- a/services/gastown/container/plugin/client.ts
+++ b/services/gastown/container/plugin/client.ts
@@ -431,13 +431,10 @@ export class MayorGastownClient {
   }
 
   async deleteBeads(rigId: string, beadIds: string[]): Promise<{ deleted: number }> {
-    return this.request<{ deleted: number }>(
-      this.mayorPath(`/rigs/${rigId}/beads/bulk-delete`),
-      {
-        method: 'POST',
-        body: JSON.stringify({ bead_ids: beadIds }),
-      }
-    );
+    return this.request<{ deleted: number }>(this.mayorPath(`/rigs/${rigId}/beads/bulk-delete`), {
+      method: 'POST',
+      body: JSON.stringify({ bead_ids: beadIds }),
+    });
   }
 
   async deleteBeadsByStatus(

--- a/services/gastown/container/plugin/client.ts
+++ b/services/gastown/container/plugin/client.ts
@@ -430,6 +430,30 @@ export class MayorGastownClient {
     });
   }
 
+  async deleteBeads(rigId: string, beadIds: string[]): Promise<{ deleted: number }> {
+    return this.request<{ deleted: number }>(
+      this.mayorPath(`/rigs/${rigId}/beads/bulk-delete`),
+      {
+        method: 'POST',
+        body: JSON.stringify({ bead_ids: beadIds }),
+      }
+    );
+  }
+
+  async deleteBeadsByStatus(
+    rigId: string,
+    status: 'open' | 'in_progress' | 'in_review' | 'closed' | 'failed',
+    type?: string
+  ): Promise<{ deleted: number }> {
+    return this.request<{ deleted: number }>(
+      this.mayorPath(`/rigs/${rigId}/beads/delete-by-status`),
+      {
+        method: 'POST',
+        body: JSON.stringify({ status, ...(type ? { type } : {}) }),
+      }
+    );
+  }
+
   async resetAgent(rigId: string, agentId: string): Promise<void> {
     await this.request<void>(this.mayorPath(`/rigs/${rigId}/agents/${agentId}/reset`), {
       method: 'POST',

--- a/services/gastown/container/plugin/client.ts
+++ b/services/gastown/container/plugin/client.ts
@@ -409,12 +409,34 @@ export class MayorGastownClient {
       status?: 'open' | 'in_progress' | 'in_review' | 'closed' | 'failed';
       priority?: 'low' | 'medium' | 'high' | 'critical';
       labels?: string[];
+      depends_on?: string[];
     }
   ): Promise<Bead> {
     return this.request<Bead>(this.mayorPath(`/rigs/${rigId}/beads/${beadId}`), {
       method: 'PATCH',
       body: JSON.stringify(input),
     });
+  }
+
+  async convoyAddBead(
+    convoyId: string,
+    beadId: string,
+    dependsOn?: string[]
+  ): Promise<{ total_beads: number }> {
+    return this.request<{ total_beads: number }>(this.mayorPath(`/convoys/${convoyId}/add-bead`), {
+      method: 'POST',
+      body: JSON.stringify({ bead_id: beadId, depends_on: dependsOn }),
+    });
+  }
+
+  async convoyRemoveBead(convoyId: string, beadId: string): Promise<{ total_beads: number }> {
+    return this.request<{ total_beads: number }>(
+      this.mayorPath(`/convoys/${convoyId}/remove-bead`),
+      {
+        method: 'POST',
+        body: JSON.stringify({ bead_id: beadId }),
+      }
+    );
   }
 
   async reassignBead(rigId: string, beadId: string, agentId: string): Promise<Bead> {

--- a/services/gastown/container/plugin/mayor-tools.ts
+++ b/services/gastown/container/plugin/mayor-tools.ts
@@ -292,7 +292,7 @@ export function createMayorTools(client: MayorGastownClient) {
     }),
 
     gt_bead_update: tool({
-      description: "Edit a bead's status, title, body, priority, or labels.",
+      description: "Edit a bead's status, title, body, priority, labels, or dependency blockers.",
       args: {
         rig_id: tool.schema.string().describe('The UUID of the rig the bead belongs to'),
         bead_id: tool.schema.string().describe('The UUID of the bead to update'),
@@ -310,6 +310,13 @@ export function createMayorTools(client: MayorGastownClient) {
           .array(tool.schema.string())
           .describe('Replacement labels array for the bead')
           .optional(),
+        depends_on: tool.schema
+          .array(tool.schema.string())
+          .describe(
+            "Replace this bead's blockers. Pass an array of bead UUIDs that must be closed before this bead can be dispatched. " +
+              'Pass an empty array [] to remove all blockers. Omit to leave dependencies unchanged.'
+          )
+          .optional(),
       },
       async execute(args) {
         const bead = await client.updateBead(args.rig_id, args.bead_id, {
@@ -318,6 +325,7 @@ export function createMayorTools(client: MayorGastownClient) {
           status: args.status,
           priority: args.priority,
           labels: args.labels,
+          depends_on: args.depends_on,
         });
         return `Bead ${bead.bead_id} updated. Status: ${bead.status}, Priority: ${bead.priority}, Title: "${bead.title}".`;
       },
@@ -376,6 +384,40 @@ export function createMayorTools(client: MayorGastownClient) {
       async execute(args) {
         await client.closeConvoy(args.convoy_id);
         return `Convoy ${args.convoy_id} force-closed.`;
+      },
+    }),
+
+    gt_convoy_add_bead: tool({
+      description:
+        'Add an existing bead to an existing convoy. Use this after gt_sling to make a standalone bead ' +
+        "part of a convoy's tracked progress and landing. The bead will count toward the convoy's " +
+        'completion and will be included in the convoy landing.',
+      args: {
+        convoy_id: tool.schema.string().describe('UUID of the convoy to add the bead to'),
+        bead_id: tool.schema.string().describe('UUID of the bead to add'),
+        depends_on: tool.schema
+          .array(tool.schema.string())
+          .describe('Optional: bead UUIDs that must complete before this bead is dispatched')
+          .optional(),
+      },
+      async execute(args) {
+        const result = await client.convoyAddBead(args.convoy_id, args.bead_id, args.depends_on);
+        return `Bead ${args.bead_id} added to convoy ${args.convoy_id}. Convoy now tracking ${result.total_beads} beads.`;
+      },
+    }),
+
+    gt_convoy_remove_bead: tool({
+      description:
+        'Remove a bead from a convoy. The bead will no longer count toward convoy progress or landing. ' +
+        'Dependency edges between this bead and other convoy beads are also removed. ' +
+        'The bead itself is not deleted — it becomes a standalone bead.',
+      args: {
+        convoy_id: tool.schema.string().describe('UUID of the convoy'),
+        bead_id: tool.schema.string().describe('UUID of the bead to remove from the convoy'),
+      },
+      async execute(args) {
+        const result = await client.convoyRemoveBead(args.convoy_id, args.bead_id);
+        return `Bead ${args.bead_id} removed from convoy ${args.convoy_id}. Convoy now tracking ${result.total_beads} beads.`;
       },
     }),
 

--- a/services/gastown/container/plugin/mayor-tools.ts
+++ b/services/gastown/container/plugin/mayor-tools.ts
@@ -337,14 +337,22 @@ export function createMayorTools(client: MayorGastownClient) {
     }),
 
     gt_bead_delete: tool({
-      description: 'Delete a bead. Use with caution — this is irreversible.',
+      description:
+        'Delete one or more beads. Use with caution — this is irreversible. Pass a single UUID string or an array of UUIDs to bulk-delete up to 5000 at once.',
       args: {
-        rig_id: tool.schema.string().describe('The UUID of the rig the bead belongs to'),
-        bead_id: tool.schema.string().describe('The UUID of the bead to delete'),
+        rig_id: tool.schema.string().describe('The UUID of the rig the bead(s) belong to'),
+        bead_id: tool.schema
+          .union([tool.schema.string(), tool.schema.array(tool.schema.string())])
+          .describe('A single bead UUID or an array of bead UUIDs to delete'),
       },
       async execute(args) {
-        await client.deleteBead(args.rig_id, args.bead_id);
-        return `Bead ${args.bead_id} deleted.`;
+        const ids = Array.isArray(args.bead_id) ? args.bead_id : [args.bead_id];
+        if (ids.length === 1 && ids[0]) {
+          await client.deleteBead(args.rig_id, ids[0]);
+          return `Bead ${ids[0]} deleted.`;
+        }
+        const result = await client.deleteBeads(args.rig_id, ids);
+        return `Deleted ${result.deleted} beads.`;
       },
     }),
 

--- a/services/gastown/container/plugin/package.json
+++ b/services/gastown/container/plugin/package.json
@@ -6,8 +6,8 @@
   "description": "Kilo plugin exposing Gastown tools to agents",
   "main": "index.ts",
   "dependencies": {
-    "@kilocode/plugin": "7.1.23",
-    "@kilocode/sdk": "7.1.23",
+    "@kilocode/plugin": "7.2.7",
+    "@kilocode/sdk": "7.2.7",
     "zod": "^4.3.5"
   }
 }

--- a/services/gastown/container/plugin/package.json
+++ b/services/gastown/container/plugin/package.json
@@ -6,8 +6,8 @@
   "description": "Kilo plugin exposing Gastown tools to agents",
   "main": "index.ts",
   "dependencies": {
-    "@kilocode/plugin": "7.2.7",
-    "@kilocode/sdk": "7.2.7",
+    "@kilocode/plugin": "7.2.14",
+    "@kilocode/sdk": "7.2.14",
     "zod": "^4.3.5"
   }
 }

--- a/services/gastown/container/src/agent-runner.ts
+++ b/services/gastown/container/src/agent-runner.ts
@@ -4,6 +4,7 @@ import { writeFile } from 'node:fs/promises';
 import { cloneRepo, createWorktree, setupRigBrowseWorktree } from './git-manager';
 import { startAgent } from './process-manager';
 import { getCurrentTownConfig } from './control-server';
+import { log } from './logger';
 import type { ManagedAgent, StartAgentRequest } from './types';
 
 /**
@@ -471,6 +472,7 @@ export async function writeMayorSystemPromptToAgentsMd(
 export async function runAgent(originalRequest: StartAgentRequest): Promise<ManagedAgent> {
   let request = originalRequest;
   let workdir: string;
+  const t0 = Date.now();
 
   if (request.role === 'triage' || request.lightweight) {
     // Triage/lightweight agents are pure reasoning — no code changes, no git needed.
@@ -570,6 +572,12 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
 
     // Pre-flight: verify git credentials can authenticate against the remote.
     await verifyGitCredentials(workdir, request.gitUrl, envVars);
+
+    log.info('agent.startup_phase', {
+      agentId: request.agentId,
+      phase: 'git_done',
+      elapsedMs: Date.now() - t0,
+    });
   }
 
   const env = buildAgentEnv(request);

--- a/services/gastown/container/src/completion-reporter.ts
+++ b/services/gastown/container/src/completion-reporter.ts
@@ -1,8 +1,7 @@
 /**
- * Reports agent completion/failure back to the Rig DO via the Gastown
- * worker API. This closes the bead and unhooks the agent, preventing
- * the infinite retry loop where witnessPatrol resets the agent to idle
- * and schedulePendingWork re-dispatches it.
+ * Reports agent completion/failure back to the Gastown worker API.
+ * This closes the bead and unhooks the agent so the reconciler does not
+ * re-dispatch it.
  */
 
 import type { ManagedAgent } from './types';

--- a/services/gastown/container/src/control-server.ts
+++ b/services/gastown/container/src/control-server.ts
@@ -520,9 +520,9 @@ app.post('/repos/setup', async c => {
 
 // POST /git/merge
 // Deterministic merge of a polecat branch into the target branch.
-// Called by the Rig DO's processReviewQueue → startMergeInContainer.
-// Runs the merge synchronously and reports the result back to the Rig DO
-// via a callback to the completeReview endpoint.
+// Called by the TownDO's startMergeInContainer.
+// Runs the merge synchronously and reports the result back via a callback
+// to the completeReview endpoint.
 app.post('/git/merge', async c => {
   const body: unknown = await c.req.json().catch(() => null);
   const parsed = MergeRequest.safeParse(body);
@@ -588,7 +588,7 @@ app.post('/git/merge', async c => {
     }
   };
 
-  // Fire and forget — the Rig DO will time out stuck entries via recoverStuckReviews
+  // Fire and forget — the TownDO will time out stuck entries via its alarm loop
   doMerge().catch(err => {
     console.error(`Merge failed for entry ${req.entryId}:`, err);
   });

--- a/services/gastown/container/src/control-server.ts
+++ b/services/gastown/container/src/control-server.ts
@@ -49,7 +49,7 @@ let lastAppliedEnvVarKeys = new Set<string>();
 // Env keys managed by the control plane that custom env_vars must never override.
 // If a custom key collides with a reserved key, the infra value wins and the
 // custom value is silently ignored — matching the !(key in env) guard in buildAgentEnv.
-const RESERVED_ENV_KEYS = new Set([
+export const RESERVED_ENV_KEYS = new Set([
   'KILOCODE_TOKEN',
   'GIT_TOKEN',
   'GITHUB_TOKEN',
@@ -64,6 +64,10 @@ const RESERVED_ENV_KEYS = new Set([
   'GASTOWN_CONTAINER_TOKEN',
   'GASTOWN_SESSION_TOKEN',
   'GASTOWN_API_URL',
+  // Runtime routing vars read by pending-nudge routes and plugin clients —
+  // must never be overwritten by user-supplied env_vars.
+  'GASTOWN_TOWN_ID',
+  'GASTOWN_RIG_ID',
 ]);
 
 /** Get the latest town config delivered via X-Town-Config header. */

--- a/services/gastown/container/src/control-server.ts
+++ b/services/gastown/container/src/control-server.ts
@@ -43,9 +43,37 @@ const TownConfigHeader = z.record(z.string(), z.unknown());
 // Used as a fallback by code that runs outside a request context (e.g. background tasks).
 let lastKnownTownConfig: Record<string, unknown> | null = null;
 
+// Track which custom env var keys were applied last sync so removed keys can be cleared.
+let lastAppliedEnvVarKeys = new Set<string>();
+
+// Env keys managed by the control plane that custom env_vars must never override.
+// If a custom key collides with a reserved key, the infra value wins and the
+// custom value is silently ignored — matching the !(key in env) guard in buildAgentEnv.
+const RESERVED_ENV_KEYS = new Set([
+  'KILOCODE_TOKEN',
+  'GIT_TOKEN',
+  'GITHUB_TOKEN',
+  'GITLAB_TOKEN',
+  'GITLAB_INSTANCE_URL',
+  'GITHUB_CLI_PAT',
+  'GH_TOKEN',
+  'GASTOWN_GIT_AUTHOR_NAME',
+  'GASTOWN_GIT_AUTHOR_EMAIL',
+  'GASTOWN_DISABLE_AI_COAUTHOR',
+  'GASTOWN_ORGANIZATION_ID',
+  'GASTOWN_CONTAINER_TOKEN',
+  'GASTOWN_SESSION_TOKEN',
+  'GASTOWN_API_URL',
+]);
+
 /** Get the latest town config delivered via X-Town-Config header. */
 export function getCurrentTownConfig(): Record<string, unknown> | null {
   return lastKnownTownConfig;
+}
+
+/** Get the set of custom env var keys applied in the last sync. */
+export function getLastAppliedEnvVarKeys(): Set<string> {
+  return lastAppliedEnvVarKeys;
 }
 
 /**
@@ -102,6 +130,27 @@ function syncTownConfigToProcessEnv(): void {
   } else {
     delete process.env.GASTOWN_ORGANIZATION_ID;
   }
+
+  // Apply custom env_vars from the town config. Reserved infra keys are
+  // skipped so the control-plane values always take precedence — matching the
+  // !(key in env) guard in buildAgentEnv.
+  const rawEnvVars = cfg.env_vars;
+  const customEnvVars: Record<string, string> =
+    rawEnvVars !== null && typeof rawEnvVars === 'object' && !Array.isArray(rawEnvVars)
+      ? (rawEnvVars as Record<string, string>)
+      : {};
+  const newCustomKeys = new Set(Object.keys(customEnvVars));
+  // Remove keys that were present in the previous sync but are gone now.
+  // Skip reserved keys — deleting those would wipe a control-plane value.
+  for (const key of lastAppliedEnvVarKeys) {
+    if (!newCustomKeys.has(key) && !RESERVED_ENV_KEYS.has(key)) delete process.env[key];
+  }
+  // Apply current custom env vars, skipping reserved keys.
+  for (const [key, value] of Object.entries(customEnvVars)) {
+    if (RESERVED_ENV_KEYS.has(key)) continue;
+    process.env[key] = String(value);
+  }
+  lastAppliedEnvVarKeys = newCustomKeys;
 }
 
 export const app = new Hono();

--- a/services/gastown/container/src/control-server.ts
+++ b/services/gastown/container/src/control-server.ts
@@ -10,6 +10,7 @@ import {
   activeServerCount,
   getUptime,
   getStartTime,
+  getMayorReadyAt,
   stopAll,
   drainAll,
   isDraining,
@@ -221,6 +222,7 @@ app.get('/health', c => {
     uptime: getUptime(),
     draining: isDraining() || undefined,
     startedAt: getStartTime(),
+    mayorReadyAt: getMayorReadyAt() ?? undefined,
   };
   return c.json(response);
 });

--- a/services/gastown/container/src/control-server.ts
+++ b/services/gastown/container/src/control-server.ts
@@ -9,12 +9,14 @@ import {
   activeAgentCount,
   activeServerCount,
   getUptime,
+  getStartTime,
   stopAll,
   drainAll,
   isDraining,
   getAgentEvents,
   registerEventSink,
 } from './process-manager';
+import { log } from './logger';
 import { startHeartbeat, stopHeartbeat, notifyContainerReady } from './heartbeat';
 import { pushContext as pushDashboardContext } from './dashboard-context';
 import { mergeBranch, setupRigBrowseWorktree } from './git-manager';
@@ -218,6 +220,7 @@ app.get('/health', c => {
     servers: activeServerCount(),
     uptime: getUptime(),
     draining: isDraining() || undefined,
+    startedAt: getStartTime(),
   };
   return c.json(response);
 });
@@ -738,6 +741,15 @@ app.post('/agents/:agentId/pty', async c => {
         console.log(
           `[control-server] Reusing existing PTY session ${running.id} for agent ${agentId}`
         );
+        const reuseAgent = getAgentStatus(agentId);
+        if (reuseAgent) {
+          log.info('agent.pty_connected', {
+            agentId,
+            containerUptimeMs: getUptime(),
+            agentUptimeMs: Date.now() - new Date(reuseAgent.startedAt).getTime(),
+            reused: true,
+          });
+        }
         return c.json(running);
       }
     }
@@ -790,6 +802,14 @@ app.post('/agents/:agentId/pty', async c => {
   console.log(
     `[control-server] Created new PTY session for agent ${agentId}: ${data.slice(0, 200)}`
   );
+  if (createResp.ok) {
+    log.info('agent.pty_connected', {
+      agentId,
+      containerUptimeMs: getUptime(),
+      agentUptimeMs: Date.now() - new Date(agent.startedAt).getTime(),
+      reused: false,
+    });
+  }
   return new Response(data, {
     status: createResp.status,
     headers: { 'Content-Type': 'application/json' },

--- a/services/gastown/container/src/main.ts
+++ b/services/gastown/container/src/main.ts
@@ -1,8 +1,8 @@
 import { startControlServer } from './control-server';
 import { log } from './logger';
-import { bootHydration } from './process-manager';
+import { bootHydration, getUptime } from './process-manager';
 
-log.info('container.cold_start', { uptime: 0, ts: new Date().toISOString() });
+log.info('container.cold_start', { uptime: getUptime(), ts: new Date().toISOString() });
 
 process.on('uncaughtException', err => {
   log.error('container.uncaught_exception', { error: err.message, stack: err.stack });

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -12,7 +12,11 @@ import * as fs from 'node:fs/promises';
 import type { ManagedAgent, StartAgentRequest } from './types';
 import { reportAgentCompleted, reportMayorWaiting } from './completion-reporter';
 import { buildKiloConfigContent } from './agent-runner';
-import { getCurrentTownConfig, getLastAppliedEnvVarKeys, RESERVED_ENV_KEYS } from './control-server';
+import {
+  getCurrentTownConfig,
+  getLastAppliedEnvVarKeys,
+  RESERVED_ENV_KEYS,
+} from './control-server';
 import { log } from './logger';
 
 const MANAGER_LOG = '[process-manager]';
@@ -1279,7 +1283,7 @@ export async function updateAgentModel(
       if (RESERVED_ENV_KEYS.has(key)) continue;
       freshCustomKeySet.add(key);
       if (value !== undefined && value !== null) {
-        hotSwapEnv[key] = String(value);
+        hotSwapEnv[key] = typeof value === 'string' ? value : JSON.stringify(value);
       } else {
         delete hotSwapEnv[key];
       }

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -78,6 +78,26 @@ export function getStartTime(): string {
   return new Date(startTime).toISOString();
 }
 
+// Timestamp (ISO 8601) of the moment the first mayor agent in this container
+// reached 'running' status. Used by /health so the Town DO can compute
+// container-start-to-mayor-ready latency. Stays null until a mayor is up;
+// survives subsequent mayor exits since the window is measured against the
+// first mayor ready in the container's lifetime.
+let mayorReadyAt: string | null = null;
+
+export function getMayorReadyAt(): string | null {
+  return mayorReadyAt;
+}
+
+function markMayorReadyOnce(): void {
+  if (mayorReadyAt !== null) return;
+  mayorReadyAt = new Date().toISOString();
+  log.info('mayor.ready', {
+    containerUptimeMs: getUptime(),
+    mayorReadyAt,
+  });
+}
+
 async function hydrateDbFromSnapshot(
   agentId: string,
   apiUrl: string,
@@ -1044,6 +1064,9 @@ export async function startAgent(
     // despite being active — causing the drain to wait indefinitely.
     if (agent.status === 'starting') {
       agent.status = 'running';
+      if (request.role === 'mayor') {
+        markMayorReadyOnce();
+      }
     }
 
     // 4. Send the initial prompt

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -74,6 +74,10 @@ export function getUptime(): number {
   return Date.now() - startTime;
 }
 
+export function getStartTime(): string {
+  return new Date(startTime).toISOString();
+}
+
 async function hydrateDbFromSnapshot(
   agentId: string,
   apiUrl: string,
@@ -943,6 +947,7 @@ export async function startAgent(
 
   const { signal } = startupAbortController;
   let sessionCounted = false;
+  const t0 = Date.now();
   try {
     // 0. Hydrate agent DB from KV snapshot before starting the SDK server
     const apiUrl = agent.gastownApiUrl;
@@ -950,10 +955,23 @@ export async function startAgent(
     if (apiUrl && token) {
       await hydrateDbFromSnapshot(request.agentId, apiUrl, token, request.rigId, request.townId);
     }
+    const tDbDone = Date.now();
+    log.info('agent.startup_phase', {
+      agentId: request.agentId,
+      phase: 'db_hydrated',
+      elapsedMs: tDbDone - t0,
+    });
 
     // 1. Ensure SDK server is running for this workdir
     const { client, port } = await ensureSDKServer(workdir, env);
     agent.serverPort = port;
+    const tSdkDone = Date.now();
+    log.info('agent.startup_phase', {
+      agentId: request.agentId,
+      phase: 'sdk_ready',
+      elapsedMs: tSdkDone - t0,
+      phaseMs: tSdkDone - tDbDone,
+    });
 
     // Check if startup was cancelled while waiting for the SDK server
     if (signal.aborted) {
@@ -1001,6 +1019,14 @@ export async function startAgent(
       );
     }
     agent.sessionId = sessionId;
+    const tSessionDone = Date.now();
+    log.info('agent.startup_phase', {
+      agentId: request.agentId,
+      phase: 'session_created',
+      elapsedMs: tSessionDone - t0,
+      phaseMs: tSessionDone - tSdkDone,
+      resumed,
+    });
 
     // Now check if startup was cancelled while creating the session.
     // agent.sessionId is already set, so the catch block will abort it.
@@ -1066,6 +1092,12 @@ export async function startAgent(
       name: request.name,
       sessionId,
       port,
+    });
+
+    log.info('agent.startup_complete', {
+      agentId: request.agentId,
+      totalMs: Date.now() - t0,
+      containerUptimeMs: getUptime(),
     });
 
     syncRegistry();

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -12,6 +12,7 @@ import * as fs from 'node:fs/promises';
 import type { ManagedAgent, StartAgentRequest } from './types';
 import { reportAgentCompleted, reportMayorWaiting } from './completion-reporter';
 import { buildKiloConfigContent } from './agent-runner';
+import { getCurrentTownConfig, getLastAppliedEnvVarKeys } from './control-server';
 import { log } from './logger';
 
 const MANAGER_LOG = '[process-manager]';
@@ -1262,6 +1263,33 @@ export async function updateAgentModel(
     if (key in hotSwapEnv) continue;
     const live = process.env[key];
     if (live) hotSwapEnv[key] = live;
+  }
+
+  // Overlay custom env_vars from the town config so hot-swap picks up
+  // values that were added/changed after the initial dispatch. Infra
+  // keys in LIVE_ENV_KEYS always take precedence (they were already
+  // populated from process.env above), so custom vars cannot override.
+  const freshConfig = getCurrentTownConfig();
+  const freshEnvVars = freshConfig?.env_vars;
+  const freshCustomKeySet = new Set<string>();
+  if (freshEnvVars !== null && typeof freshEnvVars === 'object' && !Array.isArray(freshEnvVars)) {
+    for (const [key, value] of Object.entries(freshEnvVars as Record<string, unknown>)) {
+      if (LIVE_ENV_KEYS.has(key)) continue;
+      freshCustomKeySet.add(key);
+      if (value !== undefined && value !== null) {
+        hotSwapEnv[key] = String(value);
+      } else {
+        delete hotSwapEnv[key];
+      }
+    }
+  }
+  // Remove stale custom env vars — keys that were applied in a previous
+  // sync but are no longer in the town config. Without this, startupEnv
+  // keeps carrying deleted custom keys through every hot-swap.
+  for (const key of getLastAppliedEnvVarKeys()) {
+    if (!freshCustomKeySet.has(key) && !LIVE_ENV_KEYS.has(key)) {
+      delete hotSwapEnv[key];
+    }
   }
 
   // Re-derive GH_TOKEN from live values using the same priority chain

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -113,6 +113,108 @@ async function hydrateDbFromSnapshot(
   }
 }
 
+async function deleteLocalDb(agentId: string): Promise<void> {
+  const dir = `/tmp/agent-home-${agentId}/.local/share/kilo`;
+  for (const suffix of ['kilo.db', 'kilo.db-wal', 'kilo.db-shm']) {
+    try {
+      await fs.unlink(`${dir}/${suffix}`);
+    } catch {
+      // File may not exist — that's fine.
+    }
+  }
+  console.log(`${MANAGER_LOG} Deleted local kilo.db for agent ${agentId}`);
+}
+
+async function deleteRemoteDbSnapshot(
+  agentId: string,
+  apiUrl: string,
+  token: string,
+  rigId: string,
+  townId: string
+): Promise<void> {
+  try {
+    const resp = await fetch(
+      `${apiUrl}/api/towns/${townId}/rigs/${rigId}/agents/${agentId}/db-snapshot`,
+      { method: 'DELETE', headers: { Authorization: `Bearer ${token}` } }
+    );
+    if (resp.ok) {
+      console.log(`${MANAGER_LOG} Deleted remote DB snapshot for agent ${agentId}`);
+    } else {
+      console.warn(
+        `${MANAGER_LOG} Failed to delete remote DB snapshot for ${agentId}: ${resp.status}`
+      );
+    }
+  } catch (err) {
+    console.warn(`${MANAGER_LOG} deleteRemoteDbSnapshot failed for ${agentId}:`, err);
+  }
+}
+
+/**
+ * Try session.create; if it fails (e.g. stale kilo.db from an older CLI
+ * version whose schema is incompatible), delete the local DB, tear down
+ * the SDK server, restart it fresh, and retry once.
+ */
+async function createSessionWithStaleDbFallback(
+  client: KiloClient,
+  workdir: string,
+  env: Record<string, string>,
+  agentId: string,
+  agent: ManagedAgent
+): Promise<string> {
+  const sessionResult = await client.session.create({ body: {} });
+  const rawSession: unknown = sessionResult.data ?? sessionResult;
+  const parsed = SessionResponse.safeParse(rawSession);
+  if (parsed.success) {
+    console.log(`${MANAGER_LOG} Created new session ${parsed.data.id}`);
+    return parsed.data.id;
+  }
+
+  // session.create failed — likely a stale kilo.db migration error.
+  const rawStr = JSON.stringify(rawSession).slice(0, 300);
+  console.warn(
+    `${MANAGER_LOG} session.create failed for ${agentId}, attempting stale DB recovery. Response: ${rawStr}`
+  );
+
+  // 1. Delete local kilo.db so the CLI starts with a fresh schema.
+  await deleteLocalDb(agentId);
+
+  // 2. Tear down the SDK server so ensureSDKServer creates a new one.
+  const instance = sdkInstances.get(workdir);
+  if (instance) {
+    instance.server.close();
+    sdkInstances.delete(workdir);
+  }
+
+  // 3. Delete the stale KV snapshot (fire-and-forget) so future container
+  //    restarts don't re-hydrate the broken DB.
+  const apiUrl = agent.gastownApiUrl;
+  const token = agent.gastownContainerToken ?? process.env.GASTOWN_CONTAINER_TOKEN ?? null;
+  if (apiUrl && token) {
+    void deleteRemoteDbSnapshot(agentId, apiUrl, token, agent.rigId, agent.townId);
+  }
+
+  // 4. Restart SDK server and retry session.create.
+  const { client: freshClient, port } = await ensureSDKServer(workdir, env);
+  agent.serverPort = port;
+
+  const retryResult = await freshClient.session.create({ body: {} });
+  const retryRaw: unknown = retryResult.data ?? retryResult;
+  const retryParsed = SessionResponse.safeParse(retryRaw);
+  if (!retryParsed.success) {
+    console.error(
+      `${MANAGER_LOG} session.create still failing after DB reset:`,
+      JSON.stringify(retryRaw).slice(0, 200),
+      retryParsed.error.issues
+    );
+    throw new Error('SDK session.create failed even after stale DB recovery');
+  }
+
+  console.log(
+    `${MANAGER_LOG} Stale DB recovery succeeded for ${agentId}, new session ${retryParsed.data.id}`
+  );
+  return retryParsed.data.id;
+}
+
 async function saveDbSnapshot(
   agentId: string,
   apiUrl: string,
@@ -890,19 +992,13 @@ export async function startAgent(
       }
     }
     if (!resumed) {
-      const sessionResult = await client.session.create({ body: {} });
-      const rawSession: unknown = sessionResult.data ?? sessionResult;
-      const parsed = SessionResponse.safeParse(rawSession);
-      if (!parsed.success) {
-        console.error(
-          `${MANAGER_LOG} SDK session.create returned unexpected shape:`,
-          JSON.stringify(rawSession).slice(0, 200),
-          parsed.error.issues
-        );
-        throw new Error('SDK session.create response missing required "id" field');
-      }
-      sessionId = parsed.data.id;
-      console.log(`${MANAGER_LOG} Created new session ${sessionId}`);
+      sessionId = await createSessionWithStaleDbFallback(
+        client,
+        workdir,
+        env,
+        request.agentId,
+        agent
+      );
     }
     agent.sessionId = sessionId;
 
@@ -1338,13 +1434,13 @@ export async function updateAgentModel(
       }
     }
     if (!resumedSession) {
-      const sessionResult = await client.session.create({ body: {} });
-      const rawSession: unknown = sessionResult.data ?? sessionResult;
-      const parsed = SessionResponse.safeParse(rawSession);
-      if (!parsed.success) {
-        throw new Error('SDK session.create response missing required "id" field');
-      }
-      newSessionId = parsed.data.id;
+      newSessionId = await createSessionWithStaleDbFallback(
+        client,
+        agent.workdir,
+        hotSwapEnv,
+        agentId,
+        agent
+      );
     }
     agent.sessionId = newSessionId;
 

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -12,7 +12,7 @@ import * as fs from 'node:fs/promises';
 import type { ManagedAgent, StartAgentRequest } from './types';
 import { reportAgentCompleted, reportMayorWaiting } from './completion-reporter';
 import { buildKiloConfigContent } from './agent-runner';
-import { getCurrentTownConfig, getLastAppliedEnvVarKeys } from './control-server';
+import { getCurrentTownConfig, getLastAppliedEnvVarKeys, RESERVED_ENV_KEYS } from './control-server';
 import { log } from './logger';
 
 const MANAGER_LOG = '[process-manager]';
@@ -1267,14 +1267,16 @@ export async function updateAgentModel(
 
   // Overlay custom env_vars from the town config so hot-swap picks up
   // values that were added/changed after the initial dispatch. Infra
-  // keys in LIVE_ENV_KEYS always take precedence (they were already
-  // populated from process.env above), so custom vars cannot override.
+  // keys in LIVE_ENV_KEYS and RESERVED_ENV_KEYS always take precedence
+  // (LIVE_ENV_KEYS were already populated from process.env above;
+  // RESERVED_ENV_KEYS are runtime routing vars that must never be clobbered).
   const freshConfig = getCurrentTownConfig();
   const freshEnvVars = freshConfig?.env_vars;
   const freshCustomKeySet = new Set<string>();
   if (freshEnvVars !== null && typeof freshEnvVars === 'object' && !Array.isArray(freshEnvVars)) {
     for (const [key, value] of Object.entries(freshEnvVars as Record<string, unknown>)) {
       if (LIVE_ENV_KEYS.has(key)) continue;
+      if (RESERVED_ENV_KEYS.has(key)) continue;
       freshCustomKeySet.add(key);
       if (value !== undefined && value !== null) {
         hotSwapEnv[key] = String(value);

--- a/services/gastown/container/src/types.ts
+++ b/services/gastown/container/src/types.ts
@@ -164,6 +164,7 @@ export type HealthResponse = {
   servers: number;
   uptime: number;
   draining?: boolean;
+  startedAt?: string;
 };
 
 // ── Kilo serve instance ─────────────────────────────────────────────────

--- a/services/gastown/container/src/types.ts
+++ b/services/gastown/container/src/types.ts
@@ -165,6 +165,10 @@ export type HealthResponse = {
   uptime: number;
   draining?: boolean;
   startedAt?: string;
+  /** ISO 8601 timestamp of the first mayor agent reaching 'running' status
+   *  in this container's lifetime. Used by the worker to measure container
+   *  cold-start → mayor-session-ready latency. */
+  mayorReadyAt?: string;
 };
 
 // ── Kilo serve instance ─────────────────────────────────────────────────

--- a/services/gastown/gastown-grafana-dash-1.json
+++ b/services/gastown/gastown-grafana-dash-1.json
@@ -3173,6 +3173,833 @@
       ],
       "title": "Pending Event Queue Depth",
       "type": "gauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 129
+      },
+      "id": 300,
+      "panels": [],
+      "title": "Container Startup Latency",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "bffxugc31cnpcc"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "red",
+                "value": 2000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 130
+      },
+      "id": 303,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "table",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok'",
+          "rawSql": "SELECT SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok'",
+          "refId": "A",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        }
+      ],
+      "timeFrom": "1h",
+      "title": "Avg Health Ping (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "bffxugc31cnpcc"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1000
+              },
+              {
+                "color": "red",
+                "value": 5000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 130
+      },
+      "id": 304,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "table",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true'",
+          "rawSql": "SELECT SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true'",
+          "refId": "A",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        }
+      ],
+      "timeFrom": "1h",
+      "title": "Avg Agent Start Fetch (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "bffxugc31cnpcc"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "timeout_rate"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 134
+      },
+      "id": 301,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, 'p50' AS label, quantileWeighted(0.50)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'p50' AS label, quantileWeighted(0.50)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok' GROUP BY t ORDER BY t",
+          "refId": "A",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        },
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, 'p90' AS label, quantileWeighted(0.90)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'p90' AS label, quantileWeighted(0.90)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok' GROUP BY t ORDER BY t",
+          "refId": "B",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        },
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, 'p99' AS label, quantileWeighted(0.99)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'p99' AS label, quantileWeighted(0.99)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok' GROUP BY t ORDER BY t",
+          "refId": "C",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        },
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, 'timeout_rate' AS label, SUM(IF(blob8 = 'timeout', _sample_interval, 0)) / SUM(_sample_interval) AS timeout_rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'timeout_rate' AS label, SUM(IF(blob8 = 'timeout', _sample_interval, 0)) / SUM(_sample_interval) AS timeout_rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' GROUP BY t ORDER BY t",
+          "refId": "D",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        }
+      ],
+      "title": "Container Health Ping Latency (cold-start indicator)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "bffxugc31cnpcc"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failure_rate"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 134
+      },
+      "id": 302,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, 'p50' AS label, quantileWeighted(0.50)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'p50' AS label, quantileWeighted(0.50)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true' GROUP BY t ORDER BY t",
+          "refId": "A",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        },
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, 'p90' AS label, quantileWeighted(0.90)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'p90' AS label, quantileWeighted(0.90)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true' GROUP BY t ORDER BY t",
+          "refId": "B",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        },
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, 'p99' AS label, quantileWeighted(0.99)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'p99' AS label, quantileWeighted(0.99)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true' GROUP BY t ORDER BY t",
+          "refId": "C",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        },
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, 'failure_rate' AS label, SUM(IF(blob9 = 'false', _sample_interval, 0)) / SUM(_sample_interval) AS failure_rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'failure_rate' AS label, SUM(IF(blob9 = 'false', _sample_interval, 0)) / SUM(_sample_interval) AS failure_rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' GROUP BY t ORDER BY t",
+          "refId": "D",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        }
+      ],
+      "title": "Container Agent Start Latency (Town DO \u2192 container.fetch('/agents/start') round-trip)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "bffxugc31cnpcc"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 142
+      },
+      "id": 305,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, 'timeout_rate' AS label, SUM(IF(blob8 = 'timeout', _sample_interval, 0)) / SUM(_sample_interval) AS rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'timeout_rate' AS label, SUM(IF(blob8 = 'timeout', _sample_interval, 0)) / SUM(_sample_interval) AS rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' GROUP BY t ORDER BY t",
+          "refId": "A",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        }
+      ],
+      "title": "Health Ping Timeout Rate (container cold-start frequency)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "bffxugc31cnpcc"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 0,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failure"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 142
+      },
+      "id": 306,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, IF(blob9 = 'true', 'success', 'failure') AS label, SUM(_sample_interval) AS count FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' GROUP BY t, label ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, IF(blob9 = 'true', 'success', 'failure') AS label, SUM(_sample_interval) AS count FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' GROUP BY t, label ORDER BY t",
+          "refId": "A",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        }
+      ],
+      "title": "Agent Start Attempts (success / failure)",
+      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/services/gastown/gastown-grafana-dash-1.json
+++ b/services/gastown/gastown-grafana-dash-1.json
@@ -3184,7 +3184,7 @@
       },
       "id": 300,
       "panels": [],
-      "title": "Container Startup Latency",
+      "title": "DO → Container RPC Latency",
       "type": "row"
     },
     {
@@ -3256,8 +3256,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok'",
-          "rawSql": "SELECT SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok'",
+          "query": "SELECT SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob5 = ''",
+          "rawSql": "SELECT SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob5 = ''",
           "refId": "A",
           "round": "0s",
           "showFormattedSQL": false,
@@ -3268,7 +3268,7 @@
         }
       ],
       "timeFrom": "1h",
-      "title": "Avg Health Ping (1h)",
+      "title": "Avg /health RPC (1h)",
       "type": "stat"
     },
     {
@@ -3340,8 +3340,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true'",
-          "rawSql": "SELECT SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true'",
+          "query": "SELECT SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob5 = ''",
+          "rawSql": "SELECT SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob5 = ''",
           "refId": "A",
           "round": "0s",
           "showFormattedSQL": false,
@@ -3352,7 +3352,7 @@
         }
       ],
       "timeFrom": "1h",
-      "title": "Avg Agent Start Fetch (1h)",
+      "title": "Avg /agents/start RPC (1h)",
       "type": "stat"
     },
     {
@@ -3473,8 +3473,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT $timeSeries AS t, 'p50' AS label, quantileWeighted(0.50)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok' GROUP BY t ORDER BY t",
-          "rawSql": "SELECT $timeSeries AS t, 'p50' AS label, quantileWeighted(0.50)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok' GROUP BY t ORDER BY t",
+          "query": "SELECT $timeSeries AS t, quantileWeighted(0.50)(double1, _sample_interval) AS p50 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob5 = '' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, quantileWeighted(0.50)(double1, _sample_interval) AS p50 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob5 = '' GROUP BY t ORDER BY t",
           "refId": "A",
           "round": "0s",
           "showFormattedSQL": false,
@@ -3496,8 +3496,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT $timeSeries AS t, 'p90' AS label, quantileWeighted(0.90)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok' GROUP BY t ORDER BY t",
-          "rawSql": "SELECT $timeSeries AS t, 'p90' AS label, quantileWeighted(0.90)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok' GROUP BY t ORDER BY t",
+          "query": "SELECT $timeSeries AS t, quantileWeighted(0.90)(double1, _sample_interval) AS p90 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob5 = '' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, quantileWeighted(0.90)(double1, _sample_interval) AS p90 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob5 = '' GROUP BY t ORDER BY t",
           "refId": "B",
           "round": "0s",
           "showFormattedSQL": false,
@@ -3519,8 +3519,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT $timeSeries AS t, 'p99' AS label, quantileWeighted(0.99)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok' GROUP BY t ORDER BY t",
-          "rawSql": "SELECT $timeSeries AS t, 'p99' AS label, quantileWeighted(0.99)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob8 = 'ok' GROUP BY t ORDER BY t",
+          "query": "SELECT $timeSeries AS t, quantileWeighted(0.99)(double1, _sample_interval) AS p99 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob5 = '' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, quantileWeighted(0.99)(double1, _sample_interval) AS p99 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' AND blob5 = '' GROUP BY t ORDER BY t",
           "refId": "C",
           "round": "0s",
           "showFormattedSQL": false,
@@ -3542,8 +3542,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT $timeSeries AS t, 'timeout_rate' AS label, SUM(IF(blob8 = 'timeout', _sample_interval, 0)) / SUM(_sample_interval) AS timeout_rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' GROUP BY t ORDER BY t",
-          "rawSql": "SELECT $timeSeries AS t, 'timeout_rate' AS label, SUM(IF(blob8 = 'timeout', _sample_interval, 0)) / SUM(_sample_interval) AS timeout_rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' GROUP BY t ORDER BY t",
+          "query": "SELECT $timeSeries AS t, 'timeout_rate' AS label, SUM(IF(blob5 != '', _sample_interval, 0)) / SUM(_sample_interval) AS timeout_rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'timeout_rate' AS label, SUM(IF(blob5 != '', _sample_interval, 0)) / SUM(_sample_interval) AS timeout_rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' GROUP BY t ORDER BY t",
           "refId": "D",
           "round": "0s",
           "showFormattedSQL": false,
@@ -3553,7 +3553,7 @@
           "useWindowFuncForMacros": true
         }
       ],
-      "title": "Container Health Ping Latency (cold-start indicator)",
+      "title": "/health RPC Latency (DO → container round-trip)",
       "type": "timeseries"
     },
     {
@@ -3674,8 +3674,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT $timeSeries AS t, 'p50' AS label, quantileWeighted(0.50)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true' GROUP BY t ORDER BY t",
-          "rawSql": "SELECT $timeSeries AS t, 'p50' AS label, quantileWeighted(0.50)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true' GROUP BY t ORDER BY t",
+          "query": "SELECT $timeSeries AS t, quantileWeighted(0.50)(double1, _sample_interval) AS p50 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob5 = '' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, quantileWeighted(0.50)(double1, _sample_interval) AS p50 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob5 = '' GROUP BY t ORDER BY t",
           "refId": "A",
           "round": "0s",
           "showFormattedSQL": false,
@@ -3697,8 +3697,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT $timeSeries AS t, 'p90' AS label, quantileWeighted(0.90)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true' GROUP BY t ORDER BY t",
-          "rawSql": "SELECT $timeSeries AS t, 'p90' AS label, quantileWeighted(0.90)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true' GROUP BY t ORDER BY t",
+          "query": "SELECT $timeSeries AS t, quantileWeighted(0.90)(double1, _sample_interval) AS p90 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob5 = '' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, quantileWeighted(0.90)(double1, _sample_interval) AS p90 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob5 = '' GROUP BY t ORDER BY t",
           "refId": "B",
           "round": "0s",
           "showFormattedSQL": false,
@@ -3720,8 +3720,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT $timeSeries AS t, 'p99' AS label, quantileWeighted(0.99)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true' GROUP BY t ORDER BY t",
-          "rawSql": "SELECT $timeSeries AS t, 'p99' AS label, quantileWeighted(0.99)(double1, _sample_interval) AS latency_ms FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob9 = 'true' GROUP BY t ORDER BY t",
+          "query": "SELECT $timeSeries AS t, quantileWeighted(0.99)(double1, _sample_interval) AS p99 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob5 = '' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, quantileWeighted(0.99)(double1, _sample_interval) AS p99 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' AND blob5 = '' GROUP BY t ORDER BY t",
           "refId": "C",
           "round": "0s",
           "showFormattedSQL": false,
@@ -3743,8 +3743,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT $timeSeries AS t, 'failure_rate' AS label, SUM(IF(blob9 = 'false', _sample_interval, 0)) / SUM(_sample_interval) AS failure_rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' GROUP BY t ORDER BY t",
-          "rawSql": "SELECT $timeSeries AS t, 'failure_rate' AS label, SUM(IF(blob9 = 'false', _sample_interval, 0)) / SUM(_sample_interval) AS failure_rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' GROUP BY t ORDER BY t",
+          "query": "SELECT $timeSeries AS t, 'failure_rate' AS label, SUM(IF(blob5 != '', _sample_interval, 0)) / SUM(_sample_interval) AS failure_rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'failure_rate' AS label, SUM(IF(blob5 != '', _sample_interval, 0)) / SUM(_sample_interval) AS failure_rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' GROUP BY t ORDER BY t",
           "refId": "D",
           "round": "0s",
           "showFormattedSQL": false,
@@ -3754,7 +3754,7 @@
           "useWindowFuncForMacros": true
         }
       ],
-      "title": "Container Agent Start Latency (Town DO \u2192 container.fetch('/agents/start') round-trip)",
+      "title": "Container Agent Start Latency (Town DO → container.fetch('/agents/start') round-trip)",
       "type": "timeseries"
     },
     {
@@ -3850,8 +3850,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT $timeSeries AS t, 'timeout_rate' AS label, SUM(IF(blob8 = 'timeout', _sample_interval, 0)) / SUM(_sample_interval) AS rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' GROUP BY t ORDER BY t",
-          "rawSql": "SELECT $timeSeries AS t, 'timeout_rate' AS label, SUM(IF(blob8 = 'timeout', _sample_interval, 0)) / SUM(_sample_interval) AS rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' GROUP BY t ORDER BY t",
+          "query": "SELECT $timeSeries AS t, 'timeout_rate' AS label, SUM(IF(blob5 != '', _sample_interval, 0)) / SUM(_sample_interval) AS rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'timeout_rate' AS label, SUM(IF(blob5 != '', _sample_interval, 0)) / SUM(_sample_interval) AS rate FROM gastown_events WHERE $timeFilter AND blob1 = 'container.health_ping' GROUP BY t ORDER BY t",
           "refId": "A",
           "round": "0s",
           "showFormattedSQL": false,
@@ -3861,7 +3861,7 @@
           "useWindowFuncForMacros": true
         }
       ],
-      "title": "Health Ping Timeout Rate (container cold-start frequency)",
+      "title": "/health RPC Failure Rate",
       "type": "timeseries"
     },
     {
@@ -3987,8 +3987,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT $timeSeries AS t, IF(blob9 = 'true', 'success', 'failure') AS label, SUM(_sample_interval) AS count FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' GROUP BY t, label ORDER BY t",
-          "rawSql": "SELECT $timeSeries AS t, IF(blob9 = 'true', 'success', 'failure') AS label, SUM(_sample_interval) AS count FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' GROUP BY t, label ORDER BY t",
+          "query": "SELECT $timeSeries AS t, IF(blob5 = '', 'success', 'failure') AS label, SUM(_sample_interval) AS count FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' GROUP BY t, label ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, IF(blob5 = '', 'success', 'failure') AS label, SUM(_sample_interval) AS count FROM gastown_events WHERE $timeFilter AND blob1 = 'container.agent_start_fetch' GROUP BY t, label ORDER BY t",
           "refId": "A",
           "round": "0s",
           "showFormattedSQL": false,
@@ -3998,7 +3998,326 @@
           "useWindowFuncForMacros": true
         }
       ],
-      "title": "Agent Start Attempts (success / failure)",
+      "title": "/agents/start Attempts (success / failure)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 150
+      },
+      "id": 400,
+      "panels": [],
+      "title": "Container Cold Start & Mayor Ready",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "bffxugc31cnpcc"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 151
+      },
+      "id": 401,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, quantileWeighted(0.50)(double1, _sample_interval) AS p50 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.cold_start' AND blob5 = '' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, quantileWeighted(0.50)(double1, _sample_interval) AS p50 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.cold_start' AND blob5 = '' GROUP BY t ORDER BY t",
+          "refId": "A",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        },
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, quantileWeighted(0.90)(double1, _sample_interval) AS p90 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.cold_start' AND blob5 = '' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, quantileWeighted(0.90)(double1, _sample_interval) AS p90 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.cold_start' AND blob5 = '' GROUP BY t ORDER BY t",
+          "refId": "B",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        },
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, quantileWeighted(0.99)(double1, _sample_interval) AS p99 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.cold_start' AND blob5 = '' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, quantileWeighted(0.99)(double1, _sample_interval) AS p99 FROM gastown_events WHERE $timeFilter AND blob1 = 'container.cold_start' AND blob5 = '' GROUP BY t ORDER BY t",
+          "refId": "C",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        }
+      ],
+      "title": "Container Cold Start Latency (startAndWaitForPorts, p50/p90/p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "bffxugc31cnpcc"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 151
+      },
+      "id": 402,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, quantileWeighted(0.50)(double1, _sample_interval) AS p50 FROM gastown_events WHERE $timeFilter AND blob1 = 'mayor.session_ready' AND blob5 = '' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, quantileWeighted(0.50)(double1, _sample_interval) AS p50 FROM gastown_events WHERE $timeFilter AND blob1 = 'mayor.session_ready' AND blob5 = '' GROUP BY t ORDER BY t",
+          "refId": "A",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        },
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, quantileWeighted(0.90)(double1, _sample_interval) AS p90 FROM gastown_events WHERE $timeFilter AND blob1 = 'mayor.session_ready' AND blob5 = '' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, quantileWeighted(0.90)(double1, _sample_interval) AS p90 FROM gastown_events WHERE $timeFilter AND blob1 = 'mayor.session_ready' AND blob5 = '' GROUP BY t ORDER BY t",
+          "refId": "B",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        },
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": true,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, quantileWeighted(0.99)(double1, _sample_interval) AS p99 FROM gastown_events WHERE $timeFilter AND blob1 = 'mayor.session_ready' AND blob5 = '' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, quantileWeighted(0.99)(double1, _sample_interval) AS p99 FROM gastown_events WHERE $timeFilter AND blob1 = 'mayor.session_ready' AND blob5 = '' GROUP BY t ORDER BY t",
+          "refId": "C",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "gastown_events",
+          "useWindowFuncForMacros": true
+        }
+      ],
+      "title": "Mayor Session Ready (container start → mayor running, p50/p90/p99)",
       "type": "timeseries"
     }
   ],

--- a/services/gastown/src/db/tables/town-events.table.ts
+++ b/services/gastown/src/db/tables/town-events.table.ts
@@ -13,6 +13,7 @@ export const TownEventType = z.enum([
   'nudge_timeout',
   'pr_feedback_detected',
   'pr_auto_merge',
+  'pr_conflict_detected',
 ]);
 
 export type TownEventType = z.output<typeof TownEventType>;

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -1670,14 +1670,6 @@ export class TownDO extends DurableObject<Env> {
     await this.escalateToActiveCadence();
   }
 
-  async popReviewQueue(): Promise<ReviewQueueEntry | null> {
-    return reviewQueue.popReviewQueue(this.sql);
-  }
-
-  async completeReview(entryId: string, status: 'merged' | 'failed'): Promise<void> {
-    reviewQueue.completeReview(this.sql, entryId, status);
-  }
-
   async completeReviewWithResult(input: {
     entry_id: string;
     status: 'merged' | 'failed' | 'conflict';
@@ -1712,10 +1704,9 @@ export class TownDO extends DurableObject<Env> {
       });
     }
 
-    // Rework is handled by the normal scheduling path: the failed/conflict
+    // Rework is handled by the reconciler's scheduling path: the failed/conflict
     // path in completeReviewWithResult sets the source bead to 'open' with
-    // assignee cleared. feedStrandedConvoys or rehookOrphanedBeads will
-    // hook a polecat, and schedulePendingWork will dispatch it.
+    // assignee cleared. The reconciler will hook a polecat and dispatch it.
   }
 
   async agentDone(agentId: string, input: AgentDoneInput): Promise<void> {
@@ -3558,9 +3549,9 @@ export class TownDO extends DurableObject<Env> {
     }
 
     // ── Pre-phase: Observe container status for working agents ────────
-    // Replaces witnessPatrol's zombie detection. Poll the container for
-    // each working/stalled agent and emit container_status events. These
-    // are drained in Phase 0 and applied before reconciliation.
+    // Poll the container for each working/stalled agent and emit
+    // container_status events. These are drained in Phase 0 and applied
+    // before reconciliation.
     try {
       const workingAgentRows = z
         .object({ bead_id: z.string() })
@@ -4487,8 +4478,8 @@ export class TownDO extends DurableObject<Env> {
 
     // Only count idle+hooked agents as orphaned if they've been idle for
     // longer than the dispatch cooldown. Agents that were just hooked by
-    // feedStrandedConvoys or restarted with backoff are legitimately
-    // waiting for the next scheduler tick.
+    // the reconciler or restarted with backoff are legitimately waiting
+    // for the next scheduler tick.
     const orphanedHooks = Number(
       [
         ...query(

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -343,6 +343,17 @@ export class TownDO extends DurableObject<Env> {
           });
         }
 
+        // Option B (defense-in-depth): If the reconciler re-dispatches an
+        // open triage batch bead (gt:triage, created_by='patrol') — e.g.
+        // because Option A's in_progress transition was somehow bypassed —
+        // inject the triage system prompt so the polecat gets the correct
+        // tools and instructions instead of the generic polecat prompt.
+        if (bead.labels.includes(patrol.TRIAGE_BATCH_LABEL) && bead.created_by === 'patrol') {
+          const pendingRequests = patrol.listPendingTriageRequests(this.sql);
+          const { buildTriageSystemPrompt } = await import('../prompts/triage-system.prompt');
+          systemPromptOverride = buildTriageSystemPrompt(pendingRequests);
+        }
+
         return scheduling.dispatchAgent(schedulingCtx, agent, bead, {
           systemPromptOverride,
         });
@@ -4055,6 +4066,9 @@ export class TownDO extends DurableObject<Env> {
     const systemPrompt = buildTriageSystemPrompt(pendingRequests);
 
     // Only now create the synthetic bead — preconditions are verified.
+    // Set rig_id so that if Rule 3 resets this bead to 'open' after a
+    // dispatch timeout, Rule 1 of the reconciler can pick it up and
+    // re-dispatch it (with the correct triage system prompt via Option B).
     const triageBead = beadOps.createBead(this.sql, {
       type: 'issue',
       title: `Triage batch: ${pendingCount} request(s)`,
@@ -4062,10 +4076,19 @@ export class TownDO extends DurableObject<Env> {
       priority: 'high',
       labels: [patrol.TRIAGE_BATCH_LABEL],
       created_by: 'patrol',
+      rig_id: rigId,
     });
 
     const triageAgent = agents.getOrCreateAgent(this.sql, 'polecat', rigId, this.townId);
     agents.hookBead(this.sql, triageAgent.id, triageBead.bead_id);
+
+    // Option A: Immediately mark the triage batch bead as in_progress so
+    // the reconciler's Rule 2 (idle agent + open hooked bead → dispatch_agent)
+    // does not re-fire on the next tick if the container start fails. Rule 3
+    // (stale in_progress bead + no working agent + 5-min timeout) will reset
+    // it back to open if the dispatch fails, allowing a clean retry via
+    // maybeDispatchTriageAgent with the correct triage system prompt.
+    beadOps.updateBeadStatus(this.sql, triageBead.bead_id, 'in_progress', triageAgent.id);
 
     const started = await dispatch.startAgentInContainer(this.env, this.ctx.storage, {
       townId: this.townId,

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -4423,6 +4423,30 @@ export class TownDO extends DurableObject<Env> {
 
     try {
       const container = getTownContainerStub(this.env, townId);
+
+      // Measure Cloudflare container cold-start latency from the worker's
+      // perspective: warmUp() invokes startAndWaitForPorts() directly, so the
+      // returned durationMs is the true time-to-ready without the arbitrary
+      // 5s truncation of a plain /health ping. For already-warm containers
+      // this is a cheap RPC that returns { coldStart: false }.
+      try {
+        const warm = await container.warmUp();
+        if (warm.coldStart) {
+          writeEvent(this.env, {
+            event: 'container.cold_start',
+            townId,
+            durationMs: warm.durationMs,
+          });
+        }
+      } catch (err) {
+        writeEvent(this.env, {
+          event: 'container.cold_start',
+          townId,
+          error: err instanceof Error ? err.message.slice(0, 300) : String(err).slice(0, 300),
+        });
+        // Fall through to /health ping anyway — the container may recover.
+      }
+
       // Always include X-Town-Config so the container populates
       // lastKnownTownConfig on startup — before any /agents/start arrives.
       // This ensures org context and credentials are available immediately
@@ -4473,7 +4497,11 @@ export class TownDO extends DurableObject<Env> {
           });
           const rawBody: unknown = await healthResp.json().catch(() => null);
           const HealthBody = z
-            .object({ startedAt: z.string().optional(), uptime: z.number().optional() })
+            .object({
+              startedAt: z.string().optional(),
+              uptime: z.number().optional(),
+              mayorReadyAt: z.string().optional(),
+            })
             .passthrough();
           const body = HealthBody.safeParse(rawBody);
           if (body.success && body.data.startedAt) {
@@ -4484,6 +4512,25 @@ export class TownDO extends DurableObject<Env> {
               containerStartedAt: body.data.startedAt,
               durationMs: Date.now() - containerStartedAt,
             });
+
+            // Emit mayor.session_ready exactly once per container instance.
+            // Keyed by the container's startedAt so a restart re-arms the
+            // measurement. Stored durably so restarts of this DO don't cause
+            // duplicate emissions.
+            if (body.data.mayorReadyAt) {
+              const key = `mayor:ready_reported_for:${body.data.startedAt}`;
+              const alreadyReported = await this.ctx.storage.get<boolean>(key);
+              if (!alreadyReported) {
+                await this.ctx.storage.put(key, true);
+                const mayorReadyAt = new Date(body.data.mayorReadyAt).getTime();
+                writeEvent(this.env, {
+                  event: 'mayor.session_ready',
+                  townId,
+                  containerStartedAt: body.data.startedAt,
+                  durationMs: mayorReadyAt - containerStartedAt,
+                });
+              }
+            }
           }
         }
       } catch {

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -1148,10 +1148,9 @@ export class TownDO extends DurableObject<Env> {
       const rigBeads = BeadRecord.pick({ bead_id: true })
         .array()
         .parse([
-          ...query(
-            this.sql,
+          ...this.sql.exec(
             /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${beads.rig_id} = ? AND ${beads.status} = ?${type ? ` AND ${beads.type} = ?` : ''}`,
-            type ? [rigId, status, type] : [rigId, status]
+            ...(type ? [rigId, status, type] : [rigId, status])
           ),
         ]);
       if (rigBeads.length === 0) return 0;

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -3673,6 +3673,11 @@ export class TownDO extends DurableObject<Env> {
       pendingEventCount: 0,
     };
 
+    // Fetch town config once and share across Phase 0 and Phase 1 so that
+    // applyEvent can use the full fallback chain (rig → town → default) for
+    // settings like auto_resolve_merge_conflicts.
+    const townConfig = await this.getTownConfig();
+
     // Phase 0: Drain events and apply state transitions
     try {
       const pending = events.drainEvents(this.sql);
@@ -3682,7 +3687,7 @@ export class TownDO extends DurableObject<Env> {
       }
       for (const event of pending) {
         try {
-          reconciler.applyEvent(this.sql, event);
+          reconciler.applyEvent(this.sql, event, { townConfig });
           events.markProcessed(this.sql, event.event_id);
         } catch (err) {
           logger.error('reconciler: applyEvent failed', {
@@ -3723,7 +3728,6 @@ export class TownDO extends DurableObject<Env> {
     // Phase 1: Reconcile — compute desired state vs actual state
     const sideEffects: Array<() => Promise<void>> = [];
     try {
-      const townConfig = await this.getTownConfig();
       const actions = reconciler.reconcile(this.sql, {
         draining: this._draining,
         townConfig,

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -609,6 +609,18 @@ export class TownDO extends DurableObject<Env> {
     // Reconciler event log
     events.initTownEventsTable(this.sql);
 
+    // One-shot cleanup: older versions of this DO stored a separate
+    // `mayor:ready_reported_for:<startedAt>` key per container instance,
+    // which grew unbounded over a town's lifetime. We now store a single
+    // `mayor:ready_reported_for` key instead. Delete the legacy entries
+    // on next init so long-lived towns don't leak durable storage.
+    const legacyReadyKeys = await this.ctx.storage.list<unknown>({
+      prefix: 'mayor:ready_reported_for:',
+    });
+    if (legacyReadyKeys.size > 0) {
+      await this.ctx.storage.delete([...legacyReadyKeys.keys()]);
+    }
+
     // Ensure the alarm loop is running. After a deploy/restart, the
     // Cloudflare runtime normally delivers missed alarms, but if the alarm
     // was never set or was deleted by destroy(), the loop is dead. Re-arm
@@ -1130,12 +1142,12 @@ export class TownDO extends DurableObject<Env> {
     return this.updateBeadStatus(beadId, 'closed', agentId);
   }
 
-  async deleteBead(beadId: string): Promise<void> {
-    beadOps.deleteBead(this.sql, beadId);
+  async deleteBead(beadId: string, rigId?: string): Promise<boolean> {
+    return beadOps.deleteBead(this.sql, beadId, rigId);
   }
 
-  async deleteBeads(beadIds: string[]): Promise<number> {
-    return beadOps.deleteBeads(this.sql, beadIds);
+  async deleteBeads(beadIds: string[], rigId?: string): Promise<number> {
+    return beadOps.deleteBeads(this.sql, beadIds, rigId);
   }
 
   async deleteBeadsByStatus(
@@ -4514,14 +4526,16 @@ export class TownDO extends DurableObject<Env> {
             });
 
             // Emit mayor.session_ready exactly once per container instance.
-            // Keyed by the container's startedAt so a restart re-arms the
-            // measurement. Stored durably so restarts of this DO don't cause
-            // duplicate emissions.
+            // We store just the most recently reported startedAt in a single
+            // key — when a container restarts, startedAt changes and we
+            // re-emit, overwriting the previous value. This keeps storage
+            // at O(1) rather than accumulating a key per container lifetime.
             if (body.data.mayorReadyAt) {
-              const key = `mayor:ready_reported_for:${body.data.startedAt}`;
-              const alreadyReported = await this.ctx.storage.get<boolean>(key);
-              if (!alreadyReported) {
-                await this.ctx.storage.put(key, true);
+              const lastReportedStartedAt = await this.ctx.storage.get<string>(
+                'mayor:ready_reported_for'
+              );
+              if (lastReportedStartedAt !== body.data.startedAt) {
+                await this.ctx.storage.put('mayor:ready_reported_for', body.data.startedAt);
                 const mayorReadyAt = new Date(body.data.mayorReadyAt).getTime();
                 writeEvent(this.env, {
                   event: 'mayor.session_ready',

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -1183,6 +1183,7 @@ export class TownDO extends DurableObject<Env> {
       labels: string[];
       status: BeadStatus;
       metadata: Record<string, unknown>;
+      depends_on: string[];
     }>,
     actorId: string
   ): Promise<Bead> {
@@ -1195,7 +1196,12 @@ export class TownDO extends DurableObject<Env> {
       });
     }
 
-    const bead = beadOps.updateBeadFields(this.sql, beadId, fields, actorId);
+    const { depends_on, ...beadFields } = fields;
+    const bead = beadOps.updateBeadFields(this.sql, beadId, beadFields, actorId);
+
+    if (depends_on !== undefined) {
+      beadOps.setDependencies(this.sql, beadId, depends_on);
+    }
 
     // When a bead closes via field update, check for newly unblocked beads
     if (fields.status === 'closed' || fields.status === 'failed') {
@@ -1203,6 +1209,67 @@ export class TownDO extends DurableObject<Env> {
     }
 
     return bead;
+  }
+
+  /** Add an existing bead to a convoy's tracking. Returns updated convoy metadata. */
+  async convoyAddBead(
+    convoyId: string,
+    beadId: string,
+    dependsOn?: string[]
+  ): Promise<{ total_beads: number }> {
+    const convoyCheck = [
+      ...query(
+        this.sql,
+        /* sql */ `SELECT 1 FROM ${convoy_metadata} WHERE ${convoy_metadata.bead_id} = ?`,
+        [convoyId]
+      ),
+    ];
+    if (convoyCheck.length === 0) throw new Error(`Bead ${convoyId} is not a convoy`);
+    beadOps.convoyAddBead(this.sql, convoyId, beadId);
+    if (dependsOn !== undefined) {
+      beadOps.setDependencies(this.sql, beadId, dependsOn);
+    }
+    const rows = [
+      ...query(
+        this.sql,
+        /* sql */ `
+          SELECT ${convoy_metadata.total_beads}
+          FROM ${convoy_metadata}
+          WHERE ${convoy_metadata.bead_id} = ?
+        `,
+        [convoyId]
+      ),
+    ];
+    const parsed = z.object({ total_beads: z.number() }).array().parse(rows);
+    const total = parsed[0]?.total_beads ?? 0;
+    return { total_beads: total };
+  }
+
+  /** Remove a bead from a convoy's tracking. Returns updated convoy metadata. */
+  async convoyRemoveBead(convoyId: string, beadId: string): Promise<{ total_beads: number }> {
+    const convoyCheck = [
+      ...query(
+        this.sql,
+        /* sql */ `SELECT 1 FROM ${convoy_metadata} WHERE ${convoy_metadata.bead_id} = ?`,
+        [convoyId]
+      ),
+    ];
+    if (convoyCheck.length === 0) throw new Error(`Bead ${convoyId} is not a convoy`);
+    beadOps.convoyRemoveBead(this.sql, convoyId, beadId);
+    const rows = [
+      ...query(
+        this.sql,
+        /* sql */ `
+          SELECT ${convoy_metadata.total_beads}
+          FROM ${convoy_metadata}
+          WHERE ${convoy_metadata.bead_id} = ?
+        `,
+        [convoyId]
+      ),
+    ];
+    const parsed = z.object({ total_beads: z.number() }).array().parse(rows);
+    const total = parsed[0]?.total_beads ?? 0;
+    return { total_beads: total };
   }
 
   /**

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -1134,6 +1134,34 @@ export class TownDO extends DurableObject<Env> {
     beadOps.deleteBead(this.sql, beadId);
   }
 
+  async deleteBeads(beadIds: string[]): Promise<number> {
+    return beadOps.deleteBeads(this.sql, beadIds);
+  }
+
+  async deleteBeadsByStatus(
+    status: BeadStatusType,
+    type?: BeadTypeType,
+    rigId?: string
+  ): Promise<number> {
+    if (rigId) {
+      const rigBeads = BeadRecord.pick({ bead_id: true })
+        .array()
+        .parse([
+          ...query(
+            this.sql,
+            /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${beads.rig_id} = ? AND ${beads.status} = ?${type ? ` AND ${beads.type} = ?` : ''}`,
+            type ? [rigId, status, type] : [rigId, status]
+          ),
+        ]);
+      if (rigBeads.length === 0) return 0;
+      return beadOps.deleteBeads(
+        this.sql,
+        rigBeads.map(r => r.bead_id)
+      );
+    }
+    return beadOps.deleteBeadsByStatus(this.sql, status, type);
+  }
+
   async listBeadEvents(options: {
     beadId?: string;
     since?: string;

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -2438,29 +2438,33 @@ export class TownDO extends DurableObject<Env> {
         }
       }
 
-      const started = await dispatch.startAgentInContainer(this.env, this.ctx.storage, {
-        townId,
-        rigId: `mayor-${townId}`,
-        userId: townConfig.owner_user_id ?? rigConfig?.userId ?? townId,
-        agentId: mayor.id,
-        agentName: 'mayor',
-        role: 'mayor',
-        identity: mayor.identity,
-        beadId: '',
-        beadTitle: combinedMessage,
-        beadBody: '',
-        checkpoint: agents.readCheckpoint(this.sql, mayor.id),
-        // conversationHistory is no longer needed — the mayor's kilo.db
-        // is persisted to KV and hydrated on boot, preserving the full
-        // session state across container evictions.
-        gitUrl: rigConfig?.gitUrl ?? '',
-        defaultBranch: rigConfig?.defaultBranch ?? 'main',
-        kilocodeToken,
-        townConfig,
-        rigs: await this.rigListForMayor(),
-      });
+      const { started: mayorStarted } = await dispatch.startAgentInContainer(
+        this.env,
+        this.ctx.storage,
+        {
+          townId,
+          rigId: `mayor-${townId}`,
+          userId: townConfig.owner_user_id ?? rigConfig?.userId ?? townId,
+          agentId: mayor.id,
+          agentName: 'mayor',
+          role: 'mayor',
+          identity: mayor.identity,
+          beadId: '',
+          beadTitle: combinedMessage,
+          beadBody: '',
+          checkpoint: agents.readCheckpoint(this.sql, mayor.id),
+          // conversationHistory is no longer needed — the mayor's kilo.db
+          // is persisted to KV and hydrated on boot, preserving the full
+          // session state across container evictions.
+          gitUrl: rigConfig?.gitUrl ?? '',
+          defaultBranch: rigConfig?.defaultBranch ?? 'main',
+          kilocodeToken,
+          townConfig,
+          rigs: await this.rigListForMayor(),
+        }
+      );
 
-      if (started) {
+      if (mayorStarted) {
         agents.updateAgentStatus(this.sql, mayor.id, 'working');
         this._mayorWorkingSince = Date.now();
         sessionStatus = 'starting';
@@ -2542,29 +2546,33 @@ export class TownDO extends DurableObject<Env> {
 
     // Start with an empty prompt — the mayor will be idle but its container
     // and SDK server will be running, ready for PTY connections.
-    const started = await dispatch.startAgentInContainer(this.env, this.ctx.storage, {
-      townId,
-      rigId: `mayor-${townId}`,
-      userId:
-        townConfig.owner_user_id ?? rigConfig?.userId ?? townConfig.created_by_user_id ?? townId,
-      agentId: mayor.id,
-      agentName: 'mayor',
-      role: 'mayor',
-      identity: mayor.identity,
-      beadId: '',
-      beadTitle: 'Mayor ready. Waiting for instructions.',
-      beadBody: '',
-      checkpoint: agents.readCheckpoint(this.sql, mayor.id),
-      // conversationHistory is no longer needed — kilo.db persistence
-      // handles session continuity across container evictions.
-      gitUrl: rigConfig?.gitUrl ?? '',
-      defaultBranch: rigConfig?.defaultBranch ?? 'main',
-      kilocodeToken,
-      townConfig,
-      rigs: await this.rigListForMayor(),
-    });
+    const { started: mayorStarted } = await dispatch.startAgentInContainer(
+      this.env,
+      this.ctx.storage,
+      {
+        townId,
+        rigId: `mayor-${townId}`,
+        userId:
+          townConfig.owner_user_id ?? rigConfig?.userId ?? townConfig.created_by_user_id ?? townId,
+        agentId: mayor.id,
+        agentName: 'mayor',
+        role: 'mayor',
+        identity: mayor.identity,
+        beadId: '',
+        beadTitle: 'Mayor ready. Waiting for instructions.',
+        beadBody: '',
+        checkpoint: agents.readCheckpoint(this.sql, mayor.id),
+        // conversationHistory is no longer needed — kilo.db persistence
+        // handles session continuity across container evictions.
+        gitUrl: rigConfig?.gitUrl ?? '',
+        defaultBranch: rigConfig?.defaultBranch ?? 'main',
+        kilocodeToken,
+        townConfig,
+        rigs: await this.rigListForMayor(),
+      }
+    );
 
-    if (started) {
+    if (mayorStarted) {
       agents.updateAgentStatus(this.sql, mayor.id, 'working');
       this._mayorWorkingSince = Date.now();
       return { agentId: mayor.id, sessionStatus: 'starting' };
@@ -4168,28 +4176,32 @@ export class TownDO extends DurableObject<Env> {
     // maybeDispatchTriageAgent with the correct triage system prompt.
     beadOps.updateBeadStatus(this.sql, triageBead.bead_id, 'in_progress', triageAgent.id);
 
-    const started = await dispatch.startAgentInContainer(this.env, this.ctx.storage, {
-      townId: this.townId,
-      rigId,
-      userId: rigConfig.userId,
-      agentId: triageAgent.id,
-      agentName: triageAgent.name,
-      role: 'polecat',
-      identity: triageAgent.identity,
-      beadId: triageBead.bead_id,
-      beadTitle: triageBead.title,
-      beadBody: triageBead.body ?? '',
-      checkpoint: null,
-      gitUrl: rigConfig.gitUrl,
-      defaultBranch: rigConfig.defaultBranch,
-      kilocodeToken,
-      townConfig,
-      systemPromptOverride: systemPrompt,
-      platformIntegrationId: rigConfig.platformIntegrationId,
-      lightweight: true,
-    });
+    const { started: triageStarted } = await dispatch.startAgentInContainer(
+      this.env,
+      this.ctx.storage,
+      {
+        townId: this.townId,
+        rigId,
+        userId: rigConfig.userId,
+        agentId: triageAgent.id,
+        agentName: triageAgent.name,
+        role: 'polecat',
+        identity: triageAgent.identity,
+        beadId: triageBead.bead_id,
+        beadTitle: triageBead.title,
+        beadBody: triageBead.body ?? '',
+        checkpoint: null,
+        gitUrl: rigConfig.gitUrl,
+        defaultBranch: rigConfig.defaultBranch,
+        kilocodeToken,
+        townConfig,
+        systemPromptOverride: systemPrompt,
+        platformIntegrationId: rigConfig.platformIntegrationId,
+        lightweight: true,
+      }
+    );
 
-    if (started) {
+    if (triageStarted) {
       // Mark the agent as working so the duplicate-guard on the next
       // alarm tick sees it and skips dispatch.
       agents.updateAgentStatus(this.sql, triageAgent.id, 'working');
@@ -4370,12 +4382,55 @@ export class TownDO extends DurableObject<Env> {
         headers['X-Drain-Nonce'] = this._drainNonce;
         headers['X-Town-Id'] = townId;
       }
-      await container.fetch('http://container/health', {
-        signal: AbortSignal.timeout(5_000),
-        headers,
-      });
+      const t0 = Date.now();
+      try {
+        const healthResp = await container.fetch('http://container/health', {
+          signal: AbortSignal.timeout(5_000),
+          headers,
+        });
+        const durationMs = Date.now() - t0;
+        if (!healthResp.ok) {
+          writeEvent(this.env, {
+            event: 'container.health_ping',
+            townId,
+            durationMs,
+            statusCode: healthResp.status,
+            error: `non-ok status ${healthResp.status}`,
+          });
+        } else {
+          writeEvent(this.env, {
+            event: 'container.health_ping',
+            townId,
+            durationMs,
+            statusCode: healthResp.status,
+          });
+          const rawBody: unknown = await healthResp.json().catch(() => null);
+          const HealthBody = z
+            .object({ startedAt: z.string().optional(), uptime: z.number().optional() })
+            .passthrough();
+          const body = HealthBody.safeParse(rawBody);
+          if (body.success && body.data.startedAt) {
+            const containerStartedAt = new Date(body.data.startedAt).getTime();
+            writeEvent(this.env, {
+              event: 'container.ready_observed',
+              townId,
+              containerStartedAt: body.data.startedAt,
+              durationMs: Date.now() - containerStartedAt,
+            });
+          }
+        }
+      } catch {
+        const durationMs = Date.now() - t0;
+        writeEvent(this.env, {
+          event: 'container.health_ping',
+          townId,
+          durationMs,
+          error: 'timeout',
+        });
+        // Container is starting up or unavailable — alarm will retry
+      }
     } catch {
-      // Container is starting up or unavailable — alarm will retry
+      // Outer try: buildContainerConfig or getTownContainerStub failed
     }
   }
 

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -81,7 +81,6 @@ import type {
   SendMailInput,
   Mail,
   ReviewQueueInput,
-  ReviewQueueEntry,
   AgentDoneInput,
   PrimeContext,
   Molecule,

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -797,6 +797,53 @@ export class TownDO extends DurableObject<Env> {
       }
     }
 
+    // Persist custom env_vars to DO storage so they survive container restarts.
+    // Compare against the previously-persisted set of keys to clear removed ones.
+    // Reserved infra keys are never overwritten or deleted — infra values always win.
+    const RESERVED_ENV_KEYS = new Set([
+      'KILOCODE_TOKEN',
+      'GIT_TOKEN',
+      'GITHUB_TOKEN',
+      'GITLAB_TOKEN',
+      'GITLAB_INSTANCE_URL',
+      'GITHUB_CLI_PAT',
+      'GH_TOKEN',
+      'GASTOWN_GIT_AUTHOR_NAME',
+      'GASTOWN_GIT_AUTHOR_EMAIL',
+      'GASTOWN_DISABLE_AI_COAUTHOR',
+      'GASTOWN_ORGANIZATION_ID',
+      'GASTOWN_CONTAINER_TOKEN',
+      'GASTOWN_SESSION_TOKEN',
+      'GASTOWN_API_URL',
+    ]);
+    const CUSTOM_ENV_KEYS_STORAGE_KEY = 'container:custom_env_var_keys';
+    const prevCustomKeys: string[] =
+      (await this.ctx.storage.get<string[]>(CUSTOM_ENV_KEYS_STORAGE_KEY)) ?? [];
+    const newCustomKeys = Object.keys(townConfig.env_vars).filter(
+      key => !RESERVED_ENV_KEYS.has(key)
+    );
+    const newCustomKeySet = new Set(newCustomKeys);
+
+    for (const key of prevCustomKeys) {
+      if (RESERVED_ENV_KEYS.has(key)) continue;
+      if (!newCustomKeySet.has(key)) {
+        try {
+          await container.deleteEnvVar(key);
+        } catch (err) {
+          console.warn(`[Town.do] syncConfigToContainer: delete custom ${key} failed:`, err);
+        }
+      }
+    }
+    for (const [key, value] of Object.entries(townConfig.env_vars)) {
+      if (RESERVED_ENV_KEYS.has(key)) continue;
+      try {
+        await container.setEnvVar(key, value);
+      } catch (err) {
+        console.warn(`[Town.do] syncConfigToContainer: set custom ${key} failed:`, err);
+      }
+    }
+    await this.ctx.storage.put(CUSTOM_ENV_KEYS_STORAGE_KEY, newCustomKeys);
+
     // Phase 2: Push to the running container's process.env via the
     // /sync-config endpoint. The X-Town-Config header delivers the
     // full config; the endpoint applies CONFIG_ENV_MAP to process.env.

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -72,6 +72,7 @@ import type {
   BeadFilter,
   Bead,
   BeadStatus,
+  BeadType as BeadTypeType,
   BeadPriority as BeadPriorityType,
   RegisterAgentInput,
   AgentFilter,
@@ -1139,7 +1140,7 @@ export class TownDO extends DurableObject<Env> {
   }
 
   async deleteBeadsByStatus(
-    status: BeadStatusType,
+    status: BeadStatus,
     type?: BeadTypeType,
     rigId?: string
   ): Promise<number> {

--- a/services/gastown/src/dos/TownContainer.do.ts
+++ b/services/gastown/src/dos/TownContainer.do.ts
@@ -83,6 +83,27 @@ export class TownContainerDO extends Container<Env> {
     console.log(`${TC_LOG} container started for DO id=${this.ctx.id.toString()}`);
   }
 
+  /**
+   * Ensure the container is running and its default port is ready to accept
+   * traffic. Returns how long the underlying Container class took to satisfy
+   * that (i.e. `startAndWaitForPorts`), along with whether this call actually
+   * triggered a cold start.
+   *
+   * Intended to be called from the Town DO alarm in place of a manual
+   * /health ping — gives an accurate cold-start measurement without being
+   * capped by an arbitrary client-side timeout.
+   */
+  async warmUp(): Promise<{ coldStart: boolean; durationMs: number }> {
+    const state = await this.getState();
+    const alreadyHealthy = this.ctx.container?.running === true && state.status === 'healthy';
+    if (alreadyHealthy) {
+      return { coldStart: false, durationMs: 0 };
+    }
+    const t0 = Date.now();
+    await this.startAndWaitForPorts();
+    return { coldStart: true, durationMs: Date.now() - t0 };
+  }
+
   override onStop({ exitCode, reason }: { exitCode: number; reason: string }): void {
     console.log(
       `${TC_LOG} container stopped: exitCode=${exitCode} reason=${reason} id=${this.ctx.id.toString()}`

--- a/services/gastown/src/dos/town/actions.ts
+++ b/services/gastown/src/dos/town/actions.ts
@@ -132,6 +132,12 @@ const CloseConvoy = z.object({
   convoy_id: z.string(),
 });
 
+const FailConvoy = z.object({
+  type: z.literal('fail_convoy'),
+  convoy_id: z.string(),
+  reason: z.string(),
+});
+
 // ── Side effects (deferred) ─────────────────────────────────────────
 
 const DispatchAgent = z.object({
@@ -206,6 +212,7 @@ export const Action = z.discriminatedUnion('type', [
   UpdateConvoyProgress,
   SetConvoyReadyToLand,
   CloseConvoy,
+  FailConvoy,
   // Side effects
   DispatchAgent,
   StopAgent,
@@ -239,6 +246,7 @@ export type DeleteAgent = z.infer<typeof DeleteAgent>;
 export type UpdateConvoyProgress = z.infer<typeof UpdateConvoyProgress>;
 export type SetConvoyReadyToLand = z.infer<typeof SetConvoyReadyToLand>;
 export type CloseConvoy = z.infer<typeof CloseConvoy>;
+export type FailConvoy = z.infer<typeof FailConvoy>;
 export type DispatchAgent = z.infer<typeof DispatchAgent>;
 export type StopAgent = z.infer<typeof StopAgent>;
 export type PollPr = z.infer<typeof PollPr>;
@@ -397,7 +405,22 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
     }
 
     case 'create_landing_mr': {
-      // Create an MR bead for the landing merge (feature branch → main)
+      const timestamp = now();
+      query(
+        sql,
+        /* sql */ `
+          UPDATE ${beads}
+          SET ${beads.columns.metadata} = json_set(
+            COALESCE(${beads.columns.metadata}, '{}'),
+            '$.landing_mr_attempts',
+            COALESCE(json_extract(${beads.columns.metadata}, '$.landing_mr_attempts'), 0) + 1,
+            '$.last_landing_mr_attempt_at', ?
+          ),
+          ${beads.columns.updated_at} = ?
+          WHERE ${beads.bead_id} = ?
+        `,
+        [timestamp, timestamp, action.convoy_id]
+      );
       reviewQueue.submitToReviewQueue(sql, {
         agent_id: 'system',
         bead_id: action.convoy_id,
@@ -592,7 +615,6 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
     }
 
     case 'close_convoy': {
-      // Use updateBeadStatus for terminal state guard + bead event logging
       beadOps.updateBeadStatus(sql, action.convoy_id, 'closed', 'system');
       query(
         sql,
@@ -602,6 +624,25 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
           WHERE ${convoy_metadata.columns.bead_id} = ?
         `,
         [now(), action.convoy_id]
+      );
+      return null;
+    }
+
+    case 'fail_convoy': {
+      beadOps.updateBeadStatus(sql, action.convoy_id, 'failed', 'system');
+      query(
+        sql,
+        /* sql */ `
+          UPDATE ${beads}
+          SET ${beads.columns.metadata} = json_set(
+            COALESCE(${beads.columns.metadata}, '{}'),
+            '$.failureReason', 'landing_mr_exhausted',
+            '$.failureMessage', ?
+          ),
+          ${beads.columns.updated_at} = ?
+          WHERE ${beads.bead_id} = ?
+        `,
+        [action.reason, now(), action.convoy_id]
       );
       return null;
     }

--- a/services/gastown/src/dos/town/actions.ts
+++ b/services/gastown/src/dos/town/actions.ts
@@ -22,6 +22,7 @@ import * as reviewQueue from './review-queue';
 import * as patrol from './patrol';
 import { getRig } from './rigs';
 import { parseGitUrl } from '../../util/platform-pr.util';
+import type { PRStatusResult } from './town-scm';
 
 // ── Bead mutations ──────────────────────────────────────────────────
 
@@ -279,8 +280,8 @@ export type ApplyActionContext = {
   dispatchAgent: (agentId: string, beadId: string, rigId: string) => Promise<boolean>;
   /** Stop an agent's container process. */
   stopAgent: (agentId: string) => Promise<void>;
-  /** Check a PR's status via GitHub/GitLab API. Returns 'open'|'merged'|'closed'|null. */
-  checkPRStatus: (prUrl: string) => Promise<'open' | 'merged' | 'closed' | null>;
+  /** Check a PR's status via GitHub/GitLab API. Returns PRStatusResult or null. */
+  checkPRStatus: (prUrl: string) => Promise<PRStatusResult | null>;
   /** Check PR for unresolved review comments and failing CI checks. */
   checkPRFeedback: (prUrl: string) => Promise<PRFeedbackCheckResult | null>;
   /** Merge a PR via GitHub/GitLab API. */
@@ -724,8 +725,8 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
 
       return async () => {
         try {
-          const status = await ctx.checkPRStatus(action.pr_url);
-          if (status !== null) {
+          const prStatusResult = await ctx.checkPRStatus(action.pr_url);
+          if (prStatusResult !== null) {
             // Any non-null result resets the consecutive null counter
             query(
               sql,
@@ -739,6 +740,7 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
               `,
               [action.bead_id]
             );
+            const { status, mergeable_state } = prStatusResult;
             if (status !== 'open') {
               ctx.insertEvent('pr_status_changed', {
                 bead_id: action.bead_id,
@@ -751,6 +753,124 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
             const townConfig = await ctx.getTownConfig();
             const refineryConfig = townConfig.refinery;
             if (!refineryConfig) return;
+
+            if (mergeable_state === 'unknown') {
+              // GitHub is still computing mergeability — skip this poll and
+              // check again on the next tick. Do NOT treat 'unknown' as clean
+              // or dirty to avoid prematurely clearing has_conflicts or
+              // emitting pr_conflict_detected before GitHub has a definitive answer.
+              return;
+            }
+
+            if (mergeable_state === 'dirty') {
+              // PR has merge conflicts — emit event ONCE per conflict episode.
+              // The reconciler decides whether to create a conflict bead or an escalation
+              // based on the rig's auto_resolve_merge_conflicts config.
+              const conflictMetaRows = z
+                .object({ has_conflicts: z.unknown() })
+                .array()
+                .parse([
+                  ...query(
+                    sql,
+                    /* sql */ `
+                      SELECT json_extract(${beads.columns.metadata}, '$.has_conflicts') AS has_conflicts
+                      FROM ${beads}
+                      WHERE ${beads.bead_id} = ?
+                    `,
+                    [action.bead_id]
+                  ),
+                ]);
+              const alreadyMarked = conflictMetaRows[0]?.has_conflicts === 1 ||
+                conflictMetaRows[0]?.has_conflicts === true;
+
+              if (!alreadyMarked) {
+                // Mark conflict on MR bead metadata
+                query(
+                  sql,
+                  /* sql */ `
+                    UPDATE ${beads}
+                    SET ${beads.columns.metadata} = json_set(
+                      COALESCE(${beads.columns.metadata}, '{}'),
+                      '$.has_conflicts', 1,
+                      '$.conflicts_detected_at', ?
+                    ),
+                    ${beads.columns.updated_at} = ?
+                    WHERE ${beads.bead_id} = ?
+                  `,
+                  [now(), now(), action.bead_id]
+                );
+
+                // Get MR bead source bead ID and branch for the event payload
+                const mrMetaRows = z
+                  .object({ source_bead_id: z.string().nullable(), branch: z.string().nullable() })
+                  .array()
+                  .parse([
+                    ...query(
+                      sql,
+                      /* sql */ `
+                        SELECT
+                          json_extract(${beads.columns.metadata}, '$.source_bead_id') AS source_bead_id,
+                          ${review_metadata.columns.branch} AS branch
+                        FROM ${beads}
+                        INNER JOIN ${review_metadata} ON ${review_metadata.bead_id} = ${beads.bead_id}
+                        WHERE ${beads.bead_id} = ?
+                      `,
+                      [action.bead_id]
+                    ),
+                  ]);
+                const sourceBead = mrMetaRows[0]?.source_bead_id ?? null;
+                const conflictBranch = mrMetaRows[0]?.branch ?? '';
+
+                ctx.insertEvent('pr_conflict_detected', {
+                  bead_id: action.bead_id,
+                  payload: {
+                    mr_bead_id: action.bead_id,
+                    source_bead_id: sourceBead,
+                    pr_url: action.pr_url,
+                    branch: conflictBranch,
+                  },
+                });
+              }
+
+              // A dirty PR must not proceed to the auto-merge timer — reset the
+              // grace-period clock so the timer starts fresh once conflicts are resolved.
+              query(
+                sql,
+                /* sql */ `
+                  UPDATE ${review_metadata}
+                  SET ${review_metadata.columns.auto_merge_ready_since} = NULL
+                  WHERE ${review_metadata.bead_id} = ?
+                    AND ${review_metadata.columns.auto_merge_ready_since} IS NOT NULL
+                `,
+                [action.bead_id]
+              );
+              return;
+            } else if (
+              mergeable_state === 'clean' ||
+              mergeable_state === 'blocked' ||
+              mergeable_state === 'has_hooks'
+            ) {
+              // Conflict definitively resolved — clear the has_conflicts flag.
+              // 'clean': no conflicts, all checks pass.
+              // 'blocked': no conflicts but checks are failing (e.g. required reviews).
+              // 'has_hooks': no conflicts but pre-receive hooks are pending.
+              // 'unknown' is handled above (GitHub still computing — retry next poll).
+              query(
+                sql,
+                /* sql */ `
+                  UPDATE ${beads}
+                  SET ${beads.columns.metadata} = json_remove(
+                    COALESCE(${beads.columns.metadata}, '{}'),
+                    '$.has_conflicts',
+                    '$.conflicts_detected_at'
+                  ),
+                  ${beads.columns.updated_at} = ?
+                  WHERE ${beads.bead_id} = ?
+                    AND json_extract(${beads.columns.metadata}, '$.has_conflicts') IS NOT NULL
+                `,
+                [now(), action.bead_id]
+              );
+            }
 
             const wantsAutoResolve = refineryConfig.auto_resolve_pr_feedback === true;
             const wantsAutoMerge =
@@ -777,10 +897,10 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
               // If the PR was merged externally during that window, inserting
               // pr_feedback_detected would create a feedback bead for a merged
               // PR — leading to a duplicate PR on an already-merged branch.
-              const freshStatus = await ctx.checkPRStatus(action.pr_url);
-              if (freshStatus !== 'open') {
+              const freshStatusResult = await ctx.checkPRStatus(action.pr_url);
+              if (freshStatusResult?.status !== 'open') {
                 console.log(
-                  `${LOG} poll_pr: PR status changed to '${freshStatus}' during feedback check, skipping feedback for bead=${action.bead_id}`
+                  `${LOG} poll_pr: PR status changed to '${freshStatusResult?.status ?? 'null'}' during feedback check, skipping feedback for bead=${action.bead_id}`
                 );
               } else {
                 const existingFeedback = hasExistingFeedbackBead(sql, action.bead_id);

--- a/services/gastown/src/dos/town/actions.ts
+++ b/services/gastown/src/dos/town/actions.ts
@@ -780,7 +780,8 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
                     [action.bead_id]
                   ),
                 ]);
-              const alreadyMarked = conflictMetaRows[0]?.has_conflicts === 1 ||
+              const alreadyMarked =
+                conflictMetaRows[0]?.has_conflicts === 1 ||
                 conflictMetaRows[0]?.has_conflicts === true;
 
               if (!alreadyMarked) {

--- a/services/gastown/src/dos/town/agents.ts
+++ b/services/gastown/src/dos/town/agents.ts
@@ -202,7 +202,21 @@ export function updateAgentStatus(sql: SqlStorage, agentId: string, status: stri
 }
 
 export function deleteAgent(sql: SqlStorage, agentId: string): void {
-  // Unassign beads that reference this agent
+  // Clear assignee on terminal beads (closed/failed) without reopening them.
+  query(
+    sql,
+    /* sql */ `
+      UPDATE ${beads}
+      SET ${beads.columns.assignee_agent_bead_id} = NULL,
+          ${beads.columns.updated_at} = ?
+      WHERE ${beads.assignee_agent_bead_id} = ?
+        AND ${beads.columns.status} IN ('closed', 'failed')
+    `,
+    [now(), agentId]
+  );
+
+  // Reopen non-terminal beads assigned to this agent so the reconciler
+  // can re-dispatch them.
   query(
     sql,
     /* sql */ `
@@ -211,6 +225,7 @@ export function deleteAgent(sql: SqlStorage, agentId: string): void {
           ${beads.columns.status} = 'open',
           ${beads.columns.updated_at} = ?
       WHERE ${beads.assignee_agent_bead_id} = ?
+        AND ${beads.columns.status} NOT IN ('closed', 'failed')
     `,
     [now(), agentId]
   );

--- a/services/gastown/src/dos/town/agents.ts
+++ b/services/gastown/src/dos/town/agents.ts
@@ -519,6 +519,33 @@ export function prime(sql: SqlStorage, agentId: string): PrimeContext {
     };
   }
 
+  // Build PR conflict context if the hooked bead is a PR conflict resolution request,
+  // or if it is a PR feedback bead that has also accumulated merge conflicts.
+  let pr_conflict_context: PrimeContext['pr_conflict_context'] = null;
+  if (hookedBead?.labels.includes('gt:pr-conflict') && hookedBead.metadata) {
+    const meta = hookedBead.metadata as Record<string, unknown>;
+    pr_conflict_context = {
+      pr_url: typeof meta.pr_url === 'string' ? meta.pr_url : null,
+      branch: typeof meta.branch === 'string' ? meta.branch : null,
+      target_branch: typeof meta.target_branch === 'string' ? meta.target_branch : null,
+      has_feedback: meta.has_feedback === true || meta.has_feedback === 1,
+    };
+  } else if (hookedBead?.labels.includes('gt:pr-feedback') && hookedBead.metadata) {
+    // A feedback bead can also have has_conflicts: true when a conflict was detected
+    // after the feedback bead was already created. Surface the conflict context so the
+    // agent resolves conflicts first, then addresses review feedback.
+    const meta = hookedBead.metadata as Record<string, unknown>;
+    if (meta.has_conflicts === true || meta.has_conflicts === 1) {
+      pr_conflict_context = {
+        pr_url: typeof meta.pr_url === 'string' ? meta.pr_url : null,
+        branch: typeof meta.branch === 'string' ? meta.branch : null,
+        target_branch:
+          typeof meta.conflict_target_branch === 'string' ? meta.conflict_target_branch : null,
+        has_feedback: true,
+      };
+    }
+  }
+
   return {
     agent,
     hooked_bead: hookedBead,
@@ -526,6 +553,7 @@ export function prime(sql: SqlStorage, agentId: string): PrimeContext {
     open_beads: openBeads,
     rework_context,
     pr_fixup_context,
+    pr_conflict_context,
   };
 }
 

--- a/services/gastown/src/dos/town/beads.ts
+++ b/services/gastown/src/dos/town/beads.ts
@@ -421,8 +421,8 @@ export function updateConvoyProgress(sql: SqlStorage, beadId: string, timestamp:
 
       if (featureBranch && mergeMode === 'review-then-land') {
         // Mark the convoy as ready to land by storing a flag in metadata.
-        // The alarm loop's processReviewQueue will detect this and create
-        // the final landing MR (feature branch → main).
+        // The reconciler will detect this and create the final landing
+        // MR (feature branch → main).
         query(
           sql,
           /* sql */ `

--- a/services/gastown/src/dos/town/beads.ts
+++ b/services/gastown/src/dos/town/beads.ts
@@ -531,6 +531,178 @@ export function insertDependency(
 }
 
 /**
+ * Atomically replace all 'blocks' edges for a bead.
+ * Deletes existing blockers then inserts the provided list.
+ * Self-loops are silently skipped.
+ */
+export function setDependencies(sql: SqlStorage, beadId: string, dependsOnBeadIds: string[]): void {
+  query(
+    sql,
+    /* sql */ `
+      DELETE FROM ${bead_dependencies}
+      WHERE ${bead_dependencies.bead_id} = ?
+        AND ${bead_dependencies.dependency_type} = 'blocks'
+    `,
+    [beadId]
+  );
+  for (const depId of dependsOnBeadIds) {
+    if (depId === beadId) continue; // no self-loops
+    query(
+      sql,
+      /* sql */ `
+        INSERT OR IGNORE INTO ${bead_dependencies} (
+          ${bead_dependencies.columns.bead_id},
+          ${bead_dependencies.columns.depends_on_bead_id},
+          ${bead_dependencies.columns.dependency_type}
+        ) VALUES (?, ?, 'blocks')
+      `,
+      [beadId, depId]
+    );
+  }
+}
+
+/**
+ * Add a bead to a convoy's tracking.
+ * Inserts a 'tracks' edge and increments total_beads — but only when the
+ * edge is genuinely new (INSERT OR IGNORE returns 0 changes if it already
+ * exists, so we check before updating the counter).
+ * Returns whether the bead was newly added (true) or already tracked (false).
+ */
+export function convoyAddBead(sql: SqlStorage, convoyId: string, beadId: string): boolean {
+  // Check if already tracked
+  const existing = [
+    ...query(
+      sql,
+      /* sql */ `
+        SELECT 1 FROM ${bead_dependencies}
+        WHERE ${bead_dependencies.bead_id} = ?
+          AND ${bead_dependencies.depends_on_bead_id} = ?
+          AND ${bead_dependencies.dependency_type} = 'tracks'
+      `,
+      [beadId, convoyId]
+    ),
+  ];
+  if (existing.length > 0) return false;
+
+  query(
+    sql,
+    /* sql */ `
+      INSERT INTO ${bead_dependencies} (
+        ${bead_dependencies.columns.bead_id},
+        ${bead_dependencies.columns.depends_on_bead_id},
+        ${bead_dependencies.columns.dependency_type}
+      ) VALUES (?, ?, 'tracks')
+    `,
+    [beadId, convoyId]
+  );
+  query(
+    sql,
+    /* sql */ `
+      UPDATE ${convoy_metadata}
+      SET ${convoy_metadata.columns.total_beads} = ${convoy_metadata.columns.total_beads} + 1
+      WHERE ${convoy_metadata.bead_id} = ?
+    `,
+    [convoyId]
+  );
+  return true;
+}
+
+/**
+ * Remove a bead from a convoy's tracking.
+ * Deletes the 'tracks' edge, decrements total_beads (floor 0), and removes
+ * any 'blocks' edges between this bead and other beads in the same convoy.
+ * Returns whether the bead was actually tracked (true) or not found (false).
+ */
+export function convoyRemoveBead(sql: SqlStorage, convoyId: string, beadId: string): boolean {
+  // Check if tracked
+  const existing = [
+    ...query(
+      sql,
+      /* sql */ `
+        SELECT 1 FROM ${bead_dependencies}
+        WHERE ${bead_dependencies.bead_id} = ?
+          AND ${bead_dependencies.depends_on_bead_id} = ?
+          AND ${bead_dependencies.dependency_type} = 'tracks'
+      `,
+      [beadId, convoyId]
+    ),
+  ];
+  if (existing.length === 0) return false;
+
+  // Remove the tracks edge
+  query(
+    sql,
+    /* sql */ `
+      DELETE FROM ${bead_dependencies}
+      WHERE ${bead_dependencies.bead_id} = ?
+        AND ${bead_dependencies.depends_on_bead_id} = ?
+        AND ${bead_dependencies.dependency_type} = 'tracks'
+    `,
+    [beadId, convoyId]
+  );
+  // Decrement total_beads, floor at 0
+  query(
+    sql,
+    /* sql */ `
+      UPDATE ${convoy_metadata}
+      SET ${convoy_metadata.columns.total_beads} = MAX(0, ${convoy_metadata.columns.total_beads} - 1)
+      WHERE ${convoy_metadata.bead_id} = ?
+    `,
+    [convoyId]
+  );
+
+  // Find all other beads tracked by this convoy
+  const siblingRows = [
+    ...query(
+      sql,
+      /* sql */ `
+        SELECT ${bead_dependencies.bead_id}
+        FROM ${bead_dependencies}
+        WHERE ${bead_dependencies.depends_on_bead_id} = ?
+          AND ${bead_dependencies.dependency_type} = 'tracks'
+      `,
+      [convoyId]
+    ),
+  ];
+  const siblingIds = z
+    .object({ bead_id: z.string() })
+    .array()
+    .parse(siblingRows)
+    .map(r => r.bead_id);
+
+  if (siblingIds.length > 0) {
+    // Delete 'blocks' edges where beadId is the blocker of a sibling
+    for (const siblingId of siblingIds) {
+      query(
+        sql,
+        /* sql */ `
+          DELETE FROM ${bead_dependencies}
+          WHERE ${bead_dependencies.bead_id} = ?
+            AND ${bead_dependencies.depends_on_bead_id} = ?
+            AND ${bead_dependencies.dependency_type} = 'blocks'
+        `,
+        [siblingId, beadId]
+      );
+    }
+    // Delete 'blocks' edges where beadId depends on a sibling
+    for (const siblingId of siblingIds) {
+      query(
+        sql,
+        /* sql */ `
+          DELETE FROM ${bead_dependencies}
+          WHERE ${bead_dependencies.bead_id} = ?
+            AND ${bead_dependencies.depends_on_bead_id} = ?
+            AND ${bead_dependencies.dependency_type} = 'blocks'
+        `,
+        [beadId, siblingId]
+      );
+    }
+  }
+
+  return true;
+}
+
+/**
  * Find beads that were blocked by `closedBeadId` and are now fully unblocked
  * (all their 'blocks' dependencies are resolved).
  */

--- a/services/gastown/src/dos/town/beads.ts
+++ b/services/gastown/src/dos/town/beads.ts
@@ -724,10 +724,12 @@ export function deleteBeads(sql: SqlStorage, beadIds: string[]): number {
   // Dynamic IN clauses use sql.exec directly — the type-safe query()
   // wrapper can't infer placeholder count from runtime-built strings.
   const ph = (ids: string[]) => ids.map(() => '?').join(',');
-  const childRows = [...sql.exec(
-    /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${beads.parent_bead_id} IN (${ph(beadIds)})`,
-    ...beadIds
-  )];
+  const childRows = [
+    ...sql.exec(
+      /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${beads.parent_bead_id} IN (${ph(beadIds)})`,
+      ...beadIds
+    ),
+  ];
   const childIds = BeadRecord.pick({ bead_id: true })
     .array()
     .parse(childRows)
@@ -760,7 +762,8 @@ export function deleteBeads(sql: SqlStorage, beadIds: string[]): number {
   // Delete dependencies referencing any of these beads
   sql.exec(
     /* sql */ `DELETE FROM ${bead_dependencies} WHERE ${bead_dependencies.bead_id} IN (${placeholders}) OR ${bead_dependencies.depends_on_bead_id} IN (${placeholders})`,
-    ...allIdsArr, ...allIdsArr
+    ...allIdsArr,
+    ...allIdsArr
   );
 
   // Delete events
@@ -813,11 +816,7 @@ function collectChildBeadIds(sql: SqlStorage, parentIds: string[]): string[] {
   return [...childIds, ...deeperIds];
 }
 
-export function deleteBeadsByStatus(
-  sql: SqlStorage,
-  status: BeadStatus,
-  type?: BeadType
-): number {
+export function deleteBeadsByStatus(sql: SqlStorage, status: BeadStatus, type?: BeadType): number {
   const conditions: string[] = [`${beads.status} = ?`];
   const values: unknown[] = [status];
 

--- a/services/gastown/src/dos/town/beads.ts
+++ b/services/gastown/src/dos/town/beads.ts
@@ -721,13 +721,13 @@ export function deleteBeads(sql: SqlStorage, beadIds: string[]): number {
   const allIds = new Set(beadIds);
 
   // Expand with child beads (molecule steps, etc.)
-  const childRows = [
-    ...query(
-      sql,
-      /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${beads.parent_bead_id} IN (${beadIds.map(() => '?').join(',')})`,
-      [...beadIds]
-    ),
-  ];
+  // Dynamic IN clauses use sql.exec directly — the type-safe query()
+  // wrapper can't infer placeholder count from runtime-built strings.
+  const ph = (ids: string[]) => ids.map(() => '?').join(',');
+  const childRows = [...sql.exec(
+    /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${beads.parent_bead_id} IN (${ph(beadIds)})`,
+    ...beadIds
+  )];
   const childIds = BeadRecord.pick({ bead_id: true })
     .array()
     .parse(childRows)
@@ -746,61 +746,51 @@ export function deleteBeads(sql: SqlStorage, beadIds: string[]): number {
   }
 
   const allIdsArr = [...allIds];
-  const placeholders = allIdsArr.map(() => '?').join(',');
+  const placeholders = ph(allIdsArr);
 
   // Unhook agents assigned to any of these beads
-  query(
-    sql,
-    /* sql */ `
-      UPDATE ${agent_metadata}
+  sql.exec(
+    /* sql */ `UPDATE ${agent_metadata}
       SET ${agent_metadata.columns.current_hook_bead_id} = NULL,
           ${agent_metadata.columns.status} = 'idle'
-      WHERE ${agent_metadata.current_hook_bead_id} IN (${placeholders})
-    `,
-    [...allIdsArr]
+      WHERE ${agent_metadata.current_hook_bead_id} IN (${placeholders})`,
+    ...allIdsArr
   );
 
   // Delete dependencies referencing any of these beads
-  query(
-    sql,
+  sql.exec(
     /* sql */ `DELETE FROM ${bead_dependencies} WHERE ${bead_dependencies.bead_id} IN (${placeholders}) OR ${bead_dependencies.depends_on_bead_id} IN (${placeholders})`,
-    [...allIdsArr, ...allIdsArr]
+    ...allIdsArr, ...allIdsArr
   );
 
   // Delete events
-  query(
-    sql,
+  sql.exec(
     /* sql */ `DELETE FROM ${bead_events} WHERE ${bead_events.bead_id} IN (${placeholders})`,
-    [...allIdsArr]
+    ...allIdsArr
   );
 
   // Delete satellite metadata
-  query(
-    sql,
+  sql.exec(
     /* sql */ `DELETE FROM ${agent_metadata} WHERE ${agent_metadata.bead_id} IN (${placeholders})`,
-    [...allIdsArr]
+    ...allIdsArr
   );
-  query(
-    sql,
+  sql.exec(
     /* sql */ `DELETE FROM ${review_metadata} WHERE ${review_metadata.bead_id} IN (${placeholders})`,
-    [...allIdsArr]
+    ...allIdsArr
   );
-  query(
-    sql,
+  sql.exec(
     /* sql */ `DELETE FROM ${escalation_metadata} WHERE ${escalation_metadata.bead_id} IN (${placeholders})`,
-    [...allIdsArr]
+    ...allIdsArr
   );
-  query(
-    sql,
+  sql.exec(
     /* sql */ `DELETE FROM ${convoy_metadata} WHERE ${convoy_metadata.bead_id} IN (${placeholders})`,
-    [...allIdsArr]
+    ...allIdsArr
   );
 
   // Delete the beads themselves
-  query(
-    sql,
+  sql.exec(
     /* sql */ `DELETE FROM ${beads} WHERE ${beads.bead_id} IN (${placeholders})`,
-    [...allIdsArr]
+    ...allIdsArr
   );
 
   return allIdsArr.length;
@@ -809,10 +799,9 @@ export function deleteBeads(sql: SqlStorage, beadIds: string[]): number {
 function collectChildBeadIds(sql: SqlStorage, parentIds: string[]): string[] {
   if (parentIds.length === 0) return [];
   const childRows = [
-    ...query(
-      sql,
+    ...sql.exec(
       /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${beads.parent_bead_id} IN (${parentIds.map(() => '?').join(',')})`,
-      [...parentIds]
+      ...parentIds
     ),
   ];
   const childIds = BeadRecord.pick({ bead_id: true })
@@ -838,10 +827,9 @@ export function deleteBeadsByStatus(
   }
 
   const rows = [
-    ...query(
-      sql,
+    ...sql.exec(
       /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${conditions.join(' AND ')}`,
-      values
+      ...values
     ),
   ];
   const beadIds = BeadRecord.pick({ bead_id: true })

--- a/services/gastown/src/dos/town/beads.ts
+++ b/services/gastown/src/dos/town/beads.ts
@@ -832,7 +832,26 @@ export function closeBead(sql: SqlStorage, beadId: string, agentId: string): Bea
   return updateBeadStatus(sql, beadId, 'closed', agentId);
 }
 
-export function deleteBead(sql: SqlStorage, beadId: string): void {
+/**
+ * Delete a bead (and its descendants). When `rigId` is supplied, the bead
+ * must belong to that rig — otherwise the function returns without deleting.
+ * This protects mutation endpoints that have only verified ownership of a
+ * rig, not of the specific bead being targeted.
+ */
+export function deleteBead(sql: SqlStorage, beadId: string, rigId?: string): boolean {
+  if (rigId) {
+    const row = BeadRecord.pick({ bead_id: true, rig_id: true })
+      .array()
+      .parse([
+        ...query(
+          sql,
+          /* sql */ `SELECT ${beads.bead_id}, ${beads.rig_id} FROM ${beads} WHERE ${beads.bead_id} = ?`,
+          [beadId]
+        ),
+      ]);
+    if (row.length === 0 || row[0].rig_id !== rigId) return false;
+  }
+
   // Recursively delete child beads (e.g. molecule steps) before the parent
   const children = BeadRecord.pick({ bead_id: true })
     .array()
@@ -885,21 +904,43 @@ export function deleteBead(sql: SqlStorage, beadId: string): void {
   ]);
 
   query(sql, /* sql */ `DELETE FROM ${beads} WHERE ${beads.bead_id} = ?`, [beadId]);
+  return true;
 }
 
-export function deleteBeads(sql: SqlStorage, beadIds: string[]): number {
+/**
+ * Delete many beads (and their descendants). When `rigId` is supplied, the
+ * input `beadIds` list is filtered in SQL to keep only beads actually
+ * belonging to that rig — any others are silently skipped. This prevents
+ * cross-rig deletion when the caller has only authorized one rig.
+ */
+export function deleteBeads(sql: SqlStorage, beadIds: string[], rigId?: string): number {
   if (beadIds.length === 0) return 0;
 
-  const allIds = new Set(beadIds);
-
-  // Expand with child beads (molecule steps, etc.)
   // Dynamic IN clauses use sql.exec directly — the type-safe query()
   // wrapper can't infer placeholder count from runtime-built strings.
   const ph = (ids: string[]) => ids.map(() => '?').join(',');
+
+  let rootIds = beadIds;
+  if (rigId) {
+    const ownedRows = BeadRecord.pick({ bead_id: true })
+      .array()
+      .parse([
+        ...sql.exec(
+          /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${beads.rig_id} = ? AND ${beads.bead_id} IN (${ph(beadIds)})`,
+          rigId,
+          ...beadIds
+        ),
+      ]);
+    rootIds = ownedRows.map(r => r.bead_id);
+    if (rootIds.length === 0) return 0;
+  }
+
+  const allIds = new Set(rootIds);
+
   const childRows = [
     ...sql.exec(
-      /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${beads.parent_bead_id} IN (${ph(beadIds)})`,
-      ...beadIds
+      /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${beads.parent_bead_id} IN (${ph(rootIds)})`,
+      ...rootIds
     ),
   ];
   const childIds = BeadRecord.pick({ bead_id: true })

--- a/services/gastown/src/dos/town/beads.ts
+++ b/services/gastown/src/dos/town/beads.ts
@@ -715,6 +715,144 @@ export function deleteBead(sql: SqlStorage, beadId: string): void {
   query(sql, /* sql */ `DELETE FROM ${beads} WHERE ${beads.bead_id} = ?`, [beadId]);
 }
 
+export function deleteBeads(sql: SqlStorage, beadIds: string[]): number {
+  if (beadIds.length === 0) return 0;
+
+  const allIds = new Set(beadIds);
+
+  // Expand with child beads (molecule steps, etc.)
+  const childRows = [
+    ...query(
+      sql,
+      /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${beads.parent_bead_id} IN (${beadIds.map(() => '?').join(',')})`,
+      [...beadIds]
+    ),
+  ];
+  const childIds = BeadRecord.pick({ bead_id: true })
+    .array()
+    .parse(childRows)
+    .map(r => r.bead_id);
+
+  // Recursively collect children of children
+  if (childIds.length > 0) {
+    for (const childId of childIds) {
+      allIds.add(childId);
+    }
+    // Recurse for deeper nesting
+    const deeperIds = collectChildBeadIds(sql, childIds);
+    for (const id of deeperIds) {
+      allIds.add(id);
+    }
+  }
+
+  const allIdsArr = [...allIds];
+  const placeholders = allIdsArr.map(() => '?').join(',');
+
+  // Unhook agents assigned to any of these beads
+  query(
+    sql,
+    /* sql */ `
+      UPDATE ${agent_metadata}
+      SET ${agent_metadata.columns.current_hook_bead_id} = NULL,
+          ${agent_metadata.columns.status} = 'idle'
+      WHERE ${agent_metadata.current_hook_bead_id} IN (${placeholders})
+    `,
+    [...allIdsArr]
+  );
+
+  // Delete dependencies referencing any of these beads
+  query(
+    sql,
+    /* sql */ `DELETE FROM ${bead_dependencies} WHERE ${bead_dependencies.bead_id} IN (${placeholders}) OR ${bead_dependencies.depends_on_bead_id} IN (${placeholders})`,
+    [...allIdsArr, ...allIdsArr]
+  );
+
+  // Delete events
+  query(
+    sql,
+    /* sql */ `DELETE FROM ${bead_events} WHERE ${bead_events.bead_id} IN (${placeholders})`,
+    [...allIdsArr]
+  );
+
+  // Delete satellite metadata
+  query(
+    sql,
+    /* sql */ `DELETE FROM ${agent_metadata} WHERE ${agent_metadata.bead_id} IN (${placeholders})`,
+    [...allIdsArr]
+  );
+  query(
+    sql,
+    /* sql */ `DELETE FROM ${review_metadata} WHERE ${review_metadata.bead_id} IN (${placeholders})`,
+    [...allIdsArr]
+  );
+  query(
+    sql,
+    /* sql */ `DELETE FROM ${escalation_metadata} WHERE ${escalation_metadata.bead_id} IN (${placeholders})`,
+    [...allIdsArr]
+  );
+  query(
+    sql,
+    /* sql */ `DELETE FROM ${convoy_metadata} WHERE ${convoy_metadata.bead_id} IN (${placeholders})`,
+    [...allIdsArr]
+  );
+
+  // Delete the beads themselves
+  query(
+    sql,
+    /* sql */ `DELETE FROM ${beads} WHERE ${beads.bead_id} IN (${placeholders})`,
+    [...allIdsArr]
+  );
+
+  return allIdsArr.length;
+}
+
+function collectChildBeadIds(sql: SqlStorage, parentIds: string[]): string[] {
+  if (parentIds.length === 0) return [];
+  const childRows = [
+    ...query(
+      sql,
+      /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${beads.parent_bead_id} IN (${parentIds.map(() => '?').join(',')})`,
+      [...parentIds]
+    ),
+  ];
+  const childIds = BeadRecord.pick({ bead_id: true })
+    .array()
+    .parse(childRows)
+    .map(r => r.bead_id);
+  if (childIds.length === 0) return [];
+  const deeperIds = collectChildBeadIds(sql, childIds);
+  return [...childIds, ...deeperIds];
+}
+
+export function deleteBeadsByStatus(
+  sql: SqlStorage,
+  status: BeadStatus,
+  type?: BeadType
+): number {
+  const conditions: string[] = [`${beads.status} = ?`];
+  const values: unknown[] = [status];
+
+  if (type) {
+    conditions.push(`${beads.type} = ?`);
+    values.push(type);
+  }
+
+  const rows = [
+    ...query(
+      sql,
+      /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${conditions.join(' AND ')}`,
+      values
+    ),
+  ];
+  const beadIds = BeadRecord.pick({ bead_id: true })
+    .array()
+    .parse(rows)
+    .map(r => r.bead_id);
+
+  if (beadIds.length === 0) return 0;
+  return deleteBeads(sql, beadIds);
+}
+
 // ── Bead Events ─────────────────────────────────────────────────────
 
 export function logBeadEvent(

--- a/services/gastown/src/dos/town/config.test.ts
+++ b/services/gastown/src/dos/town/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { TownConfigSchema } from '../../types';
-import { resolveModel } from './config';
+import { getTownConfig, resolveModel } from './config';
 
 const HARDCODED_FALLBACK = 'anthropic/claude-sonnet-4.6';
 
@@ -137,5 +137,49 @@ describe('resolveModel backward compatibility', () => {
     });
     // refinery: no role override, no default → hardcoded
     expect(resolveModel(configNoDefault, null, 'refinery')).toBe(HARDCODED_FALLBACK);
+  });
+});
+
+// Minimal in-memory stand-in for DurableObjectStorage. config.ts only calls
+// .get(key) and .put(key, value), so we implement just those two and widen
+// to DurableObjectStorage for the test's call sites. The double-cast is
+// intentional and isolated to this test fake — production code doesn't cast.
+function makeFakeStorage(initial: Map<string, unknown> = new Map()): DurableObjectStorage {
+  const store = initial;
+  const fake = {
+    get: async (key: string) => store.get(key),
+    put: async (key: string, value: unknown) => {
+      store.set(key, value);
+    },
+  };
+  return fake as unknown as DurableObjectStorage;
+}
+
+describe('getTownConfig seeding behavior', () => {
+  it('seeds new-style defaults for a fresh town (no persisted config)', async () => {
+    const storage = makeFakeStorage();
+    const config = await getTownConfig(storage);
+    expect(config.merge_strategy).toBe('pr');
+    expect(config.staged_convoys_default).toBe(true);
+    expect(config.refinery?.review_mode).toBe('comments');
+    expect(config.refinery?.auto_resolve_pr_feedback).toBe(true);
+    expect(config.refinery?.auto_merge_delay_minutes).toBe(5);
+    // And the seeded value is persisted so subsequent reads return the same shape
+    const reloaded = await getTownConfig(storage);
+    expect(reloaded.merge_strategy).toBe('pr');
+  });
+
+  it('does NOT retroactively apply new defaults to an existing persisted config', async () => {
+    // Legacy town stored before #2725: no merge_strategy, no refinery, no
+    // staged_convoys_default. This mirrors real storage rows from production.
+    const legacyRaw = {
+      env_vars: {},
+      default_model: 'openai/gpt-4o',
+    };
+    const storage = makeFakeStorage(new Map([['town:config', legacyRaw]]));
+    const config = await getTownConfig(storage);
+    expect(config.merge_strategy).toBe('direct');
+    expect(config.staged_convoys_default).toBe(false);
+    expect(config.refinery).toBeUndefined();
   });
 });

--- a/services/gastown/src/dos/town/config.ts
+++ b/services/gastown/src/dos/town/config.ts
@@ -89,6 +89,10 @@ export async function updateTownConfig(
               update.refinery.auto_resolve_pr_feedback ??
               current.refinery?.auto_resolve_pr_feedback ??
               false,
+            auto_resolve_merge_conflicts:
+              update.refinery.auto_resolve_merge_conflicts ??
+              current.refinery?.auto_resolve_merge_conflicts ??
+              true,
             auto_merge_delay_minutes:
               update.refinery.auto_merge_delay_minutes !== undefined
                 ? update.refinery.auto_merge_delay_minutes
@@ -191,6 +195,7 @@ export type EffectiveConfig = {
   review_mode: 'rework' | 'comments';
   code_review: boolean;
   auto_resolve_pr_feedback: boolean;
+  auto_resolve_merge_conflicts: boolean;
   auto_merge_delay_minutes: number | null;
   merge_strategy: MergeStrategy;
   convoy_merge_mode: 'review-then-land' | 'review-and-merge';
@@ -227,6 +232,10 @@ export function resolveRigConfig(
       rigOverride?.auto_resolve_pr_feedback ??
       townConfig.refinery?.auto_resolve_pr_feedback ??
       false,
+    auto_resolve_merge_conflicts:
+      rigOverride?.auto_resolve_merge_conflicts ??
+      townConfig.refinery?.auto_resolve_merge_conflicts ??
+      true,
     auto_merge_delay_minutes:
       rigOverride?.auto_merge_delay_minutes !== undefined
         ? rigOverride.auto_merge_delay_minutes

--- a/services/gastown/src/dos/town/config.ts
+++ b/services/gastown/src/dos/town/config.ts
@@ -11,12 +11,47 @@ import {
 } from '../../types';
 
 const CONFIG_KEY = 'town:config';
+const NEW_TOWN_DEFAULTS_SEEDED_KEY = 'town:config:newDefaultsSeeded';
 
 const TOWN_LOG = '[Town.do]';
 
+/**
+ * Defaults that were introduced for NEW towns in #2725 but that must NOT
+ * be retroactively applied to existing persisted configs (doing so would
+ * silently flip production behavior for every town that pre-dates the change).
+ *
+ * These are seeded exactly once per town, the first time a Town DO loads
+ * its config and finds nothing persisted (fresh create) AND has not already
+ * been seeded. Seeded state is tracked under a separate key so that legacy
+ * towns which have _other_ config saved but never touched these fields do
+ * not get silently rewritten on next load.
+ */
+const NEW_TOWN_CONFIG_DEFAULTS = {
+  merge_strategy: 'pr' as const,
+  staged_convoys_default: true,
+  refinery: {
+    gates: [] as string[],
+    auto_merge: true,
+    require_clean_merge: true,
+    code_review: true,
+    review_mode: 'comments' as const,
+    auto_resolve_pr_feedback: true,
+    auto_merge_delay_minutes: 5 as number | null,
+  },
+};
+
 export async function getTownConfig(storage: DurableObjectStorage): Promise<TownConfig> {
   const raw = await storage.get<unknown>(CONFIG_KEY);
-  if (!raw) return TownConfigSchema.parse({});
+  if (!raw) {
+    // Fresh town: seed the new-style defaults from #2725 and persist so they
+    // become the town's actual config (rather than schema-injected defaults
+    // on every read). This keeps new-town behavior modern while leaving
+    // legacy towns — which already have a persisted row — untouched.
+    const seeded = TownConfigSchema.parse(NEW_TOWN_CONFIG_DEFAULTS);
+    await storage.put(CONFIG_KEY, seeded);
+    await storage.put(NEW_TOWN_DEFAULTS_SEEDED_KEY, true);
+    return seeded;
+  }
   return TownConfigSchema.parse(raw);
 }
 

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -647,12 +647,12 @@ export async function checkAgentContainerStatus(
       signal: AbortSignal.timeout(10_000),
     });
     // 404 means the container is running but has no record of this agent
-    // (e.g. after container eviction). Report as 'not_found' so
-    // witnessPatrol can immediately reset and redispatch the agent
+    // (e.g. after container eviction). Report as 'not_found' so the
+    // reconciler can immediately reset and redispatch the agent
     // instead of waiting for the 2-hour GUPP timeout.
     if (response.status === 404) return { status: 'not_found' };
     // Non-OK but not 404 — container is having issues but may still
-    // have the agent running. Return 'unknown' so witnessPatrol doesn't
+    // have the agent running. Return 'unknown' so the reconciler doesn't
     // falsely reset a working agent.
     if (!response.ok) return { status: 'unknown' };
     const data: unknown = await response.json();
@@ -668,7 +668,7 @@ export async function checkAgentContainerStatus(
     return { status: 'unknown' };
   } catch {
     // Timeout, network error, or container starting up — return
-    // 'unknown' so witnessPatrol doesn't falsely reset working agents.
+    // 'unknown' so the reconciler doesn't falsely reset working agents.
     // True zombies will be caught after repeated 'unknown' results
     // once the GIPP/heartbeat timeout expires.
     return { status: 'unknown' };

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -9,6 +9,7 @@ import { buildPolecatSystemPrompt } from '../../prompts/polecat-system.prompt';
 import { buildMayorSystemPrompt } from '../../prompts/mayor-system.prompt';
 import type { TownConfig, RigOverrideConfig } from '../../types';
 import { buildContainerConfig, resolveModel, resolveSmallModel, resolveRigConfig } from './config';
+import { writeEvent } from '../../util/analytics.util';
 
 const TOWN_LOG = '[Town.do]';
 
@@ -378,7 +379,7 @@ export async function startAgentInContainer(
       platformIntegrationId?: string;
     }>;
   }
-): Promise<boolean> {
+): Promise<{ started: boolean; containerFetchMs: number }> {
   lastStartError = null;
   console.log(
     `${TOWN_LOG} startAgentInContainer: agentId=${params.agentId} role=${params.role} name=${params.agentName}`
@@ -402,7 +403,7 @@ export async function startAgentInContainer(
         `${TOWN_LOG} startAgentInContainer: ABORTING — failed to mint any auth token for agent ${params.agentId}. ` +
           'The agent would start without credentials and be unable to call back to the worker.'
       );
-      return false;
+      return { started: false, containerFetchMs: 0 };
     }
 
     // Build env vars from town config
@@ -454,6 +455,7 @@ export async function startAgentInContainer(
     const rigOverride = params.rigOverride ?? null;
     const effectiveConfig = resolveRigConfig(params.townConfig, rigOverride);
 
+    const fetchStart = Date.now();
     const response = await container.fetch('http://container/agents/start', {
       method: 'POST',
       signal: AbortSignal.timeout(60_000),
@@ -519,6 +521,7 @@ export async function startAgentInContainer(
       }),
     });
 
+    const durationMs = Date.now() - fetchStart;
     if (!response.ok) {
       const text = await response.text().catch(() => '(unreadable)');
       // "Already running" means a previous dispatch succeeded — the agent
@@ -528,7 +531,15 @@ export async function startAgentInContainer(
         console.log(
           `${TOWN_LOG} startAgentInContainer: agent ${params.agentId} already running — treating as success`
         );
-        return true;
+        writeEvent(env, {
+          event: 'container.agent_start_fetch',
+          townId: params.townId,
+          rigId: params.rigId,
+          agentId: params.agentId,
+          durationMs,
+          statusCode: response.status,
+        });
+        return { started: true, containerFetchMs: durationMs };
       }
       const errorMsg = `(${response.status}) ${text.slice(0, 300)}`;
       console.error(
@@ -536,13 +547,31 @@ export async function startAgentInContainer(
           `agent=${params.agentId} role=${params.role}: ${errorMsg}`
       );
       lastStartError = errorMsg;
+      writeEvent(env, {
+        event: 'container.agent_start_fetch',
+        townId: params.townId,
+        rigId: params.rigId,
+        agentId: params.agentId,
+        durationMs,
+        statusCode: response.status,
+        error: errorMsg,
+      });
+      return { started: false, containerFetchMs: durationMs };
     }
-    return response.ok;
+    writeEvent(env, {
+      event: 'container.agent_start_fetch',
+      townId: params.townId,
+      rigId: params.rigId,
+      agentId: params.agentId,
+      durationMs,
+      statusCode: response.status,
+    });
+    return { started: true, containerFetchMs: durationMs };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`${TOWN_LOG} startAgentInContainer: EXCEPTION for agent ${params.agentId}:`, err);
     lastStartError = `EXCEPTION: ${message.slice(0, 300)}`;
-    return false;
+    return { started: false, containerFetchMs: 0 };
   }
 }
 

--- a/services/gastown/src/dos/town/patrol.ts
+++ b/services/gastown/src/dos/town/patrol.ts
@@ -17,8 +17,6 @@ const LOG = '[patrol]';
 
 // ── Thresholds ──────────────────────────────────────────────────────
 
-/** First GUPP warning (existing behavior) */
-export const GUPP_WARN_MS = 30 * 60_000; // 30 min
 /** Escalate to mayor after second threshold */
 export const GUPP_ESCALATE_MS = 60 * 60_000; // 1h
 /** Force-stop agent after third threshold */

--- a/services/gastown/src/dos/town/pr-feedback.test.ts
+++ b/services/gastown/src/dos/town/pr-feedback.test.ts
@@ -16,12 +16,12 @@ describe('TownConfigSchema refinery extensions', () => {
     expect(config.refinery?.code_review).toBe(false);
   });
 
-  it('defaults auto_resolve_pr_feedback to false', () => {
+  it('defaults auto_resolve_pr_feedback to true', () => {
     const config = TownConfigSchema.parse({});
-    expect(config.refinery).toBeUndefined();
+    expect(config.refinery?.auto_resolve_pr_feedback).toBe(true);
 
     const configWithRefinery = TownConfigSchema.parse({ refinery: {} });
-    expect(configWithRefinery.refinery?.auto_resolve_pr_feedback).toBe(false);
+    expect(configWithRefinery.refinery?.auto_resolve_pr_feedback).toBe(true);
   });
 
   it('defaults auto_merge_delay_minutes to null', () => {

--- a/services/gastown/src/dos/town/pr-feedback.test.ts
+++ b/services/gastown/src/dos/town/pr-feedback.test.ts
@@ -16,12 +16,18 @@ describe('TownConfigSchema refinery extensions', () => {
     expect(config.refinery?.code_review).toBe(false);
   });
 
-  it('defaults auto_resolve_pr_feedback to true', () => {
+  // Schema-level defaults are deliberately conservative — parsing an empty
+  // object returns undefined/false/null for the keys whose "new town" values
+  // moved into seedNewTownConfig(). This protects existing persisted configs
+  // from silently flipping behavior when they're re-loaded after a deploy.
+  it('does NOT inject refinery defaults when parsing an empty object', () => {
     const config = TownConfigSchema.parse({});
-    expect(config.refinery?.auto_resolve_pr_feedback).toBe(true);
+    expect(config.refinery).toBeUndefined();
+  });
 
+  it('defaults auto_resolve_pr_feedback to false when refinery: {} is supplied', () => {
     const configWithRefinery = TownConfigSchema.parse({ refinery: {} });
-    expect(configWithRefinery.refinery?.auto_resolve_pr_feedback).toBe(true);
+    expect(configWithRefinery.refinery?.auto_resolve_pr_feedback).toBe(false);
   });
 
   it('defaults auto_merge_delay_minutes to null', () => {

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -539,7 +539,7 @@ export function reconcileAgents(sql: SqlStorage, opts?: { draining?: boolean }):
       // Agent is working with fresh heartbeat but no hook — it's running
       // in the container but has no bead to work on (gt_done already ran,
       // or the hook was cleared by another code path). Set to idle so
-      // processReviewQueue / schedulePendingWork can use it.
+      // the reconciler can dispatch it to new work.
       actions.push({
         type: 'transition_agent',
         agent_id: agent.bead_id,
@@ -810,7 +810,7 @@ export function reconcileBeads(
     });
   }
 
-  // Rule 2: Idle agents with hooks need dispatch (schedulePendingWork equivalent)
+  // Rule 2: Idle agents with hooks need dispatch
   const idleHooked = AgentRow.array().parse([
     ...query(
       sql,

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -211,7 +211,11 @@ type ConvoyRow = z.infer<typeof ConvoyRow>;
  *
  * See reconciliation-spec.md §5.2.
  */
-export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
+export function applyEvent(
+  sql: SqlStorage,
+  event: TownEventRecord,
+  opts?: { townConfig?: TownConfig }
+): void {
   const payload = event.payload;
 
   switch (event.event_type) {
@@ -403,6 +407,27 @@ export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
       const hasFailingChecks = payload.has_failing_checks === true;
       const hasUncheckedRuns = payload.has_unchecked_runs === true;
 
+      // Consolidation: if there's already an open gt:pr-conflict bead for this MR,
+      // add has_feedback: true to it instead of creating a separate feedback bead.
+      // The agent resolving conflicts will then also address review feedback afterward.
+      const existingConflictBeadId = getExistingPrConflictBeadId(sql, mrBeadId);
+      if (existingConflictBeadId) {
+        query(
+          sql,
+          /* sql */ `
+            UPDATE ${beads}
+            SET ${beads.columns.metadata} = json_set(COALESCE(${beads.metadata}, '{}'), '$.has_feedback', 1),
+                ${beads.columns.updated_at} = ?
+            WHERE ${beads.bead_id} = ?
+          `,
+          [new Date().toISOString(), existingConflictBeadId]
+        );
+        console.log(
+          `${LOG} pr_feedback_detected: merged into existing conflict bead ${existingConflictBeadId} (mrBeadId=${mrBeadId})`
+        );
+        return;
+      }
+
       const feedbackBead = beadOps.createBead(sql, {
         type: 'issue',
         title: buildFeedbackBeadTitle(
@@ -432,6 +457,109 @@ export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
 
       // Feedback bead blocks the MR bead (same pattern as rework beads)
       beadOps.insertDependency(sql, mrBeadId, feedbackBead.bead_id, 'blocks');
+      return;
+    }
+
+    case 'pr_conflict_detected': {
+      const mrBeadId = typeof payload.mr_bead_id === 'string' ? payload.mr_bead_id : null;
+      if (!mrBeadId) {
+        console.warn(`${LOG} applyEvent: pr_conflict_detected missing mr_bead_id`);
+        return;
+      }
+
+      const mrBead = beadOps.getBead(sql, mrBeadId);
+      if (!mrBead || mrBead.status === 'closed' || mrBead.status === 'failed') return;
+
+      // Idempotent: check for an existing open gt:pr-conflict bead for this pr_url
+      if (hasExistingPrConflictBead(sql, mrBeadId)) return;
+
+      const prUrl = typeof payload.pr_url === 'string' ? payload.pr_url : '';
+      const branch = typeof payload.branch === 'string' ? payload.branch : '';
+      const sourceBead = typeof payload.source_bead_id === 'string' ? payload.source_bead_id : null;
+
+      // Read the target_branch from review_metadata
+      const rmRows = z
+        .object({ target_branch: z.string() })
+        .array()
+        .parse([
+          ...query(
+            sql,
+            /* sql */ `
+              SELECT ${review_metadata.columns.target_branch}
+              FROM ${review_metadata}
+              WHERE ${review_metadata.bead_id} = ?
+            `,
+            [mrBeadId]
+          ),
+        ]);
+      const targetBranch = rmRows[0]?.target_branch ?? '';
+
+      // Read auto_resolve_merge_conflicts using the same fallback chain as
+      // auto_resolve_pr_feedback: rig override → town config → default (true).
+      const rig = mrBead.rig_id ? getRig(sql, mrBead.rig_id) : null;
+      const effectiveConfig = opts?.townConfig
+        ? resolveRigConfig(opts.townConfig, rig?.config ?? null)
+        : { auto_resolve_merge_conflicts: rig?.config?.auto_resolve_merge_conflicts !== false };
+      const autoResolveConflicts = effectiveConfig.auto_resolve_merge_conflicts !== false;
+
+      if (autoResolveConflicts) {
+        // Consolidation: if there's already an open gt:pr-feedback bead for this MR,
+        // add has_conflicts: true to it instead of creating a separate conflict bead.
+        // The agent handling the feedback bead will resolve conflicts first, then
+        // address review comments.
+        const existingFeedbackBeadId = getExistingPrFeedbackBeadId(sql, mrBeadId);
+        if (existingFeedbackBeadId) {
+          query(
+            sql,
+            /* sql */ `
+              UPDATE ${beads}
+              SET ${beads.columns.metadata} = json_set(COALESCE(${beads.metadata}, '{}'), '$.has_conflicts', 1, '$.conflict_target_branch', ?),
+                  ${beads.columns.updated_at} = ?
+              WHERE ${beads.bead_id} = ?
+            `,
+            [targetBranch, new Date().toISOString(), existingFeedbackBeadId]
+          );
+          console.log(
+            `${LOG} pr_conflict_detected: merged into existing feedback bead ${existingFeedbackBeadId} (mrBeadId=${mrBeadId})`
+          );
+          return;
+        }
+
+        const conflictBead = beadOps.createBead(sql, {
+          type: 'issue',
+          title: `Resolve merge conflicts on PR: ${branch}`,
+          body: buildConflictResolutionPrompt(prUrl, branch, targetBranch),
+          rig_id: mrBead.rig_id ?? undefined,
+          parent_bead_id: mrBeadId,
+          labels: ['gt:pr-conflict'],
+          metadata: {
+            pr_url: prUrl,
+            branch,
+            target_branch: targetBranch,
+            mr_bead_id: mrBeadId,
+            source_bead_id: sourceBead,
+          },
+        });
+
+        // Conflict bead blocks the MR bead (same pattern as feedback beads)
+        beadOps.insertDependency(sql, mrBeadId, conflictBead.bead_id, 'blocks');
+      } else {
+        // auto_resolve_merge_conflicts disabled — create an escalation bead
+        beadOps.createBead(sql, {
+          type: 'escalation',
+          title: `Merge conflict detected: ${branch}`,
+          body: `PR ${prUrl} (branch ${branch}) has merge conflicts that require manual resolution.`,
+          priority: 'high',
+          metadata: {
+            pr_url: prUrl,
+            branch,
+            target_branch: targetBranch,
+            mr_bead_id: mrBeadId,
+            source_bead_id: sourceBead,
+            conflict: true,
+          },
+        });
+      }
       return;
     }
 
@@ -2173,24 +2301,62 @@ function hasRecentNudge(sql: SqlStorage, agentId: string, tier: string): boolean
   return rows.length > 0;
 }
 
+/** Check if an MR bead has a non-terminal conflict bead (gt:pr-conflict) blocking it. */
+function hasExistingPrConflictBead(sql: SqlStorage, mrBeadId: string): boolean {
+  return getExistingPrConflictBeadId(sql, mrBeadId) !== null;
+}
+
+/** Return the bead_id of a non-terminal conflict bead (gt:pr-conflict) blocking the MR, or null. */
+function getExistingPrConflictBeadId(sql: SqlStorage, mrBeadId: string): string | null {
+  const rows = z
+    .object({ bead_id: z.string() })
+    .array()
+    .parse([
+      ...query(
+        sql,
+        /* sql */ `
+          SELECT fb.${beads.columns.bead_id}
+          FROM ${bead_dependencies} bd
+          INNER JOIN ${beads} fb ON fb.${beads.columns.bead_id} = bd.${bead_dependencies.columns.depends_on_bead_id}
+          WHERE bd.${bead_dependencies.columns.bead_id} = ?
+            AND bd.${bead_dependencies.columns.dependency_type} = 'blocks'
+            AND fb.${beads.columns.labels} LIKE '%gt:pr-conflict%'
+            AND fb.${beads.columns.status} NOT IN ('closed', 'failed')
+          LIMIT 1
+        `,
+        [mrBeadId]
+      ),
+    ]);
+  return rows.length > 0 ? rows[0].bead_id : null;
+}
+
 /** Check if an MR bead has a non-terminal feedback bead (gt:pr-feedback) blocking it. */
 function hasExistingPrFeedbackBead(sql: SqlStorage, mrBeadId: string): boolean {
-  const rows = [
-    ...query(
-      sql,
-      /* sql */ `
-        SELECT 1 FROM ${bead_dependencies} bd
-        INNER JOIN ${beads} fb ON fb.${beads.columns.bead_id} = bd.${bead_dependencies.columns.depends_on_bead_id}
-        WHERE bd.${bead_dependencies.columns.bead_id} = ?
-          AND bd.${bead_dependencies.columns.dependency_type} = 'blocks'
-          AND fb.${beads.columns.labels} LIKE '%gt:pr-feedback%'
-          AND fb.${beads.columns.status} NOT IN ('closed', 'failed')
-        LIMIT 1
-      `,
-      [mrBeadId]
-    ),
-  ];
-  return rows.length > 0;
+  return getExistingPrFeedbackBeadId(sql, mrBeadId) !== null;
+}
+
+/** Return the bead_id of a non-terminal feedback bead (gt:pr-feedback) blocking the MR, or null. */
+function getExistingPrFeedbackBeadId(sql: SqlStorage, mrBeadId: string): string | null {
+  const rows = z
+    .object({ bead_id: z.string() })
+    .array()
+    .parse([
+      ...query(
+        sql,
+        /* sql */ `
+          SELECT fb.${beads.columns.bead_id}
+          FROM ${bead_dependencies} bd
+          INNER JOIN ${beads} fb ON fb.${beads.columns.bead_id} = bd.${bead_dependencies.columns.depends_on_bead_id}
+          WHERE bd.${bead_dependencies.columns.bead_id} = ?
+            AND bd.${bead_dependencies.columns.dependency_type} = 'blocks'
+            AND fb.${beads.columns.labels} LIKE '%gt:pr-feedback%'
+            AND fb.${beads.columns.status} NOT IN ('closed', 'failed')
+          LIMIT 1
+        `,
+        [mrBeadId]
+      ),
+    ]);
+  return rows.length > 0 ? rows[0].bead_id : null;
 }
 
 /** Build a human-readable title for the feedback bead. */
@@ -2267,6 +2433,47 @@ function buildFeedbackPrompt(
   lines.push(
     'After addressing everything, push all changes in a single commit (or minimal commits) and call gt_done.'
   );
+
+  return lines.join('\n');
+}
+
+/** Build the polecat prompt body for resolving merge conflicts on a PR branch. */
+function buildConflictResolutionPrompt(
+  prUrl: string,
+  branch: string,
+  targetBranch: string
+): string {
+  const lines: string[] = [];
+  lines.push(`You are resolving merge conflicts on branch \`${branch}\`.`);
+  lines.push(`The PR is: ${prUrl}`);
+  lines.push(`The target branch is: \`${targetBranch}\``);
+  lines.push('');
+  lines.push('## Steps');
+  lines.push('');
+  lines.push('1. Fetch the latest state of the remote:');
+  lines.push('   ```');
+  lines.push('   git fetch origin');
+  lines.push('   ```');
+  lines.push('');
+  lines.push(`2. Rebase your branch onto the target branch to incorporate its latest changes:`);
+  lines.push('   ```');
+  lines.push(`   git rebase origin/${targetBranch}`);
+  lines.push('   ```');
+  lines.push('');
+  lines.push('3. If there are conflicts during rebase, resolve them:');
+  lines.push('   - Edit the conflicting files to resolve the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)');
+  lines.push('   - Stage the resolved files: `git add <file>`');
+  lines.push('   - Continue the rebase: `git rebase --continue`');
+  lines.push('   - Repeat until the rebase completes');
+  lines.push('');
+  lines.push('4. Push the rebased branch:');
+  lines.push('   ```');
+  lines.push(`   git push --force-with-lease origin ${branch}`);
+  lines.push('   ```');
+  lines.push('');
+  lines.push('5. Call `gt_done` once the push succeeds, passing both required arguments:');
+  lines.push(`   - \`pr_url\`: \`${prUrl}\``);
+  lines.push(`   - \`branch\`: \`${branch}\``);
 
   return lines.join('\n');
 }

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -1311,9 +1311,14 @@ export function reconcileReviewQueue(
     }
 
     // Orphan cleanup: open MR beads without pr_url that aren't convoy
-    // review-and-merge beads. The polecat should have created the PR
-    // (merge_strategy=pr) but didn't — fail the MR and reopen the
-    // source bead so another polecat can retry.
+    // review-and-merge beads or system-created landing MR beads.
+    // The polecat should have created the PR (merge_strategy=pr) but
+    // didn't — fail the MR and reopen the source bead so another
+    // polecat can retry.
+    // Landing MR beads (created_by='system') are excluded because they
+    // are created by reconcileConvoys for review-then-land convoys and
+    // intentionally have no pr_url at creation — the refinery creates
+    // the PR when it picks up the landing MR.
     const orphanedMrs = z
       .object({ bead_id: z.string(), source_bead_id: z.string().nullable() })
       .array()
@@ -1333,6 +1338,7 @@ export function reconcileReviewQueue(
               AND b.${beads.columns.status} = 'open'
               AND b.${beads.columns.rig_id} = ?
               AND rm.${review_metadata.columns.pr_url} IS NULL
+              AND b.${beads.columns.created_by} != 'system'
               AND NOT EXISTS (
                 SELECT 1
                 FROM ${beads} parent
@@ -1395,21 +1401,25 @@ export function reconcileReviewQueue(
       ]);
 
     for (const { rig_id } of rigsWithOpenMrs) {
-      // When code_review=false, only dispatch the refinery for convoy
-      // review-and-merge MR beads (refinery does combined review+merge).
+      // When code_review=false, only dispatch the refinery for:
+      //  1. Convoy review-and-merge MR beads (refinery does combined review+merge)
+      //  2. System-created landing MR beads (review-then-land convoy finalization)
       // MR beads WITH a pr_url are handled by the fast-track → poll_pr.
       // MR beads WITHOUT a pr_url when merge_strategy=pr are orphaned
-      // (polecat should have created the PR) — Rule 2 handles them.
+      // (polecat should have created the PR) — orphan cleanup handles them.
       const refineryNeededFilter = rigCodeReview(rig_id)
         ? ''
         : /* sql */ `
-            AND EXISTS (
-              SELECT 1
-              FROM ${beads} outer_parent
-              JOIN ${convoy_metadata} cm
-                ON cm.${convoy_metadata.columns.bead_id} = outer_parent.${beads.columns.bead_id}
-              WHERE outer_parent.${beads.columns.bead_id} = ${beads.parent_bead_id}
-                AND cm.${convoy_metadata.columns.merge_mode} = 'review-and-merge'
+            AND (
+              EXISTS (
+                SELECT 1
+                FROM ${beads} outer_parent
+                JOIN ${convoy_metadata} cm
+                  ON cm.${convoy_metadata.columns.bead_id} = outer_parent.${beads.columns.bead_id}
+                WHERE outer_parent.${beads.columns.bead_id} = ${beads.parent_bead_id}
+                  AND cm.${convoy_metadata.columns.merge_mode} = 'review-and-merge'
+              )
+              OR ${beads.created_by} = 'system'
             )`;
 
       // Check if rig already has an in_progress MR that needs the refinery.
@@ -2305,7 +2315,9 @@ export function checkInvariants(sql: SqlStorage): Violation[] {
   }
 
   // Invariant 5: Convoy beads should not be in unexpected states.
-  // Valid transient states: open, in_progress, in_review, closed.
+  // Valid states: open, in_progress, in_review, closed, failed.
+  // 'failed' is a terminal state set by FailConvoy when landing MR
+  // creation is exhausted.
   const badStateConvoys = z
     .object({ bead_id: z.string(), status: z.string() })
     .array()
@@ -2316,7 +2328,7 @@ export function checkInvariants(sql: SqlStorage): Violation[] {
         SELECT ${beads.bead_id}, ${beads.status}
         FROM ${beads}
         WHERE ${beads.type} = 'convoy'
-          AND ${beads.status} NOT IN ('open', 'in_progress', 'in_review', 'closed')
+          AND ${beads.status} NOT IN ('open', 'in_progress', 'in_review', 'closed', 'failed')
       `,
         []
       ),

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -2503,7 +2503,9 @@ function buildConflictResolutionPrompt(
   lines.push('   ```');
   lines.push('');
   lines.push('3. If there are conflicts during rebase, resolve them:');
-  lines.push('   - Edit the conflicting files to resolve the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)');
+  lines.push(
+    '   - Edit the conflicting files to resolve the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)'
+  );
   lines.push('   - Stage the resolved files: `git add <file>`');
   lines.push('   - Continue the rebase: `git rebase --continue`');
   lines.push('   - Repeat until the rebase completes');

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -18,12 +18,14 @@ import { review_metadata, ReviewMetadataRecord } from '../../db/tables/review-me
 import { convoy_metadata, ConvoyMetadataRecord } from '../../db/tables/convoy-metadata.table';
 import { bead_dependencies } from '../../db/tables/bead-dependencies.table';
 import { agent_nudges } from '../../db/tables/agent-nudges.table';
+import { escalation_metadata } from '../../db/tables/escalation-metadata.table';
 import { query } from '../../util/query.util';
 import {
   GUPP_ESCALATE_MS,
   GUPP_FORCE_STOP_MS,
   AGENT_GC_RETENTION_MS,
   TRIAGE_LABEL_LIKE,
+  createTriageRequest,
 } from './patrol';
 import { MAX_DISPATCH_ATTEMPTS } from './scheduling';
 import * as reviewQueue from './review-queue';
@@ -544,12 +546,16 @@ export function applyEvent(
         // Conflict bead blocks the MR bead (same pattern as feedback beads)
         beadOps.insertDependency(sql, mrBeadId, conflictBead.bead_id, 'blocks');
       } else {
-        // auto_resolve_merge_conflicts disabled — create an escalation bead
-        beadOps.createBead(sql, {
+        // auto_resolve_merge_conflicts disabled — route through the full
+        // escalation pipeline so escalation_metadata, triage request, and
+        // mayor notification are all created (same path as routeEscalation()).
+        const escalationBead = beadOps.createBead(sql, {
           type: 'escalation',
           title: `Merge conflict detected: ${branch}`,
           body: `PR ${prUrl} (branch ${branch}) has merge conflicts that require manual resolution.`,
           priority: 'high',
+          rig_id: mrBead.rig_id ?? undefined,
+          labels: ['gt:escalation', 'severity:high'],
           metadata: {
             pr_url: prUrl,
             branch,
@@ -558,6 +564,36 @@ export function applyEvent(
             source_bead_id: sourceBead,
             conflict: true,
           },
+        });
+        query(
+          sql,
+          /* sql */ `
+            INSERT INTO ${escalation_metadata} (
+              ${escalation_metadata.columns.bead_id},
+              ${escalation_metadata.columns.severity},
+              ${escalation_metadata.columns.category},
+              ${escalation_metadata.columns.acknowledged},
+              ${escalation_metadata.columns.re_escalation_count},
+              ${escalation_metadata.columns.acknowledged_at}
+            ) VALUES (?, ?, ?, ?, ?, ?)
+          `,
+          [escalationBead.bead_id, 'high', 'merge_conflict', 0, 0, null]
+        );
+        createTriageRequest(sql, {
+          triageType: 'escalation',
+          agentBeadId: null,
+          title: `Escalation (high): Merge conflict on ${branch}`,
+          context: {
+            escalation_bead_id: escalationBead.bead_id,
+            severity: 'high',
+            rig_id: mrBead.rig_id,
+            category: 'merge_conflict',
+            pr_url: prUrl,
+            branch,
+            mr_bead_id: mrBeadId,
+          },
+          options: ['ESCALATE_TO_MAYOR', 'RESTART', 'CLOSE_BEAD', 'REASSIGN_BEAD'],
+          rigId: mrBead.rig_id ?? undefined,
         });
       }
       return;
@@ -1990,34 +2026,40 @@ export function reconcileConvoys(sql: SqlStorage): Action[] {
           if (elapsed < cooldownMs) continue;
         }
 
-        // Fix 3 (#2260): Check that tracked beads have at least one MR with a PR URL
-        const convoyBeadsWithPr = z
-          .object({ cnt: z.number() })
-          .array()
-          .parse([
-            ...query(
-              sql,
-              /* sql */ `
-                SELECT count(*) as cnt
-                FROM ${bead_dependencies} track_dep
-                INNER JOIN ${bead_dependencies} mr_dep
-                  ON mr_dep.${bead_dependencies.columns.depends_on_bead_id} = track_dep.${bead_dependencies.columns.bead_id}
-                INNER JOIN ${review_metadata} rm
-                  ON rm.${review_metadata.columns.bead_id} = mr_dep.${bead_dependencies.columns.bead_id}
-                WHERE track_dep.${bead_dependencies.columns.depends_on_bead_id} = ?
-                  AND track_dep.${bead_dependencies.columns.dependency_type} = 'tracks'
-                  AND mr_dep.${bead_dependencies.columns.dependency_type} = 'tracks'
-                  AND rm.${review_metadata.columns.pr_url} IS NOT NULL
-              `,
-              [convoy.bead_id]
-            ),
-          ]);
+        // Fix 3 (#2260): Check that tracked beads have at least one MR with a PR URL.
+        // For review-then-land convoys using direct merge strategy, intermediate bead
+        // merges go straight into the feature branch without persisting a pr_url —
+        // skip this guard and always create the landing MR when all beads are closed.
+        const needsPrUrl = convoy.merge_mode !== 'review-then-land';
+        if (needsPrUrl) {
+          const convoyBeadsWithPr = z
+            .object({ cnt: z.number() })
+            .array()
+            .parse([
+              ...query(
+                sql,
+                /* sql */ `
+                  SELECT count(*) as cnt
+                  FROM ${bead_dependencies} track_dep
+                  INNER JOIN ${bead_dependencies} mr_dep
+                    ON mr_dep.${bead_dependencies.columns.depends_on_bead_id} = track_dep.${bead_dependencies.columns.bead_id}
+                  INNER JOIN ${review_metadata} rm
+                    ON rm.${review_metadata.columns.bead_id} = mr_dep.${bead_dependencies.columns.bead_id}
+                  WHERE track_dep.${bead_dependencies.columns.depends_on_bead_id} = ?
+                    AND track_dep.${bead_dependencies.columns.dependency_type} = 'tracks'
+                    AND mr_dep.${bead_dependencies.columns.dependency_type} = 'tracks'
+                    AND rm.${review_metadata.columns.pr_url} IS NOT NULL
+                `,
+                [convoy.bead_id]
+              ),
+            ]);
 
-        if ((convoyBeadsWithPr[0]?.cnt ?? 0) === 0) {
-          console.warn(
-            `${LOG} convoy ${convoy.bead_id} has no beads with pr_url — skipping create_landing_mr`
-          );
-          continue;
+          if ((convoyBeadsWithPr[0]?.cnt ?? 0) === 0) {
+            console.warn(
+              `${LOG} convoy ${convoy.bead_id} has no beads with pr_url — skipping create_landing_mr`
+            );
+            continue;
+          }
         }
 
         // No landing MR exists yet and cooldown has passed — create one

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -45,6 +45,15 @@ const CIRCUIT_BREAKER_FAILURE_THRESHOLD = 20;
 /** Window in minutes for counting dispatch failures. */
 const CIRCUIT_BREAKER_WINDOW_MINUTES = 30;
 
+/** Max landing MR creation attempts before failing the convoy (#2260). */
+const MAX_LANDING_MR_ATTEMPTS = 5;
+
+/** Base cooldown for landing MR retry: min(2^attempts * BASE, MAX) (#2260). */
+const LANDING_MR_COOLDOWN_BASE_MS = 30_000; // 30s
+
+/** Max cooldown for landing MR retry (#2260). */
+const LANDING_MR_COOLDOWN_MAX_MS = 30 * 60_000; // 30 min
+
 /**
  * Town-level dispatch circuit breaker. Counts beads with at least one
  * dispatch attempt in the recent window that have not yet closed
@@ -1723,14 +1732,19 @@ export function reconcileConvoys(sql: SqlStorage): Action[] {
     if (progressRows.length === 0) continue;
     const { closed_count, total_count } = progressRows[0];
 
-    // Update progress if stale
-    if (closed_count !== convoy.closed_beads) {
-      actions.push({
-        type: 'update_convoy_progress',
-        convoy_id: convoy.bead_id,
-        closed_beads: closed_count,
-      });
+    // Parse convoy metadata for landing MR tracking fields (#2260)
+    let parsedMeta: Record<string, unknown> = {};
+    try {
+      parsedMeta = JSON.parse(convoy.metadata) as Record<string, unknown>;
+    } catch {
+      /* ignore */
     }
+    const landingMrAttempts =
+      typeof parsedMeta.landing_mr_attempts === 'number' ? parsedMeta.landing_mr_attempts : 0;
+    const lastLandingMrAttemptAt =
+      typeof parsedMeta.last_landing_mr_attempt_at === 'string'
+        ? parsedMeta.last_landing_mr_attempt_at
+        : null;
 
     // Check for in-flight MR beads (open or in_progress) for tracked issue beads
     const inFlightMrCount = z
@@ -1759,31 +1773,36 @@ export function reconcileConvoys(sql: SqlStorage): Action[] {
     const hasInFlightReviews = (inFlightMrCount[0]?.cnt ?? 0) > 0;
 
     // Check if all beads done
-    if (closed_count >= total_count && total_count > 0 && !hasInFlightReviews) {
-      let parsedMeta: Record<string, unknown> = {};
-      try {
-        parsedMeta = JSON.parse(convoy.metadata) as Record<string, unknown>;
-      } catch {
-        /* ignore */
+    const allBeadsDone = closed_count >= total_count && total_count > 0 && !hasInFlightReviews;
+
+    // Update progress if stale (skip if we're failing/closing the convoy this tick)
+    if (closed_count !== convoy.closed_beads) {
+      actions.push({
+        type: 'update_convoy_progress',
+        convoy_id: convoy.bead_id,
+        closed_beads: closed_count,
+      });
+    }
+
+    if (!allBeadsDone) continue;
+
+    if (convoy.merge_mode === 'review-then-land' && convoy.feature_branch) {
+      if (!parsedMeta.ready_to_land) {
+        actions.push({
+          type: 'set_convoy_ready_to_land',
+          convoy_id: convoy.bead_id,
+        });
       }
 
-      if (convoy.merge_mode === 'review-then-land' && convoy.feature_branch) {
-        if (!parsedMeta.ready_to_land) {
-          actions.push({
-            type: 'set_convoy_ready_to_land',
-            convoy_id: convoy.bead_id,
-          });
-        }
-
-        if (parsedMeta.ready_to_land) {
-          // Check if a landing MR already exists (any status)
-          const landingMrs = z
-            .object({ status: z.string() })
-            .array()
-            .parse([
-              ...query(
-                sql,
-                /* sql */ `
+      if (parsedMeta.ready_to_land) {
+        // Check if a landing MR already exists (any status)
+        const landingMrs = z
+          .object({ status: z.string() })
+          .array()
+          .parse([
+            ...query(
+              sql,
+              /* sql */ `
                 SELECT mr.${beads.columns.status}
                 FROM ${bead_dependencies} bd
                 INNER JOIN ${beads} mr ON mr.${beads.columns.bead_id} = bd.${bead_dependencies.columns.bead_id}
@@ -1791,36 +1810,87 @@ export function reconcileConvoys(sql: SqlStorage): Action[] {
                   AND bd.${bead_dependencies.columns.dependency_type} = 'tracks'
                   AND mr.${beads.columns.type} = 'merge_request'
               `,
-                [convoy.bead_id]
-              ),
-            ]);
+              [convoy.bead_id]
+            ),
+          ]);
 
-          // If a landing MR was already merged (closed), close the convoy
-          const hasMergedLanding = landingMrs.some(mr => mr.status === 'closed');
-          if (hasMergedLanding) {
-            actions.push({
-              type: 'close_convoy',
-              convoy_id: convoy.bead_id,
-            });
-            continue;
-          }
+        // If a landing MR was already merged (closed), close the convoy
+        const hasMergedLanding = landingMrs.some(mr => mr.status === 'closed');
+        if (hasMergedLanding) {
+          actions.push({
+            type: 'close_convoy',
+            convoy_id: convoy.bead_id,
+          });
+          continue;
+        }
 
-          // If a landing MR is active (open or in_progress), wait for it
-          const hasActiveLanding = landingMrs.some(
-            mr => mr.status === 'open' || mr.status === 'in_progress'
+        // Fix 1 (#2260): If a landing MR is active (open or in_progress), wait — don't create another
+        const hasActiveLanding = landingMrs.some(
+          mr => mr.status === 'open' || mr.status === 'in_progress'
+        );
+        if (hasActiveLanding) continue;
+
+        // Fix 2 (#2260): If max landing MR attempts exceeded and no landing MR is
+        // active or merged, fail the convoy. Checked after landing MR status lookup
+        // so the final allowed attempt can still succeed.
+        if (landingMrAttempts >= MAX_LANDING_MR_ATTEMPTS) {
+          actions.push({
+            type: 'fail_convoy',
+            convoy_id: convoy.bead_id,
+            reason: `Landing MR creation failed after ${MAX_LANDING_MR_ATTEMPTS} attempts`,
+          });
+          continue;
+        }
+
+        // Fix 2 (#2260): Apply exponential cooldown between landing MR attempts
+        if (landingMrAttempts > 0 && lastLandingMrAttemptAt) {
+          const elapsed = Date.now() - new Date(lastLandingMrAttemptAt).getTime();
+          const cooldownMs = Math.min(
+            Math.pow(2, landingMrAttempts) * LANDING_MR_COOLDOWN_BASE_MS,
+            LANDING_MR_COOLDOWN_MAX_MS
           );
-          if (hasActiveLanding) continue;
+          if (elapsed < cooldownMs) continue;
+        }
 
-          // No landing MR exists yet — create one
-          {
-            // Need rig_id from one of the tracked beads
-            const rigRows = z
-              .object({ rig_id: z.string() })
-              .array()
-              .parse([
-                ...query(
-                  sql,
-                  /* sql */ `
+        // Fix 3 (#2260): Check that tracked beads have at least one MR with a PR URL
+        const convoyBeadsWithPr = z
+          .object({ cnt: z.number() })
+          .array()
+          .parse([
+            ...query(
+              sql,
+              /* sql */ `
+                SELECT count(*) as cnt
+                FROM ${bead_dependencies} track_dep
+                INNER JOIN ${bead_dependencies} mr_dep
+                  ON mr_dep.${bead_dependencies.columns.depends_on_bead_id} = track_dep.${bead_dependencies.columns.bead_id}
+                INNER JOIN ${review_metadata} rm
+                  ON rm.${review_metadata.columns.bead_id} = mr_dep.${bead_dependencies.columns.bead_id}
+                WHERE track_dep.${bead_dependencies.columns.depends_on_bead_id} = ?
+                  AND track_dep.${bead_dependencies.columns.dependency_type} = 'tracks'
+                  AND mr_dep.${bead_dependencies.columns.dependency_type} = 'tracks'
+                  AND rm.${review_metadata.columns.pr_url} IS NOT NULL
+              `,
+              [convoy.bead_id]
+            ),
+          ]);
+
+        if ((convoyBeadsWithPr[0]?.cnt ?? 0) === 0) {
+          console.warn(
+            `${LOG} convoy ${convoy.bead_id} has no beads with pr_url — skipping create_landing_mr`
+          );
+          continue;
+        }
+
+        // No landing MR exists yet and cooldown has passed — create one
+        {
+          const rigRows = z
+            .object({ rig_id: z.string() })
+            .array()
+            .parse([
+              ...query(
+                sql,
+                /* sql */ `
                   SELECT DISTINCT tracked.${beads.columns.rig_id} as rig_id
                   FROM ${bead_dependencies} bd
                   INNER JOIN ${beads} tracked ON tracked.${beads.columns.bead_id} = bd.${bead_dependencies.columns.bead_id}
@@ -1829,29 +1899,28 @@ export function reconcileConvoys(sql: SqlStorage): Action[] {
                     AND tracked.${beads.columns.rig_id} IS NOT NULL
                   LIMIT 1
                 `,
-                  [convoy.bead_id]
-                ),
-              ]);
+                [convoy.bead_id]
+              ),
+            ]);
 
-            if (rigRows.length > 0) {
-              const rig = getRig(sql, rigRows[0].rig_id);
-              actions.push({
-                type: 'create_landing_mr',
-                convoy_id: convoy.bead_id,
-                rig_id: rigRows[0].rig_id,
-                feature_branch: convoy.feature_branch,
-                target_branch: rig?.default_branch ?? 'main',
-              });
-            }
+          if (rigRows.length > 0) {
+            const rig = getRig(sql, rigRows[0].rig_id);
+            actions.push({
+              type: 'create_landing_mr',
+              convoy_id: convoy.bead_id,
+              rig_id: rigRows[0].rig_id,
+              feature_branch: convoy.feature_branch,
+              target_branch: rig?.default_branch ?? 'main',
+            });
           }
         }
-      } else {
-        // review-and-merge or no feature branch — auto-close
-        actions.push({
-          type: 'close_convoy',
-          convoy_id: convoy.bead_id,
-        });
       }
+    } else {
+      // review-and-merge or no feature branch — auto-close
+      actions.push({
+        type: 'close_convoy',
+        convoy_id: convoy.bead_id,
+      });
     }
   }
 

--- a/services/gastown/src/dos/town/review-queue.ts
+++ b/services/gastown/src/dos/town/review-queue.ts
@@ -208,53 +208,6 @@ export function submitToReviewQueue(sql: SqlStorage, input: ReviewQueueInput): v
   });
 }
 
-export function popReviewQueue(sql: SqlStorage): ReviewQueueEntry | null {
-  // Pop the oldest open MR bead, but skip any whose source bead already
-  // has another MR in_progress (i.e. a refinery is already reviewing it).
-  // This prevents popping stale MR beads and triggering failReviewWithRework
-  // while an active review is in flight for the same source.
-  //
-  // The source bead is linked via bead_dependencies (dependency_type='tracks'):
-  //   bead_dependencies.bead_id = MR bead
-  //   bead_dependencies.depends_on_bead_id = source bead
-  const rows = [
-    ...query(
-      sql,
-      /* sql */ `
-        ${REVIEW_JOIN}
-        WHERE ${beads.status} = 'open'
-          AND NOT EXISTS (
-            SELECT 1 FROM ${beads} AS active_mr
-            WHERE active_mr.${beads.columns.type} = 'merge_request'
-              AND active_mr.${beads.columns.status} = 'in_progress'
-              AND active_mr.${beads.columns.rig_id} = ${beads.rig_id}
-          )
-        ORDER BY ${beads.created_at} ASC
-        LIMIT 1
-      `,
-      []
-    ),
-  ];
-
-  if (rows.length === 0) return null;
-  const parsed = MergeRequestBeadRecord.parse(rows[0]);
-  const entry = toReviewQueueEntry(parsed);
-
-  // Mark as running (in_progress)
-  query(
-    sql,
-    /* sql */ `
-      UPDATE ${beads}
-      SET ${beads.columns.status} = 'in_progress',
-          ${beads.columns.updated_at} = ?
-      WHERE ${beads.bead_id} = ?
-    `,
-    [now(), entry.id]
-  );
-
-  return { ...entry, status: 'running', processed_at: now() };
-}
-
 export function completeReview(
   sql: SqlStorage,
   entryId: string,
@@ -369,8 +322,8 @@ export function completeReviewWithResult(
         conflict: true,
       },
     });
-    // Return source bead to open so the normal scheduling path handles
-    // rework. Clear assignee so feedStrandedConvoys can match.
+    // Return source bead to open so the reconciler's scheduling path handles
+    // rework. Clear assignee so the reconciler can match it for dispatch.
     const conflictSourceBead = getBead(sql, entry.bead_id);
     if (
       conflictSourceBead &&
@@ -390,11 +343,10 @@ export function completeReviewWithResult(
     }
   } else if (input.status === 'failed') {
     // Review failed (rework requested): return source bead to open so
-    // the normal scheduling path (feedStrandedConvoys → hookBead →
-    // schedulePendingWork → dispatch) handles rework. Clear the stale
-    // assignee so feedStrandedConvoys can match (requires assignee IS NULL).
-    // This avoids the fire-and-forget rework dispatch race in TownDO
-    // where the dispatch fails and rehookOrphanedBeads churn.
+    // the reconciler's scheduling path handles rework. Clear the stale
+    // assignee so the reconciler can match it for dispatch (requires
+    // assignee IS NULL). This avoids a fire-and-forget rework dispatch
+    // race where the dispatch fails and the bead churns.
     const sourceBead = getBead(sql, entry.bead_id);
     if (sourceBead && sourceBead.status !== 'closed' && sourceBead.status !== 'failed') {
       updateBeadStatus(sql, entry.bead_id, 'open', entry.agent_id);
@@ -498,9 +450,8 @@ export function agentDone(sql: SqlStorage, agentId: string, input: AgentDoneInpu
   const agent = getAgent(sql, agentId);
   if (!agent) throw new Error(`Agent ${agentId} not found`);
   if (!agent.current_hook_bead_id) {
-    // The agent was unhooked by a recovery path (witnessPatrol,
-    // rehookOrphanedBeads) between when the agent finished work and
-    // when it called gt_done.
+    // The agent was unhooked by a recovery path between when the agent
+    // finished work and when it called gt_done.
     //
     // For refineries, this is critical: the refinery successfully merged
     // but the hook was cleared by zombie detection. We MUST still complete
@@ -648,9 +599,9 @@ export function agentDone(sql: SqlStorage, agentId: string, input: AgentDoneInpu
 
     unhookBead(sql, agentId);
     // Set refinery to idle immediately — the review is done and the
-    // refinery is available for new work. Without this, processReviewQueue
-    // sees the refinery as 'working' and won't pop the next MR bead until
-    // agentCompleted fires (when the container process eventually exits).
+    // refinery is available for new work. Without this, the reconciler
+    // sees the refinery as 'working' and won't dispatch the next MR bead
+    // until agentCompleted fires (when the container process eventually exits).
     updateAgentStatus(sql, agentId, 'idle');
     return;
   }
@@ -659,7 +610,7 @@ export function agentDone(sql: SqlStorage, agentId: string, input: AgentDoneInpu
 
   if (!agent.rig_id) {
     console.warn(
-      `[review-queue] agentDone: agent ${agentId} has null rig_id — review entry may fail in processReviewQueue`
+      `[review-queue] agentDone: agent ${agentId} has null rig_id — review entry may fail in submitToReviewQueue`
     );
   }
 
@@ -718,13 +669,13 @@ export function agentCompleted(
       // NEVER fail or unhook a refinery from agentCompleted.
       // agentCompleted races with gt_done: the process exits, the
       // container sends /completed, but gt_done's HTTP request may
-      // still be in flight. If we unhook here, recoverStuckReviews
-      // can fire between agentCompleted and gt_done, resetting the
-      // MR bead that's about to be closed by gt_done.
+      // still be in flight. If we unhook here, a recovery path can
+      // fire between agentCompleted and gt_done, resetting the MR bead
+      // that's about to be closed by gt_done.
       //
       // Leave the hook intact. gt_done will close + unhook if the
-      // merge succeeded. recoverStuckReviews (which checks for
-      // status='working') handles the case where gt_done never arrives.
+      // merge succeeded. The reconciler (which checks for status='working')
+      // handles the case where gt_done never arrives.
       //
       // No-op for the bead — just fall through to mark agent idle.
     } else {

--- a/services/gastown/src/dos/town/review-queue.ts
+++ b/services/gastown/src/dos/town/review-queue.ts
@@ -535,10 +535,7 @@ export function agentDone(sql: SqlStorage, agentId: string, input: AgentDoneInpu
   // PR-conflict beads also skip the review queue: the polecat rebased and
   // force-pushed the branch to resolve conflicts — closing the bead unblocks
   // the parent MR bead so poll_pr can re-check mergeable_state.
-  if (
-    hookedBead?.labels.includes('gt:pr-fixup') ||
-    hookedBead?.labels.includes('gt:pr-conflict')
-  ) {
+  if (hookedBead?.labels.includes('gt:pr-fixup') || hookedBead?.labels.includes('gt:pr-conflict')) {
     console.log(
       `[review-queue] agentDone: ${hookedBead.labels.includes('gt:pr-conflict') ? 'pr-conflict' : 'pr-fixup'} bead ${agent.current_hook_bead_id} — closing directly (skip review)`
     );

--- a/services/gastown/src/dos/town/review-queue.ts
+++ b/services/gastown/src/dos/town/review-queue.ts
@@ -532,9 +532,15 @@ export function agentDone(sql: SqlStorage, agentId: string, input: AgentDoneInpu
 
   // PR-fixup beads skip the review queue. The polecat pushed fixup commits
   // to an existing PR branch — no separate review is needed.
-  if (hookedBead?.labels.includes('gt:pr-fixup')) {
+  // PR-conflict beads also skip the review queue: the polecat rebased and
+  // force-pushed the branch to resolve conflicts — closing the bead unblocks
+  // the parent MR bead so poll_pr can re-check mergeable_state.
+  if (
+    hookedBead?.labels.includes('gt:pr-fixup') ||
+    hookedBead?.labels.includes('gt:pr-conflict')
+  ) {
     console.log(
-      `[review-queue] agentDone: pr-fixup bead ${agent.current_hook_bead_id} — closing directly (skip review)`
+      `[review-queue] agentDone: ${hookedBead.labels.includes('gt:pr-conflict') ? 'pr-conflict' : 'pr-fixup'} bead ${agent.current_hook_bead_id} — closing directly (skip review)`
     );
     closeBead(sql, agent.current_hook_bead_id, agentId);
     unhookBead(sql, agentId);

--- a/services/gastown/src/dos/town/scheduling.ts
+++ b/services/gastown/src/dos/town/scheduling.ts
@@ -126,27 +126,31 @@ export async function dispatchAgent(
 
     const rigRecord = rigs.getRig(ctx.sql, rigId);
 
-    const started = await dispatch.startAgentInContainer(ctx.env, ctx.storage, {
-      townId: ctx.townId,
-      rigId,
-      userId: rigConfig.userId,
-      agentId: agent.id,
-      agentName: agent.name,
-      role: agent.role,
-      identity: agent.identity,
-      beadId: bead.bead_id,
-      beadTitle: bead.title,
-      beadBody: bead.body ?? '',
-      checkpoint: agent.checkpoint,
-      gitUrl: rigConfig.gitUrl,
-      defaultBranch: rigConfig.defaultBranch,
-      kilocodeToken,
-      townConfig,
-      rigOverride: rigRecord?.config ?? null,
-      platformIntegrationId: rigConfig.platformIntegrationId,
-      convoyFeatureBranch: convoyFeatureBranch ?? undefined,
-      systemPromptOverride: options?.systemPromptOverride,
-    });
+    const { started, containerFetchMs } = await dispatch.startAgentInContainer(
+      ctx.env,
+      ctx.storage,
+      {
+        townId: ctx.townId,
+        rigId,
+        userId: rigConfig.userId,
+        agentId: agent.id,
+        agentName: agent.name,
+        role: agent.role,
+        identity: agent.identity,
+        beadId: bead.bead_id,
+        beadTitle: bead.title,
+        beadBody: bead.body ?? '',
+        checkpoint: agent.checkpoint,
+        gitUrl: rigConfig.gitUrl,
+        defaultBranch: rigConfig.defaultBranch,
+        kilocodeToken,
+        townConfig,
+        rigOverride: rigRecord?.config ?? null,
+        platformIntegrationId: rigConfig.platformIntegrationId,
+        convoyFeatureBranch: convoyFeatureBranch ?? undefined,
+        systemPromptOverride: options?.systemPromptOverride,
+      }
+    );
 
     if (started) {
       // Reset dispatch_attempts on successful start — but NOT for refineries.
@@ -172,6 +176,7 @@ export async function dispatchAgent(
         agentId: agent.id,
         beadId: bead.bead_id,
         role: agent.role,
+        durationMs: containerFetchMs,
       });
     } else {
       // Container start returned false — but the container may have

--- a/services/gastown/src/dos/town/town-scm.ts
+++ b/services/gastown/src/dos/town/town-scm.ts
@@ -45,14 +45,20 @@ export async function resolveGitHubToken(ctx: SCMContext): Promise<string | null
   return token ?? null;
 }
 
+export type PRStatusResult = {
+  status: 'open' | 'merged' | 'closed';
+  mergeable_state?: string;
+};
+
 /**
  * Check the status of a PR/MR via its URL.
- * Returns 'open', 'merged', or 'closed' (null if cannot determine).
+ * Returns a PRStatusResult with status and optional mergeable_state (GitHub only),
+ * or null if the status cannot be determined.
  */
 export async function checkPRStatus(
   ctx: SCMContext,
   prUrl: string
-): Promise<'open' | 'merged' | 'closed' | null> {
+): Promise<PRStatusResult | null> {
   const townConfig = await ctx.getTownConfig();
 
   // GitHub PR URL format: https://github.com/{owner}/{repo}/pull/{number}
@@ -87,9 +93,9 @@ export async function checkPRStatus(
     const data = GitHubPRStatusSchema.safeParse(json);
     if (!data.success) return null;
 
-    if (data.data.merged) return 'merged';
-    if (data.data.state === 'closed') return 'closed';
-    return 'open';
+    if (data.data.merged) return { status: 'merged' };
+    if (data.data.state === 'closed') return { status: 'closed' };
+    return { status: 'open', mergeable_state: data.data.mergeable_state };
   }
 
   // GitLab MR URL format: https://{host}/{path}/-/merge_requests/{iid}
@@ -133,9 +139,9 @@ export async function checkPRStatus(
     const data = GitLabMRStatusSchema.safeParse(glJson);
     if (!data.success) return null;
 
-    if (data.data.state === 'merged') return 'merged';
-    if (data.data.state === 'closed') return 'closed';
-    return 'open';
+    if (data.data.state === 'merged') return { status: 'merged' };
+    if (data.data.state === 'closed') return { status: 'closed' };
+    return { status: 'open' };
   }
 
   console.warn(`${TOWN_LOG} checkPRStatus: unrecognized PR URL format: ${prUrl}`);

--- a/services/gastown/src/gastown.worker.ts
+++ b/services/gastown/src/gastown.worker.ts
@@ -119,6 +119,8 @@ import {
   handleMayorConvoyStart,
   handleMayorUiAction,
   handleMayorGetPendingNudges,
+  handleMayorConvoyAddBead,
+  handleMayorConvoyRemoveBead,
 } from './handlers/mayor-tools.handler';
 import { mayorAuthMiddleware } from './middleware/mayor-auth.middleware';
 import { townAuthMiddleware } from './middleware/town-auth.middleware';
@@ -1018,6 +1020,16 @@ app.post('/api/mayor/:townId/tools/escalations/:escalationId/acknowledge', c =>
 );
 app.post('/api/mayor/:townId/tools/convoys/:convoyId/start', c =>
   handleMayorConvoyStart(c, c.req.param())
+);
+app.post('/api/mayor/:townId/tools/convoys/:convoyId/add-bead', c =>
+  instrumented(c, 'POST /api/mayor/:townId/tools/convoys/:convoyId/add-bead', () =>
+    handleMayorConvoyAddBead(c, c.req.param())
+  )
+);
+app.post('/api/mayor/:townId/tools/convoys/:convoyId/remove-bead', c =>
+  instrumented(c, 'POST /api/mayor/:townId/tools/convoys/:convoyId/remove-bead', () =>
+    handleMayorConvoyRemoveBead(c, c.req.param())
+  )
 );
 // ── tRPC ────────────────────────────────────────────────────────────────
 // Serve the gastown tRPC router directly. The frontend tRPC client

--- a/services/gastown/src/gastown.worker.ts
+++ b/services/gastown/src/gastown.worker.ts
@@ -113,6 +113,8 @@ import {
   handleMayorConvoyClose,
   handleMayorConvoyUpdate,
   handleMayorBeadDelete,
+  handleMayorBulkDeleteBeads,
+  handleMayorDeleteBeadsByStatus,
   handleMayorEscalationAcknowledge,
   handleMayorConvoyStart,
   handleMayorUiAction,
@@ -976,6 +978,16 @@ app.post('/api/mayor/:townId/tools/rigs/:rigId/beads/:beadId/reassign', c =>
 app.delete('/api/mayor/:townId/tools/rigs/:rigId/beads/:beadId', c =>
   instrumented(c, 'DELETE /api/mayor/:townId/tools/rigs/:rigId/beads/:beadId', () =>
     handleMayorBeadDelete(c, c.req.param())
+  )
+);
+app.post('/api/mayor/:townId/tools/rigs/:rigId/beads/bulk-delete', c =>
+  instrumented(c, 'POST /api/mayor/:townId/tools/rigs/:rigId/beads/bulk-delete', () =>
+    handleMayorBulkDeleteBeads(c, c.req.param())
+  )
+);
+app.post('/api/mayor/:townId/tools/rigs/:rigId/beads/delete-by-status', c =>
+  instrumented(c, 'POST /api/mayor/:townId/tools/rigs/:rigId/beads/delete-by-status', () =>
+    handleMayorDeleteBeadsByStatus(c, c.req.param())
   )
 );
 app.post('/api/mayor/:townId/tools/rigs/:rigId/agents/:agentId/reset', c =>

--- a/services/gastown/src/gastown.worker.ts
+++ b/services/gastown/src/gastown.worker.ts
@@ -633,6 +633,12 @@ app.post('/api/towns/:townId/rigs/:rigId/agents/:agentId/db-snapshot', async c =
   return c.json({ success: true });
 });
 
+app.delete('/api/towns/:townId/rigs/:rigId/agents/:agentId/db-snapshot', async c => {
+  const { agentId } = c.req.param();
+  await c.env.AGENT_DB_SNAPSHOTS_KV.delete(agentId);
+  return c.json({ success: true });
+});
+
 // ── Kilo User Auth ──────────────────────────────────────────────────────
 // Validate Kilo user JWT (signed with NEXTAUTH_SECRET) for dashboard/user
 // routes. Container→worker routes use the agent JWT middleware instead

--- a/services/gastown/src/handlers/mayor-tools.handler.ts
+++ b/services/gastown/src/handlers/mayor-tools.handler.ts
@@ -635,6 +635,69 @@ export async function handleMayorBeadDelete(
   return c.json(resSuccess({ deleted: true }));
 }
 
+const MayorBulkDeleteBeadsBody = z.object({
+  bead_ids: z.array(z.string().uuid()).min(1).max(5000),
+});
+
+export async function handleMayorBulkDeleteBeads(
+  c: Context<GastownEnv>,
+  params: { townId: string; rigId: string }
+) {
+  const rigOwned = await verifyRigBelongsToTown(c, params.townId, params.rigId);
+  if (!rigOwned) {
+    return c.json(resError('Rig not found in this town'), 403);
+  }
+
+  const parsed = await parseJsonBody(c, MayorBulkDeleteBeadsBody);
+  if (!parsed.success) {
+    return c.json(resError('Invalid request body', parsed.error), 400);
+  }
+
+  const { bead_ids } = parsed.data;
+
+  console.log(
+    `${HANDLER_LOG} handleMayorBulkDeleteBeads: townId=${params.townId} rigId=${params.rigId} count=${bead_ids.length}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+  const count = await town.deleteBeads(bead_ids);
+
+  return c.json(resSuccess({ deleted: count }));
+}
+
+const MayorDeleteBeadsByStatusBody = z.object({
+  status: z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']),
+  type: z
+    .enum(['issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent'])
+    .optional(),
+});
+
+export async function handleMayorDeleteBeadsByStatus(
+  c: Context<GastownEnv>,
+  params: { townId: string; rigId: string }
+) {
+  const rigOwned = await verifyRigBelongsToTown(c, params.townId, params.rigId);
+  if (!rigOwned) {
+    return c.json(resError('Rig not found in this town'), 403);
+  }
+
+  const parsed = await parseJsonBody(c, MayorDeleteBeadsByStatusBody);
+  if (!parsed.success) {
+    return c.json(resError('Invalid request body', parsed.error), 400);
+  }
+
+  const { status, type } = parsed.data;
+
+  console.log(
+    `${HANDLER_LOG} handleMayorDeleteBeadsByStatus: townId=${params.townId} rigId=${params.rigId} status=${status}${type ? ` type=${type}` : ''}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+  const count = await town.deleteBeadsByStatus(status, type, params.rigId);
+
+  return c.json(resSuccess({ deleted: count }));
+}
+
 /**
  * POST /api/mayor/:townId/tools/escalations/:escalationId/acknowledge
  * Acknowledge an escalation, marking it as reviewed.

--- a/services/gastown/src/handlers/mayor-tools.handler.ts
+++ b/services/gastown/src/handlers/mayor-tools.handler.ts
@@ -632,7 +632,8 @@ export async function handleMayorBeadDelete(
     return c.json(resError('Bead does not belong to this rig'), 403);
   }
 
-  await town.deleteBead(params.beadId);
+  // Pass rigId as a defense-in-depth rig check in the DO delete path.
+  await town.deleteBead(params.beadId, params.rigId);
 
   return c.json(resSuccess({ deleted: true }));
 }
@@ -662,7 +663,10 @@ export async function handleMayorBulkDeleteBeads(
   );
 
   const town = getTownDOStub(c.env, params.townId);
-  const count = await town.deleteBeads(bead_ids);
+  // Pass rigId so the DO filters to beads actually belonging to this rig —
+  // prevents a mayor tool from deleting beads from a sibling rig by
+  // passing their IDs alongside an authorized rig.
+  const count = await town.deleteBeads(bead_ids, params.rigId);
 
   return c.json(resSuccess({ deleted: count }));
 }

--- a/services/gastown/src/handlers/mayor-tools.handler.ts
+++ b/services/gastown/src/handlers/mayor-tools.handler.ts
@@ -648,9 +648,9 @@ export async function handleMayorBulkDeleteBeads(
     return c.json(resError('Rig not found in this town'), 403);
   }
 
-  const parsed = await parseJsonBody(c, MayorBulkDeleteBeadsBody);
+  const parsed = MayorBulkDeleteBeadsBody.safeParse(await parseJsonBody(c));
   if (!parsed.success) {
-    return c.json(resError('Invalid request body', parsed.error), 400);
+    return c.json(resError(`Invalid request body: ${parsed.error.message}`), 400);
   }
 
   const { bead_ids } = parsed.data;
@@ -681,9 +681,9 @@ export async function handleMayorDeleteBeadsByStatus(
     return c.json(resError('Rig not found in this town'), 403);
   }
 
-  const parsed = await parseJsonBody(c, MayorDeleteBeadsByStatusBody);
+  const parsed = MayorDeleteBeadsByStatusBody.safeParse(await parseJsonBody(c));
   if (!parsed.success) {
-    return c.json(resError('Invalid request body', parsed.error), 400);
+    return c.json(resError(`Invalid request body: ${parsed.error.message}`), 400);
   }
 
   const { status, type } = parsed.data;

--- a/services/gastown/src/handlers/mayor-tools.handler.ts
+++ b/services/gastown/src/handlers/mayor-tools.handler.ts
@@ -392,6 +392,7 @@ const BeadUpdateBody = z
     metadata: z.record(z.string(), z.unknown()).optional(),
     rig_id: z.string().min(1).nullable().optional(),
     parent_bead_id: z.string().min(1).nullable().optional(),
+    depends_on: z.array(z.string().uuid()).optional(),
   })
   .refine(
     data =>
@@ -402,7 +403,8 @@ const BeadUpdateBody = z
       data.status !== undefined ||
       data.metadata !== undefined ||
       data.rig_id !== undefined ||
-      data.parent_bead_id !== undefined,
+      data.parent_bead_id !== undefined ||
+      data.depends_on !== undefined,
     { message: 'At least one field must be provided' }
   );
 
@@ -745,6 +747,69 @@ export async function handleMayorConvoyStart(
     `${HANDLER_LOG} handleMayorConvoyStart: completed, convoy=${result.convoy.id} beads=${result.beads.length}`
   );
 
+  return c.json(resSuccess(result));
+}
+
+const ConvoyAddBeadBody = z.object({
+  bead_id: z.string().uuid(),
+  depends_on: z.array(z.string().uuid()).optional(),
+});
+
+/**
+ * POST /api/mayor/:townId/tools/convoys/:convoyId/add-bead
+ * Add an existing bead to a convoy's tracking.
+ */
+export async function handleMayorConvoyAddBead(
+  c: Context<GastownEnv>,
+  params: { townId: string; convoyId: string }
+) {
+  const parsed = ConvoyAddBeadBody.safeParse(await parseJsonBody(c));
+  if (!parsed.success) {
+    return c.json(
+      { success: false, error: 'Invalid request body', issues: parsed.error.issues },
+      400
+    );
+  }
+
+  console.log(
+    `${HANDLER_LOG} handleMayorConvoyAddBead: townId=${params.townId} convoyId=${params.convoyId} beadId=${parsed.data.bead_id}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+  const result = await town.convoyAddBead(
+    params.convoyId,
+    parsed.data.bead_id,
+    parsed.data.depends_on
+  );
+  return c.json(resSuccess(result));
+}
+
+const ConvoyRemoveBeadBody = z.object({
+  bead_id: z.string().uuid(),
+});
+
+/**
+ * POST /api/mayor/:townId/tools/convoys/:convoyId/remove-bead
+ * Remove a bead from a convoy's tracking.
+ */
+export async function handleMayorConvoyRemoveBead(
+  c: Context<GastownEnv>,
+  params: { townId: string; convoyId: string }
+) {
+  const parsed = ConvoyRemoveBeadBody.safeParse(await parseJsonBody(c));
+  if (!parsed.success) {
+    return c.json(
+      { success: false, error: 'Invalid request body', issues: parsed.error.issues },
+      400
+    );
+  }
+
+  console.log(
+    `${HANDLER_LOG} handleMayorConvoyRemoveBead: townId=${params.townId} convoyId=${params.convoyId} beadId=${parsed.data.bead_id}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+  const result = await town.convoyRemoveBead(params.convoyId, parsed.data.bead_id);
   return c.json(resSuccess(result));
 }
 

--- a/services/gastown/src/handlers/rig-beads.handler.ts
+++ b/services/gastown/src/handlers/rig-beads.handler.ts
@@ -170,6 +170,7 @@ export async function handleDeleteBead(
   const town = getTownDOStub(c.env, townId);
   const bead = await town.getBeadAsync(params.beadId);
   if (!bead || bead.rig_id !== params.rigId) return c.json(resError('Bead not found'), 404);
-  await town.deleteBead(params.beadId);
+  // Pass rigId as a defense-in-depth rig check in the DO delete path.
+  await town.deleteBead(params.beadId, params.rigId);
   return c.json(resSuccess({ deleted: true }));
 }

--- a/services/gastown/src/prompts/mayor-system.prompt.ts
+++ b/services/gastown/src/prompts/mayor-system.prompt.ts
@@ -214,7 +214,7 @@ You can directly edit town state when things go wrong:
 - **gt_agent_reset** to force-reset a stuck agent to idle
 - **gt_convoy_close** to force-close a stuck convoy
 - **gt_convoy_update** to edit convoy merge_mode or feature_branch
-- **gt_bead_delete** to remove beads that shouldn't exist
+- **gt_bead_delete** to remove beads that shouldn't exist — accepts a single UUID or an array of UUIDs to bulk-delete up to 5000 at once
 - **gt_escalation_acknowledge** to acknowledge escalations
 
 Use these tools when the user reports stuck state, when you detect problems during delegation, or when you need to clean up after failures. You are the town coordinator — you have full authority over the control plane.

--- a/services/gastown/src/prompts/polecat-system.prompt.ts
+++ b/services/gastown/src/prompts/polecat-system.prompt.ts
@@ -82,6 +82,31 @@ After all gates pass and your work is complete, create a pull request before cal
 `
       : ''
   }
+## PR Conflict Resolution Workflow
+
+When your hooked bead has the \`gt:pr-conflict\` label, **or** when it has the \`gt:pr-feedback\` label and \`pr_conflict_context\` is present in your context, you are resolving merge conflicts on an existing PR branch. **This is an exception to the "do not switch branches" rule.** You MUST check out the PR branch from your bead metadata (\`pr_conflict_context.branch\`).
+
+1. Check out the PR branch: \`git fetch origin && git checkout <branch>\`
+2. Rebase onto the target branch to incorporate its latest changes:
+   ```
+   git rebase origin/<target_branch>
+   ```
+3. If there are conflicts during rebase, resolve them:
+   - Edit conflicting files to resolve conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)
+   - Stage the resolved files: \`git add <file>\`
+   - Continue the rebase: \`git rebase --continue\`
+   - Repeat until the rebase completes
+4. Push the rebased branch:
+   ```
+   git push --force-with-lease origin <branch>
+   ```
+5. If the bead metadata has `has_feedback: true`, also address the PR review feedback (see PR Fixup Workflow below) before calling gt_done.
+ 6. Call \`gt_done\` with both required arguments once all conflicts are resolved (and feedback addressed if applicable):
+    - \`pr_url\`: the PR URL from \`pr_conflict_context.pr_url\`
+    - \`branch\`: the branch name from \`pr_conflict_context.branch\`
+
+Do NOT create a new PR. Push to the existing branch.
+
 ## PR Fixup Workflow
 
 When your hooked bead has the \`gt:pr-fixup\` label, you are fixing an existing PR rather than creating new work. **This is the ONE exception to the "do not switch branches" rule.** You MUST check out the PR branch from your bead metadata instead of using the default worktree branch.
@@ -101,7 +126,7 @@ Do NOT create a new PR. Push to the existing branch.
 - Commit after every meaningful unit of work (new function, passing test, config change).
 - Push after every commit. Do not batch pushes.
 - Use descriptive commit messages referencing the bead if applicable.
-- Branch naming: your branch is pre-configured in your worktree. Do not switch branches — **unless** your bead has the \`gt:pr-fixup\` label (see PR Fixup Workflow above).
+- Branch naming: your branch is pre-configured in your worktree. Do not switch branches — **unless** your bead has the \`gt:pr-fixup\` or \`gt:pr-conflict\` label (see workflows above).
 
 ## Escalation
 

--- a/services/gastown/src/prompts/polecat-system.prompt.ts
+++ b/services/gastown/src/prompts/polecat-system.prompt.ts
@@ -88,19 +88,19 @@ When your hooked bead has the \`gt:pr-conflict\` label, **or** when it has the \
 
 1. Check out the PR branch: \`git fetch origin && git checkout <branch>\`
 2. Rebase onto the target branch to incorporate its latest changes:
-   ```
+   \`\`\`
    git rebase origin/<target_branch>
-   ```
+   \`\`\`
 3. If there are conflicts during rebase, resolve them:
-   - Edit conflicting files to resolve conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)
+   - Edit conflicting files to resolve conflict markers (\`<<<<<<<\`, \`=======\`, \`>>>>>>>\`)
    - Stage the resolved files: \`git add <file>\`
    - Continue the rebase: \`git rebase --continue\`
    - Repeat until the rebase completes
 4. Push the rebased branch:
-   ```
+   \`\`\`
    git push --force-with-lease origin <branch>
-   ```
-5. If the bead metadata has `has_feedback: true`, also address the PR review feedback (see PR Fixup Workflow below) before calling gt_done.
+   \`\`\`
+5. If the bead metadata has \`has_feedback: true\`, also address the PR review feedback (see PR Fixup Workflow below) before calling gt_done.
  6. Call \`gt_done\` with both required arguments once all conflicts are resolved (and feedback addressed if applicable):
     - \`pr_url\`: the PR URL from \`pr_conflict_context.pr_url\`
     - \`branch\`: the branch name from \`pr_conflict_context.branch\`

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -659,11 +659,14 @@ export const gastownRouter = router({
       const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
       const ids = Array.isArray(input.beadId) ? input.beadId : [input.beadId];
+      // Pass input.rigId so the DO filters to beads that actually belong
+      // to this rig — prevents cross-rig deletion when the caller has only
+      // authorized one rig.
       if (ids.length === 1) {
-        await townStub.deleteBead(ids[0]);
-        return { deleted: 1 };
+        const deleted = await townStub.deleteBead(ids[0], input.rigId);
+        return { deleted: deleted ? 1 : 0 };
       }
-      const count = await townStub.deleteBeads(ids);
+      const count = await townStub.deleteBeads(ids, input.rigId);
       return { deleted: count };
     }),
 

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -682,6 +682,7 @@ export const gastownRouter = router({
           metadata: z.record(z.string(), z.unknown()).optional(),
           rig_id: z.string().min(1).nullable().optional(),
           parent_bead_id: z.string().min(1).nullable().optional(),
+          depends_on: z.array(z.string().uuid()).optional(),
         })
         .refine(
           data =>
@@ -692,7 +693,8 @@ export const gastownRouter = router({
             data.labels !== undefined ||
             data.metadata !== undefined ||
             data.rig_id !== undefined ||
-            data.parent_bead_id !== undefined,
+            data.parent_bead_id !== undefined ||
+            data.depends_on !== undefined,
           { message: 'At least one field to update must be provided' }
         )
     )
@@ -712,6 +714,37 @@ export const gastownRouter = router({
 
       const { rigId: _rigId, beadId, townId: _townId, ...fields } = input;
       return townStub.updateBead(beadId, fields, ctx.userId);
+    }),
+
+  convoyAddBead: gastownProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        convoyId: z.string().uuid(),
+        beadId: z.string().uuid(),
+        depends_on: z.array(z.string().uuid()).optional(),
+      })
+    )
+    .output(z.object({ total_beads: z.number() }))
+    .mutation(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      return townStub.convoyAddBead(input.convoyId, input.beadId, input.depends_on);
+    }),
+
+  convoyRemoveBead: gastownProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        convoyId: z.string().uuid(),
+        beadId: z.string().uuid(),
+      })
+    )
+    .output(z.object({ total_beads: z.number() }))
+    .mutation(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      return townStub.convoyRemoveBead(input.convoyId, input.beadId);
     }),
 
   deleteBeadsByStatus: gastownProcedure

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -650,14 +650,21 @@ export const gastownRouter = router({
     .input(
       z.object({
         rigId: z.string().uuid(),
-        beadId: z.string().uuid(),
+        beadId: z.union([z.string().uuid(), z.array(z.string().uuid())]),
         townId: z.string().uuid().optional(),
       })
     )
+    .output(z.object({ deleted: z.number() }))
     .mutation(async ({ ctx, input }) => {
       const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
-      await townStub.deleteBead(input.beadId);
+      const ids = Array.isArray(input.beadId) ? input.beadId : [input.beadId];
+      if (ids.length === 1) {
+        await townStub.deleteBead(ids[0]);
+        return { deleted: 1 };
+      }
+      const count = await townStub.deleteBeads(ids);
+      return { deleted: count };
     }),
 
   updateBead: gastownProcedure
@@ -705,6 +712,25 @@ export const gastownRouter = router({
 
       const { rigId: _rigId, beadId, townId: _townId, ...fields } = input;
       return townStub.updateBead(beadId, fields, ctx.userId);
+    }),
+
+  deleteBeadsByStatus: gastownProcedure
+    .input(
+      z.object({
+        rigId: z.string().uuid(),
+        status: z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']),
+        type: z
+          .enum(['issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent'])
+          .optional(),
+        townId: z.string().uuid().optional(),
+      })
+    )
+    .output(z.object({ deleted: z.number() }))
+    .mutation(async ({ ctx, input }) => {
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
+      const townStub = getTownDOStub(ctx.env, rig.town_id);
+      const count = await townStub.deleteBeadsByStatus(input.status, input.type, rig.id);
+      return { deleted: count };
     }),
 
   // ── Agents ──────────────────────────────────────────────────────────
@@ -1590,6 +1616,37 @@ export const gastownRouter = router({
     .query(async ({ ctx, input }) => {
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.getBeadAsync(input.beadId);
+    }),
+
+  adminBulkDeleteBeads: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        beadIds: z.array(z.string().uuid()),
+      })
+    )
+    .output(z.object({ deleted: z.number() }))
+    .mutation(async ({ ctx, input }) => {
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      const count = await townStub.deleteBeads(input.beadIds);
+      return { deleted: count };
+    }),
+
+  adminDeleteBeadsByStatus: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        status: z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']),
+        type: z
+          .enum(['issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent'])
+          .optional(),
+      })
+    )
+    .output(z.object({ deleted: z.number() }))
+    .mutation(async ({ ctx, input }) => {
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      const count = await townStub.deleteBeadsByStatus(input.status, input.type);
+      return { deleted: count };
     }),
 
   // DEBUG: raw agent_metadata dump — remove after debugging

--- a/services/gastown/src/types.ts
+++ b/services/gastown/src/types.ts
@@ -263,8 +263,12 @@ export const TownConfigSchema = z.object({
    * Town-level merge strategy. Rigs inherit this when they don't set their own.
    * - 'direct': Refinery pushes directly to main (no PR)
    * - 'pr': Refinery creates a GitHub PR / GitLab MR for human review
+   *
+   * NOTE: new towns are seeded with 'pr' by seedNewTownConfig(); the schema
+   * default below is preserved at 'direct' so existing persisted configs
+   * that never specified a merge_strategy keep their historical behavior.
    */
-  merge_strategy: MergeStrategy.default('pr'),
+  merge_strategy: MergeStrategy.default('direct'),
 
   /** Refinery configuration */
   refinery: z
@@ -279,27 +283,19 @@ export const TownConfigSchema = z.object({
       /** Controls how the refinery communicates review findings:
        *  - 'rework': creates internal rework beads via gt_request_changes (default)
        *  - 'comments': posts GitHub review comments on the PR (requires merge_strategy: 'pr') */
-      review_mode: z.enum(['rework', 'comments']).default('comments'),
+      review_mode: z.enum(['rework', 'comments']).default('rework'),
       /** When enabled, a polecat is automatically dispatched to address
        *  unresolved review comments and failing CI checks on open PRs. */
-      auto_resolve_pr_feedback: z.boolean().default(true),
+      auto_resolve_pr_feedback: z.boolean().default(false),
       /** When enabled, a polecat is automatically dispatched to rebase and
        *  resolve merge conflicts on open PRs. */
       auto_resolve_merge_conflicts: z.boolean().default(true).optional(),
       /** After all CI checks pass and all review threads are resolved,
        *  automatically merge the PR after this many minutes.
        *  0 = immediate, null = disabled (require manual merge). */
-      auto_merge_delay_minutes: z.number().int().min(0).nullable().default(5),
+      auto_merge_delay_minutes: z.number().int().min(0).nullable().default(null),
     })
-    .default({
-      gates: [],
-      auto_merge: true,
-      require_clean_merge: true,
-      code_review: true,
-      review_mode: 'comments',
-      auto_resolve_pr_feedback: true,
-      auto_merge_delay_minutes: 5,
-    }),
+    .optional(),
 
   /** Alarm interval when agents are active (seconds) */
   alarm_interval_active: z.number().int().min(5).max(600).optional(),
@@ -314,8 +310,10 @@ export const TownConfigSchema = z.object({
     })
     .optional(),
 
-  /** When true, all convoys are created as staged by default (agents not dispatched until started). */
-  staged_convoys_default: z.boolean().default(true),
+  /** When true, all convoys are created as staged by default (agents not dispatched until started).
+   *  New towns are seeded with `true` via seedNewTownConfig(); existing
+   *  persisted configs that never specified this key fall back to `false`. */
+  staged_convoys_default: z.boolean().default(false),
 
   /** Default merge mode for new convoys.
    *  - 'review-then-land': beads merge into a convoy feature branch, then a single landing PR is created (default)

--- a/services/gastown/src/types.ts
+++ b/services/gastown/src/types.ts
@@ -177,6 +177,14 @@ export type PrimeContext = {
     branch: string | null;
     target_branch: string | null;
   } | null;
+  /** Present when the hooked bead is a PR conflict resolution (gt:pr-conflict label). */
+  pr_conflict_context: {
+    pr_url: string | null;
+    branch: string | null;
+    target_branch: string | null;
+    /** When true, the bead also has pending review feedback to address after resolving conflicts. */
+    has_feedback: boolean;
+  } | null;
 };
 
 // -- Agent done --
@@ -275,6 +283,9 @@ export const TownConfigSchema = z.object({
       /** When enabled, a polecat is automatically dispatched to address
        *  unresolved review comments and failing CI checks on open PRs. */
       auto_resolve_pr_feedback: z.boolean().default(false),
+      /** When enabled, a polecat is automatically dispatched to rebase and
+       *  resolve merge conflicts on open PRs. */
+      auto_resolve_merge_conflicts: z.boolean().default(true).optional(),
       /** After all CI checks pass and all review threads are resolved,
        *  automatically merge the PR after this many minutes.
        *  0 = immediate, null = disabled (require manual merge). */
@@ -347,6 +358,7 @@ export const RigOverrideConfigSchema = z.object({
   /** false = skip refinery entirely */
   code_review: z.boolean().optional(),
   auto_resolve_pr_feedback: z.boolean().optional(),
+  auto_resolve_merge_conflicts: z.boolean().optional(),
   auto_merge_delay_minutes: z.number().int().min(0).nullable().optional(),
 
   // Merge strategy
@@ -412,6 +424,7 @@ export const TownConfigUpdateSchema = z.object({
       code_review: z.boolean().optional(),
       review_mode: z.enum(['rework', 'comments']).optional(),
       auto_resolve_pr_feedback: z.boolean().optional(),
+      auto_resolve_merge_conflicts: z.boolean().optional(),
       auto_merge_delay_minutes: z.number().int().min(0).nullable().optional(),
     })
     .optional(),

--- a/services/gastown/src/types.ts
+++ b/services/gastown/src/types.ts
@@ -264,7 +264,7 @@ export const TownConfigSchema = z.object({
    * - 'direct': Refinery pushes directly to main (no PR)
    * - 'pr': Refinery creates a GitHub PR / GitLab MR for human review
    */
-  merge_strategy: MergeStrategy.default('direct'),
+  merge_strategy: MergeStrategy.default('pr'),
 
   /** Refinery configuration */
   refinery: z
@@ -279,19 +279,19 @@ export const TownConfigSchema = z.object({
       /** Controls how the refinery communicates review findings:
        *  - 'rework': creates internal rework beads via gt_request_changes (default)
        *  - 'comments': posts GitHub review comments on the PR (requires merge_strategy: 'pr') */
-      review_mode: z.enum(['rework', 'comments']).default('rework'),
+      review_mode: z.enum(['rework', 'comments']).default('comments'),
       /** When enabled, a polecat is automatically dispatched to address
        *  unresolved review comments and failing CI checks on open PRs. */
-      auto_resolve_pr_feedback: z.boolean().default(false),
+      auto_resolve_pr_feedback: z.boolean().default(true),
       /** When enabled, a polecat is automatically dispatched to rebase and
        *  resolve merge conflicts on open PRs. */
       auto_resolve_merge_conflicts: z.boolean().default(true).optional(),
       /** After all CI checks pass and all review threads are resolved,
        *  automatically merge the PR after this many minutes.
        *  0 = immediate, null = disabled (require manual merge). */
-      auto_merge_delay_minutes: z.number().int().min(0).nullable().default(null),
+      auto_merge_delay_minutes: z.number().int().min(0).nullable().default(5),
     })
-    .optional(),
+    .default({}),
 
   /** Alarm interval when agents are active (seconds) */
   alarm_interval_active: z.number().int().min(5).max(600).optional(),
@@ -307,7 +307,7 @@ export const TownConfigSchema = z.object({
     .optional(),
 
   /** When true, all convoys are created as staged by default (agents not dispatched until started). */
-  staged_convoys_default: z.boolean().default(false),
+  staged_convoys_default: z.boolean().default(true),
 
   /** Default merge mode for new convoys.
    *  - 'review-then-land': beads merge into a convoy feature branch, then a single landing PR is created (default)

--- a/services/gastown/src/types.ts
+++ b/services/gastown/src/types.ts
@@ -291,7 +291,15 @@ export const TownConfigSchema = z.object({
        *  0 = immediate, null = disabled (require manual merge). */
       auto_merge_delay_minutes: z.number().int().min(0).nullable().default(5),
     })
-    .default({}),
+    .default({
+      gates: [],
+      auto_merge: true,
+      require_clean_merge: true,
+      code_review: true,
+      review_mode: 'comments',
+      auto_resolve_pr_feedback: true,
+      auto_merge_delay_minutes: 5,
+    }),
 
   /** Alarm interval when agents are active (seconds) */
   alarm_interval_active: z.number().int().min(5).max(600).optional(),

--- a/services/gastown/src/util/analytics.util.ts
+++ b/services/gastown/src/util/analytics.util.ts
@@ -44,6 +44,11 @@ export type GastownEventData = {
   durationMs?: number;
   value?: number;
   label?: string;
+  // Container cold-start instrumentation fields.
+  // Use durationMs for timing (event name disambiguates the metric).
+  // Use error (absence = success) instead of a wasSuccess boolean.
+  statusCode?: number;
+  containerStartedAt?: string;
   // Additional doubles for reconciler_tick events (double3–double10).
   // Analytics Engine supports up to 20 doubles per data point.
   double3?: number;
@@ -82,6 +87,7 @@ export function writeEvent(
         data.role ?? '', // blob12
         data.beadType ?? '', // blob13
         data.reason ?? '', // blob14
+        data.containerStartedAt ?? '', // blob15
       ],
       doubles: [
         data.durationMs ?? 0, // double1
@@ -94,6 +100,7 @@ export function writeEvent(
         data.double8 ?? 0, // double8
         data.double9 ?? 0, // double9
         data.double10 ?? 0, // double10
+        data.statusCode ?? 0, // double11
       ],
       indexes: [data.event],
     });

--- a/services/gastown/src/util/platform-pr.util.ts
+++ b/services/gastown/src/util/platform-pr.util.ts
@@ -174,6 +174,8 @@ ${diffSection}
 export const GitHubPRStatusSchema = z.object({
   state: z.string(),
   merged: z.boolean().optional(),
+  mergeable: z.boolean().nullable().optional(),
+  mergeable_state: z.string().optional(), // 'clean', 'dirty', 'blocked', 'unknown', 'unstable'
 });
 
 /** Schema for GitLab MR status responses (used by checkPRStatus). */

--- a/services/gastown/test/integration/review-failure.test.ts
+++ b/services/gastown/test/integration/review-failure.test.ts
@@ -182,29 +182,6 @@ describe('Review failure paths — convoy progress and source bead recovery', ()
     });
   });
 
-  // ── Direct completeReview leaves source bead orphaned (regression) ─
-
-  describe('completeReview bypass (regression guard)', () => {
-    it('should leave source bead stuck in in_review when completeReview is called directly', async () => {
-      const { beadId, mrBeadId } = await setupConvoyWithMR();
-
-      // Call completeReview directly (the OLD broken path) —
-      // this is the raw SQL update that bypasses lifecycle events.
-      // We use this to verify the regression scenario.
-      await town.completeReview(mrBeadId, 'failed');
-
-      // MR bead should be failed
-      const mrBead = await town.getBeadAsync(mrBeadId);
-      expect(mrBead?.status).toBe('failed');
-
-      // Source bead is STILL in_review — this is the bug this PR fixes
-      // in processReviewQueue. The direct completeReview call doesn't
-      // return the source bead to in_progress.
-      const sourceBead = await town.getBeadAsync(beadId);
-      expect(sourceBead?.status).toBe('in_review');
-    });
-  });
-
   // ── Source bead in_review after agentDone ──────────────────────────
 
   describe('agentDone transitions source bead to in_review', () => {

--- a/services/gastown/test/integration/rig-alarm.test.ts
+++ b/services/gastown/test/integration/rig-alarm.test.ts
@@ -158,9 +158,10 @@ describe('Town DO Alarm', () => {
       // fail gracefully and mark the review as 'failed'
       await runDurableObjectAlarm(town);
 
-      // The pending entry should have been popped (no more pending entries)
-      const nextEntry = await town.popReviewQueue();
-      expect(nextEntry).toBeNull();
+      // The MR bead should no longer be open (alarm processed it)
+      const mrBeads = await town.listBeads({ type: 'merge_request' });
+      expect(mrBeads).toHaveLength(1);
+      expect(mrBeads[0].status).not.toBe('open');
     });
   });
 
@@ -293,9 +294,10 @@ describe('Town DO Alarm', () => {
       // (will fail at container level but that's expected in tests)
       await runDurableObjectAlarm(town);
 
-      // Review queue entry should have been popped and processed (failed in test env)
-      const reviewEntry = await town.popReviewQueue();
-      expect(reviewEntry).toBeNull();
+      // MR bead should have been picked up and processed (failed in test env)
+      const mrBeads = await town.listBeads({ type: 'merge_request' });
+      expect(mrBeads).toHaveLength(1);
+      expect(mrBeads[0].status).not.toBe('open');
     });
   });
 });

--- a/services/gastown/test/integration/rig-do.test.ts
+++ b/services/gastown/test/integration/rig-do.test.ts
@@ -356,7 +356,7 @@ describe('TownDO', () => {
   // ── Review Queue ───────────────────────────────────────────────────────
 
   describe('review queue', () => {
-    it('should submit to and pop from review queue', async () => {
+    it('should submit to review queue and create an open merge_request bead', async () => {
       const agent = await town.registerAgent({
         role: 'polecat',
         name: 'P1',
@@ -373,40 +373,12 @@ describe('TownDO', () => {
         summary: 'Fixed the widget',
       });
 
-      const entry = await town.popReviewQueue();
-      expect(entry).toBeDefined();
-      expect(entry?.branch).toBe('feature/fix-widget');
-      expect(entry?.pr_url).toBe('https://github.com/org/repo/pull/1');
-      expect(entry?.status).toBe('running');
-
-      // Pop again should return null (nothing pending)
-      const empty = await town.popReviewQueue();
-      expect(empty).toBeNull();
-    });
-
-    it('should complete a review', async () => {
-      const agent = await town.registerAgent({
-        role: 'polecat',
-        name: 'P1',
-        identity: `complete-review-${townName}`,
-      });
-      const bead = await town.createBead({ type: 'issue', title: 'Review complete' });
-
-      await town.submitToReviewQueue({
-        agent_id: agent.id,
-        bead_id: bead.bead_id,
-        rig_id: 'test-rig',
-        branch: 'feature/fix',
-      });
-
-      const entry = await town.popReviewQueue();
-      expect(entry).toBeDefined();
-
-      await town.completeReview(entry!.id, 'merged');
-
-      // Pop again should be null
-      const empty = await town.popReviewQueue();
-      expect(empty).toBeNull();
+      // submitToReviewQueue creates an open merge_request bead
+      const mrBeads = await town.listBeads({ type: 'merge_request' });
+      expect(mrBeads).toHaveLength(1);
+      expect(mrBeads[0].status).toBe('open');
+      expect(mrBeads[0].metadata?.pr_url).toBe('https://github.com/org/repo/pull/1');
+      expect(mrBeads[0].metadata?.source_bead_id).toBe(bead.bead_id);
     });
 
     it('should close bead on successful merge via completeReviewWithResult', async () => {
@@ -424,11 +396,12 @@ describe('TownDO', () => {
         branch: 'feature/merge-test',
       });
 
-      const entry = await town.popReviewQueue();
-      expect(entry).toBeDefined();
+      const mrBeads = await town.listBeads({ type: 'merge_request' });
+      expect(mrBeads).toHaveLength(1);
+      const mrBeadId = mrBeads[0].bead_id;
 
       await town.completeReviewWithResult({
-        entry_id: entry!.id,
+        entry_id: mrBeadId,
         status: 'merged',
         message: 'Merge successful',
         commit_sha: 'abc123',
@@ -439,9 +412,9 @@ describe('TownDO', () => {
       expect(updatedBead?.status).toBe('closed');
       expect(updatedBead?.closed_at).toBeDefined();
 
-      // Review queue should be empty
-      const empty = await town.popReviewQueue();
-      expect(empty).toBeNull();
+      // MR bead should be closed
+      const updatedMr = await town.getBeadAsync(mrBeadId);
+      expect(updatedMr?.status).toBe('closed');
     });
 
     it('should create escalation bead on merge conflict via completeReviewWithResult', async () => {
@@ -459,11 +432,12 @@ describe('TownDO', () => {
         branch: 'feature/conflict-test',
       });
 
-      const entry = await town.popReviewQueue();
-      expect(entry).toBeDefined();
+      const mrBeads = await town.listBeads({ type: 'merge_request' });
+      expect(mrBeads).toHaveLength(1);
+      const mrBeadId = mrBeads[0].bead_id;
 
       await town.completeReviewWithResult({
-        entry_id: entry!.id,
+        entry_id: mrBeadId,
         status: 'conflict',
         message: 'CONFLICT (content): Merge conflict in src/index.ts',
       });
@@ -484,9 +458,9 @@ describe('TownDO', () => {
         agent_id: agent.id,
       });
 
-      // Review queue entry should be marked as failed
-      const empty = await town.popReviewQueue();
-      expect(empty).toBeNull();
+      // MR bead should be marked as failed
+      const updatedMr = await town.getBeadAsync(mrBeadId);
+      expect(updatedMr?.status).toBe('failed');
     });
   });
 

--- a/services/gastown/wrangler.jsonc
+++ b/services/gastown/wrangler.jsonc
@@ -35,7 +35,7 @@
   "containers": [
     {
       "class_name": "TownContainerDO",
-      "image": "./container/Dockerfile.dev",
+      "image": "./container/Dockerfile",
       "instance_type": "standard-4",
       "max_instances": 810,
     },

--- a/services/gastown/wrangler.jsonc
+++ b/services/gastown/wrangler.jsonc
@@ -35,9 +35,9 @@
   "containers": [
     {
       "class_name": "TownContainerDO",
-      "image": "./container/Dockerfile",
+      "image": "registry.cloudflare.com/e115e769bcdd4c3d66af59d3332cb394/gastown-towncontainerdo:197958b7",
       "instance_type": "standard-4",
-      "max_instances": 700,
+      "max_instances": 800,
     },
   ],
 

--- a/services/gastown/wrangler.jsonc
+++ b/services/gastown/wrangler.jsonc
@@ -37,7 +37,7 @@
       "class_name": "TownContainerDO",
       "image": "./container/Dockerfile",
       "instance_type": "standard-4",
-      "max_instances": 810,
+      "max_instances": 800,
     },
   ],
 

--- a/services/gastown/wrangler.jsonc
+++ b/services/gastown/wrangler.jsonc
@@ -37,7 +37,7 @@
       "class_name": "TownContainerDO",
       "image": "registry.cloudflare.com/e115e769bcdd4c3d66af59d3332cb394/gastown-towncontainerdo:197958b7",
       "instance_type": "standard-4",
-      "max_instances": 800,
+      "max_instances": 810,
     },
   ],
 

--- a/services/gastown/wrangler.jsonc
+++ b/services/gastown/wrangler.jsonc
@@ -35,7 +35,7 @@
   "containers": [
     {
       "class_name": "TownContainerDO",
-      "image": "registry.cloudflare.com/e115e769bcdd4c3d66af59d3332cb394/gastown-towncontainerdo:197958b7",
+      "image": "./container/Dockerfile.dev",
       "instance_type": "standard-4",
       "max_instances": 810,
     },

--- a/services/wasteland/dist-types/db/tables/wasteland-config.table.d.ts
+++ b/services/wasteland/dist-types/db/tables/wasteland-config.table.d.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+export declare const WastelandConfigRecord: z.ZodObject<{
+    wasteland_id: z.ZodString;
+    name: z.ZodString;
+    owner_type: z.ZodEnum<{
+        org: "org";
+        user: "user";
+    }>;
+    owner_user_id: z.ZodNullable<z.ZodString>;
+    organization_id: z.ZodNullable<z.ZodString>;
+    dolthub_upstream: z.ZodNullable<z.ZodString>;
+    visibility: z.ZodEnum<{
+        private: "private";
+        public: "public";
+    }>;
+    status: z.ZodEnum<{
+        active: "active";
+        deleted: "deleted";
+    }>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>;
+export type WastelandConfigRecord = z.output<typeof WastelandConfigRecord>;
+export declare const wasteland_config: import("../../util/table").TableQueryInterpolator<{
+    name: "wasteland_config";
+    columns: ("created_at" | "dolthub_upstream" | "name" | "organization_id" | "owner_type" | "owner_user_id" | "status" | "updated_at" | "visibility" | "wasteland_id")[];
+}>;
+export declare function createTableWastelandConfig(): string;

--- a/services/wasteland/dist-types/db/tables/wasteland-connected-towns.table.d.ts
+++ b/services/wasteland/dist-types/db/tables/wasteland-connected-towns.table.d.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+export declare const WastelandConnectedTownRecord: z.ZodObject<{
+    town_id: z.ZodString;
+    wasteland_id: z.ZodString;
+    connected_by: z.ZodString;
+    connected_at: z.ZodString;
+}, z.core.$strip>;
+export type WastelandConnectedTownRecord = z.output<typeof WastelandConnectedTownRecord>;
+export declare const wasteland_connected_towns: import("../../util/table").TableQueryInterpolator<{
+    name: "wasteland_connected_towns";
+    columns: ("connected_at" | "connected_by" | "town_id" | "wasteland_id")[];
+}>;
+export declare function createTableWastelandConnectedTowns(): string;

--- a/services/wasteland/dist-types/db/tables/wasteland-credentials.table.d.ts
+++ b/services/wasteland/dist-types/db/tables/wasteland-credentials.table.d.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+export declare const WastelandCredentialRecord: z.ZodObject<{
+    user_id: z.ZodString;
+    wasteland_id: z.ZodString;
+    encrypted_token: z.ZodString;
+    dolthub_org: z.ZodString;
+    rig_handle: z.ZodNullable<z.ZodString>;
+    is_upstream_admin: z.ZodPipe<z.ZodUnion<readonly [z.ZodBoolean, z.ZodNumber, z.ZodNull]>, z.ZodTransform<boolean, number | boolean | null>>;
+    connected_at: z.ZodString;
+}, z.core.$strip>;
+export type WastelandCredentialRecord = z.output<typeof WastelandCredentialRecord>;
+export declare const wasteland_credentials: import("../../util/table").TableQueryInterpolator<{
+    name: "wasteland_credentials";
+    columns: ("connected_at" | "dolthub_org" | "encrypted_token" | "is_upstream_admin" | "rig_handle" | "user_id" | "wasteland_id")[];
+}>;
+export declare function createTableWastelandCredentials(): string;
+/**
+ * Idempotent migration that adds `is_upstream_admin` to existing rows.
+ * Safe to call on every DO init — SQLite's ALTER TABLE IF NOT EXISTS
+ * isn't available, so we catch the "duplicate column" error via a
+ * presence check.
+ */
+export declare function migrateAddIsUpstreamAdmin(sql: SqlStorage): void;

--- a/services/wasteland/dist-types/db/tables/wasteland-members.table.d.ts
+++ b/services/wasteland/dist-types/db/tables/wasteland-members.table.d.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+export declare const WastelandMemberRecord: z.ZodObject<{
+    member_id: z.ZodString;
+    wasteland_id: z.ZodString;
+    user_id: z.ZodString;
+    role: z.ZodEnum<{
+        contributor: "contributor";
+        maintainer: "maintainer";
+        owner: "owner";
+    }>;
+    trust_level: z.ZodNumber;
+    joined_at: z.ZodString;
+}, z.core.$strip>;
+export type WastelandMemberRecord = z.output<typeof WastelandMemberRecord>;
+export declare const wasteland_members: import("../../util/table").TableQueryInterpolator<{
+    name: "wasteland_members";
+    columns: ("joined_at" | "member_id" | "role" | "trust_level" | "user_id" | "wasteland_id")[];
+}>;
+export declare function createTableWastelandMembers(): string;

--- a/services/wasteland/dist-types/db/tables/wasteland-registry.table.d.ts
+++ b/services/wasteland/dist-types/db/tables/wasteland-registry.table.d.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+export declare const WastelandRegistryRecord: z.ZodObject<{
+    wasteland_id: z.ZodString;
+    owner_type: z.ZodEnum<{
+        org: "org";
+        user: "user";
+    }>;
+    owner_user_id: z.ZodNullable<z.ZodString>;
+    organization_id: z.ZodNullable<z.ZodString>;
+    name: z.ZodString;
+    created_at: z.ZodString;
+}, z.core.$strip>;
+export type WastelandRegistryRecord = z.output<typeof WastelandRegistryRecord>;
+export declare const wasteland_registry: import("../../util/table").TableQueryInterpolator<{
+    name: "wasteland_registry";
+    columns: ("created_at" | "name" | "organization_id" | "owner_type" | "owner_user_id" | "wasteland_id")[];
+}>;
+export declare function createTableWastelandRegistry(): string;

--- a/services/wasteland/dist-types/db/tables/wasteland-wanted-board.table.d.ts
+++ b/services/wasteland/dist-types/db/tables/wasteland-wanted-board.table.d.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+export declare const WastelandWantedBoardRecord: z.ZodObject<{
+    item_id: z.ZodString;
+    wasteland_id: z.ZodString;
+    title: z.ZodString;
+    description: z.ZodString;
+    status: z.ZodEnum<{
+        claimed: "claimed";
+        done: "done";
+        open: "open";
+    }>;
+    priority: z.ZodEnum<{
+        critical: "critical";
+        high: "high";
+        low: "low";
+        medium: "medium";
+    }>;
+    type: z.ZodEnum<{
+        bug: "bug";
+        docs: "docs";
+        feature: "feature";
+        other: "other";
+    }>;
+    claimed_by: z.ZodNullable<z.ZodString>;
+    evidence: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>;
+export type WastelandWantedBoardRecord = z.output<typeof WastelandWantedBoardRecord>;
+export declare const wasteland_wanted_board: import("../../util/table").TableQueryInterpolator<{
+    name: "wasteland_wanted_board";
+    columns: ("claimed_by" | "created_at" | "description" | "evidence" | "item_id" | "priority" | "status" | "title" | "type" | "updated_at" | "wasteland_id")[];
+}>;
+export declare function createTableWastelandWantedBoard(): string;

--- a/services/wasteland/dist-types/dos/Wasteland.do.d.ts
+++ b/services/wasteland/dist-types/dos/Wasteland.do.d.ts
@@ -1,0 +1,95 @@
+import { DurableObject } from 'cloudflare:workers';
+export type WastelandConfigResult = {
+    wasteland_id: string;
+    name: string;
+    owner_type: 'user' | 'org';
+    owner_user_id: string | null;
+    organization_id: string | null;
+    dolthub_upstream: string | null;
+    visibility: 'public' | 'private';
+    status: 'active' | 'deleted';
+    created_at: string;
+    updated_at: string;
+};
+export type WastelandMemberResult = {
+    member_id: string;
+    user_id: string;
+    trust_level: number;
+    role: 'contributor' | 'maintainer' | 'owner';
+    joined_at: string;
+};
+export type InitializeWastelandInput = {
+    wasteland_id: string;
+    name: string;
+    owner_type: 'user' | 'org';
+    owner_user_id: string | null;
+    organization_id: string | null;
+    dolthub_upstream: string | null;
+    visibility: 'public' | 'private';
+};
+export type UpdateWastelandConfigInput = {
+    name?: string;
+    visibility?: 'public' | 'private';
+    dolthub_upstream?: string | null;
+    status?: 'active' | 'deleted';
+};
+export type WastelandCredentialResult = {
+    user_id: string;
+    encrypted_token: string;
+    dolthub_org: string;
+    rig_handle: string | null;
+    is_upstream_admin: boolean;
+    connected_at: string;
+};
+export type ConnectedTownResult = {
+    town_id: string;
+    wasteland_id: string;
+    connected_by: string;
+    connected_at: string;
+};
+export type WantedItemResult = {
+    item_id: string;
+    title: string;
+    description: string;
+    status: 'open' | 'claimed' | 'done';
+    priority: 'low' | 'medium' | 'high' | 'critical';
+    type: 'feature' | 'bug' | 'docs' | 'other';
+    claimed_by: string | null;
+    evidence: string | null;
+    created_at: string;
+    updated_at: string;
+};
+export declare class WastelandDO extends DurableObject<Env> {
+    private state;
+    private sql;
+    private wastelandId;
+    constructor(state: DurableObjectState, env: Env);
+    private initializeDatabase;
+    initializeWasteland(input: InitializeWastelandInput): Promise<WastelandConfigResult>;
+    getConfig(): Promise<WastelandConfigResult | null>;
+    updateConfig(input: UpdateWastelandConfigInput): Promise<WastelandConfigResult>;
+    listMembers(): Promise<WastelandMemberResult[]>;
+    addMember(userId: string, role: string, trustLevel: number): Promise<string>;
+    removeMember(memberId: string): Promise<void>;
+    getMember(userId: string): Promise<WastelandMemberResult | null>;
+    updateMember(memberId: string, update: {
+        role?: string;
+        trust_level?: number;
+    }): Promise<WastelandMemberResult | null>;
+    storeCredential(input: {
+        userId: string;
+        encryptedToken: string;
+        dolthubOrg: string;
+        rigHandle?: string;
+        isUpstreamAdmin?: boolean;
+    }): Promise<WastelandCredentialResult>;
+    getCredential(userId: string): Promise<WastelandCredentialResult | null>;
+    setIsUpstreamAdmin(userId: string, isUpstreamAdmin: boolean): Promise<WastelandCredentialResult | null>;
+    deleteCredential(userId: string): Promise<void>;
+    connectTown(townId: string, userId: string): Promise<ConnectedTownResult>;
+    disconnectTown(townId: string): Promise<void>;
+    listConnectedTowns(): Promise<ConnectedTownResult[]>;
+    getWantedBoard(): Promise<WantedItemResult[]>;
+    refreshWantedBoard(): Promise<WantedItemResult[]>;
+}
+export declare function getWastelandDOStub(env: Env, wastelandId: string): DurableObjectStub<WastelandDO>;

--- a/services/wasteland/dist-types/dos/WastelandContainer.do.d.ts
+++ b/services/wasteland/dist-types/dos/WastelandContainer.do.d.ts
@@ -1,0 +1,34 @@
+import { Container } from '@cloudflare/containers';
+/**
+ * WastelandContainerDO — a Cloudflare Container per wasteland.
+ *
+ * Runs the `wl` CLI and a lightweight control server for protocol
+ * operations (browse, claim, post, sync) against DoltHub.
+ *
+ * This DO is intentionally thin. It manages container lifecycle and proxies
+ * ALL requests directly to the container via the base Container class's fetch().
+ *
+ * On boot, the control server reads WL_UPSTREAM, DOLTHUB_TOKEN, and
+ * DOLTHUB_ORG from its environment (injected via envVars) and runs
+ * `wl join` automatically — no callback to the worker required.
+ */
+export declare class WastelandContainerDO extends Container<Env> {
+    defaultPort: number;
+    sleepAfter: string;
+    envVars: Record<string, string>;
+    constructor(ctx: DurableObjectState<Env>, env: Env);
+    /**
+     * Store an env var that will be injected into the container OS environment.
+     * Takes effect on the next container boot (or immediately if the container
+     * hasn't started yet). Call this from the WastelandDO when storing credentials.
+     */
+    setEnvVar(key: string, value: string): Promise<void>;
+    deleteEnvVar(key: string): Promise<void>;
+    onStart(): void;
+    onStop({ exitCode, reason }: {
+        exitCode: number;
+        reason: string;
+    }): void;
+    onError(error: unknown): void;
+}
+export declare function getWastelandContainerStub(env: Env, wastelandId: string): DurableObjectStub<WastelandContainerDO>;

--- a/services/wasteland/dist-types/dos/WastelandRegistry.do.d.ts
+++ b/services/wasteland/dist-types/dos/WastelandRegistry.do.d.ts
@@ -1,0 +1,34 @@
+import { DurableObject } from 'cloudflare:workers';
+import { WastelandRegistryRecord } from '../db/tables/wasteland-registry.table';
+/**
+ * WastelandRegistryDO — singleton registry that indexes wasteland ownership.
+ *
+ * Because each WastelandDO is per-wasteland, we need a central index to
+ * answer "which wastelands does user X own?" or "which wastelands belong
+ * to org Y?". This singleton (keyed by fixed name 'registry') maintains
+ * that mapping.
+ *
+ * All creates/deletes in the tRPC router update this registry so
+ * listWastelands can resolve ownership without scanning every WastelandDO.
+ */
+export declare class WastelandRegistryDO extends DurableObject<Env> {
+    private sql;
+    private initPromise;
+    constructor(ctx: DurableObjectState, env: Env);
+    private ensureInitialized;
+    private initializeDatabase;
+    register(input: {
+        wasteland_id: string;
+        owner_type: 'user' | 'org';
+        owner_user_id: string | null;
+        organization_id: string | null;
+        name: string;
+    }): Promise<void>;
+    unregister(wastelandId: string): Promise<void>;
+    listByUser(userId: string): Promise<WastelandRegistryRecord[]>;
+    listByOrg(orgId: string): Promise<WastelandRegistryRecord[]>;
+    listAll(): Promise<WastelandRegistryRecord[]>;
+    /** Return the total number of registered (active) wastelands. */
+    countAll(): Promise<number>;
+}
+export declare function getWastelandRegistryStub(env: Env): DurableObjectStub<WastelandRegistryDO>;

--- a/services/wasteland/dist-types/dos/wasteland/config.d.ts
+++ b/services/wasteland/dist-types/dos/wasteland/config.d.ts
@@ -1,0 +1,31 @@
+export type InitializeWastelandInput = {
+    wasteland_id: string;
+    name: string;
+    owner_type: 'user' | 'org';
+    owner_user_id: string | null;
+    organization_id: string | null;
+    dolthub_upstream: string | null;
+    visibility: 'public' | 'private';
+};
+export type UpdateWastelandConfigInput = {
+    name?: string;
+    visibility?: 'public' | 'private';
+    dolthub_upstream?: string | null;
+    status?: 'active' | 'deleted';
+};
+export type WastelandConfigResult = {
+    wasteland_id: string;
+    name: string;
+    owner_type: 'user' | 'org';
+    owner_user_id: string | null;
+    organization_id: string | null;
+    dolthub_upstream: string | null;
+    visibility: 'public' | 'private';
+    status: 'active' | 'deleted';
+    created_at: string;
+    updated_at: string;
+};
+export declare function initializeDatabase(sql: SqlStorage): void;
+export declare function initializeWasteland(sql: SqlStorage, input: InitializeWastelandInput): WastelandConfigResult;
+export declare function getConfig(sql: SqlStorage, wastelandId: string): WastelandConfigResult | null;
+export declare function updateConfig(sql: SqlStorage, wastelandId: string, update: UpdateWastelandConfigInput): WastelandConfigResult;

--- a/services/wasteland/dist-types/dos/wasteland/credentials.d.ts
+++ b/services/wasteland/dist-types/dos/wasteland/credentials.d.ts
@@ -1,0 +1,22 @@
+export type WastelandCredentialResult = {
+    user_id: string;
+    encrypted_token: string;
+    dolthub_org: string;
+    rig_handle: string | null;
+    is_upstream_admin: boolean;
+    connected_at: string;
+};
+export declare function initializeDatabase(sql: SqlStorage): void;
+export declare function storeCredential(sql: SqlStorage, wastelandId: string, userId: string, input: {
+    encryptedToken: string;
+    dolthubOrg: string;
+    rigHandle?: string;
+    isUpstreamAdmin?: boolean;
+}): WastelandCredentialResult;
+export declare function getCredential(sql: SqlStorage, wastelandId: string, userId: string): WastelandCredentialResult | null;
+/**
+ * Update the `is_upstream_admin` flag for an existing credential.
+ * Returns the updated row, or null if no credential exists.
+ */
+export declare function setIsUpstreamAdmin(sql: SqlStorage, wastelandId: string, userId: string, isUpstreamAdmin: boolean): WastelandCredentialResult | null;
+export declare function deleteCredential(sql: SqlStorage, wastelandId: string, userId: string): void;

--- a/services/wasteland/dist-types/dos/wasteland/members.d.ts
+++ b/services/wasteland/dist-types/dos/wasteland/members.d.ts
@@ -1,0 +1,16 @@
+export type WastelandMemberResult = {
+    member_id: string;
+    user_id: string;
+    trust_level: number;
+    role: 'contributor' | 'maintainer' | 'owner';
+    joined_at: string;
+};
+export declare function initializeDatabase(sql: SqlStorage): void;
+export declare function listMembers(sql: SqlStorage, wastelandId: string): WastelandMemberResult[];
+export declare function addMember(sql: SqlStorage, wastelandId: string, userId: string, role: string, trustLevel: number): string;
+export declare function removeMember(sql: SqlStorage, memberId: string): void;
+export declare function getMember(sql: SqlStorage, wastelandId: string, userId: string): WastelandMemberResult | null;
+export declare function updateMember(sql: SqlStorage, wastelandId: string, memberId: string, update: {
+    role?: string;
+    trust_level?: number;
+}): WastelandMemberResult | null;

--- a/services/wasteland/dist-types/dos/wasteland/towns.d.ts
+++ b/services/wasteland/dist-types/dos/wasteland/towns.d.ts
@@ -1,0 +1,10 @@
+export type ConnectedTownResult = {
+    town_id: string;
+    wasteland_id: string;
+    connected_by: string;
+    connected_at: string;
+};
+export declare function initializeDatabase(sql: SqlStorage): void;
+export declare function connectTown(sql: SqlStorage, wastelandId: string, townId: string, userId: string): ConnectedTownResult;
+export declare function disconnectTown(sql: SqlStorage, wastelandId: string, townId: string): void;
+export declare function listConnectedTowns(sql: SqlStorage, wastelandId: string): ConnectedTownResult[];

--- a/services/wasteland/dist-types/dos/wasteland/wanted-board.d.ts
+++ b/services/wasteland/dist-types/dos/wasteland/wanted-board.d.ts
@@ -1,0 +1,15 @@
+export type WantedItemResult = {
+    item_id: string;
+    title: string;
+    description: string;
+    status: 'open' | 'claimed' | 'done';
+    priority: 'low' | 'medium' | 'high' | 'critical';
+    type: 'feature' | 'bug' | 'docs' | 'other';
+    claimed_by: string | null;
+    evidence: string | null;
+    created_at: string;
+    updated_at: string;
+};
+export declare function initializeDatabase(sql: SqlStorage): void;
+export declare function getWantedBoard(sql: SqlStorage, wastelandId: string): WantedItemResult[];
+export declare function refreshWantedBoard(sql: SqlStorage, wastelandId: string): WantedItemResult[];

--- a/services/wasteland/dist-types/inbox/inbox-classifier.d.ts
+++ b/services/wasteland/dist-types/inbox/inbox-classifier.d.ts
@@ -1,0 +1,85 @@
+declare const WL_VERBS: readonly ["post", "claim", "unclaim", "done", "update", "delete", "accept", "accept-upstream", "reject", "close", "close-upstream"];
+type WlVerb = (typeof WL_VERBS)[number];
+type ParsedCommit = {
+    kind: 'wl';
+    verb: WlVerb;
+    itemId: string;
+    reason?: string;
+} | {
+    kind: 'register';
+    handle: string;
+} | {
+    kind: 'unknown';
+    subject: string;
+};
+/**
+ * Parse a commit subject against the closed grammar produced by the `wl` CLI:
+ *   - `wl {verb}: {wanted-id}[ — {reason}]`  (reason only on `reject`)
+ *   - `Register rig: {handle}`               (no leading `wl`, capital R)
+ * Anything else returns `{ kind: 'unknown' }` so the card renders as foreign.
+ */
+export declare function parseCommitSubject(subject: string): ParsedCommit;
+type InboxCardBase = {
+    pull_id: string;
+    title: string;
+    state: string;
+    from_branch: string | null;
+    submitter: string | null;
+    creator_name: string | null;
+    created_at: string | null;
+    updated_at: string | null;
+};
+export type InboxItem = InboxCardBase & ({
+    kind: 'rig-registration';
+    handle: string;
+    display_name: string | null;
+    dolthub_org: string | null;
+    owner_email: string | null;
+    hop_uri: string | null;
+    gt_version: string | null;
+} | {
+    kind: 'wanted-post';
+    item_id: string;
+    item_title: string;
+    description: string | null;
+    type: string | null;
+    priority: string | null;
+    effort_level: string | null;
+    tags: string | null;
+    posted_by: string | null;
+} | {
+    kind: 'wanted-edit';
+    subkind: 'update' | 'delete' | 'unclaim';
+    item_id: string;
+    item_title: string;
+    submitter_is_poster: boolean | null;
+    posted_by: string | null;
+    status_transition: string | null;
+} | {
+    kind: 'work-submission';
+    item_id: string;
+    item_title: string;
+    claimer: string;
+    has_done: boolean;
+    evidence_url: string | null;
+    completion_id: string | null;
+} | {
+    kind: 'admin-action';
+    subkind: 'accept' | 'accept-upstream' | 'reject' | 'close' | 'close-upstream';
+    item_id: string;
+    item_title: string;
+    worker: string | null;
+    acceptor: string | null;
+    reject_reason: string | null;
+    stamp: {
+        quality: string | null;
+        severity: string | null;
+        skill_tags: string | null;
+        message: string | null;
+    } | null;
+} | {
+    kind: 'unknown';
+    commit_subjects: string[];
+});
+export declare function listInboxItems(upstream: string, token: string): Promise<InboxItem[]>;
+export {};

--- a/services/wasteland/dist-types/middleware/analytics.middleware.d.ts
+++ b/services/wasteland/dist-types/middleware/analytics.middleware.d.ts
@@ -1,0 +1,18 @@
+import type { Context, Next } from 'hono';
+import type { WastelandEnv } from '../wasteland.worker';
+/**
+ * Captures a high-resolution start timestamp very early in the request
+ * lifecycle. Must be the first middleware registered.
+ */
+export declare function timingMiddleware(c: Context<WastelandEnv>, next: Next): Promise<void>;
+/**
+ * Wraps an individual HTTP route handler to emit an analytics event.
+ * Applied per-route, not as global middleware,
+ * so it has access to the matched route pattern.
+ *
+ * Usage:
+ *   app.post('/api/wastelands',
+ *     c => instrumented(c, 'POST /api/wastelands',
+ *       () => handleCreateWasteland(c, c.req.param())));
+ */
+export declare function instrumented(c: Context<WastelandEnv>, route: string, handler: () => Promise<Response>): Promise<Response>;

--- a/services/wasteland/dist-types/middleware/auth.middleware.d.ts
+++ b/services/wasteland/dist-types/middleware/auth.middleware.d.ts
@@ -1,0 +1,11 @@
+export type JwtOrgMembership = {
+    orgId: string;
+    role: 'owner' | 'member' | 'billing_manager';
+};
+export type AuthVariables = {
+    kiloUserId: string;
+    kiloIsAdmin: boolean;
+    kiloApiTokenPepper: string | null;
+    kiloOrgMemberships: JwtOrgMembership[];
+    requestStartTime: number;
+};

--- a/services/wasteland/dist-types/middleware/kilo-auth.middleware.d.ts
+++ b/services/wasteland/dist-types/middleware/kilo-auth.middleware.d.ts
@@ -1,0 +1,9 @@
+import type { WastelandEnv } from '../wasteland.worker';
+/**
+ * Auth middleware that validates Kilo user JWTs (signed with NEXTAUTH_SECRET).
+ * Used for dashboard/user-facing routes where the Next.js app sends a
+ * Bearer token on behalf of the logged-in user.
+ *
+ * Sets `kiloUserId` on the Hono context.
+ */
+export declare const kiloAuthMiddleware: any;

--- a/services/wasteland/dist-types/trpc/init.d.ts
+++ b/services/wasteland/dist-types/trpc/init.d.ts
@@ -1,0 +1,40 @@
+import type { JwtOrgMembership } from '../middleware/auth.middleware';
+export type TRPCContext = {
+    env: Env;
+    userId: string;
+    isAdmin: boolean;
+    apiTokenPepper: string | null;
+    orgMemberships: JwtOrgMembership[];
+};
+export declare const router: import("@trpc/server").TRPCRouterBuilder<{
+    ctx: TRPCContext;
+    meta: object;
+    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    transformer: false;
+}>;
+/**
+ * Base procedure — requires a valid Kilo JWT (enforced by kiloAuthMiddleware
+ * running before tRPC). The userId is extracted from the JWT and set on the
+ * Hono context by kiloAuthMiddleware, then forwarded into the tRPC context
+ * by the createContext callback in wasteland.worker.ts.
+ *
+ * Also enforces per-user rate limits for operations that have them configured.
+ */
+export declare const procedure: import("@trpc/server").TRPCProcedureBuilder<TRPCContext, object, {
+    apiTokenPepper: string | null;
+    env: Env;
+    isAdmin: boolean;
+    orgMemberships: JwtOrgMembership[];
+    userId: string;
+}, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, false>;
+/**
+ * Admin-only procedure — requires `isAdmin` on the JWT. Used for admin
+ * endpoints that bypass per-user ownership checks.
+ */
+export declare const adminProcedure: import("@trpc/server").TRPCProcedureBuilder<TRPCContext, object, {
+    apiTokenPepper: string | null;
+    env: Env;
+    isAdmin: boolean;
+    orgMemberships: JwtOrgMembership[];
+    userId: string;
+}, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, import("@trpc/server").TRPCUnsetMarker, false>;

--- a/services/wasteland/dist-types/trpc/ownership.d.ts
+++ b/services/wasteland/dist-types/trpc/ownership.d.ts
@@ -1,0 +1,12 @@
+import type { TRPCContext } from './init';
+type WastelandOwnershipResult = {
+    type: 'user';
+    userId: string;
+} | {
+    type: 'org';
+    orgId: string;
+} | {
+    type: 'admin';
+};
+export declare function resolveWastelandOwnership(env: Env, ctx: TRPCContext, wastelandId: string): Promise<WastelandOwnershipResult>;
+export {};

--- a/services/wasteland/dist-types/trpc/router.d.ts
+++ b/services/wasteland/dist-types/trpc/router.d.ts
@@ -1,0 +1,1179 @@
+import type { TRPCContext } from './init';
+export declare const wastelandRouter: import("@trpc/server").TRPCBuiltRouter<{
+    ctx: TRPCContext;
+    meta: object;
+    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    transformer: false;
+}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+    createWasteland: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            name: string;
+            ownerType: "org" | "user";
+            organizationId?: string | undefined;
+            dolthubUpstream?: string | undefined;
+            visibility?: "private" | "public" | undefined;
+        };
+        output: {
+            wasteland_id: string;
+            name: string;
+            owner_type: "org" | "user";
+            owner_user_id: string | null;
+            organization_id: string | null;
+            dolthub_upstream: string | null;
+            visibility: "private" | "public";
+            status: "active" | "deleted";
+            created_at: string;
+            updated_at: string;
+        };
+        meta: object;
+    }>;
+    createUpstream: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            upstream: string;
+            rigHandle?: string | undefined;
+            rigDisplayName?: string | undefined;
+            rigEmail?: string | undefined;
+        };
+        output: {
+            success: boolean;
+        };
+        meta: object;
+    }>;
+    listWastelands: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            organizationId?: string | undefined;
+        };
+        output: {
+            wasteland_id: string;
+            name: string;
+            owner_type: "org" | "user";
+            owner_user_id: string | null;
+            organization_id: string | null;
+            dolthub_upstream: string | null;
+            visibility: "private" | "public";
+            status: "active" | "deleted";
+            created_at: string;
+            updated_at: string;
+        }[];
+        meta: object;
+    }>;
+    getWasteland: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            wastelandId: string;
+        };
+        output: {
+            wasteland_id: string;
+            name: string;
+            owner_type: "org" | "user";
+            owner_user_id: string | null;
+            organization_id: string | null;
+            dolthub_upstream: string | null;
+            visibility: "private" | "public";
+            status: "active" | "deleted";
+            created_at: string;
+            updated_at: string;
+        };
+        meta: object;
+    }>;
+    deleteWasteland: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+        };
+        output: {
+            success: boolean;
+        };
+        meta: object;
+    }>;
+    adminListWastelands: import("@trpc/server").TRPCQueryProcedure<{
+        input: void;
+        output: {
+            wasteland_id: string;
+            name: string;
+            owner_type: "org" | "user";
+            owner_user_id: string | null;
+            organization_id: string | null;
+            dolthub_upstream: string | null;
+            visibility: "private" | "public";
+            status: "active" | "deleted";
+            created_at: string;
+            updated_at: string;
+        }[];
+        meta: object;
+    }>;
+    listMembers: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            wastelandId: string;
+        };
+        output: {
+            member_id: string;
+            user_id: string;
+            trust_level: number;
+            role: "contributor" | "maintainer" | "owner";
+            joined_at: string;
+        }[];
+        meta: object;
+    }>;
+    addMember: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            userId: string;
+            role?: "contributor" | "maintainer" | "owner" | undefined;
+            trustLevel?: number | undefined;
+        };
+        output: {
+            member_id: string;
+            user_id: string;
+            trust_level: number;
+            role: "contributor" | "maintainer" | "owner";
+            joined_at: string;
+        };
+        meta: object;
+    }>;
+    removeMember: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            memberId: string;
+        };
+        output: {
+            success: boolean;
+        };
+        meta: object;
+    }>;
+    updateMember: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            memberId: string;
+            role?: "contributor" | "maintainer" | "owner" | undefined;
+            trustLevel?: number | undefined;
+        };
+        output: {
+            member_id: string;
+            user_id: string;
+            trust_level: number;
+            role: "contributor" | "maintainer" | "owner";
+            joined_at: string;
+        };
+        meta: object;
+    }>;
+    updateWastelandConfig: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            name?: string | undefined;
+            visibility?: "private" | "public" | undefined;
+            dolthubUpstream?: string | undefined;
+        };
+        output: {
+            wasteland_id: string;
+            name: string;
+            owner_type: "org" | "user";
+            owner_user_id: string | null;
+            organization_id: string | null;
+            dolthub_upstream: string | null;
+            visibility: "private" | "public";
+            status: "active" | "deleted";
+            created_at: string;
+            updated_at: string;
+        };
+        meta: object;
+    }>;
+    storeCredential: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            dolthubToken: string;
+            dolthubOrg: string;
+            rigHandle?: string | undefined;
+            doltCredsJwk?: string | undefined;
+            doltUserName?: string | undefined;
+            doltUserEmail?: string | undefined;
+            isUpstreamAdmin?: boolean | undefined;
+        };
+        output: {
+            user_id: string;
+            dolthub_org: string;
+            rig_handle: string | null;
+            is_upstream_admin: boolean;
+            connected_at: string;
+        };
+        meta: object;
+    }>;
+    getCredentialStatus: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            wastelandId: string;
+        };
+        output: {
+            user_id: string;
+            dolthub_org: string;
+            rig_handle: string | null;
+            is_upstream_admin: boolean;
+            connected_at: string;
+        } | null;
+        meta: object;
+    }>;
+    setUpstreamAdmin: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            isUpstreamAdmin: boolean;
+        };
+        output: {
+            user_id: string;
+            dolthub_org: string;
+            rig_handle: string | null;
+            is_upstream_admin: boolean;
+            connected_at: string;
+        } | null;
+        meta: object;
+    }>;
+    deleteCredential: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+        };
+        output: {
+            success: boolean;
+        };
+        meta: object;
+    }>;
+    containerStatus: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            wastelandId: string;
+        };
+        output: {
+            joined: boolean;
+            upstream: string | null;
+            dolthubOrg: string | null;
+            hasToken: boolean;
+            hasJwk: boolean;
+            doltCredPubKey: string | null;
+            wlVersion: string;
+            uptime: number;
+            lastOperation: string | null;
+        };
+        meta: object;
+    }>;
+    containerJoin: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+        };
+        output: {
+            success: boolean;
+        };
+        meta: object;
+    }>;
+    connectKiloTown: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            townId: string;
+        };
+        output: {
+            town_id: string;
+            wasteland_id: string;
+            connected_by: string;
+            connected_at: string;
+        };
+        meta: object;
+    }>;
+    disconnectKiloTown: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            townId: string;
+        };
+        output: {
+            success: boolean;
+        };
+        meta: object;
+    }>;
+    listConnectedTowns: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            wastelandId: string;
+        };
+        output: {
+            town_id: string;
+            wasteland_id: string;
+            connected_by: string;
+            connected_at: string;
+        }[];
+        meta: object;
+    }>;
+    browseWantedBoard: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            wastelandId: string;
+        };
+        output: {
+            id: string;
+            title: string;
+            description: string | null;
+            project: string | null;
+            type: string | null;
+            priority: string | number | null;
+            tags: string | null;
+            posted_by: string | null;
+            claimed_by: string | null;
+            status: string;
+            effort_level: string | null;
+            evidence_url: string | null;
+            sandbox_required: string | number | null;
+            sandbox_scope: string | null;
+            sandbox_min_tier: string | null;
+            created_at: string | null;
+            updated_at: string | null;
+        }[];
+        meta: object;
+    }>;
+    claimWantedItem: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            itemId: string;
+            direct?: boolean | undefined;
+        };
+        output: {
+            success: boolean;
+        };
+        meta: object;
+    }>;
+    unclaimWantedItem: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            itemId: string;
+            direct?: boolean | undefined;
+        };
+        output: {
+            success: boolean;
+        };
+        meta: object;
+    }>;
+    postWantedItem: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            title: string;
+            description: string;
+            priority?: "critical" | "high" | "low" | "medium" | undefined;
+            type?: "bug" | "docs" | "feature" | "other" | undefined;
+            direct?: boolean | undefined;
+        };
+        output: {
+            success: boolean;
+        };
+        meta: object;
+    }>;
+    markWantedItemDone: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            itemId: string;
+            evidence: string;
+            direct?: boolean | undefined;
+        };
+        output: {
+            success: boolean;
+        };
+        meta: object;
+    }>;
+    acceptWantedItem: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            itemId: string;
+            quality: "excellent" | "fair" | "good" | "poor";
+            message?: string | undefined;
+            direct?: boolean | undefined;
+        };
+        output: {
+            success: boolean;
+        };
+        meta: object;
+    }>;
+    rejectWantedItem: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            itemId: string;
+            reason: string;
+            direct?: boolean | undefined;
+        };
+        output: {
+            success: boolean;
+        };
+        meta: object;
+    }>;
+    closeWantedItem: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            itemId: string;
+            direct?: boolean | undefined;
+        };
+        output: {
+            success: boolean;
+        };
+        meta: object;
+    }>;
+    mergeUpstreamPR: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            pullId: string;
+        };
+        output: {
+            pull_id: string;
+            state: string;
+        };
+        meta: object;
+    }>;
+    closeUpstreamPR: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            pullId: string;
+        };
+        output: {
+            pull_id: string;
+            state: string;
+        };
+        meta: object;
+    }>;
+    verifyUpstreamAdmin: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+        };
+        output: {
+            hasWriteAccess: boolean;
+            error: string | null;
+        };
+        meta: object;
+    }>;
+    listInboxItems: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            wastelandId: string;
+        };
+        output: {
+            items: ({
+                pull_id: string;
+                title: string;
+                state: string;
+                from_branch: string | null;
+                submitter: string | null;
+                creator_name: string | null;
+                created_at: string | null;
+                updated_at: string | null;
+                kind: "rig-registration";
+                handle: string;
+                display_name: string | null;
+                dolthub_org: string | null;
+                owner_email: string | null;
+                hop_uri: string | null;
+                gt_version: string | null;
+            } | {
+                pull_id: string;
+                title: string;
+                state: string;
+                from_branch: string | null;
+                submitter: string | null;
+                creator_name: string | null;
+                created_at: string | null;
+                updated_at: string | null;
+                kind: "wanted-post";
+                item_id: string;
+                item_title: string;
+                description: string | null;
+                type: string | null;
+                priority: string | null;
+                effort_level: string | null;
+                tags: string | null;
+                posted_by: string | null;
+            } | {
+                pull_id: string;
+                title: string;
+                state: string;
+                from_branch: string | null;
+                submitter: string | null;
+                creator_name: string | null;
+                created_at: string | null;
+                updated_at: string | null;
+                kind: "wanted-edit";
+                subkind: "delete" | "unclaim" | "update";
+                item_id: string;
+                item_title: string;
+                submitter_is_poster: boolean | null;
+                posted_by: string | null;
+                status_transition: string | null;
+            } | {
+                pull_id: string;
+                title: string;
+                state: string;
+                from_branch: string | null;
+                submitter: string | null;
+                creator_name: string | null;
+                created_at: string | null;
+                updated_at: string | null;
+                kind: "work-submission";
+                item_id: string;
+                item_title: string;
+                claimer: string;
+                has_done: boolean;
+                evidence_url: string | null;
+                completion_id: string | null;
+            } | {
+                pull_id: string;
+                title: string;
+                state: string;
+                from_branch: string | null;
+                submitter: string | null;
+                creator_name: string | null;
+                created_at: string | null;
+                updated_at: string | null;
+                kind: "admin-action";
+                subkind: "accept" | "accept-upstream" | "close" | "close-upstream" | "reject";
+                item_id: string;
+                item_title: string;
+                worker: string | null;
+                acceptor: string | null;
+                reject_reason: string | null;
+                stamp: {
+                    quality: string | null;
+                    severity: string | null;
+                    skill_tags: string | null;
+                    message: string | null;
+                } | null;
+            } | {
+                pull_id: string;
+                title: string;
+                state: string;
+                from_branch: string | null;
+                submitter: string | null;
+                creator_name: string | null;
+                created_at: string | null;
+                updated_at: string | null;
+                kind: "unknown";
+                commit_subjects: string[];
+            })[];
+        };
+        meta: object;
+    }>;
+    commentOnUpstreamPR: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            pullId: string;
+            comment: string;
+        };
+        output: {
+            success: boolean;
+        };
+        meta: object;
+    }>;
+    listUpstreamRigs: import("@trpc/server").TRPCQueryProcedure<{
+        input: {
+            wastelandId: string;
+        };
+        output: {
+            rigs: {
+                rig_handle: string;
+                display_name: string | null;
+                trust_level: number;
+                registered_at: string | null;
+                last_seen_at: string | null;
+            }[];
+        };
+        meta: object;
+    }>;
+    setUpstreamRigTrust: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            wastelandId: string;
+            rigHandle: string;
+            trustLevel: number;
+        };
+        output: {
+            success: boolean;
+        };
+        meta: object;
+    }>;
+}>>;
+export type WastelandRouter = typeof wastelandRouter;
+/**
+ * Wrapped router that nests wastelandRouter under a `wasteland` key.
+ * This preserves the `trpc.wasteland.X` call pattern on the frontend,
+ * matching the Gastown wrapping convention.
+ */
+export declare const wrappedWastelandRouter: import("@trpc/server").TRPCBuiltRouter<{
+    ctx: TRPCContext;
+    meta: object;
+    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    transformer: false;
+}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+    wasteland: import("@trpc/server").TRPCBuiltRouter<{
+        ctx: TRPCContext;
+        meta: object;
+        errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+        transformer: false;
+    }, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+        createWasteland: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                name: string;
+                ownerType: "org" | "user";
+                organizationId?: string | undefined;
+                dolthubUpstream?: string | undefined;
+                visibility?: "private" | "public" | undefined;
+            };
+            output: {
+                wasteland_id: string;
+                name: string;
+                owner_type: "org" | "user";
+                owner_user_id: string | null;
+                organization_id: string | null;
+                dolthub_upstream: string | null;
+                visibility: "private" | "public";
+                status: "active" | "deleted";
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
+        }>;
+        createUpstream: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                upstream: string;
+                rigHandle?: string | undefined;
+                rigDisplayName?: string | undefined;
+                rigEmail?: string | undefined;
+            };
+            output: {
+                success: boolean;
+            };
+            meta: object;
+        }>;
+        listWastelands: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                organizationId?: string | undefined;
+            };
+            output: {
+                wasteland_id: string;
+                name: string;
+                owner_type: "org" | "user";
+                owner_user_id: string | null;
+                organization_id: string | null;
+                dolthub_upstream: string | null;
+                visibility: "private" | "public";
+                status: "active" | "deleted";
+                created_at: string;
+                updated_at: string;
+            }[];
+            meta: object;
+        }>;
+        getWasteland: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                wastelandId: string;
+            };
+            output: {
+                wasteland_id: string;
+                name: string;
+                owner_type: "org" | "user";
+                owner_user_id: string | null;
+                organization_id: string | null;
+                dolthub_upstream: string | null;
+                visibility: "private" | "public";
+                status: "active" | "deleted";
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
+        }>;
+        deleteWasteland: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+            };
+            output: {
+                success: boolean;
+            };
+            meta: object;
+        }>;
+        adminListWastelands: import("@trpc/server").TRPCQueryProcedure<{
+            input: void;
+            output: {
+                wasteland_id: string;
+                name: string;
+                owner_type: "org" | "user";
+                owner_user_id: string | null;
+                organization_id: string | null;
+                dolthub_upstream: string | null;
+                visibility: "private" | "public";
+                status: "active" | "deleted";
+                created_at: string;
+                updated_at: string;
+            }[];
+            meta: object;
+        }>;
+        listMembers: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                wastelandId: string;
+            };
+            output: {
+                member_id: string;
+                user_id: string;
+                trust_level: number;
+                role: "contributor" | "maintainer" | "owner";
+                joined_at: string;
+            }[];
+            meta: object;
+        }>;
+        addMember: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                userId: string;
+                role?: "contributor" | "maintainer" | "owner" | undefined;
+                trustLevel?: number | undefined;
+            };
+            output: {
+                member_id: string;
+                user_id: string;
+                trust_level: number;
+                role: "contributor" | "maintainer" | "owner";
+                joined_at: string;
+            };
+            meta: object;
+        }>;
+        removeMember: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                memberId: string;
+            };
+            output: {
+                success: boolean;
+            };
+            meta: object;
+        }>;
+        updateMember: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                memberId: string;
+                role?: "contributor" | "maintainer" | "owner" | undefined;
+                trustLevel?: number | undefined;
+            };
+            output: {
+                member_id: string;
+                user_id: string;
+                trust_level: number;
+                role: "contributor" | "maintainer" | "owner";
+                joined_at: string;
+            };
+            meta: object;
+        }>;
+        updateWastelandConfig: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                name?: string | undefined;
+                visibility?: "private" | "public" | undefined;
+                dolthubUpstream?: string | undefined;
+            };
+            output: {
+                wasteland_id: string;
+                name: string;
+                owner_type: "org" | "user";
+                owner_user_id: string | null;
+                organization_id: string | null;
+                dolthub_upstream: string | null;
+                visibility: "private" | "public";
+                status: "active" | "deleted";
+                created_at: string;
+                updated_at: string;
+            };
+            meta: object;
+        }>;
+        storeCredential: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                dolthubToken: string;
+                dolthubOrg: string;
+                rigHandle?: string | undefined;
+                doltCredsJwk?: string | undefined;
+                doltUserName?: string | undefined;
+                doltUserEmail?: string | undefined;
+                isUpstreamAdmin?: boolean | undefined;
+            };
+            output: {
+                user_id: string;
+                dolthub_org: string;
+                rig_handle: string | null;
+                is_upstream_admin: boolean;
+                connected_at: string;
+            };
+            meta: object;
+        }>;
+        getCredentialStatus: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                wastelandId: string;
+            };
+            output: {
+                user_id: string;
+                dolthub_org: string;
+                rig_handle: string | null;
+                is_upstream_admin: boolean;
+                connected_at: string;
+            } | null;
+            meta: object;
+        }>;
+        setUpstreamAdmin: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                isUpstreamAdmin: boolean;
+            };
+            output: {
+                user_id: string;
+                dolthub_org: string;
+                rig_handle: string | null;
+                is_upstream_admin: boolean;
+                connected_at: string;
+            } | null;
+            meta: object;
+        }>;
+        deleteCredential: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+            };
+            output: {
+                success: boolean;
+            };
+            meta: object;
+        }>;
+        containerStatus: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                wastelandId: string;
+            };
+            output: {
+                joined: boolean;
+                upstream: string | null;
+                dolthubOrg: string | null;
+                hasToken: boolean;
+                hasJwk: boolean;
+                doltCredPubKey: string | null;
+                wlVersion: string;
+                uptime: number;
+                lastOperation: string | null;
+            };
+            meta: object;
+        }>;
+        containerJoin: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+            };
+            output: {
+                success: boolean;
+            };
+            meta: object;
+        }>;
+        connectKiloTown: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                townId: string;
+            };
+            output: {
+                town_id: string;
+                wasteland_id: string;
+                connected_by: string;
+                connected_at: string;
+            };
+            meta: object;
+        }>;
+        disconnectKiloTown: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                townId: string;
+            };
+            output: {
+                success: boolean;
+            };
+            meta: object;
+        }>;
+        listConnectedTowns: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                wastelandId: string;
+            };
+            output: {
+                town_id: string;
+                wasteland_id: string;
+                connected_by: string;
+                connected_at: string;
+            }[];
+            meta: object;
+        }>;
+        browseWantedBoard: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                wastelandId: string;
+            };
+            output: {
+                id: string;
+                title: string;
+                description: string | null;
+                project: string | null;
+                type: string | null;
+                priority: string | number | null;
+                tags: string | null;
+                posted_by: string | null;
+                claimed_by: string | null;
+                status: string;
+                effort_level: string | null;
+                evidence_url: string | null;
+                sandbox_required: string | number | null;
+                sandbox_scope: string | null;
+                sandbox_min_tier: string | null;
+                created_at: string | null;
+                updated_at: string | null;
+            }[];
+            meta: object;
+        }>;
+        claimWantedItem: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                itemId: string;
+                direct?: boolean | undefined;
+            };
+            output: {
+                success: boolean;
+            };
+            meta: object;
+        }>;
+        unclaimWantedItem: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                itemId: string;
+                direct?: boolean | undefined;
+            };
+            output: {
+                success: boolean;
+            };
+            meta: object;
+        }>;
+        postWantedItem: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                title: string;
+                description: string;
+                priority?: "critical" | "high" | "low" | "medium" | undefined;
+                type?: "bug" | "docs" | "feature" | "other" | undefined;
+                direct?: boolean | undefined;
+            };
+            output: {
+                success: boolean;
+            };
+            meta: object;
+        }>;
+        markWantedItemDone: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                itemId: string;
+                evidence: string;
+                direct?: boolean | undefined;
+            };
+            output: {
+                success: boolean;
+            };
+            meta: object;
+        }>;
+        acceptWantedItem: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                itemId: string;
+                quality: "excellent" | "fair" | "good" | "poor";
+                message?: string | undefined;
+                direct?: boolean | undefined;
+            };
+            output: {
+                success: boolean;
+            };
+            meta: object;
+        }>;
+        rejectWantedItem: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                itemId: string;
+                reason: string;
+                direct?: boolean | undefined;
+            };
+            output: {
+                success: boolean;
+            };
+            meta: object;
+        }>;
+        closeWantedItem: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                itemId: string;
+                direct?: boolean | undefined;
+            };
+            output: {
+                success: boolean;
+            };
+            meta: object;
+        }>;
+        mergeUpstreamPR: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                pullId: string;
+            };
+            output: {
+                pull_id: string;
+                state: string;
+            };
+            meta: object;
+        }>;
+        closeUpstreamPR: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                pullId: string;
+            };
+            output: {
+                pull_id: string;
+                state: string;
+            };
+            meta: object;
+        }>;
+        verifyUpstreamAdmin: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+            };
+            output: {
+                hasWriteAccess: boolean;
+                error: string | null;
+            };
+            meta: object;
+        }>;
+        listInboxItems: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                wastelandId: string;
+            };
+            output: {
+                items: ({
+                    pull_id: string;
+                    title: string;
+                    state: string;
+                    from_branch: string | null;
+                    submitter: string | null;
+                    creator_name: string | null;
+                    created_at: string | null;
+                    updated_at: string | null;
+                    kind: "rig-registration";
+                    handle: string;
+                    display_name: string | null;
+                    dolthub_org: string | null;
+                    owner_email: string | null;
+                    hop_uri: string | null;
+                    gt_version: string | null;
+                } | {
+                    pull_id: string;
+                    title: string;
+                    state: string;
+                    from_branch: string | null;
+                    submitter: string | null;
+                    creator_name: string | null;
+                    created_at: string | null;
+                    updated_at: string | null;
+                    kind: "wanted-post";
+                    item_id: string;
+                    item_title: string;
+                    description: string | null;
+                    type: string | null;
+                    priority: string | null;
+                    effort_level: string | null;
+                    tags: string | null;
+                    posted_by: string | null;
+                } | {
+                    pull_id: string;
+                    title: string;
+                    state: string;
+                    from_branch: string | null;
+                    submitter: string | null;
+                    creator_name: string | null;
+                    created_at: string | null;
+                    updated_at: string | null;
+                    kind: "wanted-edit";
+                    subkind: "delete" | "unclaim" | "update";
+                    item_id: string;
+                    item_title: string;
+                    submitter_is_poster: boolean | null;
+                    posted_by: string | null;
+                    status_transition: string | null;
+                } | {
+                    pull_id: string;
+                    title: string;
+                    state: string;
+                    from_branch: string | null;
+                    submitter: string | null;
+                    creator_name: string | null;
+                    created_at: string | null;
+                    updated_at: string | null;
+                    kind: "work-submission";
+                    item_id: string;
+                    item_title: string;
+                    claimer: string;
+                    has_done: boolean;
+                    evidence_url: string | null;
+                    completion_id: string | null;
+                } | {
+                    pull_id: string;
+                    title: string;
+                    state: string;
+                    from_branch: string | null;
+                    submitter: string | null;
+                    creator_name: string | null;
+                    created_at: string | null;
+                    updated_at: string | null;
+                    kind: "admin-action";
+                    subkind: "accept" | "accept-upstream" | "close" | "close-upstream" | "reject";
+                    item_id: string;
+                    item_title: string;
+                    worker: string | null;
+                    acceptor: string | null;
+                    reject_reason: string | null;
+                    stamp: {
+                        quality: string | null;
+                        severity: string | null;
+                        skill_tags: string | null;
+                        message: string | null;
+                    } | null;
+                } | {
+                    pull_id: string;
+                    title: string;
+                    state: string;
+                    from_branch: string | null;
+                    submitter: string | null;
+                    creator_name: string | null;
+                    created_at: string | null;
+                    updated_at: string | null;
+                    kind: "unknown";
+                    commit_subjects: string[];
+                })[];
+            };
+            meta: object;
+        }>;
+        commentOnUpstreamPR: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                pullId: string;
+                comment: string;
+            };
+            output: {
+                success: boolean;
+            };
+            meta: object;
+        }>;
+        listUpstreamRigs: import("@trpc/server").TRPCQueryProcedure<{
+            input: {
+                wastelandId: string;
+            };
+            output: {
+                rigs: {
+                    rig_handle: string;
+                    display_name: string | null;
+                    trust_level: number;
+                    registered_at: string | null;
+                    last_seen_at: string | null;
+                }[];
+            };
+            meta: object;
+        }>;
+        setUpstreamRigTrust: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                wastelandId: string;
+                rigHandle: string;
+                trustLevel: number;
+            };
+            output: {
+                success: boolean;
+            };
+            meta: object;
+        }>;
+    }>>;
+}>>;
+export type WrappedWastelandRouter = typeof wrappedWastelandRouter;

--- a/services/wasteland/dist-types/trpc/schemas.d.ts
+++ b/services/wasteland/dist-types/trpc/schemas.d.ts
@@ -1,0 +1,473 @@
+import { z } from 'zod';
+export declare const WastelandOutput: z.ZodObject<{
+    wasteland_id: z.ZodString;
+    name: z.ZodString;
+    owner_type: z.ZodEnum<{
+        org: "org";
+        user: "user";
+    }>;
+    owner_user_id: z.ZodNullable<z.ZodString>;
+    organization_id: z.ZodNullable<z.ZodString>;
+    dolthub_upstream: z.ZodNullable<z.ZodString>;
+    visibility: z.ZodEnum<{
+        private: "private";
+        public: "public";
+    }>;
+    status: z.ZodEnum<{
+        active: "active";
+        deleted: "deleted";
+    }>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>;
+export declare const WastelandMemberOutput: z.ZodObject<{
+    member_id: z.ZodString;
+    user_id: z.ZodString;
+    trust_level: z.ZodNumber;
+    role: z.ZodEnum<{
+        contributor: "contributor";
+        maintainer: "maintainer";
+        owner: "owner";
+    }>;
+    joined_at: z.ZodString;
+}, z.core.$strip>;
+export declare const WastelandCredentialStatusOutput: z.ZodObject<{
+    user_id: z.ZodString;
+    dolthub_org: z.ZodString;
+    rig_handle: z.ZodNullable<z.ZodString>;
+    is_upstream_admin: z.ZodBoolean;
+    connected_at: z.ZodString;
+}, z.core.$strip>;
+export declare const WastelandConfigOutput: z.ZodObject<{
+    wasteland_id: z.ZodString;
+    name: z.ZodString;
+    owner_type: z.ZodEnum<{
+        org: "org";
+        user: "user";
+    }>;
+    owner_user_id: z.ZodNullable<z.ZodString>;
+    organization_id: z.ZodNullable<z.ZodString>;
+    dolthub_upstream: z.ZodNullable<z.ZodString>;
+    visibility: z.ZodEnum<{
+        private: "private";
+        public: "public";
+    }>;
+    status: z.ZodEnum<{
+        active: "active";
+        deleted: "deleted";
+    }>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>;
+export declare const ConnectedTownOutput: z.ZodObject<{
+    town_id: z.ZodString;
+    wasteland_id: z.ZodString;
+    connected_by: z.ZodString;
+    connected_at: z.ZodString;
+}, z.core.$strip>;
+export declare const WantedItemOutput: z.ZodObject<{
+    item_id: z.ZodString;
+    title: z.ZodString;
+    description: z.ZodString;
+    status: z.ZodEnum<{
+        claimed: "claimed";
+        done: "done";
+        open: "open";
+    }>;
+    priority: z.ZodEnum<{
+        critical: "critical";
+        high: "high";
+        low: "low";
+        medium: "medium";
+    }>;
+    type: z.ZodEnum<{
+        bug: "bug";
+        docs: "docs";
+        feature: "feature";
+        other: "other";
+    }>;
+    claimed_by: z.ZodNullable<z.ZodString>;
+    evidence: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>;
+export declare const WantedBoardRowOutput: z.ZodObject<{
+    id: z.ZodString;
+    title: z.ZodString;
+    description: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    project: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    type: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    priority: z.ZodDefault<z.ZodNullable<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>>;
+    tags: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    posted_by: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    claimed_by: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    status: z.ZodString;
+    effort_level: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    evidence_url: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    sandbox_required: z.ZodDefault<z.ZodNullable<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>>;
+    sandbox_scope: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    sandbox_min_tier: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    created_at: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    updated_at: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+}, z.core.$strip>;
+export declare const MergePullOutput: z.ZodObject<{
+    pull_id: z.ZodString;
+    state: z.ZodString;
+}, z.core.$strip>;
+export declare const UpstreamAdminVerifyOutput: z.ZodObject<{
+    hasWriteAccess: z.ZodBoolean;
+    error: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>;
+export declare const UpstreamRigOutput: z.ZodObject<{
+    rig_handle: z.ZodString;
+    display_name: z.ZodNullable<z.ZodString>;
+    trust_level: z.ZodNumber;
+    registered_at: z.ZodNullable<z.ZodString>;
+    last_seen_at: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>;
+export declare const InboxItemOutput: z.ZodDiscriminatedUnion<[z.ZodObject<{
+    pull_id: z.ZodString;
+    title: z.ZodString;
+    state: z.ZodString;
+    from_branch: z.ZodNullable<z.ZodString>;
+    submitter: z.ZodNullable<z.ZodString>;
+    creator_name: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodNullable<z.ZodString>;
+    updated_at: z.ZodNullable<z.ZodString>;
+    kind: z.ZodLiteral<"rig-registration">;
+    handle: z.ZodString;
+    display_name: z.ZodNullable<z.ZodString>;
+    dolthub_org: z.ZodNullable<z.ZodString>;
+    owner_email: z.ZodNullable<z.ZodString>;
+    hop_uri: z.ZodNullable<z.ZodString>;
+    gt_version: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    pull_id: z.ZodString;
+    title: z.ZodString;
+    state: z.ZodString;
+    from_branch: z.ZodNullable<z.ZodString>;
+    submitter: z.ZodNullable<z.ZodString>;
+    creator_name: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodNullable<z.ZodString>;
+    updated_at: z.ZodNullable<z.ZodString>;
+    kind: z.ZodLiteral<"wanted-post">;
+    item_id: z.ZodString;
+    item_title: z.ZodString;
+    description: z.ZodNullable<z.ZodString>;
+    type: z.ZodNullable<z.ZodString>;
+    priority: z.ZodNullable<z.ZodString>;
+    effort_level: z.ZodNullable<z.ZodString>;
+    tags: z.ZodNullable<z.ZodString>;
+    posted_by: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    pull_id: z.ZodString;
+    title: z.ZodString;
+    state: z.ZodString;
+    from_branch: z.ZodNullable<z.ZodString>;
+    submitter: z.ZodNullable<z.ZodString>;
+    creator_name: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodNullable<z.ZodString>;
+    updated_at: z.ZodNullable<z.ZodString>;
+    kind: z.ZodLiteral<"wanted-edit">;
+    subkind: z.ZodEnum<{
+        delete: "delete";
+        unclaim: "unclaim";
+        update: "update";
+    }>;
+    item_id: z.ZodString;
+    item_title: z.ZodString;
+    submitter_is_poster: z.ZodNullable<z.ZodBoolean>;
+    posted_by: z.ZodNullable<z.ZodString>;
+    status_transition: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    pull_id: z.ZodString;
+    title: z.ZodString;
+    state: z.ZodString;
+    from_branch: z.ZodNullable<z.ZodString>;
+    submitter: z.ZodNullable<z.ZodString>;
+    creator_name: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodNullable<z.ZodString>;
+    updated_at: z.ZodNullable<z.ZodString>;
+    kind: z.ZodLiteral<"work-submission">;
+    item_id: z.ZodString;
+    item_title: z.ZodString;
+    claimer: z.ZodString;
+    has_done: z.ZodBoolean;
+    evidence_url: z.ZodNullable<z.ZodString>;
+    completion_id: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    pull_id: z.ZodString;
+    title: z.ZodString;
+    state: z.ZodString;
+    from_branch: z.ZodNullable<z.ZodString>;
+    submitter: z.ZodNullable<z.ZodString>;
+    creator_name: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodNullable<z.ZodString>;
+    updated_at: z.ZodNullable<z.ZodString>;
+    kind: z.ZodLiteral<"admin-action">;
+    subkind: z.ZodEnum<{
+        accept: "accept";
+        "accept-upstream": "accept-upstream";
+        close: "close";
+        "close-upstream": "close-upstream";
+        reject: "reject";
+    }>;
+    item_id: z.ZodString;
+    item_title: z.ZodString;
+    worker: z.ZodNullable<z.ZodString>;
+    acceptor: z.ZodNullable<z.ZodString>;
+    reject_reason: z.ZodNullable<z.ZodString>;
+    stamp: z.ZodNullable<z.ZodObject<{
+        quality: z.ZodNullable<z.ZodString>;
+        severity: z.ZodNullable<z.ZodString>;
+        skill_tags: z.ZodNullable<z.ZodString>;
+        message: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+}, z.core.$strip>, z.ZodObject<{
+    pull_id: z.ZodString;
+    title: z.ZodString;
+    state: z.ZodString;
+    from_branch: z.ZodNullable<z.ZodString>;
+    submitter: z.ZodNullable<z.ZodString>;
+    creator_name: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodNullable<z.ZodString>;
+    updated_at: z.ZodNullable<z.ZodString>;
+    kind: z.ZodLiteral<"unknown">;
+    commit_subjects: z.ZodArray<z.ZodString>;
+}, z.core.$strip>], "kind">;
+export declare const RpcWastelandOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    wasteland_id: z.ZodString;
+    name: z.ZodString;
+    owner_type: z.ZodEnum<{
+        org: "org";
+        user: "user";
+    }>;
+    owner_user_id: z.ZodNullable<z.ZodString>;
+    organization_id: z.ZodNullable<z.ZodString>;
+    dolthub_upstream: z.ZodNullable<z.ZodString>;
+    visibility: z.ZodEnum<{
+        private: "private";
+        public: "public";
+    }>;
+    status: z.ZodEnum<{
+        active: "active";
+        deleted: "deleted";
+    }>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcWastelandMemberOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    member_id: z.ZodString;
+    user_id: z.ZodString;
+    trust_level: z.ZodNumber;
+    role: z.ZodEnum<{
+        contributor: "contributor";
+        maintainer: "maintainer";
+        owner: "owner";
+    }>;
+    joined_at: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcWastelandCredentialStatusOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    user_id: z.ZodString;
+    dolthub_org: z.ZodString;
+    rig_handle: z.ZodNullable<z.ZodString>;
+    is_upstream_admin: z.ZodBoolean;
+    connected_at: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcWastelandConfigOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    wasteland_id: z.ZodString;
+    name: z.ZodString;
+    owner_type: z.ZodEnum<{
+        org: "org";
+        user: "user";
+    }>;
+    owner_user_id: z.ZodNullable<z.ZodString>;
+    organization_id: z.ZodNullable<z.ZodString>;
+    dolthub_upstream: z.ZodNullable<z.ZodString>;
+    visibility: z.ZodEnum<{
+        private: "private";
+        public: "public";
+    }>;
+    status: z.ZodEnum<{
+        active: "active";
+        deleted: "deleted";
+    }>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcConnectedTownOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    town_id: z.ZodString;
+    wasteland_id: z.ZodString;
+    connected_by: z.ZodString;
+    connected_at: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcWantedItemOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    item_id: z.ZodString;
+    title: z.ZodString;
+    description: z.ZodString;
+    status: z.ZodEnum<{
+        claimed: "claimed";
+        done: "done";
+        open: "open";
+    }>;
+    priority: z.ZodEnum<{
+        critical: "critical";
+        high: "high";
+        low: "low";
+        medium: "medium";
+    }>;
+    type: z.ZodEnum<{
+        bug: "bug";
+        docs: "docs";
+        feature: "feature";
+        other: "other";
+    }>;
+    claimed_by: z.ZodNullable<z.ZodString>;
+    evidence: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodString;
+    updated_at: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcWantedBoardRowOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    id: z.ZodString;
+    title: z.ZodString;
+    description: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    project: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    type: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    priority: z.ZodDefault<z.ZodNullable<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>>;
+    tags: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    posted_by: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    claimed_by: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    status: z.ZodString;
+    effort_level: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    evidence_url: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    sandbox_required: z.ZodDefault<z.ZodNullable<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>>;
+    sandbox_scope: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    sandbox_min_tier: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    created_at: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    updated_at: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+}, z.core.$strip>>;
+export declare const RpcMergePullOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    pull_id: z.ZodString;
+    state: z.ZodString;
+}, z.core.$strip>>;
+export declare const RpcUpstreamAdminVerifyOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    hasWriteAccess: z.ZodBoolean;
+    error: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>>;
+export declare const RpcUpstreamRigOutput: z.ZodPipe<z.ZodAny, z.ZodObject<{
+    rig_handle: z.ZodString;
+    display_name: z.ZodNullable<z.ZodString>;
+    trust_level: z.ZodNumber;
+    registered_at: z.ZodNullable<z.ZodString>;
+    last_seen_at: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>>;
+export declare const RpcInboxItemOutput: z.ZodPipe<z.ZodAny, z.ZodDiscriminatedUnion<[z.ZodObject<{
+    pull_id: z.ZodString;
+    title: z.ZodString;
+    state: z.ZodString;
+    from_branch: z.ZodNullable<z.ZodString>;
+    submitter: z.ZodNullable<z.ZodString>;
+    creator_name: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodNullable<z.ZodString>;
+    updated_at: z.ZodNullable<z.ZodString>;
+    kind: z.ZodLiteral<"rig-registration">;
+    handle: z.ZodString;
+    display_name: z.ZodNullable<z.ZodString>;
+    dolthub_org: z.ZodNullable<z.ZodString>;
+    owner_email: z.ZodNullable<z.ZodString>;
+    hop_uri: z.ZodNullable<z.ZodString>;
+    gt_version: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    pull_id: z.ZodString;
+    title: z.ZodString;
+    state: z.ZodString;
+    from_branch: z.ZodNullable<z.ZodString>;
+    submitter: z.ZodNullable<z.ZodString>;
+    creator_name: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodNullable<z.ZodString>;
+    updated_at: z.ZodNullable<z.ZodString>;
+    kind: z.ZodLiteral<"wanted-post">;
+    item_id: z.ZodString;
+    item_title: z.ZodString;
+    description: z.ZodNullable<z.ZodString>;
+    type: z.ZodNullable<z.ZodString>;
+    priority: z.ZodNullable<z.ZodString>;
+    effort_level: z.ZodNullable<z.ZodString>;
+    tags: z.ZodNullable<z.ZodString>;
+    posted_by: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    pull_id: z.ZodString;
+    title: z.ZodString;
+    state: z.ZodString;
+    from_branch: z.ZodNullable<z.ZodString>;
+    submitter: z.ZodNullable<z.ZodString>;
+    creator_name: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodNullable<z.ZodString>;
+    updated_at: z.ZodNullable<z.ZodString>;
+    kind: z.ZodLiteral<"wanted-edit">;
+    subkind: z.ZodEnum<{
+        delete: "delete";
+        unclaim: "unclaim";
+        update: "update";
+    }>;
+    item_id: z.ZodString;
+    item_title: z.ZodString;
+    submitter_is_poster: z.ZodNullable<z.ZodBoolean>;
+    posted_by: z.ZodNullable<z.ZodString>;
+    status_transition: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    pull_id: z.ZodString;
+    title: z.ZodString;
+    state: z.ZodString;
+    from_branch: z.ZodNullable<z.ZodString>;
+    submitter: z.ZodNullable<z.ZodString>;
+    creator_name: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodNullable<z.ZodString>;
+    updated_at: z.ZodNullable<z.ZodString>;
+    kind: z.ZodLiteral<"work-submission">;
+    item_id: z.ZodString;
+    item_title: z.ZodString;
+    claimer: z.ZodString;
+    has_done: z.ZodBoolean;
+    evidence_url: z.ZodNullable<z.ZodString>;
+    completion_id: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    pull_id: z.ZodString;
+    title: z.ZodString;
+    state: z.ZodString;
+    from_branch: z.ZodNullable<z.ZodString>;
+    submitter: z.ZodNullable<z.ZodString>;
+    creator_name: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodNullable<z.ZodString>;
+    updated_at: z.ZodNullable<z.ZodString>;
+    kind: z.ZodLiteral<"admin-action">;
+    subkind: z.ZodEnum<{
+        accept: "accept";
+        "accept-upstream": "accept-upstream";
+        close: "close";
+        "close-upstream": "close-upstream";
+        reject: "reject";
+    }>;
+    item_id: z.ZodString;
+    item_title: z.ZodString;
+    worker: z.ZodNullable<z.ZodString>;
+    acceptor: z.ZodNullable<z.ZodString>;
+    reject_reason: z.ZodNullable<z.ZodString>;
+    stamp: z.ZodNullable<z.ZodObject<{
+        quality: z.ZodNullable<z.ZodString>;
+        severity: z.ZodNullable<z.ZodString>;
+        skill_tags: z.ZodNullable<z.ZodString>;
+        message: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+}, z.core.$strip>, z.ZodObject<{
+    pull_id: z.ZodString;
+    title: z.ZodString;
+    state: z.ZodString;
+    from_branch: z.ZodNullable<z.ZodString>;
+    submitter: z.ZodNullable<z.ZodString>;
+    creator_name: z.ZodNullable<z.ZodString>;
+    created_at: z.ZodNullable<z.ZodString>;
+    updated_at: z.ZodNullable<z.ZodString>;
+    kind: z.ZodLiteral<"unknown">;
+    commit_subjects: z.ZodArray<z.ZodString>;
+}, z.core.$strip>], "kind">>;

--- a/services/wasteland/dist-types/util/analytics.util.d.ts
+++ b/services/wasteland/dist-types/util/analytics.util.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Controller-level event names emitted from HTTP handlers.
+ * Internal DO events use string literals directly.
+ */
+export type WastelandEventName = 'wasteland.created' | 'wasteland.deleted' | 'credential.stored' | 'credential.deleted' | 'member.added' | 'member.removed' | 'wanted.browse' | 'wanted.claim' | 'wanted.done' | 'wanted.post' | 'wanted.sync' | (string & {});
+export type WastelandDelivery = 'http' | 'trpc' | 'internal' | 'billing';
+export type WastelandEventData = {
+    event: WastelandEventName;
+    delivery?: WastelandDelivery;
+    route?: string;
+    error?: string;
+    userId?: string;
+    wastelandId?: string;
+    memberId?: string;
+    durationMs?: number;
+    value?: number;
+    label?: string;
+};
+/**
+ * Write a single event to Cloudflare Analytics Engine.
+ * Safe to call in development (where the binding is absent) — silently no-ops.
+ */
+export declare function writeEvent(env: {
+    WASTELAND_AE?: AnalyticsEngineDataset;
+}, data: WastelandEventData): void;

--- a/services/wasteland/dist-types/util/billing.util.d.ts
+++ b/services/wasteland/dist-types/util/billing.util.d.ts
@@ -1,0 +1,29 @@
+export type BillableEvent = 'billing.wasteland_created' | 'billing.wasteland_deleted' | 'billing.api_operation' | 'billing.credential_stored' | 'billing.credential_deleted' | 'billing.member_added' | 'billing.member_removed';
+/**
+ * Categorises the API operation for metering granularity.
+ * Write operations (mutations that modify DoltHub state) are metered
+ * individually; reads are not metered today.
+ */
+export type BillingOperationKind = 'claim' | 'done' | 'post' | 'config_update' | 'member_update';
+type BillingEnv = {
+    WASTELAND_AE?: AnalyticsEngineDataset;
+};
+type MeterEventInput = {
+    event: BillableEvent;
+    userId: string;
+    wastelandId: string;
+    /** Free-form label for sub-categorisation (e.g. operation kind). */
+    label?: string;
+    /** Numeric value associated with the event (e.g. member count). */
+    value?: number;
+};
+/**
+ * Record a billable event in the Analytics Engine.
+ *
+ * Uses `delivery: 'billing'` so billing-specific queries can filter on
+ * the delivery channel without scanning the full event stream.
+ *
+ * Best-effort — never throws.
+ */
+export declare function meterEvent(env: BillingEnv, input: MeterEventInput): void;
+export {};

--- a/services/wasteland/dist-types/util/crypto.util.d.ts
+++ b/services/wasteland/dist-types/util/crypto.util.d.ts
@@ -1,0 +1,6 @@
+/** Encrypt a plaintext string. Returns base64(iv || ciphertext || tag). */
+export declare function encryptToken(plaintext: string, key: CryptoKey): Promise<string>;
+/** Decrypt a base64(iv || ciphertext || tag) string back to plaintext. */
+export declare function decryptToken(encrypted: string, key: CryptoKey): Promise<string>;
+/** Derive an AES-256-GCM CryptoKey from a secret string using PBKDF2. */
+export declare function deriveEncryptionKey(secret: string): Promise<CryptoKey>;

--- a/services/wasteland/dist-types/util/dolthub-api.util.d.ts
+++ b/services/wasteland/dist-types/util/dolthub-api.util.d.ts
@@ -1,0 +1,99 @@
+/**
+ * Thin client for the DoltHub REST API — used by admin-mode tRPC procedures
+ * to list, merge, and close pull requests on an upstream repo.
+ *
+ * Callers pass a token explicitly; this module never reads from secrets.
+ * All responses are validated with Zod before being returned.
+ */
+import { z } from 'zod';
+export declare const DOLTHUB_API_BASE = "https://www.dolthub.com/api/v1alpha1";
+export declare class DoltHubApiError extends Error {
+    readonly status: number;
+    constructor(message: string, status: number);
+}
+/**
+ * Parse a DoltHub upstream string (e.g. "hop/wl-commons") into owner + db.
+ */
+export declare function parseUpstream(upstream: string): {
+    owner: string;
+    db: string;
+};
+export declare const DoltHubPull: z.ZodObject<{
+    pull_id: z.ZodPipe<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>, z.ZodTransform<string, string | number>>;
+    title: z.ZodDefault<z.ZodString>;
+    description: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    state: z.ZodString;
+    created_at: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    updated_at: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    creator_name: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+}, z.core.$loose>;
+export type DoltHubPullT = z.infer<typeof DoltHubPull>;
+/**
+ * List pull requests on the upstream repo, optionally filtered by state
+ * ("Open" | "Closed" | "Merged"). The DoltHub API ignores the `state` query
+ * parameter server-side, so we always fetch all and filter client-side.
+ */
+export declare function listPulls(upstream: string, token: string, opts?: {
+    state?: 'Open' | 'Closed' | 'Merged';
+}): Promise<DoltHubPullT[]>;
+export declare const DoltHubPullDetail: z.ZodObject<{
+    pull_id: z.ZodPipe<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>, z.ZodTransform<string, string | number>>;
+    title: z.ZodDefault<z.ZodString>;
+    description: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    state: z.ZodString;
+    from_branch_name: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    to_branch_name: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    from_branch_owner_name: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    from_branch_repo_name: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    creator_name: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    created_at: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+    updated_at: z.ZodDefault<z.ZodNullable<z.ZodString>>;
+}, z.core.$loose>;
+export type DoltHubPullDetailT = z.infer<typeof DoltHubPullDetail>;
+export declare function getPull(upstream: string, token: string, pullId: string): Promise<DoltHubPullDetailT>;
+export declare function mergePull(upstream: string, token: string, pullId: string): Promise<{
+    state: string;
+}>;
+export declare function closePull(upstream: string, token: string, pullId: string): Promise<{
+    state: string;
+}>;
+/**
+ * Post a comment on an upstream pull request. DoltHub supports POSTing
+ * comments but does not expose a GET endpoint for reading them via REST,
+ * so the UI links out for viewing and uses this for posting only.
+ */
+export declare function commentOnPull(upstream: string, token: string, pullId: string, comment: string): Promise<void>;
+declare const SqlResponse: z.ZodObject<{
+    query_execution_status: z.ZodOptional<z.ZodString>;
+    query_execution_message: z.ZodOptional<z.ZodString>;
+    rows: z.ZodOptional<z.ZodArray<z.ZodRecord<z.ZodString, z.ZodUnknown>>>;
+}, z.core.$loose>;
+export type DoltHubSqlResultT = z.infer<typeof SqlResponse>;
+export declare function runSql(upstream: string, token: string, branch: string, sql: string): Promise<DoltHubSqlResultT>;
+/**
+ * Write API — creates `toBranch` forked from `fromBranch` and commits the
+ * DML in one call. Used for admin operations like rig trust-level edits.
+ */
+export declare function runWrite(upstream: string, token: string, fromBranch: string, toBranch: string, sql: string): Promise<DoltHubSqlResultT>;
+/**
+ * `wl` creates one PR per contribution with branch name `wl/{rig-handle}/{item-id}`.
+ * Parse the branch name back out to associate a PR with a wanted item.
+ */
+export declare function parseWlBranch(branch: string | null): {
+    rigHandle: string;
+    itemId: string;
+} | null;
+/**
+ * Delete a branch on the upstream. Used to clean up scratch branches
+ * created by admin probes and direct writes. Failures are swallowed —
+ * the caller wants best-effort cleanup, not to fail the parent op.
+ */
+export declare function deleteBranch(upstream: string, token: string, branch: string): Promise<void>;
+/**
+ * Map with a bounded concurrency pool. Useful for batch DoltHub calls
+ * (e.g. fetching detail for N pull requests) where `Promise.all` on the
+ * whole list would hammer the API and blow past Cloudflare's subrequest
+ * budget.
+ */
+export declare function mapWithLimit<T, R>(items: readonly T[], limit: number, fn: (item: T, index: number) => Promise<R>): Promise<R[]>;
+export {};

--- a/services/wasteland/dist-types/util/log.util.d.ts
+++ b/services/wasteland/dist-types/util/log.util.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Structured logging powered by workers-tagged-logger.
+ *
+ * Uses AsyncLocalStorage so tags (wastelandId, userId, etc.) propagate
+ * to all downstream functions without explicit parameter passing.
+ *
+ * Setup:
+ *   - In the Hono worker: use `useWorkersLogger` middleware to establish context.
+ *   - In DOs: wrap the entry point (alarm, RPC) with `withLogTags`.
+ *   - Anywhere: call `logger.setTags({ wastelandId })` to tag all subsequent logs.
+ *
+ * Usage:
+ *   import { logger } from '../util/log.util';
+ *   logger.info('initializeWasteland: stored config');
+ *   logger.warn('storeCredential: missing token', { userId });
+ */
+import { WorkersLogger, withLogTags } from 'workers-tagged-logger';
+export type LogTags = {
+    source?: string;
+    wastelandId?: string;
+    userId?: string;
+    memberId?: string;
+};
+export declare const logger: WorkersLogger<LogTags>;
+export { withLogTags };

--- a/services/wasteland/dist-types/util/query.util.d.ts
+++ b/services/wasteland/dist-types/util/query.util.d.ts
@@ -1,0 +1,13 @@
+/**
+ * CountOccurrences type counts the number of times a SubString appears in a String_.
+ * Uses a recursive approach with a counter represented as an array of unknown.
+ */
+type CountOccurrences<String_ extends string, SubString extends string, Count extends unknown[] = []> = String_ extends `${string}${SubString}${infer Tail}` ? CountOccurrences<Tail, SubString, [unknown, ...Count]> : Count['length'];
+type Tuple<T, N extends number, Acc extends T[] = []> = Acc['length'] extends N ? Acc : Tuple<T, N, [...Acc, T]>;
+export type SqliteParams<Query extends string> = Tuple<unknown, CountOccurrences<Query, '?'>>;
+/**
+ * Type-safe SQLite query helper. The params tuple length is statically
+ * checked against the number of `?` placeholders in the query string.
+ */
+export declare function query<Query extends string>(sql: SqlStorage, query: Query, params: SqliteParams<Query> & unknown[]): SqlStorageCursor<Record<string, SqlStorageValue>>;
+export {};

--- a/services/wasteland/dist-types/util/rate-limit.util.d.ts
+++ b/services/wasteland/dist-types/util/rate-limit.util.d.ts
@@ -1,0 +1,17 @@
+type RateLimitConfig = {
+    /** Maximum number of requests allowed within the window. */
+    maxRequests: number;
+    /** Time window in milliseconds. */
+    windowMs: number;
+};
+/** Per-operation rate limit configs. */
+export declare const RATE_LIMITS: Record<string, RateLimitConfig>;
+/**
+ * Check whether the request should be allowed under the rate limit.
+ * Throws a TRPCError with code TOO_MANY_REQUESTS if the limit is exceeded.
+ *
+ * If no rate limit is configured for the given operation, the request is
+ * always allowed.
+ */
+export declare function checkRateLimit(userId: string, operation: string): void;
+export {};

--- a/services/wasteland/dist-types/util/res.util.d.ts
+++ b/services/wasteland/dist-types/util/res.util.d.ts
@@ -1,0 +1,1 @@
+export { resSuccess, resError, type SuccessResponse, type ErrorResponse, } from '@kilocode/worker-utils';

--- a/services/wasteland/dist-types/util/secret.util.d.ts
+++ b/services/wasteland/dist-types/util/secret.util.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Resolves a secret value from either a `SecretsStoreSecret` (production, has `.get()`)
+ * or a plain string (test env vars set in wrangler.test.jsonc).
+ *
+ * Returns `null` when the Secrets Store fetch fails (transient network error,
+ * misconfigured store, etc.) so callers can return a clean 500 instead of
+ * letting an opaque "Secrets Worker: Failed to fetch secret" bubble up.
+ */
+export declare function resolveSecret(binding: SecretsStoreSecret | string): Promise<string | null>;

--- a/services/wasteland/dist-types/util/table.d.ts
+++ b/services/wasteland/dist-types/util/table.d.ts
@@ -1,0 +1,28 @@
+import type { z } from 'zod';
+export type TableInput = {
+    name: string;
+    columns: readonly string[];
+};
+export type TableQueryInterpolator<T extends TableInput> = {
+    _name: T['name'];
+    columns: {
+        [K in T['columns'][number]]: K;
+    };
+    valueOf: () => T['name'];
+    toString: () => T['name'];
+} & {
+    [K in T['columns'][number]]: `${T['name']}.${K}`;
+};
+export declare function getTable<T extends TableInput>(table: T): TableQueryInterpolator<T>;
+export declare function getTableFromZodSchema<Name extends string, Schema extends z.ZodObject<any>>(name: Name, schema: Schema): TableQueryInterpolator<{
+    name: Name;
+    columns: Array<Extract<keyof z.infer<Schema>, string>>;
+}>;
+export type BaseTableQueryInterpolator = TableQueryInterpolator<{
+    name: string;
+    columns: [];
+}>;
+export type TableSqliteTypeMap<T extends BaseTableQueryInterpolator> = {
+    [K in keyof T['columns']]: string;
+};
+export declare function getCreateTableQueryFromTable<T extends BaseTableQueryInterpolator>(table: T, columnTypeMap: TableSqliteTypeMap<T>): string;

--- a/services/wasteland/dist-types/wanted-board/wanted-board-ops.d.ts
+++ b/services/wasteland/dist-types/wanted-board/wanted-board-ops.d.ts
@@ -1,0 +1,84 @@
+/**
+ * Wanted board operations — shared business logic used by both the tRPC
+ * router and the WastelandRPCEntrypoint. Each function owns the full
+ * operation: credential decryption, container dispatch, result parsing,
+ * cache refresh, and metering.
+ *
+ * All ownership/auth checks happen in the callers (tRPC via
+ * resolveWastelandOwnership, RPC via the fact that only peer workers
+ * can call the binding).
+ */
+import { z } from 'zod';
+export declare class WantedBoardOpError extends Error {
+    /** Maps roughly to HTTP/tRPC codes. Callers translate as needed. */
+    readonly code: 'NOT_FOUND' | 'PRECONDITION_FAILED' | 'INTERNAL_SERVER_ERROR' | 'UPSTREAM_ERROR';
+    constructor(message: string, 
+    /** Maps roughly to HTTP/tRPC codes. Callers translate as needed. */
+    code: 'NOT_FOUND' | 'PRECONDITION_FAILED' | 'INTERNAL_SERVER_ERROR' | 'UPSTREAM_ERROR');
+}
+declare const PriorityEnum: z.ZodEnum<{
+    critical: "critical";
+    high: "high";
+    low: "low";
+    medium: "medium";
+}>;
+declare const TypeEnum: z.ZodEnum<{
+    bug: "bug";
+    docs: "docs";
+    feature: "feature";
+    other: "other";
+}>;
+export declare function browseWantedBoard(env: Env, wastelandId: string, userId: string): Promise<Array<Record<string, unknown>>>;
+export declare function claimWantedItem(env: Env, wastelandId: string, userId: string, itemId: string, options?: {
+    direct?: boolean;
+}): Promise<{
+    success: true;
+}>;
+export declare function unclaimWantedItem(env: Env, wastelandId: string, userId: string, itemId: string, options?: {
+    direct?: boolean;
+}): Promise<{
+    success: true;
+}>;
+export declare function acceptWantedItem(env: Env, wastelandId: string, userId: string, input: {
+    itemId: string;
+    quality: 'excellent' | 'good' | 'fair' | 'poor';
+    /** Free-form message attached to the stamp (written to `stamps.message`). */
+    message?: string;
+    direct?: boolean;
+}): Promise<{
+    success: true;
+}>;
+export declare function rejectWantedItem(env: Env, wastelandId: string, userId: string, input: {
+    itemId: string;
+    /**
+     * Rejection reason — becomes part of the `wl reject` commit message.
+     * Maps to `--reason` on the wl CLI (not `--comment`, which is an
+     * approve/request-changes flag).
+     */
+    reason: string;
+    direct?: boolean;
+}): Promise<{
+    success: true;
+}>;
+export declare function closeWantedItem(env: Env, wastelandId: string, userId: string, itemId: string, options?: {
+    direct?: boolean;
+}): Promise<{
+    success: true;
+}>;
+export declare function postWantedItem(env: Env, wastelandId: string, userId: string, input: {
+    title: string;
+    description: string;
+    priority?: z.infer<typeof PriorityEnum>;
+    type?: z.infer<typeof TypeEnum>;
+    direct?: boolean;
+}): Promise<{
+    success: true;
+}>;
+export declare function markWantedItemDone(env: Env, wastelandId: string, userId: string, input: {
+    itemId: string;
+    evidence: string;
+    direct?: boolean;
+}): Promise<{
+    success: true;
+}>;
+export {};

--- a/services/wasteland/dist-types/wasteland-rpc.entrypoint.d.ts
+++ b/services/wasteland/dist-types/wasteland-rpc.entrypoint.d.ts
@@ -1,0 +1,93 @@
+/**
+ * RPC entrypoint for peer workers (e.g. gastown) to call wasteland
+ * operations directly without going through HTTP + tRPC.
+ *
+ * Exposed as `WastelandRPCEntrypoint` in wrangler.jsonc and bound by
+ * consumers via `services` bindings with `entrypoint: "WastelandRPCEntrypoint"`.
+ *
+ * Auth model: the caller is a trusted peer worker. The userId is passed
+ * as a parameter and used for credential lookup, metering, and audit —
+ * but we do NOT re-validate it here because peer workers have already
+ * authenticated their inbound user.
+ */
+import { WorkerEntrypoint } from 'cloudflare:workers';
+import { WantedBoardOpError } from './wanted-board/wanted-board-ops';
+export type WastelandRpcResult<T> = {
+    success: true;
+    data: T;
+} | {
+    success: false;
+    code: WantedBoardOpError['code'];
+    message: string;
+};
+export declare class WastelandRPCEntrypoint extends WorkerEntrypoint<Env> {
+    browseWantedBoard(params: {
+        wastelandId: string;
+        userId: string;
+    }): Promise<WastelandRpcResult<Record<string, unknown>[]>>;
+    claimWantedItem(params: {
+        wastelandId: string;
+        userId: string;
+        itemId: string;
+        direct?: boolean;
+    }): Promise<WastelandRpcResult<{
+        success: true;
+    }>>;
+    unclaimWantedItem(params: {
+        wastelandId: string;
+        userId: string;
+        itemId: string;
+        direct?: boolean;
+    }): Promise<WastelandRpcResult<{
+        success: true;
+    }>>;
+    postWantedItem(params: {
+        wastelandId: string;
+        userId: string;
+        title: string;
+        description: string;
+        priority?: 'low' | 'medium' | 'high' | 'critical';
+        type?: 'feature' | 'bug' | 'docs' | 'other';
+        direct?: boolean;
+    }): Promise<WastelandRpcResult<{
+        success: true;
+    }>>;
+    markWantedItemDone(params: {
+        wastelandId: string;
+        userId: string;
+        itemId: string;
+        evidence: string;
+        direct?: boolean;
+    }): Promise<WastelandRpcResult<{
+        success: true;
+    }>>;
+    acceptWantedItem(params: {
+        wastelandId: string;
+        userId: string;
+        itemId: string;
+        quality: 'excellent' | 'good' | 'fair' | 'poor';
+        /** Free-form message attached to the reputation stamp. */
+        message?: string;
+        direct?: boolean;
+    }): Promise<WastelandRpcResult<{
+        success: true;
+    }>>;
+    rejectWantedItem(params: {
+        wastelandId: string;
+        userId: string;
+        itemId: string;
+        /** Rejection reason (maps to `wl reject --reason`). */
+        reason: string;
+        direct?: boolean;
+    }): Promise<WastelandRpcResult<{
+        success: true;
+    }>>;
+    closeWantedItem(params: {
+        wastelandId: string;
+        userId: string;
+        itemId: string;
+        direct?: boolean;
+    }): Promise<WastelandRpcResult<{
+        success: true;
+    }>>;
+}

--- a/services/wasteland/dist-types/wasteland.worker.d.ts
+++ b/services/wasteland/dist-types/wasteland.worker.d.ts
@@ -1,0 +1,11 @@
+import type { AuthVariables } from './middleware/auth.middleware';
+export { WastelandDO } from './dos/Wasteland.do';
+export { WastelandContainerDO } from './dos/WastelandContainer.do';
+export { WastelandRegistryDO } from './dos/WastelandRegistry.do';
+export { WastelandRPCEntrypoint } from './wasteland-rpc.entrypoint';
+export type WastelandEnv = {
+    Bindings: Env;
+    Variables: AuthVariables;
+};
+declare const _default: ExportedHandler<Env, unknown, unknown, unknown>;
+export default _default;


### PR DESCRIPTION
## Summary

Batch merge of 11 commits from `gastown-staging` into `main` (9 constituent PRs + 2 direct commits), covering a critical bead reopening bug, dispatch reliability, container env propagation, container image tooling, dead code removal, and UI improvements.

### Bug Fixes
- **Prevent `deleteAgent` from reopening terminal beads** (direct commit) — `deleteAgent()` ran a blanket `UPDATE SET status='open'` on all beads assigned to a deleted agent, bypassing the terminal-state guard in `updateBeadStatus()`. On town boot, `reconcileGC()` deletes stale idle agents, which silently reopened closed/failed beads — causing wasted re-processing and token spend. Split into two queries: terminal beads only clear their assignee, non-terminal beads are reopened for re-dispatch as before.
- **Break `create_landing_mr` infinite loop** ([#2371](https://github.com/Kilo-Org/cloud/pull/2371)) — Fixed the reconciler retrying landing MR creation every 5s without a circuit breaker (one town accumulated 5,335 actions over 41 hours). Added deduplication, max attempts with exponential cooldown (capped at 30min), PR URL validation guard, and a race condition fix. New `FailConvoy` action type for explicit convoy failure with reason tracking.
- **Propagate custom `env_vars` to running containers on settings save** ([#2366](https://github.com/Kilo-Org/cloud/pull/2366)) — Custom environment variables set in town settings were not reaching already-running container processes until restart + re-dispatch. Three gaps fixed: `syncTownConfigToProcessEnv()` now writes custom vars to `process.env` (with cleanup tracking), `syncConfigToContainer()` persists custom vars to DO storage, and `updateAgentModel()` hot-swap overlays fresh custom vars over stale startup snapshots.
- **Prevent triage batch bead dispatch loop with wrong system prompt** ([#2321](https://github.com/Kilo-Org/cloud/pull/2321)) — Two-layer fix: (A) mark triage batch bead as `in_progress` before `startAgentInContainer()` to prevent Rule 2 re-dispatch with generic polecat prompt, and (B) defense-in-depth detection in `dispatchAgent` to inject the correct triage system prompt even if Rule 2 fires.

### Features
- **Add Java JDK to container images** ([#2066](https://github.com/Kilo-Org/cloud/pull/2066)) — Install `default-jdk` (OpenJDK) in both prod and dev Dockerfiles to support Java project builds and runtime.
- **Add cmake and pkg-config to container images** ([#2060](https://github.com/Kilo-Org/cloud/pull/2060)) — Install `cmake` and `pkg-config` in both prod and dev Dockerfiles for native dependency builds.
- **Add town ID copy badge and Debug settings section** ([#2296](https://github.com/Kilo-Org/cloud/pull/2296)) — Copyable town ID badge in the Overview page sticky top bar, plus a new "Debug" section in Town Settings with a "Copy debug info" button that serializes a sanitized JSON snapshot (tokens/emails omitted, env var keys only).
- **Add dismiss actions for failed beads on Merge Queue page** ([#2295](https://github.com/Kilo-Org/cloud/pull/2295)) — Individual dismiss button per failed bead row, bulk "Dismiss all failed" button with concurrent close + loading/toast feedback, and a view button fallback fix for orphaned MR beads.

### Infrastructure
- **Bump container `max_instances`** (direct commits) — Increased from 700 → 810 across two commits.

### Cleanup
- **Remove dead code from patrol/scheduling/review-queue** ([#2339](https://github.com/Kilo-Org/cloud/pull/2339)) — Removed unused `GUPP_WARN_MS` export, updated stale comments referencing removed functions (`witnessPatrol`, `schedulePendingWork`, `processReviewQueue`, `recoverStuckReviews`) to describe the current reconciler/alarm-based architecture.
- **Remove dead `popReviewQueue` and update stale comments** ([#2318](https://github.com/Kilo-Org/cloud/pull/2318)) — Deleted dead `popReviewQueue()` and its `Town.do.ts` wrapper, removed dead `completeReview()` wrapper, updated stale comments across review-queue, reconciler, beads, and container-dispatch modules.

## Verification

- All 9 constituent PRs were individually reviewed and merged to `gastown-staging`
- Typecheck and tests passed on each PR at merge time
- The `deleteAgent` fix was verified via bead event history analysis on a local town that exhibited the bug, and passes all 182 gastown tests
- Constituent PRs linked above contain detailed per-change verification

## Visual Changes

Copyable town ID badge in Overview page top bar ([#2296](https://github.com/Kilo-Org/cloud/pull/2296))

<img width="313" height="69" alt="image" src="https://github.com/user-attachments/assets/b3efe046-5fb6-4686-bf34-02f191aecd39" />

Debug settings section with "Copy debug info" button in Town Settings ([#2296](https://github.com/Kilo-Org/cloud/pull/2296))

<img width="914" height="533" alt="image" src="https://github.com/user-attachments/assets/789f00c8-49d7-4bfe-9519-8ef479d4b37a" />

Dismiss (X) button on individual failed bead rows and bulk "Dismiss all failed" button on Merge Queue page ([#2295](https://github.com/Kilo-Org/cloud/pull/2295))

<img width="1912" height="1237" alt="image" src="https://github.com/user-attachments/assets/bff952df-ff6f-4df0-92a6-b7c5d35fa3dd" />

## Reviewer Notes

- The `deleteAgent` terminal-state fix is the most important change — without it, every town boot that triggers GC reopens all historically-assigned closed beads and re-processes them, wasting tokens. The bug predates this branch (commit `1e0cf8ae`, Feb 27) but was only diagnosed during this cycle.
- The `create_landing_mr` loop fix (#2371) stores retry metadata in the convoy bead's existing `metadata` JSON column — no schema migration needed
- The env var propagation fix (#2366) uses module-level `Set` tracking in control-server.ts (resets on container restart, which is fine since `process.env` also resets) and DO durable storage for cross-restart persistence
- Custom env var keys that collide with infra keys (`GIT_TOKEN`, `KILOCODE_TOKEN`, etc.) are silently skipped to maintain infra precedence
- The debug JSON output intentionally excludes PII (emails, tokens show as boolean `_set` fields only)