### PR TITLE
fix(kiloclaw): stop showing provisioning spinner for non-provisioning waits

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -187,16 +187,12 @@ function ClawOnboardingFlowInner({
           ) : (
             <ProvisioningStepView />
           )
-        ) : !instanceStatus ? (
-          createProvisioningStarted ? (
-            <ProvisioningStepView />
-          ) : (
-            <CreateInstanceCard
-              mutations={mutations}
-              onProvisionStart={handleCreateFlowStarted}
-              onProvisionFailed={handleCreateFlowFailed}
-            />
-          )
+        ) : !instanceStatus && !createProvisioningStarted ? (
+          <CreateInstanceCard
+            mutations={mutations}
+            onProvisionStart={handleCreateFlowStarted}
+            onProvisionFailed={handleCreateFlowFailed}
+          />
         ) : onboardingStep === 'identity' ? (
           <BotIdentityStep
             instanceRunning={isRunning && gatewayStatus?.state === 'running'}

--- a/apps/web/src/app/(app)/claw/new/page.tsx
+++ b/apps/web/src/app/(app)/claw/new/page.tsx
@@ -14,13 +14,14 @@ import { WelcomePage } from '../components/billing/WelcomePage';
 
 const ClawOnboardingWithBoundary = withStatusQueryBoundary(ClawOnboardingFlow);
 
-function LoadingState() {
+function CheckingSubscriptionState() {
   return (
     <div
-      className="container m-auto flex w-full max-w-[1140px] items-center justify-center p-4 md:p-6"
+      className="container m-auto flex w-full max-w-[1140px] items-center justify-center gap-3 p-4 md:p-6"
       style={{ minHeight: '50vh' }}
     >
-      <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
+      <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
+      <p className="text-muted-foreground text-sm">Checking subscription&hellip;</p>
     </div>
   );
 }
@@ -49,7 +50,7 @@ export default function ClawNewPage() {
   const onCreateFlowStarted = useCallback(() => setCreateFlowStarted(true), []);
 
   if (billingQuery.isLoading) {
-    return <LoadingState />;
+    return <CheckingSubscriptionState />;
   }
 
   if (billingQuery.isError) {


### PR DESCRIPTION

## Summary
- UX was showing the "Setting up your instance" full screen spinner when we were just doing a subscription/billing pre check. 
- This was causing end user confusion with the screen flip/flopping back and forth with too many full screen spinners.



## Verification
- pnpm exec oxfmt on the two edited files — formatting clean                   
- pnpm --filter web typecheck — passed (full web typecheck including tsgo)     
- pnpm --filter web lint — passed with 0 warnings, 0 errors on the web package 
- e2e local browser tests          

## Visual Changes
- Only show "Setting up your instance" full screen spinner when we are actually waiting for provisioning

## Reviewer Notes

N/A