### PR TITLE
Feature/kiloclaw admin cli admin view and schema

### DIFF
--- a/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import {
   ArrowUpCircle,
   Check,
@@ -32,6 +33,8 @@ import {
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Label } from '@/components/ui/label';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
+import { selectCurrentCliRun } from '@/lib/kiloclaw/cli-run-selection';
+import { useClawKiloCliRunHistory } from '../hooks/useClawHooks';
 import { useClawUpdateAvailable } from '../hooks/useClawUpdateAvailable';
 import { useGatewayUrl } from '../hooks/useGatewayUrl';
 import { ConfirmActionDialog } from './ConfirmActionDialog';
@@ -66,6 +69,7 @@ export function InstanceControls({
   onUpgradeHandled?: () => void;
   gatewayReady?: boolean;
 }) {
+  const router = useRouter();
   const posthog = usePostHog();
   const gatewayUrl = useGatewayUrl(status);
   const isRunning = status.status === 'running';
@@ -86,7 +90,7 @@ export function InstanceControls({
   const [confirmRestart, setConfirmRestart] = useState(false);
   const [confirmRedeploy, setConfirmRedeploy] = useState(false);
   const [redeployMode, setRedeployMode] = useState<'redeploy' | 'upgrade'>('redeploy');
-
+  const kiloCliRunHistory = useClawKiloCliRunHistory(isRunning);
   const { updateAvailable, catalogNewerThanImage, latestAvailableVersion, latestVersion } =
     useClawUpdateAvailable(status);
 
@@ -213,41 +217,41 @@ export function InstanceControls({
           </Badge>
         </div>
       </div>
-      {showUpgradeBanner && (
-        <Banner color="amber" className="mb-4">
-          <Banner.Icon>
-            <ArrowUpCircle />
-          </Banner.Icon>
-          <Banner.Content>
-            <Banner.Title>
-              {catalogNewerThanImage
-                ? `A newer OpenClaw version (${latestAvailableVersion}) is available`
-                : `A newer image (${latestVersion?.imageTag ?? 'unknown'}) is available`}
-            </Banner.Title>
-            <Banner.Description>
-              Upgrade your instance to get the latest features and fixes.
-            </Banner.Description>
-          </Banner.Content>
-          <Banner.Button
-            className="text-white"
-            onClick={() => {
-              setRedeployMode('upgrade');
-              setConfirmRedeploy(true);
-            }}
-          >
-            Upgrade now
-          </Banner.Button>
-          <button
-            type="button"
-            onClick={dismissBanner}
-            className="text-amber-400/60 hover:text-amber-400 transition-colors"
-            aria-label="Dismiss upgrade banner"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </Banner>
-      )}
-      <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+      <div className="mt-4 flex flex-wrap gap-2">
+        {showUpgradeBanner && (
+          <Banner color="amber" className="mb-2 w-full">
+            <Banner.Icon>
+              <ArrowUpCircle />
+            </Banner.Icon>
+            <Banner.Content>
+              <Banner.Title>
+                {catalogNewerThanImage
+                  ? `A newer OpenClaw version (${latestAvailableVersion}) is available`
+                  : `A newer image (${latestVersion?.imageTag ?? 'unknown'}) is available`}
+              </Banner.Title>
+              <Banner.Description>
+                Upgrade your instance to get the latest features and fixes.
+              </Banner.Description>
+            </Banner.Content>
+            <Banner.Button
+              className="text-white"
+              onClick={() => {
+                setRedeployMode('upgrade');
+                setConfirmRedeploy(true);
+              }}
+            >
+              Upgrade now
+            </Banner.Button>
+            <button
+              type="button"
+              onClick={dismissBanner}
+              className="transition-colors text-amber-400/60 hover:text-amber-400"
+              aria-label="Dismiss upgrade banner"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </Banner>
+        )}
         <OpenClawButton
           canShow={isRunning && !!gatewayReady}
           gatewayUrl={gatewayUrl}
@@ -261,8 +265,8 @@ export function InstanceControls({
           disabled={
             !isStartable ||
             mutations.start.isPending ||
-            isAutoStarting ||
             isDestroying ||
+            isAutoStarting ||
             isStarting ||
             isRestarting ||
             isRecovering
@@ -353,8 +357,18 @@ export function InstanceControls({
           variant="outline"
           className="border-emerald-500/30 text-emerald-400 hover:bg-emerald-500/10 hover:text-emerald-300"
           disabled={!isRunning || isDestroying || isStarting || isRestarting || isRecovering}
-          onClick={() => {
+          onClick={async () => {
             posthog?.capture('claw_kilo_run_clicked', { instance_status: status.status });
+            try {
+              const { data } = await kiloCliRunHistory.refetch();
+              const latestRun = selectCurrentCliRun(data?.runs, status.instanceId);
+              if (latestRun?.status === 'running') {
+                router.push(`/claw/kilo-cli-run/${latestRun.id}`);
+                return;
+              }
+            } catch {
+              // Best-effort pre-check; fall through to open the dialog
+            }
             setKiloRunOpen(true);
           }}
         >

--- a/apps/web/src/app/(app)/claw/components/StartKiloCliRunDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/StartKiloCliRunDialog.tsx
@@ -18,16 +18,15 @@ import { useKiloClawMutations } from '@/hooks/useKiloClaw';
 import type { PlatformStatusResponse } from '@/lib/kiloclaw/types';
 import { AnimatedDots } from './AnimatedDots';
 
+function getErrorUpstreamCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null || !('data' in error)) return undefined;
+  const { data } = error;
+  if (typeof data !== 'object' || data === null || !('upstreamCode' in data)) return undefined;
+  return typeof data.upstreamCode === 'string' ? data.upstreamCode : undefined;
+}
+
 function isNeedsRedeployError(error: unknown): boolean {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'data' in error &&
-    typeof (error as { data?: unknown }).data === 'object' &&
-    (error as { data?: { upstreamCode?: unknown } }).data !== null &&
-    (error as { data: { upstreamCode?: unknown } }).data.upstreamCode ===
-      'controller_route_unavailable'
-  );
+  return getErrorUpstreamCode(error) === 'controller_route_unavailable';
 }
 
 export function StartKiloCliRunDialog({
@@ -67,6 +66,8 @@ export function StartKiloCliRunDialog({
           onOpenChange(false);
           router.push(`/claw/kilo-cli-run/${data.id}`);
         },
+        onError: err =>
+          toast.error(err.message || 'Failed to start recovery run', { duration: 10000 }),
       }
     );
   };
@@ -168,7 +169,7 @@ export function StartKiloCliRunDialog({
                 onKeyDown={e => {
                   if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
                     e.preventDefault();
-                    handleStart();
+                    void handleStart();
                   }
                 }}
               />
@@ -183,7 +184,7 @@ export function StartKiloCliRunDialog({
                 Cancel
               </Button>
               <Button
-                onClick={handleStart}
+                onClick={() => void handleStart()}
                 disabled={!machineReady || !prompt.trim() || startMutation.isPending}
                 className="bg-emerald-600 text-white hover:bg-emerald-700"
               >

--- a/apps/web/src/app/(app)/claw/kilo-cli-run/[id]/page.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-cli-run/[id]/page.tsx
@@ -70,7 +70,7 @@ export default function KiloCliRunPage() {
         icon={<KiloCrabIcon className="text-muted-foreground h-4 w-4" />}
       />
       <div className="flex items-center gap-3">
-        <Button variant="ghost" size="sm" onClick={() => router.push('/claw')}>
+        <Button variant="ghost" size="sm" onClick={() => router.push('/claw/settings')}>
           <ArrowLeft className="h-4 w-4" />
           Back to Dashboard
         </Button>
@@ -123,7 +123,7 @@ export default function KiloCliRunPage() {
             <p className="text-sm text-red-400">
               {statusQuery.error?.message ?? 'Failed to load run status'}
             </p>
-            <Button variant="outline" size="sm" onClick={() => router.push('/claw')}>
+            <Button variant="outline" size="sm" onClick={() => router.push('/claw/settings')}>
               Back to Dashboard
             </Button>
           </div>

--- a/apps/web/src/app/admin/components/KiloclawCliRuns/KiloclawCliRunsTab.tsx
+++ b/apps/web/src/app/admin/components/KiloclawCliRuns/KiloclawCliRunsTab.tsx
@@ -30,6 +30,7 @@ import { stripAnsi } from '@/lib/stripAnsi';
 const PAGE_SIZE = 25;
 
 type RunStatus = 'all' | 'running' | 'completed' | 'failed' | 'cancelled';
+type InitiatedBy = 'all' | 'admin' | 'user';
 
 function StatusBadge({ status }: { status: string }) {
   switch (status) {
@@ -82,6 +83,7 @@ export function CliRunsTab() {
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<RunStatus>('all');
+  const [initiatedByFilter, setInitiatedByFilter] = useState<InitiatedBy>('all');
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
 
   const [debounceTimer, setDebounceTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
@@ -103,6 +105,7 @@ export function CliRunsTab() {
         limit: PAGE_SIZE,
         search: debouncedSearch || undefined,
         status: statusFilter,
+        initiatedBy: initiatedByFilter,
       },
       { staleTime: 10_000 }
     )
@@ -140,6 +143,22 @@ export function CliRunsTab() {
             <SelectItem value="cancelled">Cancelled</SelectItem>
           </SelectContent>
         </Select>
+        <Select
+          value={initiatedByFilter}
+          onValueChange={v => {
+            setInitiatedByFilter(v as InitiatedBy);
+            setPage(0);
+          }}
+        >
+          <SelectTrigger className="w-[150px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All users</SelectItem>
+            <SelectItem value="admin">Admin</SelectItem>
+            <SelectItem value="user">User</SelectItem>
+          </SelectContent>
+        </Select>
         {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
         {pagination && (
           <span className="text-muted-foreground ml-auto text-sm">
@@ -167,9 +186,19 @@ export function CliRunsTab() {
                 )}
               >
                 <div className="flex items-center justify-between gap-2">
-                  <span className="truncate font-mono text-xs">
-                    {run.user_email ?? run.user_id}
-                  </span>
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <span className="truncate font-mono text-xs">
+                      {run.user_email ?? run.user_id}
+                    </span>
+                    {run.initiated_by_admin_id && (
+                      <Badge
+                        variant="outline"
+                        className="shrink-0 border-purple-500/30 text-purple-400"
+                      >
+                        Admin
+                      </Badge>
+                    )}
+                  </div>
                   <StatusBadge status={run.status} />
                 </div>
                 <p className="text-muted-foreground truncate text-xs">
@@ -247,6 +276,8 @@ function RunDetail({
     id: string;
     user_id: string;
     user_email: string | null;
+    initiated_by_admin_id: string | null;
+    initiated_by_admin_email: string | null;
     prompt: string;
     status: string;
     exit_code: number | null;
@@ -268,6 +299,11 @@ function RunDetail({
           <span className="truncate font-mono text-xs">{run.user_email ?? run.user_id}</span>
           <StatusBadge status={run.status} />
         </div>
+        {run.initiated_by_admin_id && (
+          <p className="text-muted-foreground text-xs">
+            Initiated by {run.initiated_by_admin_email ?? 'Admin'}
+          </p>
+        )}
         <p className="text-sm">{run.prompt}</p>
         <div className="text-muted-foreground flex items-center gap-2 text-xs">
           <span>Started {formatDistanceToNow(new Date(run.started_at), { addSuffix: true })}</span>

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloCliRunCard.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloCliRunCard.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { Loader2, Play, RefreshCw, Square, Terminal, AlertTriangle } from 'lucide-react';
+import { toast } from 'sonner';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Textarea } from '@/components/ui/textarea';
+import { useTRPC } from '@/lib/trpc/utils';
+import { selectCurrentCliRun } from '@/lib/kiloclaw/cli-run-selection';
+import { stripAnsi } from '@/lib/stripAnsi';
+import { formatRelativeTime, DetailField } from './shared';
+
+const STATUS_BADGE_CLASSES: Record<string, string> = {
+  running: 'bg-blue-500',
+  completed: 'bg-green-600',
+  failed: 'bg-red-600',
+  cancelled: 'bg-amber-600',
+};
+
+function getStatusBadgeClass(status: string | null): string {
+  return status ? (STATUS_BADGE_CLASSES[status] ?? '') : '';
+}
+
+export function KiloCliRunCard({ userId, instanceId }: { userId: string; instanceId: string }) {
+  const trpc = useTRPC();
+  const [prompt, setPrompt] = useState('');
+  const [showOutput, setShowOutput] = useState(true);
+  const [runId, setRunId] = useState<string | null>(null);
+
+  const { data: latestRuns, refetch: refetchRuns } = useQuery(
+    trpc.admin.kiloclawInstances.listKiloCliRuns.queryOptions(
+      { userId, limit: 20 },
+      { staleTime: 10_000, refetchInterval: 3000 }
+    )
+  );
+
+  const selectedRunId = runId ?? selectCurrentCliRun(latestRuns?.runs, instanceId)?.id ?? null;
+
+  const {
+    data: runStatus,
+    isLoading: statusLoading,
+    refetch: refetchStatus,
+  } = useQuery({
+    // tRPC queryOptions requires Zod-valid input for cache key generation even
+    // when the query is disabled. The nil UUID is inert — enabled:false prevents
+    // any request.
+    ...trpc.admin.kiloclawInstances.getKiloCliRunStatus.queryOptions(
+      selectedRunId
+        ? { userId, instanceId, runId: selectedRunId }
+        : { userId, instanceId, runId: '00000000-0000-0000-0000-000000000000' }
+    ),
+    enabled: selectedRunId !== null,
+    refetchInterval: query => (query?.state?.data?.status === 'running' ? 3000 : false),
+  });
+
+  const isRunning = runStatus?.status === 'running';
+  const isUserRun = runStatus?.initiatedBy === 'user';
+
+  const { mutateAsync: startRun, isPending: isStarting } = useMutation(
+    trpc.admin.kiloclawInstances.startKiloCliRun.mutationOptions({
+      onSuccess: result => {
+        toast.success('CLI run started');
+        // Select the new run immediately instead of waiting for the next latest-runs poll.
+        setRunId(result.id);
+        setShowOutput(true);
+        void refetchRuns();
+        void refetchStatus();
+      },
+      onError: err => {
+        toast.error(`Failed to start CLI run: ${err.message}`);
+      },
+    })
+  );
+
+  const { mutateAsync: cancelRun, isPending: isCancelling } = useMutation(
+    trpc.admin.kiloclawInstances.cancelKiloCliRun.mutationOptions({
+      onSuccess: () => {
+        toast.success('CLI run cancelled');
+        void refetchRuns();
+        void refetchStatus();
+      },
+      onError: err => {
+        toast.error(`Failed to cancel CLI run: ${err.message}`);
+      },
+    })
+  );
+
+  const handleStart = () => {
+    if (!prompt.trim()) return;
+    void startRun({ userId, instanceId, prompt: prompt.trim() });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Terminal className="h-5 w-5" />
+          <div>
+            <CardTitle>Kilo CLI Run</CardTitle>
+            <CardDescription>
+              Run an autonomous agent task on this instance via <code>kilo run --auto</code>
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isRunning && isUserRun && (
+          <Alert>
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription>
+              A user-initiated CLI run is currently in progress on this instance. You can monitor or
+              cancel it below.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Prompt</label>
+          <Textarea
+            value={prompt}
+            onChange={e => setPrompt(e.target.value)}
+            placeholder="e.g., Fix the baseUrl in openclaw.json to use the correct gateway endpoint..."
+            maxLength={10_000}
+            className="min-h-[80px] resize-y font-mono text-sm"
+            rows={3}
+            disabled={isRunning || isStarting}
+          />
+          <p className="text-muted-foreground text-xs">
+            {prompt.length.toLocaleString()} / 10,000 characters
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            onClick={handleStart}
+            disabled={!prompt.trim() || isRunning || isStarting}
+          >
+            {isStarting ? (
+              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+            ) : (
+              <Play className="mr-1 h-4 w-4" />
+            )}
+            {isStarting ? 'Starting...' : 'Start CLI Run'}
+          </Button>
+
+          {isRunning && (
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() =>
+                selectedRunId && void cancelRun({ userId, instanceId, runId: selectedRunId })
+              }
+              disabled={isCancelling}
+            >
+              {isCancelling ? (
+                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+              ) : (
+                <Square className="mr-1 h-4 w-4" />
+              )}
+              Cancel
+            </Button>
+          )}
+
+          <Button size="sm" variant="outline" onClick={() => void refetchStatus()}>
+            <RefreshCw className="mr-1 h-4 w-4" />
+            Refresh Status
+          </Button>
+        </div>
+
+        {statusLoading && (
+          <div className="flex items-center gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span className="text-muted-foreground text-sm">Loading run status...</span>
+          </div>
+        )}
+
+        {statusLoading && !runStatus && (
+          <div className="space-y-3 rounded border p-3">
+            <div className="grid grid-cols-2 gap-4 md:grid-cols-5">
+              <DetailField label="Status">—</DetailField>
+              <DetailField label="Initiated By">—</DetailField>
+              <DetailField label="Exit Code">—</DetailField>
+              <DetailField label="Started">—</DetailField>
+              <DetailField label="Completed">—</DetailField>
+            </div>
+          </div>
+        )}
+
+        {runStatus?.hasRun && (
+          <div className="space-y-3 rounded border p-3">
+            <div className="grid grid-cols-2 gap-4 md:grid-cols-5">
+              <DetailField label="Status">
+                <Badge className={getStatusBadgeClass(runStatus.status)}>
+                  {runStatus.status ?? 'unknown'}
+                </Badge>
+              </DetailField>
+              <DetailField label="Initiated By">
+                <Badge variant={runStatus.initiatedBy === 'admin' ? 'default' : 'secondary'}>
+                  {runStatus.initiatedBy === 'admin'
+                    ? 'Admin-initiated'
+                    : runStatus.initiatedBy === 'user'
+                      ? 'User-initiated'
+                      : '—'}
+                </Badge>
+              </DetailField>
+              <DetailField label="Exit Code">
+                {runStatus.exitCode !== null && runStatus.exitCode !== undefined
+                  ? String(runStatus.exitCode)
+                  : '—'}
+              </DetailField>
+              <DetailField label="Started">
+                {runStatus.startedAt ? formatRelativeTime(runStatus.startedAt) : '—'}
+              </DetailField>
+              <DetailField label="Completed">
+                {runStatus.completedAt ? formatRelativeTime(runStatus.completedAt) : '—'}
+              </DetailField>
+            </div>
+
+            {runStatus.prompt && (
+              <DetailField label="Prompt">
+                <p className="text-muted-foreground max-h-[60px] overflow-y-auto text-xs">
+                  {runStatus.prompt}
+                </p>
+              </DetailField>
+            )}
+
+            {runStatus.output && (
+              <div>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setShowOutput(prev => !prev)}
+                  className="mb-1 h-auto px-0 py-1 text-xs"
+                >
+                  {showOutput ? 'Hide output' : 'Show output'}
+                </Button>
+                {showOutput && (
+                  <div className="border-border bg-background max-h-[300px] overflow-auto rounded-md border">
+                    <pre
+                      className="p-3 text-xs leading-relaxed whitespace-pre-wrap"
+                      style={{ fontFamily: "'Courier New', Courier, monospace" }}
+                    >
+                      {stripAnsi(runStatus.output)}
+                    </pre>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloCliRunCard.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloCliRunCard.tsx
@@ -38,7 +38,11 @@ export function KiloCliRunCard({ userId, instanceId }: { userId: string; instanc
     )
   );
 
-  const selectedRunId = runId ?? selectCurrentCliRun(latestRuns?.runs, instanceId)?.id ?? null;
+  const runningRun = latestRuns?.runs.find(
+    run => run.instance_id === instanceId && run.status === 'running'
+  );
+  const selectedRunId =
+    runningRun?.id ?? runId ?? selectCurrentCliRun(latestRuns?.runs, instanceId)?.id ?? null;
 
   const {
     data: runStatus,
@@ -57,7 +61,7 @@ export function KiloCliRunCard({ userId, instanceId }: { userId: string; instanc
     refetchInterval: query => (query?.state?.data?.status === 'running' ? 3000 : false),
   });
 
-  const isRunning = runStatus?.status === 'running';
+  const isRunning = runningRun !== undefined || runStatus?.status === 'running';
   const isUserRun = runStatus?.initiatedBy === 'user';
 
   const { mutateAsync: startRun, isPending: isStarting } = useMutation(

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -70,6 +70,7 @@ import { toast } from 'sonner';
 import { AdminFileEditor } from './AdminFileEditor';
 import { BumpVolumeTo15GbButton } from './BumpVolumeTo15GbDialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { stripAnsi } from '@/lib/stripAnsi';
 import {
   useKiloclawInstanceEvents,
   useKiloclawAllEvents,
@@ -77,6 +78,8 @@ import {
   type KiloclawAllEventRow,
 } from '@/app/admin/api/kiloclaw-analytics/hooks';
 import type { AnalyticsEngineResponse, ControllerTelemetryRow } from '@/lib/kiloclaw/disk-usage';
+import { KiloCliRunCard } from './KiloCliRunCard';
+import { parseTimestamp, formatRelativeTime, formatAbsoluteTime, DetailField } from './shared';
 
 function formatEpochTime(epoch: number | null): string {
   if (epoch === null) return '—';
@@ -2762,6 +2765,11 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
               )}
             </CardContent>
           </Card>
+        )}
+
+        {/* Kilo CLI Run */}
+        {isActive && gatewayControlsEnabled && (
+          <KiloCliRunCard userId={data.user_id} instanceId={data.id} />
         )}
 
         {/* Volume Reassociation (danger zone) */}

--- a/apps/web/src/app/admin/components/KiloclawInstances/shared.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/shared.tsx
@@ -18,7 +18,7 @@ export function formatRelativeTime(timestamp: string | null): string {
 }
 
 export function formatAbsoluteTime(timestamp: string): string {
-  return parseTimestamp(timestamp).toLocaleString('en-US');
+  return parseTimestamp(timestamp).toLocaleString();
 }
 
 export function DetailField({ label, children }: { label: string; children: React.ReactNode }) {

--- a/apps/web/src/lib/kiloclaw/cli-run-selection.ts
+++ b/apps/web/src/lib/kiloclaw/cli-run-selection.ts
@@ -14,9 +14,7 @@ export function selectCurrentCliRun<TRun extends CliRunLike>(
   }
 
   return (
-    (preferredRunId
-      ? runs.find(run => run.id === preferredRunId && run.instance_id === instanceId)
-      : undefined) ??
+    (preferredRunId ? runs.find(run => run.id === preferredRunId) : undefined) ??
     runs.find(run => run.instance_id === instanceId && run.status === 'running') ??
     runs.find(run => run.instance_id === instanceId) ??
     null

--- a/apps/web/src/lib/kiloclaw/cli-runs.test.ts
+++ b/apps/web/src/lib/kiloclaw/cli-runs.test.ts
@@ -1,0 +1,206 @@
+process.env.KILOCLAW_API_URL ||= 'http://localhost:8795';
+process.env.KILOCLAW_INTERNAL_API_SECRET ||= 'test-secret';
+
+import { describe, expect, it } from '@jest/globals';
+import { db } from '@/lib/drizzle';
+import {
+  createCliRun,
+  getCliRunInitiatedBy,
+  markCliRunCancelled,
+  shouldPersistCliRunControllerStatus,
+} from '@/lib/kiloclaw/cli-runs';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { kiloclaw_cli_runs, kiloclaw_instances } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
+
+async function createTestInstance(userId: string): Promise<string> {
+  const [row] = await db
+    .insert(kiloclaw_instances)
+    .values({
+      id: crypto.randomUUID(),
+      user_id: userId,
+      sandbox_id: `ki_${crypto.randomUUID().replace(/-/g, '')}`,
+    })
+    .returning({ id: kiloclaw_instances.id });
+
+  if (!row) {
+    throw new Error('Failed to create KiloClaw test instance');
+  }
+
+  return row.id;
+}
+
+async function getRunStatus(runId: string) {
+  const [row] = await db
+    .select({
+      status: kiloclaw_cli_runs.status,
+      completed_at: kiloclaw_cli_runs.completed_at,
+    })
+    .from(kiloclaw_cli_runs)
+    .where(eq(kiloclaw_cli_runs.id, runId))
+    .limit(1);
+
+  if (!row) {
+    throw new Error('Failed to load KiloClaw CLI run');
+  }
+
+  return row;
+}
+
+describe('markCliRunCancelled', () => {
+  it('does not cancel an instance-scoped run when instanceId is null', async () => {
+    const user = await insertTestUser();
+    const instanceId = await createTestInstance(user.id);
+    const runId = await createCliRun({
+      userId: user.id,
+      instanceId,
+      prompt: 'instance-scoped run',
+      startedAt: '2026-04-12T12:00:00.000Z',
+      initiatedByAdminId: null,
+    });
+
+    await markCliRunCancelled({
+      runId,
+      userId: user.id,
+      instanceId: null,
+    });
+
+    await expect(getRunStatus(runId)).resolves.toEqual({
+      status: 'running',
+      completed_at: null,
+    });
+  });
+
+  it('cancels a running run scoped to a null instance', async () => {
+    const user = await insertTestUser();
+    const runId = await createCliRun({
+      userId: user.id,
+      instanceId: null,
+      prompt: 'legacy null-instance run',
+      startedAt: '2026-04-12T12:00:00.000Z',
+      initiatedByAdminId: null,
+    });
+
+    await markCliRunCancelled({
+      runId,
+      userId: user.id,
+      instanceId: null,
+    });
+
+    const row = await getRunStatus(runId);
+    expect(row.status).toBe('cancelled');
+    expect(row.completed_at).not.toBeNull();
+  });
+
+  it('cancels a running run scoped to the provided instance id', async () => {
+    const user = await insertTestUser();
+    const instanceId = await createTestInstance(user.id);
+    const runId = await createCliRun({
+      userId: user.id,
+      instanceId,
+      prompt: 'instance-scoped run',
+      startedAt: '2026-04-12T12:00:00.000Z',
+      initiatedByAdminId: null,
+    });
+
+    await markCliRunCancelled({
+      runId,
+      userId: user.id,
+      instanceId,
+    });
+
+    const row = await getRunStatus(runId);
+    expect(row.status).toBe('cancelled');
+    expect(row.completed_at).not.toBeNull();
+  });
+});
+
+describe('shouldPersistCliRunControllerStatus', () => {
+  it('returns true when the controller run matches the stored row timestamp', () => {
+    expect(
+      shouldPersistCliRunControllerStatus(
+        { started_at: '2026-04-08T12:00:00.000Z' },
+        {
+          hasRun: true,
+          status: 'completed',
+          startedAt: '2026-04-08T12:00:00Z',
+        }
+      )
+    ).toBe(true);
+  });
+
+  it('returns false when the controller status is still running', () => {
+    expect(
+      shouldPersistCliRunControllerStatus(
+        { started_at: '2026-04-08T12:00:00.000Z' },
+        {
+          hasRun: true,
+          status: 'running',
+          startedAt: '2026-04-08T12:00:00Z',
+        }
+      )
+    ).toBe(false);
+  });
+
+  it('returns false when the controller timestamp belongs to a different run', () => {
+    expect(
+      shouldPersistCliRunControllerStatus(
+        { started_at: '2026-04-08T12:00:00.000Z' },
+        {
+          hasRun: true,
+          status: 'failed',
+          startedAt: '2026-04-08T12:05:00Z',
+        }
+      )
+    ).toBe(false);
+  });
+
+  it('returns false when the stored row timestamp is missing', () => {
+    expect(
+      shouldPersistCliRunControllerStatus(
+        { started_at: null },
+        {
+          hasRun: true,
+          status: 'completed',
+          startedAt: '2026-04-08T12:00:00Z',
+        }
+      )
+    ).toBe(false);
+  });
+
+  it('returns false when the controller timestamp is missing', () => {
+    expect(
+      shouldPersistCliRunControllerStatus(
+        { started_at: '2026-04-08T12:00:00.000Z' },
+        {
+          hasRun: true,
+          status: 'completed',
+          startedAt: null,
+        }
+      )
+    ).toBe(false);
+  });
+
+  it('returns false when there is no controller run', () => {
+    expect(
+      shouldPersistCliRunControllerStatus(
+        { started_at: '2026-04-08T12:00:00.000Z' },
+        {
+          hasRun: false,
+          status: 'completed',
+          startedAt: '2026-04-08T12:00:00Z',
+        }
+      )
+    ).toBe(false);
+  });
+});
+
+describe('getCliRunInitiatedBy', () => {
+  it('returns user when admin id is null', () => {
+    expect(getCliRunInitiatedBy({ initiated_by_admin_id: null })).toBe('user');
+  });
+
+  it('returns admin when admin id is present', () => {
+    expect(getCliRunInitiatedBy({ initiated_by_admin_id: 'admin-user-id' })).toBe('admin');
+  });
+});

--- a/apps/web/src/lib/kiloclaw/cli-runs.ts
+++ b/apps/web/src/lib/kiloclaw/cli-runs.ts
@@ -182,6 +182,11 @@ export async function cancelCliRun(params: {
     });
   }
 
+  // When result.ok is false the controller rejected the cancel (e.g. the process
+  // had already exited between our DB check and the cancel request). The DB row
+  // intentionally stays 'running' so the caller can retry or poll again — the
+  // next getKiloCliRunStatus call will pick up the terminal state from the
+  // controller and persist it.
   return { ok: result.ok, runFound: true, cancelled: result.ok };
 }
 

--- a/apps/web/src/lib/kiloclaw/cli-runs.ts
+++ b/apps/web/src/lib/kiloclaw/cli-runs.ts
@@ -87,6 +87,9 @@ export type CliRunStatusResult = KiloCliRunStatusResponse & {
   initiatedBy: 'admin' | 'user' | null;
 };
 
+const LOST_CONTROLLER_RUN_OUTPUT =
+  '[run state unavailable: controller no longer has an active CLI run for this record]';
+
 export async function markCliRunCancelled(params: CancelCliRunParams): Promise<void> {
   await db
     .update(kiloclaw_cli_runs)
@@ -228,6 +231,33 @@ export async function getCliRunStatus(params: {
     params.userId,
     effectiveWorkerInstanceId
   );
+
+  if (!controllerStatus.hasRun) {
+    const completedAt = new Date().toISOString();
+    const output = row.output ?? LOST_CONTROLLER_RUN_OUTPUT;
+    await persistCliRunControllerStatus({
+      runId: params.runId,
+      userId: params.userId,
+      instanceId: row.instance_id,
+      controllerStatus: {
+        status: 'failed',
+        exitCode: row.exit_code,
+        output,
+        completedAt,
+      },
+    });
+
+    return {
+      hasRun: true,
+      status: 'failed',
+      output,
+      exitCode: row.exit_code,
+      startedAt: row.started_at,
+      completedAt,
+      prompt: row.prompt,
+      initiatedBy: getCliRunInitiatedBy(row),
+    };
+  }
 
   if (!isControllerStatusForRun(row, controllerStatus)) {
     return {

--- a/apps/web/src/lib/kiloclaw/cli-runs.ts
+++ b/apps/web/src/lib/kiloclaw/cli-runs.ts
@@ -1,0 +1,285 @@
+import { db } from '@/lib/drizzle';
+import { and, eq, isNull, type SQL } from 'drizzle-orm';
+import { kiloclaw_cli_runs } from '@kilocode/db/schema';
+import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { resolveWorkerInstanceId } from '@/lib/kiloclaw/instance-registry';
+import type { KiloCliRunStatusResponse } from '@/lib/kiloclaw/types';
+
+export type CreateCliRunParams = {
+  userId: string;
+  instanceId: string | null;
+  prompt: string;
+  startedAt: string;
+  initiatedByAdminId: string | null;
+};
+
+export function getCliRunInitiatedBy(params: {
+  initiated_by_admin_id: string | null;
+}): 'admin' | 'user' {
+  return params.initiated_by_admin_id ? 'admin' : 'user';
+}
+
+export async function createCliRun(params: CreateCliRunParams): Promise<string> {
+  const [row] = await db
+    .insert(kiloclaw_cli_runs)
+    .values({
+      user_id: params.userId,
+      instance_id: params.instanceId,
+      initiated_by_admin_id: params.initiatedByAdminId,
+      prompt: params.prompt,
+      status: 'running',
+      started_at: params.startedAt,
+    })
+    .returning({ id: kiloclaw_cli_runs.id });
+
+  if (!row) {
+    throw new Error('Failed to create CLI run');
+  }
+
+  return row.id;
+}
+
+export type PersistCliRunControllerStatusParams = {
+  runId: string;
+  userId: string;
+  instanceId: string | null;
+  controllerStatus: Pick<
+    KiloCliRunStatusResponse,
+    'status' | 'exitCode' | 'output' | 'completedAt'
+  >;
+};
+
+export async function persistCliRunControllerStatus(
+  params: PersistCliRunControllerStatusParams
+): Promise<void> {
+  await db
+    .update(kiloclaw_cli_runs)
+    .set({
+      status: params.controllerStatus.status ?? 'failed',
+      exit_code: params.controllerStatus.exitCode,
+      output: params.controllerStatus.output,
+      completed_at: params.controllerStatus.completedAt ?? new Date().toISOString(),
+    })
+    .where(
+      and(
+        eq(kiloclaw_cli_runs.id, params.runId),
+        eq(kiloclaw_cli_runs.user_id, params.userId),
+        eq(kiloclaw_cli_runs.status, 'running'),
+        params.instanceId === null
+          ? isNull(kiloclaw_cli_runs.instance_id)
+          : eq(kiloclaw_cli_runs.instance_id, params.instanceId)
+      )
+    );
+}
+
+export type CancelCliRunParams = {
+  runId: string;
+  userId: string;
+  instanceId: string | null;
+};
+
+export type CancelCliRunResult =
+  | { ok: boolean; runFound: true; cancelled: boolean }
+  | { ok: false; runFound: false; cancelled: false };
+
+export type CliRunStatusResult = KiloCliRunStatusResponse & {
+  prompt: string | null;
+  initiatedBy: 'admin' | 'user' | null;
+};
+
+export async function markCliRunCancelled(params: CancelCliRunParams): Promise<void> {
+  await db
+    .update(kiloclaw_cli_runs)
+    .set({
+      status: 'cancelled',
+      completed_at: new Date().toISOString(),
+    })
+    .where(
+      and(
+        eq(kiloclaw_cli_runs.id, params.runId),
+        eq(kiloclaw_cli_runs.user_id, params.userId),
+        eq(kiloclaw_cli_runs.status, 'running'),
+        params.instanceId === null
+          ? isNull(kiloclaw_cli_runs.instance_id)
+          : eq(kiloclaw_cli_runs.instance_id, params.instanceId)
+      )
+    );
+}
+
+/**
+ * Build WHERE conditions for discovering a CLI run row.
+ *
+ * When the caller has an active instance, the query is narrowed to that
+ * instance. When instanceId is null (no active instance), the instance
+ * filter is omitted so runs from destroyed instances can still be found.
+ *
+ * This is intentionally broader than the UPDATE helpers
+ * ({@link markCliRunCancelled}, {@link persistCliRunControllerStatus}),
+ * which always target the exact row via `row.instance_id`.
+ */
+function getCliRunScopeConditions(params: {
+  runId: string;
+  userId: string;
+  instanceId: string | null;
+}): SQL[] {
+  const conditions: SQL[] = [
+    eq(kiloclaw_cli_runs.id, params.runId),
+    eq(kiloclaw_cli_runs.user_id, params.userId),
+  ];
+
+  if (params.instanceId !== null) {
+    conditions.push(eq(kiloclaw_cli_runs.instance_id, params.instanceId));
+  }
+
+  return conditions;
+}
+
+export function getEmptyCliRunStatus(): CliRunStatusResult {
+  return {
+    hasRun: false,
+    status: null,
+    output: null,
+    exitCode: null,
+    startedAt: null,
+    completedAt: null,
+    prompt: null,
+    initiatedBy: null,
+  };
+}
+
+export async function cancelCliRun(params: {
+  runId: string;
+  userId: string;
+  instanceId: string | null;
+  workerInstanceId?: string;
+}): Promise<CancelCliRunResult> {
+  const [row] = await db
+    .select()
+    .from(kiloclaw_cli_runs)
+    .where(and(...getCliRunScopeConditions(params)))
+    .limit(1);
+
+  if (!row) {
+    return { ok: false, runFound: false, cancelled: false };
+  }
+
+  if (row.status !== 'running') {
+    return { ok: true, runFound: true, cancelled: false };
+  }
+
+  const effectiveWorkerInstanceId =
+    params.workerInstanceId ??
+    (row.instance_id ? await resolveWorkerInstanceId(row.instance_id) : undefined);
+
+  const client = new KiloClawInternalClient();
+  const result = await client.cancelKiloCliRun(params.userId, effectiveWorkerInstanceId);
+
+  if (result.ok) {
+    await markCliRunCancelled({
+      runId: params.runId,
+      userId: params.userId,
+      instanceId: row.instance_id,
+    });
+  }
+
+  return { ok: result.ok, runFound: true, cancelled: result.ok };
+}
+
+export async function getCliRunStatus(params: {
+  runId: string;
+  userId: string;
+  instanceId: string | null;
+  workerInstanceId?: string;
+}): Promise<CliRunStatusResult> {
+  const [row] = await db
+    .select()
+    .from(kiloclaw_cli_runs)
+    .where(and(...getCliRunScopeConditions(params)))
+    .limit(1);
+
+  if (!row) {
+    return getEmptyCliRunStatus();
+  }
+
+  if (row.status !== 'running') {
+    return {
+      hasRun: true,
+      status: row.status,
+      output: row.output,
+      exitCode: row.exit_code,
+      startedAt: row.started_at,
+      completedAt: row.completed_at ?? null,
+      prompt: row.prompt,
+      initiatedBy: getCliRunInitiatedBy(row),
+    };
+  }
+
+  const effectiveWorkerInstanceId =
+    params.workerInstanceId ??
+    (row.instance_id ? await resolveWorkerInstanceId(row.instance_id) : undefined);
+
+  const client = new KiloClawInternalClient();
+  const controllerStatus = await client.getKiloCliRunStatus(
+    params.userId,
+    effectiveWorkerInstanceId
+  );
+
+  if (!isControllerStatusForRun(row, controllerStatus)) {
+    return {
+      hasRun: true,
+      status: 'running',
+      output: row.output,
+      exitCode: row.exit_code,
+      startedAt: row.started_at,
+      completedAt: row.completed_at,
+      prompt: row.prompt,
+      initiatedBy: getCliRunInitiatedBy(row),
+    };
+  }
+
+  if (shouldPersistCliRunControllerStatus(row, controllerStatus)) {
+    await persistCliRunControllerStatus({
+      runId: params.runId,
+      userId: params.userId,
+      instanceId: row.instance_id,
+      controllerStatus,
+    });
+  }
+
+  return {
+    ...controllerStatus,
+    prompt: row.prompt,
+    initiatedBy: getCliRunInitiatedBy(row),
+  };
+}
+
+export function isControllerStatusForRun(
+  row: { started_at: string | null },
+  controllerStatus: Pick<KiloCliRunStatusResponse, 'hasRun' | 'startedAt'>
+): boolean {
+  if (!controllerStatus.hasRun) {
+    return false;
+  }
+
+  const controllerStartedAtMs = controllerStatus.startedAt
+    ? Date.parse(controllerStatus.startedAt)
+    : Number.NaN;
+  const rowStartedAtMs = row.started_at ? Date.parse(row.started_at) : Number.NaN;
+
+  return (
+    Number.isFinite(controllerStartedAtMs) &&
+    Number.isFinite(rowStartedAtMs) &&
+    controllerStartedAtMs === rowStartedAtMs
+  );
+}
+
+export function shouldPersistCliRunControllerStatus(
+  row: { started_at: string | null },
+  controllerStatus: Pick<KiloCliRunStatusResponse, 'hasRun' | 'status' | 'startedAt'>
+): boolean {
+  if (controllerStatus.status === 'running') {
+    return false;
+  }
+
+  return isControllerStatusForRun(row, controllerStatus);
+}

--- a/apps/web/src/lib/kiloclaw/instance-registry.ts
+++ b/apps/web/src/lib/kiloclaw/instance-registry.ts
@@ -48,6 +48,23 @@ export function workerInstanceId(
   return sandboxId.startsWith('ki_') ? instance.id : undefined;
 }
 
+/**
+ * Resolve the worker instance ID for DO routing from a database instance row ID.
+ * Unlike {@link getInstanceById}, this includes destroyed instances — needed
+ * when routing requests for historical runs whose instance has been torn down.
+ */
+export async function resolveWorkerInstanceId(instanceId: string): Promise<string | undefined> {
+  const [row] = await db
+    .select({
+      id: kiloclaw_instances.id,
+      sandbox_id: kiloclaw_instances.sandbox_id,
+    })
+    .from(kiloclaw_instances)
+    .where(eq(kiloclaw_instances.id, instanceId))
+    .limit(1);
+  return row ? workerInstanceId(row) : undefined;
+}
+
 type EnsureActiveInstanceOpts = {
   /** Organization ID. When provided, creates an org-owned instance. */
   orgId?: string;

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -2,17 +2,25 @@ import { createCallerForUser } from '@/routers/test-utils';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import type { User } from '@kilocode/db/schema';
 import { db } from '@/lib/drizzle';
-import { kiloclaw_admin_audit_logs } from '@kilocode/db/schema';
+import {
+  kiloclaw_admin_audit_logs,
+  kiloclaw_cli_runs,
+  kiloclaw_instances,
+} from '@kilocode/db/schema';
 import { and, eq } from 'drizzle-orm';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const mockGetDebugStatus: jest.Mock<any, any> = jest.fn();
 const mockDestroyFlyMachine: jest.Mock<any, any> = jest.fn();
+const mockGetKiloCliRunStatus: jest.Mock<any, any> = jest.fn();
+const mockCancelKiloCliRun: jest.Mock<any, any> = jest.fn();
 
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => ({
   KiloClawInternalClient: jest.fn().mockImplementation(() => ({
     getDebugStatus: mockGetDebugStatus,
     destroyFlyMachine: mockDestroyFlyMachine,
+    getKiloCliRunStatus: mockGetKiloCliRunStatus,
+    cancelKiloCliRun: mockCancelKiloCliRun,
   })),
   KiloClawApiError: class KiloClawApiError extends Error {
     statusCode: number;
@@ -28,6 +36,9 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => ({
 
 let regularUser: User;
 let adminUser: User;
+let cliRunUser: User;
+let cliRunInstanceId: string;
+let cliRunId: string;
 
 const testAppName = 'acct-abc123def456';
 const testMachineId = 'd8901e123456';
@@ -46,24 +57,63 @@ function flyDebugStatus(overrides: Record<string, unknown> = {}) {
   };
 }
 
-beforeAll(async () => {
+beforeEach(async () => {
   regularUser = await insertTestUser({
-    google_user_email: 'regular-destroy-machine@example.com',
+    google_user_email: `regular-destroy-machine-${Math.random()}@example.com`,
     is_admin: false,
   });
   adminUser = await insertTestUser({
-    google_user_email: 'admin-destroy-machine@admin.example.com',
+    google_user_email: `admin-destroy-machine-${Math.random()}@admin.example.com`,
     is_admin: true,
   });
-});
 
-beforeEach(async () => {
+  cliRunUser = await insertTestUser({
+    google_user_email: `admin-cli-run-target-${Math.random()}@example.com`,
+    is_admin: false,
+  });
+
+  const [instance] = await db
+    .insert(kiloclaw_instances)
+    .values({
+      id: crypto.randomUUID(),
+      user_id: cliRunUser.id,
+      sandbox_id: `ki_${crypto.randomUUID().replace(/-/g, '')}`,
+    })
+    .returning({ id: kiloclaw_instances.id });
+
+  cliRunInstanceId = instance.id;
+
+  const [run] = await db
+    .insert(kiloclaw_cli_runs)
+    .values({
+      user_id: cliRunUser.id,
+      instance_id: cliRunInstanceId,
+      prompt: 'older admin-target run',
+      status: 'running',
+      started_at: '2026-04-08T12:00:00.000Z',
+      initiated_by_admin_id: adminUser.id,
+    })
+    .returning({ id: kiloclaw_cli_runs.id });
+
+  cliRunId = run.id;
   mockGetDebugStatus.mockReset();
   mockDestroyFlyMachine.mockReset();
+  mockGetKiloCliRunStatus.mockReset();
+  mockCancelKiloCliRun.mockReset();
   // Clean audit logs between tests so counts are accurate
   await db
     .delete(kiloclaw_admin_audit_logs)
     .where(eq(kiloclaw_admin_audit_logs.actor_id, adminUser.id));
+
+  await db
+    .update(kiloclaw_cli_runs)
+    .set({
+      status: 'running',
+      exit_code: null,
+      output: null,
+      completed_at: null,
+    })
+    .where(eq(kiloclaw_cli_runs.id, cliRunId));
 });
 
 /* eslint-disable drizzle/enforce-delete-with-where */
@@ -72,6 +122,8 @@ afterAll(async () => {
     await db
       .delete(kiloclaw_admin_audit_logs)
       .where(eq(kiloclaw_admin_audit_logs.actor_id, adminUser.id));
+    await db.delete(kiloclaw_cli_runs).where(eq(kiloclaw_cli_runs.id, cliRunId));
+    await db.delete(kiloclaw_instances).where(eq(kiloclaw_instances.id, cliRunInstanceId));
   } catch {
     // Test DB may already be torn down
   }
@@ -231,5 +283,207 @@ describe('admin.kiloclawInstances.destroyFlyMachine', () => {
     ).rejects.toThrow('Invalid Fly machine ID');
 
     expect(mockGetDebugStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('admin.kiloclawInstances.getKiloCliRunStatus', () => {
+  it('does not overwrite a stored run when controller status belongs to a newer run', async () => {
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'completed',
+      output: 'newer admin run output',
+      exitCode: 0,
+      startedAt: '2026-04-08T12:05:00Z',
+      completedAt: '2026-04-08T12:06:00Z',
+      prompt: 'newer admin run',
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.getKiloCliRunStatus({
+      userId: cliRunUser.id,
+      instanceId: cliRunInstanceId,
+      runId: cliRunId,
+    });
+
+    expect(result.status).toBe('running');
+    expect(result.output).toBeNull();
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, cliRunId));
+
+    expect(row.status).toBe('running');
+    expect(row.output).toBeNull();
+    expect(row.completed_at).toBeNull();
+  });
+
+  it('writes start audit metadata with runId and stores the initiating admin id', async () => {
+    const startKiloCliRun = jest.fn().mockResolvedValue({
+      startedAt: '2026-04-08T12:10:00.000Z',
+      status: 'running',
+    });
+    const { KiloClawInternalClient } = jest.requireMock('@/lib/kiloclaw/kiloclaw-internal-client');
+    KiloClawInternalClient.mockImplementation(() => ({
+      getDebugStatus: mockGetDebugStatus,
+      destroyFlyMachine: mockDestroyFlyMachine,
+      getKiloCliRunStatus: mockGetKiloCliRunStatus,
+      cancelKiloCliRun: mockCancelKiloCliRun,
+      startKiloCliRun,
+    }));
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.startKiloCliRun({
+      userId: cliRunUser.id,
+      instanceId: cliRunInstanceId,
+      prompt: 'new admin run',
+    });
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, result.id));
+
+    expect(row.initiated_by_admin_id).toBe(adminUser.id);
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_admin_audit_logs)
+      .where(
+        and(
+          eq(kiloclaw_admin_audit_logs.actor_id, adminUser.id),
+          eq(kiloclaw_admin_audit_logs.action, 'kiloclaw.cli_run.start')
+        )
+      );
+
+    expect(logs[0]?.metadata).toEqual({
+      runId: result.id,
+      instanceId: cliRunInstanceId,
+      promptLength: 'new admin run'.length,
+    });
+
+    await db.delete(kiloclaw_cli_runs).where(eq(kiloclaw_cli_runs.id, result.id));
+  });
+
+  it('lists the initiating admin email for admin-started runs', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.listAllCliRuns({
+      offset: 0,
+      limit: 10,
+      initiatedBy: 'admin',
+      status: 'all',
+    });
+
+    const run = result.runs.find(row => row.id === cliRunId);
+
+    expect(run?.initiated_by_admin_id).toBe(adminUser.id);
+    expect(run?.initiated_by_admin_email).toBe(adminUser.google_user_email);
+    expect(run).not.toHaveProperty('initiated_by_admin_name');
+  });
+});
+
+describe('admin.kiloclawInstances.cancelKiloCliRun', () => {
+  it('throws before calling the controller when the scoped CLI run row does not exist', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+
+    await expect(
+      caller.admin.kiloclawInstances.cancelKiloCliRun({
+        userId: cliRunUser.id,
+        instanceId: cliRunInstanceId,
+        runId: crypto.randomUUID(),
+      })
+    ).rejects.toThrow('CLI run not found');
+
+    expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
+  });
+
+  it('throws before calling the controller when the run belongs to another instance', async () => {
+    const [otherInstance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        id: crypto.randomUUID(),
+        user_id: cliRunUser.id,
+        sandbox_id: `ki_${crypto.randomUUID().replace(/-/g, '')}`,
+      })
+      .returning({ id: kiloclaw_instances.id });
+
+    const caller = await createCallerForUser(adminUser.id);
+
+    try {
+      await expect(
+        caller.admin.kiloclawInstances.cancelKiloCliRun({
+          userId: cliRunUser.id,
+          instanceId: otherInstance.id,
+          runId: cliRunId,
+        })
+      ).rejects.toThrow('CLI run not found');
+
+      expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
+    } finally {
+      await db.delete(kiloclaw_instances).where(eq(kiloclaw_instances.id, otherInstance.id));
+    }
+  });
+
+  it('returns ok without calling the controller when the run is already terminal', async () => {
+    await db
+      .update(kiloclaw_cli_runs)
+      .set({
+        status: 'completed',
+        exit_code: 0,
+        output: 'done',
+        completed_at: '2026-04-08T12:01:00.000Z',
+      })
+      .where(eq(kiloclaw_cli_runs.id, cliRunId));
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.cancelKiloCliRun({
+        userId: cliRunUser.id,
+        instanceId: cliRunInstanceId,
+        runId: cliRunId,
+      })
+    ).resolves.toEqual({ ok: true });
+
+    expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
+  });
+
+  it('calls the controller, marks the row cancelled, and writes audit metadata for a running run', async () => {
+    mockCancelKiloCliRun.mockResolvedValue({ ok: true });
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.cancelKiloCliRun({
+        userId: cliRunUser.id,
+        instanceId: cliRunInstanceId,
+        runId: cliRunId,
+      })
+    ).resolves.toEqual({ ok: true });
+
+    expect(mockCancelKiloCliRun).toHaveBeenCalledWith(cliRunUser.id, cliRunInstanceId);
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, cliRunId));
+
+    expect(row.status).toBe('cancelled');
+    expect(row.completed_at).not.toBeNull();
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_admin_audit_logs)
+      .where(
+        and(
+          eq(kiloclaw_admin_audit_logs.actor_id, adminUser.id),
+          eq(kiloclaw_admin_audit_logs.action, 'kiloclaw.cli_run.cancel')
+        )
+      );
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].target_user_id).toBe(cliRunUser.id);
+    expect(logs[0].metadata).toEqual({
+      instanceId: cliRunInstanceId,
+      runId: cliRunId,
+    });
   });
 });

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -318,6 +318,38 @@ describe('admin.kiloclawInstances.getKiloCliRunStatus', () => {
     expect(row.completed_at).toBeNull();
   });
 
+  it('marks a running DB row failed when the controller no longer has the run', async () => {
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: false,
+      status: null,
+      output: null,
+      exitCode: null,
+      startedAt: null,
+      completedAt: null,
+      prompt: null,
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.getKiloCliRunStatus({
+      userId: cliRunUser.id,
+      instanceId: cliRunInstanceId,
+      runId: cliRunId,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.output).toContain('controller no longer has an active CLI run');
+    expect(result.completedAt).not.toBeNull();
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, cliRunId));
+
+    expect(row.status).toBe('failed');
+    expect(row.output).toContain('controller no longer has an active CLI run');
+    expect(row.completed_at).not.toBeNull();
+  });
+
   it('writes start audit metadata with runId and stores the initiating admin id', async () => {
     const startKiloCliRun = jest.fn().mockResolvedValue({
       startedAt: '2026-04-08T12:10:00.000Z',

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -23,6 +23,12 @@ import {
   createKiloClawAdminAuditLog,
   listKiloClawAdminAuditLogs,
 } from '@/lib/kiloclaw/admin-audit-log';
+import {
+  cancelCliRun,
+  createCliRun,
+  getCliRunStatus,
+  getEmptyCliRunStatus,
+} from '@/lib/kiloclaw/cli-runs';
 import type {
   PlatformDebugStatusResponse,
   VolumeSnapshot,
@@ -34,6 +40,7 @@ import type {
 import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
 import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
+import { alias } from 'drizzle-orm/pg-core';
 import {
   eq,
   and,
@@ -49,6 +56,8 @@ import {
   lte,
   type SQL,
 } from 'drizzle-orm';
+
+const initiatingAdminUsers = alias(kilocode_users, 'initiating_admin_users');
 
 const ListInstancesSchema = z.object({
   offset: z.number().min(0).default(0),
@@ -159,17 +168,23 @@ function throwKiloclawAdminError(
  * Otherwise fall back to the user's active (personal) instance.
  */
 async function resolveInstance(userId: string, instanceId?: string) {
-  if (instanceId) {
-    const instance = await getInstanceById(instanceId);
-    if (!instance) {
+  const instance = instanceId ? await getInstanceById(instanceId) : await getActiveInstance(userId);
+
+  if (!instance) {
+    if (instanceId) {
       throw new TRPCError({
         code: 'NOT_FOUND',
         message: `Instance ${instanceId} not found`,
       });
     }
-    return instance;
+    return null;
   }
-  return getActiveInstance(userId);
+
+  if (instance.userId !== userId) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Instance not found' });
+  }
+
+  return instance;
 }
 
 export type AdminKiloclawInstance = {
@@ -565,29 +580,130 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         prompt: z.string().min(1).max(10_000),
       })
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ input, ctx }) => {
       const fallbackMessage = 'Failed to start kilo CLI run';
       try {
         const instance = await resolveInstance(input.userId, input.instanceId);
+        if (!instance) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Instance not found' });
+        }
         const client = new KiloClawInternalClient();
-        return await client.startKiloCliRun(input.userId, input.prompt, workerInstanceId(instance));
+        const result = await client.startKiloCliRun(
+          input.userId,
+          input.prompt,
+          workerInstanceId(instance)
+        );
+
+        const runId = await createCliRun({
+          userId: input.userId,
+          instanceId: instance.id,
+          prompt: input.prompt,
+          startedAt: result.startedAt,
+          initiatedByAdminId: ctx.user.id,
+        });
+
+        try {
+          await createKiloClawAdminAuditLog({
+            action: 'kiloclaw.cli_run.start',
+            actor_id: ctx.user.id,
+            actor_email: ctx.user.google_user_email,
+            actor_name: ctx.user.google_user_name,
+            target_user_id: input.userId,
+            message: `CLI run started on instance ${instance.id}`,
+            metadata: {
+              runId,
+              instanceId: instance.id,
+              promptLength: input.prompt.length,
+            },
+          });
+        } catch (auditErr) {
+          console.error('Failed to write audit log for startKiloCliRun:', auditErr);
+        }
+
+        return { ...result, id: runId };
       } catch (err) {
         console.error('Failed to start kilo CLI run for user:', input.userId, err);
         throwKiloclawAdminError(err, fallbackMessage);
       }
     }),
 
-  getKiloCliRunStatus: adminProcedure.input(GatewayProcessSchema).query(async ({ input }) => {
-    const fallbackMessage = 'Failed to get kilo CLI run status';
-    try {
-      const instance = await resolveInstance(input.userId, input.instanceId);
-      const client = new KiloClawInternalClient();
-      return await client.getKiloCliRunStatus(input.userId, workerInstanceId(instance));
-    } catch (err) {
-      console.error('Failed to get kilo CLI run status for user:', input.userId, err);
-      throwKiloclawAdminError(err, fallbackMessage);
-    }
-  }),
+  getKiloCliRunStatus: adminProcedure
+    .input(
+      z.object({
+        userId: z.string().min(1),
+        instanceId: z.uuid().optional(),
+        runId: z.uuid(),
+      })
+    )
+    .query(async ({ input }) => {
+      const fallbackMessage = 'Failed to get kilo CLI run status';
+      try {
+        const instance = await resolveInstance(input.userId, input.instanceId);
+        if (!instance) {
+          return getEmptyCliRunStatus();
+        }
+
+        return getCliRunStatus({
+          runId: input.runId,
+          userId: input.userId,
+          instanceId: instance.id,
+          workerInstanceId: workerInstanceId(instance),
+        });
+      } catch (err) {
+        console.error('Failed to get kilo CLI run status for user:', input.userId, err);
+        throwKiloclawAdminError(err, fallbackMessage);
+      }
+    }),
+
+  cancelKiloCliRun: adminProcedure
+    .input(
+      z.object({
+        userId: z.string().min(1),
+        instanceId: z.uuid().optional(),
+        runId: z.uuid(),
+      })
+    )
+    .mutation(async ({ input, ctx }) => {
+      const fallbackMessage = 'Failed to cancel kilo CLI run';
+      try {
+        const instance = await resolveInstance(input.userId, input.instanceId);
+        if (!instance) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Instance not found' });
+        }
+        const result = await cancelCliRun({
+          runId: input.runId,
+          userId: input.userId,
+          instanceId: instance.id,
+          workerInstanceId: workerInstanceId(instance),
+        });
+
+        if (!result.runFound) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'CLI run not found' });
+        }
+
+        try {
+          await createKiloClawAdminAuditLog({
+            action: 'kiloclaw.cli_run.cancel',
+            actor_id: ctx.user.id,
+            actor_email: ctx.user.google_user_email,
+            actor_name: ctx.user.google_user_name,
+            target_user_id: input.userId,
+            message: `CLI run cancelled on instance ${instance.id}`,
+            metadata: {
+              instanceId: instance.id,
+              runId: input.runId,
+            },
+          });
+        } catch (auditErr) {
+          console.error('Failed to write audit log for cancelKiloCliRun:', auditErr);
+        }
+
+        return { ok: result.ok };
+      } catch (err) {
+        console.error('Failed to cancel kilo CLI run for user:', input.userId, err);
+        throwKiloclawAdminError(err, fallbackMessage);
+      }
+    }),
 
   listKiloCliRuns: adminProcedure
     .input(z.object({ userId: z.string().min(1), limit: z.number().min(1).max(50).default(20) }))
@@ -609,14 +725,23 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         limit: z.number().min(1).max(100).default(25),
         search: z.string().optional(),
         status: z.enum(['all', 'running', 'completed', 'failed', 'cancelled']).default('all'),
+        initiatedBy: z.enum(['all', 'admin', 'user']).default('all'),
       })
     )
     .query(async ({ input }) => {
-      const { offset, limit, search, status } = input;
+      const { offset, limit, search, status, initiatedBy } = input;
       const conditions: SQL[] = [];
 
       if (status !== 'all') {
         conditions.push(eq(kiloclaw_cli_runs.status, status));
+      }
+
+      if (initiatedBy !== 'all') {
+        conditions.push(
+          initiatedBy === 'admin'
+            ? sql`${kiloclaw_cli_runs.initiated_by_admin_id} IS NOT NULL`
+            : sql`${kiloclaw_cli_runs.initiated_by_admin_id} IS NULL`
+        );
       }
 
       const searchTerm = search?.trim();
@@ -638,6 +763,8 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
             id: kiloclaw_cli_runs.id,
             user_id: kiloclaw_cli_runs.user_id,
             user_email: kilocode_users.google_user_email,
+            initiated_by_admin_id: kiloclaw_cli_runs.initiated_by_admin_id,
+            initiated_by_admin_email: initiatingAdminUsers.google_user_email,
             prompt: kiloclaw_cli_runs.prompt,
             status: kiloclaw_cli_runs.status,
             exit_code: kiloclaw_cli_runs.exit_code,
@@ -646,6 +773,10 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
           })
           .from(kiloclaw_cli_runs)
           .leftJoin(kilocode_users, eq(kiloclaw_cli_runs.user_id, kilocode_users.id))
+          .leftJoin(
+            initiatingAdminUsers,
+            eq(kiloclaw_cli_runs.initiated_by_admin_id, initiatingAdminUsers.id)
+          )
           .where(where)
           .orderBy(desc(kiloclaw_cli_runs.started_at))
           .limit(limit)

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -739,8 +739,8 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       if (initiatedBy !== 'all') {
         conditions.push(
           initiatedBy === 'admin'
-            ? sql`${kiloclaw_cli_runs.initiated_by_admin_id} IS NOT NULL`
-            : sql`${kiloclaw_cli_runs.initiated_by_admin_id} IS NULL`
+            ? isNotNull(kiloclaw_cli_runs.initiated_by_admin_id)
+            : isNull(kiloclaw_cli_runs.initiated_by_admin_id)
         );
       }
 

--- a/apps/web/src/routers/kiloclaw-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-router.test.ts
@@ -1,12 +1,19 @@
 process.env.STRIPE_KILOCLAW_COMMIT_PRICE_ID ||= 'price_commit';
 process.env.STRIPE_KILOCLAW_STANDARD_PRICE_ID ||= 'price_standard';
 process.env.STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID ||= 'price_standard_intro';
+process.env.KILOCLAW_API_URL ||= 'http://localhost:8795';
+process.env.KILOCLAW_INTERNAL_API_SECRET ||= 'test-secret';
 
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { cleanupDbForTest } from '@/lib/drizzle';
+import { cleanupDbForTest, db } from '@/lib/drizzle';
 import { createCallerFactory } from '@/lib/trpc/init';
 import { kiloclawRouter } from '@/routers/kiloclaw-router';
 import { insertTestUser } from '@/tests/helpers/user.helper';
+import {
+  kiloclaw_cli_runs,
+  kiloclaw_earlybird_purchases,
+  kiloclaw_instances,
+} from '@kilocode/db/schema';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyMock = jest.Mock<(...args: any[]) => any>;
@@ -14,6 +21,7 @@ type AnyMock = jest.Mock<(...args: any[]) => any>;
 type KiloClawClientMock = {
   KiloClawInternalClient: AnyMock;
   __getStatusMock: AnyMock;
+  __cancelKiloCliRunMock: AnyMock;
 };
 
 jest.mock('@/lib/stripe-client', () => {
@@ -56,9 +64,11 @@ jest.mock('next/headers', () => {
 
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   const getStatusMock = jest.fn();
+  const cancelKiloCliRunMock = jest.fn();
   return {
     KiloClawInternalClient: jest.fn().mockImplementation(() => ({
       getStatus: getStatusMock,
+      cancelKiloCliRun: cancelKiloCliRunMock,
     })),
     KiloClawApiError: class KiloClawApiError extends Error {
       statusCode: number;
@@ -70,6 +80,7 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
       }
     },
     __getStatusMock: getStatusMock,
+    __cancelKiloCliRunMock: cancelKiloCliRunMock,
   };
 });
 
@@ -77,6 +88,18 @@ const createCaller = createCallerFactory(kiloclawRouter);
 const kiloclawClientMock = jest.requireMock<KiloClawClientMock>(
   '@/lib/kiloclaw/kiloclaw-internal-client'
 );
+
+function sandboxId(): string {
+  return `ki_${crypto.randomUUID().replace(/-/g, '')}`;
+}
+
+async function grantKiloClawAccess(userId: string): Promise<void> {
+  await db.insert(kiloclaw_earlybird_purchases).values({
+    user_id: userId,
+    manual_payment_id: `manual-${crypto.randomUUID()}`,
+    amount_cents: 20_000,
+  });
+}
 
 describe('kiloclawRouter getStatus', () => {
   beforeEach(async () => {
@@ -125,6 +148,212 @@ describe('kiloclawRouter getStatus', () => {
       workerUrl: 'https://claw.kilo.ai',
       name: null,
       instanceId: null,
+    });
+  });
+});
+
+describe('kiloclawRouter listKiloCliRuns', () => {
+  beforeEach(async () => {
+    await cleanupDbForTest();
+    kiloclawClientMock.__cancelKiloCliRunMock.mockReset();
+  });
+
+  it('returns only runs for the active personal instance when one exists', async () => {
+    const user = await insertTestUser({
+      google_user_email: `kiloclaw-cli-runs-${Math.random()}@example.com`,
+    });
+
+    await grantKiloClawAccess(user.id);
+
+    const [destroyedInstance, activeInstance] = await db
+      .insert(kiloclaw_instances)
+      .values([
+        {
+          user_id: user.id,
+          sandbox_id: sandboxId(),
+          destroyed_at: '2026-04-01T00:00:00.000Z',
+        },
+        {
+          user_id: user.id,
+          sandbox_id: sandboxId(),
+        },
+      ])
+      .returning({ id: kiloclaw_instances.id });
+
+    if (!destroyedInstance || !activeInstance) {
+      throw new Error('Failed to create KiloClaw test instances');
+    }
+
+    await db.insert(kiloclaw_cli_runs).values([
+      {
+        user_id: user.id,
+        instance_id: destroyedInstance.id,
+        prompt: 'destroyed instance run',
+        status: 'completed',
+        started_at: '2026-04-01T00:00:00.000Z',
+      },
+      {
+        user_id: user.id,
+        instance_id: activeInstance.id,
+        prompt: 'active instance run',
+        status: 'completed',
+        started_at: '2026-04-03T00:00:00.000Z',
+      },
+      {
+        user_id: user.id,
+        instance_id: null,
+        prompt: 'legacy null instance run',
+        status: 'completed',
+        started_at: '2026-04-05T00:00:00.000Z',
+      },
+    ]);
+
+    const caller = createCaller({ user });
+    const result = await caller.listKiloCliRuns();
+
+    expect(result.runs).toHaveLength(1);
+    expect(result.runs[0]?.prompt).toBe('active instance run');
+    expect(result.runs[0]?.instance_id).toBe(activeInstance.id);
+  });
+
+  it('preserves user-scoped listing when no active personal instance exists', async () => {
+    const user = await insertTestUser({
+      google_user_email: `kiloclaw-cli-runs-legacy-${Math.random()}@example.com`,
+    });
+
+    await grantKiloClawAccess(user.id);
+
+    const [destroyedInstance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        user_id: user.id,
+        sandbox_id: sandboxId(),
+        destroyed_at: '2026-04-01T00:00:00.000Z',
+      })
+      .returning({ id: kiloclaw_instances.id });
+
+    if (!destroyedInstance) {
+      throw new Error('Failed to create KiloClaw test instance');
+    }
+
+    await db.insert(kiloclaw_cli_runs).values([
+      {
+        user_id: user.id,
+        instance_id: destroyedInstance.id,
+        prompt: 'destroyed instance run',
+        status: 'completed',
+        started_at: '2026-04-01T00:00:00.000Z',
+      },
+      {
+        user_id: user.id,
+        instance_id: null,
+        prompt: 'legacy null instance run',
+        status: 'completed',
+        started_at: '2026-04-02T00:00:00.000Z',
+      },
+    ]);
+
+    const caller = createCaller({ user });
+    const result = await caller.listKiloCliRuns();
+
+    expect(result.runs.map(run => run.prompt)).toEqual([
+      'legacy null instance run',
+      'destroyed instance run',
+    ]);
+  });
+
+  it('opens listed destroyed-instance runs when no active personal instance exists', async () => {
+    const user = await insertTestUser({
+      google_user_email: `kiloclaw-cli-runs-status-${Math.random()}@example.com`,
+    });
+
+    await grantKiloClawAccess(user.id);
+
+    const [destroyedInstance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        user_id: user.id,
+        sandbox_id: sandboxId(),
+        destroyed_at: '2026-04-01T00:00:00.000Z',
+      })
+      .returning({ id: kiloclaw_instances.id });
+
+    if (!destroyedInstance) {
+      throw new Error('Failed to create KiloClaw test instance');
+    }
+
+    const [run] = await db
+      .insert(kiloclaw_cli_runs)
+      .values({
+        user_id: user.id,
+        instance_id: destroyedInstance.id,
+        prompt: 'destroyed instance run',
+        status: 'completed',
+        started_at: '2026-04-01T00:00:00.000Z',
+      })
+      .returning({ id: kiloclaw_cli_runs.id });
+
+    if (!run) {
+      throw new Error('Failed to create KiloClaw CLI run');
+    }
+
+    const caller = createCaller({ user });
+    const result = await caller.getKiloCliRunStatus({ runId: run.id });
+
+    expect(result).toMatchObject({
+      hasRun: true,
+      status: 'completed',
+      prompt: 'destroyed instance run',
+    });
+  });
+
+  // Verifies that cancelling a run on a destroyed instance reaches the
+  // controller call path (resolveWorkerInstanceId succeeds). The mock for
+  // KiloClawInternalClient covers the router's direct import but not the
+  // transitive import inside cancelCliRun (cli-runs.ts), so the real
+  // constructor fires and throws about the missing env var. The assertion
+  // confirms the code got past the DB lookup and instance resolution.
+  it('reaches the controller when cancelling a destroyed-instance run', async () => {
+    const user = await insertTestUser({
+      google_user_email: `kiloclaw-cli-runs-cancel-${Math.random()}@example.com`,
+    });
+
+    await grantKiloClawAccess(user.id);
+
+    const [destroyedInstance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        user_id: user.id,
+        sandbox_id: sandboxId(),
+        destroyed_at: '2026-04-01T00:00:00.000Z',
+      })
+      .returning({ id: kiloclaw_instances.id });
+
+    if (!destroyedInstance) {
+      throw new Error('Failed to create KiloClaw test instance');
+    }
+
+    const [run] = await db
+      .insert(kiloclaw_cli_runs)
+      .values({
+        user_id: user.id,
+        instance_id: destroyedInstance.id,
+        prompt: 'destroyed instance run',
+        status: 'running',
+        started_at: '2026-04-01T00:00:00.000Z',
+      })
+      .returning({ id: kiloclaw_cli_runs.id });
+
+    if (!run) {
+      throw new Error('Failed to create KiloClaw CLI run');
+    }
+
+    kiloclawClientMock.__cancelKiloCliRunMock.mockResolvedValue({ ok: true });
+
+    const caller = createCaller({ user });
+    await expect(caller.cancelKiloCliRun({ runId: run.id })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'KILOCLAW_API_URL is not configured',
     });
   });
 });

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -84,6 +84,7 @@ import {
   KILOCLAW_PLAN_COST_MICRODOLLARS,
   KILOCLAW_STANDARD_FIRST_MONTH_MICRODOLLARS,
 } from '@/lib/kiloclaw/credit-billing';
+import { cancelCliRun, createCliRun, getCliRunStatus } from '@/lib/kiloclaw/cli-runs';
 import type { ClawBillingStatus } from '@/app/(app)/claw/components/billing/billing-types';
 import PostHogClient from '@/lib/posthog';
 import { CHANGELOG_ENTRIES } from '@/app/(app)/claw/components/changelog-data';
@@ -93,7 +94,11 @@ import { IMPACT_ORDER_ID_MACRO } from '@/lib/impact';
  * Error codes whose messages may contain raw internal details (e.g. filesystem
  * paths) and should NOT be forwarded to the client.
  */
-const UNSAFE_ERROR_CODES = new Set(['config_read_failed', 'config_replace_failed']);
+const UNSAFE_ERROR_CODES = new Set([
+  'config_read_failed',
+  'config_replace_failed',
+  'gateway_controller_error',
+]);
 
 /**
  * Adopt a single orphaned subscription onto the given active personal instance.
@@ -2181,23 +2186,26 @@ export const kiloclawRouter = createTRPCRouter({
               cause: new UpstreamApiError('controller_route_unavailable'),
             });
           }
+          if (err.statusCode === 409) {
+            throw new TRPCError({
+              code: 'CONFLICT',
+              message: 'A Kilo CLI run is already in progress',
+              cause: code ? new UpstreamApiError(code) : undefined,
+            });
+          }
         }
         throw err;
       }
 
-      // Persist the run in the database and return its ID
-      const [row] = await db
-        .insert(kiloclaw_cli_runs)
-        .values({
-          user_id: ctx.user.id,
-          instance_id: instance?.id ?? null,
-          prompt: input.prompt,
-          status: 'running',
-          started_at: result.startedAt,
-        })
-        .returning({ id: kiloclaw_cli_runs.id });
+      const runId = await createCliRun({
+        userId: ctx.user.id,
+        instanceId: instance?.id ?? null,
+        prompt: input.prompt,
+        startedAt: result.startedAt,
+        initiatedByAdminId: null,
+      });
 
-      return { ...result, id: row.id };
+      return { ...result, id: runId };
     }),
 
   getKiloCliRunStatus: clawAccessProcedure
@@ -2205,114 +2213,30 @@ export const kiloclawRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       const instance = await getActiveInstance(ctx.user.id);
 
-      // Load the requested run from the DB to avoid cross-run data leaks.
-      // The controller only tracks the *current* run, so polling it for an
-      // older run would return the wrong output.
-      const instanceFilter = instance ? eq(kiloclaw_cli_runs.instance_id, instance.id) : undefined;
-      const [row] = await db
-        .select()
-        .from(kiloclaw_cli_runs)
-        .where(
-          and(
-            eq(kiloclaw_cli_runs.id, input.runId),
-            eq(kiloclaw_cli_runs.user_id, ctx.user.id),
-            instanceFilter
-          )
-        )
-        .limit(1);
-
-      if (!row) {
-        return {
-          hasRun: false,
-          status: null,
-          output: null,
-          exitCode: null,
-          startedAt: null,
-          completedAt: null,
-          prompt: null,
-        };
-      }
-
-      // If the DB row is already terminal, return it directly — no need to
-      // poll the controller (which may be running a different job).
-      if (row.status !== 'running') {
-        return {
-          hasRun: true,
-          status: row.status as 'completed' | 'failed' | 'cancelled',
-          output: row.output,
-          exitCode: row.exit_code,
-          startedAt: row.started_at,
-          completedAt: row.completed_at ?? null,
-          prompt: row.prompt,
-        };
-      }
-
-      // Run is still active — poll the controller for live output.
-      const client = new KiloClawInternalClient();
-      const controllerStatus = await client.getKiloCliRunStatus(
-        ctx.user.id,
-        workerInstanceId(instance)
-      );
-
-      // If controller reports the run finished, persist to the DB row.
-      if (
-        controllerStatus.hasRun &&
-        controllerStatus.status !== 'running' &&
-        controllerStatus.startedAt
-      ) {
-        await db
-          .update(kiloclaw_cli_runs)
-          .set({
-            status: controllerStatus.status ?? 'failed',
-            exit_code: controllerStatus.exitCode,
-            output: controllerStatus.output,
-            completed_at: controllerStatus.completedAt ?? new Date().toISOString(),
-          })
-          .where(
-            and(
-              eq(kiloclaw_cli_runs.id, input.runId),
-              eq(kiloclaw_cli_runs.user_id, ctx.user.id),
-              instanceFilter,
-              eq(kiloclaw_cli_runs.status, 'running')
-            )
-          );
-      }
-
-      return {
-        ...controllerStatus,
-        prompt: row.prompt,
-      };
+      return getCliRunStatus({
+        runId: input.runId,
+        userId: ctx.user.id,
+        instanceId: instance?.id ?? null,
+        workerInstanceId: workerInstanceId(instance),
+      });
     }),
 
   cancelKiloCliRun: clawAccessProcedure
     .input(z.object({ runId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       const instance = await getActiveInstance(ctx.user.id);
-      const client = new KiloClawInternalClient();
-      const result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
+      const result = await cancelCliRun({
+        runId: input.runId,
+        userId: ctx.user.id,
+        instanceId: instance?.id ?? null,
+        workerInstanceId: workerInstanceId(instance),
+      });
 
-      // Mark the specific run as cancelled in DB
-      if (result.ok) {
-        const instanceFilter = instance
-          ? eq(kiloclaw_cli_runs.instance_id, instance.id)
-          : undefined;
-        await db
-          .update(kiloclaw_cli_runs)
-          .set({
-            status: 'cancelled',
-            completed_at: new Date().toISOString(),
-          })
-          .where(
-            and(
-              eq(kiloclaw_cli_runs.id, input.runId),
-              eq(kiloclaw_cli_runs.user_id, ctx.user.id),
-              instanceFilter,
-              eq(kiloclaw_cli_runs.status, 'running')
-            )
-          );
+      if (!result.runFound) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'CLI run not found' });
       }
 
-      return result;
+      return { ok: result.ok };
     }),
 
   listKiloCliRuns: clawAccessProcedure

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -26,6 +26,7 @@ import {
   kiloclaw_subscriptions,
 } from '@kilocode/db/schema';
 import { and, eq, desc, sql } from 'drizzle-orm';
+import { cancelCliRun, createCliRun, getCliRunStatus } from '@/lib/kiloclaw/cli-runs';
 import type { KiloClawDashboardStatus, KiloCodeConfigResponse } from '@/lib/kiloclaw/types';
 import { queryDiskUsage } from '@/lib/kiloclaw/disk-usage';
 import {
@@ -1147,98 +1148,65 @@ export const organizationKiloclawRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
       const client = new KiloClawInternalClient();
-      const result = await client.startKiloCliRun(
-        ctx.user.id,
-        input.prompt,
-        workerInstanceId(instance)
-      );
 
-      const [row] = await db
-        .insert(kiloclaw_cli_runs)
-        .values({
-          user_id: ctx.user.id,
-          instance_id: instance.id,
-          prompt: input.prompt,
-          status: 'running',
-          started_at: result.startedAt,
-        })
-        .returning({ id: kiloclaw_cli_runs.id });
+      let result: Awaited<ReturnType<KiloClawInternalClient['startKiloCliRun']>>;
+      try {
+        result = await client.startKiloCliRun(
+          ctx.user.id,
+          input.prompt,
+          workerInstanceId(instance)
+        );
+      } catch (err) {
+        if (err instanceof KiloClawApiError) {
+          const { code, message } = getKiloClawApiErrorPayload(err);
+          if (code === 'controller_route_unavailable') {
+            throw new TRPCError({
+              code: 'PRECONDITION_FAILED',
+              message: 'Instance needs redeploy to support Kilo CLI runs',
+              cause: new UpstreamApiError('controller_route_unavailable'),
+            });
+          }
+          if (err.statusCode === 409) {
+            throw new TRPCError({
+              code: 'CONFLICT',
+              message: message ?? 'A Kilo CLI run is already in progress',
+              cause: code ? new UpstreamApiError(code) : undefined,
+            });
+          }
+        }
+        throw err;
+      }
 
-      return { ...result, id: row.id };
+      const runId = await createCliRun({
+        userId: ctx.user.id,
+        instanceId: instance.id,
+        prompt: input.prompt,
+        startedAt: result.startedAt,
+        initiatedByAdminId: null,
+      });
+
+      return { ...result, id: runId };
     }),
 
   getKiloCliRunStatus: organizationMemberProcedure
     .input(z.object({ organizationId: z.uuid(), runId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
-      const [row] = await db
-        .select()
-        .from(kiloclaw_cli_runs)
-        .where(
-          and(
-            eq(kiloclaw_cli_runs.id, input.runId),
-            eq(kiloclaw_cli_runs.user_id, ctx.user.id),
-            eq(kiloclaw_cli_runs.instance_id, instance.id)
-          )
-        )
-        .limit(1);
-
-      if (!row) {
-        return {
-          hasRun: false,
-          status: null,
-          output: null,
-          exitCode: null,
-          startedAt: null,
-          completedAt: null,
-          prompt: null,
-        };
-      }
-
-      if (row.status !== 'running') {
-        return {
-          hasRun: true,
-          status: row.status as 'completed' | 'failed' | 'cancelled',
-          output: row.output,
-          exitCode: row.exit_code,
-          startedAt: row.started_at,
-          completedAt: row.completed_at ?? null,
-          prompt: row.prompt,
-        };
-      }
-
-      const client = new KiloClawInternalClient();
-      const controllerStatus = await client.getKiloCliRunStatus(
-        ctx.user.id,
-        workerInstanceId(instance)
-      );
-
-      if (
-        controllerStatus.hasRun &&
-        controllerStatus.status !== 'running' &&
-        controllerStatus.startedAt
-      ) {
-        await db
-          .update(kiloclaw_cli_runs)
-          .set({
-            status: controllerStatus.status ?? 'failed',
-            exit_code: controllerStatus.exitCode,
-            output: controllerStatus.output,
-            completed_at: controllerStatus.completedAt ?? new Date().toISOString(),
-          })
-          .where(
-            and(
-              eq(kiloclaw_cli_runs.id, input.runId),
-              eq(kiloclaw_cli_runs.user_id, ctx.user.id),
-              eq(kiloclaw_cli_runs.instance_id, instance.id),
-              eq(kiloclaw_cli_runs.status, 'running')
-            )
-          );
-      }
+      const status = await getCliRunStatus({
+        runId: input.runId,
+        userId: ctx.user.id,
+        instanceId: instance.id,
+        workerInstanceId: workerInstanceId(instance),
+      });
 
       return {
-        ...controllerStatus,
-        prompt: row.prompt,
+        hasRun: status.hasRun,
+        status: status.status,
+        output: status.output,
+        exitCode: status.exitCode,
+        startedAt: status.startedAt,
+        completedAt: status.completedAt,
+        prompt: status.prompt,
       };
     }),
 
@@ -1246,27 +1214,18 @@ export const organizationKiloclawRouter = createTRPCRouter({
     .input(z.object({ organizationId: z.uuid(), runId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
-      const client = new KiloClawInternalClient();
-      const result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
+      const result = await cancelCliRun({
+        runId: input.runId,
+        userId: ctx.user.id,
+        instanceId: instance.id,
+        workerInstanceId: workerInstanceId(instance),
+      });
 
-      if (result.ok) {
-        await db
-          .update(kiloclaw_cli_runs)
-          .set({
-            status: 'cancelled',
-            completed_at: new Date().toISOString(),
-          })
-          .where(
-            and(
-              eq(kiloclaw_cli_runs.id, input.runId),
-              eq(kiloclaw_cli_runs.user_id, ctx.user.id),
-              eq(kiloclaw_cli_runs.instance_id, instance.id),
-              eq(kiloclaw_cli_runs.status, 'running')
-            )
-          );
+      if (!result.runFound) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'CLI run not found' });
       }
 
-      return result;
+      return { ok: result.ok };
     }),
 
   listKiloCliRuns: organizationMemberProcedure

--- a/packages/db/src/migrations/0086_misty_beast.sql
+++ b/packages/db/src/migrations/0086_misty_beast.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "kiloclaw_cli_runs" ADD COLUMN "initiated_by_admin_id" text;--> statement-breakpoint
+ALTER TABLE "kiloclaw_cli_runs" ADD CONSTRAINT "kiloclaw_cli_runs_initiated_by_admin_id_kilocode_users_id_fk" FOREIGN KEY ("initiated_by_admin_id") REFERENCES "public"."kilocode_users"("id") ON DELETE set null ON UPDATE no action NOT VALID;--> statement-breakpoint
+ALTER TABLE "kiloclaw_cli_runs" VALIDATE CONSTRAINT "kiloclaw_cli_runs_initiated_by_admin_id_kilocode_users_id_fk";

--- a/packages/db/src/migrations/meta/0086_snapshot.json
+++ b/packages/db/src/migrations/meta/0086_snapshot.json
@@ -1,0 +1,16449 @@
+{
+  "id": "a0ca0a7a-101e-47f4-aa24-924efe6f40ec",
+  "prevId": "6e806f7d-2a53-44e6-8605-c901cdc6cb2a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_configs": {
+      "name": "agent_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_type": {
+          "name": "agent_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_agent_configs_org_id": {
+          "name": "IDX_agent_configs_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_agent_configs_owned_by_user_id": {
+          "name": "IDX_agent_configs_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_agent_configs_agent_type": {
+          "name": "IDX_agent_configs_agent_type",
+          "columns": [
+            {
+              "expression": "agent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_agent_configs_platform": {
+          "name": "IDX_agent_configs_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_configs_owned_by_organization_id_organizations_id_fk": {
+          "name": "agent_configs_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "agent_configs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_configs_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "agent_configs_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "agent_configs",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_agent_configs_org_agent_platform": {
+          "name": "UQ_agent_configs_org_agent_platform",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owned_by_organization_id",
+            "agent_type",
+            "platform"
+          ]
+        },
+        "UQ_agent_configs_user_agent_platform": {
+          "name": "UQ_agent_configs_user_agent_platform",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owned_by_user_id",
+            "agent_type",
+            "platform"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agent_configs_owner_check": {
+          "name": "agent_configs_owner_check",
+          "value": "(\n        (\"agent_configs\".\"owned_by_user_id\" IS NOT NULL AND \"agent_configs\".\"owned_by_organization_id\" IS NULL) OR\n        (\"agent_configs\".\"owned_by_user_id\" IS NULL AND \"agent_configs\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "agent_configs_agent_type_check": {
+          "name": "agent_configs_agent_type_check",
+          "value": "\"agent_configs\".\"agent_type\" IN ('code_review', 'auto_triage', 'auto_fix', 'security_scan')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_environment_profile_commands": {
+      "name": "agent_environment_profile_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_agent_env_profile_commands_profile_id": {
+          "name": "IDX_agent_env_profile_commands_profile_id",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_environment_profile_commands_profile_id_agent_environment_profiles_id_fk": {
+          "name": "agent_environment_profile_commands_profile_id_agent_environment_profiles_id_fk",
+          "tableFrom": "agent_environment_profile_commands",
+          "tableTo": "agent_environment_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_agent_env_profile_commands_profile_sequence": {
+          "name": "UQ_agent_env_profile_commands_profile_sequence",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id",
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_environment_profile_repo_bindings": {
+      "name": "agent_environment_profile_repo_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_agent_env_profile_repo_bindings_user": {
+          "name": "UQ_agent_env_profile_repo_bindings_user",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_environment_profile_repo_bindings\".\"owned_by_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_agent_env_profile_repo_bindings_org": {
+          "name": "UQ_agent_env_profile_repo_bindings_org",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_environment_profile_repo_bindings\".\"owned_by_organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_environment_profile_repo_bindings_profile_id_agent_environment_profiles_id_fk": {
+          "name": "agent_environment_profile_repo_bindings_profile_id_agent_environment_profiles_id_fk",
+          "tableFrom": "agent_environment_profile_repo_bindings",
+          "tableTo": "agent_environment_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_environment_profile_repo_bindings_owned_by_organization_id_organizations_id_fk": {
+          "name": "agent_environment_profile_repo_bindings_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "agent_environment_profile_repo_bindings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_environment_profile_repo_bindings_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "agent_environment_profile_repo_bindings_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "agent_environment_profile_repo_bindings",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_env_profile_repo_bindings_owner_check": {
+          "name": "agent_env_profile_repo_bindings_owner_check",
+          "value": "(\n        (\"agent_environment_profile_repo_bindings\".\"owned_by_user_id\" IS NOT NULL AND \"agent_environment_profile_repo_bindings\".\"owned_by_organization_id\" IS NULL) OR\n        (\"agent_environment_profile_repo_bindings\".\"owned_by_user_id\" IS NULL AND \"agent_environment_profile_repo_bindings\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_environment_profile_vars": {
+      "name": "agent_environment_profile_vars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_agent_env_profile_vars_profile_id": {
+          "name": "IDX_agent_env_profile_vars_profile_id",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_environment_profile_vars_profile_id_agent_environment_profiles_id_fk": {
+          "name": "agent_environment_profile_vars_profile_id_agent_environment_profiles_id_fk",
+          "tableFrom": "agent_environment_profile_vars",
+          "tableTo": "agent_environment_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_agent_env_profile_vars_profile_key": {
+          "name": "UQ_agent_env_profile_vars_profile_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_environment_profiles": {
+      "name": "agent_environment_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_agent_env_profiles_org_name": {
+          "name": "UQ_agent_env_profiles_org_name",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_environment_profiles\".\"owned_by_organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_agent_env_profiles_user_name": {
+          "name": "UQ_agent_env_profiles_user_name",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_environment_profiles\".\"owned_by_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_agent_env_profiles_org_default": {
+          "name": "UQ_agent_env_profiles_org_default",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_environment_profiles\".\"is_default\" = true AND \"agent_environment_profiles\".\"owned_by_organization_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_agent_env_profiles_user_default": {
+          "name": "UQ_agent_env_profiles_user_default",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_environment_profiles\".\"is_default\" = true AND \"agent_environment_profiles\".\"owned_by_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_agent_env_profiles_org_id": {
+          "name": "IDX_agent_env_profiles_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_agent_env_profiles_user_id": {
+          "name": "IDX_agent_env_profiles_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_environment_profiles_owned_by_organization_id_organizations_id_fk": {
+          "name": "agent_environment_profiles_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "agent_environment_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_environment_profiles_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "agent_environment_profiles_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "agent_environment_profiles",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_env_profiles_owner_check": {
+          "name": "agent_env_profiles_owner_check",
+          "value": "(\n        (\"agent_environment_profiles\".\"owned_by_user_id\" IS NOT NULL AND \"agent_environment_profiles\".\"owned_by_organization_id\" IS NULL) OR\n        (\"agent_environment_profiles\".\"owned_by_user_id\" IS NULL AND \"agent_environment_profiles\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_kind": {
+      "name": "api_kind",
+      "schema": "",
+      "columns": {
+        "api_kind_id": {
+          "name": "api_kind_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_kind": {
+          "name": "api_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_api_kind": {
+          "name": "UQ_api_kind",
+          "columns": [
+            {
+              "expression": "api_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_request_log": {
+      "name": "api_request_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_request_log_created_at": {
+          "name": "idx_api_request_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_builder_feedback": {
+      "name": "app_builder_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_status": {
+          "name": "preview_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streaming": {
+          "name": "is_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_text": {
+          "name": "feedback_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recent_messages": {
+          "name": "recent_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_app_builder_feedback_created_at": {
+          "name": "IDX_app_builder_feedback_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_feedback_kilo_user_id": {
+          "name": "IDX_app_builder_feedback_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_feedback_project_id": {
+          "name": "IDX_app_builder_feedback_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_builder_feedback_kilo_user_id_kilocode_users_id_fk": {
+          "name": "app_builder_feedback_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "app_builder_feedback",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "app_builder_feedback_project_id_app_builder_projects_id_fk": {
+          "name": "app_builder_feedback_project_id_app_builder_projects_id_fk",
+          "tableFrom": "app_builder_feedback",
+          "tableTo": "app_builder_projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_builder_project_sessions": {
+      "name": "app_builder_project_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_version": {
+          "name": "worker_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        }
+      },
+      "indexes": {
+        "IDX_app_builder_project_sessions_project_id": {
+          "name": "IDX_app_builder_project_sessions_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_builder_project_sessions_project_id_app_builder_projects_id_fk": {
+          "name": "app_builder_project_sessions_project_id_app_builder_projects_id_fk",
+          "tableFrom": "app_builder_project_sessions",
+          "tableTo": "app_builder_projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_app_builder_project_sessions_cloud_agent_session_id": {
+          "name": "UQ_app_builder_project_sessions_cloud_agent_session_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cloud_agent_session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_builder_projects": {
+      "name": "app_builder_projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_repo_full_name": {
+          "name": "git_repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_platform_integration_id": {
+          "name": "git_platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "migrated_at": {
+          "name": "migrated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_app_builder_projects_created_by_user_id": {
+          "name": "IDX_app_builder_projects_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_projects_owned_by_user_id": {
+          "name": "IDX_app_builder_projects_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_projects_owned_by_organization_id": {
+          "name": "IDX_app_builder_projects_owned_by_organization_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_projects_created_at": {
+          "name": "IDX_app_builder_projects_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_app_builder_projects_last_message_at": {
+          "name": "IDX_app_builder_projects_last_message_at",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_builder_projects_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "app_builder_projects_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "app_builder_projects",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_builder_projects_owned_by_organization_id_organizations_id_fk": {
+          "name": "app_builder_projects_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "app_builder_projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_builder_projects_deployment_id_deployments_id_fk": {
+          "name": "app_builder_projects_deployment_id_deployments_id_fk",
+          "tableFrom": "app_builder_projects",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_builder_projects_git_platform_integration_id_platform_integrations_id_fk": {
+          "name": "app_builder_projects_git_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "app_builder_projects",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "git_platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_builder_projects_owner_check": {
+          "name": "app_builder_projects_owner_check",
+          "value": "(\n        (\"app_builder_projects\".\"owned_by_user_id\" IS NOT NULL AND \"app_builder_projects\".\"owned_by_organization_id\" IS NULL) OR\n        (\"app_builder_projects\".\"owned_by_user_id\" IS NULL AND \"app_builder_projects\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_min_versions": {
+      "name": "app_min_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "ios_min_version": {
+          "name": "ios_min_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "android_min_version": {
+          "name": "android_min_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_reported_messages": {
+      "name": "app_reported_messages",
+      "schema": "",
+      "columns": {
+        "report_id": {
+          "name": "report_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cli_session_id": {
+          "name": "cli_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_reported_messages_cli_session_id_cli_sessions_session_id_fk": {
+          "name": "app_reported_messages_cli_session_id_cli_sessions_session_id_fk",
+          "tableFrom": "app_reported_messages",
+          "tableTo": "cli_sessions",
+          "columnsFrom": [
+            "cli_session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_fix_tickets": {
+      "name": "auto_fix_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triage_ticket_id": {
+          "name": "triage_ticket_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_url": {
+          "name": "issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_title": {
+          "name": "issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_body": {
+          "name": "issue_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_author": {
+          "name": "issue_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_labels": {
+          "name": "issue_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'label'"
+        },
+        "review_comment_id": {
+          "name": "review_comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_comment_body": {
+          "name": "review_comment_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diff_hunk": {
+          "name": "diff_hunk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_head_ref": {
+          "name": "pr_head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_summary": {
+          "name": "intent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_files": {
+          "name": "related_files",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_session_id": {
+          "name": "cli_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_branch": {
+          "name": "pr_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_auto_fix_tickets_repo_issue": {
+          "name": "UQ_auto_fix_tickets_repo_issue",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auto_fix_tickets\".\"trigger_source\" = 'label'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_auto_fix_tickets_repo_review_comment": {
+          "name": "UQ_auto_fix_tickets_repo_review_comment",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auto_fix_tickets\".\"review_comment_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_owned_by_org": {
+          "name": "IDX_auto_fix_tickets_owned_by_org",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_owned_by_user": {
+          "name": "IDX_auto_fix_tickets_owned_by_user",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_status": {
+          "name": "IDX_auto_fix_tickets_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_created_at": {
+          "name": "IDX_auto_fix_tickets_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_triage_ticket_id": {
+          "name": "IDX_auto_fix_tickets_triage_ticket_id",
+          "columns": [
+            {
+              "expression": "triage_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_fix_tickets_session_id": {
+          "name": "IDX_auto_fix_tickets_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auto_fix_tickets_owned_by_organization_id_organizations_id_fk": {
+          "name": "auto_fix_tickets_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "auto_fix_tickets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_fix_tickets_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "auto_fix_tickets_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "auto_fix_tickets",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_fix_tickets_platform_integration_id_platform_integrations_id_fk": {
+          "name": "auto_fix_tickets_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "auto_fix_tickets",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auto_fix_tickets_triage_ticket_id_auto_triage_tickets_id_fk": {
+          "name": "auto_fix_tickets_triage_ticket_id_auto_triage_tickets_id_fk",
+          "tableFrom": "auto_fix_tickets",
+          "tableTo": "auto_triage_tickets",
+          "columnsFrom": [
+            "triage_ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auto_fix_tickets_cli_session_id_cli_sessions_session_id_fk": {
+          "name": "auto_fix_tickets_cli_session_id_cli_sessions_session_id_fk",
+          "tableFrom": "auto_fix_tickets",
+          "tableTo": "cli_sessions",
+          "columnsFrom": [
+            "cli_session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auto_fix_tickets_owner_check": {
+          "name": "auto_fix_tickets_owner_check",
+          "value": "(\n        (\"auto_fix_tickets\".\"owned_by_user_id\" IS NOT NULL AND \"auto_fix_tickets\".\"owned_by_organization_id\" IS NULL) OR\n        (\"auto_fix_tickets\".\"owned_by_user_id\" IS NULL AND \"auto_fix_tickets\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "auto_fix_tickets_status_check": {
+          "name": "auto_fix_tickets_status_check",
+          "value": "\"auto_fix_tickets\".\"status\" IN ('pending', 'running', 'completed', 'failed', 'cancelled')"
+        },
+        "auto_fix_tickets_classification_check": {
+          "name": "auto_fix_tickets_classification_check",
+          "value": "\"auto_fix_tickets\".\"classification\" IN ('bug', 'feature', 'question', 'unclear')"
+        },
+        "auto_fix_tickets_confidence_check": {
+          "name": "auto_fix_tickets_confidence_check",
+          "value": "\"auto_fix_tickets\".\"confidence\" >= 0 AND \"auto_fix_tickets\".\"confidence\" <= 1"
+        },
+        "auto_fix_tickets_trigger_source_check": {
+          "name": "auto_fix_tickets_trigger_source_check",
+          "value": "\"auto_fix_tickets\".\"trigger_source\" IN ('label', 'review_comment')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auto_model": {
+      "name": "auto_model",
+      "schema": "",
+      "columns": {
+        "auto_model_id": {
+          "name": "auto_model_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auto_model": {
+          "name": "auto_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_auto_model": {
+          "name": "UQ_auto_model",
+          "columns": [
+            {
+              "expression": "auto_model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_top_up_configs": {
+      "name": "auto_top_up_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_method_id": {
+          "name": "stripe_payment_method_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5000
+        },
+        "last_auto_top_up_at": {
+          "name": "last_auto_top_up_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_started_at": {
+          "name": "attempt_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_auto_top_up_configs_owned_by_user_id": {
+          "name": "UQ_auto_top_up_configs_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auto_top_up_configs\".\"owned_by_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_auto_top_up_configs_owned_by_organization_id": {
+          "name": "UQ_auto_top_up_configs_owned_by_organization_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auto_top_up_configs\".\"owned_by_organization_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auto_top_up_configs_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "auto_top_up_configs_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "auto_top_up_configs",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "auto_top_up_configs_owned_by_organization_id_organizations_id_fk": {
+          "name": "auto_top_up_configs_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "auto_top_up_configs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auto_top_up_configs_exactly_one_owner": {
+          "name": "auto_top_up_configs_exactly_one_owner",
+          "value": "(\"auto_top_up_configs\".\"owned_by_user_id\" IS NOT NULL AND \"auto_top_up_configs\".\"owned_by_organization_id\" IS NULL) OR (\"auto_top_up_configs\".\"owned_by_user_id\" IS NULL AND \"auto_top_up_configs\".\"owned_by_organization_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auto_triage_tickets": {
+      "name": "auto_triage_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_url": {
+          "name": "issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_title": {
+          "name": "issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_body": {
+          "name": "issue_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_author": {
+          "name": "issue_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_labels": {
+          "name": "issue_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_summary": {
+          "name": "intent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_files": {
+          "name": "related_files",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_duplicate": {
+          "name": "is_duplicate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "duplicate_of_ticket_id": {
+          "name": "duplicate_of_ticket_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "similarity_score": {
+          "name": "similarity_score",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qdrant_point_id": {
+          "name": "qdrant_point_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "should_auto_fix": {
+          "name": "should_auto_fix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_metadata": {
+          "name": "action_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_auto_triage_tickets_repo_issue": {
+          "name": "UQ_auto_triage_tickets_repo_issue",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_owned_by_org": {
+          "name": "IDX_auto_triage_tickets_owned_by_org",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_owned_by_user": {
+          "name": "IDX_auto_triage_tickets_owned_by_user",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_status": {
+          "name": "IDX_auto_triage_tickets_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_created_at": {
+          "name": "IDX_auto_triage_tickets_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_qdrant_point_id": {
+          "name": "IDX_auto_triage_tickets_qdrant_point_id",
+          "columns": [
+            {
+              "expression": "qdrant_point_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_owner_status_created": {
+          "name": "IDX_auto_triage_tickets_owner_status_created",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_user_status_created": {
+          "name": "IDX_auto_triage_tickets_user_status_created",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_auto_triage_tickets_repo_classification": {
+          "name": "IDX_auto_triage_tickets_repo_classification",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auto_triage_tickets_owned_by_organization_id_organizations_id_fk": {
+          "name": "auto_triage_tickets_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "auto_triage_tickets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_triage_tickets_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "auto_triage_tickets_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "auto_triage_tickets",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_triage_tickets_platform_integration_id_platform_integrations_id_fk": {
+          "name": "auto_triage_tickets_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "auto_triage_tickets",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auto_triage_tickets_duplicate_of_ticket_id_auto_triage_tickets_id_fk": {
+          "name": "auto_triage_tickets_duplicate_of_ticket_id_auto_triage_tickets_id_fk",
+          "tableFrom": "auto_triage_tickets",
+          "tableTo": "auto_triage_tickets",
+          "columnsFrom": [
+            "duplicate_of_ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auto_triage_tickets_owner_check": {
+          "name": "auto_triage_tickets_owner_check",
+          "value": "(\n        (\"auto_triage_tickets\".\"owned_by_user_id\" IS NOT NULL AND \"auto_triage_tickets\".\"owned_by_organization_id\" IS NULL) OR\n        (\"auto_triage_tickets\".\"owned_by_user_id\" IS NULL AND \"auto_triage_tickets\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "auto_triage_tickets_issue_type_check": {
+          "name": "auto_triage_tickets_issue_type_check",
+          "value": "\"auto_triage_tickets\".\"issue_type\" IN ('issue', 'pull_request')"
+        },
+        "auto_triage_tickets_classification_check": {
+          "name": "auto_triage_tickets_classification_check",
+          "value": "\"auto_triage_tickets\".\"classification\" IN ('bug', 'feature', 'question', 'duplicate', 'unclear')"
+        },
+        "auto_triage_tickets_confidence_check": {
+          "name": "auto_triage_tickets_confidence_check",
+          "value": "\"auto_triage_tickets\".\"confidence\" >= 0 AND \"auto_triage_tickets\".\"confidence\" <= 1"
+        },
+        "auto_triage_tickets_similarity_score_check": {
+          "name": "auto_triage_tickets_similarity_score_check",
+          "value": "\"auto_triage_tickets\".\"similarity_score\" >= 0 AND \"auto_triage_tickets\".\"similarity_score\" <= 1"
+        },
+        "auto_triage_tickets_status_check": {
+          "name": "auto_triage_tickets_status_check",
+          "value": "\"auto_triage_tickets\".\"status\" IN ('pending', 'analyzing', 'actioned', 'failed', 'skipped')"
+        },
+        "auto_triage_tickets_action_taken_check": {
+          "name": "auto_triage_tickets_action_taken_check",
+          "value": "\"auto_triage_tickets\".\"action_taken\" IN ('pr_created', 'comment_posted', 'closed_duplicate', 'needs_clarification')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bot_requests": {
+      "name": "bot_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_thread_id": {
+          "name": "platform_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_message": {
+          "name": "user_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_used": {
+          "name": "model_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_bot_requests_created_at": {
+          "name": "IDX_bot_requests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_bot_requests_created_by": {
+          "name": "IDX_bot_requests_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_bot_requests_organization_id": {
+          "name": "IDX_bot_requests_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_bot_requests_platform_integration_id": {
+          "name": "IDX_bot_requests_platform_integration_id",
+          "columns": [
+            {
+              "expression": "platform_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_bot_requests_status": {
+          "name": "IDX_bot_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_requests_created_by_kilocode_users_id_fk": {
+          "name": "bot_requests_created_by_kilocode_users_id_fk",
+          "tableFrom": "bot_requests",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bot_requests_organization_id_organizations_id_fk": {
+          "name": "bot_requests_organization_id_organizations_id_fk",
+          "tableFrom": "bot_requests",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bot_requests_platform_integration_id_platform_integrations_id_fk": {
+          "name": "bot_requests_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "bot_requests",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.byok_api_keys": {
+      "name": "byok_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_byok_api_keys_organization_id": {
+          "name": "IDX_byok_api_keys_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_byok_api_keys_kilo_user_id": {
+          "name": "IDX_byok_api_keys_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_byok_api_keys_provider_id": {
+          "name": "IDX_byok_api_keys_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "byok_api_keys_organization_id_organizations_id_fk": {
+          "name": "byok_api_keys_organization_id_organizations_id_fk",
+          "tableFrom": "byok_api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "byok_api_keys_kilo_user_id_kilocode_users_id_fk": {
+          "name": "byok_api_keys_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "byok_api_keys",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_byok_api_keys_org_provider": {
+          "name": "UQ_byok_api_keys_org_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "provider_id"
+          ]
+        },
+        "UQ_byok_api_keys_user_provider": {
+          "name": "UQ_byok_api_keys_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "kilo_user_id",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "byok_api_keys_owner_check": {
+          "name": "byok_api_keys_owner_check",
+          "value": "(\n        (\"byok_api_keys\".\"kilo_user_id\" IS NOT NULL AND \"byok_api_keys\".\"organization_id\" IS NULL) OR\n        (\"byok_api_keys\".\"kilo_user_id\" IS NULL AND \"byok_api_keys\".\"organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.channel_badge_counts": {
+      "name": "channel_badge_counts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_count": {
+          "name": "badge_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_badge_counts_user_id_kilocode_users_id_fk": {
+          "name": "channel_badge_counts_user_id_kilocode_users_id_fk",
+          "tableFrom": "channel_badge_counts",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_badge_counts_user_id_channel_id_pk": {
+          "name": "channel_badge_counts_user_id_channel_id_pk",
+          "columns": [
+            "user_id",
+            "channel_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_sessions": {
+      "name": "cli_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_on_platform": {
+          "name": "created_on_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "api_conversation_history_blob_url": {
+          "name": "api_conversation_history_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_metadata_blob_url": {
+          "name": "task_metadata_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ui_messages_blob_url": {
+          "name": "ui_messages_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_state_blob_url": {
+          "name": "git_state_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_mode": {
+          "name": "last_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_model": {
+          "name": "last_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_cli_sessions_kilo_user_id": {
+          "name": "IDX_cli_sessions_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_created_at": {
+          "name": "IDX_cli_sessions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_updated_at": {
+          "name": "IDX_cli_sessions_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_organization_id": {
+          "name": "IDX_cli_sessions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_user_updated": {
+          "name": "IDX_cli_sessions_user_updated",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_sessions_kilo_user_id_kilocode_users_id_fk": {
+          "name": "cli_sessions_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_forked_from_cli_sessions_session_id_fk": {
+          "name": "cli_sessions_forked_from_cli_sessions_session_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "cli_sessions",
+          "columnsFrom": [
+            "forked_from"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_parent_session_id_cli_sessions_session_id_fk": {
+          "name": "cli_sessions_parent_session_id_cli_sessions_session_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "cli_sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_organization_id_organizations_id_fk": {
+          "name": "cli_sessions_organization_id_organizations_id_fk",
+          "tableFrom": "cli_sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_sessions_cloud_agent_session_id_unique": {
+          "name": "cli_sessions_cloud_agent_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cloud_agent_session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_sessions_v2": {
+      "name": "cli_sessions_v2",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_on_platform": {
+          "name": "created_on_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_cli_sessions_v2_parent_session_id_kilo_user_id": {
+          "name": "IDX_cli_sessions_v2_parent_session_id_kilo_user_id",
+          "columns": [
+            {
+              "expression": "parent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_cli_sessions_v2_public_id": {
+          "name": "UQ_cli_sessions_v2_public_id",
+          "columns": [
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cli_sessions_v2\".\"public_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_cli_sessions_v2_cloud_agent_session_id": {
+          "name": "UQ_cli_sessions_v2_cloud_agent_session_id",
+          "columns": [
+            {
+              "expression": "cloud_agent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cli_sessions_v2\".\"cloud_agent_session_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_v2_organization_id": {
+          "name": "IDX_cli_sessions_v2_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_v2_kilo_user_id": {
+          "name": "IDX_cli_sessions_v2_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_v2_created_at": {
+          "name": "IDX_cli_sessions_v2_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cli_sessions_v2_user_updated": {
+          "name": "IDX_cli_sessions_v2_user_updated",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_sessions_v2_kilo_user_id_kilocode_users_id_fk": {
+          "name": "cli_sessions_v2_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "cli_sessions_v2",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_v2_organization_id_organizations_id_fk": {
+          "name": "cli_sessions_v2_organization_id_organizations_id_fk",
+          "tableFrom": "cli_sessions_v2",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "cli_sessions_v2_parent_session_id_kilo_user_id_fk": {
+          "name": "cli_sessions_v2_parent_session_id_kilo_user_id_fk",
+          "tableFrom": "cli_sessions_v2",
+          "tableTo": "cli_sessions_v2",
+          "columnsFrom": [
+            "parent_session_id",
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "session_id",
+            "kilo_user_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "cli_sessions_v2_session_id_kilo_user_id_pk": {
+          "name": "cli_sessions_v2_session_id_kilo_user_id_pk",
+          "columns": [
+            "session_id",
+            "kilo_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_agent_code_reviews": {
+      "name": "cloud_agent_code_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_author": {
+          "name": "pr_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_author_github_id": {
+          "name": "pr_author_github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_ref": {
+          "name": "head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "platform_project_id": {
+          "name": "platform_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_session_id": {
+          "name": "cli_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_reason": {
+          "name": "terminal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'v1'"
+        },
+        "check_run_id": {
+          "name": "check_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens_in": {
+          "name": "total_tokens_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens_out": {
+          "name": "total_tokens_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cost_musd": {
+          "name": "total_cost_musd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_cloud_agent_code_reviews_repo_pr_sha": {
+          "name": "UQ_cloud_agent_code_reviews_repo_pr_sha",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_owned_by_org_id": {
+          "name": "idx_cloud_agent_code_reviews_owned_by_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_owned_by_user_id": {
+          "name": "idx_cloud_agent_code_reviews_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_session_id": {
+          "name": "idx_cloud_agent_code_reviews_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_cli_session_id": {
+          "name": "idx_cloud_agent_code_reviews_cli_session_id",
+          "columns": [
+            {
+              "expression": "cli_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_status": {
+          "name": "idx_cloud_agent_code_reviews_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_repo": {
+          "name": "idx_cloud_agent_code_reviews_repo",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_pr_number": {
+          "name": "idx_cloud_agent_code_reviews_pr_number",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_created_at": {
+          "name": "idx_cloud_agent_code_reviews_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cloud_agent_code_reviews_pr_author_github_id": {
+          "name": "idx_cloud_agent_code_reviews_pr_author_github_id",
+          "columns": [
+            {
+              "expression": "pr_author_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_agent_code_reviews_owned_by_organization_id_organizations_id_fk": {
+          "name": "cloud_agent_code_reviews_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "cloud_agent_code_reviews",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_agent_code_reviews_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "cloud_agent_code_reviews_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "cloud_agent_code_reviews",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_agent_code_reviews_platform_integration_id_platform_integrations_id_fk": {
+          "name": "cloud_agent_code_reviews_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "cloud_agent_code_reviews",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cloud_agent_code_reviews_owner_check": {
+          "name": "cloud_agent_code_reviews_owner_check",
+          "value": "(\n        (\"cloud_agent_code_reviews\".\"owned_by_user_id\" IS NOT NULL AND \"cloud_agent_code_reviews\".\"owned_by_organization_id\" IS NULL) OR\n        (\"cloud_agent_code_reviews\".\"owned_by_user_id\" IS NULL AND \"cloud_agent_code_reviews\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cloud_agent_feedback": {
+      "name": "cloud_agent_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streaming": {
+          "name": "is_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_text": {
+          "name": "feedback_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recent_messages": {
+          "name": "recent_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_cloud_agent_feedback_created_at": {
+          "name": "IDX_cloud_agent_feedback_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_feedback_kilo_user_id": {
+          "name": "IDX_cloud_agent_feedback_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_feedback_cloud_agent_session_id": {
+          "name": "IDX_cloud_agent_feedback_cloud_agent_session_id",
+          "columns": [
+            {
+              "expression": "cloud_agent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_agent_feedback_kilo_user_id_kilocode_users_id_fk": {
+          "name": "cloud_agent_feedback_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "cloud_agent_feedback",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "cloud_agent_feedback_organization_id_organizations_id_fk": {
+          "name": "cloud_agent_feedback_organization_id_organizations_id_fk",
+          "tableFrom": "cloud_agent_feedback",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloud_agent_webhook_triggers": {
+      "name": "cloud_agent_webhook_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloud_agent'"
+        },
+        "kiloclaw_instance_id": {
+          "name": "kiloclaw_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activation_mode": {
+          "name": "activation_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'webhook'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron_timezone": {
+          "name": "cron_timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_cloud_agent_webhook_triggers_user_trigger": {
+          "name": "UQ_cloud_agent_webhook_triggers_user_trigger",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cloud_agent_webhook_triggers\".\"user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_cloud_agent_webhook_triggers_org_trigger": {
+          "name": "UQ_cloud_agent_webhook_triggers_org_trigger",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cloud_agent_webhook_triggers\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_webhook_triggers_user": {
+          "name": "IDX_cloud_agent_webhook_triggers_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_webhook_triggers_org": {
+          "name": "IDX_cloud_agent_webhook_triggers_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_webhook_triggers_active": {
+          "name": "IDX_cloud_agent_webhook_triggers_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_cloud_agent_webhook_triggers_profile": {
+          "name": "IDX_cloud_agent_webhook_triggers_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloud_agent_webhook_triggers_user_id_kilocode_users_id_fk": {
+          "name": "cloud_agent_webhook_triggers_user_id_kilocode_users_id_fk",
+          "tableFrom": "cloud_agent_webhook_triggers",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_agent_webhook_triggers_organization_id_organizations_id_fk": {
+          "name": "cloud_agent_webhook_triggers_organization_id_organizations_id_fk",
+          "tableFrom": "cloud_agent_webhook_triggers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloud_agent_webhook_triggers_kiloclaw_instance_id_kiloclaw_instances_id_fk": {
+          "name": "cloud_agent_webhook_triggers_kiloclaw_instance_id_kiloclaw_instances_id_fk",
+          "tableFrom": "cloud_agent_webhook_triggers",
+          "tableTo": "kiloclaw_instances",
+          "columnsFrom": [
+            "kiloclaw_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cloud_agent_webhook_triggers_profile_id_agent_environment_profiles_id_fk": {
+          "name": "cloud_agent_webhook_triggers_profile_id_agent_environment_profiles_id_fk",
+          "tableFrom": "cloud_agent_webhook_triggers",
+          "tableTo": "agent_environment_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "CHK_cloud_agent_webhook_triggers_owner": {
+          "name": "CHK_cloud_agent_webhook_triggers_owner",
+          "value": "(\n        (\"cloud_agent_webhook_triggers\".\"user_id\" IS NOT NULL AND \"cloud_agent_webhook_triggers\".\"organization_id\" IS NULL) OR\n        (\"cloud_agent_webhook_triggers\".\"user_id\" IS NULL AND \"cloud_agent_webhook_triggers\".\"organization_id\" IS NOT NULL)\n      )"
+        },
+        "CHK_cloud_agent_webhook_triggers_cloud_agent_fields": {
+          "name": "CHK_cloud_agent_webhook_triggers_cloud_agent_fields",
+          "value": "(\n        \"cloud_agent_webhook_triggers\".\"target_type\" != 'cloud_agent' OR\n        (\"cloud_agent_webhook_triggers\".\"github_repo\" IS NOT NULL AND \"cloud_agent_webhook_triggers\".\"profile_id\" IS NOT NULL)\n      )"
+        },
+        "CHK_cloud_agent_webhook_triggers_kiloclaw_fields": {
+          "name": "CHK_cloud_agent_webhook_triggers_kiloclaw_fields",
+          "value": "(\n        \"cloud_agent_webhook_triggers\".\"target_type\" != 'kiloclaw_chat' OR\n        \"cloud_agent_webhook_triggers\".\"kiloclaw_instance_id\" IS NOT NULL\n      )"
+        },
+        "CHK_cloud_agent_webhook_triggers_scheduled_fields": {
+          "name": "CHK_cloud_agent_webhook_triggers_scheduled_fields",
+          "value": "(\n        \"cloud_agent_webhook_triggers\".\"activation_mode\" != 'scheduled' OR\n        \"cloud_agent_webhook_triggers\".\"cron_expression\" IS NOT NULL\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.code_indexing_manifest": {
+      "name": "code_indexing_manifest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_count": {
+          "name": "chunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_lines": {
+          "name": "total_lines",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_ai_lines": {
+          "name": "total_ai_lines",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_code_indexing_manifest_organization_id": {
+          "name": "IDX_code_indexing_manifest_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_manifest_kilo_user_id": {
+          "name": "IDX_code_indexing_manifest_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_manifest_project_id": {
+          "name": "IDX_code_indexing_manifest_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_manifest_file_hash": {
+          "name": "IDX_code_indexing_manifest_file_hash",
+          "columns": [
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_manifest_git_branch": {
+          "name": "IDX_code_indexing_manifest_git_branch",
+          "columns": [
+            {
+              "expression": "git_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_manifest_created_at": {
+          "name": "IDX_code_indexing_manifest_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "code_indexing_manifest_kilo_user_id_kilocode_users_id_fk": {
+          "name": "code_indexing_manifest_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "code_indexing_manifest",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_code_indexing_manifest_org_user_project_hash_branch": {
+          "name": "UQ_code_indexing_manifest_org_user_project_hash_branch",
+          "nullsNotDistinct": true,
+          "columns": [
+            "organization_id",
+            "kilo_user_id",
+            "project_id",
+            "file_path",
+            "git_branch"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.code_indexing_search": {
+      "name": "code_indexing_search",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_code_indexing_search_organization_id": {
+          "name": "IDX_code_indexing_search_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_search_kilo_user_id": {
+          "name": "IDX_code_indexing_search_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_search_project_id": {
+          "name": "IDX_code_indexing_search_project_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_code_indexing_search_created_at": {
+          "name": "IDX_code_indexing_search_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "code_indexing_search_kilo_user_id_kilocode_users_id_fk": {
+          "name": "code_indexing_search_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "code_indexing_search",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contributor_champion_contributors": {
+      "name": "contributor_champion_contributors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "github_login": {
+          "name": "github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_profile_url": {
+          "name": "github_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_contribution_at": {
+          "name": "first_contribution_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contribution_at": {
+          "name": "last_contribution_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_time_contributions": {
+          "name": "all_time_contributions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "manual_email": {
+          "name": "manual_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_contributor_champion_contributors_last_contribution_at": {
+          "name": "IDX_contributor_champion_contributors_last_contribution_at",
+          "columns": [
+            {
+              "expression": "last_contribution_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_contributor_champion_contributors_manual_email": {
+          "name": "IDX_contributor_champion_contributors_manual_email",
+          "columns": [
+            {
+              "expression": "manual_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_contributor_champion_contributors_github_login": {
+          "name": "UQ_contributor_champion_contributors_github_login",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_login"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contributor_champion_events": {
+      "name": "contributor_champion_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "contributor_id": {
+          "name": "contributor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_pr_number": {
+          "name": "github_pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_pr_url": {
+          "name": "github_pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_pr_title": {
+          "name": "github_pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_author_login": {
+          "name": "github_author_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_author_email": {
+          "name": "github_author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_contributor_champion_events_contributor_id": {
+          "name": "IDX_contributor_champion_events_contributor_id",
+          "columns": [
+            {
+              "expression": "contributor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_contributor_champion_events_merged_at": {
+          "name": "IDX_contributor_champion_events_merged_at",
+          "columns": [
+            {
+              "expression": "merged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_contributor_champion_events_author_email": {
+          "name": "IDX_contributor_champion_events_author_email",
+          "columns": [
+            {
+              "expression": "github_author_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contributor_champion_events_contributor_id_contributor_champion_contributors_id_fk": {
+          "name": "contributor_champion_events_contributor_id_contributor_champion_contributors_id_fk",
+          "tableFrom": "contributor_champion_events",
+          "tableTo": "contributor_champion_contributors",
+          "columnsFrom": [
+            "contributor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_contributor_champion_events_repo_pr": {
+          "name": "UQ_contributor_champion_events_repo_pr",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repo_full_name",
+            "github_pr_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contributor_champion_memberships": {
+      "name": "contributor_champion_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "contributor_id": {
+          "name": "contributor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_tier": {
+          "name": "selected_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_tier": {
+          "name": "enrolled_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_amount_microdollars": {
+          "name": "credit_amount_microdollars",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "credits_last_granted_at": {
+          "name": "credits_last_granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_kilo_user_id": {
+          "name": "linked_kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_contributor_champion_memberships_credits_due": {
+          "name": "IDX_contributor_champion_memberships_credits_due",
+          "columns": [
+            {
+              "expression": "credits_last_granted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"contributor_champion_memberships\".\"enrolled_tier\" IS NOT NULL AND \"contributor_champion_memberships\".\"credit_amount_microdollars\" > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_contributor_champion_memberships_linked_kilo_user_id": {
+          "name": "IDX_contributor_champion_memberships_linked_kilo_user_id",
+          "columns": [
+            {
+              "expression": "linked_kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contributor_champion_memberships_contributor_id_contributor_champion_contributors_id_fk": {
+          "name": "contributor_champion_memberships_contributor_id_contributor_champion_contributors_id_fk",
+          "tableFrom": "contributor_champion_memberships",
+          "tableTo": "contributor_champion_contributors",
+          "columnsFrom": [
+            "contributor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "contributor_champion_memberships_linked_kilo_user_id_kilocode_users_id_fk": {
+          "name": "contributor_champion_memberships_linked_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "contributor_champion_memberships",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "linked_kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_contributor_champion_memberships_contributor_id": {
+          "name": "UQ_contributor_champion_memberships_contributor_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contributor_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "contributor_champion_memberships_selected_tier_check": {
+          "name": "contributor_champion_memberships_selected_tier_check",
+          "value": "\"contributor_champion_memberships\".\"selected_tier\" IS NULL OR \"contributor_champion_memberships\".\"selected_tier\" IN ('contributor', 'ambassador', 'champion')"
+        },
+        "contributor_champion_memberships_enrolled_tier_check": {
+          "name": "contributor_champion_memberships_enrolled_tier_check",
+          "value": "\"contributor_champion_memberships\".\"enrolled_tier\" IS NULL OR \"contributor_champion_memberships\".\"enrolled_tier\" IN ('contributor', 'ambassador', 'champion')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.contributor_champion_sync_state": {
+      "name": "contributor_champion_sync_state",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_merged_at": {
+          "name": "last_merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_transactions": {
+      "name": "credit_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_microdollars": {
+          "name": "amount_microdollars",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration_baseline_microdollars_used": {
+          "name": "expiration_baseline_microdollars_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_baseline_microdollars_used": {
+          "name": "original_baseline_microdollars_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_free": {
+          "name": "is_free",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_transaction_id": {
+          "name": "original_transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coinbase_credit_block_id": {
+          "name": "coinbase_credit_block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_category": {
+          "name": "credit_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_category_uniqueness": {
+          "name": "check_category_uniqueness",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "IDX_credit_transactions_created_at": {
+          "name": "IDX_credit_transactions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_is_free": {
+          "name": "IDX_credit_transactions_is_free",
+          "columns": [
+            {
+              "expression": "is_free",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_kilo_user_id": {
+          "name": "IDX_credit_transactions_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_credit_category": {
+          "name": "IDX_credit_transactions_credit_category",
+          "columns": [
+            {
+              "expression": "credit_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_stripe_payment_id": {
+          "name": "IDX_credit_transactions_stripe_payment_id",
+          "columns": [
+            {
+              "expression": "stripe_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_original_transaction_id": {
+          "name": "IDX_credit_transactions_original_transaction_id",
+          "columns": [
+            {
+              "expression": "original_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_coinbase_credit_block_id": {
+          "name": "IDX_credit_transactions_coinbase_credit_block_id",
+          "columns": [
+            {
+              "expression": "coinbase_credit_block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_organization_id": {
+          "name": "IDX_credit_transactions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_credit_transactions_unique_category": {
+          "name": "IDX_credit_transactions_unique_category",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "credit_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_transactions\".\"check_category_uniqueness\" = TRUE",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_llm2": {
+      "name": "custom_llm2",
+      "schema": "",
+      "columns": {
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_builds": {
+      "name": "deployment_builds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deployment_builds_deployment_id": {
+          "name": "idx_deployment_builds_deployment_id",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployment_builds_status": {
+          "name": "idx_deployment_builds_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_builds_deployment_id_deployments_id_fk": {
+          "name": "deployment_builds_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_builds",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_env_vars": {
+      "name": "deployment_env_vars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deployment_env_vars_deployment_id": {
+          "name": "idx_deployment_env_vars_deployment_id",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_env_vars_deployment_id_deployments_id_fk": {
+          "name": "deployment_env_vars_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_env_vars",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_deployment_env_vars_deployment_key": {
+          "name": "UQ_deployment_env_vars_deployment_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deployment_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_events": {
+      "name": "deployment_events",
+      "schema": "",
+      "columns": {
+        "build_id": {
+          "name": "build_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'log'"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_deployment_events_build_id": {
+          "name": "idx_deployment_events_build_id",
+          "columns": [
+            {
+              "expression": "build_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployment_events_timestamp": {
+          "name": "idx_deployment_events_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployment_events_type": {
+          "name": "idx_deployment_events_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_events_build_id_deployment_builds_id_fk": {
+          "name": "deployment_events_build_id_deployment_builds_id_fk",
+          "tableFrom": "deployment_events",
+          "tableTo": "deployment_builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "deployment_events_build_id_event_id_pk": {
+          "name": "deployment_events_build_id_event_id_pk",
+          "columns": [
+            "build_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_threat_detections": {
+      "name": "deployment_threat_detections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threat_type": {
+          "name": "threat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deployment_threat_detections_deployment_id": {
+          "name": "idx_deployment_threat_detections_deployment_id",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployment_threat_detections_created_at": {
+          "name": "idx_deployment_threat_detections_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_threat_detections_deployment_id_deployments_id_fk": {
+          "name": "deployment_threat_detections_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_threat_detections",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deployment_threat_detections_build_id_deployment_builds_id_fk": {
+          "name": "deployment_threat_detections_build_id_deployment_builds_id_fk",
+          "tableFrom": "deployment_threat_detections",
+          "tableTo": "deployment_builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployments": {
+      "name": "deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_slug": {
+          "name": "deployment_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_worker_name": {
+          "name": "internal_worker_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_source": {
+          "name": "repository_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_url": {
+          "name": "deployment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "git_auth_token": {
+          "name": "git_auth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_deployed_at": {
+          "name": "last_deployed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_build_id": {
+          "name": "last_build_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threat_status": {
+          "name": "threat_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from": {
+          "name": "created_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_deployments_owned_by_user_id": {
+          "name": "idx_deployments_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployments_owned_by_organization_id": {
+          "name": "idx_deployments_owned_by_organization_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployments_platform_integration_id": {
+          "name": "idx_deployments_platform_integration_id",
+          "columns": [
+            {
+              "expression": "platform_integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployments_repository_source_branch": {
+          "name": "idx_deployments_repository_source_branch",
+          "columns": [
+            {
+              "expression": "repository_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deployments_threat_status_pending": {
+          "name": "idx_deployments_threat_status_pending",
+          "columns": [
+            {
+              "expression": "threat_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"deployments\".\"threat_status\" = 'pending_scan'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployments_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "deployments_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployments_owned_by_organization_id_organizations_id_fk": {
+          "name": "deployments_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_deployments_deployment_slug": {
+          "name": "UQ_deployments_deployment_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deployment_slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "deployments_owner_check": {
+          "name": "deployments_owner_check",
+          "value": "(\n        (\"deployments\".\"owned_by_user_id\" IS NOT NULL AND \"deployments\".\"owned_by_organization_id\" IS NULL) OR\n        (\"deployments\".\"owned_by_user_id\" IS NULL AND \"deployments\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "deployments_source_type_check": {
+          "name": "deployments_source_type_check",
+          "value": "\"deployments\".\"source_type\" IN ('github', 'git', 'app-builder')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_auth_requests": {
+      "name": "device_auth_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_device_auth_requests_code": {
+          "name": "UQ_device_auth_requests_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_device_auth_requests_status": {
+          "name": "IDX_device_auth_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_device_auth_requests_expires_at": {
+          "name": "IDX_device_auth_requests_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_device_auth_requests_kilo_user_id": {
+          "name": "IDX_device_auth_requests_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_auth_requests_kilo_user_id_kilocode_users_id_fk": {
+          "name": "device_auth_requests_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "device_auth_requests",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_gateway_listener": {
+      "name": "discord_gateway_listener",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "listener_id": {
+          "name": "listener_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.editor_name": {
+      "name": "editor_name",
+      "schema": "",
+      "columns": {
+        "editor_name_id": {
+          "name": "editor_name_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "editor_name": {
+          "name": "editor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_editor_name": {
+          "name": "UQ_editor_name",
+          "columns": [
+            {
+              "expression": "editor_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichment_data": {
+      "name": "enrichment_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_enrichment_data": {
+          "name": "github_enrichment_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_enrichment_data": {
+          "name": "linkedin_enrichment_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clay_enrichment_data": {
+          "name": "clay_enrichment_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_enrichment_data_user_id": {
+          "name": "IDX_enrichment_data_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrichment_data_user_id_kilocode_users_id_fk": {
+          "name": "enrichment_data_user_id_kilocode_users_id_fk",
+          "tableFrom": "enrichment_data",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_enrichment_data_user_id": {
+          "name": "UQ_enrichment_data_user_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exa_monthly_usage": {
+      "name": "exa_monthly_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month": {
+          "name": "month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost_microdollars": {
+          "name": "total_cost_microdollars",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_charged_microdollars": {
+          "name": "total_charged_microdollars",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "free_allowance_microdollars": {
+          "name": "free_allowance_microdollars",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000000
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_exa_monthly_usage_personal": {
+          "name": "idx_exa_monthly_usage_personal",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"exa_monthly_usage\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_exa_monthly_usage_org": {
+          "name": "idx_exa_monthly_usage_org",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"exa_monthly_usage\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exa_usage_log": {
+      "name": "exa_usage_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_microdollars": {
+          "name": "cost_microdollars",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "charged_to_balance": {
+          "name": "charged_to_balance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_exa_usage_log_user_created": {
+          "name": "idx_exa_usage_log_user_created",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "exa_usage_log_id_created_at_pk": {
+          "name": "exa_usage_log_id_created_at_pk",
+          "columns": [
+            "id",
+            "created_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature": {
+      "name": "feature",
+      "schema": "",
+      "columns": {
+        "feature_id": {
+          "name": "feature_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_feature": {
+          "name": "UQ_feature",
+          "columns": [
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finish_reason": {
+      "name": "finish_reason",
+      "schema": "",
+      "columns": {
+        "finish_reason_id": {
+          "name": "finish_reason_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_finish_reason": {
+          "name": "UQ_finish_reason",
+          "columns": [
+            {
+              "expression": "finish_reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.free_model_usage": {
+      "name": "free_model_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_free_model_usage_ip_created_at": {
+          "name": "idx_free_model_usage_ip_created_at",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_free_model_usage_created_at": {
+          "name": "idx_free_model_usage_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_free_model_usage_user_created_at": {
+          "name": "idx_free_model_usage_user_created_at",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"free_model_usage\".\"kilo_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.http_ip": {
+      "name": "http_ip",
+      "schema": "",
+      "columns": {
+        "http_ip_id": {
+          "name": "http_ip_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "http_ip": {
+          "name": "http_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_http_ip": {
+          "name": "UQ_http_ip",
+          "columns": [
+            {
+              "expression": "http_ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.http_user_agent": {
+      "name": "http_user_agent",
+      "schema": "",
+      "columns": {
+        "http_user_agent_id": {
+          "name": "http_user_agent_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "http_user_agent": {
+          "name": "http_user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_http_user_agent": {
+          "name": "UQ_http_user_agent",
+          "columns": [
+            {
+              "expression": "http_user_agent",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ja4_digest": {
+      "name": "ja4_digest",
+      "schema": "",
+      "columns": {
+        "ja4_digest_id": {
+          "name": "ja4_digest_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ja4_digest": {
+          "name": "ja4_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_ja4_digest": {
+          "name": "UQ_ja4_digest",
+          "columns": [
+            {
+              "expression": "ja4_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_audit_log": {
+      "name": "kilo_pass_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilo_pass_subscription_id": {
+          "name": "kilo_pass_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_credit_transaction_id": {
+          "name": "related_credit_transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_monthly_issuance_id": {
+          "name": "related_monthly_issuance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "IDX_kilo_pass_audit_log_created_at": {
+          "name": "IDX_kilo_pass_audit_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_kilo_user_id": {
+          "name": "IDX_kilo_pass_audit_log_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_kilo_pass_subscription_id": {
+          "name": "IDX_kilo_pass_audit_log_kilo_pass_subscription_id",
+          "columns": [
+            {
+              "expression": "kilo_pass_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_action": {
+          "name": "IDX_kilo_pass_audit_log_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_result": {
+          "name": "IDX_kilo_pass_audit_log_result",
+          "columns": [
+            {
+              "expression": "result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_idempotency_key": {
+          "name": "IDX_kilo_pass_audit_log_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_stripe_event_id": {
+          "name": "IDX_kilo_pass_audit_log_stripe_event_id",
+          "columns": [
+            {
+              "expression": "stripe_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_stripe_invoice_id": {
+          "name": "IDX_kilo_pass_audit_log_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_stripe_subscription_id": {
+          "name": "IDX_kilo_pass_audit_log_stripe_subscription_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_related_credit_transaction_id": {
+          "name": "IDX_kilo_pass_audit_log_related_credit_transaction_id",
+          "columns": [
+            {
+              "expression": "related_credit_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_audit_log_related_monthly_issuance_id": {
+          "name": "IDX_kilo_pass_audit_log_related_monthly_issuance_id",
+          "columns": [
+            {
+              "expression": "related_monthly_issuance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_audit_log_kilo_user_id_kilocode_users_id_fk": {
+          "name": "kilo_pass_audit_log_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "kilo_pass_audit_log",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "kilo_pass_audit_log_kilo_pass_subscription_id_kilo_pass_subscriptions_id_fk": {
+          "name": "kilo_pass_audit_log_kilo_pass_subscription_id_kilo_pass_subscriptions_id_fk",
+          "tableFrom": "kilo_pass_audit_log",
+          "tableTo": "kilo_pass_subscriptions",
+          "columnsFrom": [
+            "kilo_pass_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "kilo_pass_audit_log_related_credit_transaction_id_credit_transactions_id_fk": {
+          "name": "kilo_pass_audit_log_related_credit_transaction_id_credit_transactions_id_fk",
+          "tableFrom": "kilo_pass_audit_log",
+          "tableTo": "credit_transactions",
+          "columnsFrom": [
+            "related_credit_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "kilo_pass_audit_log_related_monthly_issuance_id_kilo_pass_issuances_id_fk": {
+          "name": "kilo_pass_audit_log_related_monthly_issuance_id_kilo_pass_issuances_id_fk",
+          "tableFrom": "kilo_pass_audit_log",
+          "tableTo": "kilo_pass_issuances",
+          "columnsFrom": [
+            "related_monthly_issuance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_audit_log_action_check": {
+          "name": "kilo_pass_audit_log_action_check",
+          "value": "\"kilo_pass_audit_log\".\"action\" IN ('stripe_webhook_received', 'kilo_pass_invoice_paid_handled', 'base_credits_issued', 'bonus_credits_issued', 'bonus_credits_skipped_idempotent', 'first_month_50pct_promo_issued', 'yearly_monthly_base_cron_started', 'yearly_monthly_base_cron_completed', 'issue_yearly_remaining_credits', 'yearly_monthly_bonus_cron_started', 'yearly_monthly_bonus_cron_completed')"
+        },
+        "kilo_pass_audit_log_result_check": {
+          "name": "kilo_pass_audit_log_result_check",
+          "value": "\"kilo_pass_audit_log\".\"result\" IN ('success', 'skipped_idempotent', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_issuance_items": {
+      "name": "kilo_pass_issuance_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_pass_issuance_id": {
+          "name": "kilo_pass_issuance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_transaction_id": {
+          "name": "credit_transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bonus_percent_applied": {
+          "name": "bonus_percent_applied",
+          "type": "numeric(6, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kilo_pass_issuance_items_issuance_id": {
+          "name": "IDX_kilo_pass_issuance_items_issuance_id",
+          "columns": [
+            {
+              "expression": "kilo_pass_issuance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_issuance_items_credit_transaction_id": {
+          "name": "IDX_kilo_pass_issuance_items_credit_transaction_id",
+          "columns": [
+            {
+              "expression": "credit_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_issuance_items_kilo_pass_issuance_id_kilo_pass_issuances_id_fk": {
+          "name": "kilo_pass_issuance_items_kilo_pass_issuance_id_kilo_pass_issuances_id_fk",
+          "tableFrom": "kilo_pass_issuance_items",
+          "tableTo": "kilo_pass_issuances",
+          "columnsFrom": [
+            "kilo_pass_issuance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "kilo_pass_issuance_items_credit_transaction_id_credit_transactions_id_fk": {
+          "name": "kilo_pass_issuance_items_credit_transaction_id_credit_transactions_id_fk",
+          "tableFrom": "kilo_pass_issuance_items",
+          "tableTo": "credit_transactions",
+          "columnsFrom": [
+            "credit_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kilo_pass_issuance_items_credit_transaction_id_unique": {
+          "name": "kilo_pass_issuance_items_credit_transaction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credit_transaction_id"
+          ]
+        },
+        "UQ_kilo_pass_issuance_items_issuance_kind": {
+          "name": "UQ_kilo_pass_issuance_items_issuance_kind",
+          "nullsNotDistinct": false,
+          "columns": [
+            "kilo_pass_issuance_id",
+            "kind"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_issuance_items_bonus_percent_applied_range_check": {
+          "name": "kilo_pass_issuance_items_bonus_percent_applied_range_check",
+          "value": "\"kilo_pass_issuance_items\".\"bonus_percent_applied\" IS NULL OR (\"kilo_pass_issuance_items\".\"bonus_percent_applied\" >= 0 AND \"kilo_pass_issuance_items\".\"bonus_percent_applied\" <= 1)"
+        },
+        "kilo_pass_issuance_items_amount_usd_non_negative_check": {
+          "name": "kilo_pass_issuance_items_amount_usd_non_negative_check",
+          "value": "\"kilo_pass_issuance_items\".\"amount_usd\" >= 0"
+        },
+        "kilo_pass_issuance_items_kind_check": {
+          "name": "kilo_pass_issuance_items_kind_check",
+          "value": "\"kilo_pass_issuance_items\".\"kind\" IN ('base', 'bonus', 'promo_first_month_50pct')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_issuances": {
+      "name": "kilo_pass_issuances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_pass_subscription_id": {
+          "name": "kilo_pass_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_month": {
+          "name": "issue_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_kilo_pass_issuances_stripe_invoice_id": {
+          "name": "UQ_kilo_pass_issuances_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kilo_pass_issuances\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_issuances_subscription_id": {
+          "name": "IDX_kilo_pass_issuances_subscription_id",
+          "columns": [
+            {
+              "expression": "kilo_pass_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_issuances_issue_month": {
+          "name": "IDX_kilo_pass_issuances_issue_month",
+          "columns": [
+            {
+              "expression": "issue_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_issuances_kilo_pass_subscription_id_kilo_pass_subscriptions_id_fk": {
+          "name": "kilo_pass_issuances_kilo_pass_subscription_id_kilo_pass_subscriptions_id_fk",
+          "tableFrom": "kilo_pass_issuances",
+          "tableTo": "kilo_pass_subscriptions",
+          "columnsFrom": [
+            "kilo_pass_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_kilo_pass_issuances_subscription_issue_month": {
+          "name": "UQ_kilo_pass_issuances_subscription_issue_month",
+          "nullsNotDistinct": false,
+          "columns": [
+            "kilo_pass_subscription_id",
+            "issue_month"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_issuances_issue_month_day_one_check": {
+          "name": "kilo_pass_issuances_issue_month_day_one_check",
+          "value": "EXTRACT(DAY FROM \"kilo_pass_issuances\".\"issue_month\") = 1"
+        },
+        "kilo_pass_issuances_source_check": {
+          "name": "kilo_pass_issuances_source_check",
+          "value": "\"kilo_pass_issuances\".\"source\" IN ('stripe_invoice', 'cron')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_pause_events": {
+      "name": "kilo_pass_pause_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_pass_subscription_id": {
+          "name": "kilo_pass_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resumes_at": {
+          "name": "resumes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_at": {
+          "name": "resumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kilo_pass_pause_events_subscription_id": {
+          "name": "IDX_kilo_pass_pause_events_subscription_id",
+          "columns": [
+            {
+              "expression": "kilo_pass_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_kilo_pass_pause_events_one_open_per_sub": {
+          "name": "UQ_kilo_pass_pause_events_one_open_per_sub",
+          "columns": [
+            {
+              "expression": "kilo_pass_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kilo_pass_pause_events\".\"resumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_pause_events_kilo_pass_subscription_id_kilo_pass_subscriptions_id_fk": {
+          "name": "kilo_pass_pause_events_kilo_pass_subscription_id_kilo_pass_subscriptions_id_fk",
+          "tableFrom": "kilo_pass_pause_events",
+          "tableTo": "kilo_pass_subscriptions",
+          "columnsFrom": [
+            "kilo_pass_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_pause_events_resumed_at_after_paused_at_check": {
+          "name": "kilo_pass_pause_events_resumed_at_after_paused_at_check",
+          "value": "\"kilo_pass_pause_events\".\"resumed_at\" IS NULL OR \"kilo_pass_pause_events\".\"resumed_at\" >= \"kilo_pass_pause_events\".\"paused_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_scheduled_changes": {
+      "name": "kilo_pass_scheduled_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_tier": {
+          "name": "from_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_cadence": {
+          "name": "from_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_tier": {
+          "name": "to_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_cadence": {
+          "name": "to_cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kilo_pass_scheduled_changes_kilo_user_id": {
+          "name": "IDX_kilo_pass_scheduled_changes_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_scheduled_changes_status": {
+          "name": "IDX_kilo_pass_scheduled_changes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_scheduled_changes_stripe_subscription_id": {
+          "name": "IDX_kilo_pass_scheduled_changes_stripe_subscription_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_kilo_pass_scheduled_changes_active_stripe_subscription_id": {
+          "name": "UQ_kilo_pass_scheduled_changes_active_stripe_subscription_id",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kilo_pass_scheduled_changes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_scheduled_changes_effective_at": {
+          "name": "IDX_kilo_pass_scheduled_changes_effective_at",
+          "columns": [
+            {
+              "expression": "effective_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_scheduled_changes_deleted_at": {
+          "name": "IDX_kilo_pass_scheduled_changes_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_scheduled_changes_kilo_user_id_kilocode_users_id_fk": {
+          "name": "kilo_pass_scheduled_changes_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "kilo_pass_scheduled_changes",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "kilo_pass_scheduled_changes_stripe_subscription_id_kilo_pass_subscriptions_stripe_subscription_id_fk": {
+          "name": "kilo_pass_scheduled_changes_stripe_subscription_id_kilo_pass_subscriptions_stripe_subscription_id_fk",
+          "tableFrom": "kilo_pass_scheduled_changes",
+          "tableTo": "kilo_pass_subscriptions",
+          "columnsFrom": [
+            "stripe_subscription_id"
+          ],
+          "columnsTo": [
+            "stripe_subscription_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_scheduled_changes_from_tier_check": {
+          "name": "kilo_pass_scheduled_changes_from_tier_check",
+          "value": "\"kilo_pass_scheduled_changes\".\"from_tier\" IN ('tier_19', 'tier_49', 'tier_199')"
+        },
+        "kilo_pass_scheduled_changes_from_cadence_check": {
+          "name": "kilo_pass_scheduled_changes_from_cadence_check",
+          "value": "\"kilo_pass_scheduled_changes\".\"from_cadence\" IN ('monthly', 'yearly')"
+        },
+        "kilo_pass_scheduled_changes_to_tier_check": {
+          "name": "kilo_pass_scheduled_changes_to_tier_check",
+          "value": "\"kilo_pass_scheduled_changes\".\"to_tier\" IN ('tier_19', 'tier_49', 'tier_199')"
+        },
+        "kilo_pass_scheduled_changes_to_cadence_check": {
+          "name": "kilo_pass_scheduled_changes_to_cadence_check",
+          "value": "\"kilo_pass_scheduled_changes\".\"to_cadence\" IN ('monthly', 'yearly')"
+        },
+        "kilo_pass_scheduled_changes_status_check": {
+          "name": "kilo_pass_scheduled_changes_status_check",
+          "value": "\"kilo_pass_scheduled_changes\".\"status\" IN ('not_started', 'active', 'completed', 'released', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kilo_pass_subscriptions": {
+      "name": "kilo_pass_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cadence": {
+          "name": "cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_streak_months": {
+          "name": "current_streak_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_yearly_issue_at": {
+          "name": "next_yearly_issue_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kilo_pass_subscriptions_kilo_user_id": {
+          "name": "IDX_kilo_pass_subscriptions_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_subscriptions_status": {
+          "name": "IDX_kilo_pass_subscriptions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kilo_pass_subscriptions_cadence": {
+          "name": "IDX_kilo_pass_subscriptions_cadence",
+          "columns": [
+            {
+              "expression": "cadence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kilo_pass_subscriptions_kilo_user_id_kilocode_users_id_fk": {
+          "name": "kilo_pass_subscriptions_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "kilo_pass_subscriptions",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kilo_pass_subscriptions_stripe_subscription_id_unique": {
+          "name": "kilo_pass_subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "kilo_pass_subscriptions_current_streak_months_non_negative_check": {
+          "name": "kilo_pass_subscriptions_current_streak_months_non_negative_check",
+          "value": "\"kilo_pass_subscriptions\".\"current_streak_months\" >= 0"
+        },
+        "kilo_pass_subscriptions_tier_check": {
+          "name": "kilo_pass_subscriptions_tier_check",
+          "value": "\"kilo_pass_subscriptions\".\"tier\" IN ('tier_19', 'tier_49', 'tier_199')"
+        },
+        "kilo_pass_subscriptions_cadence_check": {
+          "name": "kilo_pass_subscriptions_cadence_check",
+          "value": "\"kilo_pass_subscriptions\".\"cadence\" IN ('monthly', 'yearly')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_access_codes": {
+      "name": "kiloclaw_access_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_kiloclaw_access_codes_code": {
+          "name": "UQ_kiloclaw_access_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_access_codes_user_status": {
+          "name": "IDX_kiloclaw_access_codes_user_status",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_kiloclaw_access_codes_one_active_per_user": {
+          "name": "UQ_kiloclaw_access_codes_one_active_per_user",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kiloclaw_access_codes_kilo_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_access_codes_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_access_codes",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_admin_audit_logs": {
+      "name": "kiloclaw_admin_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kiloclaw_admin_audit_logs_target_user_id": {
+          "name": "IDX_kiloclaw_admin_audit_logs_target_user_id",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_admin_audit_logs_action": {
+          "name": "IDX_kiloclaw_admin_audit_logs_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_admin_audit_logs_created_at": {
+          "name": "IDX_kiloclaw_admin_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_cli_runs": {
+      "name": "kiloclaw_cli_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiated_by_admin_id": {
+          "name": "initiated_by_admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_kiloclaw_cli_runs_user_id": {
+          "name": "IDX_kiloclaw_cli_runs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_cli_runs_started_at": {
+          "name": "IDX_kiloclaw_cli_runs_started_at",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_cli_runs_instance_id": {
+          "name": "IDX_kiloclaw_cli_runs_instance_id",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kiloclaw_cli_runs_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_cli_runs_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_cli_runs",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kiloclaw_cli_runs_instance_id_kiloclaw_instances_id_fk": {
+          "name": "kiloclaw_cli_runs_instance_id_kiloclaw_instances_id_fk",
+          "tableFrom": "kiloclaw_cli_runs",
+          "tableTo": "kiloclaw_instances",
+          "columnsFrom": [
+            "instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "kiloclaw_cli_runs_initiated_by_admin_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_cli_runs_initiated_by_admin_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_cli_runs",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "initiated_by_admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_earlybird_purchases": {
+      "name": "kiloclaw_earlybird_purchases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_payment_id": {
+          "name": "manual_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kiloclaw_earlybird_purchases_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_earlybird_purchases_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_earlybird_purchases",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kiloclaw_earlybird_purchases_user_id_unique": {
+          "name": "kiloclaw_earlybird_purchases_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "kiloclaw_earlybird_purchases_stripe_charge_id_unique": {
+          "name": "kiloclaw_earlybird_purchases_stripe_charge_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_charge_id"
+          ]
+        },
+        "kiloclaw_earlybird_purchases_manual_payment_id_unique": {
+          "name": "kiloclaw_earlybird_purchases_manual_payment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "manual_payment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_email_log": {
+      "name": "kiloclaw_email_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_kiloclaw_email_log_user_type": {
+          "name": "UQ_kiloclaw_email_log_user_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kiloclaw_email_log_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_email_log_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_email_log",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_image_catalog": {
+      "name": "kiloclaw_image_catalog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "openclaw_version": {
+          "name": "openclaw_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "image_tag": {
+          "name": "image_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_digest": {
+          "name": "image_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kiloclaw_image_catalog_status": {
+          "name": "IDX_kiloclaw_image_catalog_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_image_catalog_variant": {
+          "name": "IDX_kiloclaw_image_catalog_variant",
+          "columns": [
+            {
+              "expression": "variant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kiloclaw_image_catalog_image_tag_unique": {
+          "name": "kiloclaw_image_catalog_image_tag_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "image_tag"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_instances": {
+      "name": "kiloclaw_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "destroyed_at": {
+          "name": "destroyed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "UQ_kiloclaw_instances_active": {
+          "name": "UQ_kiloclaw_instances_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kiloclaw_instances\".\"destroyed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kiloclaw_instances_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_instances_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_instances",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kiloclaw_instances_organization_id_organizations_id_fk": {
+          "name": "kiloclaw_instances_organization_id_organizations_id_fk",
+          "tableFrom": "kiloclaw_instances",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_subscriptions": {
+      "name": "kiloclaw_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_source": {
+          "name": "payment_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_plan": {
+          "name": "scheduled_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_by": {
+          "name": "scheduled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pending_conversion": {
+          "name": "pending_conversion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trial_started_at": {
+          "name": "trial_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_renewal_at": {
+          "name": "credit_renewal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_ends_at": {
+          "name": "commit_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_due_since": {
+          "name": "past_due_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destruction_deadline": {
+          "name": "destruction_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_resume_requested_at": {
+          "name": "auto_resume_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_resume_retry_after": {
+          "name": "auto_resume_retry_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_resume_attempt_count": {
+          "name": "auto_resume_attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "auto_top_up_triggered_for_period": {
+          "name": "auto_top_up_triggered_for_period",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_kiloclaw_subscriptions_status": {
+          "name": "IDX_kiloclaw_subscriptions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_subscriptions_stripe_schedule_id": {
+          "name": "IDX_kiloclaw_subscriptions_stripe_schedule_id",
+          "columns": [
+            {
+              "expression": "stripe_schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_kiloclaw_subscriptions_auto_resume_retry_after": {
+          "name": "IDX_kiloclaw_subscriptions_auto_resume_retry_after",
+          "columns": [
+            {
+              "expression": "auto_resume_retry_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_kiloclaw_subscriptions_instance": {
+          "name": "UQ_kiloclaw_subscriptions_instance",
+          "columns": [
+            {
+              "expression": "instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kiloclaw_subscriptions\".\"instance_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kiloclaw_subscriptions_user_id_kilocode_users_id_fk": {
+          "name": "kiloclaw_subscriptions_user_id_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_subscriptions",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kiloclaw_subscriptions_instance_id_kiloclaw_instances_id_fk": {
+          "name": "kiloclaw_subscriptions_instance_id_kiloclaw_instances_id_fk",
+          "tableFrom": "kiloclaw_subscriptions",
+          "tableTo": "kiloclaw_instances",
+          "columnsFrom": [
+            "instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kiloclaw_subscriptions_stripe_subscription_id_unique": {
+          "name": "kiloclaw_subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "kiloclaw_subscriptions_plan_check": {
+          "name": "kiloclaw_subscriptions_plan_check",
+          "value": "\"kiloclaw_subscriptions\".\"plan\" IN ('trial', 'commit', 'standard')"
+        },
+        "kiloclaw_subscriptions_scheduled_plan_check": {
+          "name": "kiloclaw_subscriptions_scheduled_plan_check",
+          "value": "\"kiloclaw_subscriptions\".\"scheduled_plan\" IN ('commit', 'standard')"
+        },
+        "kiloclaw_subscriptions_scheduled_by_check": {
+          "name": "kiloclaw_subscriptions_scheduled_by_check",
+          "value": "\"kiloclaw_subscriptions\".\"scheduled_by\" IN ('auto', 'user')"
+        },
+        "kiloclaw_subscriptions_status_check": {
+          "name": "kiloclaw_subscriptions_status_check",
+          "value": "\"kiloclaw_subscriptions\".\"status\" IN ('trialing', 'active', 'past_due', 'canceled', 'unpaid')"
+        },
+        "kiloclaw_subscriptions_payment_source_check": {
+          "name": "kiloclaw_subscriptions_payment_source_check",
+          "value": "\"kiloclaw_subscriptions\".\"payment_source\" IN ('stripe', 'credits')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kiloclaw_version_pins": {
+      "name": "kiloclaw_version_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_tag": {
+          "name": "image_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_by": {
+          "name": "pinned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kiloclaw_version_pins_instance_id_kiloclaw_instances_id_fk": {
+          "name": "kiloclaw_version_pins_instance_id_kiloclaw_instances_id_fk",
+          "tableFrom": "kiloclaw_version_pins",
+          "tableTo": "kiloclaw_instances",
+          "columnsFrom": [
+            "instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kiloclaw_version_pins_image_tag_kiloclaw_image_catalog_image_tag_fk": {
+          "name": "kiloclaw_version_pins_image_tag_kiloclaw_image_catalog_image_tag_fk",
+          "tableFrom": "kiloclaw_version_pins",
+          "tableTo": "kiloclaw_image_catalog",
+          "columnsFrom": [
+            "image_tag"
+          ],
+          "columnsTo": [
+            "image_tag"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "kiloclaw_version_pins_pinned_by_kilocode_users_id_fk": {
+          "name": "kiloclaw_version_pins_pinned_by_kilocode_users_id_fk",
+          "tableFrom": "kiloclaw_version_pins",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "pinned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kiloclaw_version_pins_instance_id_unique": {
+          "name": "kiloclaw_version_pins_instance_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instance_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kilocode_users": {
+      "name": "kilocode_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_user_email": {
+          "name": "google_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_user_name": {
+          "name": "google_user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_user_image_url": {
+          "name": "google_user_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hosted_domain": {
+          "name": "hosted_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microdollars_used": {
+          "name": "microdollars_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "kilo_pass_threshold": {
+          "name": "kilo_pass_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_microdollars_acquired": {
+          "name": "total_microdollars_acquired",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "next_credit_expiration_at": {
+          "name": "next_credit_expiration_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_validation_stytch": {
+          "name": "has_validation_stytch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_validation_novel_card_with_hold": {
+          "name": "has_validation_novel_card_with_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_token_pepper": {
+          "name": "api_token_pepper",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cohorts": {
+          "name": "cohorts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "completed_welcome_form": {
+          "name": "completed_welcome_form",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "linkedin_url": {
+          "name": "linkedin_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_server_membership_verified_at": {
+          "name": "discord_server_membership_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openrouter_upstream_safety_identifier": {
+          "name": "openrouter_upstream_safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_downstream_safety_identifier": {
+          "name": "vercel_downstream_safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_source": {
+          "name": "customer_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_deletion_requested_at": {
+          "name": "account_deletion_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "UQ_kilocode_users_openrouter_upstream_safety_identifier": {
+          "name": "UQ_kilocode_users_openrouter_upstream_safety_identifier",
+          "columns": [
+            {
+              "expression": "openrouter_upstream_safety_identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kilocode_users\".\"openrouter_upstream_safety_identifier\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_kilocode_users_vercel_downstream_safety_identifier": {
+          "name": "UQ_kilocode_users_vercel_downstream_safety_identifier",
+          "columns": [
+            {
+              "expression": "vercel_downstream_safety_identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kilocode_users\".\"vercel_downstream_safety_identifier\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_b1afacbcf43f2c7c4cb9f7e7faa": {
+          "name": "UQ_b1afacbcf43f2c7c4cb9f7e7faa",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_user_email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "blocked_reason_not_empty": {
+          "name": "blocked_reason_not_empty",
+          "value": "length(blocked_reason) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.magic_link_tokens": {
+      "name": "magic_link_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_magic_link_tokens_email": {
+          "name": "idx_magic_link_tokens_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_magic_link_tokens_expires_at": {
+          "name": "idx_magic_link_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_expires_at_future": {
+          "name": "check_expires_at_future",
+          "value": "\"magic_link_tokens\".\"expires_at\" > \"magic_link_tokens\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.microdollar_usage": {
+      "name": "microdollar_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_hit_tokens": {
+          "name": "cache_hit_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_model": {
+          "name": "requested_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_discount": {
+          "name": "cache_discount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_error": {
+          "name": "has_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "abuse_classification": {
+          "name": "abuse_classification",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inference_provider": {
+          "name": "inference_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_created_at": {
+          "name": "idx_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_abuse_classification": {
+          "name": "idx_abuse_classification",
+          "columns": [
+            {
+              "expression": "abuse_classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kilo_user_id_created_at2": {
+          "name": "idx_kilo_user_id_created_at2",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_microdollar_usage_organization_id": {
+          "name": "idx_microdollar_usage_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"microdollar_usage\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.microdollar_usage_metadata": {
+      "name": "microdollar_usage_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_user_agent_id": {
+          "name": "http_user_agent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_ip_id": {
+          "name": "http_ip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_ip_city_id": {
+          "name": "vercel_ip_city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_ip_country_id": {
+          "name": "vercel_ip_country_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_ip_latitude": {
+          "name": "vercel_ip_latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel_ip_longitude": {
+          "name": "vercel_ip_longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ja4_digest_id": {
+          "name": "ja4_digest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_prompt_prefix": {
+          "name": "user_prompt_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_prefix_id": {
+          "name": "system_prompt_prefix_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_length": {
+          "name": "system_prompt_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_middle_out_transform": {
+          "name": "has_middle_out_transform",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_id": {
+          "name": "upstream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason_id": {
+          "name": "finish_reason_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency": {
+          "name": "latency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_latency": {
+          "name": "moderation_latency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_time": {
+          "name": "generation_time",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_byok": {
+          "name": "is_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_user_byok": {
+          "name": "is_user_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamed": {
+          "name": "streamed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_name_id": {
+          "name": "editor_name_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_kind_id": {
+          "name": "api_kind_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_tools": {
+          "name": "has_tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode_id": {
+          "name": "mode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_model_id": {
+          "name": "auto_model_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "market_cost": {
+          "name": "market_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_free": {
+          "name": "is_free",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_microdollar_usage_metadata_created_at": {
+          "name": "idx_microdollar_usage_metadata_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "microdollar_usage_metadata_http_user_agent_id_http_user_agent_http_user_agent_id_fk": {
+          "name": "microdollar_usage_metadata_http_user_agent_id_http_user_agent_http_user_agent_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "http_user_agent",
+          "columnsFrom": [
+            "http_user_agent_id"
+          ],
+          "columnsTo": [
+            "http_user_agent_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "microdollar_usage_metadata_http_ip_id_http_ip_http_ip_id_fk": {
+          "name": "microdollar_usage_metadata_http_ip_id_http_ip_http_ip_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "http_ip",
+          "columnsFrom": [
+            "http_ip_id"
+          ],
+          "columnsTo": [
+            "http_ip_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "microdollar_usage_metadata_vercel_ip_city_id_vercel_ip_city_vercel_ip_city_id_fk": {
+          "name": "microdollar_usage_metadata_vercel_ip_city_id_vercel_ip_city_vercel_ip_city_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "vercel_ip_city",
+          "columnsFrom": [
+            "vercel_ip_city_id"
+          ],
+          "columnsTo": [
+            "vercel_ip_city_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "microdollar_usage_metadata_vercel_ip_country_id_vercel_ip_country_vercel_ip_country_id_fk": {
+          "name": "microdollar_usage_metadata_vercel_ip_country_id_vercel_ip_country_vercel_ip_country_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "vercel_ip_country",
+          "columnsFrom": [
+            "vercel_ip_country_id"
+          ],
+          "columnsTo": [
+            "vercel_ip_country_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "microdollar_usage_metadata_ja4_digest_id_ja4_digest_ja4_digest_id_fk": {
+          "name": "microdollar_usage_metadata_ja4_digest_id_ja4_digest_ja4_digest_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "ja4_digest",
+          "columnsFrom": [
+            "ja4_digest_id"
+          ],
+          "columnsTo": [
+            "ja4_digest_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "microdollar_usage_metadata_system_prompt_prefix_id_system_prompt_prefix_system_prompt_prefix_id_fk": {
+          "name": "microdollar_usage_metadata_system_prompt_prefix_id_system_prompt_prefix_system_prompt_prefix_id_fk",
+          "tableFrom": "microdollar_usage_metadata",
+          "tableTo": "system_prompt_prefix",
+          "columnsFrom": [
+            "system_prompt_prefix_id"
+          ],
+          "columnsTo": [
+            "system_prompt_prefix_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mode": {
+      "name": "mode",
+      "schema": "",
+      "columns": {
+        "mode_id": {
+          "name": "mode_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_mode": {
+          "name": "UQ_mode",
+          "columns": [
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_stats": {
+      "name": "model_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_stealth": {
+          "name": "is_stealth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_recommended": {
+          "name": "is_recommended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "openrouter_id": {
+          "name": "openrouter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aa_slug": {
+          "name": "aa_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_creator": {
+          "name": "model_creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_slug": {
+          "name": "creator_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_input": {
+          "name": "price_input",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_output": {
+          "name": "price_output",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coding_index": {
+          "name": "coding_index",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_tokens_per_sec": {
+          "name": "speed_tokens_per_sec",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openrouter_data": {
+          "name": "openrouter_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmarks": {
+          "name": "benchmarks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chart_data": {
+          "name": "chart_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_model_stats_openrouter_id": {
+          "name": "IDX_model_stats_openrouter_id",
+          "columns": [
+            {
+              "expression": "openrouter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_slug": {
+          "name": "IDX_model_stats_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_is_active": {
+          "name": "IDX_model_stats_is_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_creator_slug": {
+          "name": "IDX_model_stats_creator_slug",
+          "columns": [
+            {
+              "expression": "creator_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_price_input": {
+          "name": "IDX_model_stats_price_input",
+          "columns": [
+            {
+              "expression": "price_input",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_coding_index": {
+          "name": "IDX_model_stats_coding_index",
+          "columns": [
+            {
+              "expression": "coding_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_model_stats_context_length": {
+          "name": "IDX_model_stats_context_length",
+          "columns": [
+            {
+              "expression": "context_length",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_stats_openrouter_id_unique": {
+          "name": "model_stats_openrouter_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "openrouter_id"
+          ]
+        },
+        "model_stats_slug_unique": {
+          "name": "model_stats_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.models_by_provider": {
+      "name": "models_by_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openrouter": {
+          "name": "openrouter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vercel": {
+          "name": "vercel",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_audit_logs": {
+      "name": "organization_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_organization_audit_logs_organization_id": {
+          "name": "IDX_organization_audit_logs_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_audit_logs_action": {
+          "name": "IDX_organization_audit_logs_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_audit_logs_actor_id": {
+          "name": "IDX_organization_audit_logs_actor_id",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_audit_logs_created_at": {
+          "name": "IDX_organization_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_invitations": {
+      "name": "organization_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_organization_invitations_token": {
+          "name": "UQ_organization_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_invitations_org_id": {
+          "name": "IDX_organization_invitations_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_invitations_email": {
+          "name": "IDX_organization_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_invitations_expires_at": {
+          "name": "IDX_organization_invitations_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_membership_removals": {
+      "name": "organization_membership_removals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_role": {
+          "name": "previous_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_org_membership_removals_org_id": {
+          "name": "IDX_org_membership_removals_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_org_membership_removals_user_id": {
+          "name": "IDX_org_membership_removals_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_org_membership_removals_org_user": {
+          "name": "UQ_org_membership_removals_org_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "kilo_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_organization_memberships_org_id": {
+          "name": "IDX_organization_memberships_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_memberships_user_id": {
+          "name": "IDX_organization_memberships_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_organization_memberships_org_user": {
+          "name": "UQ_organization_memberships_org_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "kilo_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_seats_purchases": {
+      "name": "organization_seats_purchases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_stripe_id": {
+          "name": "subscription_stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_count": {
+          "name": "seat_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        }
+      },
+      "indexes": {
+        "IDX_organization_seats_org_id": {
+          "name": "IDX_organization_seats_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_seats_expires_at": {
+          "name": "IDX_organization_seats_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_seats_created_at": {
+          "name": "IDX_organization_seats_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_seats_updated_at": {
+          "name": "IDX_organization_seats_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_seats_starts_at": {
+          "name": "IDX_organization_seats_starts_at",
+          "columns": [
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_organization_seats_idempotency_key": {
+          "name": "UQ_organization_seats_idempotency_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_user_limits": {
+      "name": "organization_user_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microdollar_limit": {
+          "name": "microdollar_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_organization_user_limits_org_id": {
+          "name": "IDX_organization_user_limits_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_user_limits_user_id": {
+          "name": "IDX_organization_user_limits_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_organization_user_limits_org_user": {
+          "name": "UQ_organization_user_limits_org_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "kilo_user_id",
+            "limit_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_user_usage": {
+      "name": "organization_user_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_date": {
+          "name": "usage_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microdollar_usage": {
+          "name": "microdollar_usage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_organization_user_daily_usage_org_id": {
+          "name": "IDX_organization_user_daily_usage_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_organization_user_daily_usage_user_id": {
+          "name": "IDX_organization_user_daily_usage_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_organization_user_daily_usage_org_user_date": {
+          "name": "UQ_organization_user_daily_usage_org_user_date",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "kilo_user_id",
+            "limit_type",
+            "usage_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "microdollars_used": {
+          "name": "microdollars_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "microdollars_balance": {
+          "name": "microdollars_balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_microdollars_acquired": {
+          "name": "total_microdollars_acquired",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "next_credit_expiration_at": {
+          "name": "next_credit_expiration_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "seat_count": {
+          "name": "seat_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "require_seats": {
+          "name": "require_seats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_kilo_user_id": {
+          "name": "created_by_kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_domain": {
+          "name": "sso_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'teams'"
+        },
+        "free_trial_end_at": {
+          "name": "free_trial_end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_domain": {
+          "name": "company_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_organizations_sso_domain": {
+          "name": "IDX_organizations_sso_domain",
+          "columns": [
+            {
+              "expression": "sso_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "organizations_name_not_empty_check": {
+          "name": "organizations_name_not_empty_check",
+          "value": "length(trim(\"organizations\".\"name\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_modes": {
+      "name": "organization_modes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "IDX_organization_modes_organization_id": {
+          "name": "IDX_organization_modes_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_organization_modes_org_id_slug": {
+          "name": "UQ_organization_modes_org_id_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "stripe_fingerprint": {
+          "name": "stripe_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last4": {
+          "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line2": {
+          "name": "address_line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_zip": {
+          "name": "address_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_country": {
+          "name": "address_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "three_d_secure_supported": {
+          "name": "three_d_secure_supported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "funding": {
+          "name": "funding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regulated_status": {
+          "name": "regulated_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line1_check_status": {
+          "name": "address_line1_check_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code_check_status": {
+          "name": "postal_code_check_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_forwarded_for": {
+          "name": "http_x_forwarded_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_city": {
+          "name": "http_x_vercel_ip_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_country": {
+          "name": "http_x_vercel_ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_latitude": {
+          "name": "http_x_vercel_ip_latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_longitude": {
+          "name": "http_x_vercel_ip_longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ja4_digest": {
+          "name": "http_x_vercel_ja4_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligible_for_free_credits": {
+          "name": "eligible_for_free_credits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_data": {
+          "name": "stripe_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_d7d7fb15569674aaadcfbc0428": {
+          "name": "IDX_d7d7fb15569674aaadcfbc0428",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_e1feb919d0ab8a36381d5d5138": {
+          "name": "IDX_e1feb919d0ab8a36381d5d5138",
+          "columns": [
+            {
+              "expression": "stripe_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_payment_methods_organization_id": {
+          "name": "IDX_payment_methods_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_29df1b0403df5792c96bbbfdbe6": {
+          "name": "UQ_29df1b0403df5792c96bbbfdbe6",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_integrations": {
+      "name": "platform_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_type": {
+          "name": "integration_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_installation_id": {
+          "name": "platform_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_account_id": {
+          "name": "platform_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_account_login": {
+          "name": "platform_account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_access": {
+          "name": "repository_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repositories": {
+          "name": "repositories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repositories_synced_at": {
+          "name": "repositories_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilo_requester_user_id": {
+          "name": "kilo_requester_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_requester_account_id": {
+          "name": "platform_requester_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integration_status": {
+          "name": "integration_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_by": {
+          "name": "suspended_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_app_type": {
+          "name": "github_app_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'standard'"
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_platform_integrations_owned_by_org_platform_inst": {
+          "name": "UQ_platform_integrations_owned_by_org_platform_inst",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"platform_integrations\".\"owned_by_organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_platform_integrations_owned_by_user_platform_inst": {
+          "name": "UQ_platform_integrations_owned_by_user_platform_inst",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"platform_integrations\".\"owned_by_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_owned_by_org_id": {
+          "name": "IDX_platform_integrations_owned_by_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_owned_by_user_id": {
+          "name": "IDX_platform_integrations_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_platform_inst_id": {
+          "name": "IDX_platform_integrations_platform_inst_id",
+          "columns": [
+            {
+              "expression": "platform_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_platform": {
+          "name": "IDX_platform_integrations_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_owned_by_org_platform": {
+          "name": "IDX_platform_integrations_owned_by_org_platform",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_owned_by_user_platform": {
+          "name": "IDX_platform_integrations_owned_by_user_platform",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_integration_status": {
+          "name": "IDX_platform_integrations_integration_status",
+          "columns": [
+            {
+              "expression": "integration_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_kilo_requester": {
+          "name": "IDX_platform_integrations_kilo_requester",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kilo_requester_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_platform_integrations_platform_requester": {
+          "name": "IDX_platform_integrations_platform_requester",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_requester_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "platform_integrations_owned_by_organization_id_organizations_id_fk": {
+          "name": "platform_integrations_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "platform_integrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "platform_integrations_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "platform_integrations_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "platform_integrations",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_integrations_owner_check": {
+          "name": "platform_integrations_owner_check",
+          "value": "(\n        (\"platform_integrations\".\"owned_by_user_id\" IS NOT NULL AND \"platform_integrations\".\"owned_by_organization_id\" IS NULL) OR\n        (\"platform_integrations\".\"owned_by_user_id\" IS NULL AND \"platform_integrations\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.referral_code_usages": {
+      "name": "referral_code_usages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "referring_kilo_user_id": {
+          "name": "referring_kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeeming_kilo_user_id": {
+          "name": "redeeming_kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_referral_code_usages_redeeming_kilo_user_id": {
+          "name": "IDX_referral_code_usages_redeeming_kilo_user_id",
+          "columns": [
+            {
+              "expression": "redeeming_kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_referral_code_usages_redeeming_user_id_code": {
+          "name": "UQ_referral_code_usages_redeeming_user_id_code",
+          "nullsNotDistinct": false,
+          "columns": [
+            "redeeming_kilo_user_id",
+            "referring_kilo_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referral_codes": {
+      "name": "referral_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_redemptions": {
+          "name": "max_redemptions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_referral_codes_kilo_user_id": {
+          "name": "UQ_referral_codes_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_referral_codes_code": {
+          "name": "IDX_referral_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.security_advisor_scans": {
+      "name": "security_advisor_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_platform": {
+          "name": "source_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_method": {
+          "name": "source_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_version": {
+          "name": "plugin_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openclaw_version": {
+          "name": "openclaw_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_ip": {
+          "name": "public_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_critical": {
+          "name": "findings_critical",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "findings_warn": {
+          "name": "findings_warn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "findings_info": {
+          "name": "findings_info",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_security_advisor_scans_user_created_at": {
+          "name": "idx_security_advisor_scans_user_created_at",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_advisor_scans_created_at": {
+          "name": "idx_security_advisor_scans_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_advisor_scans_platform": {
+          "name": "idx_security_advisor_scans_platform",
+          "columns": [
+            {
+              "expression": "source_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.security_analysis_owner_state": {
+      "name": "security_analysis_owner_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_analysis_enabled_at": {
+          "name": "auto_analysis_enabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_until": {
+          "name": "blocked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_reason": {
+          "name": "block_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_actor_resolution_failures": {
+          "name": "consecutive_actor_resolution_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_actor_resolution_failure_at": {
+          "name": "last_actor_resolution_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_security_analysis_owner_state_org_owner": {
+          "name": "UQ_security_analysis_owner_state_org_owner",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"security_analysis_owner_state\".\"owned_by_organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_security_analysis_owner_state_user_owner": {
+          "name": "UQ_security_analysis_owner_state_user_owner",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"security_analysis_owner_state\".\"owned_by_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_analysis_owner_state_owned_by_organization_id_organizations_id_fk": {
+          "name": "security_analysis_owner_state_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "security_analysis_owner_state",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_analysis_owner_state_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "security_analysis_owner_state_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "security_analysis_owner_state",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "security_analysis_owner_state_owner_check": {
+          "name": "security_analysis_owner_state_owner_check",
+          "value": "(\n        (\"security_analysis_owner_state\".\"owned_by_user_id\" IS NOT NULL AND \"security_analysis_owner_state\".\"owned_by_organization_id\" IS NULL) OR\n        (\"security_analysis_owner_state\".\"owned_by_user_id\" IS NULL AND \"security_analysis_owner_state\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "security_analysis_owner_state_block_reason_check": {
+          "name": "security_analysis_owner_state_block_reason_check",
+          "value": "\"security_analysis_owner_state\".\"block_reason\" IS NULL OR \"security_analysis_owner_state\".\"block_reason\" IN ('INSUFFICIENT_CREDITS', 'ACTOR_RESOLUTION_FAILED', 'OPERATOR_PAUSE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.security_analysis_queue": {
+      "name": "security_analysis_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "finding_id": {
+          "name": "finding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queue_status": {
+          "name": "queue_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity_rank": {
+          "name": "severity_rank",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_job_id": {
+          "name": "claimed_by_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reopen_requeue_count": {
+          "name": "reopen_requeue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_redacted": {
+          "name": "last_error_redacted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_security_analysis_queue_finding_id": {
+          "name": "UQ_security_analysis_queue_finding_id",
+          "columns": [
+            {
+              "expression": "finding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_claim_path_org": {
+          "name": "idx_security_analysis_queue_claim_path_org",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"next_retry_at\", '-infinity'::timestamptz)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "severity_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_claim_path_user": {
+          "name": "idx_security_analysis_queue_claim_path_user",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"next_retry_at\", '-infinity'::timestamptz)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "severity_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_in_flight_org": {
+          "name": "idx_security_analysis_queue_in_flight_org",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queue_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_in_flight_user": {
+          "name": "idx_security_analysis_queue_in_flight_user",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queue_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_lag_dashboards": {
+          "name": "idx_security_analysis_queue_lag_dashboards",
+          "columns": [
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_pending_reconciliation": {
+          "name": "idx_security_analysis_queue_pending_reconciliation",
+          "columns": [
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_running_reconciliation": {
+          "name": "idx_security_analysis_queue_running_reconciliation",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"queue_status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_analysis_queue_failure_trend": {
+          "name": "idx_security_analysis_queue_failure_trend",
+          "columns": [
+            {
+              "expression": "failure_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_analysis_queue\".\"failure_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_analysis_queue_finding_id_security_findings_id_fk": {
+          "name": "security_analysis_queue_finding_id_security_findings_id_fk",
+          "tableFrom": "security_analysis_queue",
+          "tableTo": "security_findings",
+          "columnsFrom": [
+            "finding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_analysis_queue_owned_by_organization_id_organizations_id_fk": {
+          "name": "security_analysis_queue_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "security_analysis_queue",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_analysis_queue_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "security_analysis_queue_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "security_analysis_queue",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "security_analysis_queue_owner_check": {
+          "name": "security_analysis_queue_owner_check",
+          "value": "(\n        (\"security_analysis_queue\".\"owned_by_user_id\" IS NOT NULL AND \"security_analysis_queue\".\"owned_by_organization_id\" IS NULL) OR\n        (\"security_analysis_queue\".\"owned_by_user_id\" IS NULL AND \"security_analysis_queue\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        },
+        "security_analysis_queue_status_check": {
+          "name": "security_analysis_queue_status_check",
+          "value": "\"security_analysis_queue\".\"queue_status\" IN ('queued', 'pending', 'running', 'failed', 'completed')"
+        },
+        "security_analysis_queue_claim_token_required_check": {
+          "name": "security_analysis_queue_claim_token_required_check",
+          "value": "\"security_analysis_queue\".\"queue_status\" NOT IN ('pending', 'running') OR \"security_analysis_queue\".\"claim_token\" IS NOT NULL"
+        },
+        "security_analysis_queue_attempt_count_non_negative_check": {
+          "name": "security_analysis_queue_attempt_count_non_negative_check",
+          "value": "\"security_analysis_queue\".\"attempt_count\" >= 0"
+        },
+        "security_analysis_queue_reopen_requeue_count_non_negative_check": {
+          "name": "security_analysis_queue_reopen_requeue_count_non_negative_check",
+          "value": "\"security_analysis_queue\".\"reopen_requeue_count\" >= 0"
+        },
+        "security_analysis_queue_severity_rank_check": {
+          "name": "security_analysis_queue_severity_rank_check",
+          "value": "\"security_analysis_queue\".\"severity_rank\" IN (0, 1, 2, 3)"
+        },
+        "security_analysis_queue_failure_code_check": {
+          "name": "security_analysis_queue_failure_code_check",
+          "value": "\"security_analysis_queue\".\"failure_code\" IS NULL OR \"security_analysis_queue\".\"failure_code\" IN (\n        'NETWORK_TIMEOUT',\n        'UPSTREAM_5XX',\n        'TEMP_TOKEN_FAILURE',\n        'START_CALL_AMBIGUOUS',\n        'REQUEUE_TEMPORARY_PRECONDITION',\n        'ACTOR_RESOLUTION_FAILED',\n        'GITHUB_TOKEN_UNAVAILABLE',\n        'INVALID_CONFIG',\n        'MISSING_OWNERSHIP',\n        'PERMISSION_DENIED_PERMANENT',\n        'UNSUPPORTED_SEVERITY',\n        'INSUFFICIENT_CREDITS',\n        'STATE_GUARD_REJECTED',\n        'SKIPPED_ALREADY_IN_PROGRESS',\n        'SKIPPED_NO_LONGER_ELIGIBLE',\n        'REOPEN_LOOP_GUARD',\n        'RUN_LOST'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_state": {
+          "name": "before_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_state": {
+          "name": "after_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_security_audit_log_org_created": {
+          "name": "IDX_security_audit_log_org_created",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_security_audit_log_user_created": {
+          "name": "IDX_security_audit_log_user_created",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_security_audit_log_resource": {
+          "name": "IDX_security_audit_log_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_security_audit_log_actor": {
+          "name": "IDX_security_audit_log_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_security_audit_log_action": {
+          "name": "IDX_security_audit_log_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_audit_log_owned_by_organization_id_organizations_id_fk": {
+          "name": "security_audit_log_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_audit_log_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "security_audit_log_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "security_audit_log_owner_check": {
+          "name": "security_audit_log_owner_check",
+          "value": "(\"security_audit_log\".\"owned_by_user_id\" IS NOT NULL AND \"security_audit_log\".\"owned_by_organization_id\" IS NULL) OR (\"security_audit_log\".\"owned_by_user_id\" IS NULL AND \"security_audit_log\".\"owned_by_organization_id\" IS NOT NULL)"
+        },
+        "security_audit_log_action_check": {
+          "name": "security_audit_log_action_check",
+          "value": "\"security_audit_log\".\"action\" IN ('security.finding.created', 'security.finding.status_change', 'security.finding.dismissed', 'security.finding.auto_dismissed', 'security.finding.analysis_started', 'security.finding.analysis_completed', 'security.finding.deleted', 'security.config.enabled', 'security.config.disabled', 'security.config.updated', 'security.sync.triggered', 'security.sync.completed', 'security.audit_log.exported')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.security_findings": {
+      "name": "security_findings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ghsa_id": {
+          "name": "ghsa_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cve_id": {
+          "name": "cve_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_ecosystem": {
+          "name": "package_ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vulnerable_version_range": {
+          "name": "vulnerable_version_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patched_version": {
+          "name": "patched_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_path": {
+          "name": "manifest_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "ignored_reason": {
+          "name": "ignored_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ignored_by": {
+          "name": "ignored_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fixed_at": {
+          "name": "fixed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sla_due_at": {
+          "name": "sla_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependabot_html_url": {
+          "name": "dependabot_html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cwe_ids": {
+          "name": "cwe_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cvss_score": {
+          "name": "cvss_score",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependency_scope": {
+          "name": "dependency_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_session_id": {
+          "name": "cli_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_status": {
+          "name": "analysis_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_started_at": {
+          "name": "analysis_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_completed_at": {
+          "name": "analysis_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_error": {
+          "name": "analysis_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_detected_at": {
+          "name": "first_detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_security_findings_org_id": {
+          "name": "idx_security_findings_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_user_id": {
+          "name": "idx_security_findings_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_repo": {
+          "name": "idx_security_findings_repo",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_severity": {
+          "name": "idx_security_findings_severity",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_status": {
+          "name": "idx_security_findings_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_package": {
+          "name": "idx_security_findings_package",
+          "columns": [
+            {
+              "expression": "package_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_sla_due_at": {
+          "name": "idx_security_findings_sla_due_at",
+          "columns": [
+            {
+              "expression": "sla_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_session_id": {
+          "name": "idx_security_findings_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_cli_session_id": {
+          "name": "idx_security_findings_cli_session_id",
+          "columns": [
+            {
+              "expression": "cli_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_analysis_status": {
+          "name": "idx_security_findings_analysis_status",
+          "columns": [
+            {
+              "expression": "analysis_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_org_analysis_in_flight": {
+          "name": "idx_security_findings_org_analysis_in_flight",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "analysis_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_findings\".\"analysis_status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_findings_user_analysis_in_flight": {
+          "name": "idx_security_findings_user_analysis_in_flight",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "analysis_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"security_findings\".\"analysis_status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_findings_owned_by_organization_id_organizations_id_fk": {
+          "name": "security_findings_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "security_findings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_findings_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "security_findings_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "security_findings",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "security_findings_platform_integration_id_platform_integrations_id_fk": {
+          "name": "security_findings_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "security_findings",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_security_findings_source": {
+          "name": "uq_security_findings_source",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repo_full_name",
+            "source",
+            "source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "security_findings_owner_check": {
+          "name": "security_findings_owner_check",
+          "value": "(\n        (\"security_findings\".\"owned_by_user_id\" IS NOT NULL AND \"security_findings\".\"owned_by_organization_id\" IS NULL) OR\n        (\"security_findings\".\"owned_by_user_id\" IS NULL AND \"security_findings\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shared_cli_sessions": {
+      "name": "shared_cli_sessions",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_state": {
+          "name": "shared_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "api_conversation_history_blob_url": {
+          "name": "api_conversation_history_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_metadata_blob_url": {
+          "name": "task_metadata_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ui_messages_blob_url": {
+          "name": "ui_messages_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_state_blob_url": {
+          "name": "git_state_blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_shared_cli_sessions_session_id": {
+          "name": "IDX_shared_cli_sessions_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_shared_cli_sessions_created_at": {
+          "name": "IDX_shared_cli_sessions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shared_cli_sessions_session_id_cli_sessions_session_id_fk": {
+          "name": "shared_cli_sessions_session_id_cli_sessions_session_id_fk",
+          "tableFrom": "shared_cli_sessions",
+          "tableTo": "cli_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "shared_cli_sessions_kilo_user_id_kilocode_users_id_fk": {
+          "name": "shared_cli_sessions_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "shared_cli_sessions",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shared_cli_sessions_shared_state_check": {
+          "name": "shared_cli_sessions_shared_state_check",
+          "value": "\"shared_cli_sessions\".\"shared_state\" IN ('public', 'organization')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_bot_requests": {
+      "name": "slack_bot_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_integration_id": {
+          "name": "platform_integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_team_name": {
+          "name": "slack_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_message": {
+          "name": "user_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_message_truncated": {
+          "name": "user_message_truncated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_used": {
+          "name": "model_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls_made": {
+          "name": "tool_calls_made",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_bot_requests_created_at": {
+          "name": "idx_slack_bot_requests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_slack_team_id": {
+          "name": "idx_slack_bot_requests_slack_team_id",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_owned_by_org_id": {
+          "name": "idx_slack_bot_requests_owned_by_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_owned_by_user_id": {
+          "name": "idx_slack_bot_requests_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_status": {
+          "name": "idx_slack_bot_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_event_type": {
+          "name": "idx_slack_bot_requests_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_bot_requests_team_created": {
+          "name": "idx_slack_bot_requests_team_created",
+          "columns": [
+            {
+              "expression": "slack_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_bot_requests_owned_by_organization_id_organizations_id_fk": {
+          "name": "slack_bot_requests_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "slack_bot_requests",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_bot_requests_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "slack_bot_requests_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "slack_bot_requests",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_bot_requests_platform_integration_id_platform_integrations_id_fk": {
+          "name": "slack_bot_requests_platform_integration_id_platform_integrations_id_fk",
+          "tableFrom": "slack_bot_requests",
+          "tableTo": "platform_integrations",
+          "columnsFrom": [
+            "platform_integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "slack_bot_requests_owner_check": {
+          "name": "slack_bot_requests_owner_check",
+          "value": "(\n        (\"slack_bot_requests\".\"owned_by_user_id\" IS NOT NULL AND \"slack_bot_requests\".\"owned_by_organization_id\" IS NULL) OR\n        (\"slack_bot_requests\".\"owned_by_user_id\" IS NULL AND \"slack_bot_requests\".\"owned_by_organization_id\" IS NOT NULL) OR\n        (\"slack_bot_requests\".\"owned_by_user_id\" IS NULL AND \"slack_bot_requests\".\"owned_by_organization_id\" IS NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.source_embeddings": {
+      "name": "source_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_line": {
+          "name": "start_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_line": {
+          "name": "end_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "is_base_branch": {
+          "name": "is_base_branch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_source_embeddings_organization_id": {
+          "name": "IDX_source_embeddings_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_kilo_user_id": {
+          "name": "IDX_source_embeddings_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_project_id": {
+          "name": "IDX_source_embeddings_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_created_at": {
+          "name": "IDX_source_embeddings_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_updated_at": {
+          "name": "IDX_source_embeddings_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_file_path_lower": {
+          "name": "IDX_source_embeddings_file_path_lower",
+          "columns": [
+            {
+              "expression": "LOWER(\"file_path\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_git_branch": {
+          "name": "IDX_source_embeddings_git_branch",
+          "columns": [
+            {
+              "expression": "git_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_source_embeddings_org_project_branch": {
+          "name": "IDX_source_embeddings_org_project_branch",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "git_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_embeddings_organization_id_organizations_id_fk": {
+          "name": "source_embeddings_organization_id_organizations_id_fk",
+          "tableFrom": "source_embeddings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_embeddings_kilo_user_id_kilocode_users_id_fk": {
+          "name": "source_embeddings_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "source_embeddings",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_source_embeddings_org_project_branch_file_lines": {
+          "name": "UQ_source_embeddings_org_project_branch_file_lines",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "project_id",
+            "git_branch",
+            "file_path",
+            "start_line",
+            "end_line"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stytch_fingerprints": {
+      "name": "stytch_fingerprints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_fingerprint": {
+          "name": "visitor_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_fingerprint": {
+          "name": "browser_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_id": {
+          "name": "browser_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardware_fingerprint": {
+          "name": "hardware_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_fingerprint": {
+          "name": "network_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_action": {
+          "name": "verdict_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_device_type": {
+          "name": "detected_device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_authentic_device": {
+          "name": "is_authentic_device",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"\"}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint_data": {
+          "name": "fingerprint_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_free_tier_allowed": {
+          "name": "kilo_free_tier_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "http_x_forwarded_for": {
+          "name": "http_x_forwarded_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_city": {
+          "name": "http_x_vercel_ip_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_country": {
+          "name": "http_x_vercel_ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_latitude": {
+          "name": "http_x_vercel_ip_latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_longitude": {
+          "name": "http_x_vercel_ip_longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ja4_digest": {
+          "name": "http_x_vercel_ja4_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_user_agent": {
+          "name": "http_user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_fingerprint_data": {
+          "name": "idx_fingerprint_data",
+          "columns": [
+            {
+              "expression": "fingerprint_data",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hardware_fingerprint": {
+          "name": "idx_hardware_fingerprint",
+          "columns": [
+            {
+              "expression": "hardware_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kilo_user_id": {
+          "name": "idx_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reasons": {
+          "name": "idx_reasons",
+          "columns": [
+            {
+              "expression": "reasons",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_verdict_action": {
+          "name": "idx_verdict_action",
+          "columns": [
+            {
+              "expression": "verdict_action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_visitor_fingerprint": {
+          "name": "idx_visitor_fingerprint",
+          "columns": [
+            {
+              "expression": "visitor_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_prompt_prefix": {
+      "name": "system_prompt_prefix",
+      "schema": "",
+      "columns": {
+        "system_prompt_prefix_id": {
+          "name": "system_prompt_prefix_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "system_prompt_prefix": {
+          "name": "system_prompt_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_system_prompt_prefix": {
+          "name": "UQ_system_prompt_prefix",
+          "columns": [
+            {
+              "expression": "system_prompt_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_admin_notes": {
+      "name": "user_admin_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_content": {
+          "name": "note_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_kilo_user_id": {
+          "name": "admin_kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_34517df0b385234babc38fe81b": {
+          "name": "IDX_34517df0b385234babc38fe81b",
+          "columns": [
+            {
+              "expression": "admin_kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_ccbde98c4c14046daa5682ec4f": {
+          "name": "IDX_ccbde98c4c14046daa5682ec4f",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_d0270eb24ef6442d65a0b7853c": {
+          "name": "IDX_d0270eb24ef6442d65a0b7853c",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_affiliate_attributions": {
+      "name": "user_affiliate_attributions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_id": {
+          "name": "tracking_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_user_affiliate_attributions_user_id": {
+          "name": "IDX_user_affiliate_attributions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_affiliate_attributions_user_id_kilocode_users_id_fk": {
+          "name": "user_affiliate_attributions_user_id_kilocode_users_id_fk",
+          "tableFrom": "user_affiliate_attributions",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_user_affiliate_attributions_user_provider": {
+          "name": "UQ_user_affiliate_attributions_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_affiliate_attributions_provider_check": {
+          "name": "user_affiliate_attributions_provider_check",
+          "value": "\"user_affiliate_attributions\".\"provider\" IN ('impact')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_affiliate_events": {
+      "name": "user_affiliate_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_event_id": {
+          "name": "parent_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_state": {
+          "name": "delivery_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_user_affiliate_events_claim_path": {
+          "name": "IDX_user_affiliate_events_claim_path",
+          "columns": [
+            {
+              "expression": "delivery_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"next_retry_at\", '-infinity'::timestamptz)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_affiliate_events_parent_event_id": {
+          "name": "IDX_user_affiliate_events_parent_event_id",
+          "columns": [
+            {
+              "expression": "parent_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_affiliate_events_user_id_kilocode_users_id_fk": {
+          "name": "user_affiliate_events_user_id_kilocode_users_id_fk",
+          "tableFrom": "user_affiliate_events",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "user_affiliate_events_parent_event_id_fk": {
+          "name": "user_affiliate_events_parent_event_id_fk",
+          "tableFrom": "user_affiliate_events",
+          "tableTo": "user_affiliate_events",
+          "columnsFrom": [
+            "parent_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_user_affiliate_events_dedupe_key": {
+          "name": "UQ_user_affiliate_events_dedupe_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dedupe_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_affiliate_events_provider_check": {
+          "name": "user_affiliate_events_provider_check",
+          "value": "\"user_affiliate_events\".\"provider\" IN ('impact')"
+        },
+        "user_affiliate_events_event_type_check": {
+          "name": "user_affiliate_events_event_type_check",
+          "value": "\"user_affiliate_events\".\"event_type\" IN ('signup', 'trial_start', 'trial_end', 'sale')"
+        },
+        "user_affiliate_events_delivery_state_check": {
+          "name": "user_affiliate_events_delivery_state_check",
+          "value": "\"user_affiliate_events\".\"delivery_state\" IN ('queued', 'blocked', 'sending', 'delivered', 'failed')"
+        },
+        "user_affiliate_events_attempt_count_non_negative_check": {
+          "name": "user_affiliate_events_attempt_count_non_negative_check",
+          "value": "\"user_affiliate_events\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_auth_provider": {
+      "name": "user_auth_provider",
+      "schema": "",
+      "columns": {
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hosted_domain": {
+          "name": "hosted_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_user_auth_provider_kilo_user_id": {
+          "name": "IDX_user_auth_provider_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_auth_provider_hosted_domain": {
+          "name": "IDX_user_auth_provider_hosted_domain",
+          "columns": [
+            {
+              "expression": "hosted_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_auth_provider_provider_provider_account_id_pk": {
+          "name": "user_auth_provider_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feedback": {
+      "name": "user_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_text": {
+          "name": "feedback_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback_for": {
+          "name": "feedback_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "feedback_batch": {
+          "name": "feedback_batch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "context_json": {
+          "name": "context_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_user_feedback_created_at": {
+          "name": "IDX_user_feedback_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_feedback_kilo_user_id": {
+          "name": "IDX_user_feedback_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_feedback_feedback_for": {
+          "name": "IDX_user_feedback_feedback_for",
+          "columns": [
+            {
+              "expression": "feedback_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_feedback_feedback_batch": {
+          "name": "IDX_user_feedback_feedback_batch",
+          "columns": [
+            {
+              "expression": "feedback_batch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_feedback_source": {
+          "name": "IDX_user_feedback_source",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_feedback_kilo_user_id_kilocode_users_id_fk": {
+          "name": "user_feedback_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "user_feedback",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_period_cache": {
+      "name": "user_period_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_type": {
+          "name": "cache_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "shared_url_token": {
+          "name": "shared_url_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_at": {
+          "name": "shared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_user_period_cache_kilo_user_id": {
+          "name": "IDX_user_period_cache_kilo_user_id",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_user_period_cache": {
+          "name": "UQ_user_period_cache",
+          "columns": [
+            {
+              "expression": "kilo_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cache_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_period_cache_lookup": {
+          "name": "IDX_user_period_cache_lookup",
+          "columns": [
+            {
+              "expression": "cache_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UQ_user_period_cache_share_token": {
+          "name": "UQ_user_period_cache_share_token",
+          "columns": [
+            {
+              "expression": "shared_url_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_period_cache\".\"shared_url_token\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_period_cache_kilo_user_id_kilocode_users_id_fk": {
+          "name": "user_period_cache_kilo_user_id_kilocode_users_id_fk",
+          "tableFrom": "user_period_cache",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "kilo_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_period_cache_period_type_check": {
+          "name": "user_period_cache_period_type_check",
+          "value": "\"user_period_cache\".\"period_type\" IN ('year', 'quarter', 'month', 'week', 'custom')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_push_tokens": {
+      "name": "user_push_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UQ_user_push_tokens_token": {
+          "name": "UQ_user_push_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_user_push_tokens_user_id": {
+          "name": "IDX_user_push_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_push_tokens_user_id_kilocode_users_id_fk": {
+          "name": "user_push_tokens_user_id_kilocode_users_id_fk",
+          "tableFrom": "user_push_tokens",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_ip_city": {
+      "name": "vercel_ip_city",
+      "schema": "",
+      "columns": {
+        "vercel_ip_city_id": {
+          "name": "vercel_ip_city_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vercel_ip_city": {
+          "name": "vercel_ip_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_vercel_ip_city": {
+          "name": "UQ_vercel_ip_city",
+          "columns": [
+            {
+              "expression": "vercel_ip_city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_ip_country": {
+      "name": "vercel_ip_country",
+      "schema": "",
+      "columns": {
+        "vercel_ip_country_id": {
+          "name": "vercel_ip_country_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vercel_ip_country": {
+          "name": "vercel_ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UQ_vercel_ip_country": {
+          "name": "UQ_vercel_ip_country",
+          "columns": [
+            {
+              "expression": "vercel_ip_country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "owned_by_organization_id": {
+          "name": "owned_by_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_user_id": {
+          "name": "owned_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed": {
+          "name": "processed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handlers_triggered": {
+          "name": "handlers_triggered",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "errors": {
+          "name": "errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_signature": {
+          "name": "event_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_webhook_events_owned_by_org_id": {
+          "name": "IDX_webhook_events_owned_by_org_id",
+          "columns": [
+            {
+              "expression": "owned_by_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_webhook_events_owned_by_user_id": {
+          "name": "IDX_webhook_events_owned_by_user_id",
+          "columns": [
+            {
+              "expression": "owned_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_webhook_events_platform": {
+          "name": "IDX_webhook_events_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_webhook_events_event_type": {
+          "name": "IDX_webhook_events_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_webhook_events_created_at": {
+          "name": "IDX_webhook_events_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_events_owned_by_organization_id_organizations_id_fk": {
+          "name": "webhook_events_owned_by_organization_id_organizations_id_fk",
+          "tableFrom": "webhook_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "owned_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_events_owned_by_user_id_kilocode_users_id_fk": {
+          "name": "webhook_events_owned_by_user_id_kilocode_users_id_fk",
+          "tableFrom": "webhook_events",
+          "tableTo": "kilocode_users",
+          "columnsFrom": [
+            "owned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UQ_webhook_events_signature": {
+          "name": "UQ_webhook_events_signature",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_signature"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webhook_events_owner_check": {
+          "name": "webhook_events_owner_check",
+          "value": "(\n        (\"webhook_events\".\"owned_by_user_id\" IS NOT NULL AND \"webhook_events\".\"owned_by_organization_id\" IS NULL) OR\n        (\"webhook_events\".\"owned_by_user_id\" IS NULL AND \"webhook_events\".\"owned_by_organization_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.microdollar_usage_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kilo_user_id": {
+          "name": "kilo_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_hit_tokens": {
+          "name": "cache_hit_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_x_forwarded_for": {
+          "name": "http_x_forwarded_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_city": {
+          "name": "http_x_vercel_ip_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_country": {
+          "name": "http_x_vercel_ip_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_latitude": {
+          "name": "http_x_vercel_ip_latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ip_longitude": {
+          "name": "http_x_vercel_ip_longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_x_vercel_ja4_digest": {
+          "name": "http_x_vercel_ja4_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_model": {
+          "name": "requested_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_prompt_prefix": {
+          "name": "user_prompt_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_prefix": {
+          "name": "system_prompt_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_length": {
+          "name": "system_prompt_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_user_agent": {
+          "name": "http_user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_discount": {
+          "name": "cache_discount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_middle_out_transform": {
+          "name": "has_middle_out_transform",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_error": {
+          "name": "has_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abuse_classification": {
+          "name": "abuse_classification",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inference_provider": {
+          "name": "inference_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_id": {
+          "name": "upstream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency": {
+          "name": "latency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_latency": {
+          "name": "moderation_latency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_time": {
+          "name": "generation_time",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_byok": {
+          "name": "is_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_user_byok": {
+          "name": "is_user_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamed": {
+          "name": "streamed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_name": {
+          "name": "editor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_kind": {
+          "name": "api_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_tools": {
+          "name": "has_tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_model": {
+          "name": "auto_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "market_cost": {
+          "name": "market_cost",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_free": {
+          "name": "is_free",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "\n  SELECT\n    mu.id,\n    mu.kilo_user_id,\n    meta.message_id,\n    mu.cost,\n    mu.input_tokens,\n    mu.output_tokens,\n    mu.cache_write_tokens,\n    mu.cache_hit_tokens,\n    mu.created_at,\n    ip.http_ip AS http_x_forwarded_for,\n    city.vercel_ip_city AS http_x_vercel_ip_city,\n    country.vercel_ip_country AS http_x_vercel_ip_country,\n    meta.vercel_ip_latitude AS http_x_vercel_ip_latitude,\n    meta.vercel_ip_longitude AS http_x_vercel_ip_longitude,\n    ja4.ja4_digest AS http_x_vercel_ja4_digest,\n    mu.provider,\n    mu.model,\n    mu.requested_model,\n    meta.user_prompt_prefix,\n    spp.system_prompt_prefix,\n    meta.system_prompt_length,\n    ua.http_user_agent,\n    mu.cache_discount,\n    meta.max_tokens,\n    meta.has_middle_out_transform,\n    mu.has_error,\n    mu.abuse_classification,\n    mu.organization_id,\n    mu.inference_provider,\n    mu.project_id,\n    meta.status_code,\n    meta.upstream_id,\n    frfr.finish_reason,\n    meta.latency,\n    meta.moderation_latency,\n    meta.generation_time,\n    meta.is_byok,\n    meta.is_user_byok,\n    meta.streamed,\n    meta.cancelled,\n    edit.editor_name,\n    ak.api_kind,\n    meta.has_tools,\n    meta.machine_id,\n    feat.feature,\n    meta.session_id,\n    md.mode,\n    am.auto_model,\n    meta.market_cost,\n    meta.is_free\n  FROM \"microdollar_usage\" mu\n  LEFT JOIN \"microdollar_usage_metadata\" meta ON mu.id = meta.id\n  LEFT JOIN \"http_ip\" ip ON meta.http_ip_id = ip.http_ip_id\n  LEFT JOIN \"vercel_ip_city\" city ON meta.vercel_ip_city_id = city.vercel_ip_city_id\n  LEFT JOIN \"vercel_ip_country\" country ON meta.vercel_ip_country_id = country.vercel_ip_country_id\n  LEFT JOIN \"ja4_digest\" ja4 ON meta.ja4_digest_id = ja4.ja4_digest_id\n  LEFT JOIN \"system_prompt_prefix\" spp ON meta.system_prompt_prefix_id = spp.system_prompt_prefix_id\n  LEFT JOIN \"http_user_agent\" ua ON meta.http_user_agent_id = ua.http_user_agent_id\n  LEFT JOIN \"finish_reason\" frfr ON meta.finish_reason_id = frfr.finish_reason_id\n  LEFT JOIN \"editor_name\" edit ON meta.editor_name_id = edit.editor_name_id\n  LEFT JOIN \"api_kind\" ak ON meta.api_kind_id = ak.api_kind_id\n  LEFT JOIN \"feature\" feat ON meta.feature_id = feat.feature_id\n  LEFT JOIN \"mode\" md ON meta.mode_id = md.mode_id\n  LEFT JOIN \"auto_model\" am ON meta.auto_model_id = am.auto_model_id\n",
+      "name": "microdollar_usage_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -603,6 +603,13 @@
       "when": 1775999621732,
       "tag": "0085_mixed_pestilence",
       "breakpoints": true
+    },
+    {
+      "idx": 86,
+      "version": "7",
+      "when": 1776134824295,
+      "tag": "0086_misty_beast",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -202,7 +202,8 @@ export const KiloClawAdminAuditAction = z.enum([
   'kiloclaw.machine.resize',
   'kiloclaw.subscription.bulk_trial_grant',
   'kiloclaw.subscription.admin_cancel',
-  'kiloclaw.orphan.destroy',
+  'kiloclaw.cli_run.start',
+  'kiloclaw.cli_run.cancel',
 ]);
 
 export type KiloClawAdminAuditAction = z.infer<typeof KiloClawAdminAuditAction>;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -3999,6 +3999,7 @@ export const kiloclaw_cli_runs = pgTable(
       .notNull()
       .references(() => kilocode_users.id, { onDelete: 'cascade' }),
     instance_id: uuid().references(() => kiloclaw_instances.id),
+    initiated_by_admin_id: text().references(() => kilocode_users.id, { onDelete: 'set null' }),
     prompt: text().notNull(),
     status: text().$type<KiloClawCliRunStatus>().notNull().default('running'),
     exit_code: integer(),

--- a/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
+++ b/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
@@ -68,6 +68,7 @@ ${userPrompt}`;
 // ── Module-level state (one run at a time per machine) ────────────────
 
 let activeRun: RunState | null = null;
+let startQueue: Promise<void> = Promise.resolve();
 
 // ── Request schemas ───────────────────────────────────────────────────
 
@@ -97,6 +98,21 @@ function cleanupRun(
   // Don't null out activeRun — keep it for status queries until a new run starts
 }
 
+/**
+ * This chains each start attempt behind the previous one.
+ *
+ * `then(fn, fn)` ensures the next attempt runs regardless of whether the
+ * previous one resolved or rejected — the queue must never stall.
+ */
+function runStartExclusive<T>(fn: () => Promise<T>): Promise<T> {
+  const next = startQueue.then(fn, fn);
+  startQueue = next.then(
+    () => undefined,
+    () => undefined
+  );
+  return next;
+}
+
 // ── Route registration ────────────────────────────────────────────────
 
 export function registerKiloCliRunRoutes(app: Hono, expectedToken: string): void {
@@ -119,76 +135,80 @@ export function registerKiloCliRunRoutes(app: Hono, expectedToken: string): void
       return c.json({ error: 'KILO_API_KEY is not configured' }, 400);
     }
 
-    // Enforce one-at-a-time
-    if (activeRun?.status === 'running') {
-      return c.json({ error: 'A kilo CLI run is already in progress' }, 409);
-    }
-
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: 'Invalid JSON body' }, 400);
-    }
-
-    const parsed = StartRunBodySchema.safeParse(body);
-    if (!parsed.success) {
-      return c.json({ error: 'Invalid request body', details: parsed.error.flatten() }, 400);
-    }
-
-    const { prompt } = parsed.data;
-    const fullPrompt = buildRunPrompt(prompt);
-
-    // Spawn the kilo CLI process
-    // The prompt is passed as a separate argument to avoid shell injection
-    const child = spawn('kilo', ['run', '--auto', fullPrompt], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: process.env,
-    });
-
-    const run: RunState = {
-      process: child,
-      output: '',
-      status: 'running',
-      exitCode: null,
-      startedAt: new Date().toISOString(),
-      completedAt: null,
-      prompt,
-    };
-
-    activeRun = run;
-
-    // Capture stdout
-    child.stdout?.on('data', (chunk: Buffer | string) => {
-      const text = typeof chunk === 'string' ? chunk : chunk.toString();
-      appendOutput(run, text);
-    });
-
-    // Capture stderr (merge into same output buffer)
-    child.stderr?.on('data', (chunk: Buffer | string) => {
-      const text = typeof chunk === 'string' ? chunk : chunk.toString();
-      appendOutput(run, text);
-    });
-
-    child.once('error', err => {
-      console.error('[kilo-cli-run] Process error:', err.message);
-      if (run.status === 'running') {
-        appendOutput(run, `\n[process error: ${err.message}]\n`);
-        cleanupRun(run, null, 'failed');
+    return runStartExclusive(async () => {
+      if (activeRun?.status === 'running') {
+        return c.json({ error: 'A Kilo CLI run is already in progress' }, 409);
       }
-    });
 
-    child.once('close', (code, signal) => {
-      if (run.status !== 'running') return; // already handled by error event
-      console.log(`[kilo-cli-run] Process exited: code=${code} signal=${signal}`);
-      cleanupRun(run, code, code === 0 ? 'completed' : 'failed');
-    });
+      let body: unknown;
+      try {
+        body = await c.req.json();
+      } catch {
+        return c.json({ error: 'Invalid JSON body' }, 400);
+      }
 
-    console.log(`[kilo-cli-run] Started: pid=${child.pid}, prompt="${prompt.slice(0, 100)}..."`);
+      const parsed = StartRunBodySchema.safeParse(body);
+      if (!parsed.success) {
+        return c.json(
+          { error: 'Invalid request body', details: z.treeifyError(parsed.error) },
+          400
+        );
+      }
 
-    return c.json({
-      ok: true,
-      startedAt: run.startedAt,
+      const { prompt } = parsed.data;
+      const fullPrompt = buildRunPrompt(prompt);
+
+      // Spawn the kilo CLI process
+      // The prompt is passed as a separate argument to avoid shell injection
+      const child = spawn('kilo', ['run', '--auto', fullPrompt], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: process.env,
+      });
+
+      const run: RunState = {
+        process: child,
+        output: '',
+        status: 'running',
+        exitCode: null,
+        startedAt: new Date().toISOString(),
+        completedAt: null,
+        prompt,
+      };
+
+      activeRun = run;
+
+      // Capture stdout
+      child.stdout?.on('data', (chunk: Buffer | string) => {
+        const text = typeof chunk === 'string' ? chunk : chunk.toString();
+        appendOutput(run, text);
+      });
+
+      // Capture stderr (merge into same output buffer)
+      child.stderr?.on('data', (chunk: Buffer | string) => {
+        const text = typeof chunk === 'string' ? chunk : chunk.toString();
+        appendOutput(run, text);
+      });
+
+      child.once('error', err => {
+        console.error('[kilo-cli-run] Process error:', err.message);
+        if (run.status === 'running') {
+          appendOutput(run, `\n[process error: ${err.message}]\n`);
+          cleanupRun(run, null, 'failed');
+        }
+      });
+
+      child.once('close', (code, signal) => {
+        if (run.status !== 'running') return; // already handled by error event
+        console.log(`[kilo-cli-run] Process exited: code=${code} signal=${signal}`);
+        cleanupRun(run, code, code === 0 ? 'completed' : 'failed');
+      });
+
+      console.log(`[kilo-cli-run] Started: pid=${child.pid}, prompt="${prompt.slice(0, 100)}..."`);
+
+      return c.json({
+        ok: true,
+        startedAt: run.startedAt,
+      });
     });
   });
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/kilo-cli-run.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/kilo-cli-run.ts
@@ -3,6 +3,7 @@ import {
   KiloCliRunStartResponseSchema,
   KiloCliRunStatusResponseSchema,
   GatewayCommandResponseSchema,
+  GatewayControllerError,
 } from '../gateway-controller-types';
 import { callGatewayController, isErrorUnknownRoute } from './gateway';
 import { getRuntimeId } from './state';
@@ -11,6 +12,11 @@ import type { InstanceMutableState } from './types';
 type KiloCliRunStartResponse = {
   ok: boolean;
   startedAt: string;
+};
+
+/** Returned instead of throwing when a 409 would be lost crossing the DO RPC boundary. */
+type KiloCliRunConflict = {
+  conflict: string;
 };
 
 type KiloCliRunStatusResponse = {
@@ -25,14 +31,18 @@ type KiloCliRunStatusResponse = {
 
 /**
  * Start a `kilo run --auto` process on the controller.
+ *
+ * Returns a `{ conflict }` variant instead of throwing on 409 because
+ * custom error properties (like `.status`) are lost crossing the DO RPC
+ * boundary — only `.message` survives. Return values serialize correctly.
  */
 export async function startKiloCliRun(
   state: InstanceMutableState,
   env: KiloClawEnv,
   prompt: string
-): Promise<KiloCliRunStartResponse | null> {
+): Promise<KiloCliRunStartResponse | KiloCliRunConflict | null> {
   if (state.status !== 'running' || !getRuntimeId(state)) {
-    throw Object.assign(new Error('Instance is not running'), { status: 409 });
+    return { conflict: 'Instance is not running' };
   }
 
   try {
@@ -46,6 +56,9 @@ export async function startKiloCliRun(
     );
   } catch (error) {
     if (isErrorUnknownRoute(error)) return null;
+    if (error instanceof GatewayControllerError && error.status === 409) {
+      return { conflict: error.message };
+    }
     throw error;
   }
 }

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -301,15 +301,31 @@ async function requireProviderCapability(
   return jsonError(`${operation} is not supported for provider ${metadata.provider}`, 400);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isHttpStatus(value: unknown): value is { status: number } {
+  return isRecord(value) && typeof value.status === 'number';
+}
+
+function hasStringCode(value: unknown): value is { code: string } {
+  return isRecord(value) && typeof value.code === 'string';
+}
+
+/** Extract a string `code` from an error or its `.cause`, if present. */
+function getErrorCode(err: unknown): string | undefined {
+  if (hasStringCode(err)) return err.code;
+  if (err instanceof Error && hasStringCode(err.cause)) return err.cause.code;
+  return undefined;
+}
+
 function statusCodeFromError(err: unknown): number {
-  if (
-    typeof err === 'object' &&
-    err !== null &&
-    'status' in err &&
-    typeof (err as { status: unknown }).status === 'number'
-  ) {
-    const status = (err as { status: number }).status;
-    if (status >= 400 && status < 600) return status;
+  // Extract a valid HTTP status from the error or its cause, defaulting to 500.
+  for (const candidate of [err, err instanceof Error ? err.cause : undefined]) {
+    if (isHttpStatus(candidate) && candidate.status >= 400 && candidate.status < 600) {
+      return candidate.status;
+    }
   }
   return 500;
 }
@@ -344,6 +360,7 @@ const SAFE_ERROR_PREFIXES = [
   'Stream Chat sendMessage failed', // sendMessage HTTP errors
   'Stream Chat is not set up', // no Stream Chat on this instance
   'Provider ', // explicit not-implemented provider errors
+  'A Kilo CLI run is ', // e.g. "A Kilo CLI run is already in progress"
 ];
 
 function sanitizeError(err: unknown, operation: string): { message: string; status: number } {
@@ -398,13 +415,7 @@ function sanitizeOpenclawConfigError(
   const raw = err instanceof Error ? err.message : 'Unknown error';
   const status = statusCodeFromError(err);
   const normalized = raw.replace(/^(?:[A-Za-z]+Error:\s*)+/, '');
-  const code =
-    typeof err === 'object' &&
-    err !== null &&
-    'code' in err &&
-    typeof (err as { code?: unknown }).code === 'string'
-      ? (err as { code: string }).code
-      : undefined;
+  const code = getErrorCode(err);
 
   console.error(`[platform] ${operation} failed:`, raw);
 
@@ -1392,11 +1403,15 @@ platform.post('/kilo-cli-run/start', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
+    // The DO returns a discriminated union: success | { conflict } | null.
+    // CF Workers' RPC type wrapping turns this into `Promise<A> | Promise<B>`
+    // instead of `Promise<A | B>`, which breaks narrowing. The `.then(r => r)`
+    // collapses the RPC wrapper back to a plain Promise union.
     const response = await withResolvedDORetry(
       c.env,
       result.data.userId,
       iidResult.instanceId,
-      stub => stub.startKiloCliRun(result.data.prompt),
+      stub => stub.startKiloCliRun(result.data.prompt).then(r => r),
       'startKiloCliRun'
     );
     if (!response) {
@@ -1405,6 +1420,9 @@ platform.post('/kilo-cli-run/start', async c => {
         404,
         'controller_route_unavailable'
       );
+    }
+    if ('conflict' in response) {
+      return jsonError(response.conflict, 409);
     }
     return c.json(response, 200);
   } catch (err) {


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

Admins can not currently initiate CLI recovery runs for users, which makes customer support a time-intensive operation for certain workflows. This PR adds the recovery CLI to the admin instance view, and adds protection against concurrent CLI runs. It also introduces some small UX improvements for users that are directly related to the other changes.

Although this is a large PR, it is designed to follow existing patterns for routing, DB ops, auditing, etc.

<details><summary>More Details</summary>
<p>

- Concurrent start requests on a controller are now serialized via a promise queue (runStartExclusive) to prevent race conditions on the activeRun check.
- The controller's 409 response for an already-running CLI run is now mapped to a user-facing TRPC CONFLICT error with a clear message, and the prefix is added to the platform's safe-error allowlist.
- The "Back to Dashboard" link on the CLI run detail page now routes to /claw/settings instead of /claw.
- If a CLI run is in progress, a user clicking the Recover with Kilo button will be routed into the CLI run view page for the current operation. 
- Users can cancel admin runs, and vice versa
- stripAnsi, timestamp formatting helpers, and DetailField are extracted into shared modules to remove duplication across admin components.

</p>
</details> 

## Verification

- [x] tests pass
- [x] manually tested

## Visual Changes

## Reviewer Notes

- A follow-up PR will address the same behaviors for org instances, in addition to other fixes for orgs. Orgs are currently non functional with this flow regardless, and this PR was large as-is, so I am scoping that work separately.

<details><summary>Known Limitations</summary>
<p>

- A CLI run can be "orphaned" if the DB insert fails, which will block the user from starting a run until the one active on the machine clears. I chose not to scope this into this PR as it is a very rare edge case, and the CLI runs are quick.
- There are known issues with orgs that I will address in a follow up



</p>
</details>

> [!IMPORTANT]
>  I encourage you to enabled "hide whitespace" when reviewing the diff. It will make things easier. 

> [!NOTE]
> I have squashed the commits to avoid a wall of text