### PR TITLE
fix(models): exclude gemini-3.1-pro-preview from models/up health check

### DIFF
--- a/apps/web/src/app/api/models/up/route.ts
+++ b/apps/web/src/app/api/models/up/route.ts
@@ -33,6 +33,10 @@ type HealthResponseError = {
 const HIGH_BASELINE = 300;
 const LOW_BASELINE = 50;
 
+// Models excluded from the health check but still preferred/recommended.
+// Useful for preview models with inconsistent traffic that cause false alerts.
+const HEALTH_CHECK_EXCLUSIONS = new Set(['google/gemini-3.1-pro-preview']);
+
 export async function GET(
   request: Request
 ): Promise<NextResponse<HealthResponse | HealthResponseError>> {
@@ -43,7 +47,7 @@ export async function GET(
     return NextResponse.json({ healthy: false }, { status: 401 });
   }
 
-  const monitoredModels = await getMonitoredModels();
+  const monitoredModels = (await getMonitoredModels()).filter(m => !HEALTH_CHECK_EXCLUSIONS.has(m));
 
   try {
     const queryStartTime = Date.now();

--- a/apps/web/src/lib/monitored-models.ts
+++ b/apps/web/src/lib/monitored-models.ts
@@ -2,16 +2,9 @@ import { isKiloAutoModel } from '@/lib/kilo-auto';
 import { resolveAutoModel } from '@/lib/kilo-auto/resolution';
 import { preferredModels } from '@/lib/models';
 
-// Models excluded from the health check but still preferred/recommended.
-// Useful for preview models with inconsistent traffic that cause false alerts.
-const healthCheckExclusions = new Set(['google/gemini-3.1-pro-preview']);
-
 export async function getMonitoredModels() {
   const set = new Set<string>();
   for (const model of preferredModels) {
-    if (healthCheckExclusions.has(model)) {
-      continue;
-    }
     if (isKiloAutoModel(model)) {
       set.add(
         (await resolveAutoModel(model, null, Promise.resolve(null), Promise.resolve(0))).model

--- a/apps/web/src/lib/monitored-models.ts
+++ b/apps/web/src/lib/monitored-models.ts
@@ -2,9 +2,16 @@ import { isKiloAutoModel } from '@/lib/kilo-auto';
 import { resolveAutoModel } from '@/lib/kilo-auto/resolution';
 import { preferredModels } from '@/lib/models';
 
+// Models excluded from the health check but still preferred/recommended.
+// Useful for preview models with inconsistent traffic that cause false alerts.
+const healthCheckExclusions = new Set(['google/gemini-3.1-pro-preview']);
+
 export async function getMonitoredModels() {
   const set = new Set<string>();
   for (const model of preferredModels) {
+    if (healthCheckExclusions.has(model)) {
+      continue;
+    }
     if (isKiloAutoModel(model)) {
       set.add(
         (await resolveAutoModel(model, null, Promise.resolve(null), Promise.resolve(0))).model


### PR DESCRIPTION
## Summary

Excludes `google/gemini-3.1-pro-preview` from the `/api/models/up` health check to prevent false alerts caused by inconsistent traffic on this preview model. The model remains in `preferredModels` and is still shown as recommended to users.

## Verification

- Ran `pnpm typecheck` — no new errors introduced (pre-existing `linkify-it` error unrelated)
- Verified `preferredModels` in `models.ts` is unchanged

## Visual Changes

N/A

## Reviewer Notes

The exclusion is implemented as a `Set` in `monitored-models.ts` so additional models can easily be excluded in the future without touching `preferredModels`.
