### PR TITLE
fix(kiloclaw): preserve user-edited IDENTITY.md across redeploys

### DIFF
--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -587,6 +587,25 @@ describe('writeBotIdentityFile', () => {
       ['/root/.openclaw/workspace/BOOTSTRAP.md'],
     ]);
   });
+
+  it('preserves existing IDENTITY.md across redeploys', () => {
+    const harness = fakeDeps();
+    (harness.deps.existsSync as ReturnType<typeof vi.fn>).mockImplementation(
+      (p: string) => p === '/root/.openclaw/workspace/IDENTITY.md'
+    );
+
+    writeBotIdentityFile(
+      { KILOCLAW_BOT_NAME: 'Milo', KILOCLAW_BOT_NATURE: 'Operator' },
+      harness.deps
+    );
+
+    expect(
+      harness.renameCalls.some(call => call.to === '/root/.openclaw/workspace/IDENTITY.md')
+    ).toBe(false);
+    expect(harness.writeCalls.some(call => call.path.includes('/workspace/IDENTITY.md'))).toBe(
+      false
+    );
+  });
 });
 
 // ---- runOnboardOrDoctor ----

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -285,12 +285,17 @@ export function writeBotIdentityFile(
     'mkdirSync' | 'writeFileSync' | 'renameSync' | 'unlinkSync' | 'existsSync'
   > = defaultDeps
 ): void {
-  deps.mkdirSync(path.dirname(IDENTITY_MD_DEST), { recursive: true });
-  atomicWrite(IDENTITY_MD_DEST, formatBotIdentityMarkdown(env), {
-    writeFileSync: deps.writeFileSync,
-    renameSync: deps.renameSync,
-    unlinkSync: deps.unlinkSync,
-  });
+  // Preserve user edits: only seed IDENTITY.md when it doesn't already exist.
+  // Without this guard, every redeploy would overwrite user changes with content
+  // regenerated from KILOCLAW_BOT_* env vars.
+  if (!deps.existsSync(IDENTITY_MD_DEST)) {
+    deps.mkdirSync(path.dirname(IDENTITY_MD_DEST), { recursive: true });
+    atomicWrite(IDENTITY_MD_DEST, formatBotIdentityMarkdown(env), {
+      writeFileSync: deps.writeFileSync,
+      renameSync: deps.renameSync,
+      unlinkSync: deps.unlinkSync,
+    });
+  }
 
   for (const legacyPath of LEGACY_BOT_IDENTITY_DESTS) {
     if (!deps.existsSync(legacyPath)) continue;


### PR DESCRIPTION
## Summary

Fixes #2387.

`writeBotIdentityFile` runs on every controller boot (via `runOnboardOrDoctor`), and previously always overwrote `/root/.openclaw/workspace/IDENTITY.md` with content regenerated from `KILOCLAW_BOT_*` env vars. Any edits a user made to `IDENTITY.md` were lost on the next redeploy.

This PR mirrors the `TOOLS.md` behavior: seed on first boot, but skip the write when the file already exists. Legacy-identity-file cleanup still runs unconditionally.

## Verification

- [x] `pnpm exec vitest run controller/src/bootstrap.test.ts` in `services/kiloclaw` — 63 passed (including a new test asserting `IDENTITY.md` is not rewritten when it already exists).
- [x] `pnpm run typecheck` in `services/kiloclaw` — clean.
- [x] `scripts/lint-all.sh` — clean.
- [x] `pnpm format:check` — clean.

## Visual Changes

N/A

## Reviewer Notes

Considered an alternative (guarding the call site inside `runOnboardOrDoctor` to only run on fresh installs), but guarding inside `writeBotIdentityFile` itself keeps the seeding path working even if a config already exists for other reasons, and keeps the rule in one place. Open to flipping if reviewers prefer the other shape.