### PR TITLE
feat(promo): require account created before Apr 11 for KiloClaw email promo

### DIFF
--- a/apps/web/src/lib/promoCreditCategories.ts
+++ b/apps/web/src/lib/promoCreditCategories.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/constants';
 import { promoCategoriesOld } from '@/lib/promoCreditCategoriesOld';
 import {
+  created_before,
   has_githubAuth,
   has_githubAuthAndWelcomeCredits,
   has_holdOrPayment,
@@ -729,6 +730,7 @@ const encryptedSelfServicePromos: readonly EncryptedSelfServicePromoCreditCatego
     promotion_ends_at: new Date('2026-04-22'),
     total_redemptions_allowed: 4175,
     expiry_hours: 7 * 24,
+    customer_requirement: created_before(new Date('2026-04-11')),
   },
 ];
 

--- a/apps/web/src/lib/promoCustomerRequirement.test.ts
+++ b/apps/web/src/lib/promoCustomerRequirement.test.ts
@@ -1,0 +1,41 @@
+import type { CustomerInfo } from '@/lib/customerInfo';
+import { created_before } from './promoCustomerRequirement';
+
+function makeCustomerInfo(overrides: { created_at: string }): CustomerInfo {
+  return {
+    user: { created_at: overrides.created_at } as CustomerInfo['user'],
+  } as CustomerInfo;
+}
+
+describe('created_before', () => {
+  const cutoff = new Date('2026-04-11');
+  const requirement = created_before(cutoff);
+
+  it('succeeds when user was created before the cutoff', () => {
+    const result = requirement(makeCustomerInfo({ created_at: '2026-04-10T23:59:59Z' }));
+    expect(result.success).toBe(true);
+  });
+
+  it('succeeds when user was created well before the cutoff', () => {
+    const result = requirement(makeCustomerInfo({ created_at: '2025-01-01T00:00:00Z' }));
+    expect(result.success).toBe(true);
+  });
+
+  it('fails when user was created exactly at the cutoff', () => {
+    const result = requirement(makeCustomerInfo({ created_at: '2026-04-11T00:00:00Z' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('fails when user was created after the cutoff', () => {
+    const result = requirement(makeCustomerInfo({ created_at: '2026-04-12T00:00:00Z' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('returns a descriptive error message on failure', () => {
+    const result = requirement(makeCustomerInfo({ created_at: '2026-04-11T00:00:00Z' }));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('eligibility cutoff');
+    }
+  });
+});

--- a/apps/web/src/lib/promoCustomerRequirement.ts
+++ b/apps/web/src/lib/promoCustomerRequirement.ts
@@ -53,6 +53,14 @@ export const has_githubAuthAndWelcomeCredits: CustomerRequirement = async custom
   return has_stytchApprovedOrHoldOrPayment(customerInfo);
 };
 
+export function created_before(cutoff: Date): SyncCustomerRequirement {
+  return customerInfo =>
+    verifyOrError(
+      new Date(customerInfo.user.created_at) < cutoff,
+      'Your account was created after the eligibility cutoff date for this promotion.'
+    );
+}
+
 export const has_githubAuth: CustomerRequirement = async customerInfo => {
   const has_github_auth = await db.query.user_auth_provider.findFirst({
     where: and(


### PR DESCRIPTION
## Summary

Adds an account creation date eligibility check to the "Free AI Inference KiloClaw email" promo credit category. Users must have created their account before April 11, 2026 to redeem this promo code.

Changes:
- Added a reusable `created_before(cutoff)` customer requirement function in `promoCustomerRequirement.ts`
- Applied `created_before(new Date('2026-04-11'))` to the KiloClaw email promo category

## Verification

- `pnpm typecheck` passes (only pre-existing unrelated error in `MessageBubble.tsx`)

## Visual Changes

N/A

## Reviewer Notes

N/A
