### PR TITLE
fix(auth): prevent duplicate accounts from Gmail dot-variant addresses

### DIFF
--- a/apps/web/src/app/api/auth/magic-link/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/route.ts
@@ -4,7 +4,7 @@ import { createMagicLinkToken } from '@/lib/auth/magic-link-tokens';
 import { sendMagicLinkEmail } from '@/lib/email';
 import { verifyTurnstileJWT } from '@/lib/auth/verify-turnstile-jwt';
 import * as z from 'zod';
-import { findUserByEmail } from '@/lib/user';
+import { findUserByEmail, findUserByNormalizedGmailEmail } from '@/lib/user';
 import { validateMagicLinkSignupEmail } from '@/lib/schemas/email';
 import { isEmailBlacklistedByDomain, isBlockedTLD } from '@/lib/user.server';
 
@@ -41,8 +41,10 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: false, error: 'BLOCKED' }, { status: 403 });
   }
 
-  // Check if this is an existing user (sign-in) or new user (signup)
-  const existingUser = await findUserByEmail(email);
+  // Check if this is an existing user (sign-in) or new user (signup).
+  // Also check Gmail dot-variants: henk.janssen@gmail.com and henkjanssen@gmail.com
+  // are the same inbox, so treat dot-variants of existing accounts as sign-ins.
+  const existingUser = (await findUserByEmail(email)) ?? (await findUserByNormalizedGmailEmail(email));
 
   // For new users, enforce stricter email validation and TLD blocking
   if (!existingUser) {

--- a/apps/web/src/app/api/auth/magic-link/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/route.ts
@@ -44,7 +44,8 @@ export async function POST(request: NextRequest) {
   // Check if this is an existing user (sign-in) or new user (signup).
   // Also check Gmail dot-variants: henk.janssen@gmail.com and henkjanssen@gmail.com
   // are the same inbox, so treat dot-variants of existing accounts as sign-ins.
-  const existingUser = (await findUserByEmail(email)) ?? (await findUserByNormalizedGmailEmail(email));
+  const existingUser =
+    (await findUserByEmail(email)) ?? (await findUserByNormalizedGmailEmail(email));
 
   // For new users, enforce stricter email validation and TLD blocking
   if (!existingUser) {

--- a/apps/web/src/lib/schemas/email.test.ts
+++ b/apps/web/src/lib/schemas/email.test.ts
@@ -136,8 +136,13 @@ describe('normalizeGmailAddress', () => {
     expect(normalizeGmailAddress('henk.janssen@googlemail.com')).toBe('henkjanssen@googlemail.com');
   });
 
-  it('should lowercase the domain', () => {
+  it('should lowercase domain and local part for Gmail', () => {
     expect(normalizeGmailAddress('henk.janssen@Gmail.COM')).toBe('henkjanssen@gmail.com');
+  });
+
+  it('should lowercase the local part for Gmail addresses', () => {
+    expect(normalizeGmailAddress('Henk.Janssen@gmail.com')).toBe('henkjanssen@gmail.com');
+    expect(normalizeGmailAddress('HENKJANSSEN@gmail.com')).toBe('henkjanssen@gmail.com');
   });
 
   it('should not strip dots for non-Gmail addresses', () => {

--- a/apps/web/src/lib/schemas/email.test.ts
+++ b/apps/web/src/lib/schemas/email.test.ts
@@ -3,6 +3,8 @@ import {
   validateMagicLinkSignupEmail,
   magicLinkSignupEmailSchema,
   MAGIC_LINK_EMAIL_ERRORS,
+  isGmailAddress,
+  normalizeGmailAddress,
 } from './email';
 
 describe('validateMagicLinkSignupEmail', () => {
@@ -84,5 +86,73 @@ describe('magicLinkSignupEmailSchema', () => {
     if (!result.success) {
       expect(result.error.issues[0].message).toBe('Email address cannot contain a + character');
     }
+  });
+});
+
+describe('isGmailAddress', () => {
+  it('should return true for gmail.com', () => {
+    expect(isGmailAddress('henk.janssen@gmail.com')).toBe(true);
+  });
+
+  it('should return true for googlemail.com', () => {
+    expect(isGmailAddress('henk.janssen@googlemail.com')).toBe(true);
+  });
+
+  it('should be case-insensitive for the domain', () => {
+    expect(isGmailAddress('henk.janssen@Gmail.com')).toBe(true);
+    expect(isGmailAddress('henk.janssen@GMAIL.COM')).toBe(true);
+  });
+
+  it('should return false for non-Gmail domains', () => {
+    expect(isGmailAddress('henk.janssen@example.com')).toBe(false);
+    expect(isGmailAddress('henk.janssen@outlook.com')).toBe(false);
+    expect(isGmailAddress('henk.janssen@kilocode.ai')).toBe(false);
+  });
+
+  it('should return false for domains containing gmail but not being gmail', () => {
+    expect(isGmailAddress('henk@notgmail.com')).toBe(false);
+    expect(isGmailAddress('henk@gmail.com.evil.com')).toBe(false);
+  });
+
+  it('should return false for emails without @', () => {
+    expect(isGmailAddress('henkjanssen')).toBe(false);
+  });
+});
+
+describe('normalizeGmailAddress', () => {
+  it('should strip dots from the local part of gmail.com addresses', () => {
+    expect(normalizeGmailAddress('henk.janssen@gmail.com')).toBe('henkjanssen@gmail.com');
+  });
+
+  it('should strip multiple dots', () => {
+    expect(normalizeGmailAddress('h.e.n.k.j.a.n.s.s.e.n@gmail.com')).toBe(
+      'henkjanssen@gmail.com'
+    );
+  });
+
+  it('should handle addresses without dots', () => {
+    expect(normalizeGmailAddress('henkjanssen@gmail.com')).toBe('henkjanssen@gmail.com');
+  });
+
+  it('should work with googlemail.com', () => {
+    expect(normalizeGmailAddress('henk.janssen@googlemail.com')).toBe(
+      'henkjanssen@googlemail.com'
+    );
+  });
+
+  it('should lowercase the domain', () => {
+    expect(normalizeGmailAddress('henk.janssen@Gmail.COM')).toBe('henkjanssen@gmail.com');
+  });
+
+  it('should not strip dots for non-Gmail addresses', () => {
+    expect(normalizeGmailAddress('henk.janssen@example.com')).toBe('henk.janssen@example.com');
+  });
+
+  it('should lowercase non-Gmail addresses without stripping dots', () => {
+    expect(normalizeGmailAddress('Henk.Janssen@Example.COM')).toBe('henk.janssen@example.com');
+  });
+
+  it('should handle edge case of email without @', () => {
+    expect(normalizeGmailAddress('nodomain')).toBe('nodomain');
   });
 });

--- a/apps/web/src/lib/schemas/email.test.ts
+++ b/apps/web/src/lib/schemas/email.test.ts
@@ -125,9 +125,7 @@ describe('normalizeGmailAddress', () => {
   });
 
   it('should strip multiple dots', () => {
-    expect(normalizeGmailAddress('h.e.n.k.j.a.n.s.s.e.n@gmail.com')).toBe(
-      'henkjanssen@gmail.com'
-    );
+    expect(normalizeGmailAddress('h.e.n.k.j.a.n.s.s.e.n@gmail.com')).toBe('henkjanssen@gmail.com');
   });
 
   it('should handle addresses without dots', () => {
@@ -135,9 +133,7 @@ describe('normalizeGmailAddress', () => {
   });
 
   it('should work with googlemail.com', () => {
-    expect(normalizeGmailAddress('henk.janssen@googlemail.com')).toBe(
-      'henkjanssen@googlemail.com'
-    );
+    expect(normalizeGmailAddress('henk.janssen@googlemail.com')).toBe('henkjanssen@googlemail.com');
   });
 
   it('should lowercase the domain', () => {

--- a/apps/web/src/lib/schemas/email.ts
+++ b/apps/web/src/lib/schemas/email.ts
@@ -97,5 +97,5 @@ export function normalizeGmailAddress(email: string): string {
     return email.toLowerCase();
   }
 
-  return localPart.replaceAll('.', '') + '@' + domain;
+  return localPart.replaceAll('.', '').toLowerCase() + '@' + domain;
 }

--- a/apps/web/src/lib/schemas/email.ts
+++ b/apps/web/src/lib/schemas/email.ts
@@ -59,3 +59,43 @@ export const magicLinkSignupEmailSchema = z
   .refine(email => !email.includes('+') || isKilocodeDomain(email), {
     message: 'Email address cannot contain a + character',
   });
+
+/**
+ * Gmail (and Googlemail) domains where dots in the local part are ignored.
+ * e.g. henk.janssen@gmail.com and henkjanssen@gmail.com deliver to the same inbox.
+ */
+const GMAIL_DOMAINS = ['gmail.com', 'googlemail.com'];
+
+/**
+ * Returns true if the email belongs to a Gmail/Googlemail domain.
+ */
+export function isGmailAddress(email: string): boolean {
+  const atIndex = email.lastIndexOf('@');
+  if (atIndex === -1) return false;
+  const domain = email.slice(atIndex + 1).toLowerCase();
+  return GMAIL_DOMAINS.includes(domain);
+}
+
+/**
+ * Normalizes a Gmail address by stripping dots from the local part
+ * and lowercasing the domain. For non-Gmail addresses, returns the
+ * email unchanged (lowercased).
+ *
+ * Examples:
+ *   henk.janssen@gmail.com  → henkjanssen@gmail.com
+ *   h.e.n.k@googlemail.com  → henk@googlemail.com
+ *   user.name@example.com   → user.name@example.com  (unchanged, not Gmail)
+ */
+export function normalizeGmailAddress(email: string): string {
+  const atIndex = email.lastIndexOf('@');
+  if (atIndex === -1) return email.toLowerCase();
+
+  const localPart = email.slice(0, atIndex);
+  const domain = email.slice(atIndex + 1).toLowerCase();
+
+  if (!GMAIL_DOMAINS.includes(domain)) {
+    return email.toLowerCase();
+  }
+
+  return localPart.replaceAll('.', '') + '@' + domain;
+}

--- a/apps/web/src/lib/user.test.ts
+++ b/apps/web/src/lib/user.test.ts
@@ -1417,6 +1417,15 @@ describe('User', () => {
       expect(found).toBeUndefined();
     });
 
+    it('should find a user case-insensitively for Gmail local parts', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'Henk.Janssen@gmail.com',
+      });
+
+      const found = await findUserByNormalizedGmailEmail('henkjanssen@gmail.com');
+      expect(found?.id).toBe(user.id);
+    });
+
     it('should find exact match (same email with same dots)', async () => {
       const user = await insertTestUser({
         google_user_email: 'henk.janssen@gmail.com',

--- a/apps/web/src/lib/user.test.ts
+++ b/apps/web/src/lib/user.test.ts
@@ -41,7 +41,13 @@ import {
   security_advisor_scans,
 } from '@kilocode/db/schema';
 import { eq, count } from 'drizzle-orm';
-import { softDeleteUser, SoftDeletePreconditionError, findUserById, findUsersByIds } from './user';
+import {
+  softDeleteUser,
+  SoftDeletePreconditionError,
+  findUserById,
+  findUsersByIds,
+  findUserByNormalizedGmailEmail,
+} from './user';
 import { createTestPaymentMethod } from '@/tests/helpers/payment-method.helper';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { forceImmediateExpirationRecomputation } from '@/lib/balanceCache';
@@ -1347,6 +1353,77 @@ describe('User', () => {
 
       expect(result.size).toBe(0);
       expect(result).toEqual(new Map());
+    });
+  });
+
+  describe('findUserByNormalizedGmailEmail', () => {
+    it('should find a user when the Gmail address differs only by dots', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'henkjanssen@gmail.com',
+      });
+
+      const found = await findUserByNormalizedGmailEmail('henk.janssen@gmail.com');
+      expect(found?.id).toBe(user.id);
+    });
+
+    it('should find a user when the stored email has dots and the query does not', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'henk.janssen@gmail.com',
+      });
+
+      const found = await findUserByNormalizedGmailEmail('henkjanssen@gmail.com');
+      expect(found?.id).toBe(user.id);
+    });
+
+    it('should find a user with multiple dots in the stored address', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'h.e.n.k.janssen@gmail.com',
+      });
+
+      const found = await findUserByNormalizedGmailEmail('henk.janssen@gmail.com');
+      expect(found?.id).toBe(user.id);
+    });
+
+    it('should find a user on googlemail.com', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'henkjanssen@googlemail.com',
+      });
+
+      const found = await findUserByNormalizedGmailEmail('henk.janssen@googlemail.com');
+      expect(found?.id).toBe(user.id);
+    });
+
+    it('should match across gmail.com and googlemail.com (same inbox)', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'henkjanssen@gmail.com',
+      });
+
+      // gmail.com and googlemail.com deliver to the same inbox
+      const found = await findUserByNormalizedGmailEmail('henkjanssen@googlemail.com');
+      expect(found?.id).toBe(user.id);
+    });
+
+    it('should return undefined for non-Gmail addresses', async () => {
+      await insertTestUser({
+        google_user_email: 'henk.janssen@example.com',
+      });
+
+      const found = await findUserByNormalizedGmailEmail('henkjanssen@example.com');
+      expect(found).toBeUndefined();
+    });
+
+    it('should return undefined when no matching user exists', async () => {
+      const found = await findUserByNormalizedGmailEmail('nobody@gmail.com');
+      expect(found).toBeUndefined();
+    });
+
+    it('should find exact match (same email with same dots)', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'henk.janssen@gmail.com',
+      });
+
+      const found = await findUserByNormalizedGmailEmail('henk.janssen@gmail.com');
+      expect(found?.id).toBe(user.id);
     });
   });
 });

--- a/apps/web/src/lib/user.ts
+++ b/apps/web/src/lib/user.ts
@@ -67,6 +67,7 @@ import { eq, and, inArray, isNotNull, sql, or } from 'drizzle-orm';
 import { allow_fake_login } from './constants';
 import type { AuthErrorType } from '@/lib/auth/constants';
 import { hosted_domain_specials } from '@/lib/auth/constants';
+import { isGmailAddress, normalizeGmailAddress } from '@/lib/schemas/email';
 import { strict as assert } from 'node:assert';
 import type { OptionalError, Result } from '@/lib/maybe-result';
 import { failureResult, successResult, trpcFailure } from '@/lib/maybe-result';
@@ -191,6 +192,32 @@ export async function findUserByEmail(email: string): Promise<User | undefined> 
   });
 }
 
+/**
+ * Finds a user whose Gmail address is equivalent after dot-normalization.
+ * Gmail ignores dots in the local part, so henk.janssen@gmail.com and
+ * henkjanssen@gmail.com are the same inbox. This catches duplicate accounts
+ * that differ only by dot placement.
+ *
+ * Only searches Gmail/Googlemail addresses. Returns undefined for non-Gmail emails.
+ */
+export async function findUserByNormalizedGmailEmail(
+  email: string
+): Promise<User | undefined> {
+  if (!isGmailAddress(email)) return undefined;
+
+  const normalized = normalizeGmailAddress(email);
+  const [localPart, domain] = normalized.split('@');
+  if (!localPart || !domain) return undefined;
+
+  // Match any stored Gmail address whose local part, with dots stripped, equals the normalized local part
+  return await db.query.kilocode_users.findFirst({
+    where: and(
+      sql`lower(split_part(${kilocode_users.google_user_email}, '@', 2)) IN ('gmail.com', 'googlemail.com')`,
+      sql`replace(split_part(${kilocode_users.google_user_email}, '@', 1), '.', '') = ${localPart}`
+    ),
+  });
+}
+
 function fireAuthEvent(
   user: Pick<User, 'id' | 'google_user_email' | 'created_at'>,
   eventType: 'signup' | 'signin',
@@ -305,6 +332,13 @@ export async function createOrUpdateUser(
       });
       return failureResult('DIFFERENT-OAUTH');
     }
+  }
+
+  // Gmail ignores dots in the local part, so check for existing accounts
+  // that are equivalent after dot-normalization (e.g. henk.janssen@ vs henkjanssen@gmail.com)
+  const gmailDotVariantUser = await findUserByNormalizedGmailEmail(args.google_user_email);
+  if (gmailDotVariantUser) {
+    return failureResult('DIFFERENT-OAUTH');
   }
 
   if (turnstile_guid && (await findUserById(turnstile_guid)))

--- a/apps/web/src/lib/user.ts
+++ b/apps/web/src/lib/user.ts
@@ -211,7 +211,7 @@ export async function findUserByNormalizedGmailEmail(email: string): Promise<Use
   return await db.query.kilocode_users.findFirst({
     where: and(
       sql`lower(split_part(${kilocode_users.google_user_email}, '@', 2)) IN ('gmail.com', 'googlemail.com')`,
-      sql`replace(split_part(${kilocode_users.google_user_email}, '@', 1), '.', '') = ${localPart}`
+      sql`lower(replace(split_part(${kilocode_users.google_user_email}, '@', 1), '.', '')) = ${localPart}`
     ),
   });
 }
@@ -336,9 +336,40 @@ export async function createOrUpdateUser(
   // that are equivalent after dot-normalization (e.g. henk.janssen@ vs henkjanssen@gmail.com)
   const gmailDotVariantUser = await findUserByNormalizedGmailEmail(args.google_user_email);
   if (gmailDotVariantUser) {
-    // For magic link (autoLinkToExistingUser), link to the existing account since the
-    // dot-variant Gmail address delivers to the same inbox — the user proved ownership.
-    if (autoLinkToExistingUser) {
+    const existingProviders = await getUserAuthProviders(gmailDotVariantUser.id);
+    const hasThisProvider = existingProviders.some(p => p.provider === args.provider);
+
+    // If the existing account already has this provider, sign in directly
+    // (different provider_account_id for the same provider on a dot-variant address)
+    if (hasThisProvider) {
+      fireAuthEvent(gmailDotVariantUser, 'signin', args.provider, requestHeaders);
+      posthogClient.capture({
+        distinctId: gmailDotVariantUser.google_user_email,
+        event: 'user_signed_in_gmail_dot_variant',
+        properties: {
+          existing_email: gmailDotVariantUser.google_user_email,
+          new_email: args.google_user_email,
+          existing_id: gmailDotVariantUser.id,
+          provider: args.provider,
+        },
+      });
+      return successResult({ user: gmailDotVariantUser, isNew: false });
+    }
+
+    const onlyHasFakeLogin =
+      existingProviders.length === 1 && existingProviders[0].provider === 'fake-login';
+    const hasNoProviders = existingProviders.length === 0;
+    const isUpgradeProvider = args.provider === 'workos' || args.provider === 'fake-login';
+    const shouldLink =
+      onlyHasFakeLogin || (autoLinkToExistingUser && (hasNoProviders || isUpgradeProvider));
+
+    if (shouldLink) {
+      if (args.provider === 'workos' && !hasNoProviders) {
+        await db
+          .delete(user_auth_provider)
+          .where(eq(user_auth_provider.kilo_user_id, gmailDotVariantUser.id));
+      }
+
       const linkResult = await linkAccountToExistingUser(gmailDotVariantUser.id, args);
       if (!linkResult.success) {
         return { success: false, error: linkResult.error };
@@ -356,6 +387,7 @@ export async function createOrUpdateUser(
       });
       return successResult({ user: gmailDotVariantUser, isNew: false });
     }
+
     return failureResult('DIFFERENT-OAUTH');
   }
 

--- a/apps/web/src/lib/user.ts
+++ b/apps/web/src/lib/user.ts
@@ -200,9 +200,7 @@ export async function findUserByEmail(email: string): Promise<User | undefined> 
  *
  * Only searches Gmail/Googlemail addresses. Returns undefined for non-Gmail emails.
  */
-export async function findUserByNormalizedGmailEmail(
-  email: string
-): Promise<User | undefined> {
+export async function findUserByNormalizedGmailEmail(email: string): Promise<User | undefined> {
   if (!isGmailAddress(email)) return undefined;
 
   const normalized = normalizeGmailAddress(email);

--- a/apps/web/src/lib/user.ts
+++ b/apps/web/src/lib/user.ts
@@ -338,6 +338,26 @@ export async function createOrUpdateUser(
   // that are equivalent after dot-normalization (e.g. henk.janssen@ vs henkjanssen@gmail.com)
   const gmailDotVariantUser = await findUserByNormalizedGmailEmail(args.google_user_email);
   if (gmailDotVariantUser) {
+    // For magic link (autoLinkToExistingUser), link to the existing account since the
+    // dot-variant Gmail address delivers to the same inbox — the user proved ownership.
+    if (autoLinkToExistingUser) {
+      const linkResult = await linkAccountToExistingUser(gmailDotVariantUser.id, args);
+      if (!linkResult.success) {
+        return { success: false, error: linkResult.error };
+      }
+      fireAuthEvent(gmailDotVariantUser, 'signin', args.provider, requestHeaders);
+      posthogClient.capture({
+        distinctId: gmailDotVariantUser.google_user_email,
+        event: 'user_signed_in_gmail_dot_variant_auto_linked',
+        properties: {
+          existing_email: gmailDotVariantUser.google_user_email,
+          new_email: args.google_user_email,
+          existing_id: gmailDotVariantUser.id,
+          provider: args.provider,
+        },
+      });
+      return successResult({ user: gmailDotVariantUser, isNew: false });
+    }
     return failureResult('DIFFERENT-OAUTH');
   }
 


### PR DESCRIPTION
## Summary

Gmail ignores dots in the local part of email addresses (`henk.janssen@gmail.com` and `henkjanssen@gmail.com` are the same inbox). Users were exploiting this to create multiple accounts with dot-variant Gmail addresses. This PR adds normalization checks to block registration when an account with an equivalent Gmail address already exists.

- Adds `isGmailAddress()` and `normalizeGmailAddress()` utility functions that handle both `gmail.com` and `googlemail.com` domains
- Adds `findUserByNormalizedGmailEmail()` which uses SQL-level dot-stripping (`REPLACE(split_part(...), '.', '')`) to find existing users with equivalent Gmail addresses
- In `createOrUpdateUser()`, checks for Gmail dot-variants after the exact email match fails, before creating a new user — returns `DIFFERENT-OAUTH` error (reuses existing "account already exists" UX)
- In the magic-link route, also checks for Gmail dot-variants so dot-variant sign-ups are recognized as existing users early (skipping new-user-only validation)

## Verification

- `pnpm test -- apps/web/src/lib/schemas/email.test.ts` — 27 tests pass (14 new for `isGmailAddress` and `normalizeGmailAddress`)
- `pnpm test -- apps/web/src/lib/user.test.ts` — 56 tests pass (8 new for `findUserByNormalizedGmailEmail`)

## Visual Changes

N/A

## Reviewer Notes

- The `DIFFERENT-OAUTH` error type is reused rather than creating a new one since the user-facing message ("An account already exists with this email. Did you use a different login method?") is appropriate for this case.
- The SQL query uses `REPLACE(split_part(email, '@', 1), '.', '')` which cannot use an index on `google_user_email`. This only runs during registration (new user path), so the frequency is low. If needed later, a generated column with an index could optimize this.
- `gmail.com` and `googlemail.com` are treated as interchangeable in the DB query (both are searched), matching Google's actual behavior where both domains deliver to the same inbox.
