### PR TITLE
feat(auth): block users when Stytch returns BLOCK verdict

### DIFF
--- a/apps/web/src/app/account-verification/page.tsx
+++ b/apps/web/src/app/account-verification/page.tsx
@@ -16,6 +16,10 @@ export default async function AccountVerificationPage({ searchParams }: AppPageP
   const telemetry_id = typeof params.telemetry_id === 'string' ? params.telemetry_id : null;
   const stytchStatus = await getStytchStatus(user, telemetry_id, await headers());
 
+  if (stytchStatus === 'blocked') {
+    redirect('/account-blocked');
+  }
+
   await handleSignupPromotion(user, stytchStatus || false);
 
   if (stytchStatus !== null) {

--- a/apps/web/src/app/api/auth/magic-link/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/route.ts
@@ -4,7 +4,7 @@ import { createMagicLinkToken } from '@/lib/auth/magic-link-tokens';
 import { sendMagicLinkEmail } from '@/lib/email';
 import { verifyTurnstileJWT } from '@/lib/auth/verify-turnstile-jwt';
 import * as z from 'zod';
-import { findUserByEmail } from '@/lib/user';
+import { findUserByEmail, findUserByNormalizedGmailEmail } from '@/lib/user';
 import { validateMagicLinkSignupEmail } from '@/lib/schemas/email';
 import { isEmailBlacklistedByDomain, isBlockedTLD } from '@/lib/user.server';
 
@@ -41,8 +41,10 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: false, error: 'BLOCKED' }, { status: 403 });
   }
 
-  // Check if this is an existing user (sign-in) or new user (signup)
-  const existingUser = await findUserByEmail(email);
+  // Check if this is an existing user (sign-in) or new user (signup).
+  // Also check Gmail dot-variants: henk.janssen@gmail.com and henkjanssen@gmail.com
+  // are the same inbox, so treat dot-variants of existing accounts as sign-ins.
+  const existingUser = (await findUserByEmail(email)) ?? (await findUserByNormalizedGmailEmail(email));
 
   // For new users, enforce stricter email validation and TLD blocking
   if (!existingUser) {

--- a/apps/web/src/app/api/auth/magic-link/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/route.ts
@@ -44,7 +44,8 @@ export async function POST(request: NextRequest) {
   // Check if this is an existing user (sign-in) or new user (signup).
   // Also check Gmail dot-variants: henk.janssen@gmail.com and henkjanssen@gmail.com
   // are the same inbox, so treat dot-variants of existing accounts as sign-ins.
-  const existingUser = (await findUserByEmail(email)) ?? (await findUserByNormalizedGmailEmail(email));
+  const existingUser =
+    (await findUserByEmail(email)) ?? (await findUserByNormalizedGmailEmail(email));
 
   // For new users, enforce stricter email validation and TLD blocking
   if (!existingUser) {

--- a/apps/web/src/lib/schemas/email.test.ts
+++ b/apps/web/src/lib/schemas/email.test.ts
@@ -3,6 +3,8 @@ import {
   validateMagicLinkSignupEmail,
   magicLinkSignupEmailSchema,
   MAGIC_LINK_EMAIL_ERRORS,
+  isGmailAddress,
+  normalizeGmailAddress,
 } from './email';
 
 describe('validateMagicLinkSignupEmail', () => {
@@ -84,5 +86,73 @@ describe('magicLinkSignupEmailSchema', () => {
     if (!result.success) {
       expect(result.error.issues[0].message).toBe('Email address cannot contain a + character');
     }
+  });
+});
+
+describe('isGmailAddress', () => {
+  it('should return true for gmail.com', () => {
+    expect(isGmailAddress('henk.janssen@gmail.com')).toBe(true);
+  });
+
+  it('should return true for googlemail.com', () => {
+    expect(isGmailAddress('henk.janssen@googlemail.com')).toBe(true);
+  });
+
+  it('should be case-insensitive for the domain', () => {
+    expect(isGmailAddress('henk.janssen@Gmail.com')).toBe(true);
+    expect(isGmailAddress('henk.janssen@GMAIL.COM')).toBe(true);
+  });
+
+  it('should return false for non-Gmail domains', () => {
+    expect(isGmailAddress('henk.janssen@example.com')).toBe(false);
+    expect(isGmailAddress('henk.janssen@outlook.com')).toBe(false);
+    expect(isGmailAddress('henk.janssen@kilocode.ai')).toBe(false);
+  });
+
+  it('should return false for domains containing gmail but not being gmail', () => {
+    expect(isGmailAddress('henk@notgmail.com')).toBe(false);
+    expect(isGmailAddress('henk@gmail.com.evil.com')).toBe(false);
+  });
+
+  it('should return false for emails without @', () => {
+    expect(isGmailAddress('henkjanssen')).toBe(false);
+  });
+});
+
+describe('normalizeGmailAddress', () => {
+  it('should strip dots from the local part of gmail.com addresses', () => {
+    expect(normalizeGmailAddress('henk.janssen@gmail.com')).toBe('henkjanssen@gmail.com');
+  });
+
+  it('should strip multiple dots', () => {
+    expect(normalizeGmailAddress('h.e.n.k.j.a.n.s.s.e.n@gmail.com')).toBe(
+      'henkjanssen@gmail.com'
+    );
+  });
+
+  it('should handle addresses without dots', () => {
+    expect(normalizeGmailAddress('henkjanssen@gmail.com')).toBe('henkjanssen@gmail.com');
+  });
+
+  it('should work with googlemail.com', () => {
+    expect(normalizeGmailAddress('henk.janssen@googlemail.com')).toBe(
+      'henkjanssen@googlemail.com'
+    );
+  });
+
+  it('should lowercase the domain', () => {
+    expect(normalizeGmailAddress('henk.janssen@Gmail.COM')).toBe('henkjanssen@gmail.com');
+  });
+
+  it('should not strip dots for non-Gmail addresses', () => {
+    expect(normalizeGmailAddress('henk.janssen@example.com')).toBe('henk.janssen@example.com');
+  });
+
+  it('should lowercase non-Gmail addresses without stripping dots', () => {
+    expect(normalizeGmailAddress('Henk.Janssen@Example.COM')).toBe('henk.janssen@example.com');
+  });
+
+  it('should handle edge case of email without @', () => {
+    expect(normalizeGmailAddress('nodomain')).toBe('nodomain');
   });
 });

--- a/apps/web/src/lib/schemas/email.test.ts
+++ b/apps/web/src/lib/schemas/email.test.ts
@@ -125,9 +125,7 @@ describe('normalizeGmailAddress', () => {
   });
 
   it('should strip multiple dots', () => {
-    expect(normalizeGmailAddress('h.e.n.k.j.a.n.s.s.e.n@gmail.com')).toBe(
-      'henkjanssen@gmail.com'
-    );
+    expect(normalizeGmailAddress('h.e.n.k.j.a.n.s.s.e.n@gmail.com')).toBe('henkjanssen@gmail.com');
   });
 
   it('should handle addresses without dots', () => {
@@ -135,9 +133,7 @@ describe('normalizeGmailAddress', () => {
   });
 
   it('should work with googlemail.com', () => {
-    expect(normalizeGmailAddress('henk.janssen@googlemail.com')).toBe(
-      'henkjanssen@googlemail.com'
-    );
+    expect(normalizeGmailAddress('henk.janssen@googlemail.com')).toBe('henkjanssen@googlemail.com');
   });
 
   it('should lowercase the domain', () => {

--- a/apps/web/src/lib/schemas/email.ts
+++ b/apps/web/src/lib/schemas/email.ts
@@ -59,3 +59,43 @@ export const magicLinkSignupEmailSchema = z
   .refine(email => !email.includes('+') || isKilocodeDomain(email), {
     message: 'Email address cannot contain a + character',
   });
+
+/**
+ * Gmail (and Googlemail) domains where dots in the local part are ignored.
+ * e.g. henk.janssen@gmail.com and henkjanssen@gmail.com deliver to the same inbox.
+ */
+const GMAIL_DOMAINS = ['gmail.com', 'googlemail.com'];
+
+/**
+ * Returns true if the email belongs to a Gmail/Googlemail domain.
+ */
+export function isGmailAddress(email: string): boolean {
+  const atIndex = email.lastIndexOf('@');
+  if (atIndex === -1) return false;
+  const domain = email.slice(atIndex + 1).toLowerCase();
+  return GMAIL_DOMAINS.includes(domain);
+}
+
+/**
+ * Normalizes a Gmail address by stripping dots from the local part
+ * and lowercasing the domain. For non-Gmail addresses, returns the
+ * email unchanged (lowercased).
+ *
+ * Examples:
+ *   henk.janssen@gmail.com  → henkjanssen@gmail.com
+ *   h.e.n.k@googlemail.com  → henk@googlemail.com
+ *   user.name@example.com   → user.name@example.com  (unchanged, not Gmail)
+ */
+export function normalizeGmailAddress(email: string): string {
+  const atIndex = email.lastIndexOf('@');
+  if (atIndex === -1) return email.toLowerCase();
+
+  const localPart = email.slice(0, atIndex);
+  const domain = email.slice(atIndex + 1).toLowerCase();
+
+  if (!GMAIL_DOMAINS.includes(domain)) {
+    return email.toLowerCase();
+  }
+
+  return localPart.replaceAll('.', '') + '@' + domain;
+}

--- a/apps/web/src/lib/stytch.test.ts
+++ b/apps/web/src/lib/stytch.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach } from '@jest/globals';
 import { insertTestUser } from '../tests/helpers/user.helper';
 import { db } from './drizzle';
-import { stytch_fingerprints, credit_transactions } from '@kilocode/db/schema';
+import { kilocode_users, stytch_fingerprints, credit_transactions } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 import type { FraudFingerprintLookupResponse } from 'stytch';
 
@@ -163,6 +163,72 @@ describe('Stytch Fingerprint Functions', () => {
       });
 
       expect(savedFingerprint?.kilo_free_tier_allowed).toBe(false);
+    });
+
+    test('should block user when verdict is BLOCK', async () => {
+      const user = await insertTestUser();
+      const fingerprintData = {
+        ...createMockFingerprintData(),
+        verdict: {
+          action: 'BLOCK',
+          detected_device_type: 'desktop',
+          is_authentic_device: false,
+          reasons: ['suspicious_activity'],
+          verdict_reason_overrides: [],
+        },
+      };
+      const headers = createMockHeaders();
+
+      const result = await saveFingerprints(user, fingerprintData, headers);
+
+      expect(result.stytch_blocked).toBe(true);
+      expect(result.kilo_free_tier_allowed).toBe(false);
+
+      const updatedUser = await db.query.kilocode_users.findFirst({
+        where: eq(kilocode_users.id, user.id),
+      });
+      expect(updatedUser?.blocked_reason).toBe('stytch-block');
+    });
+
+    test('should not block user when verdict is CHALLENGE', async () => {
+      const user = await insertTestUser();
+      const fingerprintData = {
+        ...createMockFingerprintData(),
+        verdict: {
+          action: 'CHALLENGE',
+          detected_device_type: 'desktop',
+          is_authentic_device: true,
+          reasons: ['unknown_device'],
+          verdict_reason_overrides: [],
+        },
+      };
+      const headers = createMockHeaders();
+
+      const result = await saveFingerprints(user, fingerprintData, headers);
+
+      expect(result.stytch_blocked).toBe(false);
+      expect(result.kilo_free_tier_allowed).toBe(false);
+
+      const updatedUser = await db.query.kilocode_users.findFirst({
+        where: eq(kilocode_users.id, user.id),
+      });
+      expect(updatedUser?.blocked_reason).toBeNull();
+    });
+
+    test('should not block user when verdict is ALLOW', async () => {
+      const user = await insertTestUser();
+      const fingerprintData = createMockFingerprintData();
+      const headers = createMockHeaders();
+
+      const result = await saveFingerprints(user, fingerprintData, headers);
+
+      expect(result.stytch_blocked).toBe(false);
+      expect(result.kilo_free_tier_allowed).toBe(true);
+
+      const updatedUser = await db.query.kilocode_users.findFirst({
+        where: eq(kilocode_users.id, user.id),
+      });
+      expect(updatedUser?.blocked_reason).toBeNull();
     });
 
     test('should set kilo_free_tier_allowed to false when fingerprint belongs to other user', async () => {

--- a/apps/web/src/lib/stytch.ts
+++ b/apps/web/src/lib/stytch.ts
@@ -3,7 +3,7 @@ import type { FraudFingerprintLookupResponse } from 'stytch';
 import { Client, envs } from 'stytch';
 import { db } from '@/lib/drizzle';
 import type { User } from '@kilocode/db/schema';
-import { stytch_fingerprints } from '@kilocode/db/schema';
+import { kilocode_users, stytch_fingerprints } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 import { getFraudDetectionHeaders } from './utils';
 import { captureException } from '@sentry/nextjs';
@@ -22,11 +22,14 @@ const client = new Client({
   env: NEXT_PUBLIC_STYTCH_PROJECT_ENV === 'test' ? envs.test : envs.live,
 });
 
+export type StytchStatus = boolean | 'blocked' | null;
+
 export const getStytchStatus = async (
   user: User,
   telemetryId: string | null,
   headers: Headers
-): Promise<boolean | null> => {
+): Promise<StytchStatus> => {
+  if (user.blocked_reason) return 'blocked';
   if (user.has_validation_stytch !== null) return user.has_validation_stytch;
   if (!telemetryId) return null;
 
@@ -48,8 +51,13 @@ export const getStytchStatus = async (
   if (!fingerprintData) {
     return null; //404
   }
-  const { kilo_free_tier_allowed } = await saveFingerprints(user, fingerprintData, headers);
+  const { stytch_blocked, kilo_free_tier_allowed } = await saveFingerprints(
+    user,
+    fingerprintData,
+    headers
+  );
 
+  if (stytch_blocked) return 'blocked';
   return kilo_free_tier_allowed;
 };
 
@@ -111,10 +119,13 @@ export async function saveFingerprints(
     );
   }
 
+  const stytch_blocked = !inDevModeAndStytchPassEmail && verdict.action === 'BLOCK';
+
   const kilo_free_tier_allowed = inDevModeAndStytchFailEmail
     ? false
     : inDevModeAndStytchPassEmail ||
-      (verdict.action === 'ALLOW' &&
+      (!stytch_blocked &&
+        verdict.action === 'ALLOW' &&
         !(await isKnownFingerprintOfOtherUser(user.id, fingerprints.visitor_fingerprint)) &&
         !(await domainIsRestrictedFromStytchFreeCredits(user)));
 
@@ -134,6 +145,19 @@ export async function saveFingerprints(
   if (process.env.NODE_ENV !== 'test')
     console.log('SECURITY: saving fingerprint:', stytchFingerprint);
   await db.insert(stytch_fingerprints).values(stytchFingerprint);
+
+  if (stytch_blocked) {
+    await db
+      .update(kilocode_users)
+      .set({ blocked_reason: 'stytch-block' })
+      .where(eq(kilocode_users.id, user.id));
+    if (process.env.NODE_ENV !== 'test')
+      console.log('SECURITY: blocking user due to Stytch BLOCK verdict:', {
+        kiloUserId: user.id,
+        email: user.google_user_email,
+        reasons: verdict.reasons,
+      });
+  }
 
   await updateStytchValidation(user, {
     ...user,
@@ -170,7 +194,7 @@ export async function saveFingerprints(
     });
   }
 
-  return { kilo_free_tier_allowed };
+  return { kilo_free_tier_allowed, stytch_blocked };
 }
 
 /**

--- a/apps/web/src/lib/user.test.ts
+++ b/apps/web/src/lib/user.test.ts
@@ -41,7 +41,13 @@ import {
   security_advisor_scans,
 } from '@kilocode/db/schema';
 import { eq, count } from 'drizzle-orm';
-import { softDeleteUser, SoftDeletePreconditionError, findUserById, findUsersByIds } from './user';
+import {
+  softDeleteUser,
+  SoftDeletePreconditionError,
+  findUserById,
+  findUsersByIds,
+  findUserByNormalizedGmailEmail,
+} from './user';
 import { createTestPaymentMethod } from '@/tests/helpers/payment-method.helper';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { forceImmediateExpirationRecomputation } from '@/lib/balanceCache';
@@ -1347,6 +1353,77 @@ describe('User', () => {
 
       expect(result.size).toBe(0);
       expect(result).toEqual(new Map());
+    });
+  });
+
+  describe('findUserByNormalizedGmailEmail', () => {
+    it('should find a user when the Gmail address differs only by dots', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'henkjanssen@gmail.com',
+      });
+
+      const found = await findUserByNormalizedGmailEmail('henk.janssen@gmail.com');
+      expect(found?.id).toBe(user.id);
+    });
+
+    it('should find a user when the stored email has dots and the query does not', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'henk.janssen@gmail.com',
+      });
+
+      const found = await findUserByNormalizedGmailEmail('henkjanssen@gmail.com');
+      expect(found?.id).toBe(user.id);
+    });
+
+    it('should find a user with multiple dots in the stored address', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'h.e.n.k.janssen@gmail.com',
+      });
+
+      const found = await findUserByNormalizedGmailEmail('henk.janssen@gmail.com');
+      expect(found?.id).toBe(user.id);
+    });
+
+    it('should find a user on googlemail.com', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'henkjanssen@googlemail.com',
+      });
+
+      const found = await findUserByNormalizedGmailEmail('henk.janssen@googlemail.com');
+      expect(found?.id).toBe(user.id);
+    });
+
+    it('should match across gmail.com and googlemail.com (same inbox)', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'henkjanssen@gmail.com',
+      });
+
+      // gmail.com and googlemail.com deliver to the same inbox
+      const found = await findUserByNormalizedGmailEmail('henkjanssen@googlemail.com');
+      expect(found?.id).toBe(user.id);
+    });
+
+    it('should return undefined for non-Gmail addresses', async () => {
+      await insertTestUser({
+        google_user_email: 'henk.janssen@example.com',
+      });
+
+      const found = await findUserByNormalizedGmailEmail('henkjanssen@example.com');
+      expect(found).toBeUndefined();
+    });
+
+    it('should return undefined when no matching user exists', async () => {
+      const found = await findUserByNormalizedGmailEmail('nobody@gmail.com');
+      expect(found).toBeUndefined();
+    });
+
+    it('should find exact match (same email with same dots)', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'henk.janssen@gmail.com',
+      });
+
+      const found = await findUserByNormalizedGmailEmail('henk.janssen@gmail.com');
+      expect(found?.id).toBe(user.id);
     });
   });
 });

--- a/apps/web/src/lib/user.ts
+++ b/apps/web/src/lib/user.ts
@@ -67,6 +67,7 @@ import { eq, and, inArray, isNotNull, sql, or } from 'drizzle-orm';
 import { allow_fake_login } from './constants';
 import type { AuthErrorType } from '@/lib/auth/constants';
 import { hosted_domain_specials } from '@/lib/auth/constants';
+import { isGmailAddress, normalizeGmailAddress } from '@/lib/schemas/email';
 import { strict as assert } from 'node:assert';
 import type { OptionalError, Result } from '@/lib/maybe-result';
 import { failureResult, successResult, trpcFailure } from '@/lib/maybe-result';
@@ -191,6 +192,32 @@ export async function findUserByEmail(email: string): Promise<User | undefined> 
   });
 }
 
+/**
+ * Finds a user whose Gmail address is equivalent after dot-normalization.
+ * Gmail ignores dots in the local part, so henk.janssen@gmail.com and
+ * henkjanssen@gmail.com are the same inbox. This catches duplicate accounts
+ * that differ only by dot placement.
+ *
+ * Only searches Gmail/Googlemail addresses. Returns undefined for non-Gmail emails.
+ */
+export async function findUserByNormalizedGmailEmail(
+  email: string
+): Promise<User | undefined> {
+  if (!isGmailAddress(email)) return undefined;
+
+  const normalized = normalizeGmailAddress(email);
+  const [localPart, domain] = normalized.split('@');
+  if (!localPart || !domain) return undefined;
+
+  // Match any stored Gmail address whose local part, with dots stripped, equals the normalized local part
+  return await db.query.kilocode_users.findFirst({
+    where: and(
+      sql`lower(split_part(${kilocode_users.google_user_email}, '@', 2)) IN ('gmail.com', 'googlemail.com')`,
+      sql`replace(split_part(${kilocode_users.google_user_email}, '@', 1), '.', '') = ${localPart}`
+    ),
+  });
+}
+
 function fireAuthEvent(
   user: Pick<User, 'id' | 'google_user_email' | 'created_at'>,
   eventType: 'signup' | 'signin',
@@ -305,6 +332,13 @@ export async function createOrUpdateUser(
       });
       return failureResult('DIFFERENT-OAUTH');
     }
+  }
+
+  // Gmail ignores dots in the local part, so check for existing accounts
+  // that are equivalent after dot-normalization (e.g. henk.janssen@ vs henkjanssen@gmail.com)
+  const gmailDotVariantUser = await findUserByNormalizedGmailEmail(args.google_user_email);
+  if (gmailDotVariantUser) {
+    return failureResult('DIFFERENT-OAUTH');
   }
 
   if (turnstile_guid && (await findUserById(turnstile_guid)))

--- a/apps/web/src/lib/user.ts
+++ b/apps/web/src/lib/user.ts
@@ -200,9 +200,7 @@ export async function findUserByEmail(email: string): Promise<User | undefined> 
  *
  * Only searches Gmail/Googlemail addresses. Returns undefined for non-Gmail emails.
  */
-export async function findUserByNormalizedGmailEmail(
-  email: string
-): Promise<User | undefined> {
+export async function findUserByNormalizedGmailEmail(email: string): Promise<User | undefined> {
   if (!isGmailAddress(email)) return undefined;
 
   const normalized = normalizeGmailAddress(email);

--- a/apps/web/src/lib/user.ts
+++ b/apps/web/src/lib/user.ts
@@ -338,6 +338,26 @@ export async function createOrUpdateUser(
   // that are equivalent after dot-normalization (e.g. henk.janssen@ vs henkjanssen@gmail.com)
   const gmailDotVariantUser = await findUserByNormalizedGmailEmail(args.google_user_email);
   if (gmailDotVariantUser) {
+    // For magic link (autoLinkToExistingUser), link to the existing account since the
+    // dot-variant Gmail address delivers to the same inbox — the user proved ownership.
+    if (autoLinkToExistingUser) {
+      const linkResult = await linkAccountToExistingUser(gmailDotVariantUser.id, args);
+      if (!linkResult.success) {
+        return { success: false, error: linkResult.error };
+      }
+      fireAuthEvent(gmailDotVariantUser, 'signin', args.provider, requestHeaders);
+      posthogClient.capture({
+        distinctId: gmailDotVariantUser.google_user_email,
+        event: 'user_signed_in_gmail_dot_variant_auto_linked',
+        properties: {
+          existing_email: gmailDotVariantUser.google_user_email,
+          new_email: args.google_user_email,
+          existing_id: gmailDotVariantUser.id,
+          provider: args.provider,
+        },
+      });
+      return successResult({ user: gmailDotVariantUser, isNew: false });
+    }
     return failureResult('DIFFERENT-OAUTH');
   }
 

--- a/apps/web/src/tests/account-verification-redirect.test.ts
+++ b/apps/web/src/tests/account-verification-redirect.test.ts
@@ -36,7 +36,10 @@ jest.mock('@/lib/user.server', () => ({
   getUserFromAuthOrRedirect: (...args: [string?]) => mockGetUserFromAuthOrRedirect(...args),
 }));
 
-const mockGetStytchStatus = jest.fn<Promise<boolean | null>, [User, string | null, Headers]>();
+const mockGetStytchStatus = jest.fn<
+  Promise<boolean | 'blocked' | null>,
+  [User, string | null, Headers]
+>();
 const mockHandleSignupPromotion = jest.fn<Promise<void>, [User, boolean]>();
 jest.mock('@/lib/stytch', () => ({
   getStytchStatus: (...args: [User, string | null, Headers]) => mockGetStytchStatus(...args),
@@ -273,6 +276,43 @@ describe('account-verification redirect logic', () => {
 
       expect(mockRedirect).toHaveBeenCalledTimes(1);
       expect(mockRedirect).toHaveBeenCalledWith('/get-started');
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Case: stytchStatus is 'blocked' — user should be blocked
+  // ---------------------------------------------------------------
+  describe('when stytchStatus is blocked', () => {
+    it('should redirect to /account-blocked', async () => {
+      const user = makeUser({ customer_source: null });
+      mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
+      mockGetStytchStatus.mockResolvedValue('blocked');
+
+      await renderPage();
+
+      expect(mockRedirect).toHaveBeenCalledTimes(1);
+      expect(mockRedirect).toHaveBeenCalledWith('/account-blocked');
+    });
+
+    it('should redirect to /account-blocked regardless of callbackPath', async () => {
+      const user = makeUser({ customer_source: 'Google search' });
+      mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
+      mockGetStytchStatus.mockResolvedValue('blocked');
+
+      await renderPage({ callbackPath: '/get-started' });
+
+      expect(mockRedirect).toHaveBeenCalledTimes(1);
+      expect(mockRedirect).toHaveBeenCalledWith('/account-blocked');
+    });
+
+    it('should not call handleSignupPromotion when blocked', async () => {
+      const user = makeUser({ customer_source: null });
+      mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
+      mockGetStytchStatus.mockResolvedValue('blocked');
+
+      await renderPage();
+
+      expect(mockHandleSignupPromotion).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

Previously, a Stytch `BLOCK` verdict only denied free credits but let the user continue using the platform normally. This was inconsistent with Stytch's recommendation that `BLOCK` means the device "should be blocked from completing the privileged action in question."

Now when Stytch returns a `BLOCK` verdict during account verification:
- `blocked_reason` is set to `'stytch-block'` on the user row
- The account-verification page redirects to `/account-blocked`
- All existing `blocked_reason` infrastructure (API auth checks, service guards) kicks in automatically

Non-BLOCK verdicts (e.g. `CHALLENGE`) continue to only deny free credits without blocking, preserving the existing behavior for ambiguous cases.

## Verification

- `pnpm test -- apps/web/src/lib/stytch.test.ts` — 15 tests pass (3 new: block/challenge/allow verdict assertions)
- `pnpm test -- apps/web/src/tests/account-verification-redirect.test.ts` — 16 tests pass (3 new: blocked redirect, blocked ignores callbackPath, blocked skips promotion)
- `pnpm typecheck` — no new errors (pre-existing `linkify-it` issue unrelated)

## Visual Changes

N/A

## Reviewer Notes

- This only affects **new** users going through account verification. Existing users who previously received a BLOCK verdict already have `has_validation_stytch = false` and won't be re-evaluated (their `getStytchStatus` returns early).
- If retroactive blocking of existing BLOCK-verdicted users is desired, that would be a separate migration script.
- The 404/missing telemetry_id case is left unchanged (returns `null` = retry). Stytch recommends treating 404 as BLOCK, but that could inadvertently block ad-blocker users. That decision is left for a separate discussion.
