### PR TITLE
feat(gateway): enforce abuse service verdicts for soft-blocking

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -495,6 +495,45 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     userByok
   );
 
+  // Pre-request abuse enforcement (zero-wait, fail-open).
+  // The classifyPromise was started ~120 lines ago, so it has had time to resolve during
+  // auth checks, balance checks, and request preparation. We only enforce if the result is
+  // already available — no added latency for any request. If the classification hasn't
+  // resolved yet, proceed normally (fail-open).
+  let abuseRetryAfterSeconds: number | undefined;
+  {
+    const preClassifyResult = await Promise.race([
+      classifyPromise,
+      new Promise<null>(resolve => setTimeout(resolve, 0)),
+    ]);
+
+    if (preClassifyResult && preClassifyResult.verdict !== 'ALLOW') {
+      const metadata = preClassifyResult.action_metadata;
+
+      console.log('[Abuse] Enforcing verdict:', {
+        verdict: preClassifyResult.verdict,
+        risk_score: preClassifyResult.risk_score,
+        signals: preClassifyResult.signals,
+        kilo_user_id: user.id,
+        requested_model: originalModelIdLowerCased,
+        model_override: metadata?.model_override,
+        retry_after_seconds: metadata?.retry_after_seconds,
+      });
+
+      // Model downgrade: silently route to a cheaper model
+      if (metadata?.model_override) {
+        requestBodyParsed.body.model = metadata.model_override;
+      }
+
+      // Artificial delay + Retry-After header (capped at 5s)
+      const delaySec = metadata?.retry_after_seconds;
+      if (delaySec && delaySec > 0) {
+        abuseRetryAfterSeconds = Math.min(delaySec, 5);
+        await new Promise(resolve => setTimeout(resolve, abuseRetryAfterSeconds! * 1000));
+      }
+    }
+  }
+
   let response: Response;
   if (requestBodyParsed.kind === 'chat_completions' && provider.id === 'martian') {
     response = await grokCodeFastOptimizedRequest(
@@ -599,6 +638,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     request: requestBodyParsed,
   });
 
+  let finalResponse: NextResponseType<unknown>;
   {
     const errorResponse = await makeErrorReadable({
       requestedModel: originalModelIdLowerCased,
@@ -606,28 +646,50 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       response,
       isUserByok: !!userByok,
     });
+
     if (errorResponse) {
-      return errorResponse;
+      finalResponse = errorResponse;
+    } else {
+      const isFreeModelRequiringCostRemoval =
+        (provider.id === 'openrouter' || provider.id === 'vercel') &&
+        isKiloExclusiveFreeModel(originalModelIdLowerCased);
+      const isStealthModelRequiringNameRemoval =
+        provider.id !== 'martian' && isKiloStealthModel(originalModelIdLowerCased);
+
+      if (
+        (isFreeModelRequiringCostRemoval || isStealthModelRequiringNameRemoval) &&
+        requestBodyParsed.kind === 'chat_completions'
+      ) {
+        finalResponse = await rewriteFreeModelResponse_ChatCompletions(
+          response,
+          originalModelIdLowerCased
+        );
+      } else if (
+        (isFreeModelRequiringCostRemoval || isStealthModelRequiringNameRemoval) &&
+        requestBodyParsed.kind === 'responses'
+      ) {
+        finalResponse = await rewriteFreeModelResponse_Responses(
+          response,
+          originalModelIdLowerCased
+        );
+      } else if (
+        (isFreeModelRequiringCostRemoval || isStealthModelRequiringNameRemoval) &&
+        requestBodyParsed.kind === 'messages'
+      ) {
+        finalResponse = await rewriteFreeModelResponse_Messages(
+          response,
+          originalModelIdLowerCased
+        );
+      } else {
+        finalResponse = wrapInSafeNextResponse(response);
+      }
     }
   }
 
-  const isFreeModelRequiringCostRemoval =
-    (provider.id === 'openrouter' || provider.id === 'vercel') &&
-    isKiloExclusiveFreeModel(originalModelIdLowerCased);
-  const isStealthModelRequiringNameRemoval =
-    provider.id !== 'martian' && isKiloStealthModel(originalModelIdLowerCased);
-
-  if (isFreeModelRequiringCostRemoval || isStealthModelRequiringNameRemoval) {
-    if (requestBodyParsed.kind === 'chat_completions') {
-      return rewriteFreeModelResponse_ChatCompletions(response, originalModelIdLowerCased);
-    }
-    if (requestBodyParsed.kind === 'responses') {
-      return rewriteFreeModelResponse_Responses(response, originalModelIdLowerCased);
-    }
-    if (requestBodyParsed.kind === 'messages') {
-      return rewriteFreeModelResponse_Messages(response, originalModelIdLowerCased);
-    }
+  // Add Retry-After header for abuse-classified requests to signal the client to slow down
+  if (abuseRetryAfterSeconds) {
+    finalResponse.headers.set('Retry-After', String(abuseRetryAfterSeconds));
   }
 
-  return wrapInSafeNextResponse(response);
+  return finalResponse;
 }

--- a/apps/web/src/lib/abuse-service.ts
+++ b/apps/web/src/lib/abuse-service.ts
@@ -302,7 +302,8 @@ async function fetchAbuseService<T>(
  * Classify a request for potential abuse.
  * This is called before proxying requests to detect fraudulent activity.
  *
- * Currently logs the response only; does not take action.
+ * Non-ALLOW verdicts are enforced by the gateway: model downgrade,
+ * artificial delay, and Retry-After headers (zero-wait, fail-open).
  *
  * @param payload - Request details to classify
  * @returns Classification response or null if service unavailable


### PR DESCRIPTION
## Summary

Activates enforcement of the abuse detection service verdicts that were previously observe-only. The abuse service at `abuse.kiloapps.io` already classifies every gateway request and returns verdicts (`ALLOW`, `SOFT_BLOCK`, `CHALLENGE`, `HARD_BLOCK`) with action metadata — but the gateway was only logging them. This PR makes the gateway act on non-ALLOW verdicts:

- **Model downgrade**: silently routes to a cheaper model via `action_metadata.model_override`
- **Artificial delay**: pauses before the LLM request for `action_metadata.retry_after_seconds` (capped at 5s)
- **Retry-After header**: adds the header to signal the client to slow down

Uses a zero-wait `Promise.race` so enforcement only applies when the classification has already resolved during the ~120 lines of preceding work (auth, balance, provider checks). No added latency for any request — if the abuse service hasn't responded yet, fail-open.

## Verification

- [x] `pnpm typecheck` — passes (only pre-existing `linkify-it` error in unrelated file)
- [x] `pnpm format` — passes
- [x] Verified fail-open: when abuse service is unavailable, `classifyPromise` resolves to `null` and enforcement is skipped

## Visual Changes

N/A

## Reviewer Notes

- All enforcement behavior is controlled by the external abuse service's verdicts and `action_metadata`. To tune who gets soft-blocked and how, configure the abuse service — the gateway just acts on what it receives.
- The refactor of the final response return paths (from multiple `return` statements to a single `finalResponse` variable) is a structural change to enable the `Retry-After` header injection. The logic is equivalent.
- The 5s cap on `retry_after_seconds` prevents the abuse service from holding gateway connections open too long.
