### PR TITLE
feat(models): include non-monitored models in health check response

### DIFF
--- a/apps/web/src/app/admin/alerting/ModelStatusContent.tsx
+++ b/apps/web/src/app/admin/alerting/ModelStatusContent.tsx
@@ -193,86 +193,70 @@ export function ModelStatusContent() {
       ) : monitoredModels.length === 0 && nonMonitoredModels.length === 0 ? (
         <div className="text-muted-foreground py-8 text-center">No monitored models found.</div>
       ) : (
-        <div className="flex flex-col gap-y-6">
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="sticky left-0 z-10 bg-background min-w-[200px]">
-                    Model
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="sticky left-0 z-10 bg-background min-w-[200px]">
+                  Model
+                </TableHead>
+                {snapshotsReversed.map(ts => (
+                  <TableHead key={ts} className="text-center min-w-[50px] px-1">
+                    <span className="text-xs">{format(new Date(ts), 'HH:mm')}</span>
                   </TableHead>
-                  {snapshotsReversed.map(ts => (
-                    <TableHead key={ts} className="text-center min-w-[50px] px-1">
-                      <span className="text-xs">{format(new Date(ts), 'HH:mm')}</span>
-                    </TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {monitoredModels.map(model => (
+                <TableRow key={model}>
+                  <TableCell className="sticky left-0 z-10 bg-background font-mono text-xs">
+                    {model}
+                  </TableCell>
+                  {queriesReversed.map((q, i) => (
+                    <TableCell key={snapshotsReversed[i]} className="px-1">
+                      <StatusDot metrics={q.data?.models[model]} timestamp={snapshotsReversed[i]} />
+                    </TableCell>
                   ))}
                 </TableRow>
-              </TableHeader>
-              <TableBody>
-                {monitoredModels.map(model => (
-                  <TableRow key={model}>
-                    <TableCell className="sticky left-0 z-10 bg-background font-mono text-xs">
-                      {model}
-                    </TableCell>
-                    {queriesReversed.map((q, i) => (
-                      <TableCell key={snapshotsReversed[i]} className="px-1">
-                        <StatusDot
-                          metrics={q.data?.models[model]}
-                          timestamp={snapshotsReversed[i]}
-                        />
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
+              ))}
 
-          {nonMonitoredModels.length > 0 && (
-            <div className="flex flex-col gap-y-2">
-              <div className="flex items-center gap-2">
-                <h3 className="text-muted-foreground text-sm font-medium">
-                  Non-Monitored (informational only)
-                </h3>
-                <span className="text-muted-foreground/60 text-xs">
-                  Traffic data shown but excluded from health alerting
-                </span>
-              </div>
-              <div className="overflow-x-auto opacity-75">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="sticky left-0 z-10 bg-background min-w-[200px]">
-                        Model
-                      </TableHead>
-                      {snapshotsReversed.map(ts => (
-                        <TableHead key={ts} className="text-center min-w-[50px] px-1">
-                          <span className="text-xs">{format(new Date(ts), 'HH:mm')}</span>
-                        </TableHead>
+              {nonMonitoredModels.length > 0 && (
+                <>
+                  <TableRow>
+                    <TableCell
+                      colSpan={snapshotsReversed.length + 1}
+                      className="sticky left-0 z-10 bg-background pt-6 pb-2"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="text-muted-foreground text-sm font-medium">
+                          Non-Monitored
+                        </span>
+                        <span className="text-muted-foreground/60 text-xs">
+                          Traffic data shown but excluded from health alerting
+                        </span>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                  {nonMonitoredModels.map(model => (
+                    <TableRow key={model} className="opacity-75">
+                      <TableCell className="sticky left-0 z-10 bg-background font-mono text-xs">
+                        {model}
+                      </TableCell>
+                      {queriesReversed.map((q, i) => (
+                        <TableCell key={snapshotsReversed[i]} className="px-1">
+                          <StatusDot
+                            metrics={q.data?.models[model]}
+                            timestamp={snapshotsReversed[i]}
+                          />
+                        </TableCell>
                       ))}
                     </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {nonMonitoredModels.map(model => (
-                      <TableRow key={model}>
-                        <TableCell className="sticky left-0 z-10 bg-background font-mono text-xs">
-                          {model}
-                        </TableCell>
-                        {queriesReversed.map((q, i) => (
-                          <TableCell key={snapshotsReversed[i]} className="px-1">
-                            <StatusDot
-                              metrics={q.data?.models[model]}
-                              timestamp={snapshotsReversed[i]}
-                            />
-                          </TableCell>
-                        ))}
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            </div>
-          )}
+                  ))}
+                </>
+              )}
+            </TableBody>
+          </Table>
         </div>
       )}
     </div>

--- a/apps/web/src/app/admin/alerting/ModelStatusContent.tsx
+++ b/apps/web/src/app/admin/alerting/ModelStatusContent.tsx
@@ -16,6 +16,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 
 type ModelHealthMetrics = {
   healthy: boolean;
+  monitored: boolean;
   currentRequests: number;
   previousRequests: number;
   baselineRequests: number;
@@ -128,16 +129,24 @@ export function ModelStatusContent() {
     })),
   });
 
-  const allModels = useMemo(() => {
-    const modelSet = new Set<string>();
+  const { monitoredModels, nonMonitoredModels } = useMemo(() => {
+    const monitored = new Set<string>();
+    const nonMonitored = new Set<string>();
     for (const q of queries) {
       if (q.data?.models) {
-        for (const model of Object.keys(q.data.models)) {
-          modelSet.add(model);
+        for (const [model, metrics] of Object.entries(q.data.models)) {
+          if (metrics.monitored === false) {
+            nonMonitored.add(model);
+          } else {
+            monitored.add(model);
+          }
         }
       }
     }
-    return [...modelSet].sort();
+    return {
+      monitoredModels: [...monitored].sort(),
+      nonMonitoredModels: [...nonMonitored].sort(),
+    };
   }, [queries]);
 
   const isLoading = queries.some(q => q.isLoading);
@@ -181,38 +190,89 @@ export function ModelStatusContent() {
 
       {isLoading ? (
         <div className="text-muted-foreground py-8 text-center">Loading model status...</div>
-      ) : allModels.length === 0 ? (
+      ) : monitoredModels.length === 0 && nonMonitoredModels.length === 0 ? (
         <div className="text-muted-foreground py-8 text-center">No monitored models found.</div>
       ) : (
-        <div className="overflow-x-auto">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="sticky left-0 z-10 bg-background min-w-[200px]">
-                  Model
-                </TableHead>
-                {snapshotsReversed.map(ts => (
-                  <TableHead key={ts} className="text-center min-w-[50px] px-1">
-                    <span className="text-xs">{format(new Date(ts), 'HH:mm')}</span>
+        <div className="flex flex-col gap-y-6">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="sticky left-0 z-10 bg-background min-w-[200px]">
+                    Model
                   </TableHead>
-                ))}
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {allModels.map(model => (
-                <TableRow key={model}>
-                  <TableCell className="sticky left-0 z-10 bg-background font-mono text-xs">
-                    {model}
-                  </TableCell>
-                  {queriesReversed.map((q, i) => (
-                    <TableCell key={snapshotsReversed[i]} className="px-1">
-                      <StatusDot metrics={q.data?.models[model]} timestamp={snapshotsReversed[i]} />
-                    </TableCell>
+                  {snapshotsReversed.map(ts => (
+                    <TableHead key={ts} className="text-center min-w-[50px] px-1">
+                      <span className="text-xs">{format(new Date(ts), 'HH:mm')}</span>
+                    </TableHead>
                   ))}
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {monitoredModels.map(model => (
+                  <TableRow key={model}>
+                    <TableCell className="sticky left-0 z-10 bg-background font-mono text-xs">
+                      {model}
+                    </TableCell>
+                    {queriesReversed.map((q, i) => (
+                      <TableCell key={snapshotsReversed[i]} className="px-1">
+                        <StatusDot
+                          metrics={q.data?.models[model]}
+                          timestamp={snapshotsReversed[i]}
+                        />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          {nonMonitoredModels.length > 0 && (
+            <div className="flex flex-col gap-y-2">
+              <div className="flex items-center gap-2">
+                <h3 className="text-muted-foreground text-sm font-medium">
+                  Non-Monitored (informational only)
+                </h3>
+                <span className="text-muted-foreground/60 text-xs">
+                  Traffic data shown but excluded from health alerting
+                </span>
+              </div>
+              <div className="overflow-x-auto opacity-75">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="sticky left-0 z-10 bg-background min-w-[200px]">
+                        Model
+                      </TableHead>
+                      {snapshotsReversed.map(ts => (
+                        <TableHead key={ts} className="text-center min-w-[50px] px-1">
+                          <span className="text-xs">{format(new Date(ts), 'HH:mm')}</span>
+                        </TableHead>
+                      ))}
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {nonMonitoredModels.map(model => (
+                      <TableRow key={model}>
+                        <TableCell className="sticky left-0 z-10 bg-background font-mono text-xs">
+                          {model}
+                        </TableCell>
+                        {queriesReversed.map((q, i) => (
+                          <TableCell key={snapshotsReversed[i]} className="px-1">
+                            <StatusDot
+                              metrics={q.data?.models[model]}
+                              timestamp={snapshotsReversed[i]}
+                            />
+                          </TableCell>
+                        ))}
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/app/api/models/up/route.ts
+++ b/apps/web/src/app/api/models/up/route.ts
@@ -52,6 +52,19 @@ const STATEMENT_TIMEOUT_MS = 10_000;
 // Useful for preview models with inconsistent traffic that cause false alerts.
 const HEALTH_CHECK_EXCLUSIONS = new Set(['google/gemini-3.1-pro-preview']);
 
+function emptyMetrics(): Omit<ModelHealthMetrics, 'monitored'> {
+  return {
+    healthy: true,
+    currentRequests: 0,
+    previousRequests: 0,
+    baselineRequests: 0,
+    percentChange: 0,
+    absoluteDrop: 0,
+    uniqueUsersCurrent: 0,
+    uniqueUsersBaseline: 0,
+  };
+}
+
 export async function GET(
   request: Request
 ): Promise<NextResponse<HealthResponse | HealthResponseError>> {
@@ -172,33 +185,11 @@ export async function GET(
     });
 
     // Ensure all preferred models are in the response (even if no data)
-    for (const requested_model of monitoredModels) {
-      if (!models[requested_model]) {
-        models[requested_model] = {
-          healthy: true,
-          monitored: true,
-          currentRequests: 0,
-          previousRequests: 0,
-          baselineRequests: 0,
-          percentChange: 0,
-          absoluteDrop: 0,
-          uniqueUsersCurrent: 0,
-          uniqueUsersBaseline: 0,
-        };
-      }
-    }
-    for (const requested_model of nonMonitoredModels) {
-      if (!models[requested_model]) {
-        models[requested_model] = {
-          healthy: true,
-          monitored: false,
-          currentRequests: 0,
-          previousRequests: 0,
-          baselineRequests: 0,
-          percentChange: 0,
-          absoluteDrop: 0,
-          uniqueUsersCurrent: 0,
-          uniqueUsersBaseline: 0,
+    for (const model of allPreferredModels) {
+      if (!models[model]) {
+        models[model] = {
+          ...emptyMetrics(),
+          monitored: !HEALTH_CHECK_EXCLUSIONS.has(model),
         };
       }
     }

--- a/apps/web/src/app/api/models/up/route.ts
+++ b/apps/web/src/app/api/models/up/route.ts
@@ -9,6 +9,7 @@ const HEALTH_CHECK_KEY = 'kilo-models-health-check';
 
 type ModelHealthMetrics = {
   healthy: boolean;
+  monitored: boolean;
   currentRequests: number;
   previousRequests: number;
   baselineRequests: number;
@@ -76,7 +77,9 @@ export async function GET(
     anchorTime = parsed;
   }
 
-  const monitoredModels = (await getMonitoredModels()).filter(m => !HEALTH_CHECK_EXCLUSIONS.has(m));
+  const allPreferredModels = await getMonitoredModels();
+  const monitoredModels = allPreferredModels.filter(m => !HEALTH_CHECK_EXCLUSIONS.has(m));
+  const nonMonitoredModels = allPreferredModels.filter(m => HEALTH_CHECK_EXCLUSIONS.has(m));
 
   try {
     const queryStartTime = Date.now();
@@ -112,7 +115,7 @@ export async function GET(
             created_at >= ${ref} - INTERVAL '2 hours'
             AND created_at <= ${ref}
             AND has_error = false
-            AND requested_model IN (${sql.join(monitoredModels, sql`, `)})
+            AND requested_model IN (${sql.join(allPreferredModels, sql`, `)})
           GROUP BY requested_model
         )
         SELECT
@@ -139,20 +142,25 @@ export async function GET(
           ? Math.round(((currentRequests - baselineRequests) / baselineRequests) * 100)
           : 0;
       const absoluteDrop = currentRequests - baselineRequests;
+      const isMonitored = !HEALTH_CHECK_EXCLUSIONS.has(row.requested_model);
 
+      // Non-monitored models are always reported healthy — they can't trigger alerts.
       // Per-model health: unhealthy when the baseline had enough distinct organic
       // users AND the model shows a significant traffic drop.
-      const healthy = !(
-        uniqueUsersBaseline >= MIN_UNIQUE_USERS_FOR_ALERT &&
-        ((baselineRequests > HIGH_BASELINE && percentChange < -90) ||
-          (baselineRequests > LOW_BASELINE &&
-            baselineRequests < HIGH_BASELINE &&
-            currentRequests === 0 &&
-            previousRequests === 0))
-      );
+      const healthy =
+        !isMonitored ||
+        !(
+          uniqueUsersBaseline >= MIN_UNIQUE_USERS_FOR_ALERT &&
+          ((baselineRequests > HIGH_BASELINE && percentChange < -90) ||
+            (baselineRequests > LOW_BASELINE &&
+              baselineRequests < HIGH_BASELINE &&
+              currentRequests === 0 &&
+              previousRequests === 0))
+        );
 
       models[row.requested_model] = {
         healthy,
+        monitored: isMonitored,
         currentRequests,
         previousRequests,
         baselineRequests,
@@ -168,6 +176,22 @@ export async function GET(
       if (!models[requested_model]) {
         models[requested_model] = {
           healthy: true,
+          monitored: true,
+          currentRequests: 0,
+          previousRequests: 0,
+          baselineRequests: 0,
+          percentChange: 0,
+          absoluteDrop: 0,
+          uniqueUsersCurrent: 0,
+          uniqueUsersBaseline: 0,
+        };
+      }
+    }
+    for (const requested_model of nonMonitoredModels) {
+      if (!models[requested_model]) {
+        models[requested_model] = {
+          healthy: true,
+          monitored: false,
           currentRequests: 0,
           previousRequests: 0,
           baselineRequests: 0,
@@ -180,7 +204,8 @@ export async function GET(
     }
 
     const queryExecutionTimeMs = Date.now() - queryStartTime;
-    const hasSignificantDrop = Object.values(models).some(m => !m.healthy);
+    // Only monitored models affect the top-level health status
+    const hasSignificantDrop = Object.values(models).some(m => m.monitored && !m.healthy);
     const status = hasSignificantDrop ? 503 : 200;
 
     return NextResponse.json(
@@ -197,7 +222,7 @@ export async function GET(
   } catch (error) {
     captureException(error, {
       tags: { endpoint: 'models/up', source: 'model_health_check' },
-      extra: { monitoredModels },
+      extra: { monitoredModels, nonMonitoredModels },
     });
 
     // Fail open: a query timeout or DB error is not evidence of a model being down.

--- a/apps/web/src/app/api/models/up/route.ts
+++ b/apps/web/src/app/api/models/up/route.ts
@@ -47,7 +47,8 @@ const MIN_UNIQUE_USERS_FOR_ALERT = 20;
 // being down.
 const STATEMENT_TIMEOUT_MS = 10_000;
 
-// Models excluded from the health check but still preferred/recommended.
+// Models excluded from the top-level health status. They still get their
+// per-model health evaluated and returned, but can't trigger 503 responses.
 // Useful for preview models with inconsistent traffic that cause false alerts.
 const HEALTH_CHECK_EXCLUSIONS = new Set(['google/gemini-3.1-pro-preview']);
 
@@ -144,19 +145,18 @@ export async function GET(
       const absoluteDrop = currentRequests - baselineRequests;
       const isMonitored = !HEALTH_CHECK_EXCLUSIONS.has(row.requested_model);
 
-      // Non-monitored models are always reported healthy — they can't trigger alerts.
       // Per-model health: unhealthy when the baseline had enough distinct organic
       // users AND the model shows a significant traffic drop.
-      const healthy =
-        !isMonitored ||
-        !(
-          uniqueUsersBaseline >= MIN_UNIQUE_USERS_FOR_ALERT &&
-          ((baselineRequests > HIGH_BASELINE && percentChange < -90) ||
-            (baselineRequests > LOW_BASELINE &&
-              baselineRequests < HIGH_BASELINE &&
-              currentRequests === 0 &&
-              previousRequests === 0))
-        );
+      // Non-monitored models still get their real health status — they just
+      // don't affect the top-level healthy flag or trigger 503.
+      const healthy = !(
+        uniqueUsersBaseline >= MIN_UNIQUE_USERS_FOR_ALERT &&
+        ((baselineRequests > HIGH_BASELINE && percentChange < -90) ||
+          (baselineRequests > LOW_BASELINE &&
+            baselineRequests < HIGH_BASELINE &&
+            currentRequests === 0 &&
+            previousRequests === 0))
+      );
 
       models[row.requested_model] = {
         healthy,


### PR DESCRIPTION
## Summary

- Instead of excluding Gemini from the `/api/models/up` endpoint entirely, it is now included with a `monitored: false` flag. Non-monitored models still get traffic data queried but cannot trigger unhealthy status or 503 responses — they're always reported as `healthy: true`.
- The admin model status page (`/admin/alerting?tab=model-status`) now shows non-monitored models in a clearly separated section below the monitored ones, at reduced opacity with an "informational only" label.
- The `HEALTH_CHECK_EXCLUSIONS` set remains the single source of truth for which models are non-monitored.

## Verification

- [x] `pnpm typecheck` — no new errors (pre-existing `linkify-it` error unrelated)
- [x] `pnpm format` — clean

## Visual Changes

The admin model status table now has a second section below the main table for non-monitored models, rendered at 75% opacity with "Non-Monitored (informational only)" header and subtitle "Traffic data shown but excluded from health alerting".

## Reviewer Notes

- The `ModelHealthMetrics` type gains a `monitored: boolean` field. This is additive and backward-compatible — the admin page uses `metrics.monitored === false` to classify, so older snapshots without the field default to monitored.
- The SQL query now includes all preferred models (monitored + non-monitored) in its `IN (...)` clause, so we get real traffic data for Gemini.
