### PR TITLE
feat(claw-settings): add Exa search provider controls

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ExaSearchEntrySection.tsx
+++ b/apps/web/src/app/(app)/claw/components/ExaSearchEntrySection.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AlertCircle, ChevronDown, Save } from 'lucide-react';
+import { toast } from 'sonner';
+import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Separator } from '@/components/ui/separator';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+import { ExaSearchIcon } from './icons/ExaSearchIcon';
+
+type ClawMutations = ReturnType<typeof useKiloClawMutations>;
+type ExaSelection = 'enabled' | 'disabled';
+type KiloExaSearchMode = 'kilo-proxy' | 'disabled' | null;
+
+function selectionFromMode(mode: KiloExaSearchMode): ExaSelection {
+  return mode === 'kilo-proxy' ? 'enabled' : 'disabled';
+}
+
+function modeFromSelection(selection: ExaSelection): Exclude<KiloExaSearchMode, null> {
+  return selection === 'enabled' ? 'kilo-proxy' : 'disabled';
+}
+
+export function ExaSearchEntrySection({
+  mode,
+  configured,
+  braveConfigured,
+  mutations,
+  onSecretsChanged,
+  isDirty,
+}: {
+  mode: KiloExaSearchMode;
+  configured: boolean;
+  braveConfigured: boolean;
+  mutations: ClawMutations;
+  onSecretsChanged?: (entryId: string) => void;
+  isDirty: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [pendingConfirmSelection, setPendingConfirmSelection] = useState<ExaSelection | null>(
+    null
+  );
+  const [selection, setSelection] = useState<ExaSelection>(() => selectionFromMode(mode));
+  const [isSaving, setIsSaving] = useState(false);
+
+  const Icon = ExaSearchIcon;
+
+  const persistedSelection = selectionFromMode(mode);
+  const hasUnsavedSelection = selection !== persistedSelection;
+
+  useEffect(() => {
+    setSelection(selectionFromMode(mode));
+  }, [mode]);
+
+  function commitSelection(nextSelection: ExaSelection) {
+    setIsSaving(true);
+    mutations.patchWebSearchConfig.mutate(
+      {
+        exaMode: modeFromSelection(nextSelection),
+      },
+      {
+        onSuccess: () => {
+          toast.success('Exa Search setting saved. Redeploy to apply.', { duration: 8000 });
+          setPendingConfirmSelection(null);
+          onSecretsChanged?.('kilo-exa-search');
+        },
+        onError: err => {
+          setPendingConfirmSelection(null);
+          toast.error(`Failed to save: ${err.message}`);
+        },
+        onSettled: () => setIsSaving(false),
+      }
+    );
+  }
+
+  function handleSave() {
+    if (braveConfigured && (selection === 'disabled' || selection === 'enabled')) {
+      setPendingConfirmSelection(selection);
+      return;
+    }
+    commitSelection(selection);
+  }
+
+  return (
+    <>
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <div className="rounded-lg border">
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="hover:bg-muted/50 flex w-full cursor-pointer items-center gap-3 rounded-lg px-4 py-3 transition-colors"
+            >
+              <Icon className="h-5 w-5 shrink-0" />
+              <div className="flex min-w-0 flex-1 flex-col items-start">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">Exa Search</span>
+                  <Badge
+                    variant={configured ? 'default' : 'secondary'}
+                    className="px-1.5 py-0 text-[10px] leading-4"
+                  >
+                    {configured ? 'Configured' : 'Not configured'}
+                  </Badge>
+                  {isDirty && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <AlertCircle className="h-4 w-4 text-amber-500" />
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>Redeploy to apply changes</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </div>
+                <span className="text-muted-foreground text-xs">
+                  Use Kilo's integrated Exa web search provider
+                </span>
+              </div>
+              <ChevronDown
+                className={`text-muted-foreground h-4 w-4 shrink-0 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+              />
+            </button>
+          </CollapsibleTrigger>
+
+          <CollapsibleContent>
+            <Separator />
+            <div className="space-y-3 px-4 py-3">
+              <div className="space-y-2">
+                <Label className="text-xs">Status</Label>
+                <RadioGroup
+                  value={selection}
+                  onValueChange={value => setSelection(value === 'enabled' ? 'enabled' : 'disabled')}
+                  className="gap-2"
+                >
+                  <label
+                    htmlFor="settings-kilo-exa-enabled"
+                    className="flex cursor-pointer items-start gap-2"
+                  >
+                    <RadioGroupItem
+                      id="settings-kilo-exa-enabled"
+                      value="enabled"
+                      className="mt-0.5"
+                      disabled={isSaving}
+                    />
+                    <span className="text-sm">Enabled</span>
+                  </label>
+                  <label
+                    htmlFor="settings-kilo-exa-disabled"
+                    className="flex cursor-pointer items-start gap-2"
+                  >
+                    <RadioGroupItem
+                      id="settings-kilo-exa-disabled"
+                      value="disabled"
+                      className="mt-0.5"
+                      disabled={isSaving}
+                    />
+                    <span className="text-sm">Disabled</span>
+                  </label>
+                </RadioGroup>
+              </div>
+
+              <p className="text-muted-foreground text-xs">
+                Enable or disable the Kilo-integrated Exa web search provider.
+              </p>
+
+              <div className="flex items-center gap-2">
+                <Button size="sm" onClick={handleSave} disabled={isSaving || !hasUnsavedSelection}>
+                  <Save className="h-4 w-4" />
+                  {isSaving ? 'Saving...' : 'Save'}
+                </Button>
+              </div>
+            </div>
+          </CollapsibleContent>
+        </div>
+      </Collapsible>
+
+      <AlertDialog
+        open={pendingConfirmSelection !== null}
+        onOpenChange={
+          isSaving
+            ? undefined
+            : nextOpen => {
+                if (!nextOpen) {
+                  setPendingConfirmSelection(null);
+                }
+              }
+        }
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {pendingConfirmSelection === 'enabled' ? 'Enable Exa Search?' : 'Disable Exa Search?'}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingConfirmSelection === 'enabled'
+                ? 'Brave Search is currently configured. Enabling Exa will disable Brave on the next redeploy.'
+                : 'Brave Search is currently configured. Disabling Exa will re-enable Brave on the next redeploy.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isSaving}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => commitSelection(pendingConfirmSelection === 'enabled' ? 'enabled' : 'disabled')}
+              disabled={isSaving}
+            >
+              {isSaving
+                ? 'Saving...'
+                : pendingConfirmSelection === 'enabled'
+                  ? 'Enable Exa and disable Brave'
+                  : 'Disable Exa and re-enable Brave'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/claw/components/ExaSearchEntrySection.tsx
+++ b/apps/web/src/app/(app)/claw/components/ExaSearchEntrySection.tsx
@@ -53,9 +53,7 @@ export function ExaSearchEntrySection({
   isDirty: boolean;
 }) {
   const [open, setOpen] = useState(false);
-  const [pendingConfirmSelection, setPendingConfirmSelection] = useState<ExaSelection | null>(
-    null
-  );
+  const [pendingConfirmSelection, setPendingConfirmSelection] = useState<ExaSelection | null>(null);
   const [selection, setSelection] = useState<ExaSelection>(() => selectionFromMode(mode));
   const [isSaving, setIsSaving] = useState(false);
 
@@ -144,7 +142,9 @@ export function ExaSearchEntrySection({
                 <Label className="text-xs">Status</Label>
                 <RadioGroup
                   value={selection}
-                  onValueChange={value => setSelection(value === 'enabled' ? 'enabled' : 'disabled')}
+                  onValueChange={value =>
+                    setSelection(value === 'enabled' ? 'enabled' : 'disabled')
+                  }
                   className="gap-2"
                 >
                   <label
@@ -215,7 +215,9 @@ export function ExaSearchEntrySection({
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isSaving}>Cancel</AlertDialogCancel>
             <AlertDialogAction
-              onClick={() => commitSelection(pendingConfirmSelection === 'enabled' ? 'enabled' : 'disabled')}
+              onClick={() =>
+                commitSelection(pendingConfirmSelection === 'enabled' ? 'enabled' : 'disabled')
+              }
               disabled={isSaving}
             >
               {isSaving

--- a/apps/web/src/app/(app)/claw/components/ExaSearchEntrySection.tsx
+++ b/apps/web/src/app/(app)/claw/components/ExaSearchEntrySection.tsx
@@ -88,7 +88,7 @@ export function ExaSearchEntrySection({
   }
 
   function handleSave() {
-    if (braveConfigured && (selection === 'disabled' || selection === 'enabled')) {
+    if (braveConfigured) {
       setPendingConfirmSelection(selection);
       return;
     }

--- a/apps/web/src/app/(app)/claw/components/SecretEntrySection.tsx
+++ b/apps/web/src/app/(app)/claw/components/SecretEntrySection.tsx
@@ -175,112 +175,114 @@ export function SecretEntrySection({
     <>
       <Collapsible open={open} onOpenChange={setOpen}>
         <div className="rounded-lg border">
-        <CollapsibleTrigger asChild>
-          <button
-            type="button"
-            className="hover:bg-muted/50 flex w-full cursor-pointer items-center gap-3 rounded-lg px-4 py-3 transition-colors"
-          >
-            <Icon className="h-5 w-5 shrink-0" />
-            <div className="flex min-w-0 flex-1 flex-col items-start">
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium">{entry.label}</span>
-                <Badge
-                  variant={configured ? 'default' : 'secondary'}
-                  className="px-1.5 py-0 text-[10px] leading-4"
-                >
-                  {configured ? 'Configured' : 'Not configured'}
-                </Badge>
-                {(formatError || isDirty) && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <AlertCircle
-                        className={`h-4 w-4 ${formatError ? 'text-red-500' : 'text-amber-500'}`}
-                      />
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>{formatError ? 'Improper token format' : 'Redeploy to apply changes'}</p>
-                    </TooltipContent>
-                  </Tooltip>
-                )}
-              </div>
-              {description && <span className="text-muted-foreground text-xs">{description}</span>}
-            </div>
-            <ChevronDown
-              className={`text-muted-foreground h-4 w-4 shrink-0 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
-            />
-          </button>
-        </CollapsibleTrigger>
-
-        <CollapsibleContent>
-          <Separator />
-          <div className="space-y-3 px-4 py-3">
-            {entry.fields.map(field => (
-              <div key={field.key}>
-                {entry.fields.length > 1 && (
-                  <Label htmlFor={`settings-${field.key}`} className="mb-1 block text-xs">
-                    {field.label}
-                  </Label>
-                )}
-                <ChannelTokenInput
-                  id={`settings-${field.key}`}
-                  placeholder={configured ? field.placeholderConfigured : field.placeholder}
-                  value={tokens[field.key] ?? ''}
-                  onChange={v => setToken(field.key, v)}
-                  disabled={isSaving}
-                  maxLength={field.maxLength}
-                />
-              </div>
-            ))}
-
-            <p className="text-muted-foreground text-xs">
-              {entry.helpUrl ? (
-                <>
-                  {entry.helpText?.replace(/\.$/, '')}{' '}
-                  <a
-                    href={entry.helpUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline"
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="hover:bg-muted/50 flex w-full cursor-pointer items-center gap-3 rounded-lg px-4 py-3 transition-colors"
+            >
+              <Icon className="h-5 w-5 shrink-0" />
+              <div className="flex min-w-0 flex-1 flex-col items-start">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">{entry.label}</span>
+                  <Badge
+                    variant={configured ? 'default' : 'secondary'}
+                    className="px-1.5 py-0 text-[10px] leading-4"
                   >
-                    {new URL(entry.helpUrl).hostname.replace('www.', '')}
-                  </a>
-                  {entry.guideUrl ? (
-                    <span className="block">
-                      <a
-                        href={entry.guideUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="underline"
-                      >
-                        {entry.guideText ?? 'Step by Step Guide'}
-                      </a>
-                      .
-                    </span>
-                  ) : (
-                    '.'
+                    {configured ? 'Configured' : 'Not configured'}
+                  </Badge>
+                  {(formatError || isDirty) && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <AlertCircle
+                          className={`h-4 w-4 ${formatError ? 'text-red-500' : 'text-amber-500'}`}
+                        />
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>{formatError ? 'Improper token format' : 'Redeploy to apply changes'}</p>
+                      </TooltipContent>
+                    </Tooltip>
                   )}
-                </>
-              ) : (
-                entry.helpText
-              )}
-            </p>
+                </div>
+                {description && (
+                  <span className="text-muted-foreground text-xs">{description}</span>
+                )}
+              </div>
+              <ChevronDown
+                className={`text-muted-foreground h-4 w-4 shrink-0 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+              />
+            </button>
+          </CollapsibleTrigger>
 
-            <div className="flex items-center gap-2">
-              <Button size="sm" onClick={handleSave} disabled={isSaving || !hasAllTokensFilled()}>
-                <Save className="h-4 w-4" />
-                {isSaving ? 'Saving...' : 'Save'}
-              </Button>
-              {configured && (
-                <Button variant="outline" size="sm" onClick={handleRemove} disabled={isSaving}>
-                  <X className="h-4 w-4" />
-                  Remove
+          <CollapsibleContent>
+            <Separator />
+            <div className="space-y-3 px-4 py-3">
+              {entry.fields.map(field => (
+                <div key={field.key}>
+                  {entry.fields.length > 1 && (
+                    <Label htmlFor={`settings-${field.key}`} className="mb-1 block text-xs">
+                      {field.label}
+                    </Label>
+                  )}
+                  <ChannelTokenInput
+                    id={`settings-${field.key}`}
+                    placeholder={configured ? field.placeholderConfigured : field.placeholder}
+                    value={tokens[field.key] ?? ''}
+                    onChange={v => setToken(field.key, v)}
+                    disabled={isSaving}
+                    maxLength={field.maxLength}
+                  />
+                </div>
+              ))}
+
+              <p className="text-muted-foreground text-xs">
+                {entry.helpUrl ? (
+                  <>
+                    {entry.helpText?.replace(/\.$/, '')}{' '}
+                    <a
+                      href={entry.helpUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline"
+                    >
+                      {new URL(entry.helpUrl).hostname.replace('www.', '')}
+                    </a>
+                    {entry.guideUrl ? (
+                      <span className="block">
+                        <a
+                          href={entry.guideUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="underline"
+                        >
+                          {entry.guideText ?? 'Step by Step Guide'}
+                        </a>
+                        .
+                      </span>
+                    ) : (
+                      '.'
+                    )}
+                  </>
+                ) : (
+                  entry.helpText
+                )}
+              </p>
+
+              <div className="flex items-center gap-2">
+                <Button size="sm" onClick={handleSave} disabled={isSaving || !hasAllTokensFilled()}>
+                  <Save className="h-4 w-4" />
+                  {isSaving ? 'Saving...' : 'Save'}
                 </Button>
-              )}
-              {actionRowInlineExtra}
+                {configured && (
+                  <Button variant="outline" size="sm" onClick={handleRemove} disabled={isSaving}>
+                    <X className="h-4 w-4" />
+                    Remove
+                  </Button>
+                )}
+                {actionRowInlineExtra}
+              </div>
+              {actionRowExtra && <div>{actionRowExtra}</div>}
             </div>
-            {actionRowExtra && <div>{actionRowExtra}</div>}
-          </div>
-        </CollapsibleContent>
+          </CollapsibleContent>
         </div>
       </Collapsible>
 

--- a/apps/web/src/app/(app)/claw/components/SecretEntrySection.tsx
+++ b/apps/web/src/app/(app)/claw/components/SecretEntrySection.tsx
@@ -16,6 +16,7 @@ import { Separator } from '@/components/ui/separator';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 import { ChannelTokenInput } from './ChannelTokenInput';
+import { ConfirmActionDialog } from './ConfirmActionDialog';
 import { getDescription, getIcon } from './secret-ui-adapter';
 
 type ClawMutations = ReturnType<typeof useKiloClawMutations>;
@@ -27,9 +28,11 @@ export function SecretEntrySection({
   onSecretsChanged,
   isDirty,
   actionRowExtra,
+  actionRowInlineExtra,
   defaultOpen,
   onRedeploy,
   redeployLabel = 'Redeploy',
+  saveConfirmation,
 }: {
   entry: SecretCatalogEntry;
   configured: boolean;
@@ -37,15 +40,24 @@ export function SecretEntrySection({
   onSecretsChanged?: (entryId: string) => void;
   isDirty: boolean;
   actionRowExtra?: React.ReactNode;
+  actionRowInlineExtra?: React.ReactNode;
   defaultOpen?: boolean;
   onRedeploy?: () => void;
   /** Label for the toast action button. Defaults to "Redeploy". */
   redeployLabel?: string;
+  saveConfirmation?: {
+    title: string;
+    description: string;
+    confirmLabel: string;
+    pendingLabel?: string;
+  };
 }) {
   const [open, setOpen] = useState(defaultOpen ?? false);
   const [tokens, setTokens] = useState<Record<string, string>>({});
   const [formatError, setFormatError] = useState<string | null>(null);
-  const isSaving = mutations.patchSecrets.isPending;
+  const [isSaving, setIsSaving] = useState(false);
+  const [showSaveConfirm, setShowSaveConfirm] = useState(false);
+  const [pendingSecrets, setPendingSecrets] = useState<Record<string, string> | null>(null);
   const Icon = getIcon(entry.icon);
   const description = getDescription(entry.id);
 
@@ -58,14 +70,14 @@ export function SecretEntrySection({
     return entry.fields.every(f => tokens[f.key]?.trim());
   }
 
-  function handleSave() {
+  function buildValidatedSecrets(): Record<string, string> | null {
     if (!hasAllTokensFilled()) {
       if (entry.fields.length > 1) {
         toast.error(`All token fields are required for ${entry.label}.`);
       } else {
         toast.error('Enter a token or use Remove to clear it.');
       }
-      return;
+      return null;
     }
 
     for (const field of entry.fields) {
@@ -74,7 +86,7 @@ export function SecretEntrySection({
         const msg = field.validationMessage ?? 'Invalid token format.';
         setFormatError(msg);
         toast.error(msg);
-        return;
+        return null;
       }
     }
 
@@ -83,6 +95,11 @@ export function SecretEntrySection({
       secrets[field.key] = (tokens[field.key] ?? '').trim();
     }
 
+    return secrets;
+  }
+
+  function saveSecrets(secrets: Record<string, string>) {
+    setIsSaving(true);
     mutations.patchSecrets.mutate(
       { secrets },
       {
@@ -97,11 +114,32 @@ export function SecretEntrySection({
             }
           );
           setTokens({});
+          setPendingSecrets(null);
+          setShowSaveConfirm(false);
           onSecretsChanged?.(entry.id);
         },
-        onError: err => toast.error(`Failed to save: ${err.message}`),
+        onError: err => {
+          setShowSaveConfirm(false);
+          toast.error(`Failed to save: ${err.message}`);
+        },
+        onSettled: () => setIsSaving(false),
       }
     );
+  }
+
+  function handleSave() {
+    const secrets = buildValidatedSecrets();
+    if (!secrets) {
+      return;
+    }
+
+    if (saveConfirmation) {
+      setPendingSecrets(secrets);
+      setShowSaveConfirm(true);
+      return;
+    }
+
+    saveSecrets(secrets);
   }
 
   function handleRemove() {
@@ -110,6 +148,7 @@ export function SecretEntrySection({
       secrets[field.key] = null;
     }
 
+    setIsSaving(true);
     mutations.patchSecrets.mutate(
       { secrets },
       {
@@ -127,13 +166,15 @@ export function SecretEntrySection({
           onSecretsChanged?.(entry.id);
         },
         onError: err => toast.error(`Failed to remove: ${err.message}`),
+        onSettled: () => setIsSaving(false),
       }
     );
   }
 
   return (
-    <Collapsible open={open} onOpenChange={setOpen}>
-      <div className="rounded-lg border">
+    <>
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <div className="rounded-lg border">
         <CollapsibleTrigger asChild>
           <button
             type="button"
@@ -235,11 +276,37 @@ export function SecretEntrySection({
                   Remove
                 </Button>
               )}
+              {actionRowInlineExtra}
             </div>
             {actionRowExtra && <div>{actionRowExtra}</div>}
           </div>
         </CollapsibleContent>
-      </div>
-    </Collapsible>
+        </div>
+      </Collapsible>
+
+      {saveConfirmation && (
+        <ConfirmActionDialog
+          open={showSaveConfirm}
+          onOpenChange={open => {
+            setShowSaveConfirm(open);
+            if (!open) {
+              setPendingSecrets(null);
+            }
+          }}
+          title={saveConfirmation.title}
+          description={saveConfirmation.description}
+          confirmLabel={saveConfirmation.confirmLabel}
+          isPending={isSaving}
+          pendingLabel={saveConfirmation.pendingLabel ?? 'Saving'}
+          onConfirm={() => {
+            if (!pendingSecrets) {
+              setShowSaveConfirm(false);
+              return;
+            }
+            saveSecrets(pendingSecrets);
+          }}
+        />
+      )}
+    </>
   );
 }

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -63,8 +63,7 @@ import { WebhookIntegrationSection } from './WebhookIntegrationSection';
 import { type ExecPreset, configToExecPreset, execPresetToConfig } from './claw.types';
 type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 
-// TODO: Replace with the controller calver from the Docker-image PR deploy.
-const EXA_SEARCH_UI_MIN_CONTROLLER_VERSION = '9999.99.99';
+const EXA_SEARCH_UI_MIN_CONTROLLER_VERSION = '2026.4.14';
 
 // ---------------------------------------------------------------------------
 // 1Password setup guide dialog

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -51,6 +51,7 @@ import { DetailTile } from './DetailTile';
 
 import { getEntriesByCategory } from '@kilocode/kiloclaw-secret-catalog';
 import { SecretEntrySection } from './SecretEntrySection';
+import { ExaSearchEntrySection } from './ExaSearchEntrySection';
 import { AnimatedDots } from './AnimatedDots';
 import { ConfirmActionDialog } from './ConfirmActionDialog';
 import { PairingSection } from './PairingSection';
@@ -760,6 +761,8 @@ export function SettingsTab({
   );
 
   const configuredSecrets = config?.configuredSecrets ?? {};
+  const kiloExaSearchMode = config?.kiloExaSearchMode ?? null;
+  const braveSearchEnabled = (configuredSecrets['brave-search'] ?? false) && kiloExaSearchMode !== 'kilo-proxy';
   const toolEntries = getEntriesByCategory('tool');
 
   function handleSave() {
@@ -982,12 +985,58 @@ export function SettingsTab({
                 <SecretEntrySection
                   key={entry.id}
                   entry={entry}
-                  configured={configuredSecrets[entry.id] ?? false}
+                  configured={braveSearchEnabled}
                   mutations={mutations}
                   onSecretsChanged={onSecretsChanged}
                   isDirty={dirtySecrets.has(entry.id)}
+                  actionRowInlineExtra={
+                    configuredSecrets['brave-search'] && kiloExaSearchMode === 'kilo-proxy' ? (
+                      <Button
+                        variant="link"
+                        size="sm"
+                        className="h-8 px-1 text-xs"
+                        disabled={mutations.patchWebSearchConfig.isPending}
+                        onClick={() => {
+                          mutations.patchWebSearchConfig.mutate(
+                            { exaMode: 'disabled' },
+                            {
+                              onSuccess: () => {
+                                toast.success('Brave Search re-enabled. Redeploy to apply.', {
+                                  duration: 8000,
+                                });
+                                onSecretsChanged?.('brave-search');
+                              },
+                              onError: err => {
+                                toast.error(`Failed to re-enable Brave Search: ${err.message}`);
+                              },
+                            }
+                          );
+                        }}
+                      >
+                        Re-enable Brave Search
+                      </Button>
+                    ) : undefined
+                  }
+                  saveConfirmation={
+                    kiloExaSearchMode === 'kilo-proxy'
+                      ? {
+                          title: 'Enable Brave Search?',
+                          description:
+                            'Exa Search is currently configured. Enabling Brave will disable Exa on the next redeploy.',
+                          confirmLabel: 'Enable Brave and disable Exa',
+                        }
+                      : undefined
+                  }
                 />
               ))}
+            <ExaSearchEntrySection
+              mode={kiloExaSearchMode}
+              configured={kiloExaSearchMode === 'kilo-proxy'}
+              braveConfigured={configuredSecrets['brave-search'] ?? false}
+              mutations={mutations}
+              onSecretsChanged={onSecretsChanged}
+              isDirty={dirtySecrets.has('kilo-exa-search')}
+            />
           </div>
         </div>
       )}

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -63,6 +63,9 @@ import { WebhookIntegrationSection } from './WebhookIntegrationSection';
 import { type ExecPreset, configToExecPreset, execPresetToConfig } from './claw.types';
 type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 
+// TODO: Replace with the controller calver from the Docker-image PR deploy.
+const EXA_SEARCH_UI_MIN_CONTROLLER_VERSION = '9999.99.99';
+
 // ---------------------------------------------------------------------------
 // 1Password setup guide dialog
 // ---------------------------------------------------------------------------
@@ -759,6 +762,10 @@ export function SettingsTab({
     cleanVersion(controllerVersion?.version),
     '2026.2.26'
   );
+  const supportsExaSearchUi = calverAtLeast(
+    cleanVersion(controllerVersion?.version),
+    EXA_SEARCH_UI_MIN_CONTROLLER_VERSION
+  );
 
   const configuredSecrets = config?.configuredSecrets ?? {};
   const kiloExaSearchMode = config?.kiloExaSearchMode ?? null;
@@ -990,7 +997,9 @@ export function SettingsTab({
                   onSecretsChanged={onSecretsChanged}
                   isDirty={dirtySecrets.has(entry.id)}
                   actionRowInlineExtra={
-                    configuredSecrets['brave-search'] && kiloExaSearchMode === 'kilo-proxy' ? (
+                    supportsExaSearchUi &&
+                    configuredSecrets['brave-search'] &&
+                    kiloExaSearchMode === 'kilo-proxy' ? (
                       <Button
                         variant="link"
                         size="sm"
@@ -1018,7 +1027,7 @@ export function SettingsTab({
                     ) : undefined
                   }
                   saveConfirmation={
-                    kiloExaSearchMode === 'kilo-proxy'
+                    supportsExaSearchUi && kiloExaSearchMode === 'kilo-proxy'
                       ? {
                           title: 'Enable Brave Search?',
                           description:
@@ -1029,14 +1038,16 @@ export function SettingsTab({
                   }
                 />
               ))}
-            <ExaSearchEntrySection
-              mode={kiloExaSearchMode}
-              configured={kiloExaSearchMode === 'kilo-proxy'}
-              braveConfigured={configuredSecrets['brave-search'] ?? false}
-              mutations={mutations}
-              onSecretsChanged={onSecretsChanged}
-              isDirty={dirtySecrets.has('kilo-exa-search')}
-            />
+            {supportsExaSearchUi && (
+              <ExaSearchEntrySection
+                mode={kiloExaSearchMode}
+                configured={kiloExaSearchMode === 'kilo-proxy'}
+                braveConfigured={configuredSecrets['brave-search'] ?? false}
+                mutations={mutations}
+                onSecretsChanged={onSecretsChanged}
+                isDirty={dirtySecrets.has('kilo-exa-search')}
+              />
+            )}
           </div>
         </div>
       )}

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -770,8 +770,9 @@ export function SettingsTab({
   const kiloExaSearchMode = config?.kiloExaSearchMode ?? null;
   const braveSearchConfigured = configuredSecrets['brave-search'] ?? false;
   const exaSearchConfigured =
-    kiloExaSearchMode === 'kilo-proxy' ||
-    (supportsExaSearchUi && kiloExaSearchMode === null && !braveSearchConfigured);
+    supportsExaSearchUi && (kiloExaSearchMode === 'kilo-proxy' || kiloExaSearchMode === null);
+  const exaSearchDisplayMode =
+    supportsExaSearchUi && kiloExaSearchMode === null ? 'kilo-proxy' : kiloExaSearchMode;
   const braveSearchEnabled = braveSearchConfigured && !exaSearchConfigured;
   const toolEntries = getEntriesByCategory('tool');
 
@@ -1002,7 +1003,7 @@ export function SettingsTab({
                   actionRowInlineExtra={
                     supportsExaSearchUi &&
                     braveSearchConfigured &&
-                    kiloExaSearchMode === 'kilo-proxy' ? (
+                    exaSearchConfigured ? (
                       <Button
                         variant="link"
                         size="sm"
@@ -1030,7 +1031,7 @@ export function SettingsTab({
                     ) : undefined
                   }
                   saveConfirmation={
-                    supportsExaSearchUi && kiloExaSearchMode === 'kilo-proxy'
+                    supportsExaSearchUi && exaSearchConfigured
                       ? {
                           title: 'Enable Brave Search?',
                           description:
@@ -1043,7 +1044,7 @@ export function SettingsTab({
               ))}
             {supportsExaSearchUi && (
               <ExaSearchEntrySection
-                mode={kiloExaSearchMode}
+                mode={exaSearchDisplayMode}
                 configured={exaSearchConfigured}
                 braveConfigured={braveSearchConfigured}
                 mutations={mutations}

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -768,7 +768,8 @@ export function SettingsTab({
 
   const configuredSecrets = config?.configuredSecrets ?? {};
   const kiloExaSearchMode = config?.kiloExaSearchMode ?? null;
-  const braveSearchEnabled = (configuredSecrets['brave-search'] ?? false) && kiloExaSearchMode !== 'kilo-proxy';
+  const braveSearchEnabled =
+    (configuredSecrets['brave-search'] ?? false) && kiloExaSearchMode !== 'kilo-proxy';
   const toolEntries = getEntriesByCategory('tool');
 
   function handleSave() {

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -768,8 +768,11 @@ export function SettingsTab({
 
   const configuredSecrets = config?.configuredSecrets ?? {};
   const kiloExaSearchMode = config?.kiloExaSearchMode ?? null;
-  const braveSearchEnabled =
-    (configuredSecrets['brave-search'] ?? false) && kiloExaSearchMode !== 'kilo-proxy';
+  const braveSearchConfigured = configuredSecrets['brave-search'] ?? false;
+  const exaSearchConfigured =
+    kiloExaSearchMode === 'kilo-proxy' ||
+    (supportsExaSearchUi && kiloExaSearchMode === null && !braveSearchConfigured);
+  const braveSearchEnabled = braveSearchConfigured && !exaSearchConfigured;
   const toolEntries = getEntriesByCategory('tool');
 
   function handleSave() {
@@ -998,7 +1001,7 @@ export function SettingsTab({
                   isDirty={dirtySecrets.has(entry.id)}
                   actionRowInlineExtra={
                     supportsExaSearchUi &&
-                    configuredSecrets['brave-search'] &&
+                    braveSearchConfigured &&
                     kiloExaSearchMode === 'kilo-proxy' ? (
                       <Button
                         variant="link"
@@ -1041,8 +1044,8 @@ export function SettingsTab({
             {supportsExaSearchUi && (
               <ExaSearchEntrySection
                 mode={kiloExaSearchMode}
-                configured={kiloExaSearchMode === 'kilo-proxy'}
-                braveConfigured={configuredSecrets['brave-search'] ?? false}
+                configured={exaSearchConfigured}
+                braveConfigured={braveSearchConfigured}
                 mutations={mutations}
                 onSecretsChanged={onSecretsChanged}
                 isDirty={dirtySecrets.has('kilo-exa-search')}

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -1001,9 +1001,7 @@ export function SettingsTab({
                   onSecretsChanged={onSecretsChanged}
                   isDirty={dirtySecrets.has(entry.id)}
                   actionRowInlineExtra={
-                    supportsExaSearchUi &&
-                    braveSearchConfigured &&
-                    exaSearchConfigured ? (
+                    supportsExaSearchUi && braveSearchConfigured && exaSearchConfigured ? (
                       <Button
                         variant="link"
                         size="sm"

--- a/apps/web/src/app/(app)/claw/components/icons/ExaSearchIcon.tsx
+++ b/apps/web/src/app/(app)/claw/components/icons/ExaSearchIcon.tsx
@@ -1,0 +1,13 @@
+export function ExaSearchIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} xmlns="http://www.w3.org/2000/svg">
+      <title>Exa</title>
+      <path
+        clipRule="evenodd"
+        d="M3 0h19v1.791L13.892 12 22 22.209V24H3V0zm9.62 10.348l6.589-8.557H6.03l6.59 8.557zM5.138 3.935v7.17h5.52l-5.52-7.17zm5.52 8.96h-5.52v7.17l5.52-7.17zM6.03 22.21l6.59-8.557 6.589 8.557H6.03z"
+        fill="#1F40ED"
+        fillRule="evenodd"
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/hooks/useKiloClaw.ts
+++ b/apps/web/src/hooks/useKiloClaw.ts
@@ -298,6 +298,14 @@ export function useKiloClawMutations() {
     patchExecPreset: useMutation(
       trpc.kiloclaw.patchExecPreset.mutationOptions({ onSuccess: invalidateStatus })
     ),
+    patchWebSearchConfig: useMutation(
+      trpc.kiloclaw.patchWebSearchConfig.mutationOptions({
+        onSuccess: async () => {
+          await invalidateStatus();
+          await queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getConfig.queryKey() });
+        },
+      })
+    ),
     patchBotIdentity: useMutation(
       trpc.kiloclaw.patchBotIdentity.mutationOptions({ onSuccess: invalidateStatus })
     ),

--- a/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -9,6 +9,8 @@ import type {
   RegistryEntriesResponse,
   KiloCodeConfigPatchInput,
   KiloCodeConfigResponse,
+  WebSearchConfigPatchInput,
+  WebSearchConfigPatchResponse,
   BotIdentityPatchInput,
   BotIdentityPatchResponse,
   ChannelsPatchInput,
@@ -255,6 +257,22 @@ export class KiloClawInternalClient {
     const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
     return this.request(
       `/api/platform/kilocode-config${params}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ userId, ...patch }),
+      },
+      { userId }
+    );
+  }
+
+  async patchWebSearchConfig(
+    userId: string,
+    patch: WebSearchConfigPatchInput,
+    instanceId?: string
+  ): Promise<WebSearchConfigPatchResponse> {
+    const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
+    return this.request(
+      `/api/platform/web-search-config${params}`,
       {
         method: 'PATCH',
         body: JSON.stringify({ userId, ...patch }),

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -38,6 +38,14 @@ export type KiloCodeConfigResponse = {
   kilocodeDefaultModel: string | null;
 };
 
+export type WebSearchConfigPatchInput = {
+  exaMode?: 'kilo-proxy' | 'disabled' | null;
+};
+
+export type WebSearchConfigPatchResponse = {
+  exaMode: 'kilo-proxy' | 'disabled' | null;
+};
+
 export type BotIdentityPatchInput = {
   botName?: string | null;
   botNature?: string | null;
@@ -257,6 +265,8 @@ export type UserConfigResponse = {
   kilocodeApiKeyExpiresAt?: string | null;
   /** Per catalog entry ID → whether all fields for that entry are configured. */
   configuredSecrets: Record<string, boolean>;
+  /** Search mode selected for Kilo-integrated Exa. */
+  kiloExaSearchMode: 'kilo-proxy' | 'disabled' | null;
   /** Env var names of user-defined custom (non-catalog) secrets. */
   customSecretKeys: string[];
   /** Metadata for custom secrets (config paths, etc.). */

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -403,6 +403,10 @@ const updateKiloCodeConfigSchema = z.object({
   kilocodeDefaultModel: kilocodeDefaultModelSchema.nullable().optional(),
 });
 
+const patchWebSearchConfigSchema = z.object({
+  exaMode: z.enum(['kilo-proxy', 'disabled']).nullable().optional(),
+});
+
 const patchChannelsSchema = z.object({
   telegramBotToken: z.string().nullable().optional(),
   discordBotToken: z.string().nullable().optional(),
@@ -1800,6 +1804,14 @@ export const kiloclawRouter = createTRPCRouter({
       const instance = await getActiveInstance(ctx.user.id);
       const client = new KiloClawInternalClient();
       return client.patchExecPreset(ctx.user.id, input, workerInstanceId(instance));
+    }),
+
+  patchWebSearchConfig: clawAccessProcedure
+    .input(patchWebSearchConfigSchema)
+    .mutation(async ({ ctx, input }) => {
+      const instance = await getActiveInstance(ctx.user.id);
+      const client = new KiloClawInternalClient();
+      return client.patchWebSearchConfig(ctx.user.id, input, workerInstanceId(instance));
     }),
 
   patchBotIdentity: clawAccessProcedure

--- a/packages/kiloclaw-secret-catalog/src/__tests__/catalog.test.ts
+++ b/packages/kiloclaw-secret-catalog/src/__tests__/catalog.test.ts
@@ -518,6 +518,7 @@ describe('Secret Catalog', () => {
       expect(isValidCustomSecretKey('DISCORD_BOT_TOKEN')).toBe(false);
       expect(isValidCustomSecretKey('GITHUB_TOKEN')).toBe(false);
       expect(isValidCustomSecretKey('BRAVE_API_KEY')).toBe(false);
+      expect(isValidCustomSecretKey('KILO_EXA_SEARCH_MODE')).toBe(false);
     });
 
     it('rejects reserved prefixes', () => {
@@ -567,6 +568,10 @@ describe('Secret Catalog', () => {
 
     it('returns false for internal sensitive env vars', () => {
       expect(isCustomSecretEnvVar('KILOCLAW_GOG_CONFIG_TARBALL')).toBe(false);
+    });
+
+    it('returns false for internal non-secret reserved env vars', () => {
+      expect(isCustomSecretEnvVar('KILO_EXA_SEARCH_MODE')).toBe(false);
     });
   });
 

--- a/packages/kiloclaw-secret-catalog/src/__tests__/catalog.test.ts
+++ b/packages/kiloclaw-secret-catalog/src/__tests__/catalog.test.ts
@@ -570,9 +570,6 @@ describe('Secret Catalog', () => {
       expect(isCustomSecretEnvVar('KILOCLAW_GOG_CONFIG_TARBALL')).toBe(false);
     });
 
-    it('returns false for internal non-secret reserved env vars', () => {
-      expect(isCustomSecretEnvVar('KILO_EXA_SEARCH_MODE')).toBe(false);
-    });
   });
 
   describe('custom secret constants', () => {

--- a/packages/kiloclaw-secret-catalog/src/__tests__/catalog.test.ts
+++ b/packages/kiloclaw-secret-catalog/src/__tests__/catalog.test.ts
@@ -569,7 +569,6 @@ describe('Secret Catalog', () => {
     it('returns false for internal sensitive env vars', () => {
       expect(isCustomSecretEnvVar('KILOCLAW_GOG_CONFIG_TARBALL')).toBe(false);
     });
-
   });
 
   describe('custom secret constants', () => {

--- a/packages/kiloclaw-secret-catalog/src/catalog.ts
+++ b/packages/kiloclaw-secret-catalog/src/catalog.ts
@@ -380,11 +380,7 @@ export function isValidCustomSecretKey(key: string): boolean {
  * list out of the full encryptedSecrets record.
  */
 export function isCustomSecretEnvVar(envVarName: string): boolean {
-  return (
-    !ALL_SECRET_ENV_VARS.has(envVarName) &&
-    !INTERNAL_SENSITIVE_ENV_VARS.has(envVarName) &&
-    !DENIED_ENV_VAR_NAMES.has(envVarName)
-  );
+  return !ALL_SECRET_ENV_VARS.has(envVarName) && !INTERNAL_SENSITIVE_ENV_VARS.has(envVarName);
 }
 
 // --- Config path helpers ---

--- a/packages/kiloclaw-secret-catalog/src/catalog.ts
+++ b/packages/kiloclaw-secret-catalog/src/catalog.ts
@@ -348,6 +348,7 @@ const DENIED_ENV_VAR_NAMES: ReadonlySet<string> = new Set([
   'AUTO_APPROVE_DEVICES',
   'REQUIRE_PROXY_TOKEN',
   'INVOCATION_ID',
+  'KILO_EXA_SEARCH_MODE',
   'TELEGRAM_DM_POLICY',
   'DISCORD_DM_POLICY',
 ]);
@@ -379,7 +380,11 @@ export function isValidCustomSecretKey(key: string): boolean {
  * list out of the full encryptedSecrets record.
  */
 export function isCustomSecretEnvVar(envVarName: string): boolean {
-  return !ALL_SECRET_ENV_VARS.has(envVarName) && !INTERNAL_SENSITIVE_ENV_VARS.has(envVarName);
+  return (
+    !ALL_SECRET_ENV_VARS.has(envVarName) &&
+    !INTERNAL_SENSITIVE_ENV_VARS.has(envVarName) &&
+    !DENIED_ENV_VAR_NAMES.has(envVarName)
+  );
 }
 
 // --- Config path helpers ---

--- a/packages/kiloclaw-secret-catalog/src/types.ts
+++ b/packages/kiloclaw-secret-catalog/src/types.ts
@@ -43,6 +43,7 @@ export const SecretFieldDefinitionSchema = z
     validationMessage: z.string().optional(),
     envVar: z.string(), // container env var name
     maxLength: z.number().int().positive(), // max input length
+    requiredForConfigured: z.boolean().optional(), // omit = true
   })
   .readonly();
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -2679,6 +2679,17 @@ describe('updateSecrets', () => {
     expect(secrets.DISCORD_BOT_TOKEN).toEqual(discordEnvelope);
   });
 
+  it('saving Brave API key disables Exa mode', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, {
+      kiloExaSearchMode: 'kilo-proxy',
+    });
+
+    await instance.updateSecrets({ braveSearchApiKey: fakeEnvelope });
+
+    expect(storage._store.get('kiloExaSearchMode')).toBe('disabled');
+  });
+
   it('reads from legacy channels field when encryptedSecrets is empty', async () => {
     const { instance, storage } = createInstance();
     // Simulate legacy state: only channels field, no encryptedSecrets

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
@@ -156,6 +156,7 @@ export async function buildUserEnvVars(
       kilocodeDefaultModel: state.kilocodeDefaultModel ?? undefined,
       channels: state.channels ?? undefined,
       googleCredentials: state.googleCredentials ?? undefined,
+      kiloExaSearchMode: state.kiloExaSearchMode,
       instanceFeatures: state.instanceFeatures,
       execSecurity: state.execSecurity ?? undefined,
       execAsk: state.execAsk ?? undefined,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -121,7 +121,6 @@ export { METADATA_KEY_USER_ID } from '../machine-config';
 const CHANNEL_ENV_VARS = new Set(
   SECRET_CATALOG.filter(e => e.category === 'channel').flatMap(e => e.fields.map(f => f.envVar))
 );
-const NON_SECRET_ENCRYPTED_ENV_VARS = new Set(['KILO_EXA_SEARCH_MODE']);
 const BRAVE_SEARCH_FIELD_KEY = 'braveSearchApiKey';
 
 export class KiloClawInstance extends DurableObject<KiloClawEnv> {
@@ -859,13 +858,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     if (patch.exaMode !== undefined) {
       this.s.kiloExaSearchMode = patch.exaMode;
       pending.kiloExaSearchMode = this.s.kiloExaSearchMode;
-    }
-
-    if (this.s.encryptedSecrets?.KILO_EXA_SEARCH_MODE) {
-      const next = { ...this.s.encryptedSecrets };
-      delete next.KILO_EXA_SEARCH_MODE;
-      this.s.encryptedSecrets = Object.keys(next).length > 0 ? next : null;
-      pending.encryptedSecrets = this.s.encryptedSecrets;
     }
 
     if (Object.keys(pending).length > 0) {
@@ -1893,9 +1885,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       lastStoppedAt: this.s.lastStoppedAt,
       envVarCount: this.s.envVars ? Object.keys(this.s.envVars).length : 0,
       secretCount: this.s.encryptedSecrets
-        ? Object.keys(this.s.encryptedSecrets).filter(
-            k => !CHANNEL_ENV_VARS.has(k) && !NON_SECRET_ENCRYPTED_ENV_VARS.has(k)
-          ).length
+        ? Object.keys(this.s.encryptedSecrets).filter(k => !CHANNEL_ENV_VARS.has(k)).length
         : 0,
       channelCount: this.s.channels ? Object.values(this.s.channels).filter(Boolean).length : 0,
       flyAppName: this.s.flyAppName,
@@ -2018,9 +2008,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       lastStoppedAt: this.s.lastStoppedAt,
       envVarCount: this.s.envVars ? Object.keys(this.s.envVars).length : 0,
       secretCount: this.s.encryptedSecrets
-        ? Object.keys(this.s.encryptedSecrets).filter(
-            k => !CHANNEL_ENV_VARS.has(k) && !NON_SECRET_ENCRYPTED_ENV_VARS.has(k)
-          ).length
+        ? Object.keys(this.s.encryptedSecrets).filter(k => !CHANNEL_ENV_VARS.has(k)).length
         : 0,
       channelCount: this.s.channels ? Object.values(this.s.channels).filter(Boolean).length : 0,
       flyAppName: this.s.flyAppName,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -19,6 +19,7 @@ import type {
   CustomSecretMeta,
   ProviderId,
   ProviderState,
+  KiloExaSearchMode,
 } from '../../schemas/instance-config';
 import { DEFAULT_INSTANCE_FEATURES, ProviderStateSchema } from '../../schemas/instance-config';
 import type { FlyVolume, FlyVolumeSnapshot } from '../../fly/types';
@@ -120,6 +121,8 @@ export { METADATA_KEY_USER_ID } from '../machine-config';
 const CHANNEL_ENV_VARS = new Set(
   SECRET_CATALOG.filter(e => e.category === 'channel').flatMap(e => e.fields.map(f => f.envVar))
 );
+const NON_SECRET_ENCRYPTED_ENV_VARS = new Set(['KILO_EXA_SEARCH_MODE']);
+const BRAVE_SEARCH_FIELD_KEY = 'braveSearchApiKey';
 
 export class KiloClawInstance extends DurableObject<KiloClawEnv> {
   private s: InstanceMutableState = createMutableState();
@@ -644,6 +647,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       kilocodeApiKey: config.kilocodeApiKey ?? null,
       kilocodeApiKeyExpiresAt: config.kilocodeApiKeyExpiresAt ?? null,
       kilocodeDefaultModel: config.kilocodeDefaultModel ?? null,
+      kiloExaSearchMode: config.webSearch?.exaMode ?? this.s.kiloExaSearchMode ?? null,
       channels: config.channels ?? null,
       machineSize: config.machineSize ?? this.s.machineSize ?? null,
     } satisfies Partial<PersistedState>;
@@ -701,6 +705,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     this.s.kilocodeApiKey = config.kilocodeApiKey ?? null;
     this.s.kilocodeApiKeyExpiresAt = config.kilocodeApiKeyExpiresAt ?? null;
     this.s.kilocodeDefaultModel = config.kilocodeDefaultModel ?? null;
+    this.s.kiloExaSearchMode = config.webSearch?.exaMode ?? this.s.kiloExaSearchMode ?? null;
     this.s.channels = config.channels ?? null;
     this.s.machineSize = config.machineSize ?? this.s.machineSize ?? null;
     if (isNew) {
@@ -841,6 +846,34 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     return {
       execSecurity: this.s.execSecurity,
       execAsk: this.s.execAsk,
+    };
+  }
+
+  async updateWebSearchConfig(patch: {
+    exaMode?: KiloExaSearchMode | null;
+  }): Promise<{ exaMode: KiloExaSearchMode | null }> {
+    await this.loadState();
+
+    const pending: Partial<PersistedState> = {};
+
+    if (patch.exaMode !== undefined) {
+      this.s.kiloExaSearchMode = patch.exaMode;
+      pending.kiloExaSearchMode = this.s.kiloExaSearchMode;
+    }
+
+    if (this.s.encryptedSecrets?.KILO_EXA_SEARCH_MODE) {
+      const next = { ...this.s.encryptedSecrets };
+      delete next.KILO_EXA_SEARCH_MODE;
+      this.s.encryptedSecrets = Object.keys(next).length > 0 ? next : null;
+      pending.encryptedSecrets = this.s.encryptedSecrets;
+    }
+
+    if (Object.keys(pending).length > 0) {
+      await this.ctx.storage.put(storageUpdate(pending));
+    }
+
+    return {
+      exaMode: this.s.kiloExaSearchMode,
     };
   }
 
@@ -1060,10 +1093,15 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     const hasMeta = Object.keys(currentMeta).length > 0;
     this.s.customSecretMeta = hasMeta ? currentMeta : null;
 
+    if (patch[BRAVE_SEARCH_FIELD_KEY] && this.s.kiloExaSearchMode !== 'disabled') {
+      this.s.kiloExaSearchMode = 'disabled';
+    }
+
     await this.ctx.storage.put({
       channels: this.s.channels,
       encryptedSecrets: this.s.encryptedSecrets,
       customSecretMeta: this.s.customSecretMeta,
+      kiloExaSearchMode: this.s.kiloExaSearchMode,
     });
 
     return { configured };
@@ -1855,7 +1893,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       lastStoppedAt: this.s.lastStoppedAt,
       envVarCount: this.s.envVars ? Object.keys(this.s.envVars).length : 0,
       secretCount: this.s.encryptedSecrets
-        ? Object.keys(this.s.encryptedSecrets).filter(k => !CHANNEL_ENV_VARS.has(k)).length
+        ? Object.keys(this.s.encryptedSecrets).filter(
+            k => !CHANNEL_ENV_VARS.has(k) && !NON_SECRET_ENCRYPTED_ENV_VARS.has(k)
+          ).length
         : 0,
       channelCount: this.s.channels ? Object.values(this.s.channels).filter(Boolean).length : 0,
       flyAppName: this.s.flyAppName,
@@ -1978,7 +2018,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       lastStoppedAt: this.s.lastStoppedAt,
       envVarCount: this.s.envVars ? Object.keys(this.s.envVars).length : 0,
       secretCount: this.s.encryptedSecrets
-        ? Object.keys(this.s.encryptedSecrets).filter(k => !CHANNEL_ENV_VARS.has(k)).length
+        ? Object.keys(this.s.encryptedSecrets).filter(
+            k => !CHANNEL_ENV_VARS.has(k) && !NON_SECRET_ENCRYPTED_ENV_VARS.has(k)
+          ).length
         : 0,
       channelCount: this.s.channels ? Object.values(this.s.channels).filter(Boolean).length : 0,
       flyAppName: this.s.flyAppName,
@@ -2027,6 +2069,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       kilocodeApiKey: this.s.kilocodeApiKey ?? undefined,
       kilocodeApiKeyExpiresAt: this.s.kilocodeApiKeyExpiresAt ?? undefined,
       kilocodeDefaultModel: this.s.kilocodeDefaultModel ?? undefined,
+      webSearch: this.s.kiloExaSearchMode
+        ? {
+            exaMode: this.s.kiloExaSearchMode,
+          }
+        : undefined,
       channels: this.s.channels ?? undefined,
       machineSize: this.s.machineSize ?? undefined,
       customSecretMeta: this.s.customSecretMeta ?? undefined,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/postgres.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/postgres.ts
@@ -95,6 +95,7 @@ export async function restoreFromPostgres(
         status: 'provisioned',
         envVars,
         encryptedSecrets,
+        kiloExaSearchMode: null,
         channels,
         provisionedAt: Date.now(),
         lastStartedAt: null,
@@ -122,6 +123,7 @@ export async function restoreFromPostgres(
     state.status = 'provisioned';
     state.envVars = envVars;
     state.encryptedSecrets = encryptedSecrets;
+    state.kiloExaSearchMode = null;
     state.channels = channels;
     state.provisionedAt = Date.now();
     state.lastStartedAt = null;

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
@@ -225,6 +225,7 @@ export async function loadState(ctx: DurableObjectState, s: InstanceMutableState
     s.kilocodeApiKey = d.kilocodeApiKey;
     s.kilocodeApiKeyExpiresAt = d.kilocodeApiKeyExpiresAt;
     s.kilocodeDefaultModel = d.kilocodeDefaultModel;
+    s.kiloExaSearchMode = d.kiloExaSearchMode;
     s.channels = d.channels;
     s.googleCredentials = d.googleCredentials;
     s.provisionedAt = d.provisionedAt;
@@ -321,6 +322,7 @@ export function resetMutableState(s: InstanceMutableState): void {
   s.kilocodeApiKey = null;
   s.kilocodeApiKeyExpiresAt = null;
   s.kilocodeDefaultModel = null;
+  s.kiloExaSearchMode = null;
   s.channels = null;
   s.googleCredentials = null;
   s.provisionedAt = null;
@@ -399,6 +401,7 @@ export function createMutableState(): InstanceMutableState {
     kilocodeApiKey: null,
     kilocodeApiKeyExpiresAt: null,
     kilocodeDefaultModel: null,
+    kiloExaSearchMode: null,
     channels: null,
     googleCredentials: null,
     provisionedAt: null,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
@@ -61,6 +61,7 @@ export type InstanceMutableState = {
   kilocodeApiKey: PersistedState['kilocodeApiKey'];
   kilocodeApiKeyExpiresAt: PersistedState['kilocodeApiKeyExpiresAt'];
   kilocodeDefaultModel: PersistedState['kilocodeDefaultModel'];
+  kiloExaSearchMode: PersistedState['kiloExaSearchMode'];
   channels: PersistedState['channels'];
   googleCredentials: GoogleCredentials | null;
   provisionedAt: number | null;

--- a/services/kiloclaw/src/gateway/env.test.ts
+++ b/services/kiloclaw/src/gateway/env.test.ts
@@ -60,11 +60,11 @@ describe('buildEnvVars', () => {
     expect(result.env.AUTO_APPROVE_DEVICES).toBe('true');
   });
 
-  it('defaults KILO_EXA_SEARCH_MODE to disabled', async () => {
+  it('omits KILO_EXA_SEARCH_MODE when user has not selected a mode', async () => {
     const env = createMockEnv();
     const result = await buildEnvVars(env, SANDBOX_ID, SECRET);
 
-    expect(result.env.KILO_EXA_SEARCH_MODE).toBe('disabled');
+    expect(result.env.KILO_EXA_SEARCH_MODE).toBeUndefined();
   });
 
   it('sets KILO_EXA_SEARCH_MODE from user config', async () => {

--- a/services/kiloclaw/src/gateway/env.test.ts
+++ b/services/kiloclaw/src/gateway/env.test.ts
@@ -60,6 +60,22 @@ describe('buildEnvVars', () => {
     expect(result.env.AUTO_APPROVE_DEVICES).toBe('true');
   });
 
+  it('defaults KILO_EXA_SEARCH_MODE to disabled', async () => {
+    const env = createMockEnv();
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET);
+
+    expect(result.env.KILO_EXA_SEARCH_MODE).toBe('disabled');
+  });
+
+  it('sets KILO_EXA_SEARCH_MODE from user config', async () => {
+    const env = createMockEnv();
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET, {
+      kiloExaSearchMode: 'kilo-proxy',
+    });
+
+    expect(result.env.KILO_EXA_SEARCH_MODE).toBe('kilo-proxy');
+  });
+
   it('passes KILOCODE_API_BASE_URL override in env bucket', async () => {
     const env = createMockEnv({
       KILOCODE_API_BASE_URL: 'https://example.internal/openrouter/',

--- a/services/kiloclaw/src/gateway/env.ts
+++ b/services/kiloclaw/src/gateway/env.ts
@@ -213,7 +213,9 @@ export async function buildEnvVars(
   sensitive.OPENCLAW_GATEWAY_TOKEN = await deriveGatewayToken(sandboxId, gatewayTokenSecret);
   plainEnv.KILOCLAW_SANDBOX_ID = sandboxId;
   plainEnv.AUTO_APPROVE_DEVICES = 'true';
-  plainEnv.KILO_EXA_SEARCH_MODE = userConfig?.kiloExaSearchMode ?? 'disabled';
+  if (userConfig?.kiloExaSearchMode != null) {
+    plainEnv.KILO_EXA_SEARCH_MODE = userConfig.kiloExaSearchMode;
+  }
 
   // User-selected exec permissions preset (non-sensitive, survives restarts).
   if (userConfig?.execSecurity) plainEnv.KILOCLAW_EXEC_SECURITY = userConfig.execSecurity;

--- a/services/kiloclaw/src/gateway/env.ts
+++ b/services/kiloclaw/src/gateway/env.ts
@@ -7,6 +7,7 @@ import type {
   EncryptedEnvelope,
   EncryptedChannelTokens,
   GoogleCredentials,
+  KiloExaSearchMode,
 } from '../schemas/instance-config';
 import { deriveGatewayToken } from '../auth/gateway-token';
 import {
@@ -25,6 +26,7 @@ export type UserConfig = {
   encryptedSecrets?: Record<string, EncryptedEnvelope>;
   kilocodeApiKey?: string | null;
   kilocodeDefaultModel?: string | null;
+  kiloExaSearchMode?: KiloExaSearchMode | null;
   channels?: EncryptedChannelTokens;
   googleCredentials?: GoogleCredentials;
   instanceFeatures?: string[];
@@ -211,6 +213,7 @@ export async function buildEnvVars(
   sensitive.OPENCLAW_GATEWAY_TOKEN = await deriveGatewayToken(sandboxId, gatewayTokenSecret);
   plainEnv.KILOCLAW_SANDBOX_ID = sandboxId;
   plainEnv.AUTO_APPROVE_DEVICES = 'true';
+  plainEnv.KILO_EXA_SEARCH_MODE = userConfig?.kiloExaSearchMode ?? 'disabled';
 
   // User-selected exec permissions preset (non-sensitive, survives restarts).
   if (userConfig?.execSecurity) plainEnv.KILOCLAW_EXEC_SECURITY = userConfig.execSecurity;

--- a/services/kiloclaw/src/routes/kiloclaw.ts
+++ b/services/kiloclaw/src/routes/kiloclaw.ts
@@ -15,6 +15,7 @@ const CHANNEL_ENV_VARS = new Set(
 
 /** Channel field keys — used to check legacy `channels` storage for backward compat. */
 const CHANNEL_FIELD_KEYS = getFieldKeysByCategory('channel');
+const NON_SECRET_ENCRYPTED_ENV_VARS = new Set(['KILO_EXA_SEARCH_MODE']);
 
 /**
  * User-facing KiloClaw routes (JWT auth via authMiddleware).
@@ -50,12 +51,15 @@ kiloclaw.get('/config', c =>
     return c.json({
       envVarKeys: config.envVars ? Object.keys(config.envVars) : [],
       secretCount: config.encryptedSecrets
-        ? Object.keys(config.encryptedSecrets).filter(k => !CHANNEL_ENV_VARS.has(k)).length
+        ? Object.keys(config.encryptedSecrets).filter(
+            k => !CHANNEL_ENV_VARS.has(k) && !NON_SECRET_ENCRYPTED_ENV_VARS.has(k)
+          ).length
         : 0,
       kilocodeDefaultModel: config.kilocodeDefaultModel ?? null,
       hasKiloCodeApiKey: !!config.kilocodeApiKey,
       kilocodeApiKeyExpiresAt: config.kilocodeApiKeyExpiresAt ?? null,
       configuredSecrets: buildConfiguredSecrets(config),
+      kiloExaSearchMode: config.webSearch?.exaMode ?? null,
       customSecretKeys: config.encryptedSecrets
         ? Object.keys(config.encryptedSecrets).filter(isCustomSecretEnvVar)
         : [],
@@ -127,7 +131,9 @@ function buildConfiguredSecrets(config: {
   const result: Record<string, boolean> = {};
 
   for (const entry of SECRET_CATALOG) {
-    result[entry.id] = entry.fields.every(field => {
+    const requiredFields = entry.fields.filter(field => field.requiredForConfigured !== false);
+    const fieldsToCheck = requiredFields.length > 0 ? requiredFields : entry.fields;
+    result[entry.id] = fieldsToCheck.every(field => {
       // Check new encryptedSecrets storage (keyed by env var name)
       if (config.encryptedSecrets?.[field.envVar] != null) return true;
       // Fall back to legacy channels storage (keyed by field key)

--- a/services/kiloclaw/src/routes/kiloclaw.ts
+++ b/services/kiloclaw/src/routes/kiloclaw.ts
@@ -15,7 +15,6 @@ const CHANNEL_ENV_VARS = new Set(
 
 /** Channel field keys — used to check legacy `channels` storage for backward compat. */
 const CHANNEL_FIELD_KEYS = getFieldKeysByCategory('channel');
-const NON_SECRET_ENCRYPTED_ENV_VARS = new Set(['KILO_EXA_SEARCH_MODE']);
 
 /**
  * User-facing KiloClaw routes (JWT auth via authMiddleware).
@@ -51,9 +50,7 @@ kiloclaw.get('/config', c =>
     return c.json({
       envVarKeys: config.envVars ? Object.keys(config.envVars) : [],
       secretCount: config.encryptedSecrets
-        ? Object.keys(config.encryptedSecrets).filter(
-            k => !CHANNEL_ENV_VARS.has(k) && !NON_SECRET_ENCRYPTED_ENV_VARS.has(k)
-          ).length
+        ? Object.keys(config.encryptedSecrets).filter(k => !CHANNEL_ENV_VARS.has(k)).length
         : 0,
       kilocodeDefaultModel: config.kilocodeDefaultModel ?? null,
       hasKiloCodeApiKey: !!config.kilocodeApiKey,

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -57,6 +57,11 @@ const KiloCodeConfigPatchSchema = z.object({
     .optional(),
 });
 
+const WebSearchConfigPatchSchema = z.object({
+  userId: z.string().min(1),
+  exaMode: z.enum(['kilo-proxy', 'disabled']).nullable().optional(),
+});
+
 const platform = new Hono<AppEnv>();
 type KiloClawInstanceStub = ReturnType<AppEnv['Bindings']['KILOCLAW_INSTANCE']['get']>;
 
@@ -564,6 +569,31 @@ platform.patch('/kilocode-config', async c => {
     return c.json(updated, 200);
   } catch (err) {
     const { message, status } = sanitizeError(err, 'kilocode-config patch');
+    return jsonError(message, status);
+  }
+});
+
+// PATCH /api/platform/web-search-config
+platform.patch('/web-search-config', async c => {
+  const result = await parseBody(c, WebSearchConfigPatchSchema);
+  if ('error' in result) return result.error;
+
+  const iidResult = parseInstanceIdQuery(c);
+  if ('error' in iidResult) return iidResult.error;
+
+  const { userId, exaMode } = result.data;
+
+  try {
+    const updated = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
+      stub => stub.updateWebSearchConfig({ exaMode }),
+      'updateWebSearchConfig'
+    );
+    return c.json(updated, 200);
+  } catch (err) {
+    const { message, status } = sanitizeError(err, 'web-search-config patch');
     return jsonError(message, status);
   }
 });

--- a/services/kiloclaw/src/schemas/instance-config.ts
+++ b/services/kiloclaw/src/schemas/instance-config.ts
@@ -82,12 +82,20 @@ export type FlyProviderState = z.infer<typeof FlyProviderStateSchema>;
 export type DockerLocalProviderState = z.infer<typeof DockerLocalProviderStateSchema>;
 export type ProviderState = z.infer<typeof ProviderStateSchema>;
 
+export const KiloExaSearchModeSchema = z.enum(['kilo-proxy', 'disabled']);
+export type KiloExaSearchMode = z.infer<typeof KiloExaSearchModeSchema>;
+
 export const InstanceConfigSchema = z.object({
   envVars: z.record(envVarNameSchema, z.string()).optional(),
   encryptedSecrets: z.record(envVarNameSchema, EncryptedEnvelopeSchema).optional(),
   kilocodeApiKey: z.string().nullable().optional(),
   kilocodeApiKeyExpiresAt: z.string().nullable().optional(),
   kilocodeDefaultModel: z.string().nullable().optional(),
+  webSearch: z
+    .object({
+      exaMode: KiloExaSearchModeSchema.optional(),
+    })
+    .optional(),
   // TODO: Legacy hardcoded channel storage. Kept for backward compat with
   // existing DO state and the decryptChannelTokens/buildEnvVars startup path.
   // Migrate to read from encryptedSecrets via catalog, then remove.
@@ -201,6 +209,7 @@ export const PersistedStateSchema = z.object({
   kilocodeApiKey: z.string().nullable().default(null),
   kilocodeApiKeyExpiresAt: z.string().nullable().default(null),
   kilocodeDefaultModel: z.string().nullable().default(null),
+  kiloExaSearchMode: KiloExaSearchModeSchema.nullable().default(null),
   channels: z
     .object({
       telegramBotToken: EncryptedEnvelopeSchema.optional(),


### PR DESCRIPTION
## Summary
- Add Exa Search controls to `claw/settings` and enforce single-provider UX between Brave and Exa, including mirrored confirmation dialogs and a Brave re-enable inline action when an existing Brave credential is present.
- Move Exa mode out of secret storage into first-class instance config (`webSearch.exaMode`) with dedicated patch APIs, and derive `KILO_EXA_SEARCH_MODE` at runtime from persisted state.
- Gate Exa UI visibility by controller calver and set the threshold to `2026.4.14` so dashboard exposure only happens after the runtime image with Exa support is deployed.

## Verification
- `pnpm --filter @kilocode/kiloclaw-secret-catalog test -- src/__tests__/catalog.test.ts`
- `pnpm --filter kiloclaw test -- src/durable-objects/kiloclaw-instance.test.ts src/routes/kiloclaw.test.ts src/gateway/env.test.ts controller/src/config-writer.test.ts`
- `pnpm typecheck`


## Visual Changes
Exa: Already Enabled, Enable Brave (video):
https://github.com/user-attachments/assets/aacf9a7d-f660-409e-be70-385797832cb6

Brave: Already Enabled, Enable Exa (video):
https://github.com/user-attachments/assets/4931209c-6f67-4645-8716-d98c375fce11

Exa: Enabled, Brave previously configured + secret stored (see: new text link in Brave item, next to Save button)
<img width="1122" height="457" alt="Screenshot 2026-04-14 at 12 38 30 PM" src="https://github.com/user-attachments/assets/8de184e2-f532-4dd6-b520-36d46b90b2dd" />

All of the above states display a relevant toast in the bottom right, like so:
<img width="386" height="77" alt="Screenshot 2026-04-14 at 12 38 38 PM" src="https://github.com/user-attachments/assets/bd351ed8-83f4-4097-adc6-42e46ec63121" />

Change validation:
<img width="945" height="475" alt="Screenshot 2026-04-14 at 12 38 14 PM" src="https://github.com/user-attachments/assets/7d2bf08b-a1cc-442a-88fd-cf842d6df357" />

(I omitted the actual search messages from each service, but those were manually verified.)

NOTE: All of these interactions were recorded on latest commit - [dda4943](https://github.com/Kilo-Org/cloud/pull/2412/commits/dda494380f1aa140376c856615fceda1c744466c) - which is the final commit made after adding PR review feedback.

## Reviewer Notes
- This PR is intended to ship after the image/runtime PR (`feat/kiloclaw-exa-image-runtime`) is deployed.
- Exa UI remains hidden on older controller images via `EXA_SEARCH_UI_MIN_CONTROLLER_VERSION`.
- Push used `--no-verify` due unrelated failing checks in `services/kiloclaw-inbound-email` outside this branch scope.