### PR TITLE
fix(kiloclaw): harden inbound email hook delivery

### DIFF
--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -720,9 +720,53 @@ describe('generateBaseConfig', () => {
       wakeMode: 'now',
       name: 'Inbound Email',
       sessionKey: '{{payload.sessionKey}}',
-      messageTemplate: 'From: {{payload.from}}\nSubject: {{payload.subject}}\n\n{{payload.text}}',
+      textTemplate: 'From: {{payload.from}}\nSubject: {{payload.subject}}\n\n{{payload.text}}',
       deliver: false,
     });
+  });
+
+  it('migrates wake hook messageTemplate to textTemplate', () => {
+    const existing = JSON.stringify({
+      hooks: {
+        mappings: [
+          {
+            id: 'cloudflare-email-inbound',
+            match: { path: 'email' },
+            action: 'wake',
+            wakeMode: 'now',
+            name: 'Inbound Email',
+            sessionKey: '{{payload.sessionKey}}',
+            messageTemplate: 'old template',
+            deliver: false,
+          },
+          {
+            id: 'custom-wake',
+            action: 'wake',
+            messageTemplate: 'custom template',
+          },
+        ],
+      },
+    });
+    const { deps } = fakeDeps(existing);
+    const env = { ...minimalEnv(), KILOCLAW_HOOKS_TOKEN: 'test-hooks-token' };
+    const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
+
+    expect(config.hooks.mappings).toContainEqual({
+      id: 'cloudflare-email-inbound',
+      match: { path: 'email' },
+      action: 'wake',
+      wakeMode: 'now',
+      name: 'Inbound Email',
+      sessionKey: '{{payload.sessionKey}}',
+      textTemplate: 'From: {{payload.from}}\nSubject: {{payload.subject}}\n\n{{payload.text}}',
+      deliver: false,
+    });
+    expect(config.hooks.mappings).toContainEqual({
+      id: 'custom-wake',
+      action: 'wake',
+      textTemplate: 'custom template',
+    });
+    expect(JSON.stringify(config.hooks.mappings)).not.toContain('messageTemplate');
   });
 
   it('adds gmail preset when Gog credentials are configured', () => {

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -60,6 +60,14 @@ type ConfigObject = Record<string, any>;
 
 type EnvLike = Record<string, string | undefined>;
 
+function migrateWakeHookTemplate(mapping: ConfigObject): ConfigObject {
+  if (mapping.action === 'wake' && typeof mapping.messageTemplate === 'string') {
+    mapping.textTemplate = mapping.messageTemplate;
+    delete mapping.messageTemplate;
+  }
+  return mapping;
+}
+
 const INBOUND_EMAIL_HOOK_MAPPING = {
   id: 'cloudflare-email-inbound',
   match: { path: 'email' },
@@ -67,7 +75,7 @@ const INBOUND_EMAIL_HOOK_MAPPING = {
   wakeMode: 'now',
   name: 'Inbound Email',
   sessionKey: '{{payload.sessionKey}}',
-  messageTemplate: 'From: {{payload.from}}\nSubject: {{payload.subject}}\n\n{{payload.text}}',
+  textTemplate: 'From: {{payload.from}}\nSubject: {{payload.subject}}\n\n{{payload.text}}',
   deliver: false,
 };
 
@@ -371,7 +379,9 @@ export function generateBaseConfig(
     config.hooks.token = env.KILOCLAW_HOOKS_TOKEN;
     config.hooks.path = '/hooks';
 
-    config.hooks.mappings = Array.isArray(config.hooks.mappings) ? config.hooks.mappings : [];
+    config.hooks.mappings = Array.isArray(config.hooks.mappings)
+      ? config.hooks.mappings.map((mapping: ConfigObject) => migrateWakeHookTemplate(mapping))
+      : [];
     const existingEmailMappingIndex = config.hooks.mappings.findIndex(
       (mapping: ConfigObject) => mapping.id === INBOUND_EMAIL_HOOK_MAPPING.id
     );

--- a/services/kiloclaw/controller/src/routes/inbound-email.test.ts
+++ b/services/kiloclaw/controller/src/routes/inbound-email.test.ts
@@ -61,13 +61,14 @@ describe('registerInboundEmailRoute', () => {
     const mockFetch = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
     vi.stubGlobal('fetch', mockFetch);
 
+    const payload = JSON.stringify({ messageId: 'msg-1', text: 'hello' });
     const res = await app.request('/_kilo/hooks/email', {
       method: 'POST',
       headers: {
         authorization: `Bearer ${GATEWAY_TOKEN}`,
         'content-type': 'application/json',
       },
-      body: JSON.stringify({ messageId: 'msg-1', text: 'hello' }),
+      body: payload,
     });
 
     expect(res.status).toBe(200);
@@ -76,6 +77,8 @@ describe('registerInboundEmailRoute', () => {
     const [url, init] = mockFetch.mock.calls[0];
     expect(url).toBe('http://127.0.0.1:3001/hooks/email');
     expect(init.headers.authorization).toBe(`Bearer ${HOOKS_TOKEN}`);
+    expect(init.body).toBe(payload);
+    expect('duplex' in init).toBe(false);
   });
 
   it('propagates hook 4xx as permanent failure', async () => {

--- a/services/kiloclaw/controller/src/routes/inbound-email.ts
+++ b/services/kiloclaw/controller/src/routes/inbound-email.ts
@@ -22,15 +22,15 @@ export function registerInboundEmailRoute(
     }
 
     try {
+      const requestBody = await c.req.text();
       const upstream = await fetch(GATEWAY_HOOK_URL, {
         method: 'POST',
         headers: {
           'content-type': c.req.header('content-type') ?? 'application/json',
           authorization: `Bearer ${hooksToken}`,
         },
-        body: c.req.raw.body,
-        duplex: 'half',
-      } as RequestInit);
+        body: requestBody,
+      });
 
       const upstreamBody = await upstream.text();
 

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -1723,6 +1723,8 @@ const InboundEmailSchema = z.object({
   receivedAt: z.string().datetime(),
 });
 
+type InboundEmailDelivery = z.infer<typeof InboundEmailSchema>;
+
 function inboundEmailTitleSlug(subject: string): string {
   const slug = subject
     .trim()
@@ -1737,6 +1739,43 @@ function inboundEmailTitleSlug(subject: string): string {
 
 function inboundEmailSessionKey(subject: string, receivedAt: string): string {
   return `inbound-email:${receivedAt.slice(0, 10)}-${inboundEmailTitleSlug(subject)}`;
+}
+
+function inboundEmailExpectedLocalPart(instanceId: string): string {
+  return `ki-${instanceId.replace(/-/g, '')}`;
+}
+
+function inboundEmailAddressParts(address: string): {
+  localPart: string;
+  domain: string;
+  validSingleAddress: boolean;
+} {
+  const [localPart, domain, ...extra] = address.trim().toLowerCase().split('@');
+  return {
+    localPart: localPart ?? '',
+    domain: domain ?? '',
+    validSingleAddress: Boolean(localPart && domain && extra.length === 0),
+  };
+}
+
+function inboundEmailLogContext(delivery: InboundEmailDelivery) {
+  const recipient = inboundEmailAddressParts(delivery.to);
+  const sender = inboundEmailAddressParts(delivery.from);
+  const expectedRecipientLocalPart = inboundEmailExpectedLocalPart(delivery.instanceId);
+
+  return {
+    instanceId: delivery.instanceId,
+    messageIdLength: delivery.messageId.length,
+    fromDomain: sender.domain,
+    toLocalPart: recipient.localPart,
+    toDomain: recipient.domain,
+    toAddressValid: recipient.validSingleAddress,
+    expectedToLocalPart: expectedRecipientLocalPart,
+    toMatchesInstanceId: recipient.localPart === expectedRecipientLocalPart,
+    subjectLength: delivery.subject.length,
+    textLength: delivery.text.length,
+    receivedAt: delivery.receivedAt,
+  };
 }
 
 async function resolveInboundEmailDoKey(
@@ -1763,42 +1802,109 @@ async function resolveInboundEmailDoKey(
 // POST /api/platform/inbound-email
 // Deliver a Cloudflare Email Routing message to an instance's OpenClaw hook endpoint.
 platform.post('/inbound-email', async c => {
+  const startedAt = performance.now();
   const result = await parseBody(c, InboundEmailSchema);
   if ('error' in result) return result.error;
 
   const delivery = result.data;
+  const logContext = inboundEmailLogContext(delivery);
+  console.log('[platform] inbound email received', logContext);
+  if (!logContext.toMatchesInstanceId) {
+    console.warn('[platform] inbound email recipient does not match instanceId', logContext);
+  }
+
   const connectionString = c.env.HYPERDRIVE?.connectionString;
   if (!connectionString) {
+    console.error('[platform] inbound email database unavailable', logContext);
     return jsonError('Database is not configured', 503);
   }
   if (!c.env.GATEWAY_TOKEN_SECRET) {
+    console.error('[platform] inbound email gateway token secret unavailable', logContext);
     return jsonError('GATEWAY_TOKEN_SECRET is not configured', 503);
   }
 
   try {
     const instance = await getInstanceById(getWorkerDb(connectionString), delivery.instanceId);
     if (!instance) {
+      console.warn('[platform] inbound email instance not found', logContext);
       return jsonError('Instance not found', 404);
     }
     c.set('userId', instance.userId);
+    console.log('[platform] inbound email instance resolved', {
+      ...logContext,
+      userId: instance.userId,
+      sandboxId: instance.sandboxId,
+      orgId: instance.orgId,
+    });
 
     const doKey = await resolveInboundEmailDoKey(c.env, instance);
+    console.log('[platform] inbound email DO resolved', {
+      ...logContext,
+      userId: instance.userId,
+      orgId: instance.orgId,
+      doKey,
+      doKeyMatchesInstanceId: doKey === instance.id,
+    });
+
     const stub = c.env.KILOCLAW_INSTANCE.get(c.env.KILOCLAW_INSTANCE.idFromName(doKey));
     const status = await stub.getStatus();
+    console.log('[platform] inbound email status resolved', {
+      ...logContext,
+      userId: instance.userId,
+      doKey,
+      instanceStatus: status.status,
+      statusUserId: status.userId,
+      statusSandboxId: status.sandboxId,
+      hasSandboxId: Boolean(status.sandboxId),
+    });
 
     if (status.status !== 'running') {
+      console.warn('[platform] inbound email instance is not running', {
+        ...logContext,
+        userId: instance.userId,
+        doKey,
+        instanceStatus: status.status,
+      });
       return jsonError('Instance is not running', 503);
     }
     if (!status.sandboxId) {
+      console.error('[platform] inbound email instance has no sandboxId', {
+        ...logContext,
+        userId: instance.userId,
+        doKey,
+        instanceStatus: status.status,
+      });
       return jsonError('Instance has no sandboxId', 500);
     }
 
     const routingTarget = await stub.getRoutingTarget();
     if (!routingTarget) {
+      console.warn('[platform] inbound email instance not routable', {
+        ...logContext,
+        userId: instance.userId,
+        doKey,
+        instanceStatus: status.status,
+      });
       return jsonError('Instance not routable', 503);
     }
+    console.log('[platform] inbound email routing target resolved', {
+      ...logContext,
+      userId: instance.userId,
+      doKey,
+      targetOrigin: routingTarget.origin,
+      hasFlyForceInstanceId: 'fly-force-instance-id' in routingTarget.headers,
+    });
 
     const gatewayToken = await deriveGatewayToken(status.sandboxId, c.env.GATEWAY_TOKEN_SECRET);
+    const sessionKey = inboundEmailSessionKey(delivery.subject, delivery.receivedAt);
+    console.log('[platform] inbound email forwarding to controller', {
+      ...logContext,
+      userId: instance.userId,
+      doKey,
+      targetOrigin: routingTarget.origin,
+      sessionKeyPrefix: sessionKey.split(':')[0] ?? '',
+      sessionKeyLength: sessionKey.length,
+    });
     const response = await fetch(`${routingTarget.origin}/_kilo/hooks/email`, {
       method: 'POST',
       headers: {
@@ -1807,7 +1913,7 @@ platform.post('/inbound-email', async c => {
         'content-type': 'application/json',
       },
       body: JSON.stringify({
-        sessionKey: inboundEmailSessionKey(delivery.subject, delivery.receivedAt),
+        sessionKey,
         messageId: delivery.messageId,
         from: delivery.from,
         to: delivery.to,
@@ -1815,6 +1921,15 @@ platform.post('/inbound-email', async c => {
         text: delivery.text,
         receivedAt: delivery.receivedAt,
       }),
+    });
+
+    console.log('[platform] inbound email controller response', {
+      ...logContext,
+      userId: instance.userId,
+      doKey,
+      status: response.status,
+      ok: response.ok,
+      durationMs: performance.now() - startedAt,
     });
 
     if (response.ok) {
@@ -1829,15 +1944,28 @@ platform.post('/inbound-email', async c => {
     }
 
     const error = await response.text().catch(() => '');
-    console.error('[platform] inbound email controller delivery failed', {
-      instanceId: instance.id,
+    const controllerFailure = {
+      ...logContext,
+      userId: instance.userId,
+      doKey,
       status: response.status,
       error: error.slice(0, 500),
-    });
+      durationMs: performance.now() - startedAt,
+    };
+    if (response.status >= 500) {
+      console.error('[platform] inbound email controller delivery failed', controllerFailure);
+    } else {
+      console.warn('[platform] inbound email controller rejected delivery', controllerFailure);
+    }
 
     const responseStatus = response.status >= 400 && response.status < 600 ? response.status : 502;
     return jsonError('Inbound email delivery failed', responseStatus);
   } catch (err) {
+    console.error('[platform] inbound email delivery threw', {
+      ...logContext,
+      error: err instanceof Error ? err.message : String(err),
+      durationMs: performance.now() - startedAt,
+    });
     const { message, status } = sanitizeError(err, 'inbound-email');
     return jsonError(message, status);
   }


### PR DESCRIPTION
## Summary
- Buffer inbound email hook requests in the controller before forwarding to OpenClaw so delivery does not depend on streaming request body behavior.
- Use `textTemplate` for wake hook mappings and migrate existing wake mappings away from `messageTemplate` so inbound email wake actions include the expected message text.
- Add structured platform logs for inbound email delivery, covering recipient-to-instance matching, DB/DO/routing resolution, controller responses, and retryable vs permanent failures.

## Verification
- `pnpm --filter kiloclaw format`
- `pnpm --filter kiloclaw typecheck`
- `pnpm --filter kiloclaw test -- src/routes/platform-inbound-email.test.ts`

## Visual Changes
N/A

## Reviewer Notes
- The new logs intentionally avoid full email body, subject, sender address, and message ID; they include domains, lengths, routing IDs, and status metadata for debugging.
- Controller 4xx hook responses are logged as warnings in the platform handler, while 5xx responses remain errors because they are retryable infrastructure failures.