### PR TITLE
feat(gastown): add bulk bead deletion — array support for gt_bead_delete and bulk delete UI

### DIFF
--- a/apps/web/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
@@ -1,16 +1,18 @@
 'use client';
 
-import { useState, useMemo } from 'react';
-import { useQuery, useQueries } from '@tanstack/react-query';
-import { useGastownTRPC } from '@/lib/gastown/trpc';
+import { useState, useMemo, useCallback } from 'react';
+import { useQuery, useQueries, useQueryClient } from '@tanstack/react-query';
+import { useGastownTRPC, useGastownTRPCClient } from '@/lib/gastown/trpc';
 import { useDrawerStack } from '@/components/gastown/DrawerStack';
-import { Hexagon, Search } from 'lucide-react';
+import { Hexagon, Search, Trash2, X } from 'lucide-react';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { formatDistanceToNow } from 'date-fns';
 import { motion, AnimatePresence } from 'motion/react';
 import type { GastownOutputs } from '@/lib/gastown/trpc';
 
 type Bead = GastownOutputs['gastown']['listBeads'][number];
+
+type BeadWithRig = Bead & { rigName: string; rigId: string };
 
 type BeadsPageClientProps = {
   townId: string;
@@ -25,14 +27,18 @@ const STATUS_DOT: Record<string, string> = {
 
 export function BeadsPageClient({ townId }: BeadsPageClientProps) {
   const trpc = useGastownTRPC();
+  const trpcClient = useGastownTRPCClient();
+  const queryClient = useQueryClient();
   const { open: openDrawer } = useDrawerStack();
   const [statusFilter, setStatusFilter] = useState<string | null>(null);
   const [search, setSearch] = useState('');
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [confirmDelete, setConfirmDelete] = useState<'selected' | 'allFailed' | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const rigsQuery = useQuery(trpc.gastown.listRigs.queryOptions({ townId }));
   const rigs = rigsQuery.data ?? [];
 
-  // Fetch beads for each rig — useQueries handles dynamic-length arrays safely
   const rigBeadQueries = useQueries({
     queries: rigs.map(rig => ({
       ...trpc.gastown.listBeads.queryOptions({ rigId: rig.id }),
@@ -42,7 +48,7 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
 
   const rigBeadData = rigBeadQueries.map(q => q.data);
   const allBeads = useMemo(() => {
-    const beads: Array<Bead & { rigName: string; rigId: string }> = [];
+    const beads: BeadWithRig[] = [];
     rigBeadData.forEach((data, i) => {
       const rig = rigs[i];
       if (data && rig) {
@@ -51,7 +57,6 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
         }
       }
     });
-    // Sort newest first
     beads.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
     return beads;
   }, [rigBeadData, rigs]);
@@ -78,11 +83,87 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
     return counts;
   }, [allBeads]);
 
+  const failedBeadCount = statusCounts.failed ?? 0;
+
   const isLoading = rigsQuery.isLoading || rigBeadQueries.some(q => q.isLoading);
+
+  const toggleSelect = useCallback((beadId: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(beadId)) next.delete(beadId);
+      else next.add(beadId);
+      return next;
+    });
+  }, []);
+
+  const toggleSelectAll = useCallback(() => {
+    if (selectedIds.size === filteredBeads.length) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(filteredBeads.map(b => b.bead_id)));
+    }
+  }, [selectedIds.size, filteredBeads]);
+
+  const invalidateBeadQueries = useCallback(async () => {
+    for (const rig of rigs) {
+      await queryClient.invalidateQueries({
+        queryKey: trpc.gastown.listBeads.queryKey({ rigId: rig.id }),
+      });
+    }
+    await queryClient.invalidateQueries({
+      queryKey: trpc.gastown.listRigs.queryKey({ townId }),
+    });
+  }, [queryClient, trpc, rigs, townId]);
+
+  const deleteBeadsByRig = useCallback(
+    async (beadIds: string[]) => {
+      const byRig = new Map<string, string[]>();
+      for (const bead of allBeads) {
+        if (beadIds.includes(bead.bead_id)) {
+          const existing = byRig.get(bead.rigId) ?? [];
+          existing.push(bead.bead_id);
+          byRig.set(bead.rigId, existing);
+        }
+      }
+      await Promise.all(
+        [...byRig.entries()].map(([rigId, ids]) =>
+          trpcClient.gastown.deleteBead.mutate({ rigId, beadId: ids, townId })
+        )
+      );
+    },
+    [allBeads, trpcClient, townId]
+  );
+
+  const handleDeleteSelected = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      await deleteBeadsByRig([...selectedIds]);
+      await invalidateBeadQueries();
+      setSelectedIds(new Set());
+      setConfirmDelete(null);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [selectedIds, deleteBeadsByRig, invalidateBeadQueries]);
+
+  const handleDeleteAllFailed = useCallback(async () => {
+    const failedIds = allBeads.filter(b => b.status === 'failed').map(b => b.bead_id);
+    if (failedIds.length === 0) return;
+    setIsDeleting(true);
+    try {
+      await deleteBeadsByRig(failedIds);
+      await invalidateBeadQueries();
+      setSelectedIds(new Set());
+      setConfirmDelete(null);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [allBeads, deleteBeadsByRig, invalidateBeadQueries]);
+
+  const allFilteredSelected = filteredBeads.length > 0 && selectedIds.size === filteredBeads.length;
 
   return (
     <div className="flex h-full flex-col">
-      {/* Header */}
       <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/[0.06] bg-[oklch(0.1_0_0)] px-6 py-3">
         <div className="flex items-center gap-2">
           <SidebarTrigger className="-ml-3" />
@@ -90,11 +171,18 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Beads</h1>
           <span className="ml-1 font-mono text-xs text-white/30">{allBeads.length}</span>
         </div>
+        {failedBeadCount > 0 && (
+          <button
+            onClick={() => setConfirmDelete('allFailed')}
+            className="flex items-center gap-1.5 rounded-md border border-red-500/20 bg-red-500/10 px-2.5 py-1 text-[10px] font-medium text-red-400 transition-colors hover:bg-red-500/20"
+          >
+            <Trash2 className="size-3" />
+            Delete all failed ({failedBeadCount})
+          </button>
+        )}
       </div>
 
-      {/* Filter bar */}
       <div className="flex items-center gap-3 border-b border-white/[0.06] px-6 py-2">
-        {/* Search */}
         <div className="flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-2.5 py-1.5">
           <Search className="size-3 text-white/30" />
           <input
@@ -106,7 +194,6 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
           />
         </div>
 
-        {/* Status filter chips */}
         <div className="flex items-center gap-1">
           <FilterChip
             label="All"
@@ -127,7 +214,26 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
         </div>
       </div>
 
-      {/* Bead list */}
+      {selectedIds.size > 0 && (
+        <div className="flex items-center gap-3 border-b border-white/[0.06] bg-white/[0.02] px-6 py-2">
+          <span className="text-xs text-white/50">{selectedIds.size} selected</span>
+          <button
+            onClick={() => setSelectedIds(new Set())}
+            className="flex items-center gap-1 text-[10px] text-white/30 hover:text-white/50"
+          >
+            <X className="size-3" />
+            Clear
+          </button>
+          <button
+            onClick={() => setConfirmDelete('selected')}
+            className="ml-auto flex items-center gap-1.5 rounded-md border border-red-500/20 bg-red-500/10 px-2.5 py-1 text-[10px] font-medium text-red-400 transition-colors hover:bg-red-500/20"
+          >
+            <Trash2 className="size-3" />
+            Delete selected
+          </button>
+        </div>
+      )}
+
       <div className="flex-1 overflow-y-auto">
         {isLoading && (
           <div className="space-y-0">
@@ -154,6 +260,22 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
         )}
 
         <AnimatePresence mode="popLayout">
+          {filteredBeads.length > 0 && (
+            <div
+              className="flex items-center gap-3 border-b border-white/[0.04] px-6 py-1.5"
+              onClick={toggleSelectAll}
+            >
+              <input
+                type="checkbox"
+                checked={allFilteredSelected}
+                onChange={toggleSelectAll}
+                className="size-3.5 shrink-0 accent-white/50"
+              />
+              <span className="text-[9px] text-white/20">
+                {allFilteredSelected ? 'Deselect all' : 'Select all'}
+              </span>
+            </div>
+          )}
           {filteredBeads.map((bead, i) => (
             <motion.div
               key={bead.bead_id}
@@ -161,37 +283,79 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ delay: Math.min(i * 0.02, 0.3), duration: 0.15 }}
-              onClick={() => {
-                const rigId = (bead as Bead & { rigId: string }).rigId;
-                openDrawer({ type: 'bead', beadId: bead.bead_id, rigId });
-              }}
               className="group flex cursor-pointer items-center gap-3 border-b border-white/[0.04] px-6 py-2.5 transition-colors hover:bg-white/[0.02]"
             >
-              <span
-                className={`size-2 shrink-0 rounded-full ${STATUS_DOT[bead.status] ?? 'bg-white/20'}`}
+              <input
+                type="checkbox"
+                checked={selectedIds.has(bead.bead_id)}
+                onChange={e => {
+                  e.stopPropagation();
+                  toggleSelect(bead.bead_id);
+                }}
+                onClick={e => e.stopPropagation()}
+                className="size-3.5 shrink-0 accent-white/50"
               />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="truncate text-sm text-white/80">{bead.title}</span>
-                  <span className="shrink-0 rounded bg-white/[0.04] px-1.5 py-0.5 text-[9px] font-medium text-white/30">
-                    {bead.type}
-                  </span>
+              <span
+                onClick={() => openDrawer({ type: 'bead', beadId: bead.bead_id, rigId: bead.rigId })}
+                className="flex flex-1 cursor-pointer items-center gap-3 min-w-0"
+              >
+                <span
+                  className={`size-2 shrink-0 rounded-full ${STATUS_DOT[bead.status] ?? 'bg-white/20'}`}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm text-white/80">{bead.title}</span>
+                    <span className="shrink-0 rounded bg-white/[0.04] px-1.5 py-0.5 text-[9px] font-medium text-white/30">
+                      {bead.type}
+                    </span>
+                  </div>
+                  <div className="mt-0.5 flex items-center gap-2 text-[10px] text-white/30">
+                    <span className="font-mono">{bead.bead_id.slice(0, 8)}</span>
+                    <span className="text-white/15">|</span>
+                    <span>{bead.rigName}</span>
+                    <span className="text-white/15">|</span>
+                    <span>{formatDistanceToNow(new Date(bead.created_at), { addSuffix: true })}</span>
+                  </div>
                 </div>
-                <div className="mt-0.5 flex items-center gap-2 text-[10px] text-white/30">
-                  <span className="font-mono">{bead.bead_id.slice(0, 8)}</span>
-                  <span className="text-white/15">|</span>
-                  <span>{(bead as Bead & { rigName: string }).rigName}</span>
-                  <span className="text-white/15">|</span>
-                  <span>{formatDistanceToNow(new Date(bead.created_at), { addSuffix: true })}</span>
-                </div>
-              </div>
-              <span className="shrink-0 text-[10px] text-white/25 capitalize">{bead.priority}</span>
+                <span className="shrink-0 text-[10px] text-white/25 capitalize">{bead.priority}</span>
+              </span>
             </motion.div>
           ))}
         </AnimatePresence>
       </div>
 
-      {/* Drawers are rendered by the layout-level DrawerStackProvider */}
+      {confirmDelete && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <div className="w-full max-w-sm rounded-lg border border-white/[0.08] bg-[oklch(0.14_0_0)] p-6">
+            <h3 className="text-sm font-semibold text-white/90">
+              {confirmDelete === 'allFailed'
+                ? `Delete all failed beads?`
+                : `Delete ${selectedIds.size} selected bead${selectedIds.size !== 1 ? 's' : ''}?`}
+            </h3>
+            <p className="mt-2 text-xs text-white/50">
+              {confirmDelete === 'allFailed'
+                ? `This will permanently delete ${failedBeadCount} failed bead${failedBeadCount !== 1 ? 's' : ''}. This action cannot be undone.`
+                : `This will permanently delete ${selectedIds.size} bead${selectedIds.size !== 1 ? 's' : ''}. This action cannot be undone.`}
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                onClick={() => setConfirmDelete(null)}
+                disabled={isDeleting}
+                className="rounded-md border border-white/[0.08] px-3 py-1.5 text-xs text-white/60 hover:bg-white/[0.04]"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={confirmDelete === 'allFailed' ? handleDeleteAllFailed : handleDeleteSelected}
+                disabled={isDeleting}
+                className="rounded-md bg-red-500/20 px-3 py-1.5 text-xs font-medium text-red-400 hover:bg-red-500/30"
+              >
+                {isDeleting ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
+++ b/apps/web/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import { toast } from 'sonner';
@@ -47,9 +47,9 @@ const STATUS_COLORS: Record<BeadStatus, string> = {
 };
 
 type ConfirmAction = {
-  type: 'close' | 'fail';
-  beadId: string;
-  title: string;
+  type: 'close' | 'fail' | 'delete-selected' | 'delete-all-failed';
+  beadId?: string;
+  title?: string;
 };
 
 export function BeadsTab({ townId }: { townId: string }) {
@@ -59,6 +59,7 @@ export function BeadsTab({ townId }: { townId: string }) {
   const [statusFilter, setStatusFilter] = useState<BeadStatus | 'all'>('all');
   const [typeFilter, setTypeFilter] = useState<BeadType | 'all'>('all');
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   const beadsQuery = useQuery(
     trpc.admin.gastown.listBeads.queryOptions({
@@ -66,6 +67,13 @@ export function BeadsTab({ townId }: { townId: string }) {
       status: statusFilter === 'all' ? undefined : statusFilter,
       type: typeFilter === 'all' ? undefined : typeFilter,
     })
+  );
+
+  const beads = beadsQuery.data ?? [];
+
+  const failedBeadCount = useMemo(
+    () => beads.filter(b => b.status === 'failed').length,
+    [beads]
   );
 
   const forceCloseMutation = useMutation(
@@ -94,24 +102,144 @@ export function BeadsTab({ townId }: { townId: string }) {
     })
   );
 
-  const handleConfirm = () => {
-    if (!confirmAction) return;
-    if (confirmAction.type === 'close') {
-      forceCloseMutation.mutate({ townId, beadId: confirmAction.beadId });
-    } else {
-      forceFailMutation.mutate({ townId, beadId: confirmAction.beadId });
-    }
-  };
+  const deleteBeadsMutation = useMutation(
+    trpc.admin.gastown.deleteBeads.mutationOptions({
+      onSuccess: data => {
+        void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
+        setSelectedIds(new Set());
+        setConfirmAction(null);
+        toast.success(`${data.deleted} bead(s) deleted`);
+      },
+      onError: err => {
+        toast.error(`Failed to delete beads: ${err.message}`);
+      },
+    })
+  );
 
-  const beads = beadsQuery.data ?? [];
-  const isPending = forceCloseMutation.isPending || forceFailMutation.isPending;
+  const deleteBeadsByStatusMutation = useMutation(
+    trpc.admin.gastown.deleteBeadsByStatus.mutationOptions({
+      onSuccess: data => {
+        void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
+        setSelectedIds(new Set());
+        setConfirmAction(null);
+        toast.success(`${data.deleted} failed bead(s) deleted`);
+      },
+      onError: err => {
+        toast.error(`Failed to delete beads: ${err.message}`);
+      },
+    })
+  );
+
+  const handleConfirm = useCallback(() => {
+    if (!confirmAction) return;
+    switch (confirmAction.type) {
+      case 'close':
+        if (confirmAction.beadId) {
+          forceCloseMutation.mutate({ townId, beadId: confirmAction.beadId });
+        }
+        break;
+      case 'fail':
+        if (confirmAction.beadId) {
+          forceFailMutation.mutate({ townId, beadId: confirmAction.beadId });
+        }
+        break;
+      case 'delete-selected':
+        deleteBeadsMutation.mutate({ townId, beadIds: [...selectedIds] });
+        break;
+      case 'delete-all-failed':
+        deleteBeadsByStatusMutation.mutate({ townId, status: 'failed' });
+        break;
+    }
+  }, [confirmAction, townId, selectedIds, forceCloseMutation, forceFailMutation, deleteBeadsMutation, deleteBeadsByStatusMutation]);
+
+  const toggleSelect = useCallback((beadId: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(beadId)) next.delete(beadId);
+      else next.add(beadId);
+      return next;
+    });
+  }, []);
+
+  const toggleSelectAll = useCallback(() => {
+    if (selectedIds.size === beads.length) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(beads.map(b => b.bead_id)));
+    }
+  }, [selectedIds.size, beads]);
+
+  const allSelected = beads.length > 0 && selectedIds.size === beads.length;
+
+  const isPending =
+    forceCloseMutation.isPending ||
+    forceFailMutation.isPending ||
+    deleteBeadsMutation.isPending ||
+    deleteBeadsByStatusMutation.isPending;
+
+  const confirmTitle =
+    confirmAction?.type === 'close'
+      ? 'Force Close Bead'
+      : confirmAction?.type === 'fail'
+        ? 'Force Fail Bead'
+        : confirmAction?.type === 'delete-all-failed'
+          ? 'Delete All Failed Beads'
+          : 'Delete Selected Beads';
+
+  const confirmDescription =
+    confirmAction?.type === 'close'
+      ? `This will force-close bead ${confirmAction.beadId?.slice(0, 8)}…${confirmAction.title ? ` (${confirmAction.title})` : ''}. This action is logged in the audit trail.`
+      : confirmAction?.type === 'fail'
+        ? `This will force-fail bead ${confirmAction.beadId?.slice(0, 8)}…${confirmAction.title ? ` (${confirmAction.title})` : ''}. This action is logged in the audit trail.`
+        : confirmAction?.type === 'delete-all-failed'
+          ? `This will permanently delete ${failedBeadCount} failed bead${failedBeadCount !== 1 ? 's' : ''}. This action cannot be undone.`
+          : `This will permanently delete ${selectedIds.size} selected bead${selectedIds.size !== 1 ? 's' : ''}. This action cannot be undone.`;
+
+  const confirmButtonLabel =
+    confirmAction?.type === 'close'
+      ? 'Force Close'
+      : confirmAction?.type === 'fail'
+        ? 'Force Fail'
+        : isPending
+          ? 'Deleting…'
+          : 'Delete';
+
+  const confirmButtonVariant =
+    confirmAction?.type === 'close'
+      ? 'default' as const
+      : confirmAction?.type === 'fail'
+        ? 'destructive' as const
+        : 'destructive' as const;
 
   return (
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle>Beads</CardTitle>
-          <div className="flex gap-2">
+          <div className="flex items-center gap-2">
+            {selectedIds.size > 0 && (
+              <>
+                <span className="text-muted-foreground text-xs">{selectedIds.size} selected</span>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7 border-red-500/30 text-xs text-red-400 hover:bg-red-500/10"
+                  onClick={() => setConfirmAction({ type: 'delete-selected' })}
+                >
+                  Delete selected
+                </Button>
+              </>
+            )}
+            {failedBeadCount > 0 && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 border-red-500/30 text-xs text-red-400 hover:bg-red-500/10"
+                onClick={() => setConfirmAction({ type: 'delete-all-failed' })}
+              >
+                Delete all failed ({failedBeadCount})
+              </Button>
+            )}
             <Select
               value={statusFilter}
               onValueChange={v => {
@@ -174,6 +302,14 @@ export function BeadsTab({ townId }: { townId: string }) {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b">
+                  <th className="pb-2 pr-2 text-left">
+                    <input
+                      type="checkbox"
+                      checked={allSelected}
+                      onChange={toggleSelectAll}
+                      className="size-3.5"
+                    />
+                  </th>
                   <th className="text-muted-foreground pb-2 text-left font-medium">Bead</th>
                   <th className="text-muted-foreground pb-2 text-left font-medium">Type</th>
                   <th className="text-muted-foreground pb-2 text-left font-medium">Status</th>
@@ -185,6 +321,14 @@ export function BeadsTab({ townId }: { townId: string }) {
               <tbody>
                 {beads.map(bead => (
                   <tr key={bead.bead_id} className="hover:bg-muted/40 border-b transition-colors">
+                    <td className="py-2 pr-2">
+                      <input
+                        type="checkbox"
+                        checked={selectedIds.has(bead.bead_id)}
+                        onChange={() => toggleSelect(bead.bead_id)}
+                        className="size-3.5"
+                      />
+                    </td>
                     <td className="py-2 pr-4">
                       <Link
                         href={`/admin/gastown/towns/${townId}/beads/${bead.bead_id}`}
@@ -262,30 +406,15 @@ export function BeadsTab({ townId }: { townId: string }) {
       <Dialog open={!!confirmAction} onOpenChange={() => setConfirmAction(null)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>
-              {confirmAction?.type === 'close' ? 'Force Close Bead' : 'Force Fail Bead'}
-            </DialogTitle>
-            <DialogDescription>
-              This will {confirmAction?.type === 'close' ? 'force-close' : 'force-fail'} bead{' '}
-              <span className="font-mono">{confirmAction?.beadId.slice(0, 8)}…</span>
-              {confirmAction?.title ? ` (${confirmAction.title})` : ''}. This action is logged in
-              the audit trail.
-            </DialogDescription>
+            <DialogTitle>{confirmTitle}</DialogTitle>
+            <DialogDescription>{confirmDescription}</DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmAction(null)} disabled={isPending}>
               Cancel
             </Button>
-            <Button
-              variant={confirmAction?.type === 'fail' ? 'destructive' : 'default'}
-              onClick={handleConfirm}
-              disabled={isPending}
-            >
-              {isPending
-                ? 'Processing…'
-                : confirmAction?.type === 'close'
-                  ? 'Force Close'
-                  : 'Force Fail'}
+            <Button variant={confirmButtonVariant} onClick={handleConfirm} disabled={isPending}>
+              {isPending ? 'Processing…' : confirmButtonLabel}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/lib/gastown/types/router.d.ts
+++ b/apps/web/src/lib/gastown/types/router.d.ts
@@ -268,10 +268,12 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
     deleteBead: import('@trpc/server').TRPCMutationProcedure<{
       input: {
         rigId: string;
-        beadId: string;
+        beadId: string | string[];
         townId?: string | undefined;
       };
-      output: void;
+      output: {
+        deleted: number;
+      };
       meta: object;
     }>;
     updateBead: import('@trpc/server').TRPCMutationProcedure<{
@@ -1284,6 +1286,26 @@ export declare const gastownRouter: import('@trpc/server').TRPCBuiltRouter<
       };
       meta: object;
     }>;
+    adminDeleteBeads: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        beadIds: string[];
+      };
+      output: {
+        deleted: number;
+      };
+      meta: object;
+    }>;
+    adminDeleteBeadsByStatus: import('@trpc/server').TRPCMutationProcedure<{
+      input: {
+        townId: string;
+        status: string;
+      };
+      output: {
+        deleted: number;
+      };
+      meta: object;
+    }>;
     adminGetAlarmStatus: import('@trpc/server').TRPCQueryProcedure<{
       input: {
         townId: string;
@@ -1667,10 +1689,12 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
         deleteBead: import('@trpc/server').TRPCMutationProcedure<{
           input: {
             rigId: string;
-            beadId: string;
+            beadId: string | string[];
             townId?: string | undefined;
           };
-          output: void;
+          output: {
+            deleted: number;
+          };
           meta: object;
         }>;
         updateBead: import('@trpc/server').TRPCMutationProcedure<{
@@ -2680,6 +2704,26 @@ export declare const wrappedGastownRouter: import('@trpc/server').TRPCBuiltRoute
             created_at: string;
             updated_at: string;
             closed_at: string | null;
+          };
+          meta: object;
+        }>;
+        adminDeleteBeads: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            beadIds: string[];
+          };
+          output: {
+            deleted: number;
+          };
+          meta: object;
+        }>;
+        adminDeleteBeadsByStatus: import('@trpc/server').TRPCMutationProcedure<{
+          input: {
+            townId: string;
+            status: string;
+          };
+          output: {
+            deleted: number;
           };
           meta: object;
         }>;

--- a/apps/web/src/routers/admin/gastown-router.ts
+++ b/apps/web/src/routers/admin/gastown-router.ts
@@ -744,6 +744,32 @@ export const adminGastownRouter = createTRPCRouter({
       );
     }),
 
+  deleteBeads: adminProcedure
+    .input(z.object({ townId: z.string().uuid(), beadIds: z.array(z.string().uuid()) }))
+    .output(z.object({ deleted: z.number() }))
+    .mutation(async ({ input, ctx }) => {
+      const result = await gastownTrpcMutate(
+        ctx.user,
+        'gastown.adminDeleteBeads',
+        { townId: input.townId, beadIds: input.beadIds },
+        z.object({ deleted: z.number() })
+      );
+      return result ?? { deleted: 0 };
+    }),
+
+  deleteBeadsByStatus: adminProcedure
+    .input(z.object({ townId: z.string().uuid(), status: z.string() }))
+    .output(z.object({ deleted: z.number() }))
+    .mutation(async ({ input, ctx }) => {
+      const result = await gastownTrpcMutate(
+        ctx.user,
+        'gastown.adminDeleteBeadsByStatus',
+        { townId: input.townId, status: input.status },
+        z.object({ deleted: z.number() })
+      );
+      return result ?? { deleted: 0 };
+    }),
+
   forceRestartContainer: adminProcedure
     .input(z.object({ townId: z.string().uuid() }))
     .mutation(async ({ input, ctx }) => {

--- a/services/gastown/container/plugin/client.ts
+++ b/services/gastown/container/plugin/client.ts
@@ -430,6 +430,13 @@ export class MayorGastownClient {
     });
   }
 
+  async deleteBeads(rigId: string, beadIds: string[]): Promise<{ deleted: number }> {
+    return this.request<{ deleted: number }>(this.mayorPath(`/rigs/${rigId}/beads/bulk-delete`), {
+      method: 'POST',
+      body: JSON.stringify({ bead_ids: beadIds }),
+    });
+  }
+
   async resetAgent(rigId: string, agentId: string): Promise<void> {
     await this.request<void>(this.mayorPath(`/rigs/${rigId}/agents/${agentId}/reset`), {
       method: 'POST',

--- a/services/gastown/container/plugin/mayor-tools.test.ts
+++ b/services/gastown/container/plugin/mayor-tools.test.ts
@@ -153,6 +153,7 @@ function makeFakeMayorClient(overrides: Partial<MayorGastownClient> = {}): Mayor
     updateBead: vi.fn<() => Promise<Bead>>().mockResolvedValue(FAKE_BEAD),
     reassignBead: vi.fn<() => Promise<Bead>>().mockResolvedValue(FAKE_BEAD),
     deleteBead: vi.fn().mockResolvedValue(undefined),
+    deleteBeads: vi.fn().mockResolvedValue({ deleted: 1 }),
     resetAgent: vi.fn().mockResolvedValue(undefined),
     closeConvoy: vi.fn().mockResolvedValue(undefined),
     updateConvoy: vi.fn().mockResolvedValue(undefined),
@@ -313,14 +314,29 @@ describe('mayor tools', () => {
   });
 
   describe('gt_bead_delete', () => {
-    it('deletes bead and confirms', async () => {
+    it('deletes a single bead and confirms', async () => {
       const result = await tools.gt_bead_delete.execute(
         { rig_id: 'rig-1', bead_id: 'bead-1' },
         CTX
       );
       expect(result).toContain('bead-1');
       expect(result).toContain('deleted');
-      expect(client.deleteBead).toHaveBeenCalledWith('rig-1', 'bead-1');
+      expect(client.deleteBeads).toHaveBeenCalledWith('rig-1', ['bead-1']);
+    });
+
+    it('deletes multiple beads via array', async () => {
+      client.deleteBeads = vi.fn().mockResolvedValue({ deleted: 3 });
+      const result = await tools.gt_bead_delete.execute(
+        { rig_id: 'rig-1', bead_id: ['bead-1', 'bead-2', 'bead-3'] },
+        CTX
+      );
+      expect(result).toContain('3');
+      expect(result).toContain('deleted');
+      expect(client.deleteBeads).toHaveBeenCalledWith('rig-1', [
+        'bead-1',
+        'bead-2',
+        'bead-3',
+      ]);
     });
   });
 

--- a/services/gastown/container/plugin/mayor-tools.ts
+++ b/services/gastown/container/plugin/mayor-tools.ts
@@ -337,14 +337,18 @@ export function createMayorTools(client: MayorGastownClient) {
     }),
 
     gt_bead_delete: tool({
-      description: 'Delete a bead. Use with caution — this is irreversible.',
+      description:
+        'Delete one or more beads. Accepts a single bead_id string or an array of bead_id strings. Use with caution — this is irreversible.',
       args: {
-        rig_id: tool.schema.string().describe('The UUID of the rig the bead belongs to'),
-        bead_id: tool.schema.string().describe('The UUID of the bead to delete'),
+        rig_id: tool.schema.string().describe('The UUID of the rig the bead(s) belong to'),
+        bead_id: tool.schema
+          .union(tool.schema.string(), tool.schema.array(tool.schema.string()))
+          .describe('The UUID of the bead to delete, or an array of UUIDs for bulk deletion'),
       },
       async execute(args) {
-        await client.deleteBead(args.rig_id, args.bead_id);
-        return `Bead ${args.bead_id} deleted.`;
+        const ids = Array.isArray(args.bead_id) ? args.bead_id : [args.bead_id];
+        await client.deleteBeads(args.rig_id, ids);
+        return `${ids.length} bead(s) deleted: ${ids.join(', ')}`;
       },
     }),
 

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -1134,6 +1134,14 @@ export class TownDO extends DurableObject<Env> {
     beadOps.deleteBead(this.sql, beadId);
   }
 
+  async deleteBeads(beadIds: string[]): Promise<number> {
+    return beadOps.deleteBeads(this.sql, beadIds);
+  }
+
+  async deleteBeadsByStatus(status: string, rigId?: string): Promise<number> {
+    return beadOps.deleteBeadsByStatus(this.sql, status, rigId);
+  }
+
   async listBeadEvents(options: {
     beadId?: string;
     since?: string;

--- a/services/gastown/src/dos/town/beads.ts
+++ b/services/gastown/src/dos/town/beads.ts
@@ -715,6 +715,41 @@ export function deleteBead(sql: SqlStorage, beadId: string): void {
   query(sql, /* sql */ `DELETE FROM ${beads} WHERE ${beads.bead_id} = ?`, [beadId]);
 }
 
+export function deleteBeads(sql: SqlStorage, beadIds: string[]): number {
+  if (beadIds.length === 0) return 0;
+  for (const beadId of beadIds) {
+    deleteBead(sql, beadId);
+  }
+  return beadIds.length;
+}
+
+export function deleteBeadsByStatus(
+  sql: SqlStorage,
+  status: string,
+  rigId?: string
+): number {
+  const conditions = [`${beads.status} = ?`];
+  const params: string[] = [status];
+  if (rigId) {
+    conditions.push(`${beads.rig_id} = ?`);
+    params.push(rigId);
+  }
+  const whereClause = conditions.join(' AND ');
+  const ids = BeadRecord.pick({ bead_id: true })
+    .array()
+    .parse([
+      ...query(
+        sql,
+        /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${whereClause}`,
+        params
+      ),
+    ]);
+  for (const { bead_id } of ids) {
+    deleteBead(sql, bead_id);
+  }
+  return ids.length;
+}
+
 // ── Bead Events ─────────────────────────────────────────────────────
 
 export function logBeadEvent(

--- a/services/gastown/src/gastown.worker.ts
+++ b/services/gastown/src/gastown.worker.ts
@@ -113,6 +113,7 @@ import {
   handleMayorConvoyClose,
   handleMayorConvoyUpdate,
   handleMayorBeadDelete,
+  handleMayorBeadBulkDelete,
   handleMayorEscalationAcknowledge,
   handleMayorConvoyStart,
   handleMayorUiAction,
@@ -971,6 +972,11 @@ app.patch('/api/mayor/:townId/tools/rigs/:rigId/beads/:beadId', c =>
 app.post('/api/mayor/:townId/tools/rigs/:rigId/beads/:beadId/reassign', c =>
   instrumented(c, 'POST /api/mayor/:townId/tools/rigs/:rigId/beads/:beadId/reassign', () =>
     handleMayorBeadReassign(c, c.req.param())
+  )
+);
+app.post('/api/mayor/:townId/tools/rigs/:rigId/beads/bulk-delete', c =>
+  instrumented(c, 'POST /api/mayor/:townId/tools/rigs/:rigId/beads/bulk-delete', () =>
+    handleMayorBeadBulkDelete(c, c.req.param())
   )
 );
 app.delete('/api/mayor/:townId/tools/rigs/:rigId/beads/:beadId', c =>

--- a/services/gastown/src/handlers/mayor-tools.handler.ts
+++ b/services/gastown/src/handlers/mayor-tools.handler.ts
@@ -635,6 +635,48 @@ export async function handleMayorBeadDelete(
   return c.json(resSuccess({ deleted: true }));
 }
 
+const MayorBulkDeleteBody = z.object({
+  bead_ids: z.array(z.string().uuid()).min(1),
+});
+
+/**
+ * POST /api/mayor/:townId/tools/rigs/:rigId/beads/bulk-delete
+ * Delete multiple beads that belong to the specified rig.
+ */
+export async function handleMayorBeadBulkDelete(
+  c: Context<GastownEnv>,
+  params: { townId: string; rigId: string }
+) {
+  const rigOwned = await verifyRigBelongsToTown(c, params.townId, params.rigId);
+  if (!rigOwned) {
+    return c.json(resError('Rig not found in this town'), 403);
+  }
+
+  const parsed = MayorBulkDeleteBody.safeParse(await parseJsonBody(c));
+  if (!parsed.success) {
+    return c.json(resError('Invalid request body', parsed.error.issues), 400);
+  }
+
+  const { bead_ids } = parsed.data;
+
+  console.log(
+    `${HANDLER_LOG} handleMayorBeadBulkDelete: townId=${params.townId} rigId=${params.rigId} count=${bead_ids.length}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+
+  for (const beadId of bead_ids) {
+    const bead = await town.getBeadAsync(beadId);
+    if (bead && bead.rig_id !== params.rigId) {
+      return c.json(resError(`Bead ${beadId} does not belong to this rig`), 403);
+    }
+  }
+
+  const deleted = await town.deleteBeads(bead_ids);
+
+  return c.json(resSuccess({ deleted }));
+}
+
 /**
  * POST /api/mayor/:townId/tools/escalations/:escalationId/acknowledge
  * Acknowledge an escalation, marking it as reviewed.

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -650,14 +650,17 @@ export const gastownRouter = router({
     .input(
       z.object({
         rigId: z.string().uuid(),
-        beadId: z.string().uuid(),
+        beadId: z.union([z.string().uuid(), z.array(z.string().uuid())]),
         townId: z.string().uuid().optional(),
       })
     )
+    .output(z.object({ deleted: z.number() }))
     .mutation(async ({ ctx, input }) => {
       const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
-      await townStub.deleteBead(input.beadId);
+      const ids = Array.isArray(input.beadId) ? input.beadId : [input.beadId];
+      await townStub.deleteBeads(ids);
+      return { deleted: ids.length };
     }),
 
   updateBead: gastownProcedure
@@ -1555,6 +1558,34 @@ export const gastownRouter = router({
         message: 'Manually failed by admin',
         source: 'admin',
       });
+    }),
+
+  adminDeleteBeads: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        beadIds: z.array(z.string().uuid()),
+      })
+    )
+    .output(z.object({ deleted: z.number() }))
+    .mutation(async ({ ctx, input }) => {
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      const deleted = await townStub.deleteBeads(input.beadIds);
+      return { deleted };
+    }),
+
+  adminDeleteBeadsByStatus: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        status: z.string(),
+      })
+    )
+    .output(z.object({ deleted: z.number() }))
+    .mutation(async ({ ctx, input }) => {
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      const deleted = await townStub.deleteBeadsByStatus(input.status);
+      return { deleted };
     }),
 
   adminGetAlarmStatus: adminProcedure


### PR DESCRIPTION
## Summary
- Add bulk delete route handler (`POST /api/mayor/:townId/tools/rigs/:rigId/beads/bulk-delete`) to the gastown worker, enabling the mayor's `gt_bead_delete` tool to delete multiple beads in one request
- Add `deleteBeads` and `deleteBeadsByStatus` admin tRPC proxy procedures to the web app's admin gastown router
- Update `router.d.ts` type definitions: `deleteBead` now correctly reflects `beadId: string | string[]` and `output: { deleted: number }`; added `adminDeleteBeads` and `adminDeleteBeadsByStatus` types
- Update `gt_bead_delete` mayor tool test to assert on `client.deleteBeads` (bulk method) instead of old `client.deleteBead`, and add test for array input
- Add bulk delete UI to BeadsPageClient: checkbox column for multi-select, "Select all" header, bulk action bar with "Delete selected" button, "Delete all failed" shortcut button in header, and confirmation dialog
- Add bulk delete UI to admin BeadsTab: checkbox column, "Delete selected" button, "Delete all failed" button, all with confirmation dialogs

## Verification
- Read and verified all relevant source files before making changes
- Followed existing code patterns (tRPC mutation patterns, SQL query conventions, UI component patterns)

## Visual Changes
- BeadsPageClient now has checkboxes, bulk action bar, and "Delete all failed" button
- Admin BeadsTab now has checkboxes, "Delete selected", and "Delete all failed" buttons

## Reviewer Notes
- The `deleteBeads` SQL function still loops individual `deleteBead` calls (for cascade safety), but the HTTP/tRPC layer is now bulk-aware — a single request can delete N beads
- The mayor bulk-delete route validates each bead belongs to the rig before deletion
- The BeadsPageClient uses `useGastownTRPCClient` for imperative mutations since beads may span multiple rigs (one mutation call per rig)