### PR TITLE
(admin) Recover with Kilo CLI: Phase 1 changes — utilities

### DIFF
--- a/apps/web/src/app/(app)/claw/components/RunDoctorDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/RunDoctorDialog.tsx
@@ -12,14 +12,9 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
+import { stripAnsi } from '@/lib/stripAnsi';
 
 type DoctorMutation = ReturnType<typeof useKiloClawMutations>['runDoctor'];
-
-/** Strip ANSI escape codes so raw terminal output can render in a browser &lt;pre&gt;. */
-function stripAnsi(raw: string): string {
-  // eslint-disable-next-line no-control-regex
-  return raw.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '');
-}
 
 export function RunDoctorDialog({
   open,

--- a/apps/web/src/app/(app)/claw/kilo-cli-run/[id]/page.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-cli-run/[id]/page.tsx
@@ -8,12 +8,7 @@ import { useKiloCliRunStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { SetPageTitle } from '@/components/SetPageTitle';
 import KiloCrabIcon from '@/components/KiloCrabIcon';
 import { ClawConfigServiceBannerWithStatus } from '../../components/ClawConfigServiceBanner';
-
-/** Strip ANSI escape codes so raw terminal output renders in a browser <pre>. */
-function stripAnsi(raw: string): string {
-  // eslint-disable-next-line no-control-regex
-  return raw.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '');
-}
+import { stripAnsi } from '@/lib/stripAnsi';
 
 function StatusBadge({ status }: { status: string | null }) {
   switch (status) {

--- a/apps/web/src/app/admin/components/KiloclawCliRuns/KiloclawCliRunsTab.tsx
+++ b/apps/web/src/app/admin/components/KiloclawCliRuns/KiloclawCliRunsTab.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { cn } from '@/lib/utils';
+import { stripAnsi } from '@/lib/stripAnsi';
 
 const PAGE_SIZE = 25;
 
@@ -63,12 +64,6 @@ function StatusBadge({ status }: { status: string }) {
     default:
       return <Badge variant="outline">{status}</Badge>;
   }
-}
-
-/** Strip ANSI escape codes for display in browser. */
-function stripAnsi(raw: string): string {
-  // eslint-disable-next-line no-control-regex
-  return raw.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '');
 }
 
 function formatDuration(start: string, end: string): string {

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -63,6 +63,8 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
+import { stripAnsi } from '@/lib/stripAnsi';
+import { DetailField, formatAbsoluteTime, formatRelativeTime, parseTimestamp } from './shared';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { toast } from 'sonner';
 import { AdminFileEditor } from './AdminFileEditor';
@@ -75,27 +77,6 @@ import {
   type KiloclawAllEventRow,
 } from '@/app/admin/api/kiloclaw-analytics/hooks';
 import type { AnalyticsEngineResponse, ControllerTelemetryRow } from '@/lib/kiloclaw/disk-usage';
-
-function parseTimestamp(timestamp: string): Date {
-  const normalized = timestamp.includes('T') ? timestamp : timestamp.replace(' ', 'T');
-  const hasTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(normalized);
-  const parsed = new Date(hasTimezone ? normalized : `${normalized}Z`);
-
-  if (!Number.isNaN(parsed.getTime())) {
-    return parsed;
-  }
-
-  return new Date(timestamp);
-}
-
-function formatRelativeTime(timestamp: string | null): string {
-  if (!timestamp) return '—';
-  return formatDistanceToNow(parseTimestamp(timestamp), { addSuffix: true });
-}
-
-function formatAbsoluteTime(timestamp: string): string {
-  return parseTimestamp(timestamp).toLocaleString();
-}
 
 function formatEpochTime(epoch: number | null): string {
   if (epoch === null) return '—';
@@ -166,15 +147,6 @@ function StatusBadge({ status }: { status: string | null }) {
     default:
       return <Badge variant="outline">Unknown</Badge>;
   }
-}
-
-function DetailField({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div>
-      <div className="text-muted-foreground text-xs">{label}</div>
-      <div className="text-sm">{children}</div>
-    </div>
-  );
 }
 
 function CopySshCommandButton({
@@ -1179,12 +1151,6 @@ function InstanceEventsCard({
       </CardContent>
     </Card>
   );
-}
-
-/** Strip ANSI escape codes so raw terminal output can render in a browser &lt;pre&gt;. */
-function stripAnsi(raw: string): string {
-  // eslint-disable-next-line no-control-regex
-  return raw.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '');
 }
 
 export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstancesPage.tsx
@@ -35,7 +35,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { ChevronLeft, ChevronRight, X, Bomb } from 'lucide-react';
 import Link from 'next/link';
-import { formatDistanceToNow, format, parseISO } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import {
   ComposedChart,
   Bar,
@@ -46,6 +46,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import type { KiloClawSubscriptionStatus } from '@kilocode/db/schema-types';
+import { formatRelativeTime } from './shared';
 
 type SortField = 'created_at' | 'destroyed_at';
 type SortOrder = 'asc' | 'desc';
@@ -67,11 +68,6 @@ function toSortedSearchParams(obj: Record<string, unknown>): URLSearchParams {
     if (value) params.set(key, String(value));
   }
   return params;
-}
-
-function formatRelativeTime(timestamp: string | null): string {
-  if (!timestamp) return '—';
-  return formatDistanceToNow(new Date(timestamp), { addSuffix: true });
 }
 
 function formatLifespan(minutes: number | null): string {

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawOrphansTab.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawOrphansTab.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { format, formatDistanceToNow, subDays } from 'date-fns';
+import { format, subDays } from 'date-fns';
 import Link from 'next/link';
 import { AlertTriangle, Loader2, Search, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
@@ -38,6 +38,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
+import { formatRelativeTime } from './shared';
 
 type OrphanRow = {
   id: string;
@@ -57,10 +58,6 @@ function toDatetimeLocalInput(date: Date): string {
 
 function toIsoFromDatetimeLocal(value: string): string {
   return new Date(value).toISOString();
-}
-
-function formatRelativeTime(timestamp: string): string {
-  return formatDistanceToNow(new Date(timestamp), { addSuffix: true });
 }
 
 function TroubleshootingEventsDialog({

--- a/apps/web/src/app/admin/components/KiloclawInstances/shared.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/shared.tsx
@@ -18,7 +18,7 @@ export function formatRelativeTime(timestamp: string | null): string {
 }
 
 export function formatAbsoluteTime(timestamp: string): string {
-  return parseTimestamp(timestamp).toLocaleString();
+  return parseTimestamp(timestamp).toLocaleString('en-US');
 }
 
 export function DetailField({ label, children }: { label: string; children: React.ReactNode }) {

--- a/apps/web/src/app/admin/components/KiloclawInstances/shared.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/shared.tsx
@@ -1,0 +1,31 @@
+import { formatDistanceToNow } from 'date-fns';
+
+export function parseTimestamp(timestamp: string): Date {
+  const normalized = timestamp.includes('T') ? timestamp : timestamp.replace(' ', 'T');
+  const hasTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(normalized);
+  const parsed = new Date(hasTimezone ? normalized : `${normalized}Z`);
+
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed;
+  }
+
+  return new Date(timestamp);
+}
+
+export function formatRelativeTime(timestamp: string | null): string {
+  if (!timestamp) return '—';
+  return formatDistanceToNow(parseTimestamp(timestamp), { addSuffix: true });
+}
+
+export function formatAbsoluteTime(timestamp: string): string {
+  return parseTimestamp(timestamp).toLocaleString();
+}
+
+export function DetailField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-muted-foreground text-xs">{label}</div>
+      <div className="text-sm">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/kiloclaw/cli-run-selection.test.ts
+++ b/apps/web/src/lib/kiloclaw/cli-run-selection.test.ts
@@ -1,0 +1,21 @@
+import { selectCurrentCliRun } from './cli-run-selection';
+
+describe('selectCurrentCliRun', () => {
+  const runs = [
+    { id: 'preferred-other', instance_id: 'other-instance', status: 'completed' },
+    { id: 'running-current', instance_id: 'current-instance', status: 'running' },
+    { id: 'completed-current', instance_id: 'current-instance', status: 'completed' },
+  ];
+
+  it('does not select a preferred run from another instance', () => {
+    expect(selectCurrentCliRun(runs, 'current-instance', 'preferred-other')?.id).toBe(
+      'running-current'
+    );
+  });
+
+  it('selects a preferred run from the current instance', () => {
+    expect(selectCurrentCliRun(runs, 'current-instance', 'completed-current')?.id).toBe(
+      'completed-current'
+    );
+  });
+});

--- a/apps/web/src/lib/kiloclaw/cli-run-selection.ts
+++ b/apps/web/src/lib/kiloclaw/cli-run-selection.ts
@@ -1,0 +1,22 @@
+type CliRunLike = {
+  id: string;
+  instance_id: string | null;
+  status: string | null;
+};
+
+export function selectCurrentCliRun<TRun extends CliRunLike>(
+  runs: TRun[] | undefined,
+  instanceId: string | null | undefined,
+  preferredRunId?: string | null
+): TRun | null {
+  if (!runs || !instanceId) {
+    return null;
+  }
+
+  return (
+    (preferredRunId ? runs.find(run => run.id === preferredRunId) : undefined) ??
+    runs.find(run => run.instance_id === instanceId && run.status === 'running') ??
+    runs.find(run => run.instance_id === instanceId) ??
+    null
+  );
+}

--- a/apps/web/src/lib/kiloclaw/cli-run-selection.ts
+++ b/apps/web/src/lib/kiloclaw/cli-run-selection.ts
@@ -14,7 +14,9 @@ export function selectCurrentCliRun<TRun extends CliRunLike>(
   }
 
   return (
-    (preferredRunId ? runs.find(run => run.id === preferredRunId) : undefined) ??
+    (preferredRunId
+      ? runs.find(run => run.id === preferredRunId && run.instance_id === instanceId)
+      : undefined) ??
     runs.find(run => run.instance_id === instanceId && run.status === 'running') ??
     runs.find(run => run.instance_id === instanceId) ??
     null

--- a/apps/web/src/lib/stripAnsi.test.ts
+++ b/apps/web/src/lib/stripAnsi.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from '@jest/globals';
+import { stripAnsi } from '@/lib/stripAnsi';
+
+describe('stripAnsi', () => {
+  it('removes ANSI escape sequences while preserving text', () => {
+    expect(stripAnsi('\x1b[32mcompleted\x1b[0m\nnext line')).toBe('completed\nnext line');
+  });
+
+  it('returns unchanged text when no ANSI sequences are present', () => {
+    expect(stripAnsi('plain output')).toBe('plain output');
+  });
+});

--- a/apps/web/src/lib/stripAnsi.ts
+++ b/apps/web/src/lib/stripAnsi.ts
@@ -1,0 +1,4 @@
+export function stripAnsi(raw: string): string {
+  // eslint-disable-next-line no-control-regex
+  return raw.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '');
+}


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

This is the first split-out phase from the larger KiloClaw admin CLI run work. This PR adds shared utilities up front so follow-up PRs can stay focused on behavior instead of mixing feature changes with extraction.

Callers have been updated where safe. `apps/web/src/lib/kiloclaw/cli-run-selection.ts` is not ready to be used yet.

## Reviewer Notes
This PR is intentionally additive and does not wire the helpers into existing UI yet. The consumer wiring was deferred to the later UI phase because those edits depend on the admin/router/schema work from subsequent split PRs.

Phase 1 for #2376 