### PR TITLE
(admin) Recover with Kilo CLI: Enforce single recovery run

### DIFF
--- a/apps/web/src/lib/kiloclaw/cli-runs.test.ts
+++ b/apps/web/src/lib/kiloclaw/cli-runs.test.ts
@@ -236,6 +236,45 @@ describe('cancelCliRun', () => {
       completed_at: '2026-04-12T12:01:00.000Z',
     });
   });
+
+  it('returns ok: false when the controller rejects the cancel', async () => {
+    const user = await insertTestUser();
+    const instanceId = await createTestInstance(user.id);
+    const startedAt = '2026-04-12T12:00:00.000Z';
+    const runId = await createCliRun({
+      userId: user.id,
+      instanceId,
+      prompt: 'run that exits between status poll and cancel',
+      startedAt,
+      initiatedByAdminId: null,
+    });
+
+    const result = await cancelCliRun({
+      runId,
+      userId: user.id,
+      instanceId,
+      workerInstanceId: 'ki_current',
+      getControllerStatus: async () => ({
+        hasRun: true,
+        status: 'running',
+        output: null,
+        exitCode: null,
+        startedAt,
+        completedAt: null,
+        prompt: 'run that exits between status poll and cancel',
+      }),
+      // The run exited between the status poll and the cancel request.
+      cancelControllerRun: async () => ({ ok: false }),
+    });
+
+    expect(result).toEqual({ ok: false, runFound: true, cancelled: false });
+
+    // The DB row should remain 'running' so the caller can retry or poll.
+    await expect(getRunStatus(runId)).resolves.toEqual({
+      status: 'running',
+      completed_at: null,
+    });
+  });
 });
 
 describe('markCliRunCancelled', () => {

--- a/apps/web/src/lib/kiloclaw/cli-runs.test.ts
+++ b/apps/web/src/lib/kiloclaw/cli-runs.test.ts
@@ -114,6 +114,47 @@ describe('cancelCliRun', () => {
     });
   });
 
+  it('persists failed and does not cancel when controller has no active run', async () => {
+    const user = await insertTestUser();
+    const instanceId = await createTestInstance(user.id);
+    const runId = await createCliRun({
+      userId: user.id,
+      instanceId,
+      prompt: 'lost run before cancel',
+      startedAt: '2026-04-12T12:00:00.000Z',
+      initiatedByAdminId: null,
+    });
+    const cancelControllerRun = jest.fn(async () => ({ ok: true }));
+
+    await expect(
+      cancelCliRun({
+        runId,
+        userId: user.id,
+        instanceId,
+        workerInstanceId: 'ki_current',
+        getControllerStatus: async () => ({
+          hasRun: false,
+          status: null,
+          output: null,
+          exitCode: null,
+          startedAt: null,
+          completedAt: null,
+          prompt: null,
+        }),
+        cancelControllerRun,
+      })
+    ).resolves.toEqual({ ok: true, runFound: true, cancelled: false });
+
+    expect(cancelControllerRun).not.toHaveBeenCalled();
+
+    const row = await getRunRow(runId);
+    expect(row.status).toBe('failed');
+    expect(row.output).toBe(
+      '[run state unavailable: controller no longer has an active CLI run for this record]'
+    );
+    expect(row.completed_at).not.toBeNull();
+  });
+
   it('persists failed and does not cancel when controller timestamp belongs to a different run', async () => {
     const user = await insertTestUser();
     const instanceId = await createTestInstance(user.id);

--- a/apps/web/src/lib/kiloclaw/cli-runs.test.ts
+++ b/apps/web/src/lib/kiloclaw/cli-runs.test.ts
@@ -194,6 +194,54 @@ describe('cancelCliRun', () => {
     expect(row.completed_at).not.toBeNull();
   });
 
+  it('preserves existing partial output when controller reports hasRun: false during cancel', async () => {
+    const user = await insertTestUser();
+    const instanceId = await createTestInstance(user.id);
+    const runId = await createCliRun({
+      userId: user.id,
+      instanceId,
+      prompt: 'run with partial output before lost',
+      startedAt: '2026-04-12T12:00:00.000Z',
+      initiatedByAdminId: null,
+    });
+
+    // Simulate partial output already written to the row while it was running.
+    await db
+      .update(kiloclaw_cli_runs)
+      .set({ output: 'partial output before cancel' })
+      .where(eq(kiloclaw_cli_runs.id, runId));
+
+    const cancelControllerRun = jest.fn(async () => ({ ok: true }));
+
+    await expect(
+      cancelCliRun({
+        runId,
+        userId: user.id,
+        instanceId,
+        workerInstanceId: 'ki_current',
+        getControllerStatus: async () => ({
+          hasRun: false,
+          status: null,
+          output: null,
+          exitCode: null,
+          startedAt: null,
+          completedAt: null,
+          prompt: null,
+        }),
+        cancelControllerRun,
+      })
+    ).resolves.toEqual({ ok: true, runFound: true, cancelled: false });
+
+    expect(cancelControllerRun).not.toHaveBeenCalled();
+
+    // The row's existing partial output should be preserved, not replaced with
+    // the LOST_CONTROLLER_RUN_OUTPUT sentinel.
+    const row = await getRunRow(runId);
+    expect(row.status).toBe('failed');
+    expect(row.output).toBe('partial output before cancel');
+    expect(row.completed_at).not.toBeNull();
+  });
+
   it('reports cancelled: false when the DB row left running between the SELECT and the cancel UPDATE', async () => {
     const user = await insertTestUser();
     const instanceId = await createTestInstance(user.id);

--- a/apps/web/src/lib/kiloclaw/cli-runs.ts
+++ b/apps/web/src/lib/kiloclaw/cli-runs.ts
@@ -156,6 +156,19 @@ export function getEmptyCliRunStatus(): CliRunStatusResult {
   };
 }
 
+/**
+ * Cancel a running CLI run, reconciling controller and DB state.
+ *
+ * Limitation: when the controller reports `hasRun: false`, the run's actual
+ * terminal state is already evicted from controller memory. We record the row
+ * as `'failed'` with a sentinel output, even though the run may have completed
+ * successfully just before the cancel arrived. A re-poll cannot recover the
+ * real outcome because the controller has already discarded it. This is a
+ * strict improvement over leaving the row stuck in `'running'` forever, but
+ * callers should be aware that a `'failed'` status with the
+ * `LOST_CONTROLLER_RUN_OUTPUT` sentinel does not necessarily mean the run
+ * actually failed — it means the outcome is unknown.
+ */
 export async function cancelCliRun(params: {
   runId: string;
   userId: string;
@@ -283,6 +296,14 @@ export async function cancelCliRun(params: {
   return { ok: true, runFound: true, cancelled: didUpdate };
 }
 
+/**
+ * Poll the status of a CLI run, reconciling controller and DB state.
+ *
+ * Limitation: when the controller reports `hasRun: false`, the run's actual
+ * terminal state is already evicted from controller memory. We record the row
+ * as `'failed'` with a sentinel output, even though the run may have completed
+ * successfully. See {@link cancelCliRun} for the same limitation and rationale.
+ */
 export async function getCliRunStatus(params: {
   runId: string;
   userId: string;

--- a/apps/web/src/lib/kiloclaw/cli-runs.ts
+++ b/apps/web/src/lib/kiloclaw/cli-runs.ts
@@ -206,6 +206,21 @@ export async function cancelCliRun(params: {
     });
 
   const controllerStatus = await getControllerStatus(params.userId, effectiveWorkerInstanceId);
+  if (!controllerStatus.hasRun) {
+    await persistCliRunControllerStatus({
+      runId: params.runId,
+      userId: params.userId,
+      instanceId: row.instance_id,
+      controllerStatus: {
+        status: 'failed',
+        exitCode: row.exit_code,
+        output: row.output ?? LOST_CONTROLLER_RUN_OUTPUT,
+        completedAt: new Date().toISOString(),
+      },
+    });
+    return { ok: true, runFound: true, cancelled: false };
+  }
+
   if (!isControllerStatusForRun(row, controllerStatus)) {
     // Controller has moved on — persist 'failed' so the row doesn't stay
     // 'running' forever, then report not-cancelled (there's nothing to cancel).

--- a/apps/web/src/lib/kiloclaw/cli-runs.ts
+++ b/apps/web/src/lib/kiloclaw/cli-runs.ts
@@ -1,7 +1,7 @@
 import { db } from '@/lib/drizzle';
 import { and, eq, isNull, type SQL } from 'drizzle-orm';
 import { kiloclaw_cli_runs } from '@kilocode/db/schema';
-import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { resolveWorkerInstanceId } from '@/lib/kiloclaw/instance-registry';
 import type { KiloCliRunStatusResponse } from '@/lib/kiloclaw/types';
 
@@ -200,9 +200,19 @@ export async function cancelCliRun(params: {
     });
   const cancelControllerRun =
     params.cancelControllerRun ??
-    ((userId: string, workerInstanceId: string | undefined) => {
+    (async (userId: string, workerInstanceId: string | undefined) => {
       if (!client) throw new Error('KiloClaw internal client is not available');
-      return client.cancelKiloCliRun(userId, workerInstanceId);
+      try {
+        return await client.cancelKiloCliRun(userId, workerInstanceId);
+      } catch (err) {
+        // The run finished between our status poll and the cancel request —
+        // the controller rejects with 409. Translate to { ok: false } so the
+        // caller can retry or poll for the terminal state.
+        if (err instanceof KiloClawApiError && err.statusCode === 409) {
+          return { ok: false };
+        }
+        throw err;
+      }
     });
 
   const controllerStatus = await getControllerStatus(params.userId, effectiveWorkerInstanceId);

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -257,7 +257,6 @@ describe('admin.kiloclawInstances.destroyFlyMachine', () => {
   });
 });
 
-
 describe('admin.kiloclawInstances.startKiloCliRun', () => {
   it('maps worker 409 to tRPC CONFLICT', async () => {
     const { KiloClawApiError } = jest.requireMock<{
@@ -339,7 +338,6 @@ describe('admin.kiloclawInstances.startKiloCliRun', () => {
     });
   });
 });
-
 
 describe('admin.kiloclawInstances inbound email controls', () => {
   it('cycles the active alias and writes an audit log', async () => {

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -13,11 +13,13 @@ import { and, eq } from 'drizzle-orm';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const mockGetDebugStatus: jest.Mock<any, any> = jest.fn();
 const mockDestroyFlyMachine: jest.Mock<any, any> = jest.fn();
+const mockStartKiloCliRun: jest.Mock<any, any> = jest.fn();
 
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => ({
   KiloClawInternalClient: jest.fn().mockImplementation(() => ({
     getDebugStatus: mockGetDebugStatus,
     destroyFlyMachine: mockDestroyFlyMachine,
+    startKiloCliRun: mockStartKiloCliRun,
   })),
   KiloClawApiError: class KiloClawApiError extends Error {
     statusCode: number;
@@ -78,6 +80,7 @@ beforeAll(async () => {
 beforeEach(async () => {
   mockGetDebugStatus.mockReset();
   mockDestroyFlyMachine.mockReset();
+  mockStartKiloCliRun.mockReset();
   // Clean audit logs between tests so counts are accurate
   await db
     .delete(kiloclaw_admin_audit_logs)
@@ -251,6 +254,57 @@ describe('admin.kiloclawInstances.destroyFlyMachine', () => {
     expect(mockGetDebugStatus).not.toHaveBeenCalled();
   });
 });
+
+
+describe('admin.kiloclawInstances.startKiloCliRun', () => {
+  it('maps worker 409 to tRPC CONFLICT', async () => {
+    const { KiloClawApiError } = jest.requireMock<{
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      KiloClawApiError: new (statusCode: number, responseBody: string) => any;
+    }>('@/lib/kiloclaw/kiloclaw-internal-client');
+
+    mockStartKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(409, JSON.stringify({ error: 'A CLI run is already in progress' }))
+    );
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.startKiloCliRun({
+        userId: testUserId,
+        prompt: 'test prompt',
+      })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'A CLI run is already in progress',
+    });
+  });
+
+  it('maps controller_route_unavailable to PRECONDITION_FAILED', async () => {
+    const { KiloClawApiError } = jest.requireMock<{
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      KiloClawApiError: new (statusCode: number, responseBody: string) => any;
+    }>('@/lib/kiloclaw/kiloclaw-internal-client');
+
+    mockStartKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(
+        404,
+        JSON.stringify({ error: 'Route not found', code: 'controller_route_unavailable' })
+      )
+    );
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.startKiloCliRun({
+        userId: testUserId,
+        prompt: 'test prompt',
+      })
+    ).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'Instance needs redeploy to support recovery',
+    });
+  });
+});
+
 
 describe('admin.kiloclawInstances inbound email controls', () => {
   it('cycles the active alias and writes an audit log', async () => {

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -9,6 +9,8 @@ import {
   kiloclaw_instances,
 } from '@kilocode/db/schema';
 import { and, eq } from 'drizzle-orm';
+import { TRPCError } from '@trpc/server';
+import { UpstreamApiError } from '@/lib/trpc/init';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const mockGetDebugStatus: jest.Mock<any, any> = jest.fn();
@@ -281,8 +283,7 @@ describe('admin.kiloclawInstances.startKiloCliRun', () => {
 
   it('maps controller_route_unavailable to PRECONDITION_FAILED', async () => {
     const { KiloClawApiError } = jest.requireMock<{
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      KiloClawApiError: new (statusCode: number, responseBody: string) => any;
+      KiloClawApiError: new (statusCode: number, responseBody: string) => Error;
     }>('@/lib/kiloclaw/kiloclaw-internal-client');
 
     mockStartKiloCliRun.mockRejectedValue(
@@ -302,6 +303,20 @@ describe('admin.kiloclawInstances.startKiloCliRun', () => {
       code: 'PRECONDITION_FAILED',
       message: 'Instance needs redeploy to support recovery',
     });
+
+    try {
+      await caller.admin.kiloclawInstances.startKiloCliRun({
+        userId: testUserId,
+        prompt: 'test prompt',
+      });
+      throw new Error('Expected startKiloCliRun to reject');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TRPCError);
+      if (!(err instanceof TRPCError)) throw err;
+      expect(err.cause).toBeInstanceOf(UpstreamApiError);
+      if (!(err.cause instanceof UpstreamApiError)) throw err;
+      expect(err.cause.upstreamCode).toBe('controller_route_unavailable');
+    }
   });
 
   it('maps worker 409 with empty body to CONFLICT with fallback message', async () => {

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -303,6 +303,26 @@ describe('admin.kiloclawInstances.startKiloCliRun', () => {
       message: 'Instance needs redeploy to support recovery',
     });
   });
+
+  it('maps worker 409 with empty body to CONFLICT with fallback message', async () => {
+    const { KiloClawApiError } = jest.requireMock<{
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      KiloClawApiError: new (statusCode: number, responseBody: string) => any;
+    }>('@/lib/kiloclaw/kiloclaw-internal-client');
+
+    mockStartKiloCliRun.mockRejectedValue(new KiloClawApiError(409, ''));
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.startKiloCliRun({
+        userId: testUserId,
+        prompt: 'test prompt',
+      })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Failed to start kilo CLI run',
+    });
+  });
 });
 
 

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -155,21 +155,21 @@ function throwKiloclawAdminError(
 ): never {
   if (err instanceof KiloClawApiError) {
     const payload = getKiloclawApiErrorPayload(err, fallbackMessage);
+    if (payload.code === 'controller_route_unavailable') {
+      throw new TRPCError({
+        code: options?.statusCodeOverrides?.[err.statusCode] ?? 'PRECONDITION_FAILED',
+        message:
+          options?.messageOverrides?.[err.statusCode] ??
+          'Instance needs redeploy to support recovery',
+        cause: new UpstreamApiError('controller_route_unavailable'),
+      });
+    }
+
     throw new TRPCError({
       code:
-        options?.statusCodeOverrides?.[err.statusCode] ??
-        (payload.code === 'controller_route_unavailable'
-          ? 'PRECONDITION_FAILED'
-          : kiloclawStatusToTrpcCode(err.statusCode)),
-      message:
-        options?.messageOverrides?.[err.statusCode] ??
-        (payload.code === 'controller_route_unavailable'
-          ? 'Instance needs redeploy to support recovery'
-          : payload.message),
-      cause:
-        payload.code === 'controller_route_unavailable'
-          ? new UpstreamApiError('controller_route_unavailable')
-          : err,
+        options?.statusCodeOverrides?.[err.statusCode] ?? kiloclawStatusToTrpcCode(err.statusCode),
+      message: options?.messageOverrides?.[err.statusCode] ?? payload.message,
+      cause: err,
     });
   }
 

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -102,6 +102,7 @@ type KiloclawTrpcCode =
   | 'NOT_FOUND'
   | 'CONFLICT'
   | 'TOO_MANY_REQUESTS'
+  | 'PRECONDITION_FAILED'
   | 'INTERNAL_SERVER_ERROR';
 
 function kiloclawStatusToTrpcCode(statusCode: number): KiloclawTrpcCode {
@@ -112,6 +113,8 @@ function kiloclawStatusToTrpcCode(statusCode: number): KiloclawTrpcCode {
       return 'NOT_FOUND';
     case 409:
       return 'CONFLICT';
+    case 412:
+      return 'PRECONDITION_FAILED';
     case 429:
       return 'TOO_MANY_REQUESTS';
     default:
@@ -119,21 +122,27 @@ function kiloclawStatusToTrpcCode(statusCode: number): KiloclawTrpcCode {
   }
 }
 
-function getKiloclawApiErrorMessage(err: KiloClawApiError, fallbackMessage: string): string {
-  if (!err.responseBody) return fallbackMessage;
+function getKiloclawApiErrorPayload(
+  err: KiloClawApiError,
+  fallbackMessage: string
+): { code?: string; message: string } {
+  if (!err.responseBody) return { message: fallbackMessage };
 
   try {
     const parsed: unknown = JSON.parse(err.responseBody);
     if (typeof parsed === 'object' && parsed !== null) {
-      const record = parsed as { error?: unknown; message?: unknown };
-      if (typeof record.error === 'string') return record.error;
-      if (typeof record.message === 'string') return record.message;
+      const code = 'code' in parsed && typeof parsed.code === 'string' ? parsed.code : undefined;
+      const error = 'error' in parsed ? parsed.error : undefined;
+      const message = 'message' in parsed ? parsed.message : undefined;
+      if (typeof error === 'string') return { code, message: error };
+      if (typeof message === 'string') return { code, message };
+      return { code, message: fallbackMessage };
     }
   } catch {
     // Fall back to the raw response body when the controller did not return JSON.
   }
 
-  return err.responseBody.trim() || fallbackMessage;
+  return { message: err.responseBody.trim() || fallbackMessage };
 }
 
 function throwKiloclawAdminError(
@@ -145,13 +154,22 @@ function throwKiloclawAdminError(
   }
 ): never {
   if (err instanceof KiloClawApiError) {
+    const payload = getKiloclawApiErrorPayload(err, fallbackMessage);
     throw new TRPCError({
       code:
-        options?.statusCodeOverrides?.[err.statusCode] ?? kiloclawStatusToTrpcCode(err.statusCode),
+        options?.statusCodeOverrides?.[err.statusCode] ??
+        (payload.code === 'controller_route_unavailable'
+          ? 'PRECONDITION_FAILED'
+          : kiloclawStatusToTrpcCode(err.statusCode)),
       message:
         options?.messageOverrides?.[err.statusCode] ??
-        getKiloclawApiErrorMessage(err, fallbackMessage),
-      cause: err,
+        (payload.code === 'controller_route_unavailable'
+          ? 'Instance needs redeploy to support recovery'
+          : payload.message),
+      cause:
+        payload.code === 'controller_route_unavailable'
+          ? new UpstreamApiError('controller_route_unavailable')
+          : err,
     });
   }
 
@@ -253,7 +271,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     } catch (err) {
       workerStatusError =
         err instanceof KiloClawApiError
-          ? getKiloclawApiErrorMessage(err, 'Failed to fetch worker status')
+          ? getKiloclawApiErrorPayload(err, 'Failed to fetch worker status').message
           : err instanceof Error
             ? err.message
             : 'Failed to fetch worker status';

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -65,6 +65,7 @@ import { APP_URL } from '@/lib/constants';
 import { getAffiliateAttribution } from '@/lib/affiliate-attribution';
 import { buildAffiliateEventDedupeKey, enqueueAffiliateEventForUser } from '@/lib/affiliate-events';
 import { clawAccessProcedure } from '@/lib/kiloclaw/access-gate';
+import { cancelCliRun, getCliRunStatus } from '@/lib/kiloclaw/cli-runs';
 import {
   getStripePriceIdForClawPlan,
   getStripePriceIdForClawPlanIntro,
@@ -2241,133 +2242,33 @@ export const kiloclawRouter = createTRPCRouter({
     .input(z.object({ runId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
       const instance = await getActiveInstance(ctx.user.id);
-
-      // Load the requested run from the DB to avoid cross-run data leaks.
-      // The controller only tracks the *current* run, so polling it for an
-      // older run would return the wrong output.
-      const instanceFilter = instance ? eq(kiloclaw_cli_runs.instance_id, instance.id) : undefined;
-      const [row] = await db
-        .select()
-        .from(kiloclaw_cli_runs)
-        .where(
-          and(
-            eq(kiloclaw_cli_runs.id, input.runId),
-            eq(kiloclaw_cli_runs.user_id, ctx.user.id),
-            instanceFilter
-          )
-        )
-        .limit(1);
-
-      if (!row) {
-        return {
-          hasRun: false,
-          status: null,
-          output: null,
-          exitCode: null,
-          startedAt: null,
-          completedAt: null,
-          prompt: null,
-        };
-      }
-
-      // If the DB row is already terminal, return it directly — no need to
-      // poll the controller (which may be running a different job).
-      if (row.status !== 'running') {
-        return {
-          hasRun: true,
-          status: row.status as 'completed' | 'failed' | 'cancelled',
-          output: row.output,
-          exitCode: row.exit_code,
-          startedAt: row.started_at,
-          completedAt: row.completed_at ?? null,
-          prompt: row.prompt,
-        };
-      }
-
-      // Run is still active — poll the controller for live output.
-      const client = new KiloClawInternalClient();
-      const controllerStatus = await client.getKiloCliRunStatus(
-        ctx.user.id,
-        workerInstanceId(instance)
-      );
-
-      // If controller reports the run finished, persist to the DB row.
-      if (
-        controllerStatus.hasRun &&
-        controllerStatus.status !== 'running' &&
-        controllerStatus.startedAt
-      ) {
-        await db
-          .update(kiloclaw_cli_runs)
-          .set({
-            status: controllerStatus.status ?? 'failed',
-            exit_code: controllerStatus.exitCode,
-            output: controllerStatus.output,
-            completed_at: controllerStatus.completedAt ?? new Date().toISOString(),
-          })
-          .where(
-            and(
-              eq(kiloclaw_cli_runs.id, input.runId),
-              eq(kiloclaw_cli_runs.user_id, ctx.user.id),
-              instanceFilter,
-              eq(kiloclaw_cli_runs.status, 'running')
-            )
-          );
-      }
-
-      return {
-        ...controllerStatus,
-        prompt: row.prompt,
-      };
+      return getCliRunStatus({
+        runId: input.runId,
+        userId: ctx.user.id,
+        instanceId: instance?.id ?? null,
+        workerInstanceId: workerInstanceId(instance),
+      });
     }),
 
   cancelKiloCliRun: clawAccessProcedure
     .input(z.object({ runId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       const instance = await getActiveInstance(ctx.user.id);
-      const client = new KiloClawInternalClient();
+      const result = await cancelCliRun({
+        runId: input.runId,
+        userId: ctx.user.id,
+        instanceId: instance?.id ?? null,
+        workerInstanceId: workerInstanceId(instance),
+      });
 
-      const instanceFilter = instance ? eq(kiloclaw_cli_runs.instance_id, instance.id) : undefined;
-      const markRunCancelled = async () => {
-        await db
-          .update(kiloclaw_cli_runs)
-          .set({
-            status: 'cancelled',
-            completed_at: new Date().toISOString(),
-          })
-          .where(
-            and(
-              eq(kiloclaw_cli_runs.id, input.runId),
-              eq(kiloclaw_cli_runs.user_id, ctx.user.id),
-              instanceFilter,
-              eq(kiloclaw_cli_runs.status, 'running')
-            )
-          );
-      };
-
-      let result: Awaited<ReturnType<KiloClawInternalClient['cancelKiloCliRun']>>;
-      try {
-        result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
-      } catch (err) {
-        if (err instanceof KiloClawApiError && err.statusCode === 409) {
-          const { code, message } = getKiloClawApiErrorPayload(err);
-          if (code === 'kilo_cli_run_no_active_run') {
-            await markRunCancelled();
-          }
-          throw new TRPCError({
-            code: 'CONFLICT',
-            message: message ?? 'Instance is not running',
-            cause: code ? new UpstreamApiError(code) : undefined,
-          });
-        }
-        throw err;
+      if (!result.runFound) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Kilo CLI run not found',
+        });
       }
 
-      if (result.ok) {
-        await markRunCancelled();
-      }
-
-      return result;
+      return { ok: result.ok };
     }),
 
   listKiloCliRuns: clawAccessProcedure

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2203,12 +2203,18 @@ export const kiloclawRouter = createTRPCRouter({
         );
       } catch (err) {
         if (err instanceof KiloClawApiError) {
-          const { code } = getKiloClawApiErrorPayload(err);
+          const { code, message } = getKiloClawApiErrorPayload(err);
           if (code === 'controller_route_unavailable') {
             throw new TRPCError({
               code: 'PRECONDITION_FAILED',
               message: 'Instance needs redeploy to support recovery',
               cause: new UpstreamApiError('controller_route_unavailable'),
+            });
+          }
+          if (err.statusCode === 409) {
+            throw new TRPCError({
+              code: 'CONFLICT',
+              message: message ?? 'Instance is busy',
             });
           }
         }

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2326,25 +2326,8 @@ export const kiloclawRouter = createTRPCRouter({
       const instance = await getActiveInstance(ctx.user.id);
       const client = new KiloClawInternalClient();
 
-      let result: Awaited<ReturnType<KiloClawInternalClient['cancelKiloCliRun']>>;
-      try {
-        result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
-      } catch (err) {
-        if (err instanceof KiloClawApiError && err.statusCode === 409) {
-          const { message } = getKiloClawApiErrorPayload(err);
-          throw new TRPCError({
-            code: 'CONFLICT',
-            message: message ?? 'Instance is not running',
-          });
-        }
-        throw err;
-      }
-
-      // Mark the specific run as cancelled in DB
-      if (result.ok) {
-        const instanceFilter = instance
-          ? eq(kiloclaw_cli_runs.instance_id, instance.id)
-          : undefined;
+      const instanceFilter = instance ? eq(kiloclaw_cli_runs.instance_id, instance.id) : undefined;
+      const markRunCancelled = async () => {
         await db
           .update(kiloclaw_cli_runs)
           .set({
@@ -2359,6 +2342,28 @@ export const kiloclawRouter = createTRPCRouter({
               eq(kiloclaw_cli_runs.status, 'running')
             )
           );
+      };
+
+      let result: Awaited<ReturnType<KiloClawInternalClient['cancelKiloCliRun']>>;
+      try {
+        result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
+      } catch (err) {
+        if (err instanceof KiloClawApiError && err.statusCode === 409) {
+          const { code, message } = getKiloClawApiErrorPayload(err);
+          if (code === 'kilo_cli_run_no_active_run') {
+            await markRunCancelled();
+          }
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: message ?? 'Instance is not running',
+            cause: code ? new UpstreamApiError(code) : undefined,
+          });
+        }
+        throw err;
+      }
+
+      if (result.ok) {
+        await markRunCancelled();
       }
 
       return result;

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2325,7 +2325,20 @@ export const kiloclawRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const instance = await getActiveInstance(ctx.user.id);
       const client = new KiloClawInternalClient();
-      const result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
+
+      let result: Awaited<ReturnType<KiloClawInternalClient['cancelKiloCliRun']>>;
+      try {
+        result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
+      } catch (err) {
+        if (err instanceof KiloClawApiError && err.statusCode === 409) {
+          const { message } = getKiloClawApiErrorPayload(err);
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: message ?? 'Instance is not running',
+          });
+        }
+        throw err;
+      }
 
       // Mark the specific run as cancelled in DB
       if (result.ok) {

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2215,6 +2215,7 @@ export const kiloclawRouter = createTRPCRouter({
             throw new TRPCError({
               code: 'CONFLICT',
               message: message ?? 'Instance is busy',
+              cause: code ? new UpstreamApiError(code) : undefined,
             });
           }
         }

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -5,15 +5,16 @@ import { kiloclaw_instances, kiloclaw_subscriptions, kiloclaw_cli_runs } from '@
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createOrganization } from '@/lib/organizations/organizations';
 import type { User, Organization } from '@kilocode/db/schema';
+import type { createCallerForUser as createCallerForUserType } from '@/routers/test-utils';
+import type { KiloClawApiError as KiloClawApiErrorType } from '@/lib/kiloclaw/kiloclaw-internal-client';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyMock = jest.Mock<(...args: any[]) => any>;
+type StartKiloCliRunResult = { ok: true; startedAt: string };
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
-const mockStartKiloCliRun: AnyMock = jest.fn();
+const mockStartKiloCliRun = jest.fn<() => Promise<StartKiloCliRunResult>>();
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   const actual: Record<string, unknown> = jest.requireActual(
     '@/lib/kiloclaw/kiloclaw-internal-client'
@@ -27,17 +28,17 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
 });
 
 jest.mock('next/headers', () => {
-  const fn = jest.fn as (...args: unknown[]) => AnyMock;
+  const get = jest.fn<() => unknown>();
   return {
-    cookies: fn().mockResolvedValue({ get: fn() }),
-    headers: fn().mockReturnValue(new Map()),
+    cookies: jest.fn<() => Promise<{ get: typeof get }>>().mockResolvedValue({ get }),
+    headers: jest.fn<() => Map<string, string>>().mockReturnValue(new Map()),
   };
 });
 
 // ── Dynamic imports (after mocks) ──────────────────────────────────────────
 
-let createCallerForUser: (typeof import('@/routers/test-utils'))['createCallerForUser'];
-let KiloClawApiError: (typeof import('@/lib/kiloclaw/kiloclaw-internal-client'))['KiloClawApiError'];
+let createCallerForUser: typeof createCallerForUserType;
+let KiloClawApiError: typeof KiloClawApiErrorType;
 
 beforeAll(async () => {
   const mod = await import('@/routers/test-utils');

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, beforeAll, beforeEach, jest } from '@jest/globals';
+import { db, cleanupDbForTest } from '@/lib/drizzle';
+import { kiloclaw_instances, kiloclaw_subscriptions } from '@kilocode/db/schema';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { createOrganization, addUserToOrganization } from '@/lib/organizations/organizations';
+import type { User, Organization } from '@kilocode/db/schema';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockStartKiloCliRun: jest.Mock<any> = jest.fn();
+jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    '@/lib/kiloclaw/kiloclaw-internal-client'
+  );
+  return {
+    KiloClawInternalClient: jest.fn().mockImplementation(() => ({
+      startKiloCliRun: mockStartKiloCliRun,
+    })),
+    KiloClawApiError: actual.KiloClawApiError,
+  };
+});
+
+jest.mock('next/headers', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fn = jest.fn as (...args: any[]) => jest.Mock<any>;
+  return {
+    cookies: fn().mockResolvedValue({ get: fn() }),
+    headers: fn().mockReturnValue(new Map()),
+  };
+});
+
+// ── Dynamic imports (after mocks) ──────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let createCallerForUser: (userId: string) => Promise<any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let KiloClawApiError: any;
+
+beforeAll(async () => {
+  const mod = await import('@/routers/test-utils');
+  createCallerForUser = mod.createCallerForUser;
+  const clientMod = await import('@/lib/kiloclaw/kiloclaw-internal-client');
+  KiloClawApiError = clientMod.KiloClawApiError;
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+let user: User;
+let org: Organization;
+
+beforeEach(async () => {
+  await cleanupDbForTest();
+  mockStartKiloCliRun.mockReset();
+
+  user = await insertTestUser({
+    google_user_email: `clirun-test-${Math.random()}@example.com`,
+  });
+});
+
+async function createPersonalInstance(userId: string): Promise<string> {
+  const [row] = await db
+    .insert(kiloclaw_instances)
+    .values({
+      user_id: userId,
+      sandbox_id: `sandbox-${userId.slice(0, 8)}`,
+    })
+    .returning();
+  return row.id;
+}
+
+async function createOrgInstance(userId: string, organizationId: string): Promise<string> {
+  const [row] = await db
+    .insert(kiloclaw_instances)
+    .values({
+      user_id: userId,
+      sandbox_id: `sandbox-org-${userId.slice(0, 8)}`,
+      organization_id: organizationId,
+    })
+    .returning();
+  return row.id;
+}
+
+async function grantKiloClawAccess(userId: string): Promise<void> {
+  await db.insert(kiloclaw_subscriptions).values({
+    user_id: userId,
+    plan: 'standard',
+    status: 'active',
+    stripe_subscription_id: `sub_test_${userId.slice(0, 8)}`,
+  });
+}
+
+// ── Personal router: kiloclaw.startKiloCliRun ──────────────────────────────
+
+describe('kiloclaw.startKiloCliRun error translation', () => {
+  beforeEach(async () => {
+    await grantKiloClawAccess(user.id);
+    await createPersonalInstance(user.id);
+  });
+
+  it('maps worker 409 to tRPC CONFLICT', async () => {
+    mockStartKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(409, '{"error":"A CLI run is already in progress"}')
+    );
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.startKiloCliRun({ prompt: 'test prompt' })).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'A CLI run is already in progress',
+    });
+  });
+
+  it('maps worker 409 without message body to CONFLICT with fallback message', async () => {
+    mockStartKiloCliRun.mockRejectedValue(new KiloClawApiError(409, ''));
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.startKiloCliRun({ prompt: 'test prompt' })).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Instance is busy',
+    });
+  });
+
+  it('maps controller_route_unavailable to PRECONDITION_FAILED', async () => {
+    mockStartKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(404, '{"error":"Route not found","code":"controller_route_unavailable"}')
+    );
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.startKiloCliRun({ prompt: 'test prompt' })).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'Instance needs redeploy to support recovery',
+    });
+  });
+});
+
+// ── Org router: organizations.kiloclaw.startKiloCliRun ─────────────────────
+
+describe('organizations.kiloclaw.startKiloCliRun error translation', () => {
+  beforeEach(async () => {
+    org = await createOrganization('Test Org', user.id);
+    await createOrgInstance(user.id, org.id);
+  });
+
+  it('maps worker 409 to tRPC CONFLICT', async () => {
+    mockStartKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(409, '{"error":"A CLI run is already in progress"}')
+    );
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.startKiloCliRun({
+        organizationId: org.id,
+        prompt: 'test prompt',
+      })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'A CLI run is already in progress',
+    });
+  });
+
+  it('maps worker 409 without message body to CONFLICT with fallback message', async () => {
+    mockStartKiloCliRun.mockRejectedValue(new KiloClawApiError(409, ''));
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.startKiloCliRun({
+        organizationId: org.id,
+        prompt: 'test prompt',
+      })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Instance is busy',
+    });
+  });
+
+  it('maps controller_route_unavailable to PRECONDITION_FAILED', async () => {
+    mockStartKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(404, '{"error":"Route not found","code":"controller_route_unavailable"}')
+    );
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.startKiloCliRun({
+        organizationId: org.id,
+        prompt: 'test prompt',
+      })
+    ).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'Instance needs redeploy to support recovery',
+    });
+  });
+});

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeAll, beforeEach, jest } from '@jest/globals
 import { db, cleanupDbForTest } from '@/lib/drizzle';
 import { kiloclaw_instances, kiloclaw_subscriptions } from '@kilocode/db/schema';
 import { insertTestUser } from '@/tests/helpers/user.helper';
-import { createOrganization, addUserToOrganization } from '@/lib/organizations/organizations';
+import { createOrganization } from '@/lib/organizations/organizations';
 import type { User, Organization } from '@kilocode/db/schema';
 
 // ── Mocks ──────────────────────────────────────────────────────────────────

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -279,63 +279,13 @@ describe('kiloclaw.cancelKiloCliRun error translation', () => {
     await createPersonalInstance(user.id);
   });
 
-  it('maps worker 409 to tRPC CONFLICT', async () => {
-    mockCancelKiloCliRun.mockRejectedValue(
-      new KiloClawApiError(409, '{"error":"Instance is not running"}')
-    );
-
+  it('maps missing run to tRPC NOT_FOUND', async () => {
     const caller = await createCallerForUser(user.id);
     await expect(
       caller.kiloclaw.cancelKiloCliRun({ runId: '10000000-1000-4000-8000-000000000001' })
     ).rejects.toMatchObject({
-      code: 'CONFLICT',
-      message: 'Instance is not running',
-    });
-  });
-
-  it('marks a running row cancelled when controller has no active run', async () => {
-    const [instance] = await db
-      .select()
-      .from(kiloclaw_instances)
-      .where(eq(kiloclaw_instances.user_id, user.id));
-    const [run] = await db
-      .insert(kiloclaw_cli_runs)
-      .values({
-        user_id: user.id,
-        instance_id: instance.id,
-        prompt: 'stale run',
-        status: 'running',
-      })
-      .returning();
-    mockCancelKiloCliRun.mockRejectedValue(
-      new KiloClawApiError(
-        409,
-        '{"error":"No active run to cancel","code":"kilo_cli_run_no_active_run"}'
-      )
-    );
-
-    const caller = await createCallerForUser(user.id);
-    await expect(caller.kiloclaw.cancelKiloCliRun({ runId: run.id })).rejects.toMatchObject({
-      code: 'CONFLICT',
-      message: 'No active run to cancel',
-    });
-
-    const rows = await db.select().from(kiloclaw_cli_runs).where(eq(kiloclaw_cli_runs.id, run.id));
-    expect(rows[0]).toMatchObject({
-      status: 'cancelled',
-      completed_at: expect.any(String),
-    });
-  });
-
-  it('maps worker 409 without message body to CONFLICT with fallback message', async () => {
-    mockCancelKiloCliRun.mockRejectedValue(new KiloClawApiError(409, ''));
-
-    const caller = await createCallerForUser(user.id);
-    await expect(
-      caller.kiloclaw.cancelKiloCliRun({ runId: '10000000-1000-4000-8000-000000000001' })
-    ).rejects.toMatchObject({
-      code: 'CONFLICT',
-      message: 'Instance is not running',
+      code: 'NOT_FOUND',
+      message: 'Kilo CLI run not found',
     });
   });
 });
@@ -348,11 +298,7 @@ describe('organizations.kiloclaw.cancelKiloCliRun error translation', () => {
     await createOrgInstance(user.id, org.id);
   });
 
-  it('maps worker 409 to tRPC CONFLICT', async () => {
-    mockCancelKiloCliRun.mockRejectedValue(
-      new KiloClawApiError(409, '{"error":"Instance is not running"}')
-    );
-
+  it('maps missing run to tRPC NOT_FOUND', async () => {
     const caller = await createCallerForUser(user.id);
     await expect(
       caller.organizations.kiloclaw.cancelKiloCliRun({
@@ -360,62 +306,8 @@ describe('organizations.kiloclaw.cancelKiloCliRun error translation', () => {
         runId: '10000000-1000-4000-8000-000000000001',
       })
     ).rejects.toMatchObject({
-      code: 'CONFLICT',
-      message: 'Instance is not running',
-    });
-  });
-
-  it('marks a running org row cancelled when controller has no active run', async () => {
-    const [instance] = await db
-      .select()
-      .from(kiloclaw_instances)
-      .where(eq(kiloclaw_instances.organization_id, org.id));
-    const [run] = await db
-      .insert(kiloclaw_cli_runs)
-      .values({
-        user_id: user.id,
-        instance_id: instance.id,
-        prompt: 'stale org run',
-        status: 'running',
-      })
-      .returning();
-    mockCancelKiloCliRun.mockRejectedValue(
-      new KiloClawApiError(
-        409,
-        '{"error":"No active run to cancel","code":"kilo_cli_run_no_active_run"}'
-      )
-    );
-
-    const caller = await createCallerForUser(user.id);
-    await expect(
-      caller.organizations.kiloclaw.cancelKiloCliRun({
-        organizationId: org.id,
-        runId: run.id,
-      })
-    ).rejects.toMatchObject({
-      code: 'CONFLICT',
-      message: 'No active run to cancel',
-    });
-
-    const rows = await db.select().from(kiloclaw_cli_runs).where(eq(kiloclaw_cli_runs.id, run.id));
-    expect(rows[0]).toMatchObject({
-      status: 'cancelled',
-      completed_at: expect.any(String),
-    });
-  });
-
-  it('maps worker 409 without message body to CONFLICT with fallback message', async () => {
-    mockCancelKiloCliRun.mockRejectedValue(new KiloClawApiError(409, ''));
-
-    const caller = await createCallerForUser(user.id);
-    await expect(
-      caller.organizations.kiloclaw.cancelKiloCliRun({
-        organizationId: org.id,
-        runId: '10000000-1000-4000-8000-000000000001',
-      })
-    ).rejects.toMatchObject({
-      code: 'CONFLICT',
-      message: 'Instance is not running',
+      code: 'NOT_FOUND',
+      message: 'Kilo CLI run not found',
     });
   });
 });

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeAll, beforeEach, jest } from '@jest/globals';
+import { TRPCError } from '@trpc/server';
 import { eq } from 'drizzle-orm';
 import { db, cleanupDbForTest } from '@/lib/drizzle';
 import { kiloclaw_instances, kiloclaw_subscriptions, kiloclaw_cli_runs } from '@kilocode/db/schema';
@@ -7,6 +8,7 @@ import { createOrganization } from '@/lib/organizations/organizations';
 import type { User, Organization } from '@kilocode/db/schema';
 import type { createCallerForUser as createCallerForUserType } from '@/routers/test-utils';
 import type { KiloClawApiError as KiloClawApiErrorType } from '@/lib/kiloclaw/kiloclaw-internal-client';
+import { UpstreamApiError } from '@/lib/trpc/init';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -137,6 +139,17 @@ describe('kiloclaw.startKiloCliRun error translation', () => {
       code: 'PRECONDITION_FAILED',
       message: 'Instance needs redeploy to support recovery',
     });
+
+    try {
+      await caller.kiloclaw.startKiloCliRun({ prompt: 'test prompt' });
+      throw new Error('Expected startKiloCliRun to reject');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TRPCError);
+      if (!(err instanceof TRPCError)) throw err;
+      expect(err.cause).toBeInstanceOf(UpstreamApiError);
+      if (!(err.cause instanceof UpstreamApiError)) throw err;
+      expect(err.cause.upstreamCode).toBe('controller_route_unavailable');
+    }
   });
 
   it('inserts a running kiloclaw_cli_runs row on success', async () => {
@@ -216,6 +229,20 @@ describe('organizations.kiloclaw.startKiloCliRun error translation', () => {
       code: 'PRECONDITION_FAILED',
       message: 'Instance needs redeploy to support recovery',
     });
+
+    try {
+      await caller.organizations.kiloclaw.startKiloCliRun({
+        organizationId: org.id,
+        prompt: 'test prompt',
+      });
+      throw new Error('Expected startKiloCliRun to reject');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TRPCError);
+      if (!(err instanceof TRPCError)) throw err;
+      expect(err.cause).toBeInstanceOf(UpstreamApiError);
+      if (!(err.cause instanceof UpstreamApiError)) throw err;
+      expect(err.cause.upstreamCode).toBe('controller_route_unavailable');
+    }
   });
 
   it('inserts a running kiloclaw_cli_runs row on success', async () => {
@@ -266,6 +293,40 @@ describe('kiloclaw.cancelKiloCliRun error translation', () => {
     });
   });
 
+  it('marks a running row cancelled when controller has no active run', async () => {
+    const [instance] = await db
+      .select()
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.user_id, user.id));
+    const [run] = await db
+      .insert(kiloclaw_cli_runs)
+      .values({
+        user_id: user.id,
+        instance_id: instance.id,
+        prompt: 'stale run',
+        status: 'running',
+      })
+      .returning();
+    mockCancelKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(
+        409,
+        '{"error":"No active run to cancel","code":"kilo_cli_run_no_active_run"}'
+      )
+    );
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.cancelKiloCliRun({ runId: run.id })).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'No active run to cancel',
+    });
+
+    const rows = await db.select().from(kiloclaw_cli_runs).where(eq(kiloclaw_cli_runs.id, run.id));
+    expect(rows[0]).toMatchObject({
+      status: 'cancelled',
+      completed_at: expect.any(String),
+    });
+  });
+
   it('maps worker 409 without message body to CONFLICT with fallback message', async () => {
     mockCancelKiloCliRun.mockRejectedValue(new KiloClawApiError(409, ''));
 
@@ -301,6 +362,45 @@ describe('organizations.kiloclaw.cancelKiloCliRun error translation', () => {
     ).rejects.toMatchObject({
       code: 'CONFLICT',
       message: 'Instance is not running',
+    });
+  });
+
+  it('marks a running org row cancelled when controller has no active run', async () => {
+    const [instance] = await db
+      .select()
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.organization_id, org.id));
+    const [run] = await db
+      .insert(kiloclaw_cli_runs)
+      .values({
+        user_id: user.id,
+        instance_id: instance.id,
+        prompt: 'stale org run',
+        status: 'running',
+      })
+      .returning();
+    mockCancelKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(
+        409,
+        '{"error":"No active run to cancel","code":"kilo_cli_run_no_active_run"}'
+      )
+    );
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.cancelKiloCliRun({
+        organizationId: org.id,
+        runId: run.id,
+      })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'No active run to cancel',
+    });
+
+    const rows = await db.select().from(kiloclaw_cli_runs).where(eq(kiloclaw_cli_runs.id, run.id));
+    expect(rows[0]).toMatchObject({
+      status: 'cancelled',
+      completed_at: expect.any(String),
     });
   });
 

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -11,10 +11,12 @@ import type { KiloClawApiError as KiloClawApiErrorType } from '@/lib/kiloclaw/ki
 // ── Types ──────────────────────────────────────────────────────────────────
 
 type StartKiloCliRunResult = { ok: true; startedAt: string };
+type CancelKiloCliRunResult = { ok: boolean };
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
 const mockStartKiloCliRun = jest.fn<() => Promise<StartKiloCliRunResult>>();
+const mockCancelKiloCliRun = jest.fn<() => Promise<CancelKiloCliRunResult>>();
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   const actual: Record<string, unknown> = jest.requireActual(
     '@/lib/kiloclaw/kiloclaw-internal-client'
@@ -22,6 +24,7 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   return {
     KiloClawInternalClient: jest.fn().mockImplementation(() => ({
       startKiloCliRun: mockStartKiloCliRun,
+      cancelKiloCliRun: mockCancelKiloCliRun,
     })),
     KiloClawApiError: actual.KiloClawApiError,
   };
@@ -55,6 +58,7 @@ let org: Organization;
 beforeEach(async () => {
   await cleanupDbForTest();
   mockStartKiloCliRun.mockReset();
+  mockCancelKiloCliRun.mockReset();
 
   user = await insertTestUser({
     google_user_email: `clirun-test-${Math.random()}@example.com`,
@@ -236,6 +240,82 @@ describe('organizations.kiloclaw.startKiloCliRun error translation', () => {
       instance_id: expect.any(String),
       prompt: 'fix the org config',
       status: 'running',
+    });
+  });
+});
+
+// ── Personal router: kiloclaw.cancelKiloCliRun ────────────────────────────
+
+describe('kiloclaw.cancelKiloCliRun error translation', () => {
+  beforeEach(async () => {
+    await grantKiloClawAccess(user.id);
+    await createPersonalInstance(user.id);
+  });
+
+  it('maps worker 409 to tRPC CONFLICT', async () => {
+    mockCancelKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(409, '{"error":"Instance is not running"}')
+    );
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.kiloclaw.cancelKiloCliRun({ runId: '10000000-1000-4000-8000-000000000001' })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Instance is not running',
+    });
+  });
+
+  it('maps worker 409 without message body to CONFLICT with fallback message', async () => {
+    mockCancelKiloCliRun.mockRejectedValue(new KiloClawApiError(409, ''));
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.kiloclaw.cancelKiloCliRun({ runId: '10000000-1000-4000-8000-000000000001' })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Instance is not running',
+    });
+  });
+});
+
+// ── Org router: organizations.kiloclaw.cancelKiloCliRun ───────────────────
+
+describe('organizations.kiloclaw.cancelKiloCliRun error translation', () => {
+  beforeEach(async () => {
+    org = await createOrganization('Test Org', user.id);
+    await createOrgInstance(user.id, org.id);
+  });
+
+  it('maps worker 409 to tRPC CONFLICT', async () => {
+    mockCancelKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(409, '{"error":"Instance is not running"}')
+    );
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.cancelKiloCliRun({
+        organizationId: org.id,
+        runId: '10000000-1000-4000-8000-000000000001',
+      })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Instance is not running',
+    });
+  });
+
+  it('maps worker 409 without message body to CONFLICT with fallback message', async () => {
+    mockCancelKiloCliRun.mockRejectedValue(new KiloClawApiError(409, ''));
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.cancelKiloCliRun({
+        organizationId: org.id,
+        runId: '10000000-1000-4000-8000-000000000001',
+      })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Instance is not running',
     });
   });
 });

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it, beforeAll, beforeEach, jest } from '@jest/globals';
+import { eq } from 'drizzle-orm';
 import { db, cleanupDbForTest } from '@/lib/drizzle';
-import { kiloclaw_instances, kiloclaw_subscriptions } from '@kilocode/db/schema';
+import { kiloclaw_instances, kiloclaw_subscriptions, kiloclaw_cli_runs } from '@kilocode/db/schema';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createOrganization } from '@/lib/organizations/organizations';
 import type { User, Organization } from '@kilocode/db/schema';
 
-// ── Mocks ──────────────────────────────────────────────────────────────────
+// ── Types ──────────────────────────────────────────────────────────────────
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockStartKiloCliRun: jest.Mock<any> = jest.fn();
+type AnyMock = jest.Mock<(...args: any[]) => any>;
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockStartKiloCliRun: AnyMock = jest.fn();
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   const actual: Record<string, unknown> = jest.requireActual(
     '@/lib/kiloclaw/kiloclaw-internal-client'
@@ -22,8 +27,7 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
 });
 
 jest.mock('next/headers', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const fn = jest.fn as (...args: any[]) => jest.Mock<any>;
+  const fn = jest.fn as (...args: unknown[]) => AnyMock;
   return {
     cookies: fn().mockResolvedValue({ get: fn() }),
     headers: fn().mockReturnValue(new Map()),
@@ -32,10 +36,8 @@ jest.mock('next/headers', () => {
 
 // ── Dynamic imports (after mocks) ──────────────────────────────────────────
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let createCallerForUser: (userId: string) => Promise<any>;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let KiloClawApiError: any;
+let createCallerForUser: (typeof import('@/routers/test-utils'))['createCallerForUser'];
+let KiloClawApiError: (typeof import('@/lib/kiloclaw/kiloclaw-internal-client'))['KiloClawApiError'];
 
 beforeAll(async () => {
   const mod = await import('@/routers/test-utils');
@@ -131,6 +133,27 @@ describe('kiloclaw.startKiloCliRun error translation', () => {
       message: 'Instance needs redeploy to support recovery',
     });
   });
+
+  it('inserts a running kiloclaw_cli_runs row on success', async () => {
+    const startedAt = '2024-01-01T00:00:00.000Z';
+    mockStartKiloCliRun.mockResolvedValue({ ok: true, startedAt });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.startKiloCliRun({ prompt: 'fix the config' });
+
+    expect(result).toMatchObject({ ok: true, startedAt, id: expect.any(String) });
+
+    const rows = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, result.id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      user_id: user.id,
+      prompt: 'fix the config',
+      status: 'running',
+    });
+  });
 });
 
 // ── Org router: organizations.kiloclaw.startKiloCliRun ─────────────────────
@@ -187,6 +210,31 @@ describe('organizations.kiloclaw.startKiloCliRun error translation', () => {
     ).rejects.toMatchObject({
       code: 'PRECONDITION_FAILED',
       message: 'Instance needs redeploy to support recovery',
+    });
+  });
+
+  it('inserts a running kiloclaw_cli_runs row on success', async () => {
+    const startedAt = '2024-01-01T00:00:00.000Z';
+    mockStartKiloCliRun.mockResolvedValue({ ok: true, startedAt });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.organizations.kiloclaw.startKiloCliRun({
+      organizationId: org.id,
+      prompt: 'fix the org config',
+    });
+
+    expect(result).toMatchObject({ ok: true, startedAt, id: expect.any(String) });
+
+    const rows = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, result.id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      user_id: user.id,
+      instance_id: expect.any(String),
+      prompt: 'fix the org config',
+      status: 'running',
     });
   });
 });

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -14,11 +14,21 @@ import { UpstreamApiError } from '@/lib/trpc/init';
 
 type StartKiloCliRunResult = { ok: true; startedAt: string };
 type CancelKiloCliRunResult = { ok: boolean };
+type KiloCliRunStatusResult = {
+  hasRun: boolean;
+  status: 'running' | 'completed' | 'failed' | 'cancelled' | null;
+  output: string | null;
+  exitCode: number | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  prompt: string | null;
+};
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
 const mockStartKiloCliRun = jest.fn<() => Promise<StartKiloCliRunResult>>();
 const mockCancelKiloCliRun = jest.fn<() => Promise<CancelKiloCliRunResult>>();
+const mockGetKiloCliRunStatus = jest.fn<() => Promise<KiloCliRunStatusResult>>();
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   const actual: Record<string, unknown> = jest.requireActual(
     '@/lib/kiloclaw/kiloclaw-internal-client'
@@ -27,6 +37,7 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
     KiloClawInternalClient: jest.fn().mockImplementation(() => ({
       startKiloCliRun: mockStartKiloCliRun,
       cancelKiloCliRun: mockCancelKiloCliRun,
+      getKiloCliRunStatus: mockGetKiloCliRunStatus,
     })),
     KiloClawApiError: actual.KiloClawApiError,
   };
@@ -61,6 +72,7 @@ beforeEach(async () => {
   await cleanupDbForTest();
   mockStartKiloCliRun.mockReset();
   mockCancelKiloCliRun.mockReset();
+  mockGetKiloCliRunStatus.mockReset();
 
   user = await insertTestUser({
     google_user_email: `clirun-test-${Math.random()}@example.com`,
@@ -74,7 +86,8 @@ async function createPersonalInstance(userId: string): Promise<string> {
       user_id: userId,
       sandbox_id: `sandbox-${userId.slice(0, 8)}`,
     })
-    .returning();
+    .returning({ id: kiloclaw_instances.id });
+  if (!row) throw new Error('Failed to create personal KiloClaw instance');
   return row.id;
 }
 
@@ -86,7 +99,8 @@ async function createOrgInstance(userId: string, organizationId: string): Promis
       sandbox_id: `sandbox-org-${userId.slice(0, 8)}`,
       organization_id: organizationId,
     })
-    .returning();
+    .returning({ id: kiloclaw_instances.id });
+  if (!row) throw new Error('Failed to create organization KiloClaw instance');
   return row.id;
 }
 
@@ -96,6 +110,39 @@ async function grantKiloClawAccess(userId: string): Promise<void> {
     plan: 'standard',
     status: 'active',
     stripe_subscription_id: `sub_test_${userId.slice(0, 8)}`,
+  });
+}
+
+async function createRunningCliRun(params: {
+  userId: string;
+  instanceId: string;
+  prompt: string;
+  startedAt: string;
+}): Promise<string> {
+  const [row] = await db
+    .insert(kiloclaw_cli_runs)
+    .values({
+      user_id: params.userId,
+      instance_id: params.instanceId,
+      prompt: params.prompt,
+      status: 'running',
+      started_at: params.startedAt,
+    })
+    .returning({ id: kiloclaw_cli_runs.id });
+
+  if (!row) throw new Error('Failed to create Kilo CLI run');
+  return row.id;
+}
+
+function mockRunningCliStatus(params: { startedAt: string; prompt: string }): void {
+  mockGetKiloCliRunStatus.mockResolvedValue({
+    hasRun: true,
+    status: 'running',
+    output: null,
+    exitCode: null,
+    startedAt: params.startedAt,
+    completedAt: null,
+    prompt: params.prompt,
   });
 }
 
@@ -288,6 +335,27 @@ describe('kiloclaw.cancelKiloCliRun error translation', () => {
       message: 'Kilo CLI run not found',
     });
   });
+
+  it('maps a late worker 409 during cancel to ok: false', async () => {
+    const [instance] = await db
+      .select({ id: kiloclaw_instances.id })
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.user_id, user.id))
+      .limit(1);
+    if (!instance) throw new Error('Expected personal KiloClaw instance');
+
+    const instanceId = instance.id;
+    const startedAt = '2026-04-12T12:00:00.000Z';
+    const prompt = 'run that exits between status poll and cancel';
+    const runId = await createRunningCliRun({ userId: user.id, instanceId, prompt, startedAt });
+    mockRunningCliStatus({ startedAt, prompt });
+    mockCancelKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(409, '{"code":"kilo_cli_run_no_active_run"}')
+    );
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.cancelKiloCliRun({ runId })).resolves.toEqual({ ok: false });
+  });
 });
 
 // ── Org router: organizations.kiloclaw.cancelKiloCliRun ───────────────────
@@ -309,5 +377,32 @@ describe('organizations.kiloclaw.cancelKiloCliRun error translation', () => {
       code: 'NOT_FOUND',
       message: 'Kilo CLI run not found',
     });
+  });
+
+  it('maps a late worker 409 during cancel to ok: false', async () => {
+    const [instance] = await db
+      .select({ id: kiloclaw_instances.id })
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.organization_id, org.id))
+      .limit(1);
+    if (!instance) throw new Error('Expected organization KiloClaw instance');
+
+    const startedAt = '2026-04-12T12:00:00.000Z';
+    const prompt = 'org run that exits between status poll and cancel';
+    const runId = await createRunningCliRun({
+      userId: user.id,
+      instanceId: instance.id,
+      prompt,
+      startedAt,
+    });
+    mockRunningCliStatus({ startedAt, prompt });
+    mockCancelKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(409, '{"code":"kilo_cli_run_no_active_run"}')
+    );
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.cancelKiloCliRun({ organizationId: org.id, runId })
+    ).resolves.toEqual({ ok: false });
   });
 });

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -1288,21 +1288,7 @@ export const organizationKiloclawRouter = createTRPCRouter({
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
       const client = new KiloClawInternalClient();
 
-      let result: Awaited<ReturnType<KiloClawInternalClient['cancelKiloCliRun']>>;
-      try {
-        result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
-      } catch (err) {
-        if (err instanceof KiloClawApiError && err.statusCode === 409) {
-          const { message } = getKiloClawApiErrorPayload(err);
-          throw new TRPCError({
-            code: 'CONFLICT',
-            message: message ?? 'Instance is not running',
-          });
-        }
-        throw err;
-      }
-
-      if (result.ok) {
+      const markRunCancelled = async () => {
         await db
           .update(kiloclaw_cli_runs)
           .set({
@@ -1317,6 +1303,28 @@ export const organizationKiloclawRouter = createTRPCRouter({
               eq(kiloclaw_cli_runs.status, 'running')
             )
           );
+      };
+
+      let result: Awaited<ReturnType<KiloClawInternalClient['cancelKiloCliRun']>>;
+      try {
+        result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
+      } catch (err) {
+        if (err instanceof KiloClawApiError && err.statusCode === 409) {
+          const { code, message } = getKiloClawApiErrorPayload(err);
+          if (code === 'kilo_cli_run_no_active_run') {
+            await markRunCancelled();
+          }
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: message ?? 'Instance is not running',
+            cause: code ? new UpstreamApiError(code) : undefined,
+          });
+        }
+        throw err;
+      }
+
+      if (result.ok) {
+        await markRunCancelled();
       }
 
       return result;

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -1165,11 +1165,33 @@ export const organizationKiloclawRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
       const client = new KiloClawInternalClient();
-      const result = await client.startKiloCliRun(
-        ctx.user.id,
-        input.prompt,
-        workerInstanceId(instance)
-      );
+
+      let result: Awaited<ReturnType<KiloClawInternalClient['startKiloCliRun']>>;
+      try {
+        result = await client.startKiloCliRun(
+          ctx.user.id,
+          input.prompt,
+          workerInstanceId(instance)
+        );
+      } catch (err) {
+        if (err instanceof KiloClawApiError) {
+          const { code, message } = getKiloClawApiErrorPayload(err);
+          if (code === 'controller_route_unavailable') {
+            throw new TRPCError({
+              code: 'PRECONDITION_FAILED',
+              message: 'Instance needs redeploy to support recovery',
+              cause: new UpstreamApiError('controller_route_unavailable'),
+            });
+          }
+          if (err.statusCode === 409) {
+            throw new TRPCError({
+              code: 'CONFLICT',
+              message: message ?? 'Instance is busy',
+            });
+          }
+        }
+        throw err;
+      }
 
       const [row] = await db
         .insert(kiloclaw_cli_runs)

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -1287,7 +1287,20 @@ export const organizationKiloclawRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
       const client = new KiloClawInternalClient();
-      const result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
+
+      let result: Awaited<ReturnType<KiloClawInternalClient['cancelKiloCliRun']>>;
+      try {
+        result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
+      } catch (err) {
+        if (err instanceof KiloClawApiError && err.statusCode === 409) {
+          const { message } = getKiloClawApiErrorPayload(err);
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: message ?? 'Instance is not running',
+          });
+        }
+        throw err;
+      }
 
       if (result.ok) {
         await db

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -27,6 +27,7 @@ import {
 } from '@kilocode/db/schema';
 import { and, eq, desc, sql } from 'drizzle-orm';
 import type { KiloClawDashboardStatus, KiloCodeConfigResponse } from '@/lib/kiloclaw/types';
+import { cancelCliRun, getCliRunStatus } from '@/lib/kiloclaw/cli-runs';
 import { queryDiskUsage } from '@/lib/kiloclaw/disk-usage';
 import {
   cycleInboundEmailAddressForInstance,
@@ -1212,123 +1213,33 @@ export const organizationKiloclawRouter = createTRPCRouter({
     .input(z.object({ organizationId: z.uuid(), runId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
-      const [row] = await db
-        .select()
-        .from(kiloclaw_cli_runs)
-        .where(
-          and(
-            eq(kiloclaw_cli_runs.id, input.runId),
-            eq(kiloclaw_cli_runs.user_id, ctx.user.id),
-            eq(kiloclaw_cli_runs.instance_id, instance.id)
-          )
-        )
-        .limit(1);
-
-      if (!row) {
-        return {
-          hasRun: false,
-          status: null,
-          output: null,
-          exitCode: null,
-          startedAt: null,
-          completedAt: null,
-          prompt: null,
-        };
-      }
-
-      if (row.status !== 'running') {
-        return {
-          hasRun: true,
-          status: row.status as 'completed' | 'failed' | 'cancelled',
-          output: row.output,
-          exitCode: row.exit_code,
-          startedAt: row.started_at,
-          completedAt: row.completed_at ?? null,
-          prompt: row.prompt,
-        };
-      }
-
-      const client = new KiloClawInternalClient();
-      const controllerStatus = await client.getKiloCliRunStatus(
-        ctx.user.id,
-        workerInstanceId(instance)
-      );
-
-      if (
-        controllerStatus.hasRun &&
-        controllerStatus.status !== 'running' &&
-        controllerStatus.startedAt
-      ) {
-        await db
-          .update(kiloclaw_cli_runs)
-          .set({
-            status: controllerStatus.status ?? 'failed',
-            exit_code: controllerStatus.exitCode,
-            output: controllerStatus.output,
-            completed_at: controllerStatus.completedAt ?? new Date().toISOString(),
-          })
-          .where(
-            and(
-              eq(kiloclaw_cli_runs.id, input.runId),
-              eq(kiloclaw_cli_runs.user_id, ctx.user.id),
-              eq(kiloclaw_cli_runs.instance_id, instance.id),
-              eq(kiloclaw_cli_runs.status, 'running')
-            )
-          );
-      }
-
-      return {
-        ...controllerStatus,
-        prompt: row.prompt,
-      };
+      return getCliRunStatus({
+        runId: input.runId,
+        userId: ctx.user.id,
+        instanceId: instance.id,
+        workerInstanceId: workerInstanceId(instance),
+      });
     }),
 
   cancelKiloCliRun: organizationMemberMutationProcedure
     .input(z.object({ organizationId: z.uuid(), runId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
-      const client = new KiloClawInternalClient();
+      const result = await cancelCliRun({
+        runId: input.runId,
+        userId: ctx.user.id,
+        instanceId: instance.id,
+        workerInstanceId: workerInstanceId(instance),
+      });
 
-      const markRunCancelled = async () => {
-        await db
-          .update(kiloclaw_cli_runs)
-          .set({
-            status: 'cancelled',
-            completed_at: new Date().toISOString(),
-          })
-          .where(
-            and(
-              eq(kiloclaw_cli_runs.id, input.runId),
-              eq(kiloclaw_cli_runs.user_id, ctx.user.id),
-              eq(kiloclaw_cli_runs.instance_id, instance.id),
-              eq(kiloclaw_cli_runs.status, 'running')
-            )
-          );
-      };
-
-      let result: Awaited<ReturnType<KiloClawInternalClient['cancelKiloCliRun']>>;
-      try {
-        result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
-      } catch (err) {
-        if (err instanceof KiloClawApiError && err.statusCode === 409) {
-          const { code, message } = getKiloClawApiErrorPayload(err);
-          if (code === 'kilo_cli_run_no_active_run') {
-            await markRunCancelled();
-          }
-          throw new TRPCError({
-            code: 'CONFLICT',
-            message: message ?? 'Instance is not running',
-            cause: code ? new UpstreamApiError(code) : undefined,
-          });
-        }
-        throw err;
+      if (!result.runFound) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Kilo CLI run not found',
+        });
       }
 
-      if (result.ok) {
-        await markRunCancelled();
-      }
-
-      return result;
+      return { ok: result.ok };
     }),
 
   listKiloCliRuns: organizationMemberProcedure

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -1187,6 +1187,7 @@ export const organizationKiloclawRouter = createTRPCRouter({
             throw new TRPCError({
               code: 'CONFLICT',
               message: message ?? 'Instance is busy',
+              cause: code ? new UpstreamApiError(code) : undefined,
             });
           }
         }

--- a/services/kiloclaw/controller/src/routes/kilo-cli-run.test.ts
+++ b/services/kiloclaw/controller/src/routes/kilo-cli-run.test.ts
@@ -224,6 +224,55 @@ describe('/_kilo/cli-run routes', () => {
     expect(mockKill).toHaveBeenCalledWith('SIGTERM');
   });
 
+  // ── Serialized concurrent starts ────────────────────────────────────
+
+  it('serializes concurrent starts: exactly one 200 and one 409', async () => {
+    const [r1, r2] = await Promise.all([
+      app.request('/_kilo/cli-run/start', {
+        method: 'POST',
+        headers: authHeaders(),
+        body: JSON.stringify({ prompt: 'task A' }),
+      }),
+      app.request('/_kilo/cli-run/start', {
+        method: 'POST',
+        headers: authHeaders(),
+        body: JSON.stringify({ prompt: 'task B' }),
+      }),
+    ]);
+
+    const statuses = [r1.status, r2.status].sort((a, b) => a - b);
+    expect(statuses).toEqual([200, 409]);
+  });
+
+  it('queue continues after a failed start attempt', async () => {
+    // Make the first spawn call throw synchronously
+    const spawnMock = vi.mocked(spawn);
+    spawnMock.mockImplementationOnce(() => {
+      throw new Error('spawn failed intentionally');
+    });
+
+    const r1 = await app.request('/_kilo/cli-run/start', {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({ prompt: 'failing task' }),
+    });
+    // Should get a 500 (spawn threw)
+    expect(r1.status).toBe(500);
+
+    // Run state should not be set to running after the failure
+    expect(_getActiveRun()).toBeNull();
+
+    // Now restore the default spawn mock and try a valid start
+    const r2 = await app.request('/_kilo/cli-run/start', {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({ prompt: 'recovery task' }),
+    });
+    expect(r2.status).toBe(200);
+    const body = (await r2.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+  });
+
   // ── GET /_kilo/cli-run/status (with active run) ────────────────────
 
   it('returns run status after start', async () => {

--- a/services/kiloclaw/controller/src/routes/kilo-cli-run.test.ts
+++ b/services/kiloclaw/controller/src/routes/kilo-cli-run.test.ts
@@ -189,17 +189,25 @@ describe('/_kilo/cli-run routes', () => {
     });
     expect(resp.status).toBe(409);
     const body = (await resp.json()) as Record<string, unknown>;
-    expect(body.error).toContain('already in progress');
+    expect(body).toMatchObject({
+      code: 'kilo_cli_run_already_active',
+      error: expect.stringContaining('already in progress'),
+    });
   });
 
   // ── POST /_kilo/cli-run/cancel ──────────────────────────────────────
 
-  it('returns 404 when cancelling with no active run', async () => {
+  it('returns 409 when cancelling with no active run', async () => {
     const resp = await app.request('/_kilo/cli-run/cancel', {
       method: 'POST',
       headers: authHeaders(),
     });
-    expect(resp.status).toBe(404);
+    expect(resp.status).toBe(409);
+    const body = (await resp.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      code: 'kilo_cli_run_no_active_run',
+      error: 'No active run to cancel',
+    });
   });
 
   it('cancels an active run', async () => {

--- a/services/kiloclaw/controller/src/routes/kilo-cli-run.test.ts
+++ b/services/kiloclaw/controller/src/routes/kilo-cli-run.test.ts
@@ -6,6 +6,7 @@ import {
   buildRunPrompt,
   _getActiveRun,
   _resetActiveRun,
+  _resetStartQueue,
 } from './kilo-cli-run';
 
 // Mock child_process.spawn
@@ -62,6 +63,7 @@ describe('/_kilo/cli-run routes', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     _resetActiveRun();
+    _resetStartQueue();
     app = new Hono();
     registerKiloCliRunRoutes(app, 'test-token');
     // Set env vars needed by the routes

--- a/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
+++ b/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
@@ -135,27 +135,25 @@ export function registerKiloCliRunRoutes(app: Hono, expectedToken: string): void
       return c.json({ error: 'KILO_API_KEY is not configured' }, 400);
     }
 
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+
+    const parsed = StartRunBodySchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'Invalid request body', details: z.treeifyError(parsed.error) }, 400);
+    }
+
+    const { prompt } = parsed.data;
+
     return runStartExclusive(async () => {
       if (activeRun?.status === 'running') {
         return c.json({ error: 'A Kilo CLI run is already in progress' }, 409);
       }
 
-      let body: unknown;
-      try {
-        body = await c.req.json();
-      } catch {
-        return c.json({ error: 'Invalid JSON body' }, 400);
-      }
-
-      const parsed = StartRunBodySchema.safeParse(body);
-      if (!parsed.success) {
-        return c.json(
-          { error: 'Invalid request body', details: z.treeifyError(parsed.error) },
-          400
-        );
-      }
-
-      const { prompt } = parsed.data;
       const fullPrompt = buildRunPrompt(prompt);
 
       // Spawn the kilo CLI process

--- a/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
+++ b/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
@@ -68,6 +68,7 @@ ${userPrompt}`;
 // ── Module-level state (one run at a time per machine) ────────────────
 
 let activeRun: RunState | null = null;
+let startQueue: Promise<void> = Promise.resolve();
 
 // ── Request schemas ───────────────────────────────────────────────────
 
@@ -97,6 +98,21 @@ function cleanupRun(
   // Don't null out activeRun — keep it for status queries until a new run starts
 }
 
+/**
+ * This chains each start attempt behind the previous one.
+ *
+ * `then(fn, fn)` ensures the next attempt runs regardless of whether the
+ * previous one resolved or rejected — the queue must never stall.
+ */
+function runStartExclusive<T>(fn: () => Promise<T>): Promise<T> {
+  const next = startQueue.then(fn, fn);
+  startQueue = next.then(
+    () => undefined,
+    () => undefined
+  );
+  return next;
+}
+
 // ── Route registration ────────────────────────────────────────────────
 
 export function registerKiloCliRunRoutes(app: Hono, expectedToken: string): void {
@@ -119,76 +135,80 @@ export function registerKiloCliRunRoutes(app: Hono, expectedToken: string): void
       return c.json({ error: 'KILO_API_KEY is not configured' }, 400);
     }
 
-    // Enforce one-at-a-time
-    if (activeRun?.status === 'running') {
-      return c.json({ error: 'A kilo CLI run is already in progress' }, 409);
-    }
-
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: 'Invalid JSON body' }, 400);
-    }
-
-    const parsed = StartRunBodySchema.safeParse(body);
-    if (!parsed.success) {
-      return c.json({ error: 'Invalid request body', details: parsed.error.flatten() }, 400);
-    }
-
-    const { prompt } = parsed.data;
-    const fullPrompt = buildRunPrompt(prompt);
-
-    // Spawn the kilo CLI process
-    // The prompt is passed as a separate argument to avoid shell injection
-    const child = spawn('kilo', ['run', '--auto', fullPrompt], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: process.env,
-    });
-
-    const run: RunState = {
-      process: child,
-      output: '',
-      status: 'running',
-      exitCode: null,
-      startedAt: new Date().toISOString(),
-      completedAt: null,
-      prompt,
-    };
-
-    activeRun = run;
-
-    // Capture stdout
-    child.stdout?.on('data', (chunk: Buffer | string) => {
-      const text = typeof chunk === 'string' ? chunk : chunk.toString();
-      appendOutput(run, text);
-    });
-
-    // Capture stderr (merge into same output buffer)
-    child.stderr?.on('data', (chunk: Buffer | string) => {
-      const text = typeof chunk === 'string' ? chunk : chunk.toString();
-      appendOutput(run, text);
-    });
-
-    child.once('error', err => {
-      console.error('[kilo-cli-run] Process error:', err.message);
-      if (run.status === 'running') {
-        appendOutput(run, `\n[process error: ${err.message}]\n`);
-        cleanupRun(run, null, 'failed');
+    return runStartExclusive(async () => {
+      if (activeRun?.status === 'running') {
+        return c.json({ error: 'A Kilo CLI run is already in progress' }, 409);
       }
-    });
 
-    child.once('close', (code, signal) => {
-      if (run.status !== 'running') return; // already handled by error event
-      console.log(`[kilo-cli-run] Process exited: code=${code} signal=${signal}`);
-      cleanupRun(run, code, code === 0 ? 'completed' : 'failed');
-    });
+      let body: unknown;
+      try {
+        body = await c.req.json();
+      } catch {
+        return c.json({ error: 'Invalid JSON body' }, 400);
+      }
 
-    console.log(`[kilo-cli-run] Started: pid=${child.pid}, prompt="${prompt.slice(0, 100)}..."`);
+      const parsed = StartRunBodySchema.safeParse(body);
+      if (!parsed.success) {
+        return c.json(
+          { error: 'Invalid request body', details: z.treeifyError(parsed.error) },
+          400
+        );
+      }
 
-    return c.json({
-      ok: true,
-      startedAt: run.startedAt,
+      const { prompt } = parsed.data;
+      const fullPrompt = buildRunPrompt(prompt);
+
+      // Spawn the kilo CLI process
+      // The prompt is passed as a separate argument to avoid shell injection
+      const child = spawn('kilo', ['run', '--auto', fullPrompt], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: process.env,
+      });
+
+      const run: RunState = {
+        process: child,
+        output: '',
+        status: 'running',
+        exitCode: null,
+        startedAt: new Date().toISOString(),
+        completedAt: null,
+        prompt,
+      };
+
+      activeRun = run;
+
+      // Capture stdout
+      child.stdout?.on('data', (chunk: Buffer | string) => {
+        const text = typeof chunk === 'string' ? chunk : chunk.toString();
+        appendOutput(run, text);
+      });
+
+      // Capture stderr (merge into same output buffer)
+      child.stderr?.on('data', (chunk: Buffer | string) => {
+        const text = typeof chunk === 'string' ? chunk : chunk.toString();
+        appendOutput(run, text);
+      });
+
+      child.once('error', err => {
+        console.error('[kilo-cli-run] Process error:', err.message);
+        if (run.status === 'running') {
+          appendOutput(run, `\n[process error: ${err.message}]\n`);
+          cleanupRun(run, null, 'failed');
+        }
+      });
+
+      child.once('close', (code, signal) => {
+        if (run.status !== 'running') return; // already handled by error event
+        console.log(`[kilo-cli-run] Process exited: code=${code} signal=${signal}`);
+        cleanupRun(run, code, code === 0 ? 'completed' : 'failed');
+      });
+
+      console.log(`[kilo-cli-run] Started: pid=${child.pid}, prompt="${prompt.slice(0, 100)}..."`);
+
+      return c.json({
+        ok: true,
+        startedAt: run.startedAt,
+      });
     });
   });
 

--- a/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
+++ b/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
@@ -272,3 +272,8 @@ export function _getActiveRun(): RunState | null {
 export function _resetActiveRun(): void {
   activeRun = null;
 }
+
+/** Exported for testing. */
+export function _resetStartQueue(): void {
+  startQueue = Promise.resolve();
+}

--- a/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
+++ b/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
@@ -151,7 +151,13 @@ export function registerKiloCliRunRoutes(app: Hono, expectedToken: string): void
 
     return runStartExclusive(async () => {
       if (activeRun?.status === 'running') {
-        return c.json({ error: 'A Kilo CLI run is already in progress' }, 409);
+        return c.json(
+          {
+            code: 'kilo_cli_run_already_active',
+            error: 'A Kilo CLI run is already in progress',
+          },
+          409
+        );
       }
 
       const fullPrompt = buildRunPrompt(prompt);
@@ -238,7 +244,7 @@ export function registerKiloCliRunRoutes(app: Hono, expectedToken: string): void
   // POST /_kilo/cli-run/cancel — kill the active run
   app.post('/_kilo/cli-run/cancel', c => {
     if (!activeRun || activeRun.status !== 'running') {
-      return c.json({ error: 'No active run to cancel' }, 404);
+      return c.json({ code: 'kilo_cli_run_no_active_run', error: 'No active run to cancel' }, 409);
     }
 
     try {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -5209,6 +5209,32 @@ describe('kilo CLI run routing', () => {
     fetchSpy.mockRestore();
   });
 
+  it('returns { conflict } from startKiloCliRun when instance is not running', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage); // status: 'provisioned', not 'running'
+
+    const result = await instance.startKiloCliRun('fix something');
+
+    expect(result).toEqual({ conflict: 'Instance is not running' });
+  });
+
+  it('returns { conflict } from startKiloCliRun when controller returns 409', async () => {
+    const { instance, storage } = createInstance();
+    await seedDockerInstance(storage, { status: 'running' });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'A Kilo CLI run is already in progress' }), {
+        status: 409,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const result = await instance.startKiloCliRun('fix something');
+
+    expect(result).toEqual({ conflict: 'A Kilo CLI run is already in progress' });
+    fetchSpy.mockRestore();
+  });
+
   it('returns { conflict } from cancelKiloCliRun when instance is not running', async () => {
     const { instance, storage } = createInstance();
     await seedProvisioned(storage); // status: 'provisioned', not 'running'

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -5215,10 +5215,43 @@ describe('kilo CLI run routing', () => {
 
     const result = await instance.startKiloCliRun('fix something');
 
-    expect(result).toEqual({ conflict: 'Instance is not running' });
+    expect(result).toEqual({
+      conflict: {
+        code: 'kilo_cli_run_instance_not_running',
+        error: 'Instance is not running',
+      },
+    });
   });
 
   it('returns { conflict } from startKiloCliRun when controller returns 409', async () => {
+    const { instance, storage } = createInstance();
+    await seedDockerInstance(storage, { status: 'running' });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          code: 'kilo_cli_run_already_active',
+          error: 'A Kilo CLI run is already in progress',
+        }),
+        {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+
+    const result = await instance.startKiloCliRun('fix something');
+
+    expect(result).toEqual({
+      conflict: {
+        code: 'kilo_cli_run_already_active',
+        error: 'A Kilo CLI run is already in progress',
+      },
+    });
+    fetchSpy.mockRestore();
+  });
+
+  it('uses the start-specific code when controller start returns an unstructured 409', async () => {
     const { instance, storage } = createInstance();
     await seedDockerInstance(storage, { status: 'running' });
 
@@ -5231,7 +5264,12 @@ describe('kilo CLI run routing', () => {
 
     const result = await instance.startKiloCliRun('fix something');
 
-    expect(result).toEqual({ conflict: 'A Kilo CLI run is already in progress' });
+    expect(result).toEqual({
+      conflict: {
+        code: 'kilo_cli_run_already_active',
+        error: 'A Kilo CLI run is already in progress',
+      },
+    });
     fetchSpy.mockRestore();
   });
 
@@ -5241,7 +5279,62 @@ describe('kilo CLI run routing', () => {
 
     const result = await instance.cancelKiloCliRun();
 
-    expect(result).toEqual({ conflict: 'Instance is not running' });
+    expect(result).toEqual({
+      conflict: {
+        code: 'kilo_cli_run_instance_not_running',
+        error: 'Instance is not running',
+      },
+    });
+  });
+
+  it('returns { conflict } from cancelKiloCliRun when controller returns 409', async () => {
+    const { instance, storage } = createInstance();
+    await seedDockerInstance(storage, { status: 'running' });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          code: 'kilo_cli_run_no_active_run',
+          error: 'No active run to cancel',
+        }),
+        {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+
+    const result = await instance.cancelKiloCliRun();
+
+    expect(result).toEqual({
+      conflict: {
+        code: 'kilo_cli_run_no_active_run',
+        error: 'No active run to cancel',
+      },
+    });
+    fetchSpy.mockRestore();
+  });
+
+  it('uses the cancel-specific code when controller cancel returns an unrecognized 409', async () => {
+    const { instance, storage } = createInstance();
+    await seedDockerInstance(storage, { status: 'running' });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'No active run to cancel' }), {
+        status: 409,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const result = await instance.cancelKiloCliRun();
+
+    expect(result).toEqual({
+      conflict: {
+        code: 'kilo_cli_run_no_active_run',
+        error: 'No active run to cancel',
+      },
+    });
+    fetchSpy.mockRestore();
   });
 
   it('cancels a Kilo CLI run for docker-local via controller without flyMachineId', async () => {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -5209,6 +5209,15 @@ describe('kilo CLI run routing', () => {
     fetchSpy.mockRestore();
   });
 
+  it('returns { conflict } from cancelKiloCliRun when instance is not running', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage); // status: 'provisioned', not 'running'
+
+    const result = await instance.cancelKiloCliRun();
+
+    expect(result).toEqual({ conflict: 'Instance is not running' });
+  });
+
   it('cancels a Kilo CLI run for docker-local via controller without flyMachineId', async () => {
     const { instance, storage } = createInstance();
     await seedDockerInstance(storage, { status: 'running' });

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/kilo-cli-run.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/kilo-cli-run.ts
@@ -93,13 +93,17 @@ export async function getKiloCliRunStatus(
 
 /**
  * Cancel the active kilo CLI run on the controller.
+ *
+ * Returns a `{ conflict }` variant instead of throwing on not-running because
+ * custom error properties (like `.status`) are lost crossing the DO RPC
+ * boundary — only `.message` survives. Return values serialize correctly.
  */
 export async function cancelKiloCliRun(
   state: InstanceMutableState,
   env: KiloClawEnv
-): Promise<{ ok: boolean }> {
+): Promise<{ ok: boolean } | KiloCliRunConflict> {
   if (state.status !== 'running' || !getRuntimeId(state)) {
-    throw Object.assign(new Error('Instance is not running'), { status: 409 });
+    return { conflict: 'Instance is not running' };
   }
 
   return callGatewayController(

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/kilo-cli-run.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/kilo-cli-run.ts
@@ -14,10 +14,44 @@ type KiloCliRunStartResponse = {
   startedAt: string;
 };
 
+type KiloCliRunConflictCode =
+  | 'kilo_cli_run_instance_not_running'
+  | 'kilo_cli_run_already_active'
+  | 'kilo_cli_run_no_active_run';
+
 /** Returned instead of throwing when a 409 would be lost crossing the DO RPC boundary. */
 type KiloCliRunConflict = {
-  conflict: string;
+  conflict: {
+    code: KiloCliRunConflictCode;
+    error: string;
+  };
 };
+
+function kiloCliRunConflict(code: KiloCliRunConflictCode, error: string): KiloCliRunConflict {
+  return { conflict: { code, error } };
+}
+
+/**
+ * Older controllers can return 409 without a structured code. For start, the
+ * legacy 409 contract meant "a run is already active", so preserve that
+ * operation-specific meaning instead of using a shared default.
+ */
+function startConflictCodeFromController(error: GatewayControllerError): KiloCliRunConflictCode {
+  if (error.code === 'kilo_cli_run_already_active') return error.code;
+  if (error.code === 'kilo_cli_run_no_active_run') return error.code;
+  return 'kilo_cli_run_already_active';
+}
+
+/**
+ * Older controllers can return 409 without a structured code. For cancel, the
+ * legacy 409 contract meant "there is no active run to cancel", so this must
+ * not share start's fallback or stale running rows would keep the wrong cause.
+ */
+function cancelConflictCodeFromController(error: GatewayControllerError): KiloCliRunConflictCode {
+  if (error.code === 'kilo_cli_run_already_active') return error.code;
+  if (error.code === 'kilo_cli_run_no_active_run') return error.code;
+  return 'kilo_cli_run_no_active_run';
+}
 
 type KiloCliRunStatusResponse = {
   hasRun: boolean;
@@ -32,7 +66,7 @@ type KiloCliRunStatusResponse = {
 /**
  * Start a `kilo run --auto` process on the controller.
  *
- * Returns a `{ conflict }` variant instead of throwing on 409 because
+ * Returns a `{ conflict: { code, error } }` variant instead of throwing on 409 because
  * custom error properties (like `.status`) are lost crossing the DO RPC
  * boundary — only `.message` survives. Return values serialize correctly.
  */
@@ -42,7 +76,7 @@ export async function startKiloCliRun(
   prompt: string
 ): Promise<KiloCliRunStartResponse | KiloCliRunConflict | null> {
   if (state.status !== 'running' || !getRuntimeId(state)) {
-    return { conflict: 'Instance is not running' };
+    return kiloCliRunConflict('kilo_cli_run_instance_not_running', 'Instance is not running');
   }
 
   try {
@@ -57,7 +91,7 @@ export async function startKiloCliRun(
   } catch (error) {
     if (isErrorUnknownRoute(error)) return null;
     if (error instanceof GatewayControllerError && error.status === 409) {
-      return { conflict: error.message };
+      return kiloCliRunConflict(startConflictCodeFromController(error), error.message);
     }
     throw error;
   }
@@ -94,7 +128,7 @@ export async function getKiloCliRunStatus(
 /**
  * Cancel the active kilo CLI run on the controller.
  *
- * Returns a `{ conflict }` variant instead of throwing on not-running because
+ * Returns a `{ conflict: { code, error } }` variant instead of throwing on not-running because
  * custom error properties (like `.status`) are lost crossing the DO RPC
  * boundary — only `.message` survives. Return values serialize correctly.
  */
@@ -103,14 +137,21 @@ export async function cancelKiloCliRun(
   env: KiloClawEnv
 ): Promise<{ ok: boolean } | KiloCliRunConflict> {
   if (state.status !== 'running' || !getRuntimeId(state)) {
-    return { conflict: 'Instance is not running' };
+    return kiloCliRunConflict('kilo_cli_run_instance_not_running', 'Instance is not running');
   }
 
-  return callGatewayController(
-    state,
-    env,
-    '/_kilo/cli-run/cancel',
-    'POST',
-    GatewayCommandResponseSchema
-  );
+  try {
+    return await callGatewayController(
+      state,
+      env,
+      '/_kilo/cli-run/cancel',
+      'POST',
+      GatewayCommandResponseSchema
+    );
+  } catch (error) {
+    if (error instanceof GatewayControllerError && error.status === 409) {
+      return kiloCliRunConflict(cancelConflictCodeFromController(error), error.message);
+    }
+    throw error;
+  }
 }

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/kilo-cli-run.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/kilo-cli-run.ts
@@ -3,6 +3,7 @@ import {
   KiloCliRunStartResponseSchema,
   KiloCliRunStatusResponseSchema,
   GatewayCommandResponseSchema,
+  GatewayControllerError,
 } from '../gateway-controller-types';
 import { callGatewayController, isErrorUnknownRoute } from './gateway';
 import { getRuntimeId } from './state';
@@ -11,6 +12,11 @@ import type { InstanceMutableState } from './types';
 type KiloCliRunStartResponse = {
   ok: boolean;
   startedAt: string;
+};
+
+/** Returned instead of throwing when a 409 would be lost crossing the DO RPC boundary. */
+type KiloCliRunConflict = {
+  conflict: string;
 };
 
 type KiloCliRunStatusResponse = {
@@ -25,14 +31,18 @@ type KiloCliRunStatusResponse = {
 
 /**
  * Start a `kilo run --auto` process on the controller.
+ *
+ * Returns a `{ conflict }` variant instead of throwing on 409 because
+ * custom error properties (like `.status`) are lost crossing the DO RPC
+ * boundary — only `.message` survives. Return values serialize correctly.
  */
 export async function startKiloCliRun(
   state: InstanceMutableState,
   env: KiloClawEnv,
   prompt: string
-): Promise<KiloCliRunStartResponse | null> {
+): Promise<KiloCliRunStartResponse | KiloCliRunConflict | null> {
   if (state.status !== 'running' || !getRuntimeId(state)) {
-    throw Object.assign(new Error('Instance is not running'), { status: 409 });
+    return { conflict: 'Instance is not running' };
   }
 
   try {
@@ -46,6 +56,9 @@ export async function startKiloCliRun(
     );
   } catch (error) {
     if (isErrorUnknownRoute(error)) return null;
+    if (error instanceof GatewayControllerError && error.status === 409) {
+      return { conflict: error.message };
+    }
     throw error;
   }
 }

--- a/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
+++ b/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
@@ -97,6 +97,44 @@ describe('sanitizeError: Instance-not-* status correction', () => {
   });
 });
 
+describe('kilo-cli-run/start: conflict response handling', () => {
+  /** Minimal env whose DO startKiloCliRun returns a conflict discriminated-union value. */
+  function envWithStartConflict(message: string) {
+    return {
+      KILOCLAW_INSTANCE: {
+        idFromName: (id: string) => id,
+        get: () => ({ startKiloCliRun: () => Promise.resolve({ conflict: message }) }),
+      },
+      KILOCLAW_AE: { writeDataPoint: vi.fn() },
+      KV_CLAW_CACHE: {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        list: vi.fn().mockResolvedValue({ keys: [], list_complete: true }),
+        getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null }),
+      },
+    } as never;
+  }
+
+  it('returns 409 when the DO signals a run is already in progress', async () => {
+    const env = envWithStartConflict('A Kilo CLI run is already in progress');
+
+    const resp = await platform.request(
+      '/kilo-cli-run/start',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: 'user-1', prompt: 'fix this' }),
+      },
+      env
+    );
+
+    expect(resp.status).toBe(409);
+    const body = await jsonBody(resp);
+    expect(body.error).toBe('A Kilo CLI run is already in progress');
+  });
+});
+
 describe('kilo-cli-run/cancel: conflict response handling', () => {
   /** Minimal env whose DO cancelKiloCliRun returns a conflict discriminated-union value. */
   function envWithCancelConflict(message: string) {

--- a/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
+++ b/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
@@ -73,7 +73,8 @@ describe('sanitizeError: Instance-not-* status correction', () => {
   });
 
   it('does not override status for non-"Instance not" safe errors', async () => {
-    // "Instance is not running" uses a different prefix — should stay 500
+    // "Instance is not running" thrown by DO lifecycle methods (not CLI cancel) stays 500
+    // because only "Instance not provisioned" has a correctLostStatus entry.
     const err = new Error('Instance is not running');
     const env = envWithDOError(err);
 
@@ -93,6 +94,44 @@ describe('sanitizeError: Instance-not-* status correction', () => {
     expect(resp.status).toBe(500);
     const body = await jsonBody(resp);
     expect(body.error).toBe('status failed');
+  });
+});
+
+describe('kilo-cli-run/cancel: conflict response handling', () => {
+  /** Minimal env whose DO cancelKiloCliRun returns a conflict discriminated-union value. */
+  function envWithCancelConflict(message: string) {
+    return {
+      KILOCLAW_INSTANCE: {
+        idFromName: (id: string) => id,
+        get: () => ({ cancelKiloCliRun: () => Promise.resolve({ conflict: message }) }),
+      },
+      KILOCLAW_AE: { writeDataPoint: vi.fn() },
+      KV_CLAW_CACHE: {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        list: vi.fn().mockResolvedValue({ keys: [], list_complete: true }),
+        getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null }),
+      },
+    } as never;
+  }
+
+  it('returns 409 when the DO signals instance is not running', async () => {
+    const env = envWithCancelConflict('Instance is not running');
+
+    const resp = await platform.request(
+      '/kilo-cli-run/cancel',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: 'user-1' }),
+      },
+      env
+    );
+
+    expect(resp.status).toBe(409);
+    const body = await jsonBody(resp);
+    expect(body.error).toBe('Instance is not running');
   });
 });
 

--- a/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
+++ b/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
@@ -1,10 +1,20 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { KiloClawEnv } from '../types';
+import type { InstanceMutableState } from '../durable-objects/kiloclaw-instance/types';
+import {
+  cancelKiloCliRun,
+  startKiloCliRun,
+} from '../durable-objects/kiloclaw-instance/kilo-cli-run';
 import { platform } from './platform';
 
 vi.mock('cloudflare:workers', () => ({
   DurableObject: class {},
   waitUntil: (p: Promise<unknown>) => p,
 }));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 /** Minimal env whose DO stub rejects with the given error (simulates RPC boundary). */
 function envWithDOError(error: Error) {
@@ -32,6 +42,47 @@ function envWithDOError(error: Error) {
 
 async function jsonBody(res: Response): Promise<Record<string, unknown>> {
   return res.json();
+}
+
+type ControllerTestState = Pick<
+  InstanceMutableState,
+  | 'status'
+  | 'sandboxId'
+  | 'provider'
+  | 'providerState'
+  | 'flyAppName'
+  | 'flyMachineId'
+  | 'flyVolumeId'
+  | 'flyRegion'
+>;
+
+type ControllerTestEnv = Pick<KiloClawEnv, 'GATEWAY_TOKEN_SECRET' | 'FLY_APP_NAME' | 'WORKER_ENV'>;
+
+function runningFlyState(): ControllerTestState {
+  return {
+    status: 'running',
+    sandboxId: 'sandbox-1',
+    provider: 'fly',
+    flyAppName: 'app-1',
+    flyMachineId: 'machine-1',
+    flyVolumeId: 'volume-1',
+    flyRegion: 'iad',
+    providerState: {
+      provider: 'fly',
+      machineId: 'machine-1',
+      appName: 'app-1',
+      volumeId: 'volume-1',
+      region: 'iad',
+    },
+  };
+}
+
+function controllerEnv(): ControllerTestEnv {
+  return {
+    GATEWAY_TOKEN_SECRET: 'test-gateway-token-secret',
+    FLY_APP_NAME: 'app-1',
+    WORKER_ENV: 'development',
+  };
 }
 
 describe('sanitizeError: Instance-not-* status correction', () => {
@@ -98,12 +149,11 @@ describe('sanitizeError: Instance-not-* status correction', () => {
 });
 
 describe('kilo-cli-run/start: conflict response handling', () => {
-  /** Minimal env whose DO startKiloCliRun returns a conflict discriminated-union value. */
-  function envWithStartConflict(message: string) {
+  function envWithStartRun(startRun: () => Promise<unknown>) {
     return {
       KILOCLAW_INSTANCE: {
         idFromName: (id: string) => id,
-        get: () => ({ startKiloCliRun: () => Promise.resolve({ conflict: message }) }),
+        get: () => ({ startKiloCliRun: startRun }),
       },
       KILOCLAW_AE: { writeDataPoint: vi.fn() },
       KV_CLAW_CACHE: {
@@ -116,8 +166,28 @@ describe('kilo-cli-run/start: conflict response handling', () => {
     } as never;
   }
 
-  it('returns 409 when the DO signals a run is already in progress', async () => {
-    const env = envWithStartConflict('A Kilo CLI run is already in progress');
+  it('returns 409 when the DO-level start helper converts a controller 409 to conflict', async () => {
+    const state = runningFlyState();
+    const envForController = controllerEnv();
+    const startRun = () =>
+      startKiloCliRun(
+        state as InstanceMutableState,
+        envForController as KiloClawEnv,
+        'fix this'
+      ).then(response => response);
+    const env = envWithStartRun(startRun);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          code: 'kilo_cli_run_already_active',
+          error: 'A Kilo CLI run is already in progress',
+        }),
+        {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
 
     const resp = await platform.request(
       '/kilo-cli-run/start',
@@ -131,17 +201,44 @@ describe('kilo-cli-run/start: conflict response handling', () => {
 
     expect(resp.status).toBe(409);
     const body = await jsonBody(resp);
-    expect(body.error).toBe('A Kilo CLI run is already in progress');
+    expect(body).toMatchObject({
+      code: 'kilo_cli_run_already_active',
+      error: 'A Kilo CLI run is already in progress',
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://app-1.fly.dev/_kilo/cli-run/start',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ prompt: 'fix this' }) })
+    );
+  });
+
+  it('returns 502 when the DO returns a malformed start conflict', async () => {
+    const env = envWithStartRun(() => Promise.resolve({ conflict: { error: 'Conflict' } }));
+
+    const resp = await platform.request(
+      '/kilo-cli-run/start',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: 'user-1', prompt: 'fix this' }),
+      },
+      env
+    );
+
+    expect(resp.status).toBe(502);
+    const body = await jsonBody(resp);
+    expect(body).toMatchObject({
+      code: 'upstream_invalid_response',
+      error: 'Invalid Kilo CLI conflict response',
+    });
   });
 });
 
 describe('kilo-cli-run/cancel: conflict response handling', () => {
-  /** Minimal env whose DO cancelKiloCliRun returns a conflict discriminated-union value. */
-  function envWithCancelConflict(message: string) {
+  function envWithCancelRun(cancelRun: () => Promise<unknown>) {
     return {
       KILOCLAW_INSTANCE: {
         idFromName: (id: string) => id,
-        get: () => ({ cancelKiloCliRun: () => Promise.resolve({ conflict: message }) }),
+        get: () => ({ cancelKiloCliRun: cancelRun }),
       },
       KILOCLAW_AE: { writeDataPoint: vi.fn() },
       KV_CLAW_CACHE: {
@@ -154,8 +251,26 @@ describe('kilo-cli-run/cancel: conflict response handling', () => {
     } as never;
   }
 
-  it('returns 409 when the DO signals instance is not running', async () => {
-    const env = envWithCancelConflict('Instance is not running');
+  it('returns 409 when the DO-level cancel helper converts a controller 409 to conflict', async () => {
+    const state = runningFlyState();
+    const envForController = controllerEnv();
+    const cancelRun = () =>
+      cancelKiloCliRun(state as InstanceMutableState, envForController as KiloClawEnv).then(
+        response => response
+      );
+    const env = envWithCancelRun(cancelRun);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          code: 'kilo_cli_run_no_active_run',
+          error: 'No active run to cancel',
+        }),
+        {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
 
     const resp = await platform.request(
       '/kilo-cli-run/cancel',
@@ -169,7 +284,35 @@ describe('kilo-cli-run/cancel: conflict response handling', () => {
 
     expect(resp.status).toBe(409);
     const body = await jsonBody(resp);
-    expect(body.error).toBe('Instance is not running');
+    expect(body).toMatchObject({
+      code: 'kilo_cli_run_no_active_run',
+      error: 'No active run to cancel',
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://app-1.fly.dev/_kilo/cli-run/cancel',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('returns 502 when the DO returns a malformed cancel conflict', async () => {
+    const env = envWithCancelRun(() => Promise.resolve({ conflict: { error: 'Conflict' } }));
+
+    const resp = await platform.request(
+      '/kilo-cli-run/cancel',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: 'user-1' }),
+      },
+      env
+    );
+
+    expect(resp.status).toBe(502);
+    const body = await jsonBody(resp);
+    expect(body).toMatchObject({
+      code: 'upstream_invalid_response',
+      error: 'Invalid Kilo CLI conflict response',
+    });
   });
 });
 

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -1463,13 +1463,18 @@ platform.post('/kilo-cli-run/cancel', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
+    // The DO returns a discriminated union: success | { conflict }.
+    // See startKiloCliRun for the same pattern and the reason for .then(r => r).
     const response = await withResolvedDORetry(
       c.env,
       result.data.userId,
       iidResult.instanceId,
-      stub => stub.cancelKiloCliRun(),
+      stub => stub.cancelKiloCliRun().then(r => r),
       'cancelKiloCliRun'
     );
+    if ('conflict' in response) {
+      return jsonError(response.conflict, 409);
+    }
     return c.json(response, 200);
   } catch (err) {
     const { message, status } = sanitizeError(err, 'kilo-cli-run cancel');

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -64,6 +64,17 @@ const WebSearchConfigPatchSchema = z.object({
   exaMode: z.enum(['kilo-proxy', 'disabled']).nullable().optional(),
 });
 
+const KiloCliRunConflictSchema = z.object({
+  conflict: z.object({
+    code: z.enum([
+      'kilo_cli_run_instance_not_running',
+      'kilo_cli_run_already_active',
+      'kilo_cli_run_no_active_run',
+    ]),
+    error: z.string().min(1),
+  }),
+});
+
 const platform = new Hono<AppEnv>();
 type KiloClawInstanceStub = ReturnType<AppEnv['Bindings']['KILOCLAW_INSTANCE']['get']>;
 
@@ -337,6 +348,20 @@ function jsonError(message: string, status: number, code?: string): Response {
     status,
     headers: { 'content-type': 'application/json' },
   });
+}
+
+function kiloCliRunConflictResponse(response: unknown): Response | undefined {
+  const result = KiloCliRunConflictSchema.safeParse(response);
+  if (result.success) {
+    const { code, error } = result.data.conflict;
+    return jsonError(error, 409, code);
+  }
+
+  if (isRecord(response) && 'conflict' in response) {
+    return jsonError('Invalid Kilo CLI conflict response', 502, 'upstream_invalid_response');
+  }
+
+  return undefined;
 }
 
 /**
@@ -1423,9 +1448,8 @@ platform.post('/kilo-cli-run/start', async c => {
         'controller_route_unavailable'
       );
     }
-    if (isRecord(response) && typeof response.conflict === 'string') {
-      return jsonError(response.conflict, 409);
-    }
+    const conflictResponse = kiloCliRunConflictResponse(response);
+    if (conflictResponse) return conflictResponse;
     return c.json(response, 200);
   } catch (err) {
     const { message, status, code } = sanitizeOpenclawConfigError(err, 'kilo-cli-run start');
@@ -1472,9 +1496,8 @@ platform.post('/kilo-cli-run/cancel', async c => {
       stub => stub.cancelKiloCliRun().then(r => r),
       'cancelKiloCliRun'
     );
-    if (isRecord(response) && typeof response.conflict === 'string') {
-      return jsonError(response.conflict, 409);
-    }
+    const conflictResponse = kiloCliRunConflictResponse(response);
+    if (conflictResponse) return conflictResponse;
     return c.json(response, 200);
   } catch (err) {
     const { message, status } = sanitizeError(err, 'kilo-cli-run cancel');

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -387,7 +387,6 @@ const SAFE_ERROR_PREFIXES = [
   'Stream Chat sendMessage failed', // sendMessage HTTP errors
   'Stream Chat is not set up', // no Stream Chat on this instance
   'Provider ', // explicit not-implemented provider errors
-  'A Kilo CLI run is ', // e.g. "A Kilo CLI run is already in progress"
 ];
 
 function sanitizeError(err: unknown, operation: string): { message: string; status: number } {

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -1423,7 +1423,7 @@ platform.post('/kilo-cli-run/start', async c => {
         'controller_route_unavailable'
       );
     }
-    if ('conflict' in response) {
+    if (isRecord(response) && typeof response.conflict === 'string') {
       return jsonError(response.conflict, 409);
     }
     return c.json(response, 200);
@@ -1472,7 +1472,7 @@ platform.post('/kilo-cli-run/cancel', async c => {
       stub => stub.cancelKiloCliRun().then(r => r),
       'cancelKiloCliRun'
     );
-    if ('conflict' in response) {
+    if (isRecord(response) && typeof response.conflict === 'string') {
       return jsonError(response.conflict, 409);
     }
     return c.json(response, 200);

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -303,15 +303,31 @@ async function requireProviderCapability(
   return jsonError(`${operation} is not supported for provider ${metadata.provider}`, 400);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isHttpStatus(value: unknown): value is { status: number } {
+  return isRecord(value) && typeof value.status === 'number';
+}
+
+function hasStringCode(value: unknown): value is { code: string } {
+  return isRecord(value) && typeof value.code === 'string';
+}
+
+/** Extract a string `code` from an error or its `.cause`, if present. */
+function getErrorCode(err: unknown): string | undefined {
+  if (hasStringCode(err)) return err.code;
+  if (err instanceof Error && hasStringCode(err.cause)) return err.cause.code;
+  return undefined;
+}
+
 function statusCodeFromError(err: unknown): number {
-  if (
-    typeof err === 'object' &&
-    err !== null &&
-    'status' in err &&
-    typeof (err as { status: unknown }).status === 'number'
-  ) {
-    const status = (err as { status: number }).status;
-    if (status >= 400 && status < 600) return status;
+  // Extract a valid HTTP status from the error or its cause, defaulting to 500.
+  for (const candidate of [err, err instanceof Error ? err.cause : undefined]) {
+    if (isHttpStatus(candidate) && candidate.status >= 400 && candidate.status < 600) {
+      return candidate.status;
+    }
   }
   return 500;
 }
@@ -346,6 +362,7 @@ const SAFE_ERROR_PREFIXES = [
   'Stream Chat sendMessage failed', // sendMessage HTTP errors
   'Stream Chat is not set up', // no Stream Chat on this instance
   'Provider ', // explicit not-implemented provider errors
+  'A Kilo CLI run is ', // e.g. "A Kilo CLI run is already in progress"
 ];
 
 function sanitizeError(err: unknown, operation: string): { message: string; status: number } {
@@ -400,13 +417,7 @@ function sanitizeOpenclawConfigError(
   const raw = err instanceof Error ? err.message : 'Unknown error';
   const status = statusCodeFromError(err);
   const normalized = raw.replace(/^(?:[A-Za-z]+Error:\s*)+/, '');
-  const code =
-    typeof err === 'object' &&
-    err !== null &&
-    'code' in err &&
-    typeof (err as { code?: unknown }).code === 'string'
-      ? (err as { code: string }).code
-      : undefined;
+  const code = getErrorCode(err);
 
   console.error(`[platform] ${operation} failed:`, raw);
 
@@ -1394,11 +1405,15 @@ platform.post('/kilo-cli-run/start', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
+    // The DO returns a discriminated union: success | { conflict } | null.
+    // CF Workers' RPC type wrapping turns this into `Promise<A> | Promise<B>`
+    // instead of `Promise<A | B>`, which breaks narrowing. The `.then(r => r)`
+    // collapses the RPC wrapper back to a plain Promise union.
     const response = await withResolvedDORetry(
       c.env,
       result.data.userId,
       iidResult.instanceId,
-      stub => stub.startKiloCliRun(result.data.prompt),
+      stub => stub.startKiloCliRun(result.data.prompt).then(r => r),
       'startKiloCliRun'
     );
     if (!response) {
@@ -1407,6 +1422,9 @@ platform.post('/kilo-cli-run/start', async c => {
         404,
         'controller_route_unavailable'
       );
+    }
+    if ('conflict' in response) {
+      return jsonError(response.conflict, 409);
     }
     return c.json(response, 200);
   } catch (err) {


### PR DESCRIPTION
## Summary

Kilo CLI run conflicts were surfacing as generic failures because expected 409s lost their status/code while crossing the Durable Object RPC boundary. This PR preserves those conflicts end-to-end, prevents concurrent recovery runs from racing on the controller, and deduplicates cancel/status logic into shared helpers.

<details><summary>Details</summary>
<p>

- Return a serializable `{ conflict: { code, error } }` shape from the DO for expected CLI run conflicts, then map it back to HTTP 409 and tRPC CONFLICT in the platform, personal, org, and admin paths.
- Serialize controller start requests via a promise queue (`runStartExclusive`) so only one recovery run can start on a machine at a time.
- Change the controller cancel endpoint from 404 to 409 with a structured `{ code, error }` response when there is no active run, matching the start conflict shape.
- Translate controller 409 on cancel to `{ ok: false }` in the shared `cancelCliRun` helper so late-arriving cancels don't surface as unhandled errors.
- Reconcile stale running DB rows when cancel discovers the controller has no active run (marks them `failed` with a descriptive output message).
- Extract duplicated `getKiloCliRunStatus` and `cancelKiloCliRun` DB + controller polling logic from the personal and org routers into shared helpers in `cli-runs.ts`.
- Add `controller_route_unavailable` → `PRECONDITION_FAILED` handling to the org router's `startKiloCliRun` (previously only in the personal router).
- Add test coverage across the controller, DO, platform, and tRPC boundaries using the same conflict shapes production sees.

</p>
</details> 



## Verification

<details><summary>Details</summary>
<p>

- [x] `pnpm typecheck` — passes
- [x] `pnpm format` — applied
- [x] `pnpm test -- apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts` — all pass
- [x] `pnpm test -- apps/web/src/routers/admin-kiloclaw-instances-router.test.ts` — all pass
- [x] `pnpm test -- apps/web/src/lib/kiloclaw/cli-runs.test.ts` — all pass
- [x] `pnpm test -- services/kiloclaw/controller/src/routes/kilo-cli-run.test.ts` — all pass (via `pnpm --filter kiloclaw-controller test`)
- [x] `pnpm test -- services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts` — all pass
- [x] `pnpm test -- services/kiloclaw/src/routes/platform-sanitize-error.test.ts` — all pass

</p>
</details> 


## Visual Changes

N/A

## Reviewer Notes

- The DO returns conflicts as values instead of throwing because Cloudflare RPC strips custom error properties. Only `.message` survives across the boundary. 
  - The platform route validates the conflict shape with `KiloCliRunConflictSchema` and returns 502 if the shape is malformed.
- Start and cancel intentionally keep different fallback conflict codes. This preserves operation-specific meaning even when older controllers return 409 without a structured code field.
  - `kilo_cli_run_already_active` for start
  - `kilo_cli_run_no_active_run` for cancel. 
- The controller's cancel endpoint changed from 404 to 409 (the resource exists, it's just in the wrong state for the operation). The web app's `cancelCliRun` helper catches this 409 and translates it to `{ ok: false }` so the caller can retry or poll.
- Cancel/status logic was previously duplicated across `kiloclaw-router.ts` and `organization-kiloclaw-router.ts`. Both now delegate to the shared `cancelCliRun` / `getCliRunStatus` helpers in `cli-runs.ts`, which also handle the new conflict translation.