### PR TITLE
fix(cloud-agent-next): enforce timeouts on all sandbox exec calls

### DIFF
--- a/services/cloud-agent-next/src/execution/orchestrator.ts
+++ b/services/cloud-agent-next/src/execution/orchestrator.ts
@@ -18,11 +18,30 @@ import type { ExecutionPlan, ExecutionResult } from './types.js';
 import { ExecutionError } from './errors.js';
 import { SessionService, type PreparedSession } from '../session-service.js';
 import { logger } from '../logger.js';
+import { logSandboxOperationTimeout } from '../sandbox-timeout-logging.js';
 import { updateGitRemoteToken } from '../workspace.js';
 import { WrapperClient, type WrapperPromptOptions } from '../kilo/wrapper-client.js';
 import { withDORetry } from '../utils/do-retry.js';
 import { normalizeAgentMode } from '../schema.js';
 import { buildImagePromptParts, downloadImagePromptParts } from './image-prompt-parts.js';
+import { withTimeout } from '@kilocode/worker-utils';
+
+/** Maximum time allowed for workspace preparation (resume, init, fast path). */
+const PREPARE_WORKSPACE_TIMEOUT_MS = 5 * 60 * 1000;
+
+function withWorkspacePreparationTimeout<T>(operation: Promise<T>, step: string): Promise<T> {
+  return withTimeout(
+    operation,
+    PREPARE_WORKSPACE_TIMEOUT_MS,
+    `Workspace preparation timed out during ${step} after ${PREPARE_WORKSPACE_TIMEOUT_MS / 1000}s`,
+    () =>
+      logSandboxOperationTimeout({
+        operation: `workspace.prepare:${step}`,
+        timeoutMs: PREPARE_WORKSPACE_TIMEOUT_MS,
+        timeoutLayer: 'outer',
+      })
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -220,19 +239,22 @@ export class ExecutionOrchestrator {
           throw new Error('Missing kilocodeToken in resume context');
         }
 
-        return await this.sessionService.resume({
-          sandbox,
-          sandboxId: workspace.sandboxId as ServiceSandboxId,
-          orgId,
-          userId,
-          sessionId: sessionId as ServiceSessionId,
-          kilocodeToken: resumeContext.kilocodeToken,
-          kilocodeModel: resumeContext.kilocodeModel ?? 'default',
-          env: this.deps.env,
-          githubToken: resumeContext.githubToken,
-          gitToken: resumeContext.gitToken,
-          onProgress,
-        });
+        return await withWorkspacePreparationTimeout(
+          this.sessionService.resume({
+            sandbox,
+            sandboxId: workspace.sandboxId as ServiceSandboxId,
+            orgId,
+            userId,
+            sessionId: sessionId as ServiceSessionId,
+            kilocodeToken: resumeContext.kilocodeToken,
+            kilocodeModel: resumeContext.kilocodeModel ?? 'default',
+            env: this.deps.env,
+            githubToken: resumeContext.githubToken,
+            gitToken: resumeContext.gitToken,
+            onProgress,
+          }),
+          'resume'
+        );
       }
 
       const initContext = workspace.initContext;
@@ -271,16 +293,19 @@ export class ExecutionOrchestrator {
           envVars: initContext.envVars,
         };
 
-        const session = await this.sessionService.getOrCreateSession(
-          sandbox,
-          context,
-          this.deps.env,
-          initContext.kilocodeToken,
-          initContext.kilocodeModel ?? 'default',
-          orgId,
-          initContext.encryptedSecrets,
-          initContext.createdOnPlatform,
-          existingMetadata.appendSystemPrompt
+        const session = await withWorkspacePreparationTimeout(
+          this.sessionService.getOrCreateSession(
+            sandbox,
+            context,
+            this.deps.env,
+            initContext.kilocodeToken,
+            initContext.kilocodeModel ?? 'default',
+            orgId,
+            initContext.encryptedSecrets,
+            initContext.createdOnPlatform,
+            existingMetadata.appendSystemPrompt
+          ),
+          'prepared session creation'
         );
 
         return {
@@ -307,7 +332,35 @@ export class ExecutionOrchestrator {
           throw new Error('Prepared session is missing kiloSessionId');
         }
 
-        return await this.sessionService.initiateFromKiloSessionWithRetry({
+        return await withWorkspacePreparationTimeout(
+          this.sessionService.initiateFromKiloSessionWithRetry({
+            getSandbox: () => this.deps.getSandbox(workspace.sandboxId ?? ''),
+            sandboxId: (workspace.sandboxId ?? '') as ServiceSandboxId,
+            orgId,
+            userId,
+            sessionId: sessionId as ServiceSessionId,
+            kilocodeToken: initContext.kilocodeToken,
+            kilocodeModel: initContext.kilocodeModel ?? 'default',
+            kiloSessionId: initContext.kiloSessionId,
+            env: this.deps.env,
+            envVars: initContext.envVars,
+            encryptedSecrets: initContext.encryptedSecrets,
+            setupCommands: initContext.setupCommands,
+            mcpServers: initContext.mcpServers,
+            botId: initContext.botId,
+            githubAppType: initContext.githubAppType,
+            createdOnPlatform: initContext.createdOnPlatform,
+            // Note: existingMetadata requires CloudAgentSessionState, not our simplified type
+            ...gitSource,
+          }),
+          'legacy prepared session initialization'
+        );
+      }
+
+      // Brand new session
+      logger.info('Initializing new session');
+      return await withWorkspacePreparationTimeout(
+        this.sessionService.initiateWithRetry({
           getSandbox: () => this.deps.getSandbox(workspace.sandboxId ?? ''),
           sandboxId: (workspace.sandboxId ?? '') as ServiceSandboxId,
           orgId,
@@ -315,45 +368,23 @@ export class ExecutionOrchestrator {
           sessionId: sessionId as ServiceSessionId,
           kilocodeToken: initContext.kilocodeToken,
           kilocodeModel: initContext.kilocodeModel ?? 'default',
-          kiloSessionId: initContext.kiloSessionId,
+          githubRepo: initContext.githubRepo,
+          githubToken: initContext.githubToken,
+          gitUrl: initContext.gitUrl,
+          gitToken: initContext.gitToken,
           env: this.deps.env,
           envVars: initContext.envVars,
           encryptedSecrets: initContext.encryptedSecrets,
           setupCommands: initContext.setupCommands,
           mcpServers: initContext.mcpServers,
+          upstreamBranch: initContext.upstreamBranch,
           botId: initContext.botId,
           githubAppType: initContext.githubAppType,
+          platform: initContext.platform,
           createdOnPlatform: initContext.createdOnPlatform,
-          // Note: existingMetadata requires CloudAgentSessionState, not our simplified type
-          ...gitSource,
-        });
-      }
-
-      // Brand new session
-      logger.info('Initializing new session');
-      return await this.sessionService.initiateWithRetry({
-        getSandbox: () => this.deps.getSandbox(workspace.sandboxId ?? ''),
-        sandboxId: (workspace.sandboxId ?? '') as ServiceSandboxId,
-        orgId,
-        userId,
-        sessionId: sessionId as ServiceSessionId,
-        kilocodeToken: initContext.kilocodeToken,
-        kilocodeModel: initContext.kilocodeModel ?? 'default',
-        githubRepo: initContext.githubRepo,
-        githubToken: initContext.githubToken,
-        gitUrl: initContext.gitUrl,
-        gitToken: initContext.gitToken,
-        env: this.deps.env,
-        envVars: initContext.envVars,
-        encryptedSecrets: initContext.encryptedSecrets,
-        setupCommands: initContext.setupCommands,
-        mcpServers: initContext.mcpServers,
-        upstreamBranch: initContext.upstreamBranch,
-        botId: initContext.botId,
-        githubAppType: initContext.githubAppType,
-        platform: initContext.platform,
-        createdOnPlatform: initContext.createdOnPlatform,
-      });
+        }),
+        'new session initialization'
+      );
     } catch (error) {
       if (error instanceof ExecutionError) throw error;
       throw ExecutionError.workspaceSetupFailed(

--- a/services/cloud-agent-next/src/execution/orchestrator.ts
+++ b/services/cloud-agent-next/src/execution/orchestrator.ts
@@ -27,7 +27,7 @@ import { buildImagePromptParts, downloadImagePromptParts } from './image-prompt-
 import { withTimeout } from '@kilocode/worker-utils';
 
 /** Maximum time allowed for workspace preparation (resume, init, fast path). */
-const PREPARE_WORKSPACE_TIMEOUT_MS = 5 * 60 * 1000;
+const PREPARE_WORKSPACE_TIMEOUT_MS = 10 * 60 * 1000;
 
 function withWorkspacePreparationTimeout<T>(operation: Promise<T>, step: string): Promise<T> {
   return withTimeout(

--- a/services/cloud-agent-next/src/logger.ts
+++ b/services/cloud-agent-next/src/logger.ts
@@ -25,6 +25,9 @@ export type CloudAgentTags = {
 
   // Source tracking (auto-added by decorators)
   source?: string;
+
+  // Stable searchable log tag for cross-cutting events
+  logTag?: string;
 };
 
 /**

--- a/services/cloud-agent-next/src/sandbox-timeout-logging.test.ts
+++ b/services/cloud-agent-next/src/sandbox-timeout-logging.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { mockWarn, mockWithFields, mockWithTags } = vi.hoisted(() => {
+  const warn = vi.fn();
+  const withFields = vi.fn(() => ({ warn }));
+  const withTags = vi.fn(() => ({ withFields }));
+  return { mockWarn: warn, mockWithFields: withFields, mockWithTags: withTags };
+});
+
+vi.mock('./logger.js', () => ({
+  logger: {
+    withTags: mockWithTags,
+  },
+}));
+
+import {
+  isSandboxOperationTimeoutError,
+  logSandboxOperationTimeout,
+  withSandboxOperationTimeoutLog,
+} from './sandbox-timeout-logging.js';
+
+describe('sandbox timeout logging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('classifies known sandbox timeout messages conservatively', () => {
+    expect(isSandboxOperationTimeoutError(new Error('Command timeout after 30000ms'))).toBe(true);
+    expect(isSandboxOperationTimeoutError(new Error('Git clone timed out after 120000ms'))).toBe(
+      true
+    );
+    expect(isSandboxOperationTimeoutError(new Error('Request timeout after 60000ms'))).toBe(true);
+    expect(isSandboxOperationTimeoutError(new Error('Stream idle timeout after 10000ms'))).toBe(
+      true
+    );
+    expect(
+      isSandboxOperationTimeoutError(new Error('Process did not become ready within 30s'))
+    ).toBe(true);
+    expect(isSandboxOperationTimeoutError(new Error('Operation was aborted'))).toBe(false);
+    expect(isSandboxOperationTimeoutError(new Error('authentication failed'))).toBe(false);
+  });
+
+  it('logs and rethrows timeout errors unchanged', async () => {
+    const error = new Error('Command timeout after 30000ms');
+
+    await expect(
+      withSandboxOperationTimeoutLog(Promise.reject(error), {
+        operation: 'session.runSetupCommand',
+        timeoutMs: 30000,
+        timeoutLayer: 'exec',
+      })
+    ).rejects.toBe(error);
+
+    expect(mockWithTags).toHaveBeenCalledWith({ logTag: 'sandbox-operation-timeout' });
+    expect(mockWithFields).toHaveBeenCalledWith({
+      operation: 'session.runSetupCommand',
+      timeoutMs: 30000,
+      timeoutLayer: 'exec',
+      error: 'Command timeout after 30000ms',
+    });
+    expect(mockWarn).toHaveBeenCalledWith('Sandbox operation timed out');
+  });
+
+  it('logs outer timeouts directly without requiring an error', () => {
+    logSandboxOperationTimeout({
+      operation: 'workspace.prepare:resume',
+      timeoutMs: 300000,
+      timeoutLayer: 'outer',
+    });
+
+    expect(mockWithFields).toHaveBeenCalledWith({
+      operation: 'workspace.prepare:resume',
+      timeoutMs: 300000,
+      timeoutLayer: 'outer',
+    });
+    expect(mockWarn).toHaveBeenCalledWith('Sandbox operation timed out');
+  });
+});

--- a/services/cloud-agent-next/src/sandbox-timeout-logging.ts
+++ b/services/cloud-agent-next/src/sandbox-timeout-logging.ts
@@ -7,8 +7,8 @@ export const FAST_SANDBOX_COMMAND_TIMEOUT_MS = 30_000;
 /** Timeout for git network operations (fetch, pull, push). */
 export const GIT_COMMAND_TIMEOUT_MS = 120_000;
 
-/** Timeout for git clone via SDK. */
-export const GIT_CLONE_TIMEOUT_MS = 120_000;
+/** Timeout for git clone via SDK (large repos need headroom). */
+export const GIT_CLONE_TIMEOUT_MS = 5 * 60 * 1000;
 
 /** Timeout for disk-space checks. */
 export const DISK_CHECK_TIMEOUT_MS = 10_000;
@@ -34,37 +34,11 @@ export function isSandboxOperationTimeoutError(error: unknown): boolean {
     return false;
   }
 
-  const message = error.message;
-  if (message.includes('Operation was aborted')) {
-    return false;
-  }
-
-  if (message.includes('Command timeout after ')) {
-    return true;
-  }
-  if (message.includes('Git clone timed out after ')) {
-    return true;
-  }
-  if (message.includes('Request timeout after ')) {
-    return true;
-  }
-  if (message.includes('Stream idle timeout after ')) {
-    return true;
-  }
-  if (message.includes('WebSocket connection timeout after ')) {
-    return true;
-  }
-  if (message.includes('Process did not become ready within ')) {
-    return true;
-  }
-  if (message.includes('Operation timed out')) {
-    return true;
-  }
-  if (message.includes('timed out after ')) {
-    return true;
-  }
-
-  return false;
+  const msg = error.message;
+  if (msg.includes('Operation was aborted')) return false;
+  return (
+    msg.includes('timeout') || msg.includes('timed out') || msg.includes('did not become ready')
+  );
 }
 
 export function logSandboxOperationTimeout(

--- a/services/cloud-agent-next/src/sandbox-timeout-logging.ts
+++ b/services/cloud-agent-next/src/sandbox-timeout-logging.ts
@@ -1,0 +1,128 @@
+import type { ExecResult, ExecOptions } from '@cloudflare/sandbox';
+import { logger, type CloudAgentTags } from './logger.js';
+
+/** Timeout for lightweight sandbox commands (mkdir, stat, git config, etc.) */
+export const FAST_SANDBOX_COMMAND_TIMEOUT_MS = 30_000;
+
+/** Timeout for git network operations (fetch, pull, push). */
+export const GIT_COMMAND_TIMEOUT_MS = 120_000;
+
+/** Timeout for git clone via SDK. */
+export const GIT_CLONE_TIMEOUT_MS = 120_000;
+
+/** Timeout for disk-space checks. */
+export const DISK_CHECK_TIMEOUT_MS = 10_000;
+
+export type SandboxOperationTimeoutLayer = 'sdk' | 'outer' | 'exec';
+
+export type SandboxOperationTimeoutLogContext = {
+  operation: string;
+  timeoutMs: number;
+  timeoutLayer: SandboxOperationTimeoutLayer;
+  tags?: CloudAgentTags;
+};
+
+const SANDBOX_TIMEOUT_LOG_TAG = 'sandbox-operation-timeout';
+const SANDBOX_TIMEOUT_LOG_MESSAGE = 'Sandbox operation timed out';
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function isSandboxOperationTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message;
+  if (message.includes('Operation was aborted')) {
+    return false;
+  }
+
+  if (message.includes('Command timeout after ')) {
+    return true;
+  }
+  if (message.includes('Git clone timed out after ')) {
+    return true;
+  }
+  if (message.includes('Request timeout after ')) {
+    return true;
+  }
+  if (message.includes('Stream idle timeout after ')) {
+    return true;
+  }
+  if (message.includes('WebSocket connection timeout after ')) {
+    return true;
+  }
+  if (message.includes('Process did not become ready within ')) {
+    return true;
+  }
+  if (message.includes('Operation timed out')) {
+    return true;
+  }
+  if (message.includes('timed out after ')) {
+    return true;
+  }
+
+  return false;
+}
+
+export function logSandboxOperationTimeout(
+  context: SandboxOperationTimeoutLogContext,
+  error?: unknown
+): void {
+  logger
+    .withTags({ logTag: SANDBOX_TIMEOUT_LOG_TAG, ...context.tags })
+    .withFields({
+      operation: context.operation,
+      timeoutMs: context.timeoutMs,
+      timeoutLayer: context.timeoutLayer,
+      ...(error !== undefined && { error: getErrorMessage(error) }),
+    })
+    .warn(SANDBOX_TIMEOUT_LOG_MESSAGE);
+}
+
+export async function withSandboxOperationTimeoutLog<T>(
+  operation: Promise<T>,
+  context: SandboxOperationTimeoutLogContext
+): Promise<T> {
+  try {
+    return await operation;
+  } catch (error) {
+    if (isSandboxOperationTimeoutError(error)) {
+      logSandboxOperationTimeout(context, error);
+    }
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// timedExec – single-line wrapper that adds a timeout to exec + logs on timeout
+// ---------------------------------------------------------------------------
+
+type Executable = {
+  exec(command: string, options?: ExecOptions): Promise<ExecResult>;
+};
+
+/**
+ * Run a command with an explicit timeout and structured timeout logging.
+ * Defaults to {@link FAST_SANDBOX_COMMAND_TIMEOUT_MS} when `timeoutMs` is omitted.
+ */
+export function timedExec(
+  executor: Executable,
+  command: string,
+  operation: string,
+  options?: {
+    timeoutMs?: number;
+    cwd?: string;
+  }
+): Promise<ExecResult> {
+  const timeoutMs = options?.timeoutMs ?? FAST_SANDBOX_COMMAND_TIMEOUT_MS;
+  return withSandboxOperationTimeoutLog(
+    executor.exec(command, {
+      timeout: timeoutMs,
+      ...(options?.cwd !== undefined && { cwd: options.cwd }),
+    }),
+    { operation, timeoutMs, timeoutLayer: 'exec' }
+  );
+}

--- a/services/cloud-agent-next/src/sandbox-timeout-logging.ts
+++ b/services/cloud-agent-next/src/sandbox-timeout-logging.ts
@@ -7,8 +7,8 @@ export const FAST_SANDBOX_COMMAND_TIMEOUT_MS = 30_000;
 /** Timeout for git network operations (fetch, pull, push). */
 export const GIT_COMMAND_TIMEOUT_MS = 120_000;
 
-/** Timeout for git clone via SDK (large repos need headroom). */
-export const GIT_CLONE_TIMEOUT_MS = 5 * 60 * 1000;
+/** Timeout for git clone via SDK. */
+export const GIT_CLONE_TIMEOUT_MS = 2 * 60 * 1000;
 
 /** Timeout for disk-space checks. */
 export const DISK_CHECK_TIMEOUT_MS = 10_000;

--- a/services/cloud-agent-next/src/session-service.test.ts
+++ b/services/cloud-agent-next/src/session-service.test.ts
@@ -4,6 +4,32 @@ vi.mock('@cloudflare/sandbox', () => ({
   getSandbox: vi.fn(),
 }));
 
+const { mockTimeoutWarn, mockTimeoutWithFields, mockTimeoutWithTags } = vi.hoisted(() => {
+  const warn = vi.fn();
+  const loggerChain = { warn, info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  const withFields = vi.fn(() => loggerChain);
+  const withTags = vi.fn(() => ({ ...loggerChain, withFields }));
+  return {
+    mockTimeoutWarn: warn,
+    mockTimeoutWithFields: withFields,
+    mockTimeoutWithTags: withTags,
+  };
+});
+
+vi.mock('./logger.js', () => ({
+  logger: {
+    setTags: vi.fn(),
+    withTags: mockTimeoutWithTags,
+    withFields: vi.fn(() => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() })),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+  WithLogTags: () => (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+}));
+
 vi.mock('./workspace.js', () => {
   const setupWorkspace = vi.fn();
   const cloneGitHubRepo = vi.fn();
@@ -28,6 +54,8 @@ vi.mock('./workspace.js', () => {
     getKilocodeCliDir: (sessionHome: string) => `${sessionHome}/.kilocode/cli`,
     getKilocodeTasksDir: (sessionHome: string) => `${sessionHome}/.kilocode/cli/global/tasks`,
     getKilocodeLogsDir: (sessionHome: string) => `${sessionHome}/.kilocode/cli/logs`,
+    FAST_SANDBOX_COMMAND_TIMEOUT_MS: 30000,
+    GIT_COMMAND_TIMEOUT_MS: 120000,
   };
 });
 
@@ -45,6 +73,9 @@ import type { PersistenceEnv, CloudAgentSessionState } from './persistence/types
 describe('SessionService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockTimeoutWarn.mockClear();
+    mockTimeoutWithFields.mockClear();
+    mockTimeoutWithTags.mockClear();
     (mockEnv.SESSION_INGEST as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch = vi
       .fn()
       .mockResolvedValue(new Response(JSON.stringify({ info: {}, messages: [] })));
@@ -169,7 +200,8 @@ describe('SessionService', () => {
       expect(mockManageBranch).not.toHaveBeenCalled();
       // Instead, session.exec should be called with git checkout -b
       expect(fakeSession.exec).toHaveBeenCalledWith(
-        expect.stringContaining(`git checkout -b 'session/${sessionId}'`)
+        expect.stringContaining(`git checkout -b 'session/${sessionId}'`),
+        expect.any(Object)
       );
       expect(result.context.sessionId).toBe(sessionId);
     });
@@ -393,6 +425,46 @@ describe('SessionService', () => {
       // Verify context includes repo info
       expect(result.context.githubRepo).toBe('facebook/react');
       expect(result.context.githubToken).toBe('test-token');
+    });
+
+    it('logs timeout during resume repo existence check', async () => {
+      const fakeSession = {
+        exec: vi.fn().mockRejectedValueOnce(new Error('Command timeout after 30000ms')),
+        gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        deleteFile: vi.fn().mockResolvedValue(undefined),
+      };
+      const sandbox = {
+        createSession: vi.fn().mockResolvedValue(fakeSession),
+        mkdir: vi.fn().mockResolvedValue(undefined),
+        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SandboxInstance;
+
+      const service = new SessionService();
+      await expect(
+        service.resume({
+          sandbox,
+          sandboxId: `${orgId}__${userId}`,
+          orgId,
+          userId,
+          sessionId,
+          kilocodeToken: 'test-token',
+          kilocodeModel: 'test-model',
+          env: mockEnv,
+        })
+      ).rejects.toThrow('Command timeout after 30000ms');
+
+      expect(mockTimeoutWithTags).toHaveBeenCalledWith({ logTag: 'sandbox-operation-timeout' });
+      expect(mockTimeoutWithFields).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'session.resume.repoExists',
+          timeoutMs: 30000,
+          timeoutLayer: 'exec',
+          error: 'Command timeout after 30000ms',
+        })
+      );
+      expect(mockTimeoutWarn).toHaveBeenCalledWith('Sandbox operation timed out');
     });
 
     it('should use fresh githubToken from request instead of stale metadata token during reclone', async () => {
@@ -1886,7 +1958,10 @@ describe('SessionService', () => {
 
       // exec should only be called once for git checkout -b, not for setup commands
       expect(fakeSession.exec).toHaveBeenCalledTimes(1);
-      expect(fakeSession.exec).toHaveBeenCalledWith(expect.stringContaining('git checkout -b'));
+      expect(fakeSession.exec).toHaveBeenCalledWith(
+        expect.stringContaining('git checkout -b'),
+        expect.any(Object)
+      );
     });
   });
 
@@ -3502,7 +3577,8 @@ describe('SessionService', () => {
 
       // git checkout -b SHOULD be called to create session branch
       expect(fakeSession.exec).toHaveBeenCalledWith(
-        expect.stringContaining(`git checkout -b 'session/${sessionId}'`)
+        expect.stringContaining(`git checkout -b 'session/${sessionId}'`),
+        expect.any(Object)
       );
     });
 

--- a/services/cloud-agent-next/src/session-service.ts
+++ b/services/cloud-agent-next/src/session-service.ts
@@ -16,11 +16,13 @@ import {
   cleanupWorkspace,
   getSessionHomePath,
   getSessionWorkspacePath,
+  GIT_COMMAND_TIMEOUT_MS,
   manageBranch,
   restoreWorkspace,
   setupWorkspace,
 } from './workspace.js';
 import { logger, WithLogTags } from './logger.js';
+import { timedExec } from './sandbox-timeout-logging.js';
 import type {
   PersistenceEnv,
   CloudAgentSessionState,
@@ -287,9 +289,9 @@ export async function runSetupCommands(
   for (const command of setupCommands) {
     try {
       // Run command in workspace directory
-      const result = await session.exec(command, {
+      const result = await timedExec(session, command, 'session.runSetupCommand', {
+        timeoutMs: SETUP_COMMAND_TIMEOUT_SECONDS * 1000,
         cwd: context.workspacePath,
-        timeout: SETUP_COMMAND_TIMEOUT_SECONDS * 1000, // Convert to milliseconds
       });
 
       if (result.exitCode !== 0) {
@@ -342,7 +344,7 @@ export async function writeAuthFile(
   const authDir = `${sessionHome}/.local/share/kilo`;
   const authPath = `${authDir}/auth.json`;
 
-  await sandbox.exec(`mkdir -p ${authDir}`);
+  await timedExec(sandbox, `mkdir -p ${authDir}`, 'session.writeAuthFile.mkdir');
 
   const authContent = JSON.stringify({ kilo: { type: 'api', key: kilocodeToken } }, null, 2);
   await sandbox.writeFile(authPath, authContent);
@@ -361,7 +363,7 @@ export async function writeGlobalRules(
   const rulesDir = `${sessionHome}/.kilocode/rules`;
   const rulesPath = `${rulesDir}/cloud-agent.md`;
 
-  await sandbox.exec(`mkdir -p ${rulesDir}`);
+  await timedExec(sandbox, `mkdir -p ${rulesDir}`, 'session.writeGlobalRules.mkdir');
 
   const content = [
     '# Cloud Agent Environment',
@@ -906,8 +908,10 @@ export class SessionService {
     } else {
       // For session branches on initiate, create directly (can't exist remotely with UUID-based name)
       logger.withTags({ branchName: context.branchName }).info('Creating session branch');
-      const result = await session.exec(
-        `cd ${context.workspacePath} && git checkout -b '${context.branchName}'`
+      const result = await timedExec(
+        session,
+        `cd ${context.workspacePath} && git checkout -b '${context.branchName}'`,
+        'session.initiate.createBranch'
       );
       if (result.exitCode !== 0) {
         throw new Error(
@@ -1080,8 +1084,10 @@ export class SessionService {
       } else {
         // For session branches on initiate, create directly (can't exist remotely with UUID-based name)
         logger.withTags({ branchName: context.branchName }).info('Creating session branch');
-        const result = await session.exec(
-          `cd ${context.workspacePath} && git checkout -b '${context.branchName}'`
+        const result = await timedExec(
+          session,
+          `cd ${context.workspacePath} && git checkout -b '${context.branchName}'`,
+          'session.initiateFromKiloSession.createBranch'
         );
         if (result.exitCode !== 0) {
           throw new Error(
@@ -1231,7 +1237,11 @@ export class SessionService {
     );
 
     // Check if workspace repo exists - if not, we may need to reclone
-    const repoCheck = await session.exec(`test -d ${workspacePath}/.git && echo exists`);
+    const repoCheck = await timedExec(
+      session,
+      `test -d ${workspacePath}/.git && echo exists`,
+      'session.resume.repoExists'
+    );
     const repoExists = repoCheck.stdout?.includes('exists') ?? false;
     const isColdStart = !repoExists;
 
@@ -1325,9 +1335,11 @@ export class SessionService {
 
       const escapedId = metadata.kiloSessionId.replaceAll("'", "'\\''");
       const escapedWorkspace = context.workspacePath.replaceAll("'", "'\\''");
-      const restoreResult = await session.exec(
+      const restoreResult = await timedExec(
+        session,
         `bun /usr/local/bin/kilo-restore-session.js '${escapedId}' '${escapedWorkspace}'`,
-        { cwd: dirname(context.workspacePath) }
+        'session.coldStart.restore',
+        { timeoutMs: GIT_COMMAND_TIMEOUT_MS, cwd: dirname(context.workspacePath) }
       );
 
       if (restoreResult.exitCode !== 0) {

--- a/services/cloud-agent-next/src/workspace.test.ts
+++ b/services/cloud-agent-next/src/workspace.test.ts
@@ -1,4 +1,30 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { mockTimeoutWarn, mockTimeoutWithFields, mockTimeoutWithTags } = vi.hoisted(() => {
+  const warn = vi.fn();
+  const loggerChain = { warn, info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  const withFields = vi.fn(() => loggerChain);
+  const withTags = vi.fn(() => ({ ...loggerChain, withFields }));
+  return {
+    mockTimeoutWarn: warn,
+    mockTimeoutWithFields: withFields,
+    mockTimeoutWithTags: withTags,
+  };
+});
+
+vi.mock('./logger.js', () => ({
+  logger: {
+    setTags: vi.fn(),
+    withTags: mockTimeoutWithTags,
+    withFields: vi.fn(() => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() })),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+  WithLogTags: () => (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+}));
 import {
   manageBranch,
   cloneGitHubRepo,
@@ -283,6 +309,9 @@ describe('disk space checking', () => {
   let mockGitCheckout: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    mockTimeoutWarn.mockClear();
+    mockTimeoutWithFields.mockClear();
+    mockTimeoutWithTags.mockClear();
     mockExec = vi.fn();
     mockGitCheckout = vi.fn();
     fakeSession = {
@@ -519,6 +548,25 @@ describe('disk space checking', () => {
         expect.any(Object)
       );
     });
+
+    it('logs sdk timeout when gitCheckout rejects with clone timeout', async () => {
+      mockGitCheckout.mockRejectedValueOnce(new Error('Git clone timed out after 120000ms'));
+
+      await expect(
+        cloneGitRepo(fakeSession, '/workspace', 'https://example.com/repo.git')
+      ).rejects.toThrow('Failed to clone repository from https://example.com/repo.git');
+
+      expect(mockTimeoutWithTags).toHaveBeenCalledWith({ logTag: 'sandbox-operation-timeout' });
+      expect(mockTimeoutWithFields).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'git.clone',
+          timeoutMs: 120000,
+          timeoutLayer: 'sdk',
+          error: 'Git clone timed out after 120000ms',
+        })
+      );
+      expect(mockTimeoutWarn).toHaveBeenCalledWith('Sandbox operation timed out');
+    });
   });
 
   describe('updateGitRemoteToken', () => {
@@ -533,7 +581,10 @@ describe('disk space checking', () => {
         'gitlab'
       );
 
-      expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('oauth2:new-token'));
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.stringContaining('oauth2:new-token'),
+        expect.any(Object)
+      );
     });
 
     it('should use x-access-token username for github platform', async () => {
@@ -547,7 +598,10 @@ describe('disk space checking', () => {
         'github'
       );
 
-      expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('x-access-token:new-token'));
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.stringContaining('x-access-token:new-token'),
+        expect.any(Object)
+      );
     });
 
     it('should use x-access-token username when platform is undefined', async () => {
@@ -560,7 +614,10 @@ describe('disk space checking', () => {
         'new-token'
       );
 
-      expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('x-access-token:new-token'));
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.stringContaining('x-access-token:new-token'),
+        expect.any(Object)
+      );
     });
   });
 

--- a/services/cloud-agent-next/src/workspace.ts
+++ b/services/cloud-agent-next/src/workspace.ts
@@ -2,6 +2,15 @@ import type { SandboxInstance, ExecutionSession, SystemSandboxUsageEvent } from 
 import type { ExecResult, ExecOptions } from '@cloudflare/sandbox';
 import { logger } from './logger.js';
 import { findWrapperForSessionInProcesses } from './kilo/wrapper-manager.js';
+import {
+  DISK_CHECK_TIMEOUT_MS,
+  FAST_SANDBOX_COMMAND_TIMEOUT_MS,
+  GIT_CLONE_TIMEOUT_MS,
+  GIT_COMMAND_TIMEOUT_MS,
+  logSandboxOperationTimeout,
+  timedExec,
+  withSandboxOperationTimeoutLog,
+} from './sandbox-timeout-logging.js';
 import { withTimeout } from '@kilocode/worker-utils';
 
 /**
@@ -46,6 +55,14 @@ const KILOCODE_DIR = `.kilocode`;
 const CLI_DIR = `${KILOCODE_DIR}/cli`;
 const CLI_GLOBAL_TASKS_PATH = `${CLI_DIR}/global/tasks`;
 const CLI_LOGS_PATH = `${CLI_DIR}/logs`;
+
+// Re-export timeout constants so existing imports from workspace.ts keep working.
+export {
+  DISK_CHECK_TIMEOUT_MS,
+  FAST_SANDBOX_COMMAND_TIMEOUT_MS,
+  GIT_CLONE_TIMEOUT_MS,
+  GIT_COMMAND_TIMEOUT_MS,
+} from './sandbox-timeout-logging.js';
 
 export function getBaseWorkspacePath(
   kilocodeOrganizationId: string | undefined,
@@ -96,10 +113,10 @@ export function getKilocodeGlobalDir(sessionHome: string): string {
   return `${getKilocodeCliDir(sessionHome)}/global`;
 }
 
-export interface SessionPaths {
+export type SessionPaths = {
   workspacePath: string;
   sessionHome: string;
-}
+};
 
 /**
  * Check disk space and clean up stale workspaces if low, using the sandbox
@@ -176,7 +193,11 @@ export async function cleanupWorkspace(
 
   try {
     // Delete workspace directory
-    const workspaceResult = await executor.exec(`rm -rf '${workspacePath}'`);
+    const workspaceResult = await timedExec(
+      executor,
+      `rm -rf '${workspacePath}'`,
+      'workspace.cleanup.workspace'
+    );
     if (workspaceResult.exitCode !== 0) {
       logger
         .withFields({ stderr: workspaceResult.stderr })
@@ -184,7 +205,11 @@ export async function cleanupWorkspace(
     }
 
     // Delete session home directory
-    const homeResult = await executor.exec(`rm -rf '${sessionHome}'`);
+    const homeResult = await timedExec(
+      executor,
+      `rm -rf '${sessionHome}'`,
+      'workspace.cleanup.home'
+    );
     if (homeResult.exitCode !== 0) {
       logger
         .withFields({ stderr: homeResult.stderr })
@@ -216,7 +241,11 @@ export async function cleanupStaleWorkspaces(
 
   let sessionDirs: string[];
   try {
-    const lsResult = await sandbox.exec(`ls -1 '${baseWorkspacePath}/sessions/'`);
+    const lsResult = await timedExec(
+      sandbox,
+      `ls -1 '${baseWorkspacePath}/sessions/'`,
+      'workspace.cleanupStale.listSessions'
+    );
     if (lsResult.exitCode !== 0 || !lsResult.stdout) {
       logger
         .withFields({ stderr: lsResult.stderr })
@@ -267,7 +296,11 @@ export async function cleanupStaleWorkspaces(
       // If we can't determine age (stat fails or unparseable), also skip — unknown
       // age is treated as potentially recent to avoid destroying active work.
       const workspacePath = `${baseWorkspacePath}/sessions/${candidateSessionId}`;
-      const statResult = await sandbox.exec(`stat -c %Y '${workspacePath}'`);
+      const statResult = await timedExec(
+        sandbox,
+        `stat -c %Y '${workspacePath}'`,
+        'workspace.cleanupStale.statSession'
+      );
       if (statResult.exitCode !== 0 || !statResult.stdout) {
         logger
           .withFields({ candidateSessionId })
@@ -349,7 +382,12 @@ export async function checkDiskSpace(executor: CommandExecutor): Promise<DiskSpa
   // df -B1 gives output in bytes for clean numeric parsing (no M/G/K suffixes)
   // --output=avail,size gives available and total space
   // Always use "/" since all container paths share the same root filesystem
-  const result = await executor.exec('df -B1 --output=avail,size / | tail -1');
+  const result = await timedExec(
+    executor,
+    'df -B1 --output=avail,size / | tail -1',
+    'workspace.checkDiskSpace',
+    { timeoutMs: DISK_CHECK_TIMEOUT_MS }
+  );
 
   if (result.exitCode !== 0) {
     logger
@@ -462,16 +500,29 @@ export async function cloneGitRepo(
   logger.info('Cloning generic git repository');
 
   try {
-    // Git clone with 2-minute timeout to prevent indefinite hangs
-    const CLONE_TIMEOUT_MS = 120_000; // 2 minutes
+    // SDK clone timeout terminates the subprocess; the outer timeout bounds the request.
     const result = await withTimeout(
-      session.gitCheckout(repoUrl, {
-        targetDir: workspacePath,
-        // Use depth: 1 for shallow clones (faster, less disk space)
-        ...(shallow && { depth: 1 }),
-      }),
-      CLONE_TIMEOUT_MS,
-      `Git clone timed out after ${CLONE_TIMEOUT_MS / 1000} seconds for ${sanitizedGitUrl}`
+      withSandboxOperationTimeoutLog(
+        session.gitCheckout(repoUrl, {
+          targetDir: workspacePath,
+          cloneTimeoutMs: GIT_CLONE_TIMEOUT_MS,
+          // Use depth: 1 for shallow clones (faster, less disk space)
+          ...(shallow && { depth: 1 }),
+        }),
+        {
+          operation: 'git.clone',
+          timeoutMs: GIT_CLONE_TIMEOUT_MS,
+          timeoutLayer: 'sdk',
+        }
+      ),
+      GIT_CLONE_TIMEOUT_MS + FAST_SANDBOX_COMMAND_TIMEOUT_MS,
+      `Git clone request timed out after ${(GIT_CLONE_TIMEOUT_MS + FAST_SANDBOX_COMMAND_TIMEOUT_MS) / 1000} seconds for ${sanitizedGitUrl}`,
+      () =>
+        logSandboxOperationTimeout({
+          operation: 'git.clone',
+          timeoutMs: GIT_CLONE_TIMEOUT_MS + FAST_SANDBOX_COMMAND_TIMEOUT_MS,
+          timeoutLayer: 'outer',
+        })
     );
 
     if (!result.success) {
@@ -481,8 +532,16 @@ export async function cloneGitRepo(
     const authorName = gitAuthor?.name ?? 'Kilo Code Cloud';
     const authorEmail = gitAuthor?.email ?? 'agent@kilocode.ai';
 
-    await session.exec(`cd ${workspacePath} && git config user.name "${authorName}"`);
-    await session.exec(`cd ${workspacePath} && git config user.email "${authorEmail}"`);
+    await timedExec(
+      session,
+      `cd ${workspacePath} && git config user.name "${authorName}"`,
+      'git.config.userName'
+    );
+    await timedExec(
+      session,
+      `cd ${workspacePath} && git config user.email "${authorEmail}"`,
+      'git.config.userEmail'
+    );
 
     logger.info('Successfully cloned generic git repository');
   } catch (err) {
@@ -558,8 +617,10 @@ export async function updateGitRemoteToken(
   logger.setTags({ workspacePath, gitUrl: sanitizedGitUrl });
   logger.info('Updating git remote URL with new token');
 
-  const result = await session.exec(
-    `cd '${workspacePath}' && git remote set-url origin '${newUrl.toString()}'`
+  const result = await timedExec(
+    session,
+    `cd '${workspacePath}' && git remote set-url origin '${newUrl.toString()}'`,
+    'git.updateRemoteToken'
   );
 
   if (result.exitCode !== 0) {
@@ -575,7 +636,9 @@ export async function updateGitRemoteToken(
 }
 
 async function gitFetch(session: ExecutionSession, workspacePath: string): Promise<void> {
-  const result = await session.exec(`cd ${workspacePath} && git fetch origin`);
+  const result = await timedExec(session, `cd ${workspacePath} && git fetch origin`, 'git.fetch', {
+    timeoutMs: GIT_COMMAND_TIMEOUT_MS,
+  });
   if (result.exitCode !== 0) {
     logger.withFields({ stderr: sanitizeGitOutput(result.stderr) }).warn('Git fetch failed');
   }
@@ -586,8 +649,10 @@ async function branchExistsLocally(
   workspacePath: string,
   branchName: string
 ): Promise<boolean> {
-  const result = await session.exec(
-    `cd ${workspacePath} && git rev-parse --verify '${branchName}' 2>/dev/null`
+  const result = await timedExec(
+    session,
+    `cd ${workspacePath} && git rev-parse --verify '${branchName}' 2>/dev/null`,
+    'git.branchExistsLocal'
   );
   return result.exitCode === 0;
 }
@@ -597,8 +662,10 @@ async function branchExistsRemotely(
   workspacePath: string,
   branchName: string
 ): Promise<boolean> {
-  const result = await session.exec(
-    `cd ${workspacePath} && git rev-parse --verify 'origin/${branchName}' 2>/dev/null`
+  const result = await timedExec(
+    session,
+    `cd ${workspacePath} && git rev-parse --verify 'origin/${branchName}' 2>/dev/null`,
+    'git.branchExistsRemote'
   );
   return result.exitCode === 0;
 }
@@ -608,7 +675,11 @@ async function checkoutExistingBranch(
   workspacePath: string,
   branchName: string
 ): Promise<void> {
-  const result = await session.exec(`cd ${workspacePath} && git checkout '${branchName}'`);
+  const result = await timedExec(
+    session,
+    `cd ${workspacePath} && git checkout '${branchName}'`,
+    'git.checkoutExistingBranch'
+  );
   if (result.exitCode !== 0) {
     throw new Error(
       `Failed to checkout branch ${branchName}: ${sanitizeGitOutput(result.stderr || result.stdout)}`
@@ -621,7 +692,12 @@ async function pullLatestChangesLenient(
   workspacePath: string,
   branchName: string
 ): Promise<void> {
-  const result = await session.exec(`cd ${workspacePath} && git pull origin '${branchName}'`);
+  const result = await timedExec(
+    session,
+    `cd ${workspacePath} && git pull origin '${branchName}'`,
+    'git.pullLatestChanges',
+    { timeoutMs: GIT_COMMAND_TIMEOUT_MS }
+  );
   if (result.exitCode !== 0) {
     // Session branches might have unpushed work or conflicts, just warn
     logger
@@ -635,8 +711,10 @@ async function createTrackingBranch(
   workspacePath: string,
   branchName: string
 ): Promise<void> {
-  const result = await session.exec(
-    `cd ${workspacePath} && git checkout -b '${branchName}' 'origin/${branchName}'`
+  const result = await timedExec(
+    session,
+    `cd ${workspacePath} && git checkout -b '${branchName}' 'origin/${branchName}'`,
+    'git.createTrackingBranch'
   );
   if (result.exitCode !== 0) {
     throw new Error(
@@ -650,7 +728,11 @@ async function createNewBranch(
   workspacePath: string,
   branchName: string
 ): Promise<void> {
-  const result = await session.exec(`cd ${workspacePath} && git checkout -b '${branchName}'`);
+  const result = await timedExec(
+    session,
+    `cd ${workspacePath} && git checkout -b '${branchName}'`,
+    'git.createNewBranch'
+  );
   if (result.exitCode !== 0) {
     throw new Error(
       `Failed to create branch ${branchName}: ${sanitizeGitOutput(result.stderr || result.stdout)}`
@@ -669,15 +751,22 @@ async function fetchPullRefAndCheckout(
     throw new Error(`Invalid pull ref format: ${pullRef}`);
   }
 
-  const fetchResult = await session.exec(`cd ${workspacePath} && git fetch origin '${pullRef}'`);
+  const fetchResult = await timedExec(
+    session,
+    `cd ${workspacePath} && git fetch origin '${pullRef}'`,
+    'git.fetchPullRef',
+    { timeoutMs: GIT_COMMAND_TIMEOUT_MS }
+  );
   if (fetchResult.exitCode !== 0) {
     throw new Error(
       `Failed to fetch pull ref ${pullRef}: ${sanitizeGitOutput(fetchResult.stderr || fetchResult.stdout)}`
     );
   }
 
-  const checkoutResult = await session.exec(
-    `cd ${workspacePath} && git checkout -B '${pullRef}' FETCH_HEAD`
+  const checkoutResult = await timedExec(
+    session,
+    `cd ${workspacePath} && git checkout -B '${pullRef}' FETCH_HEAD`,
+    'git.checkoutPullRef'
   );
   if (checkoutResult.exitCode !== 0) {
     throw new Error(


### PR DESCRIPTION
## Summary

Many `session.exec` / `sandbox.exec` calls had no timeout — a stuck command would block indefinitely until the sandbox was killed. This PR enforces explicit timeouts on every exec call via a `timedExec` helper (defaults to 30s, git network ops use 120s). An outer 5-minute ceiling covers the full session resume/init path. Structured warnings are emitted when timeouts fire (`logTag: "sandbox-operation-timeout"`).

## Verification

- [x] `pnpm --filter cloud-agent-next typecheck` — passes
- [x] `pnpm --filter cloud-agent-next test` — 129 tests pass
- [x] `pnpm format` + `pnpm lint` — clean
- [x] Manually verified locally

## Visual Changes

N/A

## Reviewer Notes

- Behavior change: exec calls that previously hung indefinitely now fail after their timeout.
- `cloneGitRepo` has two timeout layers: inner SDK timeout + outer safety net.
- Timeout constants moved from `workspace.ts` to `sandbox-timeout-logging.ts` with re-exports for backward compat.