### PR TITLE
fix(gateway): stop gateway error rate query from hammering production DB

### DIFF
--- a/apps/web/src/lib/providers/gateway-error-rate.ts
+++ b/apps/web/src/lib/providers/gateway-error-rate.ts
@@ -1,60 +1,80 @@
-import { db, sql } from '@/lib/drizzle';
-import { unstable_cache } from 'next/cache';
+import { readDb, sql } from '@/lib/drizzle';
 import * as z from 'zod';
 
-const getGatewayErrorRate_cached = unstable_cache(
-  async () => {
-    console.debug(`[getGatewayErrorRate_cached] refreshing at ${new Date().toISOString()}`);
-    const { rows } = await db.execute(sql`
-        select
-            mu.provider as "gateway",
-            1.0 * count(*) filter(where mu.has_error = true) / count(*) as "errorRate"
-        from microdollar_usage mu
-        join microdollar_usage_metadata meta on mu.id = meta.id
-        where true
-            and mu.created_at >= now() - interval '10 minutes'
-            and meta.is_user_byok = false
-            and mu.provider in ('openrouter', 'vercel')
-        group by mu.provider
-    `);
-    return z
-      .array(
-        z.object({
-          gateway: z.string(),
-          errorRate: z.coerce.number(),
-        })
-      )
-      .parse(rows);
-  },
-  undefined,
-  { revalidate: 600 }
-);
+type GatewayErrorRates = { openrouter: number; vercel: number };
 
-export async function getGatewayErrorRate() {
-  const start = performance.now();
-  try {
-    const result = await Promise.race([
-      getGatewayErrorRate_cached(),
-      new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 500)),
-    ]);
-    if (result === 'timeout') {
-      console.debug(`[getGatewayErrorRate] query timeout after ${performance.now() - start}ms`);
-      return {
-        openrouter: 0,
-        vercel: 0,
-      };
-    } else {
-      console.debug(`[getGatewayErrorRate] query success after ${performance.now() - start}ms`);
-      return {
-        openrouter: result.find(r => r.gateway === 'openrouter')?.errorRate ?? 0,
-        vercel: result.find(r => r.gateway === 'vercel')?.errorRate ?? 0,
-      };
-    }
-  } catch (e) {
-    console.debug(`[getGatewayErrorRate] query error after ${performance.now() - start}ms`, e);
-  }
+const REFRESH_INTERVAL_MS = 60_000;
+const DEFAULT_RATES: GatewayErrorRates = { openrouter: 0, vercel: 0 };
+
+let cachedResult: GatewayErrorRates | null = null;
+let lastRefreshAt = 0;
+let refreshInFlight: Promise<GatewayErrorRates> | null = null;
+
+async function fetchGatewayErrorRates(): Promise<GatewayErrorRates> {
+  console.debug(`[getGatewayErrorRate] refreshing at ${new Date().toISOString()}`);
+  const { rows } = await readDb.execute(sql`
+      select
+          mu.provider as "gateway",
+          1.0 * count(*) filter(where mu.has_error = true) / count(*) as "errorRate"
+      from microdollar_usage mu
+      join microdollar_usage_metadata meta on mu.id = meta.id
+      where true
+          and mu.created_at >= now() - interval '10 minutes'
+          and meta.is_user_byok = false
+          and mu.provider in ('openrouter', 'vercel')
+      group by mu.provider
+  `);
+  const parsed = z
+    .array(
+      z.object({
+        gateway: z.string(),
+        errorRate: z.coerce.number(),
+      })
+    )
+    .parse(rows);
   return {
-    openrouter: 0,
-    vercel: 0,
+    openrouter: parsed.find(r => r.gateway === 'openrouter')?.errorRate ?? 0,
+    vercel: parsed.find(r => r.gateway === 'vercel')?.errorRate ?? 0,
   };
+}
+
+async function refreshIfNeeded(): Promise<GatewayErrorRates> {
+  const now = Date.now();
+  if (now - lastRefreshAt < REFRESH_INTERVAL_MS && cachedResult) {
+    return cachedResult;
+  }
+
+  // If a refresh is already in-flight, wait for it rather than starting another
+  if (refreshInFlight) {
+    return cachedResult ?? refreshInFlight;
+  }
+
+  refreshInFlight = fetchGatewayErrorRates()
+    .then(result => {
+      cachedResult = result;
+      lastRefreshAt = Date.now();
+      return result;
+    })
+    .catch(e => {
+      console.debug(`[getGatewayErrorRate] refresh error`, e);
+      return cachedResult ?? DEFAULT_RATES;
+    })
+    .finally(() => {
+      refreshInFlight = null;
+    });
+
+  // If we have a stale cached result, return it immediately while refresh runs in background
+  if (cachedResult) {
+    return cachedResult;
+  }
+
+  // No cached result yet — must wait for the first fetch
+  return refreshInFlight;
+}
+
+export async function getGatewayErrorRate(): Promise<GatewayErrorRates> {
+  const start = performance.now();
+  const result = await refreshIfNeeded();
+  console.debug(`[getGatewayErrorRate] returned after ${performance.now() - start}ms`);
+  return result;
 }


### PR DESCRIPTION
## Summary

The `getGatewayErrorRate` query joins `microdollar_usage` with `microdollar_usage_metadata` and takes 12-15s to execute. Despite `unstable_cache` with `revalidate: 600`, the 500ms `Promise.race` timeout meant the cache **never got populated** — every call re-fired the full query against the primary database. We observed 146 executions in a 2-hour window, each taking ~12s.

This PR:
- Switches from `db` to `readDb` so the query runs against the read replica
- Replaces the broken `unstable_cache` + `Promise.race` pattern with an in-memory stale-while-revalidate cache that deduplicates in-flight requests and serves stale data during background refresh
- Refresh interval is 60s; the first call on a cold start blocks until the query completes, subsequent calls return instantly

## Verification

- `pnpm typecheck` passes (only pre-existing `linkify-it` error in `MessageBubble.tsx`)
- Reviewed that the exported `getGatewayErrorRate()` signature and return type are unchanged — no caller modifications needed

## Visual Changes

N/A

## Reviewer Notes

- The SQL query itself is unchanged
- On cold start (first call with no cached result), the caller will block for the full query duration (12-15s). This is acceptable since it only happens once per instance lifecycle, and the previous behavior was effectively the same (always timing out and returning zeros)
- The in-memory cache is per-Vercel-instance, which is fine for this use case — even if multiple instances each run one query on startup, that's far better than every request spawning a new 12s query
