### PR TITLE
fix(kiloclaw): update inbound email hook schema

### DIFF
--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -837,16 +837,16 @@ describe('generateBaseConfig', () => {
     expect(config.hooks.mappings).toContainEqual({
       id: 'cloudflare-email-inbound',
       match: { path: 'email' },
-      action: 'wake',
+      action: 'agent',
       wakeMode: 'now',
       name: 'Inbound Email',
       sessionKey: '{{payload.sessionKey}}',
-      textTemplate: 'From: {{payload.from}}\nSubject: {{payload.subject}}\n\n{{payload.text}}',
+      messageTemplate: 'From: {{payload.from}}\nSubject: {{payload.subject}}\n\n{{payload.text}}',
       deliver: false,
     });
   });
 
-  it('migrates wake hook messageTemplate to textTemplate', () => {
+  it('migrates existing inbound email wake hook to agent mapping', () => {
     const existing = JSON.stringify({
       hooks: {
         mappings: [
@@ -857,7 +857,7 @@ describe('generateBaseConfig', () => {
             wakeMode: 'now',
             name: 'Inbound Email',
             sessionKey: '{{payload.sessionKey}}',
-            messageTemplate: 'old template',
+            textTemplate: 'old template',
             deliver: false,
           },
           {
@@ -875,11 +875,11 @@ describe('generateBaseConfig', () => {
     expect(config.hooks.mappings).toContainEqual({
       id: 'cloudflare-email-inbound',
       match: { path: 'email' },
-      action: 'wake',
+      action: 'agent',
       wakeMode: 'now',
       name: 'Inbound Email',
       sessionKey: '{{payload.sessionKey}}',
-      textTemplate: 'From: {{payload.from}}\nSubject: {{payload.subject}}\n\n{{payload.text}}',
+      messageTemplate: 'From: {{payload.from}}\nSubject: {{payload.subject}}\n\n{{payload.text}}',
       deliver: false,
     });
     expect(config.hooks.mappings).toContainEqual({
@@ -887,7 +887,15 @@ describe('generateBaseConfig', () => {
       action: 'wake',
       textTemplate: 'custom template',
     });
-    expect(JSON.stringify(config.hooks.mappings)).not.toContain('messageTemplate');
+    expect(config.hooks.mappings).not.toContainEqual(
+      expect.objectContaining({ id: 'cloudflare-email-inbound', action: 'wake' })
+    );
+    expect(config.hooks.mappings).not.toContainEqual(
+      expect.objectContaining({ id: 'cloudflare-email-inbound', textTemplate: expect.any(String) })
+    );
+    expect(config.hooks.mappings).toContainEqual(
+      expect.objectContaining({ id: 'cloudflare-email-inbound', wakeMode: 'now' })
+    );
   });
 
   it('adds gmail preset when Gog credentials are configured', () => {

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -83,7 +83,20 @@ type ConfigObject = Record<string, any>;
 
 type EnvLike = Record<string, string | undefined>;
 
-function migrateWakeHookTemplate(mapping: ConfigObject): ConfigObject {
+const INBOUND_EMAIL_HOOK_ID = 'cloudflare-email-inbound';
+
+function migrateHookMapping(mapping: ConfigObject): ConfigObject {
+  if (mapping.id === INBOUND_EMAIL_HOOK_ID) {
+    if (mapping.action === 'wake') {
+      mapping.action = 'agent';
+    }
+    if (typeof mapping.textTemplate === 'string' && typeof mapping.messageTemplate !== 'string') {
+      mapping.messageTemplate = mapping.textTemplate;
+    }
+    delete mapping.textTemplate;
+    return mapping;
+  }
+
   if (mapping.action === 'wake' && typeof mapping.messageTemplate === 'string') {
     mapping.textTemplate = mapping.messageTemplate;
     delete mapping.messageTemplate;
@@ -92,13 +105,13 @@ function migrateWakeHookTemplate(mapping: ConfigObject): ConfigObject {
 }
 
 const INBOUND_EMAIL_HOOK_MAPPING = {
-  id: 'cloudflare-email-inbound',
+  id: INBOUND_EMAIL_HOOK_ID,
   match: { path: 'email' },
-  action: 'wake',
+  action: 'agent',
   wakeMode: 'now',
   name: 'Inbound Email',
   sessionKey: '{{payload.sessionKey}}',
-  textTemplate: 'From: {{payload.from}}\nSubject: {{payload.subject}}\n\n{{payload.text}}',
+  messageTemplate: 'From: {{payload.from}}\nSubject: {{payload.subject}}\n\n{{payload.text}}',
   deliver: false,
 };
 
@@ -445,7 +458,7 @@ export function generateBaseConfig(
     config.hooks.path = '/hooks';
 
     config.hooks.mappings = Array.isArray(config.hooks.mappings)
-      ? config.hooks.mappings.map((mapping: ConfigObject) => migrateWakeHookTemplate(mapping))
+      ? config.hooks.mappings.map((mapping: ConfigObject) => migrateHookMapping(mapping))
       : [];
     const existingEmailMappingIndex = config.hooks.mappings.findIndex(
       (mapping: ConfigObject) => mapping.id === INBOUND_EMAIL_HOOK_MAPPING.id


### PR DESCRIPTION
## Summary

- `action: "wake"` sends each email to the main channel as a notification
- `action: "agent"` creates a new channel for each new email

We had some debate in Slack, but in the end I think it makes the most sense to mimick the behavior of the OpenClaw gmail pub/sub webhook integration, so that's why I'm making this change!
