### PR TITLE
fix(gateway): optimize error rate query and fix cache-defeating timeout

### DIFF
--- a/apps/web/src/lib/providers/gateway-error-rate.ts
+++ b/apps/web/src/lib/providers/gateway-error-rate.ts
@@ -1,20 +1,24 @@
-import { db, sql } from '@/lib/drizzle';
+import { readDb, sql } from '@/lib/drizzle';
 import { unstable_cache } from 'next/cache';
 import * as z from 'zod';
 
 const getGatewayErrorRate_cached = unstable_cache(
   async () => {
     console.debug(`[getGatewayErrorRate_cached] refreshing at ${new Date().toISOString()}`);
-    const { rows } = await db.execute(sql`
+    // Use EXISTS instead of JOIN to force a semi-join plan (PK lookup per row)
+    // rather than hash-joining the entire microdollar_usage_metadata table.
+    const { rows } = await readDb.execute(sql`
         select
             mu.provider as "gateway",
             1.0 * count(*) filter(where mu.has_error = true) / count(*) as "errorRate"
         from microdollar_usage mu
-        join microdollar_usage_metadata meta on mu.id = meta.id
         where true
             and mu.created_at >= now() - interval '10 minutes'
-            and meta.is_user_byok = false
             and mu.provider in ('openrouter', 'vercel')
+            and exists (
+                select 1 from microdollar_usage_metadata meta
+                where meta.id = mu.id and meta.is_user_byok = false
+            )
         group by mu.provider
     `);
     return z
@@ -27,29 +31,18 @@ const getGatewayErrorRate_cached = unstable_cache(
       .parse(rows);
   },
   undefined,
-  { revalidate: 600 }
+  { revalidate: 60 }
 );
 
 export async function getGatewayErrorRate() {
   const start = performance.now();
   try {
-    const result = await Promise.race([
-      getGatewayErrorRate_cached(),
-      new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 500)),
-    ]);
-    if (result === 'timeout') {
-      console.debug(`[getGatewayErrorRate] query timeout after ${performance.now() - start}ms`);
-      return {
-        openrouter: 0,
-        vercel: 0,
-      };
-    } else {
-      console.debug(`[getGatewayErrorRate] query success after ${performance.now() - start}ms`);
-      return {
-        openrouter: result.find(r => r.gateway === 'openrouter')?.errorRate ?? 0,
-        vercel: result.find(r => r.gateway === 'vercel')?.errorRate ?? 0,
-      };
-    }
+    const result = await getGatewayErrorRate_cached();
+    console.debug(`[getGatewayErrorRate] query success after ${performance.now() - start}ms`);
+    return {
+      openrouter: result.find(r => r.gateway === 'openrouter')?.errorRate ?? 0,
+      vercel: result.find(r => r.gateway === 'vercel')?.errorRate ?? 0,
+    };
   } catch (e) {
     console.debug(`[getGatewayErrorRate] query error after ${performance.now() - start}ms`, e);
   }


### PR DESCRIPTION
## Summary

The `getGatewayErrorRate` query was taking 12-15s and hammering the production primary database (146 executions in a 2-hour window). Three root causes, all fixed:

- **Slow JOIN → EXISTS**: The `JOIN microdollar_usage_metadata` caused Postgres to hash-join the entire metadata table just to filter `is_user_byok = false` (~5% of rows are BYOK). Rewritten as `EXISTS(SELECT 1 FROM ... WHERE meta.id = mu.id AND meta.is_user_byok = false)` which forces a semi-join plan — a B-tree PK lookup per row from the 10-minute window, instead of scanning millions of metadata rows.
- **`db` → `readDb`**: Read-only analytics query was running against the primary. Now uses the read replica.
- **Removed broken `Promise.race(500ms)` timeout**: The query always exceeded 500ms, so `unstable_cache` was never populated — every request spawned a new 12-15s query. With the optimized query, `unstable_cache` works as designed. Revalidate interval lowered from 600s to 60s for fresher error rate data.

## Verification

- `pnpm typecheck` — no new errors (only pre-existing `linkify-it` error in `MessageBubble.tsx`)
- `pnpm format` — clean
- Exported `getGatewayErrorRate()` signature unchanged — no caller modifications needed

## Visual Changes

N/A

## Reviewer Notes

- The SQL semantics are preserved: same `is_user_byok = false` filter, same aggregation, same grouping
- The `EXISTS` rewrite relies on the PK index on `microdollar_usage_metadata.id` which is already present
- The `idx_created_at` index on `microdollar_usage.created_at` handles the 10-minute window scan
- No new indices or schema changes required
