### PR TITLE
refactor(claw): extract onboarding state machine

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { TriangleAlert } from 'lucide-react';
+import type { PopulatedClawStatus } from './ClawOnboardingFlow.state';
+import {
+  CLAW_ONBOARDING_FAKE_STEPS,
+  type ClawOnboardingRenderStep,
+  isPairingChannel,
+  type PairingChannelId,
+} from './ClawOnboardingFlow.state';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { BotIdentityStep } from './BotIdentityStep';
+import { ChannelPairingStepView } from './ChannelPairingStep';
+import { ChannelSelectionStepView } from './ChannelSelectionStep';
+import { ClawConfigServiceBanner } from './ClawConfigServiceBanner';
+import { ClawHeader } from './ClawHeader';
+import { ClawSetupCompleteStep } from './ClawOnboardingFlow';
+import { CreateInstanceCardView } from './CreateInstanceCard';
+import { PermissionStep } from './PermissionStep';
+import { ProvisioningStepView } from './ProvisioningStep';
+
+const FAKE_STEP_LABELS: Record<ClawOnboardingRenderStep, string> = {
+  'create-instance': 'Create',
+  identity: 'Identity',
+  permissions: 'Permissions',
+  channels: 'Channels',
+  provisioning: 'Provisioning',
+  pairing: 'Pairing',
+  complete: 'Complete',
+};
+
+const fakeStatus = {
+  userId: 'fake-user',
+  sandboxId: 'fake-sandbox',
+  provider: 'fly',
+  runtimeId: 'fake-machine',
+  storageId: 'fake-volume',
+  region: 'iad',
+  status: 'running',
+  provisionedAt: 1,
+  lastStartedAt: 2,
+  lastStoppedAt: null,
+  envVarCount: 0,
+  secretCount: 0,
+  channelCount: 0,
+  flyAppName: 'fake-kiloclaw',
+  flyMachineId: 'fake-machine',
+  flyVolumeId: 'fake-volume',
+  flyRegion: 'iad',
+  machineSize: null,
+  openclawVersion: 'fake',
+  imageVariant: null,
+  trackedImageTag: null,
+  trackedImageDigest: null,
+  googleConnected: false,
+  gmailNotificationsEnabled: false,
+  execSecurity: 'allowlist',
+  execAsk: 'on-miss',
+  botName: 'KiloClaw',
+  botNature: 'AI assistant',
+  botVibe: 'Helpful, capable, professional',
+  botEmoji: '🤖',
+  workerUrl: 'https://claw.kilo.ai',
+  name: 'Fake KiloClaw',
+  instanceId: 'fake-instance',
+} satisfies PopulatedClawStatus;
+
+export function ClawOnboardingFakeWalkthrough({
+  initialStep,
+  basePath,
+}: {
+  initialStep: ClawOnboardingRenderStep;
+  basePath: string;
+}) {
+  const [step, setStep] = useState<ClawOnboardingRenderStep>(initialStep);
+  const [selectedChannelId, setSelectedChannelId] = useState<string | null>('telegram');
+
+  useEffect(() => {
+    setStep(initialStep);
+  }, [initialStep]);
+
+  if (process.env.NODE_ENV === 'production') return null;
+
+  const pairingChannelId: PairingChannelId = isPairingChannel(selectedChannelId)
+    ? selectedChannelId
+    : 'telegram';
+  const totalSteps = isPairingChannel(selectedChannelId) ? 6 : 5;
+
+  return (
+    <div className="container m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
+      <ClawHeader
+        status={fakeStatus.status}
+        sandboxId={fakeStatus.sandboxId}
+        region={fakeStatus.flyRegion}
+        gatewayUrl={fakeStatus.workerUrl}
+        gatewayReady
+        isSetupWizard
+      />
+
+      <Alert variant="warning">
+        <TriangleAlert className="size-4" />
+        <AlertDescription>
+          Development-only fake KiloClaw onboarding. This walkthrough does not call billing,
+          provisioning, gateway, mutation, or pairing services.
+        </AlertDescription>
+      </Alert>
+
+      <ClawConfigServiceBanner status={fakeStatus} />
+      <FakeWalkthroughControls currentStep={step} onStepChange={setStep} />
+      {renderFakeStep({
+        step,
+        setStep,
+        selectedChannelId,
+        setSelectedChannelId,
+        pairingChannelId,
+        totalSteps,
+        basePath,
+      })}
+    </div>
+  );
+}
+
+type FakeWalkthroughControlsProps = {
+  currentStep: ClawOnboardingRenderStep;
+  onStepChange: (step: ClawOnboardingRenderStep) => void;
+};
+
+function FakeWalkthroughControls({ currentStep, onStepChange }: FakeWalkthroughControlsProps) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-3 p-4">
+        <div>
+          <p className="text-sm font-semibold">Fake walkthrough controls</p>
+          <p className="text-muted-foreground text-xs">
+            Jump to any onboarding screen without waiting for external dependencies.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {CLAW_ONBOARDING_FAKE_STEPS.map(step => (
+            <Button
+              key={step}
+              type="button"
+              variant={currentStep === step ? 'default' : 'outline'}
+              size="sm"
+              aria-pressed={currentStep === step}
+              onClick={() => onStepChange(step)}
+            >
+              {FAKE_STEP_LABELS[step]}
+            </Button>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+type RenderFakeStepInput = {
+  step: ClawOnboardingRenderStep;
+  setStep: (step: ClawOnboardingRenderStep) => void;
+  selectedChannelId: string | null;
+  setSelectedChannelId: (channelId: string | null) => void;
+  pairingChannelId: PairingChannelId;
+  totalSteps: number;
+  basePath: string;
+};
+
+function renderFakeStep({
+  step,
+  setStep,
+  selectedChannelId,
+  setSelectedChannelId,
+  pairingChannelId,
+  totalSteps,
+  basePath,
+}: RenderFakeStepInput) {
+  switch (step) {
+    case 'create-instance':
+      return <CreateInstanceCardView onCreate={() => setStep('identity')} />;
+    case 'identity':
+      return <BotIdentityStep instanceRunning={false} onContinue={() => setStep('permissions')} />;
+    case 'permissions':
+      return <PermissionStep instanceRunning={false} onSelect={() => setStep('channels')} />;
+    case 'channels':
+      return (
+        <ChannelSelectionStepView
+          instanceRunning={false}
+          defaultSelected={isPairingChannel(selectedChannelId) ? selectedChannelId : null}
+          onSelect={channelId => {
+            setSelectedChannelId(channelId);
+            setStep('provisioning');
+          }}
+          onSkip={() => {
+            setSelectedChannelId(null);
+            setStep('provisioning');
+          }}
+        />
+      );
+    case 'provisioning':
+      return (
+        <div className="flex flex-col gap-4">
+          <ProvisioningStepView totalSteps={totalSteps} />
+          <Card>
+            <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-muted-foreground text-sm">
+                Fake mode keeps this spinner static so you can inspect the final provisioning state.
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() =>
+                    setStep(isPairingChannel(selectedChannelId) ? 'pairing' : 'complete')
+                  }
+                >
+                  Continue
+                </Button>
+                <Button type="button" onClick={() => setStep('complete')}>
+                  Complete setup
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      );
+    case 'pairing':
+      return (
+        <ChannelPairingStepView
+          channelId={pairingChannelId}
+          matchingRequest={{
+            channel: pairingChannelId,
+            code: '123456',
+            id: `fake-${pairingChannelId}-user`,
+          }}
+          onApprove={() => setStep('complete')}
+          onSkip={() => setStep('complete')}
+        />
+      );
+    case 'complete':
+      return <ClawSetupCompleteStep status={fakeStatus} gatewayReady basePath={basePath} />;
+  }
+}

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, test } from '@jest/globals';
+import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
+import {
+  type ClawOnboardingFlowStateInput,
+  getClawOnboardingFlowState,
+  hasPopulatedStatus,
+  isPairingChannel,
+} from './ClawOnboardingFlow.state';
+
+const machineStatuses = [
+  'provisioned',
+  'starting',
+  'restarting',
+  'recovering',
+  'running',
+  'stopped',
+  'destroying',
+  'restoring',
+] satisfies NonNullable<KiloClawDashboardStatus['status']>[];
+
+const waitingMachineStatuses = machineStatuses.filter(status => status !== 'running');
+
+function createStatus(status: KiloClawDashboardStatus['status']): KiloClawDashboardStatus {
+  return {
+    userId: 'user-1',
+    sandboxId: 'sandbox-1',
+    provider: status === null ? null : 'fly',
+    runtimeId: status === null ? null : 'machine-1',
+    storageId: status === null ? null : 'vol-1',
+    region: status === null ? null : 'iad',
+    name: null,
+    status,
+    provisionedAt: status === null ? null : 1,
+    lastStartedAt: status === null ? null : 2,
+    lastStoppedAt: null,
+    envVarCount: 0,
+    secretCount: 0,
+    channelCount: 0,
+    flyAppName: null,
+    flyMachineId: null,
+    flyVolumeId: null,
+    flyRegion: status === null ? null : 'iad',
+    machineSize: null,
+    openclawVersion: null,
+    imageVariant: null,
+    trackedImageTag: null,
+    trackedImageDigest: null,
+    googleConnected: false,
+    gmailNotificationsEnabled: false,
+    execSecurity: null,
+    execAsk: null,
+    botName: null,
+    botNature: null,
+    botVibe: null,
+    botEmoji: null,
+    workerUrl: 'https://claw.kilo.ai',
+    instanceId: null,
+  };
+}
+
+function createInput(
+  overrides: Partial<ClawOnboardingFlowStateInput> = {}
+): ClawOnboardingFlowStateInput {
+  return {
+    status: undefined,
+    mode: 'create-first',
+    createSetupStarted: false,
+    onboardingStep: 'identity',
+    selectedPreset: null,
+    hasBotIdentity: false,
+    selectedChannelId: null,
+    gatewayState: null,
+    ...overrides,
+  };
+}
+
+describe('ClawOnboardingFlow state machine', () => {
+  test('detects populated statuses', () => {
+    expect(hasPopulatedStatus(undefined)).toBe(false);
+    expect(hasPopulatedStatus(createStatus(null))).toBe(false);
+    expect(hasPopulatedStatus(createStatus('running'))).toBe(true);
+  });
+
+  test('detects channels that need a pairing step', () => {
+    expect(isPairingChannel('telegram')).toBe(true);
+    expect(isPairingChannel('discord')).toBe(true);
+    expect(isPairingChannel('slack')).toBe(false);
+    expect(isPairingChannel(null)).toBe(false);
+  });
+
+  test('renders the create card before provisioning starts', () => {
+    const state = getClawOnboardingFlowState(createInput());
+
+    expect(state.renderStep).toBe('create-instance');
+    expect(state.createSetupActive).toBe(false);
+    expect(state.instanceStatus).toBeNull();
+  });
+
+  test('renders identity after provisioning has been requested', () => {
+    const state = getClawOnboardingFlowState(
+      createInput({
+        createSetupStarted: true,
+      })
+    );
+
+    expect(state.renderStep).toBe('identity');
+    expect(state.createSetupActive).toBe(true);
+  });
+
+  test('keeps create setup active once an instance status exists', () => {
+    const state = getClawOnboardingFlowState(
+      createInput({
+        status: createStatus('starting'),
+      })
+    );
+
+    expect(state.renderStep).toBe('identity');
+    expect(state.createSetupActive).toBe(true);
+  });
+
+  test('maps the normal create-first wizard steps', () => {
+    expect(getClawOnboardingFlowState(createInput({ createSetupStarted: true })).renderStep).toBe(
+      'identity'
+    );
+    expect(
+      getClawOnboardingFlowState(
+        createInput({
+          createSetupStarted: true,
+          onboardingStep: 'permissions',
+          hasBotIdentity: true,
+        })
+      ).renderStep
+    ).toBe('permissions');
+    expect(
+      getClawOnboardingFlowState(
+        createInput({
+          createSetupStarted: true,
+          onboardingStep: 'channels',
+          hasBotIdentity: true,
+          selectedPreset: 'always-ask',
+        })
+      ).renderStep
+    ).toBe('channels');
+    expect(
+      getClawOnboardingFlowState(
+        createInput({
+          createSetupStarted: true,
+          onboardingStep: 'provisioning',
+          hasBotIdentity: true,
+          selectedPreset: 'always-ask',
+        })
+      ).renderStep
+    ).toBe('provisioning');
+    expect(
+      getClawOnboardingFlowState(
+        createInput({
+          createSetupStarted: true,
+          onboardingStep: 'pairing',
+          hasBotIdentity: true,
+          selectedPreset: 'always-ask',
+          selectedChannelId: 'telegram',
+        })
+      ).renderStep
+    ).toBe('pairing');
+    expect(
+      getClawOnboardingFlowState(
+        createInput({
+          createSetupStarted: true,
+          onboardingStep: 'done',
+        })
+      ).renderStep
+    ).toBe('complete');
+  });
+
+  test('uses six steps only when the selected channel requires pairing', () => {
+    expect(
+      getClawOnboardingFlowState(createInput({ selectedChannelId: 'telegram' })).totalSteps
+    ).toBe(6);
+    expect(
+      getClawOnboardingFlowState(createInput({ selectedChannelId: 'discord' })).totalSteps
+    ).toBe(6);
+    expect(getClawOnboardingFlowState(createInput({ selectedChannelId: 'slack' })).totalSteps).toBe(
+      5
+    );
+    expect(getClawOnboardingFlowState(createInput()).totalSteps).toBe(5);
+  });
+
+  test.each(waitingMachineStatuses)(
+    'renders the post-provisioning spinner while machine status is %s',
+    status => {
+      const state = getClawOnboardingFlowState(
+        createInput({
+          mode: 'post-provisioning',
+          status: createStatus(status),
+        })
+      );
+
+      expect(state.renderStep).toBe('provisioning');
+      expect(state.postProvisioningReady).toBe(false);
+    }
+  );
+
+  test('renders the post-provisioning spinner before a populated status exists', () => {
+    expect(getClawOnboardingFlowState(createInput({ mode: 'post-provisioning' })).renderStep).toBe(
+      'provisioning'
+    );
+    expect(
+      getClawOnboardingFlowState(
+        createInput({ mode: 'post-provisioning', status: createStatus(null) })
+      ).renderStep
+    ).toBe('provisioning');
+  });
+
+  test('renders complete in post-provisioning mode once the machine is running', () => {
+    const state = getClawOnboardingFlowState(
+      createInput({
+        mode: 'post-provisioning',
+        status: createStatus('running'),
+        gatewayState: 'crashed',
+      })
+    );
+
+    expect(state.renderStep).toBe('complete');
+    expect(state.postProvisioningReady).toBe(true);
+    expect(state.gatewayReady).toBe(false);
+    expect(state.instanceRunning).toBe(false);
+  });
+
+  test('uses gateway status only for gateway readiness and instance-running checks', () => {
+    const runningState = getClawOnboardingFlowState(
+      createInput({
+        createSetupStarted: true,
+        status: createStatus('running'),
+        gatewayState: 'running',
+      })
+    );
+    const startingGatewayState = getClawOnboardingFlowState(
+      createInput({
+        createSetupStarted: true,
+        status: createStatus('running'),
+        gatewayState: 'starting',
+      })
+    );
+
+    expect(runningState.isRunning).toBe(true);
+    expect(runningState.gatewayReady).toBe(true);
+    expect(runningState.instanceRunning).toBe(true);
+    expect(startingGatewayState.isRunning).toBe(true);
+    expect(startingGatewayState.gatewayReady).toBe(false);
+    expect(startingGatewayState.instanceRunning).toBe(false);
+  });
+
+  test('normalizes impossible local wizard states to the earliest safe prerequisite', () => {
+    expect(
+      getClawOnboardingFlowState(
+        createInput({
+          createSetupStarted: true,
+          onboardingStep: 'permissions',
+          hasBotIdentity: false,
+        })
+      ).renderStep
+    ).toBe('identity');
+    expect(
+      getClawOnboardingFlowState(
+        createInput({
+          createSetupStarted: true,
+          onboardingStep: 'channels',
+          hasBotIdentity: true,
+          selectedPreset: null,
+        })
+      ).renderStep
+    ).toBe('permissions');
+    expect(
+      getClawOnboardingFlowState(
+        createInput({
+          createSetupStarted: true,
+          onboardingStep: 'provisioning',
+          hasBotIdentity: true,
+          selectedPreset: null,
+        })
+      ).renderStep
+    ).toBe('permissions');
+    expect(
+      getClawOnboardingFlowState(
+        createInput({
+          createSetupStarted: true,
+          onboardingStep: 'pairing',
+          hasBotIdentity: true,
+          selectedPreset: 'always-ask',
+          selectedChannelId: 'slack',
+        })
+      ).renderStep
+    ).toBe('complete');
+  });
+});

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
@@ -1,0 +1,175 @@
+import type { GatewayProcessStatusResponse, KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
+import type { ExecPreset } from './claw.types';
+
+export type PopulatedClawStatus = KiloClawDashboardStatus & {
+  status: NonNullable<KiloClawDashboardStatus['status']>;
+};
+
+export type ClawOnboardingMode = 'create-first' | 'post-provisioning';
+
+export type OnboardingStep =
+  | 'identity'
+  | 'permissions'
+  | 'channels'
+  | 'provisioning'
+  | 'pairing'
+  | 'done';
+
+export type ClawOnboardingRenderStep =
+  | 'create-instance'
+  | 'identity'
+  | 'permissions'
+  | 'channels'
+  | 'provisioning'
+  | 'pairing'
+  | 'complete';
+
+export type PairingChannelId = 'telegram' | 'discord';
+
+export const FAKE_ONBOARDING_STEP_PARAM = 'fakeOnboardingStep';
+
+export const CLAW_ONBOARDING_FAKE_STEPS = [
+  'create-instance',
+  'identity',
+  'permissions',
+  'channels',
+  'provisioning',
+  'pairing',
+  'complete',
+] satisfies ClawOnboardingRenderStep[];
+
+export function parseClawOnboardingFakeStep(value: string | null): ClawOnboardingRenderStep | null {
+  for (const step of CLAW_ONBOARDING_FAKE_STEPS) {
+    if (value === step) return step;
+  }
+  return null;
+}
+
+export type ClawOnboardingFlowStateInput = {
+  status: KiloClawDashboardStatus | undefined;
+  mode: ClawOnboardingMode;
+  createSetupStarted: boolean;
+  onboardingStep: OnboardingStep;
+  selectedPreset: ExecPreset | null;
+  hasBotIdentity: boolean;
+  selectedChannelId: string | null;
+  gatewayState?: GatewayProcessStatusResponse['state'] | null;
+};
+
+export type ClawOnboardingFlowState = {
+  renderStep: ClawOnboardingRenderStep;
+  instanceStatus: PopulatedClawStatus | null;
+  isRunning: boolean;
+  gatewayReady: boolean;
+  instanceRunning: boolean;
+  createSetupActive: boolean;
+  postProvisioningReady: boolean;
+  hasPairingStep: boolean;
+  totalSteps: number;
+};
+
+export function hasPopulatedStatus(
+  candidate: KiloClawDashboardStatus | undefined
+): candidate is PopulatedClawStatus {
+  return candidate !== undefined && candidate.status !== null;
+}
+
+export function isPairingChannel(channelId: string | null): channelId is PairingChannelId {
+  return channelId === 'telegram' || channelId === 'discord';
+}
+
+export function getClawOnboardingFlowState({
+  status,
+  mode,
+  createSetupStarted,
+  onboardingStep,
+  selectedPreset,
+  hasBotIdentity,
+  selectedChannelId,
+  gatewayState,
+}: ClawOnboardingFlowStateInput): ClawOnboardingFlowState {
+  const instanceStatus = hasPopulatedStatus(status) ? status : null;
+  const isRunning = instanceStatus?.status === 'running';
+  const gatewayReady = gatewayState === 'running';
+  const instanceRunning = isRunning && gatewayReady;
+  const postProvisioningReady = isRunning;
+  const createSetupActive =
+    mode === 'create-first' && (createSetupStarted || instanceStatus !== null);
+  const hasPairingStep = isPairingChannel(selectedChannelId);
+  const totalSteps = hasPairingStep ? 6 : 5;
+
+  return {
+    renderStep: getRenderStep({
+      mode,
+      createSetupStarted,
+      instanceStatus,
+      postProvisioningReady,
+      onboardingStep,
+      selectedPreset,
+      hasBotIdentity,
+      hasPairingStep,
+    }),
+    instanceStatus,
+    isRunning,
+    gatewayReady,
+    instanceRunning,
+    createSetupActive,
+    postProvisioningReady,
+    hasPairingStep,
+    totalSteps,
+  };
+}
+
+type RenderStepInput = Pick<
+  ClawOnboardingFlowStateInput,
+  'mode' | 'createSetupStarted' | 'onboardingStep' | 'selectedPreset' | 'hasBotIdentity'
+> & {
+  instanceStatus: PopulatedClawStatus | null;
+  postProvisioningReady: boolean;
+  hasPairingStep: boolean;
+};
+
+function getRenderStep({
+  mode,
+  createSetupStarted,
+  instanceStatus,
+  postProvisioningReady,
+  onboardingStep,
+  selectedPreset,
+  hasBotIdentity,
+  hasPairingStep,
+}: RenderStepInput): ClawOnboardingRenderStep {
+  if (mode === 'post-provisioning') {
+    return postProvisioningReady ? 'complete' : 'provisioning';
+  }
+
+  if (instanceStatus === null && !createSetupStarted) {
+    return 'create-instance';
+  }
+
+  if (onboardingStep === 'done') {
+    return 'complete';
+  }
+
+  if (onboardingStep === 'identity' || !hasBotIdentity) {
+    return 'identity';
+  }
+
+  if (onboardingStep === 'permissions' || selectedPreset === null) {
+    return 'permissions';
+  }
+
+  if (onboardingStep === 'channels') {
+    return 'channels';
+  }
+
+  if (onboardingStep === 'provisioning') {
+    return 'provisioning';
+  }
+
+  if (onboardingStep === 'pairing' && hasPairingStep) {
+    return 'pairing';
+  }
+
+  return 'complete';
+}

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -44,6 +44,10 @@ function MaybeBillingWrapper({
   return <BillingWrapper hideBanners={hideBanners}>{children}</BillingWrapper>;
 }
 
+function assertNever(value: never): never {
+  throw new Error(`Unhandled KiloClaw onboarding render step: ${value}`);
+}
+
 export type { ClawOnboardingMode };
 
 export function ClawOnboardingFlow({
@@ -301,7 +305,9 @@ function ClawOnboardingFlowInner({
   }
 
   function renderStepContent() {
-    switch (flowState.renderStep) {
+    const renderStep = flowState.renderStep;
+
+    switch (renderStep) {
       case 'create-instance':
         return renderCreateInstanceStep();
       case 'identity':
@@ -316,6 +322,8 @@ function ClawOnboardingFlowInner({
         return renderPairingStep();
       case 'complete':
         return renderCompleteStep();
+      default:
+        return assertNever(renderStep);
     }
   }
 

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -23,16 +23,13 @@ import { CreateInstanceCard } from './CreateInstanceCard';
 import { PermissionStep } from './PermissionStep';
 import { ProvisioningStep, ProvisioningStepView } from './ProvisioningStep';
 import type { BotIdentity, ExecPreset } from './claw.types';
-
-type PopulatedClawStatus = KiloClawDashboardStatus & {
-  status: NonNullable<KiloClawDashboardStatus['status']>;
-};
-
-function hasPopulatedStatus(
-  candidate: KiloClawDashboardStatus | undefined
-): candidate is PopulatedClawStatus {
-  return candidate !== undefined && candidate.status !== null;
-}
+import {
+  getClawOnboardingFlowState,
+  isPairingChannel,
+  type ClawOnboardingMode,
+  type OnboardingStep,
+  type PopulatedClawStatus,
+} from './ClawOnboardingFlow.state';
 
 function MaybeBillingWrapper({
   skip,
@@ -47,9 +44,7 @@ function MaybeBillingWrapper({
   return <BillingWrapper hideBanners={hideBanners}>{children}</BillingWrapper>;
 }
 
-export type ClawOnboardingMode = 'create-first' | 'post-provisioning';
-
-type OnboardingStep = 'identity' | 'permissions' | 'channels' | 'provisioning' | 'pairing' | 'done';
+export type { ClawOnboardingMode };
 
 export function ClawOnboardingFlow({
   status,
@@ -94,20 +89,6 @@ function ClawOnboardingFlowInner({
   const mutations = organizationId ? orgMutations : personalMutations;
 
   const gatewayUrl = useGatewayUrl(status);
-  const instanceStatus = hasPopulatedStatus(status) ? status : null;
-  const isRunning = instanceStatus?.status === 'running';
-  const postProvisioningReady = isRunning;
-
-  const personalGateway = useKiloClawGatewayStatus(!organizationId && isRunning);
-  const orgGateway = useOrgKiloClawGatewayStatus(
-    organizationId ?? '',
-    !!organizationId && isRunning
-  );
-  const { data: gatewayStatus } = organizationId ? orgGateway : personalGateway;
-  const instanceRunning = isRunning && gatewayStatus?.state === 'running';
-
-  const { data: isServiceDegraded } = useClawServiceDegraded();
-  const posthog = usePostHog();
 
   const [onboardingStep, setOnboardingStep] = useState<OnboardingStep>('identity');
   const [selectedPreset, setSelectedPreset] = useState<ExecPreset | null>(null);
@@ -115,26 +96,56 @@ function ClawOnboardingFlowInner({
   const [channelTokens, setChannelTokens] = useState<Record<string, string> | null>(null);
   const [selectedChannelId, setSelectedChannelId] = useState<string | null>(null);
   const [createSetupStarted, setCreateSetupStarted] = useState(false);
-  const hasPairingStep = selectedChannelId === 'telegram' || selectedChannelId === 'discord';
   const hasCapturedIdentityView = useRef(false);
   const hasCapturedDoneView = useRef(false);
 
-  const createSetupActive =
-    mode === 'create-first' && (createSetupStarted || instanceStatus !== null);
+  const stateInput = {
+    status,
+    mode,
+    createSetupStarted,
+    onboardingStep,
+    selectedPreset,
+    hasBotIdentity: botIdentity !== null,
+    selectedChannelId,
+  };
+  const preGatewayFlowState = getClawOnboardingFlowState({
+    ...stateInput,
+    gatewayState: null,
+  });
+
+  const personalGateway = useKiloClawGatewayStatus(
+    !organizationId && preGatewayFlowState.isRunning
+  );
+  const orgGateway = useOrgKiloClawGatewayStatus(
+    organizationId ?? '',
+    !!organizationId && preGatewayFlowState.isRunning
+  );
+  const { data: gatewayStatus } = organizationId ? orgGateway : personalGateway;
+  const flowState = getClawOnboardingFlowState({
+    ...stateInput,
+    gatewayState: gatewayStatus?.state ?? null,
+  });
+
+  const { data: isServiceDegraded } = useClawServiceDegraded();
+  const posthog = usePostHog();
 
   useEffect(() => {
-    if (!createSetupActive || hasCapturedIdentityView.current) return;
+    if (!flowState.createSetupActive || hasCapturedIdentityView.current) return;
     hasCapturedIdentityView.current = true;
     posthog?.capture('claw_setup_identity_viewed');
-  }, [createSetupActive, posthog]);
+  }, [flowState.createSetupActive, posthog]);
 
   useEffect(() => {
-    if (mode !== 'post-provisioning' || !postProvisioningReady || hasCapturedDoneView.current) {
+    if (
+      mode !== 'post-provisioning' ||
+      !flowState.postProvisioningReady ||
+      hasCapturedDoneView.current
+    ) {
       return;
     }
     hasCapturedDoneView.current = true;
     posthog?.capture('claw_setup_done_viewed');
-  }, [mode, postProvisioningReady, posthog]);
+  }, [mode, flowState.postProvisioningReady, posthog]);
 
   const resetWizardSelections = useCallback(() => {
     setOnboardingStep('identity');
@@ -159,6 +170,155 @@ function ClawOnboardingFlowInner({
 
   const basePath = organizationId ? `/organizations/${organizationId}/claw` : '/claw';
 
+  function renderCreateInstanceStep() {
+    return (
+      <CreateInstanceCard
+        mutations={mutations}
+        onProvisionStart={handleCreateFlowStarted}
+        onProvisionFailed={handleCreateFlowFailed}
+      />
+    );
+  }
+
+  function renderIdentityStep() {
+    return (
+      <BotIdentityStep
+        instanceRunning={flowState.instanceRunning}
+        onContinue={identity => {
+          posthog?.capture('claw_setup_identity_completed', {
+            bot_name_is_custom: identity.botName !== 'KiloClaw',
+            bot_nature: identity.botNature,
+            bot_emoji_is_custom: identity.botEmoji !== '🤖',
+          });
+          posthog?.capture('claw_setup_permissions_viewed');
+          setBotIdentity(identity);
+          setOnboardingStep('permissions');
+        }}
+      />
+    );
+  }
+
+  function renderPermissionsStep() {
+    return (
+      <PermissionStep
+        instanceRunning={flowState.instanceRunning}
+        onSelect={preset => {
+          posthog?.capture('claw_setup_permissions_completed', { preset });
+          posthog?.capture('claw_setup_channels_viewed');
+          setSelectedPreset(preset);
+          setOnboardingStep('channels');
+        }}
+      />
+    );
+  }
+
+  function renderChannelsStep() {
+    return (
+      <ChannelSelectionStepView
+        instanceRunning={flowState.instanceRunning}
+        onSelect={(channelId, tokens) => {
+          posthog?.capture('claw_setup_channels_completed', {
+            channel: channelId,
+            skipped: false,
+          });
+          posthog?.capture('claw_setup_provisioning_viewed');
+          setSelectedChannelId(channelId);
+          setChannelTokens(tokens);
+          setOnboardingStep('provisioning');
+        }}
+        onSkip={() => {
+          posthog?.capture('claw_setup_channels_completed', {
+            channel: null,
+            skipped: true,
+          });
+          posthog?.capture('claw_setup_provisioning_viewed');
+          setSelectedChannelId(null);
+          setChannelTokens(null);
+          setOnboardingStep('provisioning');
+        }}
+      />
+    );
+  }
+
+  function renderProvisioningStep() {
+    if (mode === 'post-provisioning') return <ProvisioningStepView />;
+    if (selectedPreset === null) return renderPermissionsStep();
+
+    return (
+      <ProvisioningStep
+        preset={selectedPreset}
+        channelTokens={channelTokens}
+        botIdentity={botIdentity}
+        instanceRunning={flowState.instanceRunning}
+        mutations={mutations}
+        totalSteps={flowState.totalSteps}
+        onComplete={() => {
+          posthog?.capture('claw_setup_provisioned');
+          posthog?.capture(
+            flowState.hasPairingStep ? 'claw_setup_pairing_viewed' : 'claw_setup_done_viewed'
+          );
+          setOnboardingStep(flowState.hasPairingStep ? 'pairing' : 'done');
+        }}
+      />
+    );
+  }
+
+  function renderPairingStep() {
+    if (!isPairingChannel(selectedChannelId)) return renderCompleteStep();
+
+    return (
+      <ChannelPairingStep
+        channelId={selectedChannelId}
+        mutations={mutations}
+        onComplete={() => {
+          posthog?.capture('claw_setup_pairing_completed', {
+            channel: selectedChannelId,
+            skipped: false,
+          });
+          posthog?.capture('claw_setup_done_viewed');
+          setOnboardingStep('done');
+        }}
+        onSkip={() => {
+          posthog?.capture('claw_setup_pairing_completed', {
+            channel: selectedChannelId,
+            skipped: true,
+          });
+          posthog?.capture('claw_setup_done_viewed');
+          setOnboardingStep('done');
+        }}
+      />
+    );
+  }
+
+  function renderCompleteStep() {
+    return (
+      <ClawSetupCompleteStep
+        status={flowState.instanceStatus}
+        gatewayReady={flowState.gatewayReady}
+        basePath={basePath}
+      />
+    );
+  }
+
+  function renderStepContent() {
+    switch (flowState.renderStep) {
+      case 'create-instance':
+        return renderCreateInstanceStep();
+      case 'identity':
+        return renderIdentityStep();
+      case 'permissions':
+        return renderPermissionsStep();
+      case 'channels':
+        return renderChannelsStep();
+      case 'provisioning':
+        return renderProvisioningStep();
+      case 'pairing':
+        return renderPairingStep();
+      case 'complete':
+        return renderCompleteStep();
+    }
+  }
+
   return (
     <div className="container m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
       <ClawHeader
@@ -166,7 +326,7 @@ function ClawOnboardingFlowInner({
         sandboxId={status?.sandboxId || null}
         region={status?.flyRegion || null}
         gatewayUrl={gatewayUrl}
-        gatewayReady={gatewayStatus?.state === 'running'}
+        gatewayReady={flowState.gatewayReady}
         isSetupWizard
       />
 
@@ -193,115 +353,7 @@ function ClawOnboardingFlowInner({
       <ClawConfigServiceBanner status={status} />
 
       <MaybeBillingWrapper skip={!!organizationId} hideBanners>
-        {mode === 'post-provisioning' ? (
-          postProvisioningReady ? (
-            <ClawSetupCompleteStep
-              status={instanceStatus}
-              gatewayReady={gatewayStatus?.state === 'running'}
-              basePath={basePath}
-            />
-          ) : (
-            <ProvisioningStepView />
-          )
-        ) : !instanceStatus && !createSetupStarted ? (
-          <CreateInstanceCard
-            mutations={mutations}
-            onProvisionStart={handleCreateFlowStarted}
-            onProvisionFailed={handleCreateFlowFailed}
-          />
-        ) : onboardingStep === 'identity' ? (
-          <BotIdentityStep
-            instanceRunning={instanceRunning}
-            onContinue={identity => {
-              posthog?.capture('claw_setup_identity_completed', {
-                bot_name_is_custom: identity.botName !== 'KiloClaw',
-                bot_nature: identity.botNature,
-                bot_emoji_is_custom: identity.botEmoji !== '🤖',
-              });
-              posthog?.capture('claw_setup_permissions_viewed');
-              setBotIdentity(identity);
-              setOnboardingStep('permissions');
-            }}
-          />
-        ) : onboardingStep === 'permissions' ? (
-          <PermissionStep
-            instanceRunning={instanceRunning}
-            onSelect={preset => {
-              posthog?.capture('claw_setup_permissions_completed', { preset });
-              posthog?.capture('claw_setup_channels_viewed');
-              setSelectedPreset(preset);
-              setOnboardingStep('channels');
-            }}
-          />
-        ) : onboardingStep === 'channels' ? (
-          <ChannelSelectionStepView
-            instanceRunning={instanceRunning}
-            onSelect={(channelId, tokens) => {
-              posthog?.capture('claw_setup_channels_completed', {
-                channel: channelId,
-                skipped: false,
-              });
-              posthog?.capture('claw_setup_provisioning_viewed');
-              setSelectedChannelId(channelId);
-              setChannelTokens(tokens);
-              setOnboardingStep('provisioning');
-            }}
-            onSkip={() => {
-              posthog?.capture('claw_setup_channels_completed', {
-                channel: null,
-                skipped: true,
-              });
-              posthog?.capture('claw_setup_provisioning_viewed');
-              setSelectedChannelId(null);
-              setChannelTokens(null);
-              setOnboardingStep('provisioning');
-            }}
-          />
-        ) : onboardingStep === 'provisioning' && selectedPreset ? (
-          <ProvisioningStep
-            preset={selectedPreset}
-            channelTokens={channelTokens}
-            botIdentity={botIdentity}
-            instanceRunning={instanceRunning}
-            mutations={mutations}
-            totalSteps={hasPairingStep ? 6 : 5}
-            onComplete={() => {
-              posthog?.capture('claw_setup_provisioned');
-              posthog?.capture(
-                hasPairingStep ? 'claw_setup_pairing_viewed' : 'claw_setup_done_viewed'
-              );
-              setOnboardingStep(hasPairingStep ? 'pairing' : 'done');
-            }}
-          />
-        ) : onboardingStep === 'pairing' &&
-          (selectedChannelId === 'telegram' || selectedChannelId === 'discord') ? (
-          <ChannelPairingStep
-            channelId={selectedChannelId}
-            mutations={mutations}
-            onComplete={() => {
-              posthog?.capture('claw_setup_pairing_completed', {
-                channel: selectedChannelId,
-                skipped: false,
-              });
-              posthog?.capture('claw_setup_done_viewed');
-              setOnboardingStep('done');
-            }}
-            onSkip={() => {
-              posthog?.capture('claw_setup_pairing_completed', {
-                channel: selectedChannelId,
-                skipped: true,
-              });
-              posthog?.capture('claw_setup_done_viewed');
-              setOnboardingStep('done');
-            }}
-          />
-        ) : (
-          <ClawSetupCompleteStep
-            status={instanceStatus}
-            gatewayReady={gatewayStatus?.state === 'running'}
-            basePath={basePath}
-          />
-        )}
+        {renderStepContent()}
       </MaybeBillingWrapper>
     </div>
   );

--- a/apps/web/src/app/(app)/claw/components/ProvisioningStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/ProvisioningStep.tsx
@@ -247,9 +247,7 @@ export function ProvisioningErrorView({ totalSteps = 5 }: { totalSteps?: number 
 
 /** Pure visual shell — extracted so Storybook can render it without wiring up mutations. */
 export function ProvisioningStepView({ totalSteps = 5 }: { totalSteps?: number }) {
-  const [phraseIndex, setPhraseIndex] = useState(() =>
-    Math.floor(Math.random() * PROVISIONING_PHRASES.length)
-  );
+  const [phraseIndex, setPhraseIndex] = useState(0);
   const [visible, setVisible] = useState(true);
 
   useEffect(() => {

--- a/apps/web/src/app/(app)/claw/new/ClawNewClient.tsx
+++ b/apps/web/src/app/(app)/claw/new/ClawNewClient.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { useKiloClawStatus } from '@/hooks/useKiloClaw';
+import { useTRPC } from '@/lib/trpc/utils';
+import {
+  ClawOnboardingFlow,
+  type ClawOnboardingMode,
+  withStatusQueryBoundary,
+} from '../components';
+import type { ClawOnboardingRenderStep } from '../components/ClawOnboardingFlow.state';
+import { ClawOnboardingFakeWalkthrough } from '../components/ClawOnboardingFakeWalkthrough';
+import { WelcomePage } from '../components/billing/WelcomePage';
+
+const ClawOnboardingWithBoundary = withStatusQueryBoundary(ClawOnboardingFlow);
+
+function LoadingState() {
+  return (
+    <div
+      className="container m-auto flex w-full max-w-[1140px] items-center justify-center p-4 md:p-6"
+      style={{ minHeight: '50vh' }}
+    >
+      <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
+    </div>
+  );
+}
+
+function ClawNewLoader({
+  mode,
+  createFlowStartedAt,
+  billingUpdatedAt,
+  onCreateFlowStarted,
+  onCreateFlowFailed,
+}: {
+  mode: ClawOnboardingMode;
+  createFlowStartedAt: number | null;
+  billingUpdatedAt: number;
+  onCreateFlowStarted: () => void;
+  onCreateFlowFailed: () => void;
+}) {
+  const statusQuery = useKiloClawStatus();
+
+  if (mode === 'create-first') {
+    const status =
+      createFlowStartedAt !== null && statusQuery.dataUpdatedAt >= createFlowStartedAt
+        ? statusQuery.data
+        : undefined;
+
+    return (
+      <ClawOnboardingFlow
+        status={status}
+        mode={mode}
+        onCreateFlowStarted={onCreateFlowStarted}
+        onCreateFlowFailed={onCreateFlowFailed}
+      />
+    );
+  }
+
+  const statusQueryForBoundary =
+    statusQuery.error || statusQuery.dataUpdatedAt >= billingUpdatedAt
+      ? statusQuery
+      : {
+          data: undefined,
+          isLoading: true,
+          error: null,
+        };
+
+  return (
+    <ClawOnboardingWithBoundary
+      statusQuery={statusQueryForBoundary}
+      mode={mode}
+      onCreateFlowStarted={onCreateFlowStarted}
+    />
+  );
+}
+
+export function ClawNewClient({
+  fakeOnboardingStep,
+}: {
+  fakeOnboardingStep: ClawOnboardingRenderStep | null;
+}) {
+  if (fakeOnboardingStep) {
+    return <ClawOnboardingFakeWalkthrough initialStep={fakeOnboardingStep} basePath="/claw" />;
+  }
+
+  return <ClawNewLiveClient />;
+}
+
+function ClawNewLiveClient() {
+  const trpc = useTRPC();
+  const billingQuery = useQuery(trpc.kiloclaw.getBillingStatus.queryOptions());
+  const [createFlowStartedAt, setCreateFlowStartedAt] = useState<number | null>(null);
+  const onCreateFlowStarted = useCallback(() => setCreateFlowStartedAt(Date.now()), []);
+  const onCreateFlowFailed = useCallback(() => setCreateFlowStartedAt(null), []);
+
+  if (billingQuery.isLoading) {
+    return <LoadingState />;
+  }
+
+  if (billingQuery.isError) {
+    return (
+      <div
+        className="container m-auto flex w-full max-w-[1140px] items-center justify-center p-4 md:p-6"
+        style={{ minHeight: '50vh' }}
+      >
+        <p className="text-destructive text-sm">
+          Unable to load billing status. Please refresh the page or try again later.
+        </p>
+      </div>
+    );
+  }
+
+  if (createFlowStartedAt === null && billingQuery.isFetching) {
+    return <LoadingState />;
+  }
+
+  const billing = billingQuery.data;
+  const isNewUser =
+    billing &&
+    !billing.hasAccess &&
+    billing.instance === null &&
+    !billing.earlybird &&
+    !billing.trial?.expired;
+
+  if (isNewUser && !billing.trialEligible) {
+    return (
+      <div className="container m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
+        <WelcomePage />
+      </div>
+    );
+  }
+
+  const hasActiveInstance =
+    billing?.instance?.exists === true && billing.instance.destroyed === false;
+  const mode: ClawOnboardingMode =
+    createFlowStartedAt !== null || !hasActiveInstance ? 'create-first' : 'post-provisioning';
+
+  return (
+    <ClawNewLoader
+      mode={mode}
+      createFlowStartedAt={createFlowStartedAt}
+      billingUpdatedAt={billingQuery.dataUpdatedAt}
+      onCreateFlowStarted={onCreateFlowStarted}
+      onCreateFlowFailed={onCreateFlowFailed}
+    />
+  );
+}

--- a/apps/web/src/app/(app)/claw/new/page.tsx
+++ b/apps/web/src/app/(app)/claw/new/page.tsx
@@ -1,135 +1,27 @@
-'use client';
-
-import { useCallback, useState } from 'react';
-import { Loader2 } from 'lucide-react';
-import { useQuery } from '@tanstack/react-query';
-import { useKiloClawStatus } from '@/hooks/useKiloClaw';
-import { useTRPC } from '@/lib/trpc/utils';
 import {
-  ClawOnboardingFlow,
-  type ClawOnboardingMode,
-  withStatusQueryBoundary,
-} from '../components';
-import { WelcomePage } from '../components/billing/WelcomePage';
+  FAKE_ONBOARDING_STEP_PARAM,
+  parseClawOnboardingFakeStep,
+} from '../components/ClawOnboardingFlow.state';
+import { ClawNewClient } from './ClawNewClient';
 
-const ClawOnboardingWithBoundary = withStatusQueryBoundary(ClawOnboardingFlow);
+type ClawNewPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
 
-function LoadingState() {
-  return (
-    <div
-      className="container m-auto flex w-full max-w-[1140px] items-center justify-center p-4 md:p-6"
-      style={{ minHeight: '50vh' }}
-    >
-      <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
-    </div>
-  );
+export default async function ClawNewPage({ searchParams }: ClawNewPageProps) {
+  const params = await searchParams;
+  const fakeOnboardingStep =
+    process.env.NODE_ENV === 'production'
+      ? null
+      : parseClawOnboardingFakeStep(getSearchParam(params, FAKE_ONBOARDING_STEP_PARAM));
+
+  return <ClawNewClient fakeOnboardingStep={fakeOnboardingStep} />;
 }
 
-function ClawNewLoader({
-  mode,
-  createFlowStartedAt,
-  billingUpdatedAt,
-  onCreateFlowStarted,
-  onCreateFlowFailed,
-}: {
-  mode: ClawOnboardingMode;
-  createFlowStartedAt: number | null;
-  billingUpdatedAt: number;
-  onCreateFlowStarted: () => void;
-  onCreateFlowFailed: () => void;
-}) {
-  const statusQuery = useKiloClawStatus();
-
-  if (mode === 'create-first') {
-    const status =
-      createFlowStartedAt !== null && statusQuery.dataUpdatedAt >= createFlowStartedAt
-        ? statusQuery.data
-        : undefined;
-
-    return (
-      <ClawOnboardingFlow
-        status={status}
-        mode={mode}
-        onCreateFlowStarted={onCreateFlowStarted}
-        onCreateFlowFailed={onCreateFlowFailed}
-      />
-    );
-  }
-
-  const statusQueryForBoundary =
-    statusQuery.error || statusQuery.dataUpdatedAt >= billingUpdatedAt
-      ? statusQuery
-      : {
-          data: undefined,
-          isLoading: true,
-          error: null,
-        };
-
-  return (
-    <ClawOnboardingWithBoundary
-      statusQuery={statusQueryForBoundary}
-      mode={mode}
-      onCreateFlowStarted={onCreateFlowStarted}
-    />
-  );
-}
-
-export default function ClawNewPage() {
-  const trpc = useTRPC();
-  const billingQuery = useQuery(trpc.kiloclaw.getBillingStatus.queryOptions());
-  const [createFlowStartedAt, setCreateFlowStartedAt] = useState<number | null>(null);
-  const onCreateFlowStarted = useCallback(() => setCreateFlowStartedAt(Date.now()), []);
-  const onCreateFlowFailed = useCallback(() => setCreateFlowStartedAt(null), []);
-
-  if (billingQuery.isLoading) {
-    return <LoadingState />;
-  }
-
-  if (billingQuery.isError) {
-    return (
-      <div
-        className="container m-auto flex w-full max-w-[1140px] items-center justify-center p-4 md:p-6"
-        style={{ minHeight: '50vh' }}
-      >
-        <p className="text-destructive text-sm">
-          Unable to load billing status. Please refresh the page or try again later.
-        </p>
-      </div>
-    );
-  }
-
-  if (createFlowStartedAt === null && billingQuery.isFetching) {
-    return <LoadingState />;
-  }
-
-  const billing = billingQuery.data;
-  const isNewUser =
-    billing &&
-    !billing.hasAccess &&
-    billing.instance === null &&
-    !billing.earlybird &&
-    !billing.trial?.expired;
-
-  if (isNewUser && !billing.trialEligible) {
-    return (
-      <div className="container m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
-        <WelcomePage />
-      </div>
-    );
-  }
-
-  const hasActiveInstance =
-    billing?.instance?.exists === true && billing.instance.destroyed === false;
-  const mode: ClawOnboardingMode =
-    createFlowStartedAt !== null || !hasActiveInstance ? 'create-first' : 'post-provisioning';
-
-  return (
-    <ClawNewLoader
-      mode={mode}
-      createFlowStartedAt={createFlowStartedAt}
-      billingUpdatedAt={billingQuery.dataUpdatedAt}
-      onCreateFlowStarted={onCreateFlowStarted}
-      onCreateFlowFailed={onCreateFlowFailed}
-    />
-  );
+function getSearchParam(
+  params: Record<string, string | string[] | undefined>,
+  key: string
+): string | null {
+  const value = params[key];
+  return typeof value === 'string' ? value : null;
 }

--- a/apps/web/src/app/(app)/organizations/[id]/claw/new/OrgClawNewClient.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/claw/new/OrgClawNewClient.tsx
@@ -6,11 +6,32 @@ import {
   ClawOnboardingFlow,
   type ClawOnboardingMode,
 } from '@/app/(app)/claw/components/ClawOnboardingFlow';
+import type { ClawOnboardingRenderStep } from '@/app/(app)/claw/components/ClawOnboardingFlow.state';
+import { ClawOnboardingFakeWalkthrough } from '@/app/(app)/claw/components/ClawOnboardingFakeWalkthrough';
 import { withStatusQueryBoundary } from '@/app/(app)/claw/components/withStatusQueryBoundary';
 
 const ClawOnboardingWithBoundary = withStatusQueryBoundary(ClawOnboardingFlow);
 
-export function OrgClawNewClient({ organizationId }: { organizationId: string }) {
+export function OrgClawNewClient({
+  organizationId,
+  fakeOnboardingStep,
+}: {
+  organizationId: string;
+  fakeOnboardingStep: ClawOnboardingRenderStep | null;
+}) {
+  if (fakeOnboardingStep) {
+    return (
+      <ClawOnboardingFakeWalkthrough
+        initialStep={fakeOnboardingStep}
+        basePath={`/organizations/${organizationId}/claw`}
+      />
+    );
+  }
+
+  return <OrgClawNewLiveClient organizationId={organizationId} />;
+}
+
+function OrgClawNewLiveClient({ organizationId }: { organizationId: string }) {
   const statusQuery = useOrgKiloClawStatus(organizationId);
   const [createFlowStartedAt, setCreateFlowStartedAt] = useState<number | null>(null);
   const [hasSettledStatus, setHasSettledStatus] = useState(false);

--- a/apps/web/src/app/(app)/organizations/[id]/claw/new/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/claw/new/page.tsx
@@ -1,15 +1,41 @@
 import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import {
+  FAKE_ONBOARDING_STEP_PARAM,
+  parseClawOnboardingFakeStep,
+} from '@/app/(app)/claw/components/ClawOnboardingFlow.state';
 import { OrgClawNewClient } from './OrgClawNewClient';
 
 type OrgClawNewPageProps = {
   params: Promise<{ id: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
-export default async function OrgClawNewPage({ params }: OrgClawNewPageProps) {
+export default async function OrgClawNewPage({ params, searchParams }: OrgClawNewPageProps) {
+  const resolvedSearchParams = await searchParams;
+  const fakeOnboardingStep =
+    process.env.NODE_ENV === 'production'
+      ? null
+      : parseClawOnboardingFakeStep(
+          getSearchParam(resolvedSearchParams, FAKE_ONBOARDING_STEP_PARAM)
+        );
+
   return (
     <OrganizationByPageLayout
       params={params}
-      render={org => <OrgClawNewClient organizationId={org.organization.id} />}
+      render={org => (
+        <OrgClawNewClient
+          organizationId={org.organization.id}
+          fakeOnboardingStep={fakeOnboardingStep}
+        />
+      )}
     />
   );
+}
+
+function getSearchParam(
+  params: Record<string, string | string[] | undefined>,
+  key: string
+): string | null {
+  const value = params[key];
+  return typeof value === 'string' ? value : null;
 }


### PR DESCRIPTION
## Summary
- Extract KiloClaw onboarding branching into a pure state-machine helper with unit coverage for create-first, post-provisioning, pairing, and invalid local states.
- Refactor the onboarding component to render from the derived state while preserving existing PostHog and mutation behavior.
- Add a development-only fake walkthrough via `?fakeOnboardingStep=...` for personal and organization KiloClaw onboarding without billing/provisioning/gateway dependencies.

## Visual Changes

https://github.com/user-attachments/assets/9d47146e-8010-4d49-a0d6-041f8144caa6
