### PR TITLE
fix(kiloclaw): simplify update availability copy

### DIFF
--- a/apps/storybook/stories/claw/KiloClawUpdateAvailableBanner.stories.tsx
+++ b/apps/storybook/stories/claw/KiloClawUpdateAvailableBanner.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { KiloClawUpdateAvailableBanner } from '@/app/(app)/claw/components/KiloClawUpdateAvailableBanner';
+
+const meta = {
+  title: 'Claw/UpdateAvailableBanner',
+  component: KiloClawUpdateAvailableBanner,
+  parameters: {
+    layout: 'padded',
+    backgrounds: {
+      default: 'dark',
+    },
+  },
+  args: {
+    catalogNewerThanImage: false,
+    onUpgrade: () => undefined,
+    onDismiss: () => undefined,
+  },
+  decorators: [
+    Story => (
+      <div className="mx-auto w-full max-w-[1140px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof KiloClawUpdateAvailableBanner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const KiloClawOnly: Story = {};
+
+export const IncludesNewerOpenClawVersion: Story = {
+  args: {
+    catalogNewerThanImage: true,
+  },
+};
+
+export const StateComparison: Story = {
+  render: args => (
+    <div className="flex flex-col gap-4">
+      <KiloClawUpdateAvailableBanner {...args} catalogNewerThanImage={false} />
+      <KiloClawUpdateAvailableBanner {...args} catalogNewerThanImage />
+    </div>
+  ),
+};

--- a/apps/storybook/stories/claw/KiloClawUpdateAvailableBanner.stories.tsx
+++ b/apps/storybook/stories/claw/KiloClawUpdateAvailableBanner.stories.tsx
@@ -29,7 +29,7 @@ type Story = StoryObj<typeof meta>;
 
 export const KiloClawOnly: Story = {};
 
-export const IncludesNewerOpenClawVersion: Story = {
+export const IncludesNewOpenClawVersion: Story = {
   args: {
     catalogNewerThanImage: true,
   },

--- a/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  ArrowUpCircle,
   Check,
   Cpu,
   HardDrive,
@@ -17,7 +16,6 @@ import {
 import { usePostHog } from 'posthog-js/react';
 import { toast } from 'sonner';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
-import { Banner } from '@/components/shared/Banner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -39,6 +37,7 @@ import { RunDoctorDialog } from './RunDoctorDialog';
 import { StartKiloCliRunDialog } from './StartKiloCliRunDialog';
 import { AnimatedDots } from './AnimatedDots';
 import { OpenClawButton } from './OpenClawButton';
+import { KiloClawUpdateAvailableBanner } from './KiloClawUpdateAvailableBanner';
 
 const VOLUME_SIZE_GB = 10;
 // Default machine spec fallback (matches kiloclaw DEFAULT_MACHINE_GUEST)
@@ -87,7 +86,7 @@ export function InstanceControls({
   const [confirmRedeploy, setConfirmRedeploy] = useState(false);
   const [redeployMode, setRedeployMode] = useState<'redeploy' | 'upgrade'>('redeploy');
 
-  const { updateAvailable, latestAvailableVersion, latestVersion, openClawUpdateExcerpt } =
+  const { updateAvailable, catalogNewerThanImage, latestAvailableVersion, latestVersion } =
     useClawUpdateAvailable(status);
 
   const upgradeVersion = latestAvailableVersion ?? latestVersion?.imageTag ?? '';
@@ -214,35 +213,15 @@ export function InstanceControls({
         </div>
       </div>
       {showUpgradeBanner && (
-        <Banner color="amber" className="mb-4">
-          <Banner.Icon>
-            <ArrowUpCircle />
-          </Banner.Icon>
-          <Banner.Content>
-            <Banner.Title>A newer version of KiloClaw is available</Banner.Title>
-            <Banner.Description>
-              {openClawUpdateExcerpt ? `${openClawUpdateExcerpt} ` : null}
-              Upgrade your instance to get the latest features and fixes.
-            </Banner.Description>
-          </Banner.Content>
-          <Banner.Button
-            className="text-white"
-            onClick={() => {
-              setRedeployMode('upgrade');
-              setConfirmRedeploy(true);
-            }}
-          >
-            Upgrade now
-          </Banner.Button>
-          <button
-            type="button"
-            onClick={dismissBanner}
-            className="text-amber-400/60 hover:text-amber-400 transition-colors"
-            aria-label="Dismiss upgrade banner"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </Banner>
+        <KiloClawUpdateAvailableBanner
+          className="mb-4"
+          catalogNewerThanImage={catalogNewerThanImage}
+          onUpgrade={() => {
+            setRedeployMode('upgrade');
+            setConfirmRedeploy(true);
+          }}
+          onDismiss={dismissBanner}
+        />
       )}
       <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
         <OpenClawButton

--- a/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
@@ -87,7 +87,7 @@ export function InstanceControls({
   const [confirmRedeploy, setConfirmRedeploy] = useState(false);
   const [redeployMode, setRedeployMode] = useState<'redeploy' | 'upgrade'>('redeploy');
 
-  const { updateAvailable, catalogNewerThanImage, latestAvailableVersion, latestVersion } =
+  const { updateAvailable, latestAvailableVersion, latestVersion, openClawUpdateExcerpt } =
     useClawUpdateAvailable(status);
 
   const upgradeVersion = latestAvailableVersion ?? latestVersion?.imageTag ?? '';
@@ -219,12 +219,9 @@ export function InstanceControls({
             <ArrowUpCircle />
           </Banner.Icon>
           <Banner.Content>
-            <Banner.Title>
-              {catalogNewerThanImage
-                ? `A newer OpenClaw version (${latestAvailableVersion}) is available`
-                : `A newer image (${latestVersion?.imageTag ?? 'unknown'}) is available`}
-            </Banner.Title>
+            <Banner.Title>A newer version of KiloClaw is available</Banner.Title>
             <Banner.Description>
+              {openClawUpdateExcerpt ? `${openClawUpdateExcerpt} ` : null}
               Upgrade your instance to get the latest features and fixes.
             </Banner.Description>
           </Banner.Content>
@@ -452,7 +449,7 @@ export function InstanceControls({
                 mutations.restartMachine.mutate(imageTag ? { imageTag } : undefined, {
                   onSuccess: () => {
                     toast.success(
-                      redeployMode === 'upgrade' ? 'Upgrading to latest image' : 'Redeploying'
+                      redeployMode === 'upgrade' ? 'Upgrading KiloClaw' : 'Redeploying'
                     );
                     setConfirmRedeploy(false);
                     onRedeploySuccess?.();

--- a/apps/web/src/app/(app)/claw/components/KiloClawUpdateAvailableBanner.tsx
+++ b/apps/web/src/app/(app)/claw/components/KiloClawUpdateAvailableBanner.tsx
@@ -22,9 +22,9 @@ export function KiloClawUpdateAvailableBanner({
         <ArrowUpCircle />
       </Banner.Icon>
       <Banner.Content>
-        <Banner.Title>A newer version of KiloClaw is available</Banner.Title>
+        <Banner.Title>A new version of KiloClaw is available</Banner.Title>
         <Banner.Description>
-          {catalogNewerThanImage ? 'This update includes a newer OpenClaw version. ' : null}
+          {catalogNewerThanImage ? 'This update includes a new OpenClaw version. ' : null}
           Upgrade your instance to get the latest features and fixes.
         </Banner.Description>
       </Banner.Content>

--- a/apps/web/src/app/(app)/claw/components/KiloClawUpdateAvailableBanner.tsx
+++ b/apps/web/src/app/(app)/claw/components/KiloClawUpdateAvailableBanner.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { ArrowUpCircle, X } from 'lucide-react';
+import { Banner } from '@/components/shared/Banner';
+
+type KiloClawUpdateAvailableBannerProps = {
+  catalogNewerThanImage: boolean;
+  onUpgrade: () => void;
+  onDismiss: () => void;
+  className?: string;
+};
+
+export function KiloClawUpdateAvailableBanner({
+  catalogNewerThanImage,
+  onUpgrade,
+  onDismiss,
+  className,
+}: KiloClawUpdateAvailableBannerProps) {
+  return (
+    <Banner color="amber" className={className}>
+      <Banner.Icon>
+        <ArrowUpCircle />
+      </Banner.Icon>
+      <Banner.Content>
+        <Banner.Title>A newer version of KiloClaw is available</Banner.Title>
+        <Banner.Description>
+          {catalogNewerThanImage ? 'This update includes a newer OpenClaw version. ' : null}
+          Upgrade your instance to get the latest features and fixes.
+        </Banner.Description>
+      </Banner.Content>
+      <Banner.Button className="text-white" onClick={onUpgrade}>
+        Upgrade now
+      </Banner.Button>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="text-amber-400/60 hover:text-amber-400 transition-colors"
+        aria-label="Dismiss upgrade banner"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </Banner>
+  );
+}

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -699,7 +699,7 @@ export function SettingsTab({
   const isRunning = status.status === 'running';
   const {
     updateAvailable,
-    openClawUpdateExcerpt,
+    catalogNewerThanImage,
     needsImageUpgrade,
     isModified,
     hasVersionInfo,
@@ -868,8 +868,8 @@ export function SettingsTab({
                       </TooltipTrigger>
                       <TooltipContent>
                         <p>
-                          {openClawUpdateExcerpt
-                            ? `A newer version of KiloClaw is available. ${openClawUpdateExcerpt} Click to upgrade.`
+                          {catalogNewerThanImage
+                            ? 'A newer version of KiloClaw is available. This update includes a newer OpenClaw version. Click to upgrade.'
                             : 'A newer version of KiloClaw is available — click to upgrade.'}
                         </p>
                       </TooltipContent>

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -869,8 +869,8 @@ export function SettingsTab({
                       <TooltipContent>
                         <p>
                           {catalogNewerThanImage
-                            ? 'A newer version of KiloClaw is available. This update includes a newer OpenClaw version. Click to upgrade.'
-                            : 'A newer version of KiloClaw is available — click to upgrade.'}
+                            ? 'A new version of KiloClaw is available. This update includes a new OpenClaw version. Click to upgrade.'
+                            : 'A new version of KiloClaw is available — click to upgrade.'}
                         </p>
                       </TooltipContent>
                     </Tooltip>

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -699,14 +699,13 @@ export function SettingsTab({
   const isRunning = status.status === 'running';
   const {
     updateAvailable,
-    catalogNewerThanImage,
+    openClawUpdateExcerpt,
     needsImageUpgrade,
     isModified,
     hasVersionInfo,
     variantsMatch,
     trackedVersion,
     runningVersion,
-    latestAvailableVersion,
     latestVersion,
     controllerVersion,
     isLoadingControllerVersion,
@@ -869,9 +868,9 @@ export function SettingsTab({
                       </TooltipTrigger>
                       <TooltipContent>
                         <p>
-                          {catalogNewerThanImage
-                            ? `A newer OpenClaw version (${latestAvailableVersion}) is available — click to upgrade`
-                            : `A newer image (${latestVersion?.imageTag ?? 'unknown'}) is available — click to upgrade`}
+                          {openClawUpdateExcerpt
+                            ? `A newer version of KiloClaw is available. ${openClawUpdateExcerpt} Click to upgrade.`
+                            : 'A newer version of KiloClaw is available — click to upgrade.'}
                         </p>
                       </TooltipContent>
                     </Tooltip>

--- a/apps/web/src/app/(app)/claw/hooks/useClawUpdateAvailable.ts
+++ b/apps/web/src/app/(app)/claw/hooks/useClawUpdateAvailable.ts
@@ -55,15 +55,10 @@ export function useClawUpdateAvailable(status: {
         calverAtLeast(latestAvailableVersion, runningVersion) &&
         latestAvailableVersion !== runningVersion)
     : imageTagDiffers;
-  const openClawUpdateExcerpt =
-    catalogNewerThanImage && latestAvailableVersion
-      ? `Includes OpenClaw ${latestAvailableVersion}.`
-      : null;
 
   return {
     updateAvailable,
     catalogNewerThanImage,
-    openClawUpdateExcerpt,
     needsImageUpgrade,
     isModified,
     hasVersionInfo,

--- a/apps/web/src/app/(app)/claw/hooks/useClawUpdateAvailable.ts
+++ b/apps/web/src/app/(app)/claw/hooks/useClawUpdateAvailable.ts
@@ -55,10 +55,15 @@ export function useClawUpdateAvailable(status: {
         calverAtLeast(latestAvailableVersion, runningVersion) &&
         latestAvailableVersion !== runningVersion)
     : imageTagDiffers;
+  const openClawUpdateExcerpt =
+    catalogNewerThanImage && latestAvailableVersion
+      ? `Includes OpenClaw ${latestAvailableVersion}.`
+      : null;
 
   return {
     updateAvailable,
     catalogNewerThanImage,
+    openClawUpdateExcerpt,
     needsImageUpgrade,
     isModified,
     hasVersionInfo,


### PR DESCRIPTION
## Summary
- Replaces technical KiloClaw update messaging that referenced image tags with user-facing copy that says a new KiloClaw version is available.

## Visual Changes

<img width="1922" height="186" alt="CleanShot 2026-04-15 at 14 30 32@2x" src="https://github.com/user-attachments/assets/fcb9730a-f271-476f-9fef-d8cb491fb7f5" />
<img width="1916" height="182" alt="CleanShot 2026-04-15 at 14 30 51@2x" src="https://github.com/user-attachments/assets/4ca09f01-d602-4a20-81b6-c0ae3c4f096a" />
