### PR TITLE
fix(claw): update onboarding status fixtures

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
@@ -66,6 +66,7 @@ const fakeStatus = {
   workerUrl: 'https://claw.kilo.ai',
   name: 'Fake KiloClaw',
   instanceId: 'fake-instance',
+  inboundEmailAddress: null,
 } satisfies PopulatedClawStatus;
 
 export function ClawOnboardingFakeWalkthrough({

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
@@ -55,6 +55,7 @@ function createStatus(status: KiloClawDashboardStatus['status']): KiloClawDashbo
     botEmoji: null,
     workerUrl: 'https://claw.kilo.ai',
     instanceId: null,
+    inboundEmailAddress: null,
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds the missing `inboundEmailAddress` field to KiloClaw onboarding fake/test status objects so they satisfy the updated dashboard status types.

## Verification
- `pnpm format`
- `pnpm typecheck`

## Visual Changes
N/A

## Reviewer Notes
N/A