### PR TITLE
docs(pr-template): clarify verification guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 
 ## Verification
 
-<!-- List the checks you ran and what passed. Add command output notes when useful. -->
+<!-- Only list manually tested paths, not automated tests. If you didn't run any manual tests, point that out, and explain why. -->
 
 - [ ]
 


### PR DESCRIPTION
## Summary

- Clarifies that PR Verification should document manually tested paths rather than automated checks. Because automated checks run on each PR anyway
- Asks authors to explicitly note when no manual testing was run and why.
