### PR TITLE
docs(kiloclaw): announce read-only email address

### DIFF
--- a/apps/web/src/app/(app)/claw/components/changelog-data.ts
+++ b/apps/web/src/app/(app)/claw/components/changelog-data.ts
@@ -15,7 +15,7 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
     description:
       'KiloClaw instances now come with a read-only email address for receiving messages and notifications without granting send access. You can find the address on the KiloClaw settings page.',
     category: 'feature',
-    deployHint: null,
+    deployHint: 'redeploy_suggested',
   },
   {
     date: '2026-04-06',

--- a/apps/web/src/app/(app)/claw/components/changelog-data.ts
+++ b/apps/web/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,13 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-04-15',
+    description:
+      'KiloClaw instances now come with a read-only email address for receiving messages and notifications without granting send access. You can find the address on the KiloClaw settings page.',
+    category: 'feature',
+    deployHint: null,
+  },
+  {
     date: '2026-04-06',
     description: 'Updated OpenClaw to 2026.4.5.',
     category: 'feature',


### PR DESCRIPTION
## Summary
- Added a KiloClaw changelog entry announcing that instances now include a read-only email address.
- Mentioned that users can find the address on the KiloClaw settings page.

## Verification
- `pnpm format`
- `pnpm typecheck`
- `pnpm lint`

## Visual Changes
N/A

## Reviewer Notes
N/A