### PR TITLE
fix(kiloclaw): reconcile CLI run lifecycle state

### DIFF
--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -8,11 +8,13 @@ import { and, eq } from 'drizzle-orm';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const mockGetDebugStatus: jest.Mock<any, any> = jest.fn();
 const mockDestroyFlyMachine: jest.Mock<any, any> = jest.fn();
+const mockStartKiloCliRun: jest.Mock<any, any> = jest.fn();
 
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => ({
   KiloClawInternalClient: jest.fn().mockImplementation(() => ({
     getDebugStatus: mockGetDebugStatus,
     destroyFlyMachine: mockDestroyFlyMachine,
+    startKiloCliRun: mockStartKiloCliRun,
   })),
   KiloClawApiError: class KiloClawApiError extends Error {
     statusCode: number;
@@ -60,6 +62,7 @@ beforeAll(async () => {
 beforeEach(async () => {
   mockGetDebugStatus.mockReset();
   mockDestroyFlyMachine.mockReset();
+  mockStartKiloCliRun.mockReset();
   // Clean audit logs between tests so counts are accurate
   await db
     .delete(kiloclaw_admin_audit_logs)
@@ -231,5 +234,54 @@ describe('admin.kiloclawInstances.destroyFlyMachine', () => {
     ).rejects.toThrow('Invalid Fly machine ID');
 
     expect(mockGetDebugStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('admin.kiloclawInstances.startKiloCliRun', () => {
+  it('maps worker 409 to tRPC CONFLICT', async () => {
+    const { KiloClawApiError } = jest.requireMock<{
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      KiloClawApiError: new (statusCode: number, responseBody: string) => any;
+    }>('@/lib/kiloclaw/kiloclaw-internal-client');
+
+    mockStartKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(409, JSON.stringify({ error: 'A CLI run is already in progress' }))
+    );
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.startKiloCliRun({
+        userId: testUserId,
+        prompt: 'test prompt',
+      })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'A CLI run is already in progress',
+    });
+  });
+
+  it('maps controller_route_unavailable to PRECONDITION_FAILED', async () => {
+    const { KiloClawApiError } = jest.requireMock<{
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      KiloClawApiError: new (statusCode: number, responseBody: string) => any;
+    }>('@/lib/kiloclaw/kiloclaw-internal-client');
+
+    mockStartKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(
+        404,
+        JSON.stringify({ error: 'Route not found', code: 'controller_route_unavailable' })
+      )
+    );
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.startKiloCliRun({
+        userId: testUserId,
+        prompt: 'test prompt',
+      })
+    ).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'Instance needs redeploy to support recovery',
+    });
   });
 });

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -93,6 +93,7 @@ type KiloclawTrpcCode =
   | 'NOT_FOUND'
   | 'CONFLICT'
   | 'TOO_MANY_REQUESTS'
+  | 'PRECONDITION_FAILED'
   | 'INTERNAL_SERVER_ERROR';
 
 function kiloclawStatusToTrpcCode(statusCode: number): KiloclawTrpcCode {
@@ -103,6 +104,8 @@ function kiloclawStatusToTrpcCode(statusCode: number): KiloclawTrpcCode {
       return 'NOT_FOUND';
     case 409:
       return 'CONFLICT';
+    case 412:
+      return 'PRECONDITION_FAILED';
     case 429:
       return 'TOO_MANY_REQUESTS';
     default:
@@ -110,21 +113,27 @@ function kiloclawStatusToTrpcCode(statusCode: number): KiloclawTrpcCode {
   }
 }
 
-function getKiloclawApiErrorMessage(err: KiloClawApiError, fallbackMessage: string): string {
-  if (!err.responseBody) return fallbackMessage;
+function getKiloclawApiErrorPayload(
+  err: KiloClawApiError,
+  fallbackMessage: string
+): { code?: string; message: string } {
+  if (!err.responseBody) return { message: fallbackMessage };
 
   try {
     const parsed: unknown = JSON.parse(err.responseBody);
     if (typeof parsed === 'object' && parsed !== null) {
-      const record = parsed as { error?: unknown; message?: unknown };
-      if (typeof record.error === 'string') return record.error;
-      if (typeof record.message === 'string') return record.message;
+      const code = 'code' in parsed && typeof parsed.code === 'string' ? parsed.code : undefined;
+      const error = 'error' in parsed ? parsed.error : undefined;
+      const message = 'message' in parsed ? parsed.message : undefined;
+      if (typeof error === 'string') return { code, message: error };
+      if (typeof message === 'string') return { code, message };
+      return { code, message: fallbackMessage };
     }
   } catch {
     // Fall back to the raw response body when the controller did not return JSON.
   }
 
-  return err.responseBody.trim() || fallbackMessage;
+  return { message: err.responseBody.trim() || fallbackMessage };
 }
 
 function throwKiloclawAdminError(
@@ -136,13 +145,22 @@ function throwKiloclawAdminError(
   }
 ): never {
   if (err instanceof KiloClawApiError) {
+    const payload = getKiloclawApiErrorPayload(err, fallbackMessage);
     throw new TRPCError({
       code:
-        options?.statusCodeOverrides?.[err.statusCode] ?? kiloclawStatusToTrpcCode(err.statusCode),
+        options?.statusCodeOverrides?.[err.statusCode] ??
+        (payload.code === 'controller_route_unavailable'
+          ? 'PRECONDITION_FAILED'
+          : kiloclawStatusToTrpcCode(err.statusCode)),
       message:
         options?.messageOverrides?.[err.statusCode] ??
-        getKiloclawApiErrorMessage(err, fallbackMessage),
-      cause: err,
+        (payload.code === 'controller_route_unavailable'
+          ? 'Instance needs redeploy to support recovery'
+          : payload.message),
+      cause:
+        payload.code === 'controller_route_unavailable'
+          ? new UpstreamApiError('controller_route_unavailable')
+          : err,
     });
   }
 
@@ -240,7 +258,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     } catch (err) {
       workerStatusError =
         err instanceof KiloClawApiError
-          ? getKiloclawApiErrorMessage(err, 'Failed to fetch worker status')
+          ? getKiloclawApiErrorPayload(err, 'Failed to fetch worker status').message
           : err instanceof Error
             ? err.message
             : 'Failed to fetch worker status';

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2301,7 +2301,20 @@ export const kiloclawRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const instance = await getActiveInstance(ctx.user.id);
       const client = new KiloClawInternalClient();
-      const result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
+
+      let result: Awaited<ReturnType<KiloClawInternalClient['cancelKiloCliRun']>>;
+      try {
+        result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
+      } catch (err) {
+        if (err instanceof KiloClawApiError && err.statusCode === 409) {
+          const { message } = getKiloClawApiErrorPayload(err);
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: message ?? 'Instance is not running',
+          });
+        }
+        throw err;
+      }
 
       // Mark the specific run as cancelled in DB
       if (result.ok) {

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2266,12 +2266,41 @@ export const kiloclawRouter = createTRPCRouter({
         workerInstanceId(instance)
       );
 
-      // If controller reports the run finished, persist to the DB row.
-      if (
-        controllerStatus.hasRun &&
-        controllerStatus.status !== 'running' &&
-        controllerStatus.startedAt
-      ) {
+      const controllerMatchesRow =
+        controllerStatus.hasRun && controllerStatus.startedAt === row.started_at;
+
+      if (!controllerMatchesRow) {
+        const completedAt = new Date().toISOString();
+        const output = row.output ?? '[controller lost track of this run]';
+
+        await db
+          .update(kiloclaw_cli_runs)
+          .set({
+            status: 'failed',
+            output,
+            completed_at: completedAt,
+          })
+          .where(
+            and(
+              eq(kiloclaw_cli_runs.id, input.runId),
+              eq(kiloclaw_cli_runs.user_id, ctx.user.id),
+              instanceFilter,
+              eq(kiloclaw_cli_runs.status, 'running')
+            )
+          );
+
+        return {
+          hasRun: true,
+          status: 'failed' as const,
+          output,
+          exitCode: row.exit_code,
+          startedAt: row.started_at,
+          completedAt,
+          prompt: row.prompt,
+        };
+      }
+
+      if (controllerStatus.status !== 'running') {
         await db
           .update(kiloclaw_cli_runs)
           .set({
@@ -2301,6 +2330,54 @@ export const kiloclawRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const instance = await getActiveInstance(ctx.user.id);
       const client = new KiloClawInternalClient();
+      const instanceFilter = instance ? eq(kiloclaw_cli_runs.instance_id, instance.id) : undefined;
+      const [run] = await db
+        .select()
+        .from(kiloclaw_cli_runs)
+        .where(
+          and(
+            eq(kiloclaw_cli_runs.id, input.runId),
+            eq(kiloclaw_cli_runs.user_id, ctx.user.id),
+            instanceFilter,
+            eq(kiloclaw_cli_runs.status, 'running')
+          )
+        )
+        .limit(1);
+
+      if (!run) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'Kilo CLI run is no longer running',
+        });
+      }
+
+      const controllerStatus = await client.getKiloCliRunStatus(
+        ctx.user.id,
+        workerInstanceId(instance)
+      );
+
+      if (!controllerStatus.hasRun || controllerStatus.startedAt !== run.started_at) {
+        await db
+          .update(kiloclaw_cli_runs)
+          .set({
+            status: 'failed',
+            output: run.output ?? '[controller lost track of this run]',
+            completed_at: new Date().toISOString(),
+          })
+          .where(
+            and(
+              eq(kiloclaw_cli_runs.id, input.runId),
+              eq(kiloclaw_cli_runs.user_id, ctx.user.id),
+              instanceFilter,
+              eq(kiloclaw_cli_runs.status, 'running')
+            )
+          );
+
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'Kilo CLI run is no longer active on the controller',
+        });
+      }
 
       let result: Awaited<ReturnType<KiloClawInternalClient['cancelKiloCliRun']>>;
       try {
@@ -2316,12 +2393,8 @@ export const kiloclawRouter = createTRPCRouter({
         throw err;
       }
 
-      // Mark the specific run as cancelled in DB
       if (result.ok) {
-        const instanceFilter = instance
-          ? eq(kiloclaw_cli_runs.instance_id, instance.id)
-          : undefined;
-        await db
+        const [updated] = await db
           .update(kiloclaw_cli_runs)
           .set({
             status: 'cancelled',
@@ -2334,7 +2407,15 @@ export const kiloclawRouter = createTRPCRouter({
               instanceFilter,
               eq(kiloclaw_cli_runs.status, 'running')
             )
-          );
+          )
+          .returning({ id: kiloclaw_cli_runs.id });
+
+        if (!updated) {
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: 'Kilo CLI run was already resolved',
+          });
+        }
       }
 
       return result;

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2179,12 +2179,18 @@ export const kiloclawRouter = createTRPCRouter({
         );
       } catch (err) {
         if (err instanceof KiloClawApiError) {
-          const { code } = getKiloClawApiErrorPayload(err);
+          const { code, message } = getKiloClawApiErrorPayload(err);
           if (code === 'controller_route_unavailable') {
             throw new TRPCError({
               code: 'PRECONDITION_FAILED',
               message: 'Instance needs redeploy to support recovery',
               cause: new UpstreamApiError('controller_route_unavailable'),
+            });
+          }
+          if (err.statusCode === 409) {
+            throw new TRPCError({
+              code: 'CONFLICT',
+              message: message ?? 'Instance is busy',
             });
           }
         }

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -39,6 +39,7 @@ import { deleteWorkerTrigger } from '@/lib/webhook-agent/webhook-agent-client';
 import { sentryLogger } from '@/lib/utils.server';
 import type { KiloClawDashboardStatus, KiloCodeConfigResponse } from '@/lib/kiloclaw/types';
 import { queryDiskUsage } from '@/lib/kiloclaw/disk-usage';
+import { isControllerStatusForRun, persistCliRunControllerStatus } from '@/lib/kiloclaw/cli-runs';
 import { getInboundEmailAddressForInstance } from '@/lib/kiloclaw/inbound-email-alias';
 import {
   ensureActiveInstance,
@@ -2266,8 +2267,7 @@ export const kiloclawRouter = createTRPCRouter({
         workerInstanceId(instance)
       );
 
-      const controllerMatchesRow =
-        controllerStatus.hasRun && controllerStatus.startedAt === row.started_at;
+      const controllerMatchesRow = isControllerStatusForRun(row, controllerStatus);
 
       if (!controllerMatchesRow) {
         const completedAt = new Date().toISOString();
@@ -2356,7 +2356,7 @@ export const kiloclawRouter = createTRPCRouter({
         workerInstanceId(instance)
       );
 
-      if (!controllerStatus.hasRun || controllerStatus.startedAt !== run.started_at) {
+      if (!isControllerStatusForRun(run, controllerStatus)) {
         await db
           .update(kiloclaw_cli_runs)
           .set({
@@ -2376,6 +2376,20 @@ export const kiloclawRouter = createTRPCRouter({
         throw new TRPCError({
           code: 'CONFLICT',
           message: 'Kilo CLI run is no longer active on the controller',
+        });
+      }
+
+      if (controllerStatus.status !== 'running') {
+        await persistCliRunControllerStatus({
+          runId: input.runId,
+          userId: ctx.user.id,
+          instanceId: run.instance_id,
+          controllerStatus,
+        });
+
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'Kilo CLI run is no longer running',
         });
       }
 

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -5,15 +5,16 @@ import { kiloclaw_instances, kiloclaw_subscriptions, kiloclaw_cli_runs } from '@
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createOrganization } from '@/lib/organizations/organizations';
 import type { User, Organization } from '@kilocode/db/schema';
+import type { createCallerForUser as createCallerForUserType } from '@/routers/test-utils';
+import type { KiloClawApiError as KiloClawApiErrorType } from '@/lib/kiloclaw/kiloclaw-internal-client';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyMock = jest.Mock<(...args: any[]) => any>;
+type StartKiloCliRunResult = { ok: true; startedAt: string };
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
-const mockStartKiloCliRun: AnyMock = jest.fn();
+const mockStartKiloCliRun = jest.fn<() => Promise<StartKiloCliRunResult>>();
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   const actual: Record<string, unknown> = jest.requireActual(
     '@/lib/kiloclaw/kiloclaw-internal-client'
@@ -27,17 +28,17 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
 });
 
 jest.mock('next/headers', () => {
-  const fn = jest.fn as (...args: unknown[]) => AnyMock;
+  const get = jest.fn<() => unknown>();
   return {
-    cookies: fn().mockResolvedValue({ get: fn() }),
-    headers: fn().mockReturnValue(new Map()),
+    cookies: jest.fn<() => Promise<{ get: typeof get }>>().mockResolvedValue({ get }),
+    headers: jest.fn<() => Map<string, string>>().mockReturnValue(new Map()),
   };
 });
 
 // ── Dynamic imports (after mocks) ──────────────────────────────────────────
 
-let createCallerForUser: (typeof import('@/routers/test-utils'))['createCallerForUser'];
-let KiloClawApiError: (typeof import('@/lib/kiloclaw/kiloclaw-internal-client'))['KiloClawApiError'];
+let createCallerForUser: typeof createCallerForUserType;
+let KiloClawApiError: typeof KiloClawApiErrorType;
 
 beforeAll(async () => {
   const mod = await import('@/routers/test-utils');

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, beforeAll, beforeEach, jest } from '@jest/globals';
+import { db, cleanupDbForTest } from '@/lib/drizzle';
+import { kiloclaw_instances, kiloclaw_subscriptions } from '@kilocode/db/schema';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { createOrganization, addUserToOrganization } from '@/lib/organizations/organizations';
+import type { User, Organization } from '@kilocode/db/schema';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockStartKiloCliRun: jest.Mock<any> = jest.fn();
+jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    '@/lib/kiloclaw/kiloclaw-internal-client'
+  );
+  return {
+    KiloClawInternalClient: jest.fn().mockImplementation(() => ({
+      startKiloCliRun: mockStartKiloCliRun,
+    })),
+    KiloClawApiError: actual.KiloClawApiError,
+  };
+});
+
+jest.mock('next/headers', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fn = jest.fn as (...args: any[]) => jest.Mock<any>;
+  return {
+    cookies: fn().mockResolvedValue({ get: fn() }),
+    headers: fn().mockReturnValue(new Map()),
+  };
+});
+
+// ── Dynamic imports (after mocks) ──────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let createCallerForUser: (userId: string) => Promise<any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let KiloClawApiError: any;
+
+beforeAll(async () => {
+  const mod = await import('@/routers/test-utils');
+  createCallerForUser = mod.createCallerForUser;
+  const clientMod = await import('@/lib/kiloclaw/kiloclaw-internal-client');
+  KiloClawApiError = clientMod.KiloClawApiError;
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+let user: User;
+let org: Organization;
+
+beforeEach(async () => {
+  await cleanupDbForTest();
+  mockStartKiloCliRun.mockReset();
+
+  user = await insertTestUser({
+    google_user_email: `clirun-test-${Math.random()}@example.com`,
+  });
+});
+
+async function createPersonalInstance(userId: string): Promise<string> {
+  const [row] = await db
+    .insert(kiloclaw_instances)
+    .values({
+      user_id: userId,
+      sandbox_id: `sandbox-${userId.slice(0, 8)}`,
+    })
+    .returning();
+  return row.id;
+}
+
+async function createOrgInstance(userId: string, organizationId: string): Promise<string> {
+  const [row] = await db
+    .insert(kiloclaw_instances)
+    .values({
+      user_id: userId,
+      sandbox_id: `sandbox-org-${userId.slice(0, 8)}`,
+      organization_id: organizationId,
+    })
+    .returning();
+  return row.id;
+}
+
+async function grantKiloClawAccess(userId: string): Promise<void> {
+  await db.insert(kiloclaw_subscriptions).values({
+    user_id: userId,
+    plan: 'standard',
+    status: 'active',
+    stripe_subscription_id: `sub_test_${userId.slice(0, 8)}`,
+  });
+}
+
+// ── Personal router: kiloclaw.startKiloCliRun ──────────────────────────────
+
+describe('kiloclaw.startKiloCliRun error translation', () => {
+  beforeEach(async () => {
+    await grantKiloClawAccess(user.id);
+    await createPersonalInstance(user.id);
+  });
+
+  it('maps worker 409 to tRPC CONFLICT', async () => {
+    mockStartKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(409, '{"error":"A CLI run is already in progress"}')
+    );
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.startKiloCliRun({ prompt: 'test prompt' })).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'A CLI run is already in progress',
+    });
+  });
+
+  it('maps worker 409 without message body to CONFLICT with fallback message', async () => {
+    mockStartKiloCliRun.mockRejectedValue(new KiloClawApiError(409, ''));
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.startKiloCliRun({ prompt: 'test prompt' })).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Instance is busy',
+    });
+  });
+
+  it('maps controller_route_unavailable to PRECONDITION_FAILED', async () => {
+    mockStartKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(404, '{"error":"Route not found","code":"controller_route_unavailable"}')
+    );
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.startKiloCliRun({ prompt: 'test prompt' })).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'Instance needs redeploy to support recovery',
+    });
+  });
+});
+
+// ── Org router: organizations.kiloclaw.startKiloCliRun ─────────────────────
+
+describe('organizations.kiloclaw.startKiloCliRun error translation', () => {
+  beforeEach(async () => {
+    org = await createOrganization('Test Org', user.id);
+    await createOrgInstance(user.id, org.id);
+  });
+
+  it('maps worker 409 to tRPC CONFLICT', async () => {
+    mockStartKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(409, '{"error":"A CLI run is already in progress"}')
+    );
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.startKiloCliRun({
+        organizationId: org.id,
+        prompt: 'test prompt',
+      })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'A CLI run is already in progress',
+    });
+  });
+
+  it('maps worker 409 without message body to CONFLICT with fallback message', async () => {
+    mockStartKiloCliRun.mockRejectedValue(new KiloClawApiError(409, ''));
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.startKiloCliRun({
+        organizationId: org.id,
+        prompt: 'test prompt',
+      })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Instance is busy',
+    });
+  });
+
+  it('maps controller_route_unavailable to PRECONDITION_FAILED', async () => {
+    mockStartKiloCliRun.mockRejectedValue(
+      new KiloClawApiError(404, '{"error":"Route not found","code":"controller_route_unavailable"}')
+    );
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.startKiloCliRun({
+        organizationId: org.id,
+        prompt: 'test prompt',
+      })
+    ).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'Instance needs redeploy to support recovery',
+    });
+  });
+});

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeAll, beforeEach, jest } from '@jest/globals
 import { db, cleanupDbForTest } from '@/lib/drizzle';
 import { kiloclaw_instances, kiloclaw_subscriptions } from '@kilocode/db/schema';
 import { insertTestUser } from '@/tests/helpers/user.helper';
-import { createOrganization, addUserToOrganization } from '@/lib/organizations/organizations';
+import { createOrganization } from '@/lib/organizations/organizations';
 import type { User, Organization } from '@kilocode/db/schema';
 
 // ── Mocks ──────────────────────────────────────────────────────────────────

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -263,7 +263,7 @@ describe('kiloclaw.getKiloCliRunStatus reconciliation', () => {
       status: 'completed',
       output: 'task done',
       exitCode: 0,
-      startedAt: run.startedAt,
+      startedAt: '2024-01-01T00:00:00.000Z',
       completedAt: '2024-01-01T00:05:00.000Z',
       prompt: 'test prompt',
     });
@@ -406,6 +406,39 @@ describe('kiloclaw.cancelKiloCliRun identity validation', () => {
     expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
   });
 
+  it('persists terminal status and rejects cancel when controller reports same run already completed', async () => {
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
+    const instanceId = await createPersonalInstance(user.id);
+    const run = await insertRunningCliRun(user.id, instanceId, startedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'completed',
+      output: 'task done',
+      exitCode: 0,
+      startedAt: '2024-01-01T00:00:00.000Z',
+      completedAt: '2024-01-01T00:05:00.000Z',
+      prompt: 'test prompt',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.cancelKiloCliRun({ runId })).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Kilo CLI run is no longer running',
+    });
+
+    expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
+
+    const [dbRow] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, runId));
+    expect(dbRow.status).toBe('completed');
+    expect(dbRow.exit_code).toBe(0);
+    expect(Date.parse(dbRow.completed_at ?? '')).toBe(Date.parse('2024-01-01T00:05:00.000Z'));
+  });
+
   it('cancels successfully when controller matches the DB run', async () => {
     const startedAt = '2024-01-01T00:00:00.000+00:00';
     const instanceId = await createPersonalInstance(user.id);
@@ -417,7 +450,7 @@ describe('kiloclaw.cancelKiloCliRun identity validation', () => {
       status: 'running',
       output: 'in progress',
       exitCode: null,
-      startedAt: run.startedAt,
+      startedAt: '2024-01-01T00:00:00.000Z',
       completedAt: null,
       prompt: 'test prompt',
     });
@@ -608,7 +641,7 @@ describe('organizations.kiloclaw.getKiloCliRunStatus reconciliation', () => {
       status: 'completed',
       output: 'task done',
       exitCode: 0,
-      startedAt: run.startedAt,
+      startedAt: '2024-01-01T00:00:00.000Z',
       completedAt: '2024-01-01T00:05:00.000Z',
       prompt: 'test prompt',
     });
@@ -766,6 +799,41 @@ describe('organizations.kiloclaw.cancelKiloCliRun identity validation', () => {
     expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
   });
 
+  it('persists terminal status and rejects cancel when controller reports same run already completed', async () => {
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
+    const instanceId = await createOrgInstance(user.id, org.id);
+    const run = await insertRunningCliRun(user.id, instanceId, startedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'completed',
+      output: 'task done',
+      exitCode: 0,
+      startedAt: '2024-01-01T00:00:00.000Z',
+      completedAt: '2024-01-01T00:05:00.000Z',
+      prompt: 'test prompt',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.cancelKiloCliRun({ organizationId: org.id, runId })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Kilo CLI run is no longer running',
+    });
+
+    expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
+
+    const [dbRow] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, runId));
+    expect(dbRow.status).toBe('completed');
+    expect(dbRow.exit_code).toBe(0);
+    expect(Date.parse(dbRow.completed_at ?? '')).toBe(Date.parse('2024-01-01T00:05:00.000Z'));
+  });
+
   it('cancels successfully when controller matches the DB run', async () => {
     const startedAt = '2024-01-01T00:00:00.000+00:00';
     const instanceId = await createOrgInstance(user.id, org.id);
@@ -777,7 +845,7 @@ describe('organizations.kiloclaw.cancelKiloCliRun identity validation', () => {
       status: 'running',
       output: 'in progress',
       exitCode: null,
-      startedAt: run.startedAt,
+      startedAt: '2024-01-01T00:00:00.000Z',
       completedAt: null,
       prompt: 'test prompt',
     });

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it, beforeAll, beforeEach, jest } from '@jest/globals';
+import { eq } from 'drizzle-orm';
 import { db, cleanupDbForTest } from '@/lib/drizzle';
-import { kiloclaw_instances, kiloclaw_subscriptions } from '@kilocode/db/schema';
+import { kiloclaw_instances, kiloclaw_subscriptions, kiloclaw_cli_runs } from '@kilocode/db/schema';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createOrganization } from '@/lib/organizations/organizations';
 import type { User, Organization } from '@kilocode/db/schema';
 
-// ── Mocks ──────────────────────────────────────────────────────────────────
+// ── Types ──────────────────────────────────────────────────────────────────
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockStartKiloCliRun: jest.Mock<any> = jest.fn();
+type AnyMock = jest.Mock<(...args: any[]) => any>;
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockStartKiloCliRun: AnyMock = jest.fn();
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   const actual: Record<string, unknown> = jest.requireActual(
     '@/lib/kiloclaw/kiloclaw-internal-client'
@@ -22,8 +27,7 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
 });
 
 jest.mock('next/headers', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const fn = jest.fn as (...args: any[]) => jest.Mock<any>;
+  const fn = jest.fn as (...args: unknown[]) => AnyMock;
   return {
     cookies: fn().mockResolvedValue({ get: fn() }),
     headers: fn().mockReturnValue(new Map()),
@@ -32,10 +36,8 @@ jest.mock('next/headers', () => {
 
 // ── Dynamic imports (after mocks) ──────────────────────────────────────────
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let createCallerForUser: (userId: string) => Promise<any>;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let KiloClawApiError: any;
+let createCallerForUser: (typeof import('@/routers/test-utils'))['createCallerForUser'];
+let KiloClawApiError: (typeof import('@/lib/kiloclaw/kiloclaw-internal-client'))['KiloClawApiError'];
 
 beforeAll(async () => {
   const mod = await import('@/routers/test-utils');
@@ -131,6 +133,27 @@ describe('kiloclaw.startKiloCliRun error translation', () => {
       message: 'Instance needs redeploy to support recovery',
     });
   });
+
+  it('inserts a running kiloclaw_cli_runs row on success', async () => {
+    const startedAt = '2024-01-01T00:00:00.000Z';
+    mockStartKiloCliRun.mockResolvedValue({ ok: true, startedAt });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.startKiloCliRun({ prompt: 'fix the config' });
+
+    expect(result).toMatchObject({ ok: true, startedAt, id: expect.any(String) });
+
+    const rows = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, result.id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      user_id: user.id,
+      prompt: 'fix the config',
+      status: 'running',
+    });
+  });
 });
 
 // ── Org router: organizations.kiloclaw.startKiloCliRun ─────────────────────
@@ -187,6 +210,31 @@ describe('organizations.kiloclaw.startKiloCliRun error translation', () => {
     ).rejects.toMatchObject({
       code: 'PRECONDITION_FAILED',
       message: 'Instance needs redeploy to support recovery',
+    });
+  });
+
+  it('inserts a running kiloclaw_cli_runs row on success', async () => {
+    const startedAt = '2024-01-01T00:00:00.000Z';
+    mockStartKiloCliRun.mockResolvedValue({ ok: true, startedAt });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.organizations.kiloclaw.startKiloCliRun({
+      organizationId: org.id,
+      prompt: 'fix the org config',
+    });
+
+    expect(result).toMatchObject({ ok: true, startedAt, id: expect.any(String) });
+
+    const rows = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, result.id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      user_id: user.id,
+      instance_id: expect.any(String),
+      prompt: 'fix the org config',
+      status: 'running',
     });
   });
 });

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -15,6 +15,8 @@ type StartKiloCliRunResult = { ok: true; startedAt: string };
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
 const mockStartKiloCliRun = jest.fn<() => Promise<StartKiloCliRunResult>>();
+const mockGetKiloCliRunStatus: AnyMock = jest.fn();
+const mockCancelKiloCliRun: AnyMock = jest.fn();
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   const actual: Record<string, unknown> = jest.requireActual(
     '@/lib/kiloclaw/kiloclaw-internal-client'
@@ -22,6 +24,8 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   return {
     KiloClawInternalClient: jest.fn().mockImplementation(() => ({
       startKiloCliRun: mockStartKiloCliRun,
+      getKiloCliRunStatus: mockGetKiloCliRunStatus,
+      cancelKiloCliRun: mockCancelKiloCliRun,
     })),
     KiloClawApiError: actual.KiloClawApiError,
   };
@@ -55,6 +59,8 @@ let org: Organization;
 beforeEach(async () => {
   await cleanupDbForTest();
   mockStartKiloCliRun.mockReset();
+  mockGetKiloCliRunStatus.mockReset();
+  mockCancelKiloCliRun.mockReset();
 
   user = await insertTestUser({
     google_user_email: `clirun-test-${Math.random()}@example.com`,
@@ -82,6 +88,24 @@ async function createOrgInstance(userId: string, organizationId: string): Promis
     })
     .returning();
   return row.id;
+}
+
+async function insertRunningCliRun(
+  userId: string,
+  instanceId: string,
+  startedAt: string
+): Promise<{ id: string; startedAt: string }> {
+  const [row] = await db
+    .insert(kiloclaw_cli_runs)
+    .values({
+      user_id: userId,
+      instance_id: instanceId,
+      prompt: 'test prompt',
+      status: 'running',
+      started_at: startedAt,
+    })
+    .returning({ id: kiloclaw_cli_runs.id, startedAt: kiloclaw_cli_runs.started_at });
+  return { id: row.id, startedAt: row.startedAt };
 }
 
 async function grantKiloClawAccess(userId: string): Promise<void> {
@@ -136,7 +160,7 @@ describe('kiloclaw.startKiloCliRun error translation', () => {
   });
 
   it('inserts a running kiloclaw_cli_runs row on success', async () => {
-    const startedAt = '2024-01-01T00:00:00.000Z';
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
     mockStartKiloCliRun.mockResolvedValue({ ok: true, startedAt });
 
     const caller = await createCallerForUser(user.id);
@@ -154,6 +178,262 @@ describe('kiloclaw.startKiloCliRun error translation', () => {
       prompt: 'fix the config',
       status: 'running',
     });
+  });
+});
+
+// ── Personal router: kiloclaw.getKiloCliRunStatus ──────────────────────────
+
+describe('kiloclaw.getKiloCliRunStatus reconciliation', () => {
+  beforeEach(async () => {
+    await grantKiloClawAccess(user.id);
+  });
+
+  it('terminalizes a running row when controller has no run', async () => {
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
+    const instanceId = await createPersonalInstance(user.id);
+    const run = await insertRunningCliRun(user.id, instanceId, startedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: false,
+      status: null,
+      output: null,
+      exitCode: null,
+      startedAt: null,
+      completedAt: null,
+      prompt: null,
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.getKiloCliRunStatus({ runId });
+
+    expect(result).toMatchObject({
+      hasRun: true,
+      status: 'failed',
+    });
+
+    const [dbRow] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, runId));
+    expect(dbRow.status).toBe('failed');
+    expect(dbRow.completed_at).not.toBeNull();
+  });
+
+  it('terminalizes a running row when controller reports a different run', async () => {
+    const rowStartedAt = '2024-01-01T00:00:00.000+00:00';
+    const controllerStartedAt = '2024-01-02T00:00:00.000+00:00';
+    const instanceId = await createPersonalInstance(user.id);
+    const run = await insertRunningCliRun(user.id, instanceId, rowStartedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'running',
+      output: 'some output from new run',
+      exitCode: null,
+      startedAt: controllerStartedAt,
+      completedAt: null,
+      prompt: 'different prompt',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.getKiloCliRunStatus({ runId });
+
+    expect(result).toMatchObject({
+      hasRun: true,
+      status: 'failed',
+    });
+
+    const [dbRow] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, runId));
+    expect(dbRow.status).toBe('failed');
+  });
+
+  it('persists terminal status when controller matches and is complete', async () => {
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
+    const instanceId = await createPersonalInstance(user.id);
+    const run = await insertRunningCliRun(user.id, instanceId, startedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'completed',
+      output: 'task done',
+      exitCode: 0,
+      startedAt: run.startedAt,
+      completedAt: '2024-01-01T00:05:00.000Z',
+      prompt: 'test prompt',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.getKiloCliRunStatus({ runId });
+
+    expect(result).toMatchObject({
+      hasRun: true,
+      status: 'completed',
+      output: 'task done',
+      exitCode: 0,
+    });
+
+    const [dbRow] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, runId));
+    expect(dbRow.status).toBe('completed');
+    expect(dbRow.exit_code).toBe(0);
+  });
+
+  it('returns live output without terminalizing when controller matches and is running', async () => {
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
+    const instanceId = await createPersonalInstance(user.id);
+    const run = await insertRunningCliRun(user.id, instanceId, startedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'running',
+      output: 'in progress...',
+      exitCode: null,
+      startedAt: run.startedAt,
+      completedAt: null,
+      prompt: 'test prompt',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.getKiloCliRunStatus({ runId });
+
+    expect(result).toMatchObject({
+      hasRun: true,
+      status: 'running',
+      output: 'in progress...',
+    });
+
+    const [dbRow] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, runId));
+    expect(dbRow.status).toBe('running');
+  });
+});
+
+// ── Personal router: kiloclaw.cancelKiloCliRun ─────────────────────────────
+
+describe('kiloclaw.cancelKiloCliRun identity validation', () => {
+  beforeEach(async () => {
+    await grantKiloClawAccess(user.id);
+  });
+
+  it('rejects cancel when the run is not running', async () => {
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
+    const instanceId = await createPersonalInstance(user.id);
+    const [row] = await db
+      .insert(kiloclaw_cli_runs)
+      .values({
+        user_id: user.id,
+        instance_id: instanceId,
+        prompt: 'test prompt',
+        status: 'completed',
+        started_at: startedAt,
+        completed_at: '2024-01-01T00:05:00.000Z',
+      })
+      .returning({ id: kiloclaw_cli_runs.id });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.cancelKiloCliRun({ runId: row.id })).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Kilo CLI run is no longer running',
+    });
+
+    expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
+  });
+
+  it('rejects cancel and terminalizes row when controller has no run', async () => {
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
+    const instanceId = await createPersonalInstance(user.id);
+    const run = await insertRunningCliRun(user.id, instanceId, startedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: false,
+      status: null,
+      output: null,
+      exitCode: null,
+      startedAt: null,
+      completedAt: null,
+      prompt: null,
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.cancelKiloCliRun({ runId })).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Kilo CLI run is no longer active on the controller',
+    });
+
+    expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
+
+    const [dbRow] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, runId));
+    expect(dbRow.status).toBe('failed');
+  });
+
+  it('rejects cancel when controller is running a different run', async () => {
+    const rowStartedAt = '2024-01-01T00:00:00.000+00:00';
+    const controllerStartedAt = '2024-01-02T00:00:00.000+00:00';
+    const instanceId = await createPersonalInstance(user.id);
+    const run = await insertRunningCliRun(user.id, instanceId, rowStartedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'running',
+      output: 'new run output',
+      exitCode: null,
+      startedAt: controllerStartedAt,
+      completedAt: null,
+      prompt: 'different prompt',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.cancelKiloCliRun({ runId })).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+
+    expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
+  });
+
+  it('cancels successfully when controller matches the DB run', async () => {
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
+    const instanceId = await createPersonalInstance(user.id);
+    const run = await insertRunningCliRun(user.id, instanceId, startedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'running',
+      output: 'in progress',
+      exitCode: null,
+      startedAt: run.startedAt,
+      completedAt: null,
+      prompt: 'test prompt',
+    });
+    mockCancelKiloCliRun.mockResolvedValue({ ok: true });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.cancelKiloCliRun({ runId });
+
+    expect(result).toMatchObject({ ok: true });
+
+    const [dbRow] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, runId));
+    expect(dbRow.status).toBe('cancelled');
+    expect(dbRow.completed_at).not.toBeNull();
   });
 });
 
@@ -215,7 +495,7 @@ describe('organizations.kiloclaw.startKiloCliRun error translation', () => {
   });
 
   it('inserts a running kiloclaw_cli_runs row on success', async () => {
-    const startedAt = '2024-01-01T00:00:00.000Z';
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
     mockStartKiloCliRun.mockResolvedValue({ ok: true, startedAt });
 
     const caller = await createCallerForUser(user.id);
@@ -237,5 +517,285 @@ describe('organizations.kiloclaw.startKiloCliRun error translation', () => {
       prompt: 'fix the org config',
       status: 'running',
     });
+  });
+});
+
+// ── Org router: organizations.kiloclaw.getKiloCliRunStatus ─────────────────
+
+describe('organizations.kiloclaw.getKiloCliRunStatus reconciliation', () => {
+  beforeEach(async () => {
+    org = await createOrganization('Test Org', user.id);
+  });
+
+  it('terminalizes a running row when controller has no run', async () => {
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
+    const instanceId = await createOrgInstance(user.id, org.id);
+    const run = await insertRunningCliRun(user.id, instanceId, startedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: false,
+      status: null,
+      output: null,
+      exitCode: null,
+      startedAt: null,
+      completedAt: null,
+      prompt: null,
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.organizations.kiloclaw.getKiloCliRunStatus({
+      organizationId: org.id,
+      runId,
+    });
+
+    expect(result).toMatchObject({
+      hasRun: true,
+      status: 'failed',
+    });
+
+    const [dbRow] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, runId));
+    expect(dbRow.status).toBe('failed');
+    expect(dbRow.completed_at).not.toBeNull();
+  });
+
+  it('terminalizes a running row when controller reports a different run', async () => {
+    const rowStartedAt = '2024-01-01T00:00:00.000+00:00';
+    const controllerStartedAt = '2024-01-02T00:00:00.000+00:00';
+    const instanceId = await createOrgInstance(user.id, org.id);
+    const run = await insertRunningCliRun(user.id, instanceId, rowStartedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'running',
+      output: 'some output from new run',
+      exitCode: null,
+      startedAt: controllerStartedAt,
+      completedAt: null,
+      prompt: 'different prompt',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.organizations.kiloclaw.getKiloCliRunStatus({
+      organizationId: org.id,
+      runId,
+    });
+
+    expect(result).toMatchObject({
+      hasRun: true,
+      status: 'failed',
+    });
+
+    const [dbRow] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, runId));
+    expect(dbRow.status).toBe('failed');
+  });
+
+  it('persists terminal status when controller matches and is complete', async () => {
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
+    const instanceId = await createOrgInstance(user.id, org.id);
+    const run = await insertRunningCliRun(user.id, instanceId, startedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'completed',
+      output: 'task done',
+      exitCode: 0,
+      startedAt: run.startedAt,
+      completedAt: '2024-01-01T00:05:00.000Z',
+      prompt: 'test prompt',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.organizations.kiloclaw.getKiloCliRunStatus({
+      organizationId: org.id,
+      runId,
+    });
+
+    expect(result).toMatchObject({
+      hasRun: true,
+      status: 'completed',
+      output: 'task done',
+      exitCode: 0,
+    });
+
+    const [dbRow] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, runId));
+    expect(dbRow.status).toBe('completed');
+    expect(dbRow.exit_code).toBe(0);
+  });
+
+  it('returns live output without terminalizing when controller matches and is running', async () => {
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
+    const instanceId = await createOrgInstance(user.id, org.id);
+    const run = await insertRunningCliRun(user.id, instanceId, startedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'running',
+      output: 'in progress...',
+      exitCode: null,
+      startedAt: run.startedAt,
+      completedAt: null,
+      prompt: 'test prompt',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.organizations.kiloclaw.getKiloCliRunStatus({
+      organizationId: org.id,
+      runId,
+    });
+
+    expect(result).toMatchObject({
+      hasRun: true,
+      status: 'running',
+      output: 'in progress...',
+    });
+
+    const [dbRow] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, runId));
+    expect(dbRow.status).toBe('running');
+  });
+});
+
+// ── Org router: organizations.kiloclaw.cancelKiloCliRun ────────────────────
+
+describe('organizations.kiloclaw.cancelKiloCliRun identity validation', () => {
+  beforeEach(async () => {
+    org = await createOrganization('Test Org', user.id);
+  });
+
+  it('rejects cancel when the run is not running', async () => {
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
+    const instanceId = await createOrgInstance(user.id, org.id);
+    const [row] = await db
+      .insert(kiloclaw_cli_runs)
+      .values({
+        user_id: user.id,
+        instance_id: instanceId,
+        prompt: 'test prompt',
+        status: 'completed',
+        started_at: startedAt,
+        completed_at: '2024-01-01T00:05:00.000Z',
+      })
+      .returning({ id: kiloclaw_cli_runs.id });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.cancelKiloCliRun({
+        organizationId: org.id,
+        runId: row.id,
+      })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Kilo CLI run is no longer running',
+    });
+
+    expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
+  });
+
+  it('rejects cancel and terminalizes row when controller has no run', async () => {
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
+    const instanceId = await createOrgInstance(user.id, org.id);
+    const run = await insertRunningCliRun(user.id, instanceId, startedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: false,
+      status: null,
+      output: null,
+      exitCode: null,
+      startedAt: null,
+      completedAt: null,
+      prompt: null,
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.cancelKiloCliRun({ organizationId: org.id, runId })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Kilo CLI run is no longer active on the controller',
+    });
+
+    expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
+
+    const [dbRow] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, runId));
+    expect(dbRow.status).toBe('failed');
+  });
+
+  it('rejects cancel when controller is running a different run', async () => {
+    const rowStartedAt = '2024-01-01T00:00:00.000+00:00';
+    const controllerStartedAt = '2024-01-02T00:00:00.000+00:00';
+    const instanceId = await createOrgInstance(user.id, org.id);
+    const run = await insertRunningCliRun(user.id, instanceId, rowStartedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'running',
+      output: 'new run output',
+      exitCode: null,
+      startedAt: controllerStartedAt,
+      completedAt: null,
+      prompt: 'different prompt',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.cancelKiloCliRun({ organizationId: org.id, runId })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+
+    expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
+  });
+
+  it('cancels successfully when controller matches the DB run', async () => {
+    const startedAt = '2024-01-01T00:00:00.000+00:00';
+    const instanceId = await createOrgInstance(user.id, org.id);
+    const run = await insertRunningCliRun(user.id, instanceId, startedAt);
+    const runId = run.id;
+
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'running',
+      output: 'in progress',
+      exitCode: null,
+      startedAt: run.startedAt,
+      completedAt: null,
+      prompt: 'test prompt',
+    });
+    mockCancelKiloCliRun.mockResolvedValue({ ok: true });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.organizations.kiloclaw.cancelKiloCliRun({
+      organizationId: org.id,
+      runId,
+    });
+
+    expect(result).toMatchObject({ ok: true });
+
+    const [dbRow] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, runId));
+    expect(dbRow.status).toBe('cancelled');
+    expect(dbRow.completed_at).not.toBeNull();
   });
 });

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -15,8 +15,10 @@ type StartKiloCliRunResult = { ok: true; startedAt: string };
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
 const mockStartKiloCliRun = jest.fn<() => Promise<StartKiloCliRunResult>>();
-const mockGetKiloCliRunStatus: AnyMock = jest.fn();
-const mockCancelKiloCliRun: AnyMock = jest.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockGetKiloCliRunStatus = jest.fn<(...args: any[]) => any>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockCancelKiloCliRun = jest.fn<(...args: any[]) => any>();
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   const actual: Record<string, unknown> = jest.requireActual(
     '@/lib/kiloclaw/kiloclaw-internal-client'

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -1153,11 +1153,33 @@ export const organizationKiloclawRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
       const client = new KiloClawInternalClient();
-      const result = await client.startKiloCliRun(
-        ctx.user.id,
-        input.prompt,
-        workerInstanceId(instance)
-      );
+
+      let result: Awaited<ReturnType<KiloClawInternalClient['startKiloCliRun']>>;
+      try {
+        result = await client.startKiloCliRun(
+          ctx.user.id,
+          input.prompt,
+          workerInstanceId(instance)
+        );
+      } catch (err) {
+        if (err instanceof KiloClawApiError) {
+          const { code, message } = getKiloClawApiErrorPayload(err);
+          if (code === 'controller_route_unavailable') {
+            throw new TRPCError({
+              code: 'PRECONDITION_FAILED',
+              message: 'Instance needs redeploy to support recovery',
+              cause: new UpstreamApiError('controller_route_unavailable'),
+            });
+          }
+          if (err.statusCode === 409) {
+            throw new TRPCError({
+              code: 'CONFLICT',
+              message: message ?? 'Instance is busy',
+            });
+          }
+        }
+        throw err;
+      }
 
       const [row] = await db
         .insert(kiloclaw_cli_runs)

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -28,6 +28,7 @@ import {
 import { and, eq, desc, sql } from 'drizzle-orm';
 import type { KiloClawDashboardStatus, KiloCodeConfigResponse } from '@/lib/kiloclaw/types';
 import { queryDiskUsage } from '@/lib/kiloclaw/disk-usage';
+import { isControllerStatusForRun, persistCliRunControllerStatus } from '@/lib/kiloclaw/cli-runs';
 import { getInboundEmailAddressForInstance } from '@/lib/kiloclaw/inbound-email-alias';
 import {
   ensureActiveInstance,
@@ -1241,8 +1242,7 @@ export const organizationKiloclawRouter = createTRPCRouter({
         workerInstanceId(instance)
       );
 
-      const controllerMatchesRow =
-        controllerStatus.hasRun && controllerStatus.startedAt === row.started_at;
+      const controllerMatchesRow = isControllerStatusForRun(row, controllerStatus);
 
       if (!controllerMatchesRow) {
         const completedAt = new Date().toISOString();
@@ -1330,7 +1330,7 @@ export const organizationKiloclawRouter = createTRPCRouter({
         workerInstanceId(instance)
       );
 
-      if (!controllerStatus.hasRun || controllerStatus.startedAt !== run.started_at) {
+      if (!isControllerStatusForRun(run, controllerStatus)) {
         await db
           .update(kiloclaw_cli_runs)
           .set({
@@ -1350,6 +1350,20 @@ export const organizationKiloclawRouter = createTRPCRouter({
         throw new TRPCError({
           code: 'CONFLICT',
           message: 'Kilo CLI run is no longer active on the controller',
+        });
+      }
+
+      if (controllerStatus.status !== 'running') {
+        await persistCliRunControllerStatus({
+          runId: input.runId,
+          userId: ctx.user.id,
+          instanceId: run.instance_id,
+          controllerStatus,
+        });
+
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'Kilo CLI run is no longer running',
         });
       }
 

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -1241,11 +1241,41 @@ export const organizationKiloclawRouter = createTRPCRouter({
         workerInstanceId(instance)
       );
 
-      if (
-        controllerStatus.hasRun &&
-        controllerStatus.status !== 'running' &&
-        controllerStatus.startedAt
-      ) {
+      const controllerMatchesRow =
+        controllerStatus.hasRun && controllerStatus.startedAt === row.started_at;
+
+      if (!controllerMatchesRow) {
+        const completedAt = new Date().toISOString();
+        const output = row.output ?? '[controller lost track of this run]';
+
+        await db
+          .update(kiloclaw_cli_runs)
+          .set({
+            status: 'failed',
+            output,
+            completed_at: completedAt,
+          })
+          .where(
+            and(
+              eq(kiloclaw_cli_runs.id, input.runId),
+              eq(kiloclaw_cli_runs.user_id, ctx.user.id),
+              eq(kiloclaw_cli_runs.instance_id, instance.id),
+              eq(kiloclaw_cli_runs.status, 'running')
+            )
+          );
+
+        return {
+          hasRun: true,
+          status: 'failed' as const,
+          output,
+          exitCode: row.exit_code,
+          startedAt: row.started_at,
+          completedAt,
+          prompt: row.prompt,
+        };
+      }
+
+      if (controllerStatus.status !== 'running') {
         await db
           .update(kiloclaw_cli_runs)
           .set({
@@ -1275,6 +1305,53 @@ export const organizationKiloclawRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
       const client = new KiloClawInternalClient();
+      const [run] = await db
+        .select()
+        .from(kiloclaw_cli_runs)
+        .where(
+          and(
+            eq(kiloclaw_cli_runs.id, input.runId),
+            eq(kiloclaw_cli_runs.user_id, ctx.user.id),
+            eq(kiloclaw_cli_runs.instance_id, instance.id),
+            eq(kiloclaw_cli_runs.status, 'running')
+          )
+        )
+        .limit(1);
+
+      if (!run) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'Kilo CLI run is no longer running',
+        });
+      }
+
+      const controllerStatus = await client.getKiloCliRunStatus(
+        ctx.user.id,
+        workerInstanceId(instance)
+      );
+
+      if (!controllerStatus.hasRun || controllerStatus.startedAt !== run.started_at) {
+        await db
+          .update(kiloclaw_cli_runs)
+          .set({
+            status: 'failed',
+            output: run.output ?? '[controller lost track of this run]',
+            completed_at: new Date().toISOString(),
+          })
+          .where(
+            and(
+              eq(kiloclaw_cli_runs.id, input.runId),
+              eq(kiloclaw_cli_runs.user_id, ctx.user.id),
+              eq(kiloclaw_cli_runs.instance_id, instance.id),
+              eq(kiloclaw_cli_runs.status, 'running')
+            )
+          );
+
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'Kilo CLI run is no longer active on the controller',
+        });
+      }
 
       let result: Awaited<ReturnType<KiloClawInternalClient['cancelKiloCliRun']>>;
       try {
@@ -1291,7 +1368,7 @@ export const organizationKiloclawRouter = createTRPCRouter({
       }
 
       if (result.ok) {
-        await db
+        const [updated] = await db
           .update(kiloclaw_cli_runs)
           .set({
             status: 'cancelled',
@@ -1304,7 +1381,15 @@ export const organizationKiloclawRouter = createTRPCRouter({
               eq(kiloclaw_cli_runs.instance_id, instance.id),
               eq(kiloclaw_cli_runs.status, 'running')
             )
-          );
+          )
+          .returning({ id: kiloclaw_cli_runs.id });
+
+        if (!updated) {
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: 'Kilo CLI run was already resolved',
+          });
+        }
       }
 
       return result;

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -1275,7 +1275,20 @@ export const organizationKiloclawRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
       const client = new KiloClawInternalClient();
-      const result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
+
+      let result: Awaited<ReturnType<KiloClawInternalClient['cancelKiloCliRun']>>;
+      try {
+        result = await client.cancelKiloCliRun(ctx.user.id, workerInstanceId(instance));
+      } catch (err) {
+        if (err instanceof KiloClawApiError && err.statusCode === 409) {
+          const { message } = getKiloClawApiErrorPayload(err);
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: message ?? 'Instance is not running',
+          });
+        }
+        throw err;
+      }
 
       if (result.ok) {
         await db

--- a/services/kiloclaw/controller/src/routes/kilo-cli-run.test.ts
+++ b/services/kiloclaw/controller/src/routes/kilo-cli-run.test.ts
@@ -6,6 +6,7 @@ import {
   buildRunPrompt,
   _getActiveRun,
   _resetActiveRun,
+  _resetStartQueue,
 } from './kilo-cli-run';
 
 // Mock child_process.spawn
@@ -62,6 +63,7 @@ describe('/_kilo/cli-run routes', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     _resetActiveRun();
+    _resetStartQueue();
     app = new Hono();
     registerKiloCliRunRoutes(app, 'test-token');
     // Set env vars needed by the routes

--- a/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
+++ b/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
@@ -135,27 +135,25 @@ export function registerKiloCliRunRoutes(app: Hono, expectedToken: string): void
       return c.json({ error: 'KILO_API_KEY is not configured' }, 400);
     }
 
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+
+    const parsed = StartRunBodySchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'Invalid request body', details: z.treeifyError(parsed.error) }, 400);
+    }
+
+    const { prompt } = parsed.data;
+
     return runStartExclusive(async () => {
       if (activeRun?.status === 'running') {
         return c.json({ error: 'A Kilo CLI run is already in progress' }, 409);
       }
 
-      let body: unknown;
-      try {
-        body = await c.req.json();
-      } catch {
-        return c.json({ error: 'Invalid JSON body' }, 400);
-      }
-
-      const parsed = StartRunBodySchema.safeParse(body);
-      if (!parsed.success) {
-        return c.json(
-          { error: 'Invalid request body', details: z.treeifyError(parsed.error) },
-          400
-        );
-      }
-
-      const { prompt } = parsed.data;
       const fullPrompt = buildRunPrompt(prompt);
 
       // Spawn the kilo CLI process

--- a/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
+++ b/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
@@ -68,6 +68,7 @@ ${userPrompt}`;
 // ── Module-level state (one run at a time per machine) ────────────────
 
 let activeRun: RunState | null = null;
+let startQueue: Promise<void> = Promise.resolve();
 
 // ── Request schemas ───────────────────────────────────────────────────
 
@@ -97,6 +98,21 @@ function cleanupRun(
   // Don't null out activeRun — keep it for status queries until a new run starts
 }
 
+/**
+ * This chains each start attempt behind the previous one.
+ *
+ * `then(fn, fn)` ensures the next attempt runs regardless of whether the
+ * previous one resolved or rejected — the queue must never stall.
+ */
+function runStartExclusive<T>(fn: () => Promise<T>): Promise<T> {
+  const next = startQueue.then(fn, fn);
+  startQueue = next.then(
+    () => undefined,
+    () => undefined
+  );
+  return next;
+}
+
 // ── Route registration ────────────────────────────────────────────────
 
 export function registerKiloCliRunRoutes(app: Hono, expectedToken: string): void {
@@ -119,76 +135,80 @@ export function registerKiloCliRunRoutes(app: Hono, expectedToken: string): void
       return c.json({ error: 'KILO_API_KEY is not configured' }, 400);
     }
 
-    // Enforce one-at-a-time
-    if (activeRun?.status === 'running') {
-      return c.json({ error: 'A kilo CLI run is already in progress' }, 409);
-    }
-
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: 'Invalid JSON body' }, 400);
-    }
-
-    const parsed = StartRunBodySchema.safeParse(body);
-    if (!parsed.success) {
-      return c.json({ error: 'Invalid request body', details: parsed.error.flatten() }, 400);
-    }
-
-    const { prompt } = parsed.data;
-    const fullPrompt = buildRunPrompt(prompt);
-
-    // Spawn the kilo CLI process
-    // The prompt is passed as a separate argument to avoid shell injection
-    const child = spawn('kilo', ['run', '--auto', fullPrompt], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: process.env,
-    });
-
-    const run: RunState = {
-      process: child,
-      output: '',
-      status: 'running',
-      exitCode: null,
-      startedAt: new Date().toISOString(),
-      completedAt: null,
-      prompt,
-    };
-
-    activeRun = run;
-
-    // Capture stdout
-    child.stdout?.on('data', (chunk: Buffer | string) => {
-      const text = typeof chunk === 'string' ? chunk : chunk.toString();
-      appendOutput(run, text);
-    });
-
-    // Capture stderr (merge into same output buffer)
-    child.stderr?.on('data', (chunk: Buffer | string) => {
-      const text = typeof chunk === 'string' ? chunk : chunk.toString();
-      appendOutput(run, text);
-    });
-
-    child.once('error', err => {
-      console.error('[kilo-cli-run] Process error:', err.message);
-      if (run.status === 'running') {
-        appendOutput(run, `\n[process error: ${err.message}]\n`);
-        cleanupRun(run, null, 'failed');
+    return runStartExclusive(async () => {
+      if (activeRun?.status === 'running') {
+        return c.json({ error: 'A Kilo CLI run is already in progress' }, 409);
       }
-    });
 
-    child.once('close', (code, signal) => {
-      if (run.status !== 'running') return; // already handled by error event
-      console.log(`[kilo-cli-run] Process exited: code=${code} signal=${signal}`);
-      cleanupRun(run, code, code === 0 ? 'completed' : 'failed');
-    });
+      let body: unknown;
+      try {
+        body = await c.req.json();
+      } catch {
+        return c.json({ error: 'Invalid JSON body' }, 400);
+      }
 
-    console.log(`[kilo-cli-run] Started: pid=${child.pid}, prompt="${prompt.slice(0, 100)}..."`);
+      const parsed = StartRunBodySchema.safeParse(body);
+      if (!parsed.success) {
+        return c.json(
+          { error: 'Invalid request body', details: z.treeifyError(parsed.error) },
+          400
+        );
+      }
 
-    return c.json({
-      ok: true,
-      startedAt: run.startedAt,
+      const { prompt } = parsed.data;
+      const fullPrompt = buildRunPrompt(prompt);
+
+      // Spawn the kilo CLI process
+      // The prompt is passed as a separate argument to avoid shell injection
+      const child = spawn('kilo', ['run', '--auto', fullPrompt], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: process.env,
+      });
+
+      const run: RunState = {
+        process: child,
+        output: '',
+        status: 'running',
+        exitCode: null,
+        startedAt: new Date().toISOString(),
+        completedAt: null,
+        prompt,
+      };
+
+      activeRun = run;
+
+      // Capture stdout
+      child.stdout?.on('data', (chunk: Buffer | string) => {
+        const text = typeof chunk === 'string' ? chunk : chunk.toString();
+        appendOutput(run, text);
+      });
+
+      // Capture stderr (merge into same output buffer)
+      child.stderr?.on('data', (chunk: Buffer | string) => {
+        const text = typeof chunk === 'string' ? chunk : chunk.toString();
+        appendOutput(run, text);
+      });
+
+      child.once('error', err => {
+        console.error('[kilo-cli-run] Process error:', err.message);
+        if (run.status === 'running') {
+          appendOutput(run, `\n[process error: ${err.message}]\n`);
+          cleanupRun(run, null, 'failed');
+        }
+      });
+
+      child.once('close', (code, signal) => {
+        if (run.status !== 'running') return; // already handled by error event
+        console.log(`[kilo-cli-run] Process exited: code=${code} signal=${signal}`);
+        cleanupRun(run, code, code === 0 ? 'completed' : 'failed');
+      });
+
+      console.log(`[kilo-cli-run] Started: pid=${child.pid}, prompt="${prompt.slice(0, 100)}..."`);
+
+      return c.json({
+        ok: true,
+        startedAt: run.startedAt,
+      });
     });
   });
 

--- a/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
+++ b/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
@@ -272,3 +272,8 @@ export function _getActiveRun(): RunState | null {
 export function _resetActiveRun(): void {
   activeRun = null;
 }
+
+/** Exported for testing. */
+export function _resetStartQueue(): void {
+  startQueue = Promise.resolve();
+}

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -5209,6 +5209,15 @@ describe('kilo CLI run routing', () => {
     fetchSpy.mockRestore();
   });
 
+  it('returns { conflict } from cancelKiloCliRun when instance is not running', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage); // status: 'provisioned', not 'running'
+
+    const result = await instance.cancelKiloCliRun();
+
+    expect(result).toEqual({ conflict: 'Instance is not running' });
+  });
+
   it('cancels a Kilo CLI run for docker-local via controller without flyMachineId', async () => {
     const { instance, storage } = createInstance();
     await seedDockerInstance(storage, { status: 'running' });

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/kilo-cli-run.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/kilo-cli-run.ts
@@ -93,13 +93,17 @@ export async function getKiloCliRunStatus(
 
 /**
  * Cancel the active kilo CLI run on the controller.
+ *
+ * Returns a `{ conflict }` variant instead of throwing on not-running because
+ * custom error properties (like `.status`) are lost crossing the DO RPC
+ * boundary — only `.message` survives. Return values serialize correctly.
  */
 export async function cancelKiloCliRun(
   state: InstanceMutableState,
   env: KiloClawEnv
-): Promise<{ ok: boolean }> {
+): Promise<{ ok: boolean } | KiloCliRunConflict> {
   if (state.status !== 'running' || !getRuntimeId(state)) {
-    throw Object.assign(new Error('Instance is not running'), { status: 409 });
+    return { conflict: 'Instance is not running' };
   }
 
   return callGatewayController(

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/kilo-cli-run.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/kilo-cli-run.ts
@@ -3,6 +3,7 @@ import {
   KiloCliRunStartResponseSchema,
   KiloCliRunStatusResponseSchema,
   GatewayCommandResponseSchema,
+  GatewayControllerError,
 } from '../gateway-controller-types';
 import { callGatewayController, isErrorUnknownRoute } from './gateway';
 import { getRuntimeId } from './state';
@@ -11,6 +12,11 @@ import type { InstanceMutableState } from './types';
 type KiloCliRunStartResponse = {
   ok: boolean;
   startedAt: string;
+};
+
+/** Returned instead of throwing when a 409 would be lost crossing the DO RPC boundary. */
+type KiloCliRunConflict = {
+  conflict: string;
 };
 
 type KiloCliRunStatusResponse = {
@@ -25,14 +31,18 @@ type KiloCliRunStatusResponse = {
 
 /**
  * Start a `kilo run --auto` process on the controller.
+ *
+ * Returns a `{ conflict }` variant instead of throwing on 409 because
+ * custom error properties (like `.status`) are lost crossing the DO RPC
+ * boundary — only `.message` survives. Return values serialize correctly.
  */
 export async function startKiloCliRun(
   state: InstanceMutableState,
   env: KiloClawEnv,
   prompt: string
-): Promise<KiloCliRunStartResponse | null> {
+): Promise<KiloCliRunStartResponse | KiloCliRunConflict | null> {
   if (state.status !== 'running' || !getRuntimeId(state)) {
-    throw Object.assign(new Error('Instance is not running'), { status: 409 });
+    return { conflict: 'Instance is not running' };
   }
 
   try {
@@ -46,6 +56,9 @@ export async function startKiloCliRun(
     );
   } catch (error) {
     if (isErrorUnknownRoute(error)) return null;
+    if (error instanceof GatewayControllerError && error.status === 409) {
+      return { conflict: error.message };
+    }
     throw error;
   }
 }

--- a/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
+++ b/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
@@ -97,6 +97,44 @@ describe('sanitizeError: Instance-not-* status correction', () => {
   });
 });
 
+describe('kilo-cli-run/start: conflict response handling', () => {
+  /** Minimal env whose DO startKiloCliRun returns a conflict discriminated-union value. */
+  function envWithStartConflict(message: string) {
+    return {
+      KILOCLAW_INSTANCE: {
+        idFromName: (id: string) => id,
+        get: () => ({ startKiloCliRun: () => Promise.resolve({ conflict: message }) }),
+      },
+      KILOCLAW_AE: { writeDataPoint: vi.fn() },
+      KV_CLAW_CACHE: {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        list: vi.fn().mockResolvedValue({ keys: [], list_complete: true }),
+        getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null }),
+      },
+    } as never;
+  }
+
+  it('returns 409 when the DO signals a run is already in progress', async () => {
+    const env = envWithStartConflict('A Kilo CLI run is already in progress');
+
+    const resp = await platform.request(
+      '/kilo-cli-run/start',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: 'user-1', prompt: 'fix this' }),
+      },
+      env
+    );
+
+    expect(resp.status).toBe(409);
+    const body = await jsonBody(resp);
+    expect(body.error).toBe('A Kilo CLI run is already in progress');
+  });
+});
+
 describe('kilo-cli-run/cancel: conflict response handling', () => {
   /** Minimal env whose DO cancelKiloCliRun returns a conflict discriminated-union value. */
   function envWithCancelConflict(message: string) {

--- a/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
+++ b/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
@@ -73,7 +73,8 @@ describe('sanitizeError: Instance-not-* status correction', () => {
   });
 
   it('does not override status for non-"Instance not" safe errors', async () => {
-    // "Instance is not running" uses a different prefix — should stay 500
+    // "Instance is not running" thrown by DO lifecycle methods (not CLI cancel) stays 500
+    // because only "Instance not provisioned" has a correctLostStatus entry.
     const err = new Error('Instance is not running');
     const env = envWithDOError(err);
 
@@ -93,6 +94,44 @@ describe('sanitizeError: Instance-not-* status correction', () => {
     expect(resp.status).toBe(500);
     const body = await jsonBody(resp);
     expect(body.error).toBe('status failed');
+  });
+});
+
+describe('kilo-cli-run/cancel: conflict response handling', () => {
+  /** Minimal env whose DO cancelKiloCliRun returns a conflict discriminated-union value. */
+  function envWithCancelConflict(message: string) {
+    return {
+      KILOCLAW_INSTANCE: {
+        idFromName: (id: string) => id,
+        get: () => ({ cancelKiloCliRun: () => Promise.resolve({ conflict: message }) }),
+      },
+      KILOCLAW_AE: { writeDataPoint: vi.fn() },
+      KV_CLAW_CACHE: {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        list: vi.fn().mockResolvedValue({ keys: [], list_complete: true }),
+        getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null }),
+      },
+    } as never;
+  }
+
+  it('returns 409 when the DO signals instance is not running', async () => {
+    const env = envWithCancelConflict('Instance is not running');
+
+    const resp = await platform.request(
+      '/kilo-cli-run/cancel',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: 'user-1' }),
+      },
+      env
+    );
+
+    expect(resp.status).toBe(409);
+    const body = await jsonBody(resp);
+    expect(body.error).toBe('Instance is not running');
   });
 });
 

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -1461,13 +1461,18 @@ platform.post('/kilo-cli-run/cancel', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
+    // The DO returns a discriminated union: success | { conflict }.
+    // See startKiloCliRun for the same pattern and the reason for .then(r => r).
     const response = await withResolvedDORetry(
       c.env,
       result.data.userId,
       iidResult.instanceId,
-      stub => stub.cancelKiloCliRun(),
+      stub => stub.cancelKiloCliRun().then(r => r),
       'cancelKiloCliRun'
     );
+    if ('conflict' in response) {
+      return jsonError(response.conflict, 409);
+    }
     return c.json(response, 200);
   } catch (err) {
     const { message, status } = sanitizeError(err, 'kilo-cli-run cancel');

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -1421,7 +1421,7 @@ platform.post('/kilo-cli-run/start', async c => {
         'controller_route_unavailable'
       );
     }
-    if ('conflict' in response) {
+    if (isRecord(response) && typeof response.conflict === 'string') {
       return jsonError(response.conflict, 409);
     }
     return c.json(response, 200);
@@ -1470,7 +1470,7 @@ platform.post('/kilo-cli-run/cancel', async c => {
       stub => stub.cancelKiloCliRun().then(r => r),
       'cancelKiloCliRun'
     );
-    if ('conflict' in response) {
+    if (isRecord(response) && typeof response.conflict === 'string') {
       return jsonError(response.conflict, 409);
     }
     return c.json(response, 200);

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -301,15 +301,31 @@ async function requireProviderCapability(
   return jsonError(`${operation} is not supported for provider ${metadata.provider}`, 400);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isHttpStatus(value: unknown): value is { status: number } {
+  return isRecord(value) && typeof value.status === 'number';
+}
+
+function hasStringCode(value: unknown): value is { code: string } {
+  return isRecord(value) && typeof value.code === 'string';
+}
+
+/** Extract a string `code` from an error or its `.cause`, if present. */
+function getErrorCode(err: unknown): string | undefined {
+  if (hasStringCode(err)) return err.code;
+  if (err instanceof Error && hasStringCode(err.cause)) return err.cause.code;
+  return undefined;
+}
+
 function statusCodeFromError(err: unknown): number {
-  if (
-    typeof err === 'object' &&
-    err !== null &&
-    'status' in err &&
-    typeof (err as { status: unknown }).status === 'number'
-  ) {
-    const status = (err as { status: number }).status;
-    if (status >= 400 && status < 600) return status;
+  // Extract a valid HTTP status from the error or its cause, defaulting to 500.
+  for (const candidate of [err, err instanceof Error ? err.cause : undefined]) {
+    if (isHttpStatus(candidate) && candidate.status >= 400 && candidate.status < 600) {
+      return candidate.status;
+    }
   }
   return 500;
 }
@@ -344,6 +360,7 @@ const SAFE_ERROR_PREFIXES = [
   'Stream Chat sendMessage failed', // sendMessage HTTP errors
   'Stream Chat is not set up', // no Stream Chat on this instance
   'Provider ', // explicit not-implemented provider errors
+  'A Kilo CLI run is ', // e.g. "A Kilo CLI run is already in progress"
 ];
 
 function sanitizeError(err: unknown, operation: string): { message: string; status: number } {
@@ -398,13 +415,7 @@ function sanitizeOpenclawConfigError(
   const raw = err instanceof Error ? err.message : 'Unknown error';
   const status = statusCodeFromError(err);
   const normalized = raw.replace(/^(?:[A-Za-z]+Error:\s*)+/, '');
-  const code =
-    typeof err === 'object' &&
-    err !== null &&
-    'code' in err &&
-    typeof (err as { code?: unknown }).code === 'string'
-      ? (err as { code: string }).code
-      : undefined;
+  const code = getErrorCode(err);
 
   console.error(`[platform] ${operation} failed:`, raw);
 
@@ -1392,11 +1403,15 @@ platform.post('/kilo-cli-run/start', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
+    // The DO returns a discriminated union: success | { conflict } | null.
+    // CF Workers' RPC type wrapping turns this into `Promise<A> | Promise<B>`
+    // instead of `Promise<A | B>`, which breaks narrowing. The `.then(r => r)`
+    // collapses the RPC wrapper back to a plain Promise union.
     const response = await withResolvedDORetry(
       c.env,
       result.data.userId,
       iidResult.instanceId,
-      stub => stub.startKiloCliRun(result.data.prompt),
+      stub => stub.startKiloCliRun(result.data.prompt).then(r => r),
       'startKiloCliRun'
     );
     if (!response) {
@@ -1405,6 +1420,9 @@ platform.post('/kilo-cli-run/start', async c => {
         404,
         'controller_route_unavailable'
       );
+    }
+    if ('conflict' in response) {
+      return jsonError(response.conflict, 409);
     }
     return c.json(response, 200);
   } catch (err) {


### PR DESCRIPTION
## Summary

Kilo CLI run DB rows could remain `running` after the controller forgot the run or moved on to a different one, and stale cancel requests could cancel the controller's current run instead of the requested DB run. This change reconciles personal and organization run state by matching controller status to the DB row's `startedAt`, terminalizing lost/superseded rows, and validating run identity before canceling.

The implementation keeps the personal and organization router flows intentionally parallel and extends the existing Kilo CLI router test patterns.

## Verification

- `pnpm test -- apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts`
- `pnpm test -- apps/web/src/routers/admin-kiloclaw-instances-router.test.ts`
- `pnpm --filter web typecheck`
- `pnpm format`

Note: `pnpm typecheck` was also attempted, but failed in unrelated `services/kiloclaw-inbound-email` module resolution for `@kilocode/db/*` / `drizzle-orm`.

## Visual Changes

N/A

## Reviewer Notes

Focus areas:
- `startedAt` identity checks before trusting controller status.
- Cancel now validates the requested DB run before calling controller cancel.
- Personal and organization behavior should remain symmetrical.