### PR TITLE
feat(alerting): show percent change next to status dots on model-status tab

### DIFF
--- a/apps/web/src/app/admin/alerting/ModelStatusContent.tsx
+++ b/apps/web/src/app/admin/alerting/ModelStatusContent.tsx
@@ -56,6 +56,19 @@ async function fetchSnapshot(at: string | null): Promise<HealthSnapshot> {
   return res.json();
 }
 
+function formatChange(pct: number): string {
+  if (pct === 0) return '0%';
+  const sign = pct > 0 ? '+' : '';
+  return `${sign}${pct}%`;
+}
+
+function changeColor(pct: number): string {
+  if (pct === 0) return 'text-muted-foreground';
+  if (pct > 0) return 'text-green-600';
+  if (pct > -30) return 'text-yellow-600';
+  return 'text-red-600';
+}
+
 function StatusDot({
   metrics,
   timestamp,
@@ -68,8 +81,9 @@ function StatusDot({
       <TooltipProvider delayDuration={100}>
         <Tooltip>
           <TooltipTrigger asChild>
-            <div className="flex justify-center">
+            <div className="flex flex-col items-center gap-0.5">
               <div className="size-3 rounded-full border border-dashed border-gray-400" />
+              <span className="text-muted-foreground text-[10px] leading-none">—</span>
             </div>
           </TooltipTrigger>
           <TooltipContent side="top" className="text-xs">
@@ -92,8 +106,16 @@ function StatusDot({
     <TooltipProvider delayDuration={100}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="flex justify-center">
+          <div className="flex flex-col items-center gap-0.5">
             <div className={cn('size-3 rounded-full', color)} />
+            <span
+              className={cn(
+                'text-[10px] leading-none',
+                noTraffic ? 'text-muted-foreground' : changeColor(metrics.percentChange)
+              )}
+            >
+              {noTraffic ? '—' : formatChange(metrics.percentChange)}
+            </span>
           </div>
         </TooltipTrigger>
         <TooltipContent side="top" className="text-xs">
@@ -201,7 +223,7 @@ export function ModelStatusContent() {
                   Model
                 </TableHead>
                 {snapshotsReversed.map(ts => (
-                  <TableHead key={ts} className="text-center min-w-[50px] px-1">
+                  <TableHead key={ts} className="text-center min-w-[55px] px-1">
                     <span className="text-xs">{format(new Date(ts), 'HH:mm')}</span>
                   </TableHead>
                 ))}


### PR DESCRIPTION
## Summary

Adds a compact percent-change label below each status dot on the model-status alerting tab. This gives a quick visual overview of traffic changes without needing to hover over each dot:

- Positive changes shown in green (e.g. `+15%`)
- Moderate drops shown in yellow (e.g. `-20%`)
- Large drops (>30%) shown in red (e.g. `-45%`)
- No-traffic and no-data slots show a dash (`—`)

## Verification

- `pnpm --filter web typecheck` passes
- `pnpm format` applied

## Visual Changes
<img width="782" height="970" alt="CleanShot 2026-04-15 at 16 45 39@2x" src="https://github.com/user-attachments/assets/27690702-c17a-486c-9da1-12acc572d992" />