### PR TITLE
fix(claw): show onboarding flow when credit enrollment skips provisioning

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
@@ -202,15 +202,18 @@ describe('ClawOnboardingFlow state machine', () => {
     }
   );
 
-  test('renders the post-provisioning spinner before a populated status exists', () => {
+  test('renders create-instance when post-provisioning has no provisioned DO', () => {
+    // status undefined — no DO state at all (e.g. credit enrollment created DB
+    // row + subscription but never triggered provision)
     expect(getClawOnboardingFlowState(createInput({ mode: 'post-provisioning' })).renderStep).toBe(
-      'provisioning'
+      'create-instance'
     );
+    // status with null machine status — DO exists but returned status: null
     expect(
       getClawOnboardingFlowState(
         createInput({ mode: 'post-provisioning', status: createStatus(null) })
       ).renderStep
-    ).toBe('provisioning');
+    ).toBe('create-instance');
   });
 
   test('renders complete in post-provisioning mode once the machine is running', () => {

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
@@ -140,7 +140,12 @@ function getRenderStep({
   hasPairingStep,
 }: RenderStepInput): ClawOnboardingRenderStep {
   if (mode === 'post-provisioning') {
-    return postProvisioningReady ? 'complete' : 'provisioning';
+    if (postProvisioningReady) return 'complete';
+    // DB row + subscription exist but no DO provisioned yet (e.g. credit
+    // enrollment created the billing records without triggering provision).
+    // Show the onboarding entry point so the user can kick off provisioning.
+    if (!instanceStatus) return 'create-instance';
+    return 'provisioning';
   }
 
   if (instanceStatus === null && !createSetupStarted) {


### PR DESCRIPTION
## Summary

Fix infinite spinner for users who enroll in KiloClaw via credits but have no provisioned Durable Object.

### Why this change is needed

When a user signs up for KiloClaw through `enrollWithCredits` (from WelcomePage or Kilo Pass awarding callback), the backend creates a `kiloclaw_instances` DB row and an active `kiloclaw_subscriptions` record — but never provisions a Durable Object or Fly machine. That only happens when the user explicitly calls the `provision` tRPC mutation.

After enrollment, `ClawNewPage` sees `billing.hasAccess = true` and `billing.instance.exists = true`, computes `hasActiveInstance = true`, and sets `mode = 'post-provisioning'`. In that mode, `getRenderStep()` unconditionally returns `'provisioning'` (the spinner step) when the machine isn't running. Since no DO exists (`status.status === null`), the spinner runs indefinitely with no way for the user to proceed.

### How this is addressed

- Added a `!instanceStatus` check in `getRenderStep()` inside the `post-provisioning` branch. When the billing/DB state indicates an active instance but the DO has no state (never provisioned), the function returns `'create-instance'` instead of `'provisioning'`, rendering the "Get Started" onboarding card.
- Clicking "Get Started" triggers `handleCreateFlowStarted` (switching mode to `create-first`) and fires `mutations.provision.mutate()`, which flows through `ensureProvisionAccess` → DO `provision()` → `startAsync()` → `fly.createMachine()` — the normal machine creation path.
- Updated the existing test case to assert the new `'create-instance'` render step for the `post-provisioning` + no-DO-status scenario.
- Both affected entry points are fixed: direct credit enrollment from WelcomePage, and the Kilo Pass awarding callback redirect to `/claw`.

## Human Verification

- Paired with Florian to trace the full code path from `enrollWithCredits` through `ClawNewPage` → `ClawOnboardingFlowInner` → `getRenderStep()` to confirm the render logic and verify the fix would address the root cause.

## Visual Changes

N/A

## Reviewer Notes

### Human Reviewer

- The `post-provisioning` + `!instanceStatus` combination was previously unreachable — credit enrollment introduced this gap by creating a DB row without provisioning. The new branch only fires in that specific case.
- No backend changes. The `ensureProvisionAccess` check in the `provision` tRPC route works correctly because the active credit subscription already grants access.

### Code Reviewer Agent

<details>
<summary>Code Reviewer Notes</summary>

- The fix is in `getRenderStep()` in `ClawOnboardingFlow.state.ts` (line ~142). It checks `!instanceStatus` before falling through to `'provisioning'`.
- `instanceStatus` is derived from `hasPopulatedStatus(status)` which checks `status !== undefined && status.status !== null`. An unprovisioned DO returns `status: null` from `getStatus()`.
- After the user clicks "Get Started", `handleCreateFlowStarted` sets `createFlowStarted = true` in the parent `ClawNewPage`, which switches mode from `post-provisioning` to `create-first`, and the existing `create-first` flow takes over.
- The upstream refactored the inline ternary chains into extracted `render*` functions and a `getRenderStep()` state machine, so the fix location shifted from `ClawOnboardingFlow.tsx` to `ClawOnboardingFlow.state.ts` during rebase.

</details>