### PR TITLE
test(web): stabilize kiloclaw router db harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ After making changes, verify your work. At minimum run typecheck; run the full s
 
 Target a specific test file: `pnpm test -- <path>`. Run tests for a specific service: `pnpm --filter <package> test`.
 
+**Before running tests**, ensure the test database is running. If there is no active Postgres instance, run `pnpm test:db` first — this starts the Postgres container and applies migrations. You can check whether Postgres is already running with `docker compose -f dev/docker-compose.yml ps postgres`.
+
 ## Coding Standards
 
 - Prefer `type` over `interface`.

--- a/apps/web/src/lib/drizzle.ts
+++ b/apps/web/src/lib/drizzle.ts
@@ -170,11 +170,25 @@ export type DrizzleTransaction = Parameters<Parameters<typeof db.transaction>[0]
 export async function cleanupDbForTest(): Promise<void> {
   // Use primary for test cleanup to ensure consistency
   const { rows: tables } = await primaryDb.execute<{ tablename: string }>(
-    sql`SELECT tablename FROM pg_tables WHERE schemaname = 'public' and tablename != 'migrations'`
+    sql`
+      SELECT tablename
+      FROM pg_tables
+      WHERE schemaname = 'public'
+        AND tablename != 'migrations'
+        AND NOT EXISTS (
+          SELECT 1
+          FROM pg_inherits
+          JOIN pg_class child ON pg_inherits.inhrelid = child.oid
+          JOIN pg_namespace child_ns ON child.relnamespace = child_ns.oid
+          WHERE child_ns.nspname = 'public'
+            AND child.relname = pg_tables.tablename
+        )
+      ORDER BY tablename
+    `
   );
 
-  const truncates = tables
-    .map(({ tablename }) => `TRUNCATE TABLE "${tablename}" RESTART IDENTITY CASCADE;\n`)
-    .join('');
-  await primaryDb.execute(sql.raw(truncates));
+  if (tables.length === 0) return;
+
+  const truncateTargets = tables.map(({ tablename }) => `"${tablename}"`).join(', ');
+  await primaryDb.execute(sql.raw(`TRUNCATE TABLE ${truncateTargets} RESTART IDENTITY CASCADE;`));
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:e2e": "pnpm --filter web run test:e2e",
     "dependency-cycle-check": "pnpm --filter web run dependency-cycle-check",
     "worktree:prepare": "bash scripts/worktree-prepare.sh",
-    "test:db": "docker compose -f dev/docker-compose.yml up -d postgres && pnpm drizzle migrate",
+    "test:db": "docker compose -f dev/docker-compose.yml up -d --wait postgres && pnpm drizzle migrate",
     "dev:start": "tsx dev/local/cli.ts up",
     "dev:stop": "tsx dev/local/cli.ts stop",
     "dev:status": "tsx dev/local/cli.ts status",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "pnpm --filter web run test:e2e",
     "dependency-cycle-check": "pnpm --filter web run dependency-cycle-check",
     "worktree:prepare": "bash scripts/worktree-prepare.sh",
+    "test:db": "docker compose -f dev/docker-compose.yml up -d postgres && pnpm drizzle migrate",
     "dev:start": "tsx dev/local/cli.ts up",
     "dev:stop": "tsx dev/local/cli.ts stop",
     "dev:status": "tsx dev/local/cli.ts status",


### PR DESCRIPTION
## Summary

Fixes flaky test failures in the kiloclaw router test harness caused by partition table truncation conflicts, and adds a lightweight `test:db` script so tests can run without spinning up the full dev environment.

### Why this change is needed

The test cleanup function `cleanupDbForTest` was discovering both parent and child partition tables from `pg_tables`, then truncating each separately. This caused intermittent failures: `TRUNCATE parent CASCADE` already handles child partitions, so the subsequent explicit child truncation would hit lock conflicts or errors. Additionally, issuing one `TRUNCATE` statement per table introduced ordering issues when cascading foreign keys overlapped. There was also no simple way to start just the test database — `pnpm dev:start` brings up the full tmux-based environment, which is heavy for running tests.

### How this is addressed

- Filter out partition child tables from the cleanup query using `pg_inherits`, so only parent tables are truncated (partitions cascade automatically).
- Combine all table names into a single `TRUNCATE TABLE ... CASCADE` statement, eliminating ordering and cascading conflicts.
- Add early return guard when no tables are found.
- Add `pnpm test:db` script that starts only the Postgres container and runs migrations.
- Document the `test:db` prerequisite in AGENTS.md.

## Human Verification

- Full test suite ran and passed: 223 suites, 3819 passed, 2 skipped, 0 failures.
- Verified `pnpm test:db` from a clean state (postgres down → script starts container + applies migrations → tests pass).

## Visual Changes

N/A

## Reviewer Notes

### Human Reviewer

- The `pg_inherits` subquery is standard Postgres catalog usage for detecting partition children — no exotic features involved.
- `pnpm test:db` is intentionally minimal (just postgres + migrations). It does not start Redis or other infra, which is sufficient for the current test suite.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- The `NOT EXISTS` subquery in `cleanupDbForTest` joins `pg_inherits → pg_class → pg_namespace` to identify partition children. Verify the join conditions are correct for all partitioning schemes (range, list, hash).
- The single `TRUNCATE TABLE "a", "b", "c" RESTART IDENTITY CASCADE` call is atomic and handles foreign key ordering internally.
- The `test:db` script chains `docker compose up -d postgres` with `pnpm drizzle migrate` — if postgres is already running, both commands are idempotent.

</details>