### PR TITLE
feat(claw): add Pylon chat widget to KiloClaw pages

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -118,6 +118,13 @@ vercel env pull
 
 This creates `.env.local` with all required environment variables.
 
+The KiloClaw pages (`/claw/*`) render the Pylon support chat widget, which requires two env vars to activate:
+
+- `NEXT_PUBLIC_PYLON_APP_ID` — the Pylon app ID from the Pylon dashboard
+- `PYLON_IDENTITY_SECRET` — the identity verification secret used to HMAC-sign user emails
+
+Both are already present in Vercel and pulled by `vercel env pull`. If either is missing the widget is silently skipped, so local dev continues to work without Pylon configured.
+
 ### 4. Start the database
 
 The project uses PostgreSQL 18 with pgvector, running via Docker. The compose file is at `dev/docker-compose.yml`:

--- a/apps/web/src/app/(app)/claw/layout.tsx
+++ b/apps/web/src/app/(app)/claw/layout.tsx
@@ -1,7 +1,13 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+import { PylonWidget } from '@/components/pylon-widget';
 import './claw-chat.css';
 
 export default async function ClawLayout({ children }: { children: React.ReactNode }) {
   await getUserFromAuthOrRedirect();
-  return <>{children}</>;
+  return (
+    <>
+      {children}
+      <PylonWidget />
+    </>
+  );
 }

--- a/apps/web/src/app/api/pylon/identity/route.ts
+++ b/apps/web/src/app/api/pylon/identity/route.ts
@@ -1,0 +1,27 @@
+import { createHmac } from 'node:crypto';
+import { NextResponse } from 'next/server';
+import { PYLON_IDENTITY_SECRET } from '@/lib/config.server';
+import { getUserFromAuth } from '@/lib/user.server';
+
+type IdentityResponse = { email: string; name: string; emailHash: string } | { error: string };
+
+export async function GET(): Promise<NextResponse<IdentityResponse>> {
+  const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
+
+  if (authFailedResponse) {
+    return authFailedResponse;
+  }
+
+  if (!PYLON_IDENTITY_SECRET) {
+    return NextResponse.json({ error: 'Pylon not configured' }, { status: 503 });
+  }
+
+  const email = user.google_user_email;
+  const name = user.google_user_name;
+  // Pylon's identity secret is hex-encoded and must be decoded to raw bytes before HMAC.
+  // See: https://docs.usepylon.com/pylon-docs/chat-widget/identity-verification
+  const secretBytes = Buffer.from(PYLON_IDENTITY_SECRET, 'hex');
+  const emailHash = createHmac('sha256', secretBytes).update(email).digest('hex');
+
+  return NextResponse.json({ email, name, emailHash });
+}

--- a/apps/web/src/components/pylon-widget.tsx
+++ b/apps/web/src/components/pylon-widget.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from '@tanstack/react-query';
 import Script from 'next/script';
 import { z } from 'zod';
+import { useUser } from '@/hooks/useUser';
 
 const pylonIdentitySchema = z.object({
   email: z.string(),
@@ -24,11 +25,14 @@ async function fetchPylonIdentity(): Promise<PylonIdentity | null> {
 
 export function PylonWidget() {
   const appId = process.env.NEXT_PUBLIC_PYLON_APP_ID;
+  const { data: user } = useUser();
 
+  // Key by user.id so logout/login in the same tab can't serve a previous
+  // user's signed identity payload from cache.
   const { data: identity } = useQuery({
-    queryKey: ['pylon-identity'],
+    queryKey: ['pylon-identity', user?.id],
     queryFn: fetchPylonIdentity,
-    enabled: Boolean(appId),
+    enabled: Boolean(appId && user?.id),
     staleTime: 5 * 60 * 1000,
   });
 

--- a/apps/web/src/components/pylon-widget.tsx
+++ b/apps/web/src/components/pylon-widget.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import Script from 'next/script';
+import { z } from 'zod';
+
+const pylonIdentitySchema = z.object({
+  email: z.string(),
+  name: z.string(),
+  emailHash: z.string(),
+});
+type PylonIdentity = z.infer<typeof pylonIdentitySchema>;
+
+async function fetchPylonIdentity(): Promise<PylonIdentity | null> {
+  const res = await fetch('/api/pylon/identity');
+  if (res.status === 401 || res.status === 403 || res.status === 503) {
+    return null;
+  }
+  if (!res.ok) {
+    throw new Error('Failed to fetch Pylon identity');
+  }
+  return pylonIdentitySchema.parse(await res.json());
+}
+
+export function PylonWidget() {
+  const appId = process.env.NEXT_PUBLIC_PYLON_APP_ID;
+
+  const { data: identity } = useQuery({
+    queryKey: ['pylon-identity'],
+    queryFn: fetchPylonIdentity,
+    enabled: Boolean(appId),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (!appId || !identity) {
+    return null;
+  }
+
+  const safeJson = (value: unknown) => JSON.stringify(value).replace(/</g, '\\u003c');
+  const safeAppId = encodeURIComponent(appId);
+  // Single inline script: assign chat_settings, then run Pylon loader IIFE.
+  // Combining guarantees settings are in place before the widget script loads.
+  const script = `window.pylon = { chat_settings: { app_id: ${safeJson(appId)}, email: ${safeJson(identity.email)}, name: ${safeJson(identity.name)}, email_hash: ${safeJson(identity.emailHash)} } };(function(){var e=window;var t=document;var n=function(){n.e(arguments)};n.q=[];n.e=function(e){n.q.push(e)};e.Pylon=n;var r=function(){var e=t.createElement("script");e.setAttribute("type","text/javascript");e.setAttribute("async","true");e.setAttribute("src","https://widget.usepylon.com/widget/${safeAppId}");var n=t.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};if(t.readyState==="complete"){r()}else if(e.addEventListener){e.addEventListener("load",r,false)}})();`;
+
+  return (
+    <Script id="pylon-chat" strategy="afterInteractive">
+      {script}
+    </Script>
+  );
+}

--- a/apps/web/src/lib/config.server.ts
+++ b/apps/web/src/lib/config.server.ts
@@ -231,6 +231,11 @@ export const SECURITY_CLEANUP_BETTERSTACK_HEARTBEAT_URL = getEnvVariable(
   'SECURITY_CLEANUP_BETTERSTACK_HEARTBEAT_URL'
 );
 
+// Pylon chat widget (support chat on KiloClaw pages).
+// PYLON_IDENTITY_SECRET is the shared secret from the Pylon dashboard used to HMAC-sign
+// the user's email so the widget can verify the end user's identity.
+export const PYLON_IDENTITY_SECRET = getEnvVariable('PYLON_IDENTITY_SECRET') || '';
+
 // Pipe-delimited list of TLDs to block from new signups, each with a leading dot (e.g. ".shop|.top|.co.uk")
 const blacklistTldsEnv = getEnvVariable('BLACKLIST_TLDS');
 export const BLACKLIST_TLDS = blacklistTldsEnv


### PR DESCRIPTION
## Summary
                                                                                
  Mounts the Pylon support chat widget on all `/claw/*` routes (chat,           
  subscription, settings) so KiloClaw users can reach support without leaving
  the product.                                                                  
                                                      
  - New `PylonWidget` client component rendered from the shared                 
  `app/(app)/claw/layout.tsx`, so any current or future `/claw/*` subroute
  inherits it automatically.                                                    
  - Server-side HMAC-SHA256 identity verification: new `/api/pylon/identity`
  route looks up the authenticated user, hex-decodes `PYLON_IDENTITY_SECRET` to 
  raw bytes per Pylon's spec, and returns `{ email, name, emailHash }`. The raw
  secret never leaves the server.                                               
  - Response is validated with a Zod schema on the client (`z.infer` drives the
  TS type), so a malformed server response fails loudly instead of silently     
  corrupting widget state.
  - Graceful degradation: when `NEXT_PUBLIC_PYLON_APP_ID` or                    
  `PYLON_IDENTITY_SECRET` are missing, the identity route returns 503 and the   
  component silently renders nothing. Local dev without Pylon configured
  continues to work.                                                            
  - Inline script hardening: `<` is escaped to `\u003c` to prevent `</script>`
  breakout from any user field, app id is URL-encoded in the loader src, and the
   settings assignment + Pylon loader IIFE are combined into a single `<Script>`
   tag to eliminate ordering races.                                             
  - Documents the two new env vars (`NEXT_PUBLIC_PYLON_APP_ID`,
  `PYLON_IDENTITY_SECRET`) in `DEVELOPMENT.md` under the existing "Set up       
  environment variables" section. Both are pulled from Vercel via `vercel env
  pull`.       


## Verification                                     
                                                    
  - [x] Ran `pnpm run format:check`, `pnpm --filter web lint` — clean.          
  - [x] Loaded `http://localhost:3000/claw/chat` in dev, confirmed
  `/api/pylon/identity` returns 200 with the expected shape and that            
  `window.pylon.chat_settings` is populated with app id, email, name, and email
  hash.                                                                         
  - [x] Confirmed the Pylon widget bubble renders and `POST
  https://apichatwidget.usepylon.com/chatwidget/unreads` returns 200 (identity  
  - [x] Confirmed the widget also appears on `/claw/subscription` and
  `/claw/settings`.                                                             
  - [x] Confirmed that with `NEXT_PUBLIC_PYLON_APP_ID` unset, the component     
  renders nothing and no network request to `/api/pylon/identity` is made. 
  - [x] Confirmed that with `PYLON_IDENTITY_SECRET` unset on the server,        
  `/api/pylon/identity` returns 503 and the widget cleanly no-ops.


## Visual Changes                                   
                                                                                
  | Before | After |                                  
  | ------ | ----- |                                
  | No support chat on `/claw/*` pages | Pylon chat bubble in the bottom-right on `/claw/chat`, `/claw/subscription`, `/claw/settings` |

## Reviewer Notes


