### PR TITLE
feat(gastown): dispatch gt:pr-conflict polecat with rebase context and consolidate with pr-feedback agents

### DIFF
--- a/services/gastown/src/db/tables/town-events.table.ts
+++ b/services/gastown/src/db/tables/town-events.table.ts
@@ -13,6 +13,7 @@ export const TownEventType = z.enum([
   'nudge_timeout',
   'pr_feedback_detected',
   'pr_auto_merge',
+  'pr_conflict_detected',
 ]);
 
 export type TownEventType = z.output<typeof TownEventType>;

--- a/services/gastown/src/dos/town/actions.ts
+++ b/services/gastown/src/dos/town/actions.ts
@@ -747,6 +747,39 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
               return;
             }
 
+            // PR is open — if it previously had conflicts flagged, clear the flag now.
+            // Once the polecat resolves conflicts and the next poll succeeds, the
+            // has_conflicts flag on the MR bead metadata is stale and should be cleared.
+            const conflictFlagRows = z
+              .object({ has_conflicts: z.unknown() })
+              .array()
+              .parse([
+                ...query(
+                  sql,
+                  /* sql */ `
+                    SELECT json_extract(${beads.columns.metadata}, '$.has_conflicts') AS has_conflicts
+                    FROM ${beads}
+                    WHERE ${beads.bead_id} = ?
+                  `,
+                  [action.bead_id]
+                ),
+              ]);
+            if (conflictFlagRows[0]?.has_conflicts) {
+              query(
+                sql,
+                /* sql */ `
+                  UPDATE ${beads}
+                  SET ${beads.columns.metadata} = json_remove(
+                    COALESCE(${beads.columns.metadata}, '{}'),
+                    '$.has_conflicts'
+                  ),
+                  ${beads.columns.updated_at} = ?
+                  WHERE ${beads.bead_id} = ?
+                `,
+                [now(), action.bead_id]
+              );
+            }
+
             // PR is open — check for feedback and auto-merge if configured
             const townConfig = await ctx.getTownConfig();
             const refineryConfig = townConfig.refinery;

--- a/services/gastown/src/dos/town/agents.ts
+++ b/services/gastown/src/dos/town/agents.ts
@@ -519,6 +519,30 @@ export function prime(sql: SqlStorage, agentId: string): PrimeContext {
     };
   }
 
+  // Build PR conflict context if the hooked bead is a conflict resolution request.
+  // This also fires for consolidated beads: gt:pr-feedback beads that have
+  // has_conflicts=true in their metadata (set by the reconciler when a conflict is
+  // detected on a PR that already has an active feedback bead).
+  let pr_conflict_context: PrimeContext['pr_conflict_context'] = null;
+  const isPureConflictBead = hookedBead?.labels.includes('gt:pr-conflict');
+  const isConsolidatedFeedbackBead =
+    hookedBead?.labels.includes('gt:pr-feedback') &&
+    hookedBead.metadata !== null &&
+    (hookedBead.metadata as Record<string, unknown>).has_conflicts === true;
+
+  if ((isPureConflictBead || isConsolidatedFeedbackBead) && hookedBead?.metadata) {
+    const meta = hookedBead.metadata as Record<string, unknown>;
+    pr_conflict_context = {
+      pr_url: typeof meta.pr_url === 'string' ? meta.pr_url : null,
+      branch: typeof meta.branch === 'string' ? meta.branch : null,
+      target_branch: typeof meta.target_branch === 'string' ? meta.target_branch : null,
+      conflict_details: typeof meta.conflict_details === 'string' ? meta.conflict_details : null,
+      // True when this is a consolidated bead: the polecat must also address review comments/CI
+      // after resolving the conflicts.
+      has_feedback: isConsolidatedFeedbackBead,
+    };
+  }
+
   return {
     agent,
     hooked_bead: hookedBead,
@@ -526,6 +550,7 @@ export function prime(sql: SqlStorage, agentId: string): PrimeContext {
     open_beads: openBeads,
     rework_context,
     pr_fixup_context,
+    pr_conflict_context,
   };
 }
 

--- a/services/gastown/src/dos/town/agents.ts
+++ b/services/gastown/src/dos/town/agents.ts
@@ -528,7 +528,7 @@ export function prime(sql: SqlStorage, agentId: string): PrimeContext {
   const isConsolidatedFeedbackBead =
     hookedBead?.labels.includes('gt:pr-feedback') &&
     hookedBead.metadata !== null &&
-    (hookedBead.metadata as Record<string, unknown>).has_conflicts === true;
+    Boolean((hookedBead.metadata as Record<string, unknown>).has_conflicts);
 
   if ((isPureConflictBead || isConsolidatedFeedbackBead) && hookedBead?.metadata) {
     const meta = hookedBead.metadata as Record<string, unknown>;

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -461,6 +461,88 @@ export function applyEvent(sql: SqlStorage, event: TownEventRecord): void {
       return;
     }
 
+    case 'pr_conflict_detected': {
+      const mrBeadId = typeof payload.mr_bead_id === 'string' ? payload.mr_bead_id : null;
+      if (!mrBeadId) {
+        console.warn(`${LOG} applyEvent: pr_conflict_detected missing mr_bead_id`);
+        return;
+      }
+
+      const mrBead = beadOps.getBead(sql, mrBeadId);
+      if (!mrBead || mrBead.status === 'closed' || mrBead.status === 'failed') return;
+
+      const prUrl = typeof payload.pr_url === 'string' ? payload.pr_url : '';
+      const branch = typeof payload.branch === 'string' ? payload.branch : '';
+      const targetBranch = typeof payload.target_branch === 'string' ? payload.target_branch : '';
+      const conflictDetails =
+        typeof payload.conflict_details === 'string' ? payload.conflict_details : null;
+
+      // Consolidation: if there is already an open gt:pr-feedback bead for this PR,
+      // update it with has_conflicts=true instead of creating a new gt:pr-conflict bead.
+      // This ensures one polecat handles everything (rebase + feedback + CI) in one pass.
+      const existingFeedbackBead = getExistingPrFeedbackBeadForPr(sql, mrBeadId);
+      if (existingFeedbackBead) {
+        console.log(
+          `${LOG} applyEvent: pr_conflict_detected — consolidating into existing feedback bead ${existingFeedbackBead}`
+        );
+        query(
+          sql,
+          /* sql */ `
+            UPDATE ${beads}
+            SET ${beads.columns.metadata} = json_set(
+              COALESCE(${beads.columns.metadata}, '{}'),
+              '$.has_conflicts', 1,
+              '$.target_branch', ?,
+              '$.conflict_details', ?
+            ),
+            ${beads.columns.updated_at} = ?
+            WHERE ${beads.bead_id} = ?
+          `,
+          [targetBranch, conflictDetails, new Date().toISOString(), existingFeedbackBead]
+        );
+        return;
+      }
+
+      // No existing feedback bead — create a new gt:pr-conflict bead.
+      // Check for an existing non-terminal conflict bead to prevent duplicates.
+      if (hasExistingPrConflictBead(sql, mrBeadId)) return;
+
+      const conflictBead = beadOps.createBead(sql, {
+        type: 'issue',
+        title: `Resolve merge conflicts on PR ${prUrl || branch}`,
+        body: conflictDetails ?? `PR has merge conflicts. Rebase onto ${targetBranch} to resolve.`,
+        rig_id: mrBead.rig_id ?? undefined,
+        parent_bead_id: mrBeadId,
+        labels: ['gt:pr-conflict'],
+        metadata: {
+          pr_conflict_for: mrBeadId,
+          pr_url: prUrl,
+          branch,
+          target_branch: targetBranch,
+          conflict_details: conflictDetails,
+        },
+      });
+
+      // Mark the MR bead as having conflicts so poll_pr can clear it once resolved.
+      query(
+        sql,
+        /* sql */ `
+          UPDATE ${beads}
+          SET ${beads.columns.metadata} = json_set(
+            COALESCE(${beads.columns.metadata}, '{}'),
+            '$.has_conflicts', 1
+          ),
+          ${beads.columns.updated_at} = ?
+          WHERE ${beads.bead_id} = ?
+        `,
+        [new Date().toISOString(), mrBeadId]
+      );
+
+      // Conflict bead blocks the MR bead (same pattern as feedback/rework beads)
+      beadOps.insertDependency(sql, mrBeadId, conflictBead.bead_id, 'blocks');
+      return;
+    }
+
     default: {
       console.warn(`${LOG} applyEvent: unknown event type: ${event.event_type}`);
     }
@@ -2175,6 +2257,55 @@ function hasExistingPrFeedbackBead(sql: SqlStorage, mrBeadId: string): boolean {
           AND bd.${bead_dependencies.columns.dependency_type} = 'blocks'
           AND fb.${beads.columns.labels} LIKE '%gt:pr-feedback%'
           AND fb.${beads.columns.status} NOT IN ('closed', 'failed')
+        LIMIT 1
+      `,
+      [mrBeadId]
+    ),
+  ];
+  return rows.length > 0;
+}
+
+/**
+ * Return the bead_id of an existing open gt:pr-feedback bead blocking the given MR bead,
+ * or null if none exists. Used for consolidation: when conflicts are detected on a PR
+ * that already has an active feedback bead, we update that bead instead of creating a
+ * separate gt:pr-conflict bead.
+ */
+function getExistingPrFeedbackBeadForPr(sql: SqlStorage, mrBeadId: string): string | null {
+  const rows = z
+    .object({ bead_id: z.string() })
+    .array()
+    .parse([
+      ...query(
+        sql,
+        /* sql */ `
+          SELECT fb.${beads.columns.bead_id}
+          FROM ${bead_dependencies} bd
+          INNER JOIN ${beads} fb ON fb.${beads.columns.bead_id} = bd.${bead_dependencies.columns.depends_on_bead_id}
+          WHERE bd.${bead_dependencies.columns.bead_id} = ?
+            AND bd.${bead_dependencies.columns.dependency_type} = 'blocks'
+            AND fb.${beads.columns.labels} LIKE '%gt:pr-feedback%'
+            AND fb.${beads.columns.status} NOT IN ('closed', 'failed')
+          LIMIT 1
+        `,
+        [mrBeadId]
+      ),
+    ]);
+  return rows[0]?.bead_id ?? null;
+}
+
+/** Check if an MR bead has a non-terminal conflict bead (gt:pr-conflict) blocking it. */
+function hasExistingPrConflictBead(sql: SqlStorage, mrBeadId: string): boolean {
+  const rows = [
+    ...query(
+      sql,
+      /* sql */ `
+        SELECT 1 FROM ${bead_dependencies} bd
+        INNER JOIN ${beads} cb ON cb.${beads.columns.bead_id} = bd.${bead_dependencies.columns.depends_on_bead_id}
+        WHERE bd.${bead_dependencies.columns.bead_id} = ?
+          AND bd.${bead_dependencies.columns.dependency_type} = 'blocks'
+          AND cb.${beads.columns.labels} LIKE '%gt:pr-conflict%'
+          AND cb.${beads.columns.status} NOT IN ('closed', 'failed')
         LIMIT 1
       `,
       [mrBeadId]

--- a/services/gastown/src/dos/town/review-queue.ts
+++ b/services/gastown/src/dos/town/review-queue.ts
@@ -541,6 +541,18 @@ export function agentDone(sql: SqlStorage, agentId: string, input: AgentDoneInpu
     return;
   }
 
+  // PR-conflict beads skip the review queue. The polecat rebased/resolved
+  // conflicts on the existing PR branch — the MR bead is still active and
+  // resumes polling on the next tick.
+  if (hookedBead?.labels.includes('gt:pr-conflict')) {
+    console.log(
+      `[review-queue] agentDone: pr-conflict bead ${agent.current_hook_bead_id} — closing directly (skip review)`
+    );
+    closeBead(sql, agent.current_hook_bead_id, agentId);
+    unhookBead(sql, agentId);
+    return;
+  }
+
   // PR-feedback beads (address review comments, fix CI) skip the review
   // queue. The polecat pushed commits to the existing PR branch — closing
   // the feedback bead unblocks the parent MR bead so poll_pr can re-check

--- a/services/gastown/src/prompts/polecat-system.prompt.ts
+++ b/services/gastown/src/prompts/polecat-system.prompt.ts
@@ -96,6 +96,38 @@ When your hooked bead has the \`gt:pr-fixup\` label, you are fixing an existing 
 
 Do NOT create a new PR. Push to the existing branch.
 
+## PR Conflict Workflow
+
+When your hooked bead has the \`gt:pr-conflict\` label, OR when your \`gt:pr-feedback\` bead has \`pr_conflict_context\` with conflict data in your Gastown context, the PR has merge conflicts that must be resolved before it can be merged. **Check out the PR branch from \`pr_conflict_context.branch\` in your Gastown context.**
+
+1. Fetch and check out the conflicting branch:
+   \`\`\`
+   git fetch origin
+   git checkout <pr_conflict_context.branch>
+   \`\`\`
+2. Rebase onto the target branch to pick up the latest changes:
+   \`\`\`
+   git rebase origin/<pr_conflict_context.target_branch>
+   \`\`\`
+   Alternatively, merge if rebase is not suitable:
+   \`\`\`
+   git merge origin/<pr_conflict_context.target_branch>
+   \`\`\`
+3. Resolve any conflict markers in the affected files. Read \`pr_conflict_context.conflict_details\` for hints about which files are conflicted.
+4. After resolving all conflicts, complete the rebase/merge:
+   \`\`\`
+   git add <resolved-files>
+   git rebase --continue  # or: git commit (for merge)
+   \`\`\`
+5. Push the resolved branch (force-with-lease is safe here since you rebased):
+   \`\`\`
+   git push --force-with-lease origin <branch>
+   \`\`\`
+6. If \`pr_conflict_context.has_feedback\` is true, the bead also has review comments and/or CI failures to address. After resolving conflicts and pushing, address all feedback as described in the PR Feedback section below, then call gt_done.
+7. If \`has_feedback\` is false, call gt_done with the PR URL after pushing.
+
+Do NOT create a new PR. Push to the existing branch.
+
 ## Commit & Push Hygiene
 
 - Commit after every meaningful unit of work (new function, passing test, config change).

--- a/services/gastown/src/types.ts
+++ b/services/gastown/src/types.ts
@@ -177,6 +177,15 @@ export type PrimeContext = {
     branch: string | null;
     target_branch: string | null;
   } | null;
+  /** Present when the hooked bead is a PR conflict resolution (gt:pr-conflict label). */
+  pr_conflict_context: {
+    pr_url: string | null;
+    branch: string | null;
+    target_branch: string | null;
+    conflict_details: string | null;
+    /** True when this bead also carries PR feedback (consolidation: conflicts + comments/CI). */
+    has_feedback: boolean;
+  } | null;
 };
 
 // -- Agent done --


### PR DESCRIPTION
## Summary

- **`gt:pr-conflict` bead dispatch**: Adds a new `pr_conflict_detected` event type that creates a `gt:pr-conflict` issue bead when a PR has merge conflicts, blocking the MR bead (same pattern as `gt:pr-feedback`). The reconciler's Rule 1 dispatches a polecat to resolve the conflicts.
- **`pr_conflict_context` in PrimeContext**: Added to `types.ts` and populated in `agents.prime()`. For pure `gt:pr-conflict` beads it carries `pr_url`, `branch`, `target_branch`, `conflict_details`, and `has_feedback=false`. For consolidated beads (`gt:pr-feedback` with `has_conflicts=true` in metadata), it exposes the same fields with `has_feedback=true`.
- **Consolidation**: When `pr_conflict_detected` fires and a non-terminal `gt:pr-feedback` bead already exists for the same PR, the conflict info is merged into that bead (`has_conflicts=true` in metadata) rather than creating a separate bead. One polecat handles rebase + feedback + CI in one pass.
- **`agentDone` skip review queue**: `gt:pr-conflict` beads are handled like `gt:pr-fixup` and `gt:pr-feedback` — closed directly without submitting to the review queue (the MR bead resumes polling).
- **Polecat system prompt**: Added "PR Conflict Workflow" section with step-by-step rebase instructions, including consolidated flow when `has_feedback=true`.
- **Clear `has_conflicts` flag**: `poll_pr` action clears `has_conflicts` from MR bead metadata after a successful open-PR poll (conflicts resolved).

## Verification

- Reviewed all modified files for correct patterns (same as existing `gt:pr-feedback` / `gt:pr-fixup` patterns)
- `hasExistingPrConflictBead` and `getExistingPrFeedbackBeadForPr` follow same SQL pattern as existing `hasExistingPrFeedbackBead`
- No type errors expected — `pr_conflict_context` type added to `PrimeContext`, returned from `prime()`, field present in return object

## Visual Changes

N/A

## Reviewer Notes

- The `pr_conflict_detected` event is fired externally (by bead 0 / bead 1 from the convoy); this bead only adds the handler in `applyEvent` + the downstream dispatch path.
- Consolidation logic: when a feedback bead exists for the same MR, we update it with `has_conflicts=1` instead of creating a new bead. The `pr_conflict_context` in `PrimeContext` will then be populated for the consolidated feedback bead.
- The `has_conflicts` flag on the MR bead is cleared on the next successful `poll_pr` tick (when status is 'open'), representing the PR being back to a clean state after the polecat's rebase push.