### PR TITLE
fix(cloud-agent): clean up auto-commit timeouts

### DIFF
--- a/services/cloud-agent-next/test/unit/wrapper/auto-commit.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/auto-commit.test.ts
@@ -11,12 +11,18 @@ import type { ExecResult } from '../../../wrapper/src/utils.js';
 // Mock the utils module (spawns git processes + writes log files)
 // ---------------------------------------------------------------------------
 
-vi.mock('../../../wrapper/src/utils.js', () => ({
-  git: vi.fn(),
-  getCurrentBranch: vi.fn(),
-  hasGitUpstream: vi.fn(),
-  logToFile: vi.fn(),
-}));
+vi.mock('../../../wrapper/src/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../wrapper/src/utils.js')>(
+    '../../../wrapper/src/utils.js'
+  );
+  return {
+    ...actual,
+    git: vi.fn(),
+    getCurrentBranch: vi.fn(),
+    hasGitUpstream: vi.fn(),
+    logToFile: vi.fn(),
+  };
+});
 
 // Import mocked functions so we can configure per-test return values
 import { git, getCurrentBranch, hasGitUpstream } from '../../../wrapper/src/utils.js';

--- a/services/cloud-agent-next/test/unit/wrapper/auto-commit.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/auto-commit.test.ts
@@ -106,6 +106,26 @@ describe('runAutoCommit', () => {
     );
   });
 
+  it('does not report aborted branch detection as detached HEAD', async () => {
+    mockGetCurrentBranch.mockRejectedValue(new Error('git branch aborted'));
+
+    const { opts, events } = createOpts();
+    const result = await runAutoCommit(opts);
+
+    expect(result).toEqual({ success: false, error: 'git branch aborted' });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        streamEventType: 'autocommit_completed',
+        data: expect.objectContaining({
+          success: false,
+          message: 'Auto-commit failed: git branch aborted',
+        }),
+      })
+    );
+    expect(mockGit).not.toHaveBeenCalled();
+  });
+
   // -------------------------------------------------------------------------
   // Protected branch — no upstreamBranch
   // -------------------------------------------------------------------------
@@ -247,5 +267,49 @@ describe('runAutoCommit', () => {
         commitMessage: 'test commit',
       })
     );
+  });
+
+  it('reports aborted git status distinctly from timeout', async () => {
+    mockGetCurrentBranch.mockResolvedValue('feature/cool-stuff');
+    mockGit.mockResolvedValueOnce({
+      stdout: '',
+      stderr: 'exec aborted',
+      exitCode: 124,
+      terminationReason: 'abort',
+    });
+
+    const { opts, events } = createOpts();
+    const result = await runAutoCommit(opts);
+
+    expect(result).toEqual({ success: false, error: 'git status aborted' });
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ message: 'git status aborted' }),
+      })
+    );
+  });
+
+  it('clears commit message timeout when lifecycle signal aborts generation', async () => {
+    vi.useFakeTimers();
+    try {
+      mockGetCurrentBranch.mockResolvedValue('feature/cool-stuff');
+      mockGit.mockResolvedValue(ok());
+      mockGit.mockResolvedValueOnce(ok(' M file.ts'));
+      const controller = new AbortController();
+      const kiloClient = createMockKiloClient();
+      vi.mocked(kiloClient.generateCommitMessage).mockReturnValue(new Promise(() => {}));
+      const { opts } = createOpts({ kiloClient, signal: controller.signal });
+
+      const resultPromise = runAutoCommit(opts);
+      await vi.advanceTimersByTimeAsync(1);
+      controller.abort();
+      const result = await resultPromise;
+
+      expect(result).toEqual({ success: true });
+      expect(kiloClient.generateCommitMessage).toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/services/cloud-agent-next/test/unit/wrapper/auto-commit.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/auto-commit.test.ts
@@ -269,6 +269,49 @@ describe('runAutoCommit', () => {
     );
   });
 
+  it('uses fallback commit message and still pushes when generation times out', async () => {
+    vi.useFakeTimers();
+    try {
+      mockGetCurrentBranch.mockResolvedValue('feature/cool-stuff');
+      mockGit
+        .mockResolvedValueOnce(ok(' M file.ts'))
+        .mockResolvedValueOnce(ok())
+        .mockResolvedValueOnce(ok('[feature/cool-stuff abc1234] wip'))
+        .mockResolvedValueOnce(ok('abc1234'))
+        .mockResolvedValueOnce(ok());
+      const kiloClient = createMockKiloClient();
+      vi.mocked(kiloClient.generateCommitMessage).mockReturnValue(new Promise(() => {}));
+      const { opts, events } = createOpts({ kiloClient });
+
+      const resultPromise = runAutoCommit(opts);
+      await vi.advanceTimersByTimeAsync(30_000);
+      const result = await resultPromise;
+
+      expect(result).toEqual({ success: true });
+      expect(mockGit).toHaveBeenNthCalledWith(
+        3,
+        ['commit', '-m', 'wip'],
+        expect.objectContaining({ cwd: '/workspace', timeoutMs: 30_000 })
+      );
+      expect(mockGit).toHaveBeenLastCalledWith(
+        ['push'],
+        expect.objectContaining({ cwd: '/workspace', timeoutMs: 60_000 })
+      );
+      const completed = events.find(e => e.streamEventType === 'autocommit_completed');
+      expect(completed?.data).toEqual(
+        expect.objectContaining({
+          success: true,
+          message: 'Changes committed and pushed',
+          commitHash: 'abc1234',
+          commitMessage: 'wip',
+        })
+      );
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('reports aborted git status distinctly from timeout', async () => {
     mockGetCurrentBranch.mockResolvedValue('feature/cool-stuff');
     mockGit.mockResolvedValueOnce({

--- a/services/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
@@ -17,6 +17,14 @@ import {
 } from '../../../wrapper/src/lifecycle.js';
 import { WrapperState, type JobContext } from '../../../wrapper/src/state.js';
 import type { WrapperKiloClient } from '../../../wrapper/src/kilo-api.js';
+
+vi.mock('../../../wrapper/src/auto-commit.js', () => ({
+  runAutoCommit: vi.fn(),
+}));
+
+import { runAutoCommit } from '../../../wrapper/src/auto-commit.js';
+
+const mockRunAutoCommit = vi.mocked(runAutoCommit);
 // ---------------------------------------------------------------------------
 // Test Helpers
 // ---------------------------------------------------------------------------
@@ -84,6 +92,7 @@ describe('createLifecycleManager', () => {
     kiloClient = createMockKiloClient();
     connectionFns = createMockConnectionFns();
     config = createDefaultConfig();
+    mockRunAutoCommit.mockResolvedValue({ success: true });
   });
 
   afterEach(() => {
@@ -409,10 +418,70 @@ describe('createLifecycleManager', () => {
       await vi.advanceTimersByTimeAsync(1000);
     });
 
-    it('sends error event if auto-commit fails', async () => {
-      // This would require mocking runAutoCommit which is imported
-      // For unit tests, we verify the error handling path exists
-      // Full integration testing would mock the auto-commit module
+    it('aborts auto-commit when the lifecycle timeout fires', async () => {
+      const sendToIngestSpy = vi.fn();
+      state.setSendToIngestFn(sendToIngestSpy);
+      mockRunAutoCommit.mockImplementation(
+        ({ signal }) =>
+          new Promise(resolve => {
+            signal?.addEventListener(
+              'abort',
+              () => resolve({ success: false, error: 'exec aborted' }),
+              {
+                once: true,
+              }
+            );
+          })
+      );
+
+      const mgr = createManager({}, { autoCommit: true });
+      state.startJob(createJobContext());
+
+      mgr.triggerDrainAndClose();
+      await vi.advanceTimersByTimeAsync(120_000);
+      await vi.advanceTimersByTimeAsync(300);
+
+      const autoCommitCall = mockRunAutoCommit.mock.calls[0]?.[0];
+      expect(autoCommitCall?.signal?.aborted).toBe(true);
+      expect(sendToIngestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          streamEventType: 'error',
+          data: { error: 'Auto-commit timed out', fatal: false },
+        })
+      );
+      expect(sendToIngestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ streamEventType: 'complete' })
+      );
+    });
+
+    it('does not report lifecycle timeout when auto-commit wins the timeout race', async () => {
+      const sendToIngestSpy = vi.fn();
+      state.setSendToIngestFn(sendToIngestSpy);
+      mockRunAutoCommit.mockImplementation(
+        ({ signal }) =>
+          new Promise(resolve => {
+            signal?.addEventListener('abort', () => resolve({ success: true }), {
+              once: true,
+            });
+          })
+      );
+
+      const mgr = createManager({}, { autoCommit: true });
+      state.startJob(createJobContext());
+
+      mgr.triggerDrainAndClose();
+      await vi.advanceTimersByTimeAsync(120_000);
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(sendToIngestSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          streamEventType: 'error',
+          data: { error: 'Auto-commit timed out', fatal: false },
+        })
+      );
+      expect(sendToIngestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ streamEventType: 'complete' })
+      );
     });
   });
 

--- a/services/cloud-agent-next/test/unit/wrapper/utils.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/utils.test.ts
@@ -1,0 +1,134 @@
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { git } from '../../../wrapper/src/utils.js';
+
+const createdRepos: string[] = [];
+
+async function createRepo(): Promise<string> {
+  const repoPath = await mkdtemp(join(tmpdir(), 'wrapper-git-timeout-'));
+  createdRepos.push(repoPath);
+  await git(['init'], { cwd: repoPath, timeoutMs: 5_000 });
+  await git(['config', 'user.email', 'test@example.com'], { cwd: repoPath, timeoutMs: 5_000 });
+  await git(['config', 'user.name', 'Test User'], { cwd: repoPath, timeoutMs: 5_000 });
+  return repoPath;
+}
+
+describe('git', () => {
+  afterEach(async () => {
+    await Promise.all(
+      createdRepos.splice(0).map(repoPath => rm(repoPath, { recursive: true, force: true }))
+    );
+  });
+
+  it('waits for close and returns timeout result after terminating a hook process group', async () => {
+    const repoPath = await createRepo();
+    const hooksPath = join(repoPath, '.git', 'hooks');
+    await writeFile(
+      join(hooksPath, 'pre-commit'),
+      '#!/bin/sh\ntrap "exit 0" TERM\nsleep 30 &\nwait\n',
+      { mode: 0o755 }
+    );
+    await writeFile(join(repoPath, 'file.txt'), 'content\n');
+    await git(['add', 'file.txt'], { cwd: repoPath, timeoutMs: 5_000 });
+
+    const start = Date.now();
+    const result = await git(['commit', '-m', 'test'], { cwd: repoPath, timeoutMs: 50 });
+    const elapsedMs = Date.now() - start;
+
+    expect(result.exitCode).toBe(124);
+    expect(result.terminationReason).toBe('timeout');
+    expect(result.stderr).toContain('exec timeout reached');
+    expect(elapsedMs).toBeLessThan(10_000);
+  }, 15_000);
+
+  it('settles after the SIGKILL grace when an escaped child keeps stdio open', async () => {
+    const repoPath = await createRepo();
+    const hooksPath = join(repoPath, '.git', 'hooks');
+    const escapedChildPidPath = join(repoPath, '.git', 'escaped-child.pid');
+    await writeFile(
+      join(hooksPath, 'pre-commit'),
+      `#!/bin/sh
+node <<'NODE'
+const { spawn } = require('child_process');
+const { writeFileSync } = require('fs');
+const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 10000)'], {
+  detached: true,
+  stdio: 'inherit',
+});
+writeFileSync('.git/escaped-child.pid', String(child.pid));
+child.unref();
+setTimeout(() => {}, 10000);
+NODE
+`,
+      { mode: 0o755 }
+    );
+    await writeFile(join(repoPath, 'file.txt'), 'content\n');
+    await git(['add', 'file.txt'], { cwd: repoPath, timeoutMs: 5_000 });
+
+    let escapedChildPid: number | undefined;
+    try {
+      const start = Date.now();
+      const result = await git(['commit', '-m', 'test'], { cwd: repoPath, timeoutMs: 50 });
+      const elapsedMs = Date.now() - start;
+      const pidText = await readFile(escapedChildPidPath, 'utf8').catch(() => '');
+      const pid = Number(pidText);
+      if (Number.isInteger(pid) && pid > 0) {
+        escapedChildPid = pid;
+      }
+
+      expect(result.exitCode).toBe(124);
+      expect(result.terminationReason).toBe('timeout');
+      expect(result.stderr).toContain('exec timeout reached');
+      expect(elapsedMs).toBeLessThan(4_000);
+    } finally {
+      if (escapedChildPid !== undefined) {
+        try {
+          process.kill(escapedChildPid, 'SIGKILL');
+        } catch {
+          // The escaped child may have exited before cleanup.
+        }
+      }
+    }
+  }, 15_000);
+
+  it('cancels an in-flight git command with an AbortSignal', async () => {
+    const repoPath = await createRepo();
+    const hooksPath = join(repoPath, '.git', 'hooks');
+    await writeFile(join(hooksPath, 'pre-commit'), '#!/bin/sh\nsleep 30\n', { mode: 0o755 });
+    await writeFile(join(repoPath, 'file.txt'), 'content\n');
+    await git(['add', 'file.txt'], { cwd: repoPath, timeoutMs: 5_000 });
+
+    const controller = new AbortController();
+    const promise = git(['commit', '-m', 'test'], {
+      cwd: repoPath,
+      timeoutMs: 30_000,
+      signal: controller.signal,
+    });
+    setTimeout(() => controller.abort(), 50);
+
+    const result = await promise;
+
+    expect(result.exitCode).toBe(124);
+    expect(result.terminationReason).toBe('abort');
+    expect(result.stderr).toContain('exec aborted');
+  }, 15_000);
+
+  it('does not spawn git when AbortSignal is already aborted', async () => {
+    const missingPath = await mkdtemp(join(tmpdir(), 'wrapper-git-timeout-missing-'));
+    await rm(missingPath, { recursive: true, force: true });
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await git(['status', '--porcelain'], {
+      cwd: missingPath,
+      timeoutMs: 30_000,
+      signal: controller.signal,
+    });
+
+    expect(result.exitCode).toBe(124);
+    expect(result.terminationReason).toBe('abort');
+    expect(result.stderr).toContain('exec aborted');
+  }, 15_000);
+});

--- a/services/cloud-agent-next/test/unit/wrapper/utils.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/utils.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { git } from '../../../wrapper/src/utils.js';
+import { git, runProcess } from '../../../wrapper/src/utils.js';
 
 const createdRepos: string[] = [];
 
@@ -14,6 +14,16 @@ async function createRepo(): Promise<string> {
   await git(['config', 'user.name', 'Test User'], { cwd: repoPath, timeoutMs: 5_000 });
   return repoPath;
 }
+
+describe('runProcess', () => {
+  it('runs non-git commands with captured output', async () => {
+    const result = await runProcess(process.execPath, ['-e', 'console.log("hello")'], {
+      timeoutMs: 5_000,
+    });
+
+    expect(result).toEqual({ stdout: 'hello\n', stderr: '', exitCode: 0 });
+  });
+});
 
 describe('git', () => {
   afterEach(async () => {

--- a/services/cloud-agent-next/wrapper/src/auto-commit.ts
+++ b/services/cloud-agent-next/wrapper/src/auto-commit.ts
@@ -25,6 +25,7 @@ export type AutoCommitOptions = {
    *  committing to that branch even if it is main/master. Protection is only bypassed
    *  when the current branch matches this value exactly. */
   upstreamBranch?: string;
+  signal?: AbortSignal;
 };
 
 function emitStarted(
@@ -58,13 +59,13 @@ function emitCompleted(
 }
 
 export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommitResult> {
-  const { workspacePath, onEvent, kiloClient, messageId } = opts;
+  const { workspacePath, onEvent, kiloClient, messageId, signal } = opts;
 
   logToFile(`auto-commit: starting workspacePath=${workspacePath}`);
 
   try {
     // Check current branch (agent may have switched branches during execution)
-    const branch = await getCurrentBranch(workspacePath, GIT_LOCAL_TIMEOUT_MS);
+    const branch = await getCurrentBranch(workspacePath, GIT_LOCAL_TIMEOUT_MS, signal);
     logToFile(`auto-commit: branch=${branch || '(detached HEAD)'}`);
     if (!branch) {
       logToFile('auto-commit: skipping - detached HEAD state');
@@ -102,14 +103,21 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     }
 
     // Check actual git upstream (not stale config) to decide push strategy
-    const trackingUpstream = await hasGitUpstream(workspacePath, GIT_LOCAL_TIMEOUT_MS);
+    const trackingUpstream = await hasGitUpstream(workspacePath, GIT_LOCAL_TIMEOUT_MS, signal);
     logToFile(`auto-commit: hasGitUpstream=${trackingUpstream}`);
 
     // Check for uncommitted changes
     const status = await git(['status', '--porcelain'], {
       cwd: workspacePath,
       timeoutMs: GIT_LOCAL_TIMEOUT_MS,
+      signal,
     });
+    if (status.terminationReason === 'abort') {
+      const msg = 'git status aborted';
+      logToFile(`auto-commit: ${msg} (exit 124)`);
+      emitCompleted(onEvent, { success: false, message: msg }, messageId);
+      return { success: false, error: msg };
+    }
     if (status.exitCode === 124) {
       const msg = 'git status timed out';
       logToFile(`auto-commit: ${msg} (exit 124)`);
@@ -134,13 +142,29 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     let commitMessage: string;
     try {
       const commitMsgPromise = kiloClient.generateCommitMessage({ path: workspacePath });
-      const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      let abortHandler: (() => void) | undefined;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeout = setTimeout(
           () => reject(new Error('Commit message generation timed out')),
           COMMIT_MESSAGE_TIMEOUT_MS
-        )
+        );
+      });
+      const abortPromise = new Promise<never>((_, reject) => {
+        if (!signal) return;
+        abortHandler = () => reject(new Error('Commit message generation aborted'));
+        if (signal.aborted) {
+          abortHandler();
+          return;
+        }
+        signal.addEventListener('abort', abortHandler, { once: true });
+      });
+      const result = await Promise.race([commitMsgPromise, timeoutPromise, abortPromise]).finally(
+        () => {
+          if (timeout) clearTimeout(timeout);
+          if (signal && abortHandler) signal.removeEventListener('abort', abortHandler);
+        }
       );
-      const result = await Promise.race([commitMsgPromise, timeoutPromise]);
       commitMessage = result.message.trim() || 'wip';
       logToFile(`auto-commit: generated commit message: ${commitMessage}`);
     } catch (err) {
@@ -156,6 +180,7 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     const addResult = await git(['add', '-A'], {
       cwd: workspacePath,
       timeoutMs: GIT_LOCAL_TIMEOUT_MS,
+      signal,
     });
     if (addResult.exitCode !== 0) {
       const msg = `git add failed: ${addResult.stderr.trim()}`;
@@ -169,12 +194,14 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     let commitResult = await git(['commit', '-m', commitMessage], {
       cwd: workspacePath,
       timeoutMs: GIT_LOCAL_TIMEOUT_MS,
+      signal,
     });
     if (commitResult.exitCode !== 0) {
       logToFile('auto-commit: commit failed, retrying with --no-verify');
       commitResult = await git(['commit', '--no-verify', '-m', commitMessage], {
         cwd: workspacePath,
         timeoutMs: GIT_LOCAL_TIMEOUT_MS,
+        signal,
       });
       if (commitResult.exitCode !== 0) {
         const msg = `git commit failed: ${commitResult.stderr.trim()}`;
@@ -191,6 +218,7 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
       const hashResult = await git(['rev-parse', '--short', 'HEAD'], {
         cwd: workspacePath,
         timeoutMs: GIT_LOCAL_TIMEOUT_MS,
+        signal,
       });
       if (hashResult.exitCode === 0 && hashResult.stdout.trim()) {
         commitHash = hashResult.stdout.trim();
@@ -204,7 +232,11 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     const pushArgs = trackingUpstream ? ['push'] : ['push', '-u', 'origin', branch];
     logToFile(`auto-commit: pushing with args: git ${pushArgs.join(' ')}`);
 
-    const pushResult = await git(pushArgs, { cwd: workspacePath, timeoutMs: GIT_PUSH_TIMEOUT_MS });
+    const pushResult = await git(pushArgs, {
+      cwd: workspacePath,
+      timeoutMs: GIT_PUSH_TIMEOUT_MS,
+      signal,
+    });
     if (pushResult.exitCode !== 0) {
       // Push failure is non-fatal — changes are committed locally
       const msg = `git push failed: ${pushResult.stderr.trim()}`;

--- a/services/cloud-agent-next/wrapper/src/auto-commit.ts
+++ b/services/cloud-agent-next/wrapper/src/auto-commit.ts
@@ -1,6 +1,6 @@
 import type { IngestEvent } from '../../src/shared/protocol.js';
 import type { WrapperKiloClient } from './kilo-api.js';
-import { git, getCurrentBranch, hasGitUpstream, logToFile } from './utils.js';
+import { git, getCurrentBranch, hasGitUpstream, logToFile, withTimeoutAndAbort } from './utils.js';
 
 /** Timeout for local git operations (status, add, commit) */
 const GIT_LOCAL_TIMEOUT_MS = 30_000;
@@ -141,28 +141,13 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     logToFile('auto-commit: generating commit message');
     let commitMessage: string;
     try {
-      const commitMsgPromise = kiloClient.generateCommitMessage({ path: workspacePath });
-      let timeout: ReturnType<typeof setTimeout> | undefined;
-      let abortHandler: (() => void) | undefined;
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        timeout = setTimeout(
-          () => reject(new Error('Commit message generation timed out')),
-          COMMIT_MESSAGE_TIMEOUT_MS
-        );
-      });
-      const abortPromise = new Promise<never>((_, reject) => {
-        if (!signal) return;
-        abortHandler = () => reject(new Error('Commit message generation aborted'));
-        if (signal.aborted) {
-          abortHandler();
-          return;
-        }
-        signal.addEventListener('abort', abortHandler, { once: true });
-      });
-      const result = await Promise.race([commitMsgPromise, timeoutPromise, abortPromise]).finally(
-        () => {
-          if (timeout) clearTimeout(timeout);
-          if (signal && abortHandler) signal.removeEventListener('abort', abortHandler);
+      const result = await withTimeoutAndAbort(
+        kiloClient.generateCommitMessage({ path: workspacePath }),
+        {
+          timeoutMs: COMMIT_MESSAGE_TIMEOUT_MS,
+          timeoutMessage: 'Commit message generation timed out',
+          signal,
+          abortMessage: 'Commit message generation aborted',
         }
       );
       commitMessage = result.message.trim() || 'wip';

--- a/services/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/services/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -150,19 +150,23 @@ export function createLifecycleManager(
     if (perTurn.autoCommit) {
       logToFile('running auto-commit');
       try {
-        const autoCommitPromise = runAutoCommit({
+        const autoCommitController = new AbortController();
+        let autoCommitTimedOut = false;
+        const timeout = setTimeout(() => {
+          autoCommitTimedOut = true;
+          logToFile('auto-commit lifecycle timeout reached; aborting in-flight work');
+          autoCommitController.abort();
+        }, AUTO_COMMIT_TIMEOUT_MS);
+        const result = await runAutoCommit({
           workspacePath: config.workspacePath,
           onEvent: event => state.sendToIngest(event),
           kiloClient,
           messageId: state.lastAssistantMessageId ?? undefined,
           upstreamBranch: perTurn.upstreamBranch,
-        });
-        const timeoutPromise = new Promise<'timeout'>(resolve =>
-          setTimeout(() => resolve('timeout'), AUTO_COMMIT_TIMEOUT_MS)
-        );
-        const result = await Promise.race([autoCommitPromise, timeoutPromise]);
-        if (result === 'timeout') {
-          logToFile('auto-commit timed out');
+          signal: autoCommitController.signal,
+        }).finally(() => clearTimeout(timeout));
+        if (autoCommitTimedOut && !result.success) {
+          logToFile('auto-commit aborted by lifecycle timeout');
           state.sendToIngest({
             streamEventType: 'error',
             data: { error: 'Auto-commit timed out', fatal: false },

--- a/services/cloud-agent-next/wrapper/src/utils.ts
+++ b/services/cloud-agent-next/wrapper/src/utils.ts
@@ -5,67 +5,182 @@ export type ExecResult = {
   stdout: string;
   stderr: string;
   exitCode: number;
+  terminationReason?: TerminationReason;
 };
 
+export type GitOptions = {
+  cwd?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+};
+
+const GIT_TIMEOUT_EXIT_CODE = 124;
+const GIT_TERMINATION_GRACE_MS = 2_000;
+const EXEC_TIMEOUT_MESSAGE = 'exec timeout reached';
+const EXEC_ABORTED_MESSAGE = 'exec aborted';
+
+export type TerminationReason = 'timeout' | 'abort';
+
+function withStderrSuffix(stderr: string, suffix: string): string {
+  return `${stderr}${stderr.endsWith('\n') || stderr.length === 0 ? '' : '\n'}${suffix}`;
+}
+
 /** Spawn a git command with an argv array (no shell interpolation). */
-export function git(
-  args: string[],
-  opts?: { cwd?: string; timeoutMs?: number }
-): Promise<ExecResult> {
+export function git(args: string[], opts?: GitOptions): Promise<ExecResult> {
+  if (opts?.signal?.aborted) {
+    return Promise.resolve({
+      stdout: '',
+      stderr: EXEC_ABORTED_MESSAGE,
+      exitCode: GIT_TIMEOUT_EXIT_CODE,
+      terminationReason: 'abort',
+    });
+  }
+
   return new Promise((resolve, reject) => {
     const proc = spawn('git', args, {
       cwd: opts?.cwd,
+      detached: process.platform !== 'win32',
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let stdout = '';
     let stderr = '';
     let settled = false;
+    let terminationReason: TerminationReason | null = null;
+    let terminationTimer: ReturnType<typeof setTimeout> | undefined;
+
+    function abortHandler(): void {
+      terminate('abort');
+    }
+
+    const clearTimers = () => {
+      if (timer) clearTimeout(timer);
+      if (terminationTimer) clearTimeout(terminationTimer);
+    };
+
+    const removeAbortHandler = () => {
+      opts?.signal?.removeEventListener('abort', abortHandler);
+    };
+
+    const destroyPipes = (): void => {
+      proc.stdin.destroy();
+      proc.stdout.destroy();
+      proc.stderr.destroy();
+    };
+
+    const resolveTermination = (destroyOpenPipes = false): void => {
+      const reason = terminationReason;
+      if (settled || reason === null) return;
+      settled = true;
+      clearTimers();
+      removeAbortHandler();
+      if (destroyOpenPipes) destroyPipes();
+      resolve({
+        stdout,
+        stderr: withStderrSuffix(
+          stderr,
+          reason === 'timeout' ? EXEC_TIMEOUT_MESSAGE : EXEC_ABORTED_MESSAGE
+        ),
+        exitCode: GIT_TIMEOUT_EXIT_CODE,
+        terminationReason: reason,
+      });
+    };
+
+    const killProcess = (signal: NodeJS.Signals): void => {
+      if (proc.pid === undefined) return;
+      if (process.platform !== 'win32') {
+        try {
+          process.kill(-proc.pid, signal);
+          return;
+        } catch {
+          // Fall back to killing the direct child below.
+        }
+      }
+      proc.kill(signal);
+    };
+
+    const terminate = (reason: TerminationReason): void => {
+      if (settled || terminationReason !== null) return;
+      terminationReason = reason;
+      if (timer) clearTimeout(timer);
+      killProcess('SIGTERM');
+      terminationTimer = setTimeout(() => {
+        killProcess('SIGKILL');
+        resolveTermination(true);
+      }, GIT_TERMINATION_GRACE_MS);
+    };
 
     const timer =
       opts?.timeoutMs !== undefined
-        ? setTimeout(() => {
-            if (!settled) {
-              settled = true;
-              proc.kill('SIGTERM');
-              resolve({ stdout, stderr: stderr + '\nexec timeout reached', exitCode: 124 });
-            }
-          }, opts.timeoutMs)
+        ? setTimeout(() => terminate('timeout'), opts.timeoutMs)
         : undefined;
 
     proc.stdout.on('data', d => (stdout += d));
     proc.stderr.on('data', d => (stderr += d));
-    proc.on('exit', code => {
-      if (!settled) {
-        settled = true;
-        if (timer) clearTimeout(timer);
-        resolve({ stdout, stderr, exitCode: code ?? 0 });
+
+    if (opts?.signal) {
+      if (opts.signal.aborted) {
+        terminate('abort');
+      } else {
+        opts.signal.addEventListener('abort', abortHandler, { once: true });
       }
+    }
+    proc.on('close', code => {
+      if (settled) return;
+      if (terminationReason !== null) {
+        resolveTermination();
+        return;
+      }
+      settled = true;
+      clearTimers();
+      removeAbortHandler();
+      resolve({ stdout, stderr, exitCode: code ?? 0 });
     });
     proc.on('error', err => {
       if (!settled) {
         settled = true;
-        if (timer) clearTimeout(timer);
+        clearTimers();
+        removeAbortHandler();
         reject(err);
       }
     });
   });
 }
 
-export async function getCurrentBranch(workspacePath: string, timeoutMs?: number): Promise<string> {
+export async function getCurrentBranch(
+  workspacePath: string,
+  timeoutMs?: number,
+  signal?: AbortSignal
+): Promise<string> {
+  let result: ExecResult;
   try {
-    const result = await git(['branch', '--show-current'], { cwd: workspacePath, timeoutMs });
-    return result.stdout.trim();
+    result = await git(['branch', '--show-current'], {
+      cwd: workspacePath,
+      timeoutMs,
+      signal,
+    });
   } catch {
     return '';
   }
+  if (result.terminationReason === 'abort') {
+    throw new Error('git branch aborted');
+  }
+  if (result.terminationReason === 'timeout') {
+    throw new Error('git branch timed out');
+  }
+  return result.stdout.trim();
 }
 
 /** Check if the current branch has a remote tracking branch configured in git. */
-export async function hasGitUpstream(workspacePath: string, timeoutMs?: number): Promise<boolean> {
+export async function hasGitUpstream(
+  workspacePath: string,
+  timeoutMs?: number,
+  signal?: AbortSignal
+): Promise<boolean> {
   try {
     const result = await git(['rev-parse', '--abbrev-ref', '@{upstream}'], {
       cwd: workspacePath,
       timeoutMs,
+      signal,
     });
     return result.exitCode === 0 && result.stdout.trim() !== '';
   } catch {

--- a/services/cloud-agent-next/wrapper/src/utils.ts
+++ b/services/cloud-agent-next/wrapper/src/utils.ts
@@ -8,14 +8,24 @@ export type ExecResult = {
   terminationReason?: TerminationReason;
 };
 
-export type GitOptions = {
+export type ProcessOptions = {
   cwd?: string;
   timeoutMs?: number;
   signal?: AbortSignal;
+  terminationGraceMs?: number;
 };
 
-const GIT_TIMEOUT_EXIT_CODE = 124;
-const GIT_TERMINATION_GRACE_MS = 2_000;
+export type GitOptions = ProcessOptions;
+
+export type TimeoutAbortOptions = {
+  timeoutMs: number;
+  timeoutMessage: string;
+  signal?: AbortSignal;
+  abortMessage: string;
+};
+
+const EXEC_TIMEOUT_EXIT_CODE = 124;
+const EXEC_TERMINATION_GRACE_MS = 2_000;
 const EXEC_TIMEOUT_MESSAGE = 'exec timeout reached';
 const EXEC_ABORTED_MESSAGE = 'exec aborted';
 
@@ -25,22 +35,25 @@ function withStderrSuffix(stderr: string, suffix: string): string {
   return `${stderr}${stderr.endsWith('\n') || stderr.length === 0 ? '' : '\n'}${suffix}`;
 }
 
-/** Spawn a git command with an argv array (no shell interpolation). */
-export function git(args: string[], opts?: GitOptions): Promise<ExecResult> {
+export function runProcess(
+  command: string,
+  args: string[],
+  opts?: ProcessOptions
+): Promise<ExecResult> {
   if (opts?.signal?.aborted) {
     return Promise.resolve({
       stdout: '',
       stderr: EXEC_ABORTED_MESSAGE,
-      exitCode: GIT_TIMEOUT_EXIT_CODE,
+      exitCode: EXEC_TIMEOUT_EXIT_CODE,
       terminationReason: 'abort',
     });
   }
 
   return new Promise((resolve, reject) => {
-    const proc = spawn('git', args, {
+    const proc = spawn(command, args, {
       cwd: opts?.cwd,
-      detached: process.platform !== 'win32',
-      stdio: ['pipe', 'pipe', 'pipe'],
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
     let stdout = '';
     let stderr = '';
@@ -62,7 +75,6 @@ export function git(args: string[], opts?: GitOptions): Promise<ExecResult> {
     };
 
     const destroyPipes = (): void => {
-      proc.stdin.destroy();
       proc.stdout.destroy();
       proc.stderr.destroy();
     };
@@ -80,22 +92,19 @@ export function git(args: string[], opts?: GitOptions): Promise<ExecResult> {
           stderr,
           reason === 'timeout' ? EXEC_TIMEOUT_MESSAGE : EXEC_ABORTED_MESSAGE
         ),
-        exitCode: GIT_TIMEOUT_EXIT_CODE,
+        exitCode: EXEC_TIMEOUT_EXIT_CODE,
         terminationReason: reason,
       });
     };
 
     const killProcess = (signal: NodeJS.Signals): void => {
       if (proc.pid === undefined) return;
-      if (process.platform !== 'win32') {
-        try {
-          process.kill(-proc.pid, signal);
-          return;
-        } catch {
-          // Fall back to killing the direct child below.
-        }
+      try {
+        process.kill(-proc.pid, signal);
+        return;
+      } catch {
+        proc.kill(signal);
       }
-      proc.kill(signal);
     };
 
     const terminate = (reason: TerminationReason): void => {
@@ -106,7 +115,7 @@ export function git(args: string[], opts?: GitOptions): Promise<ExecResult> {
       terminationTimer = setTimeout(() => {
         killProcess('SIGKILL');
         resolveTermination(true);
-      }, GIT_TERMINATION_GRACE_MS);
+      }, opts?.terminationGraceMs ?? EXEC_TERMINATION_GRACE_MS);
     };
 
     const timer =
@@ -143,6 +152,37 @@ export function git(args: string[], opts?: GitOptions): Promise<ExecResult> {
         reject(err);
       }
     });
+  });
+}
+
+/** Spawn a git command with an argv array (no shell interpolation). */
+export function git(args: string[], opts?: GitOptions): Promise<ExecResult> {
+  return runProcess('git', args, opts);
+}
+
+export async function withTimeoutAndAbort<T>(
+  promise: Promise<T>,
+  opts: TimeoutAbortOptions
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let abortHandler: (() => void) | undefined;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(opts.timeoutMessage)), opts.timeoutMs);
+  });
+  const abortPromise = new Promise<never>((_, reject) => {
+    if (!opts.signal) return;
+    abortHandler = () => reject(new Error(opts.abortMessage));
+    if (opts.signal.aborted) {
+      abortHandler();
+      return;
+    }
+    opts.signal.addEventListener('abort', abortHandler, { once: true });
+  });
+
+  return Promise.race([promise, timeoutPromise, abortPromise]).finally(() => {
+    if (timeout) clearTimeout(timeout);
+    if (opts.signal && abortHandler) opts.signal.removeEventListener('abort', abortHandler);
   });
 }
 


### PR DESCRIPTION
## Summary

- Add abort-aware git execution in the cloud-agent wrapper so timeout cleanup waits for process close, escalates stuck commands, and distinguishes lifecycle aborts from local command timeouts.
- Pass lifecycle abort signals through auto-commit git operations and commit-message generation so the 120s lifecycle timeout stops in-flight work instead of leaving it running.
- Cover wrapper git cancellation, auto-commit abort handling, and lifecycle timeout race behavior with targeted unit tests.
