### PR TITLE
feat(kiloclaw): add env key diagnostics to admin debug UI

### DIFF
--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -2283,6 +2283,115 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         {data.workerStatus && (
           <Card>
             <CardHeader>
+              <CardTitle>Env Key Diagnostics</CardTitle>
+              <CardDescription>
+                Encryption key state from the App DO — helps debug boot decryption failures
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                <DetailField label="App DO Key">
+                  <code className="text-xs">{data.workerStatus.envKeyAppDOKey ?? '—'}</code>
+                </DetailField>
+
+                <DetailField label="App DO Fly App Name">
+                  {data.workerStatus.envKeyAppDOFlyAppName ? (
+                    <code className="text-xs">{data.workerStatus.envKeyAppDOFlyAppName}</code>
+                  ) : (
+                    <span className="text-destructive text-xs font-medium">
+                      null (no Fly secret sync!)
+                    </span>
+                  )}
+                </DetailField>
+
+                <DetailField label="Instance DO Fly App Name">
+                  <code className="text-xs">{data.workerStatus.flyAppName ?? '—'}</code>
+                </DetailField>
+
+                <DetailField label="App DO envKeySet">
+                  {data.workerStatus.envKeyAppDOKeySet === null
+                    ? '—'
+                    : data.workerStatus.envKeyAppDOKeySet
+                      ? 'true'
+                      : 'false'}
+                </DetailField>
+
+                <DetailField label="Env Key Fingerprint">
+                  {data.workerStatus.envKeyAppDOFingerprint ? (
+                    <code className="text-xs">{data.workerStatus.envKeyAppDOFingerprint}...</code>
+                  ) : (
+                    <span className="text-destructive text-xs font-medium">no key</span>
+                  )}
+                </DetailField>
+
+                {data.workerStatus.envKeyAppDOFlyAppName !== null &&
+                  data.workerStatus.flyAppName !== null &&
+                  data.workerStatus.envKeyAppDOFlyAppName !== data.workerStatus.flyAppName && (
+                    <div className="bg-destructive/10 border-destructive/30 col-span-full rounded-md border p-3">
+                      <p className="text-destructive text-sm font-medium">
+                        Fly app name mismatch: App DO thinks it&apos;s{' '}
+                        <code>{data.workerStatus.envKeyAppDOFlyAppName}</code> but Instance DO has{' '}
+                        <code>{data.workerStatus.flyAppName}</code>. The App DO will set the Fly
+                        secret on the wrong app.
+                      </p>
+                    </div>
+                  )}
+
+                {data.workerStatus.envKeyAppDOFlyAppName === null &&
+                  data.workerStatus.flyAppName !== null && (
+                    <div className="bg-destructive/10 border-destructive/30 col-span-full rounded-md border p-3">
+                      <p className="text-destructive text-sm font-medium">
+                        App DO has no flyAppName — ensureEnvKey() will not call setAppSecret().
+                        Encrypted env vars will use the App DO&apos;s key but the Fly secret will be
+                        stale or missing.
+                      </p>
+                    </div>
+                  )}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {data.workerStatus &&
+          (data.workerStatus.lastStartErrorMessage ||
+            data.workerStatus.lastRestartErrorMessage) && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Start / Restart Errors</CardTitle>
+                <CardDescription>Most recent start or restart failure</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="grid gap-4 md:grid-cols-2">
+                  {data.workerStatus.lastStartErrorMessage && (
+                    <DetailField label="Last Start Error">
+                      <span className="text-destructive text-xs">
+                        <code>{data.workerStatus.lastStartErrorMessage}</code>
+                        <br />
+                        <span className="text-muted-foreground">
+                          {formatEpochTime(data.workerStatus.lastStartErrorAt)}
+                        </span>
+                      </span>
+                    </DetailField>
+                  )}
+                  {data.workerStatus.lastRestartErrorMessage && (
+                    <DetailField label="Last Restart Error">
+                      <span className="text-destructive text-xs">
+                        <code>{data.workerStatus.lastRestartErrorMessage}</code>
+                        <br />
+                        <span className="text-muted-foreground">
+                          {formatEpochTime(data.workerStatus.lastRestartErrorAt)}
+                        </span>
+                      </span>
+                    </DetailField>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+        {data.workerStatus && (
+          <Card>
+            <CardHeader>
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <CardTitle>Unexpected Stop Recovery</CardTitle>

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -221,6 +221,8 @@ export type PlatformDebugStatusResponse = PlatformStatusResponse & {
   lastDestroyErrorStatus: number | null;
   lastDestroyErrorMessage: string | null;
   lastDestroyErrorAt: number | null;
+  lastStartErrorMessage: string | null;
+  lastStartErrorAt: number | null;
   lastRestartErrorMessage: string | null;
   lastRestartErrorAt: number | null;
   recoveryStartedAt: number | null;
@@ -233,6 +235,11 @@ export type PlatformDebugStatusResponse = PlatformStatusResponse & {
   restoreStartedAt: string | null;
   pendingRestoreVolumeId: string | null;
   instanceReadyEmailSent: boolean;
+  // Env key diagnostics from the App DO
+  envKeyAppDOKey: string | null;
+  envKeyAppDOFlyAppName: string | null;
+  envKeyAppDOKeySet: boolean | null;
+  envKeyAppDOFingerprint: string | null;
 };
 
 export type CleanupRecoveryPreviousVolumeResponse = {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-app.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-app.ts
@@ -263,6 +263,23 @@ export class KiloClawApp extends DurableObject<KiloClawEnv> {
   }
 
   /**
+   * Return diagnostic info for the admin debug UI.
+   * Exposes enough to debug env key mismatches without leaking the full key.
+   */
+  async getDiagnostics(): Promise<{
+    flyAppName: string | null;
+    envKeySet: boolean;
+    envKeyFingerprint: string | null;
+  }> {
+    await this.loadState();
+    return {
+      flyAppName: this.flyAppName,
+      envKeySet: this.envKeySet,
+      envKeyFingerprint: this.envKey ? this.envKey.slice(0, 8) : null,
+    };
+  }
+
+  /**
    * Delete the Fly App entirely.
    * For future use (e.g. account deletion). Not called on instance destroy.
    */

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -52,7 +52,7 @@ import type { GatewayProcessStatus } from '../gateway-controller-types';
 
 // Domain modules
 import type { InstanceMutableState, InstanceStatus, DestroyResult } from './types';
-import { getFlyConfig } from './types';
+import { getAppKey, getFlyConfig } from './types';
 import {
   applyProviderState,
   createMutableState,
@@ -1994,9 +1994,31 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     restoreStartedAt: string | null;
     pendingRestoreVolumeId: string | null;
     instanceReadyEmailSent: boolean;
+    // --- env key diagnostics ---
+    envKeyAppDOKey: string | null;
+    envKeyAppDOFlyAppName: string | null;
+    envKeyAppDOKeySet: boolean | null;
+    envKeyAppDOFingerprint: string | null;
   }> {
     await this.loadState();
     const alarmScheduledAt = await this.ctx.storage.getAlarm();
+
+    // Fetch env key diagnostics from the App DO (best-effort, don't fail the whole response).
+    let envKeyDiag: {
+      flyAppName: string | null;
+      envKeySet: boolean;
+      envKeyFingerprint: string | null;
+    } | null = null;
+    let envKeyAppDOKey: string | null = null;
+    try {
+      if (this.s.userId || this.s.sandboxId) {
+        envKeyAppDOKey = getAppKey({ userId: this.s.userId, sandboxId: this.s.sandboxId });
+        const appStub = this.env.KILOCLAW_APP.get(this.env.KILOCLAW_APP.idFromName(envKeyAppDOKey));
+        envKeyDiag = await appStub.getDiagnostics();
+      }
+    } catch {
+      // Swallow — diagnostics are best-effort.
+    }
 
     return {
       userId: this.s.userId,
@@ -2050,6 +2072,10 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       restoreStartedAt: this.s.restoreStartedAt,
       pendingRestoreVolumeId: this.s.pendingRestoreVolumeId,
       instanceReadyEmailSent: this.s.instanceReadyEmailSent,
+      envKeyAppDOKey,
+      envKeyAppDOFlyAppName: envKeyDiag?.flyAppName ?? null,
+      envKeyAppDOKeySet: envKeyDiag?.envKeySet ?? null,
+      envKeyAppDOFingerprint: envKeyDiag?.envKeyFingerprint ?? null,
     };
   }
 


### PR DESCRIPTION
## Summary

- Add an "Env Key Diagnostics" card to the KiloClaw admin instance detail page that surfaces encryption key state from the App DO. This shows the resolved App DO key, the App DO's `flyAppName`, `envKeySet` flag, and a key fingerprint (first 8 base64 chars) — enough to debug boot decryption mismatches without leaking the full key.
- Inline warning banners detect two specific failure modes: (1) App DO `flyAppName` is `null` (meaning `ensureEnvKey()` won't call `setAppSecret()`), and (2) App DO `flyAppName` differs from the Instance DO's cached `flyAppName` (secret set on wrong or stale Fly app).
- Add `getDiagnostics()` RPC method to the `KiloClawApp` DO.
- Add missing `lastStartErrorMessage` / `lastStartErrorAt` fields to `PlatformDebugStatusResponse` (these were already returned by the DO's `getDebugState()` but silently dropped by the web type).
- Surface start/restart errors in a new "Start / Restart Errors" card (previously only available via raw API).

## Verification

- [x] `pnpm typecheck` — all packages pass
- [x] `pnpm format` — no formatting issues
- [ ] Manual verification of the admin UI card rendering

## Visual Changes

| Before | After |
| ------ | ----- |
| No env key info in admin detail | New "Env Key Diagnostics" card with App DO key, flyAppName, envKeySet, fingerprint, and mismatch warnings |
| Start/restart errors not surfaced | New "Start / Restart Errors" card when errors exist |

## Reviewer Notes

- The `getDiagnostics()` call in `getDebugState()` is wrapped in try/catch to avoid breaking the debug endpoint if the App DO is unreachable. Best-effort only.
- The env key fingerprint is the first 8 chars of the base64-encoded key — sufficient for visual comparison (e.g., comparing what the App DO holds vs what a machine received via `echo $KILOCLAW_ENV_KEY | cut -c1-8`).
- This is observability-only — no changes to the encryption/decryption flow itself.