### PR TITLE
fix(cloud-agent): refresh expired stream tickets

### DIFF
--- a/apps/web/src/components/cloud-agent-next/CloudAgentProvider.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudAgentProvider.tsx
@@ -77,7 +77,7 @@ export function CloudAgentProvider({ children, organizationId }: CloudAgentProvi
         return { type: 'read-only', kiloSessionId };
       },
 
-      getTicket: async (sessionId: CloudAgentSessionId): Promise<string> => {
+      getTicket: async (sessionId: CloudAgentSessionId) => {
         const body: Record<string, string> = { cloudAgentSessionId: sessionId };
         if (organizationId) body.organizationId = organizationId;
         const response = await fetch('/api/cloud-agent-next/sessions/stream-ticket', {
@@ -89,8 +89,7 @@ export function CloudAgentProvider({ children, organizationId }: CloudAgentProvi
           const errorData = (await response.json()) as { error?: string };
           throw new Error(errorData.error ?? 'Failed to get stream ticket');
         }
-        const result = (await response.json()) as { ticket: string };
-        return result.ticket;
+        return (await response.json()) as { ticket: string; expiresAt: number };
       },
 
       fetchSnapshot: async (id: KiloSessionId) => {

--- a/apps/web/src/lib/cloud-agent-next/websocket-manager.test.ts
+++ b/apps/web/src/lib/cloud-agent-next/websocket-manager.test.ts
@@ -134,7 +134,7 @@ describe('cloud-agent-next websocket-manager', () => {
     );
   });
 
-  it('does not refresh again or create a third socket after repeated ambiguous 1006', async () => {
+  it('falls back to timer reconnect after repeated ambiguous 1006', async () => {
     const onRefreshTicket = jest.fn().mockResolvedValue('new-ticket');
     const onStateChange = jest.fn();
     const manager = createWebSocketManager(createConfig({ onRefreshTicket, onStateChange }));
@@ -156,15 +156,28 @@ describe('cloud-agent-next websocket-manager', () => {
     }
 
     secondWs.simulateClose(1006, '');
-    await flushPromises();
 
     expect(onRefreshTicket).toHaveBeenCalledTimes(1);
-    expect(MockWebSocket.instances).toHaveLength(2);
     expect(onStateChange).toHaveBeenCalledWith({
+      status: 'reconnecting',
+      lastEventId: 0,
+      attempt: 1,
+    });
+    expect(onStateChange).not.toHaveBeenCalledWith({
       status: 'error',
       error: 'Authentication failed after ticket refresh. Check server configuration.',
       retryable: false,
     });
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    jest.advanceTimersByTime(1000);
+
+    expect(MockWebSocket.instances).toHaveLength(3);
+    const thirdWs = MockWebSocket.instances[2];
+    if (thirdWs === undefined) {
+      throw new Error('Expected reconnected WebSocket');
+    }
+    expect(thirdWs.url).toContain('ticket=new-ticket');
   });
 
   it('uses timer reconnect with the same ticket on normal non-auth close', async () => {

--- a/apps/web/src/lib/cloud-agent-next/websocket-manager.test.ts
+++ b/apps/web/src/lib/cloud-agent-next/websocket-manager.test.ts
@@ -1,0 +1,203 @@
+import { createWebSocketManager, type WebSocketManagerConfig } from './websocket-manager';
+
+class MockCloseEvent extends Event {
+  code: number;
+  reason: string;
+  wasClean: boolean;
+
+  constructor(type: string, init: { code: number; reason: string; wasClean: boolean }) {
+    super(type);
+    this.code = init.code;
+    this.reason = init.reason;
+    this.wasClean = init.wasClean;
+  }
+}
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  url: string;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  readyState = 0;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  close() {
+    this.readyState = 3;
+  }
+
+  simulateMessage(data: string) {
+    if (this.onmessage === null) {
+      throw new Error('MockWebSocket.simulateMessage called but onmessage handler is not set');
+    }
+    this.onmessage(new MessageEvent('message', { data }));
+  }
+
+  simulateClose(code: number, reason = '') {
+    this.readyState = 3;
+    this.onclose?.(new MockCloseEvent('close', { code, reason, wasClean: code === 1000 }));
+  }
+
+  static reset() {
+    MockWebSocket.instances = [];
+  }
+}
+
+const originalWebSocket = global.WebSocket;
+
+beforeAll(() => {
+  Object.defineProperty(global, 'WebSocket', {
+    configurable: true,
+    writable: true,
+    value: MockWebSocket,
+  });
+});
+
+afterAll(() => {
+  Object.defineProperty(global, 'WebSocket', {
+    configurable: true,
+    writable: true,
+    value: originalWebSocket,
+  });
+});
+
+const flushPromises = () => new Promise(jest.requireActual('timers').setImmediate);
+const mockRandom = jest.spyOn(Math, 'random');
+
+function eventMessage(eventId: number): string {
+  return JSON.stringify({
+    eventId,
+    executionId: 'exec-123',
+    sessionId: 'session-123',
+    streamEventType: 'status',
+    timestamp: new Date().toISOString(),
+    data: {},
+  });
+}
+
+function createConfig(overrides: Partial<WebSocketManagerConfig> = {}): WebSocketManagerConfig {
+  return {
+    url: 'wss://example.com/stream?sessionId=test',
+    ticket: 'old-ticket',
+    onEvent: jest.fn(),
+    onStateChange: jest.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  MockWebSocket.reset();
+  jest.useFakeTimers();
+  mockRandom.mockReturnValue(0.5);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  mockRandom.mockReset();
+});
+
+describe('cloud-agent-next websocket-manager', () => {
+  it('refreshes the ticket on ambiguous 1006 and reconnects immediately with fromId preserved', async () => {
+    const onRefreshTicket = jest.fn().mockResolvedValue('new-ticket');
+    const onStateChange = jest.fn();
+    const manager = createWebSocketManager(createConfig({ onRefreshTicket, onStateChange }));
+
+    manager.connect();
+
+    const firstWs = MockWebSocket.instances[0];
+    if (firstWs === undefined) {
+      throw new Error('Expected initial WebSocket');
+    }
+
+    firstWs.simulateMessage(eventMessage(2269));
+    firstWs.simulateClose(1006, '');
+
+    expect(onRefreshTicket).toHaveBeenCalledTimes(1);
+    expect(onStateChange).toHaveBeenCalledWith({ status: 'refreshing_ticket' });
+
+    await flushPromises();
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+    const secondWs = MockWebSocket.instances[1];
+    if (secondWs === undefined) {
+      throw new Error('Expected refreshed WebSocket');
+    }
+    expect(secondWs.url).toContain('ticket=new-ticket');
+    expect(secondWs.url).toContain('fromId=2269');
+    expect(onStateChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'reconnecting' })
+    );
+  });
+
+  it('does not refresh again or create a third socket after repeated ambiguous 1006', async () => {
+    const onRefreshTicket = jest.fn().mockResolvedValue('new-ticket');
+    const onStateChange = jest.fn();
+    const manager = createWebSocketManager(createConfig({ onRefreshTicket, onStateChange }));
+
+    manager.connect();
+
+    const firstWs = MockWebSocket.instances[0];
+    if (firstWs === undefined) {
+      throw new Error('Expected initial WebSocket');
+    }
+
+    firstWs.simulateClose(1006, '');
+    await flushPromises();
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+    const secondWs = MockWebSocket.instances[1];
+    if (secondWs === undefined) {
+      throw new Error('Expected refreshed WebSocket');
+    }
+
+    secondWs.simulateClose(1006, '');
+    await flushPromises();
+
+    expect(onRefreshTicket).toHaveBeenCalledTimes(1);
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(onStateChange).toHaveBeenCalledWith({
+      status: 'error',
+      error: 'Authentication failed after ticket refresh. Check server configuration.',
+      retryable: false,
+    });
+  });
+
+  it('uses timer reconnect with the same ticket on normal non-auth close', async () => {
+    const onRefreshTicket = jest.fn().mockResolvedValue('new-ticket');
+    const onStateChange = jest.fn();
+    const manager = createWebSocketManager(createConfig({ onRefreshTicket, onStateChange }));
+
+    manager.connect();
+
+    const firstWs = MockWebSocket.instances[0];
+    if (firstWs === undefined) {
+      throw new Error('Expected initial WebSocket');
+    }
+
+    firstWs.simulateMessage(eventMessage(2269));
+    firstWs.simulateClose(1001, 'Going away');
+
+    expect(onRefreshTicket).not.toHaveBeenCalled();
+    expect(onStateChange).toHaveBeenCalledWith({
+      status: 'reconnecting',
+      lastEventId: 2269,
+      attempt: 1,
+    });
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    jest.advanceTimersByTime(1000);
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+    const secondWs = MockWebSocket.instances[1];
+    if (secondWs === undefined) {
+      throw new Error('Expected reconnected WebSocket');
+    }
+    expect(secondWs.url).toContain('ticket=old-ticket');
+    expect(secondWs.url).toContain('fromId=2269');
+  });
+});

--- a/apps/web/src/lib/cloud-agent-next/websocket-manager.ts
+++ b/apps/web/src/lib/cloud-agent-next/websocket-manager.ts
@@ -272,9 +272,9 @@ export function createWebSocketManager(config: WebSocketManagerConfig): {
 
       // If we already tried refreshing the ticket and still get an explicit auth close,
       // don't keep retrying - the issue is likely not the ticket.
-      if (shouldRefreshTicket && ticketRefreshAttempted) {
+      if (isAuthFailure && ticketRefreshAttempted) {
         console.log(
-          '[WebSocketManager] Auth-like failure after ticket refresh - stopping retries (likely origin/config issue)'
+          '[WebSocketManager] Explicit auth failure after ticket refresh - stopping retries (likely origin/config issue)'
         );
         setState({
           status: 'error',

--- a/apps/web/src/lib/cloud-agent-next/websocket-manager.ts
+++ b/apps/web/src/lib/cloud-agent-next/websocket-manager.ts
@@ -73,12 +73,20 @@ const AUTH_FAILURE_KEYWORDS = ['unauthorized', '401', 'auth', 'ticket'] as const
  * - Close code 4001 (custom) - explicit auth failure code
  * - Close reason containing auth-related keywords
  */
+function isAuthFailureCode(code: number): boolean {
+  return AUTH_FAILURE_CLOSE_CODES.some(authFailureCode => authFailureCode === code);
+}
+
 function isAuthFailureClose(event: CloseEvent): boolean {
-  if (AUTH_FAILURE_CLOSE_CODES.includes(event.code as (typeof AUTH_FAILURE_CLOSE_CODES)[number])) {
+  if (isAuthFailureCode(event.code)) {
     return true;
   }
   const reason = event.reason?.toLowerCase() ?? '';
   return AUTH_FAILURE_KEYWORDS.some(keyword => reason.includes(keyword));
+}
+
+function isAmbiguousAbnormalClose(event: CloseEvent): boolean {
+  return event.code === 1006 && event.reason === '';
 }
 
 export function createWebSocketManager(config: WebSocketManagerConfig): {
@@ -245,25 +253,28 @@ export function createWebSocketManager(config: WebSocketManagerConfig): {
       }
 
       const isAuthFailure = isAuthFailureClose(event);
+      const isAmbiguousAbnormal = isAmbiguousAbnormalClose(event);
+      const shouldRefreshTicket = isAuthFailure || isAmbiguousAbnormal;
 
       console.log('[WebSocketManager] Auth failure check', {
         isAuthFailure,
+        isAmbiguousAbnormalClose: isAmbiguousAbnormal,
         ticketRefreshAttempted,
         hasRefreshHandler: !!config.onRefreshTicket,
-        willRefresh: isAuthFailure && !ticketRefreshAttempted && !!config.onRefreshTicket,
+        willRefresh: shouldRefreshTicket && !ticketRefreshAttempted && !!config.onRefreshTicket,
       });
 
-      if (isAuthFailure && !ticketRefreshAttempted && config.onRefreshTicket) {
+      if (shouldRefreshTicket && !ticketRefreshAttempted && config.onRefreshTicket) {
         console.log('[WebSocketManager] Auth failure detected, attempting ticket refresh');
         void refreshTicketAndReconnect();
         return;
       }
 
-      // If we already tried refreshing the ticket and still getting auth failures,
-      // don't keep retrying - the issue is likely not the ticket
-      if (isAuthFailure && ticketRefreshAttempted) {
+      // If we already tried refreshing the ticket and still get an explicit auth close,
+      // don't keep retrying - the issue is likely not the ticket.
+      if (shouldRefreshTicket && ticketRefreshAttempted) {
         console.log(
-          '[WebSocketManager] Auth failure after ticket refresh - stopping retries (likely origin/config issue)'
+          '[WebSocketManager] Auth-like failure after ticket refresh - stopping retries (likely origin/config issue)'
         );
         setState({
           status: 'error',

--- a/apps/web/src/lib/cloud-agent-sdk/base-connection.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/base-connection.ts
@@ -11,6 +11,7 @@ export type BaseConnectionConfig<T = unknown> = {
   onError?: (message: string) => void;
   isAuthFailure?: (event: CloseEvent) => boolean;
   refreshAuth?: () => Promise<void>;
+  shouldRefreshAuthBeforeConnect?: () => boolean;
   onOpen?: (ws: WebSocket) => void;
   /** How long to wait for a server message (e.g. heartbeat) on tab resume before
    *  treating the connection as stale. Should exceed the server's heartbeat interval. */
@@ -47,6 +48,7 @@ export function createBaseConnection<T>(config: BaseConnectionConfig<T>): Connec
   let hasConnectedOnce = false;
   let stalenessTimeoutId: ReturnType<typeof setTimeout> | null = null;
   let lastMessageTime = 0;
+  let preconnectAuthRefreshAttempted = false;
   const stalenessTimeoutMs = config.stalenessTimeoutMs ?? DEFAULT_STALENESS_TIMEOUT_MS;
 
   // Bound handler references for event listener cleanup
@@ -73,6 +75,8 @@ export function createBaseConnection<T>(config: BaseConnectionConfig<T>): Connec
       return;
     }
 
+    preconnectAuthRefreshAttempted = true;
+
     try {
       await config.refreshAuth();
       if (destroyed || intentionalDisconnect || expectedGeneration !== generation) {
@@ -85,19 +89,31 @@ export function createBaseConnection<T>(config: BaseConnectionConfig<T>): Connec
       if (destroyed || intentionalDisconnect || expectedGeneration !== generation) return;
       config.onUnexpectedDisconnect?.();
       scheduleReconnect(0, expectedGeneration);
+    } finally {
+      if (expectedGeneration === generation) {
+        preconnectAuthRefreshAttempted = false;
+      }
     }
   }
 
   async function refreshAndConnect(expectedGeneration: number): Promise<void> {
-    if (config.refreshAuth) {
-      try {
-        await config.refreshAuth();
-      } catch {
-        // Continue with existing auth — the old ticket might still work
+    preconnectAuthRefreshAttempted = true;
+
+    try {
+      if (config.refreshAuth) {
+        try {
+          await config.refreshAuth();
+        } catch {
+          // Continue with existing auth — the old ticket might still work
+        }
+        if (destroyed || intentionalDisconnect || expectedGeneration !== generation) return;
       }
-      if (destroyed || intentionalDisconnect || expectedGeneration !== generation) return;
+      connectInternal(0, expectedGeneration);
+    } finally {
+      if (expectedGeneration === generation) {
+        preconnectAuthRefreshAttempted = false;
+      }
     }
-    connectInternal(0, expectedGeneration);
   }
 
   function scheduleReconnect(attempt: number, expectedGeneration: number) {
@@ -126,6 +142,15 @@ export function createBaseConnection<T>(config: BaseConnectionConfig<T>): Connec
 
   function connectInternal(attempt = 0, expectedGeneration = generation) {
     if (destroyed || intentionalDisconnect || expectedGeneration !== generation) return;
+
+    if (
+      config.refreshAuth &&
+      (config.shouldRefreshAuthBeforeConnect?.() ?? false) &&
+      !preconnectAuthRefreshAttempted
+    ) {
+      void refreshAndConnect(expectedGeneration);
+      return;
+    }
 
     reconnectAttempt = attempt;
     clearStalenessTimeout();
@@ -366,6 +391,7 @@ export function createBaseConnection<T>(config: BaseConnectionConfig<T>): Connec
     intentionalDisconnect = false;
     destroyed = false;
     authRefreshAttempted = false;
+    preconnectAuthRefreshAttempted = false;
     connected = false;
     reconnectAttempt = 0;
     hasConnectedOnce = false;
@@ -380,6 +406,7 @@ export function createBaseConnection<T>(config: BaseConnectionConfig<T>): Connec
   function disconnect() {
     intentionalDisconnect = true;
     generation += 1;
+    preconnectAuthRefreshAttempted = false;
 
     clearReconnectTimer();
     clearStalenessTimeout();
@@ -399,6 +426,7 @@ export function createBaseConnection<T>(config: BaseConnectionConfig<T>): Connec
   function destroy() {
     destroyed = true;
     generation += 1;
+    preconnectAuthRefreshAttempted = false;
 
     clearReconnectTimer();
     clearStalenessTimeout();

--- a/apps/web/src/lib/cloud-agent-sdk/cloud-agent-connection.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cloud-agent-connection.test.ts
@@ -18,12 +18,27 @@ function createDeferred<T>() {
   return { promise, resolve };
 }
 
+class MockCloseEvent extends Event {
+  code: number;
+  reason: string;
+  wasClean: boolean;
+
+  constructor(init: { code: number; reason: string; wasClean: boolean }) {
+    super('close');
+    this.code = init.code;
+    this.reason = init.reason;
+    this.wasClean = init.wasClean;
+  }
+}
+
 function emitClose(socket: MockWebSocket, close: Partial<CloseEvent>): void {
-  socket.onclose?.({
-    code: close.code ?? 1006,
-    reason: close.reason ?? '',
-    wasClean: close.wasClean ?? false,
-  } as CloseEvent);
+  socket.onclose?.(
+    new MockCloseEvent({
+      code: close.code ?? 1006,
+      reason: close.reason ?? '',
+      wasClean: close.wasClean ?? false,
+    })
+  );
 }
 
 describe('createConnection', () => {
@@ -86,6 +101,69 @@ describe('createConnection', () => {
     connection.destroy();
 
     expect(webSocketMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes an expiring ticket before opening the websocket', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const onRefreshTicket = jest.fn().mockResolvedValue({
+      ticket: 'new-ticket',
+      expiresAt: nowSeconds + 60,
+    });
+
+    const connection = createConnection({
+      websocketUrl: 'ws://localhost:9999/stream',
+      ticket: {
+        ticket: 'old-ticket',
+        expiresAt: nowSeconds + 5,
+      },
+      onEvent: jest.fn(),
+      onConnected: jest.fn(),
+      onDisconnected: jest.fn(),
+      onRefreshTicket,
+    });
+
+    connection.connect();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onRefreshTicket).toHaveBeenCalledTimes(1);
+    expect(webSocketMock).toHaveBeenCalledTimes(1);
+    expect(sockets[0]?.url).toContain('ticket=new-ticket');
+    expect(sockets[0]?.url).not.toContain('ticket=old-ticket');
+
+    connection.destroy();
+  });
+
+  it('treats ambiguous 1006 as a reconnectable transport failure', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    const onRefreshTicket = jest.fn().mockResolvedValue('new-ticket');
+
+    const connection = createConnection({
+      websocketUrl: 'ws://localhost:9999/stream',
+      ticket: 'old-ticket',
+      onEvent: jest.fn(),
+      onConnected: jest.fn(),
+      onDisconnected: jest.fn(),
+      onRefreshTicket,
+    });
+
+    connection.connect();
+
+    const firstSocket = sockets[0];
+    if (firstSocket === undefined) {
+      throw new Error('Expected initial WebSocket');
+    }
+    emitClose(firstSocket, { code: 1006, reason: '' });
+
+    expect(onRefreshTicket).not.toHaveBeenCalled();
+    expect(webSocketMock).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(500);
+
+    expect(webSocketMock).toHaveBeenCalledTimes(2);
+    expect(sockets[1]?.url).toContain('ticket=old-ticket');
+
+    connection.destroy();
   });
 
   it('manual connect() must cancel pending reconnect timer', () => {

--- a/apps/web/src/lib/cloud-agent-sdk/cloud-agent-connection.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cloud-agent-connection.ts
@@ -5,17 +5,18 @@ import {
   type StreamError,
 } from '@/lib/cloud-agent-next/event-types';
 import { createBaseConnection, type Connection } from './base-connection';
+import type { CloudAgentStreamTicket, CloudAgentStreamTicketResult } from './transport';
 
 export type ConnectionConfig = {
   websocketUrl: string;
-  ticket: string;
+  ticket: CloudAgentStreamTicketResult;
   onEvent: (event: CloudAgentEvent) => void;
   onConnected: () => void;
   onDisconnected: () => void;
   onUnexpectedDisconnect?: () => void;
   onReconnected?: () => void;
   onError?: (error: StreamError) => void;
-  onRefreshTicket?: () => Promise<string>;
+  onRefreshTicket?: () => Promise<CloudAgentStreamTicketResult>;
   heartbeatTimeoutMs?: number;
   reconnectDelayMs?: number;
 };
@@ -25,6 +26,18 @@ export type { Connection };
 type ParsedMessage =
   | { type: 'event'; event: CloudAgentEvent }
   | { type: 'error'; error: StreamError };
+
+const TICKET_EXPIRY_SKEW_SECONDS = 10;
+
+function normalizeTicket(ticket: CloudAgentStreamTicketResult): CloudAgentStreamTicket {
+  return typeof ticket === 'string' ? { ticket, expiresAt: undefined } : ticket;
+}
+
+function isTicketExpiringSoon(expiresAt?: number): boolean {
+  if (!expiresAt) return false;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  return expiresAt - nowSeconds <= TICKET_EXPIRY_SKEW_SECONDS;
+}
 
 function parseMessage(data: unknown): ParsedMessage | null {
   if (typeof data !== 'string') {
@@ -47,8 +60,12 @@ function parseMessage(data: unknown): ParsedMessage | null {
 const AUTH_FAILURE_CLOSE_CODES = [1008, 4001] as const;
 const AUTH_FAILURE_KEYWORDS = ['unauthorized', '401', 'auth', 'ticket'] as const;
 
+function isAuthFailureCode(code: number): boolean {
+  return AUTH_FAILURE_CLOSE_CODES.some(authFailureCode => authFailureCode === code);
+}
+
 function isAuthFailureClose(event: CloseEvent): boolean {
-  if (AUTH_FAILURE_CLOSE_CODES.includes(event.code as (typeof AUTH_FAILURE_CLOSE_CODES)[number])) {
+  if (isAuthFailureCode(event.code)) {
     return true;
   }
   const reason = event.reason?.toLowerCase() ?? '';
@@ -56,14 +73,14 @@ function isAuthFailureClose(event: CloseEvent): boolean {
 }
 
 export function createConnection(config: ConnectionConfig): Connection {
-  let currentTicket = config.ticket;
+  let currentTicket = normalizeTicket(config.ticket);
   const refreshTicket = config.onRefreshTicket;
 
   return createBaseConnection({
     stalenessTimeoutMs: config.heartbeatTimeoutMs,
     buildUrl: () => {
       const url = new URL(config.websocketUrl);
-      url.searchParams.set('ticket', currentTicket);
+      url.searchParams.set('ticket', currentTicket.ticket);
       return url.toString();
     },
     parseMessage: (data: unknown) => {
@@ -88,8 +105,9 @@ export function createConnection(config: ConnectionConfig): Connection {
     isAuthFailure: isAuthFailureClose,
     refreshAuth: refreshTicket
       ? async () => {
-          currentTicket = await refreshTicket();
+          currentTicket = normalizeTicket(await refreshTicket());
         }
       : undefined,
+    shouldRefreshAuthBeforeConnect: () => isTicketExpiringSoon(currentTicket.expiresAt),
   });
 }

--- a/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.test.ts
@@ -262,6 +262,32 @@ describe('CloudAgentTransport ticket handling', () => {
 
     transport.destroy();
   });
+
+  it('refreshes an expiring ticket before opening the websocket', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const getTicket = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ticket: 'expiring-ticket',
+        expiresAt: nowSeconds + 5,
+      })
+      .mockResolvedValueOnce({
+        ticket: 'fresh-ticket',
+        expiresAt: nowSeconds + 60,
+      });
+    const { transport } = createTransportWithSinks(getTicket);
+
+    transport.connect();
+    await flushPromises();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getTicket).toHaveBeenCalledTimes(2);
+    expect(webSocketConstructor).toHaveBeenCalledTimes(1);
+    expect(webSocketConstructor.mock.calls[0]?.[0]).toContain('ticket=fresh-ticket');
+
+    transport.destroy();
+  });
 });
 
 describe('CloudAgentTransport lifecycle', () => {

--- a/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.ts
@@ -11,13 +11,20 @@ import { createConnection, type Connection } from './cloud-agent-connection';
 import { normalize, isChatEvent } from './normalizer';
 import type { ServiceEvent } from './normalizer';
 import type { CloudAgentSessionId, KiloSessionId, SessionSnapshot } from './types';
-import type { CloudAgentApi, TransportFactory, TransportSink } from './transport';
+import type {
+  CloudAgentApi,
+  CloudAgentStreamTicketResult,
+  TransportFactory,
+  TransportSink,
+} from './transport';
 
 type CloudAgentTransportConfig = {
   sessionId: CloudAgentSessionId;
   kiloSessionId: KiloSessionId;
   api: CloudAgentApi;
-  getTicket: (sessionId: CloudAgentSessionId) => string | Promise<string>;
+  getTicket: (
+    sessionId: CloudAgentSessionId
+  ) => CloudAgentStreamTicketResult | Promise<CloudAgentStreamTicketResult>;
   fetchSnapshot: (kiloSessionId: KiloSessionId) => Promise<SessionSnapshot>;
   websocketBaseUrl?: string;
   onError?: (message: string) => void;
@@ -62,7 +69,10 @@ function createCloudAgentTransport(config: CloudAgentTransportConfig): Transport
       }
     }
 
-    function connectWebSocket(ticket: string, expectedGeneration: number): void {
+    function connectWebSocket(
+      ticket: CloudAgentStreamTicketResult,
+      expectedGeneration: number
+    ): void {
       if (expectedGeneration !== lifecycleGeneration) return;
 
       const stoppedEvent: ServiceEvent = { type: 'stopped', reason: 'disconnected' };

--- a/apps/web/src/lib/cloud-agent-sdk/index.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/index.ts
@@ -47,7 +47,14 @@ export type { CliHistoricalTransportConfig } from './cli-historical-transport';
 export { createCliLiveTransport } from './cli-live-transport';
 export type { CliLiveTransportConfig } from './cli-live-transport';
 
-export type { TransportSink, Transport, TransportFactory, CloudAgentApi } from './transport';
+export type {
+  CloudAgentApi,
+  CloudAgentStreamTicket,
+  CloudAgentStreamTicketResult,
+  TransportFactory,
+  TransportSink,
+  Transport,
+} from './transport';
 
 export { createConnection } from './cloud-agent-connection';
 export type { Connection, ConnectionConfig } from './cloud-agent-connection';

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -10,7 +10,7 @@ import { createCloudAgentSession } from './session';
 import type { JotaiSessionStorage } from './storage/jotai';
 import type { AssistantMessage, UserMessage } from '@/types/opencode.gen';
 import { kiloId, cloudAgentId, stubUserMessage } from './test-helpers';
-import type { ResolvedSession } from './types';
+import type { CloudStatus, ResolvedSession } from './types';
 
 // ---------------------------------------------------------------------------
 // Mock createCloudAgentSession — prevents real WebSocket connections
@@ -34,7 +34,7 @@ const mockSession = {
     }),
     getActivity: jest.fn(() => ({ type: 'idle' as const })),
     getStatus: jest.fn<{ type: 'idle' | 'disconnected' }, []>(() => ({ type: 'idle' })),
-    getCloudStatus: jest.fn(() => null),
+    getCloudStatus: jest.fn<CloudStatus | null, []>(() => null),
     getQuestion: jest.fn(() => null),
     getSessionInfo: jest.fn(() => null),
     getPermission: jest.fn(() => null),
@@ -204,6 +204,7 @@ describe('createSessionManager', () => {
       return () => {};
     });
     mockSession.state.getStatus.mockReturnValue({ type: 'idle' });
+    mockSession.state.getCloudStatus.mockReturnValue(null);
     mockSession.storage = latestStorage;
     latestStorage = null;
     mockSessionCallbacks.onQuestionAsked = undefined;
@@ -382,6 +383,43 @@ describe('createSessionManager', () => {
         variant?: string | null;
       }>(config.store, mgr.atoms.sessionConfig);
       expect(sessionConfig?.variant).toBe(null);
+    });
+
+    it('clears cloud status indicator when cloud status returns to ready', async () => {
+      let subscriptionCallback = (): void => {
+        throw new Error('Expected service state subscription callback');
+      };
+      let cloudStatus: CloudStatus | null = {
+        type: 'preparing',
+        message: 'Setting up environment...',
+      };
+      mockSession.state.getCloudStatus.mockImplementation(() => cloudStatus);
+      mockSession.state.subscribe.mockImplementation(callback => {
+        subscriptionCallback = callback;
+        callback();
+        return () => {};
+      });
+
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-1'));
+
+      expect(
+        atomValue<{ type: string; message: string } | null>(config.store, mgr.atoms.statusIndicator)
+      ).toEqual(
+        expect.objectContaining({
+          type: 'progress',
+          message: 'Setting up environment...',
+        })
+      );
+
+      cloudStatus = { type: 'ready' };
+      subscriptionCallback();
+
+      expect(
+        atomValue<{ type: string; message: string } | null>(config.store, mgr.atoms.statusIndicator)
+      ).toBeNull();
     });
   });
 

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -33,7 +33,7 @@ const mockSession = {
       return () => {};
     }),
     getActivity: jest.fn(() => ({ type: 'idle' as const })),
-    getStatus: jest.fn(() => ({ type: 'idle' as const })),
+    getStatus: jest.fn<{ type: 'idle' | 'disconnected' }, []>(() => ({ type: 'idle' })),
     getCloudStatus: jest.fn(() => null),
     getQuestion: jest.fn(() => null),
     getSessionInfo: jest.fn(() => null),
@@ -203,6 +203,7 @@ describe('createSessionManager', () => {
       callback();
       return () => {};
     });
+    mockSession.state.getStatus.mockReturnValue({ type: 'idle' });
     mockSession.storage = latestStorage;
     latestStorage = null;
     mockSessionCallbacks.onQuestionAsked = undefined;
@@ -611,6 +612,47 @@ describe('createSessionManager', () => {
       await mgr.send({ prompt: 'My prompt', mode: 'code', model: 'claude-3-5-sonnet' });
 
       expect(onSendFailed).toHaveBeenCalledWith('My prompt');
+    });
+
+    it('preserves disconnected status indicator when send fails after transport disconnect', async () => {
+      const onSendFailed = jest.fn();
+      const config = createMockConfig({ onSendFailed });
+      const mgr = createSessionManager(config);
+
+      mockSession.state.getStatus.mockReturnValue({ type: 'disconnected' });
+      await mgr.switchSession(kiloId('ses-1'));
+
+      expect(atomValue<StoredMessage[]>(config.store, mgr.atoms.messagesList)).toHaveLength(0);
+      const disconnectedIndicator = atomValue<{ type: string; message: string } | null>(
+        config.store,
+        mgr.atoms.statusIndicator
+      );
+      expect(disconnectedIndicator).toEqual(
+        expect.objectContaining({
+          type: 'error',
+          message: 'Agent connection lost',
+        })
+      );
+
+      mockSession.send.mockRejectedValue(new Error('Transport disconnected'));
+      const accepted = await mgr.send({
+        prompt: 'My prompt',
+        mode: 'code',
+        model: 'claude-3-5-sonnet',
+      });
+
+      expect(accepted).toBe(false);
+      expect(onSendFailed).toHaveBeenCalledWith('My prompt');
+      expect(atomValue<string | null>(config.store, mgr.atoms.failedPrompt)).toBe('My prompt');
+      expect(atomValue<StoredMessage[]>(config.store, mgr.atoms.messagesList)).toHaveLength(0);
+      expect(
+        atomValue<{ type: string; message: string } | null>(config.store, mgr.atoms.statusIndicator)
+      ).toEqual(
+        expect.objectContaining({
+          type: 'error',
+          message: 'Agent connection lost',
+        })
+      );
     });
 
     it('passes variant through to session.send', async () => {

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
@@ -6,7 +6,7 @@ import { createCloudAgentSession } from './session';
 import type { CloudAgentSession } from './session';
 import { createJotaiStorage } from './storage/jotai';
 import type { JotaiSessionStorage, JotaiStore } from './storage/jotai';
-import type { CloudAgentApi } from './transport';
+import type { CloudAgentApi, CloudAgentStreamTicketResult } from './transport';
 import type {
   CloudAgentSessionId,
   KiloSessionId,
@@ -88,7 +88,9 @@ type PrepareInput = {
 type SessionManagerConfig = {
   store: JotaiStore;
   resolveSession: (kiloSessionId: KiloSessionId) => Promise<ResolvedSession>;
-  getTicket: (sessionId: CloudAgentSessionId) => string | Promise<string>;
+  getTicket: (
+    sessionId: CloudAgentSessionId
+  ) => CloudAgentStreamTicketResult | Promise<CloudAgentStreamTicketResult>;
   fetchSnapshot: (kiloSessionId: KiloSessionId) => Promise<SessionSnapshot>;
   getAuthToken: () => string | Promise<string>;
   cliWebsocketUrl?: string;
@@ -594,7 +596,9 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     images?: Images;
   }): Promise<boolean> {
     store.set(errorAtom, null);
-    setIndicator(null);
+    if (store.get(agentStatusAtom).type !== 'disconnected') {
+      setIndicator(null);
+    }
 
     const storage = store.get(sessionStorageAtom);
     const kiloSessionId = activeSessionId;
@@ -642,7 +646,9 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       }
       store.set(failedPromptAtom, payload.prompt);
       config.onSendFailed?.(payload.prompt);
-      setIndicator({ type: 'error', message: formatError(err), timestamp: Date.now() });
+      if (store.get(agentStatusAtom).type !== 'disconnected') {
+        setIndicator({ type: 'error', message: formatError(err), timestamp: Date.now() });
+      }
       return false;
     }
   }

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
@@ -364,6 +364,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     let prevAct = '';
     let prevSk = '';
     let prevCsk = '';
+    let prevCloudStatusHadIndicator = false;
     const sKey = (s: AgentStatus) => (s.type === 'autocommit' ? `${s.type}:${s.step}` : s.type);
     const csKey = (cs: CloudStatus | null) =>
       cs === null
@@ -414,16 +415,21 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       if (cs && cs.type !== 'ready') {
         if (csk !== prevCsk) {
           const cloudInd = indicatorForCloudStatus(cs);
-          if (cloudInd) setIndicator(cloudInd);
+          if (cloudInd) {
+            setIndicator(cloudInd);
+            prevCloudStatusHadIndicator = true;
+          }
           prevCsk = csk;
         }
       } else {
+        const shouldClearCloudIndicator = prevCloudStatusHadIndicator;
         if (csk !== prevCsk) prevCsk = csk;
+        prevCloudStatusHadIndicator = false;
         // Fall through to existing agent status indicator logic
         const sk = sKey(st);
-        if (sk !== prevSk) {
+        if (sk !== prevSk || shouldClearCloudIndicator) {
           const ind = indicatorForStatus(st);
-          if (ind !== null) setIndicator(ind);
+          if (ind !== null || shouldClearCloudIndicator) setIndicator(ind);
           prevSk = sk;
         }
       }

--- a/apps/web/src/lib/cloud-agent-sdk/session.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session.ts
@@ -14,7 +14,13 @@ import type { ServiceState } from './service-state';
 import { createCloudAgentTransport } from './cloud-agent-transport';
 import { createCliLiveTransport } from './cli-live-transport';
 import { createCliHistoricalTransport } from './cli-historical-transport';
-import type { CloudAgentApi, TransportFactory, TransportSink, Transport } from './transport';
+import type {
+  CloudAgentApi,
+  CloudAgentStreamTicketResult,
+  TransportFactory,
+  TransportSink,
+  Transport,
+} from './transport';
 import { createMemoryStorage } from './storage/memory';
 import type { SessionStorage } from './storage/types';
 import type {
@@ -76,7 +82,9 @@ type CloudAgentSessionRespondToPermissionInput = {
 
 type CloudAgentSessionTransport = {
   // Cloud Agent transport construction
-  getTicket?: (sessionId: CloudAgentSessionId) => string | Promise<string>;
+  getTicket?: (
+    sessionId: CloudAgentSessionId
+  ) => CloudAgentStreamTicketResult | Promise<CloudAgentStreamTicketResult>;
   api?: CloudAgentApi;
 
   // Shared

--- a/apps/web/src/lib/cloud-agent-sdk/transport.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/transport.ts
@@ -8,6 +8,14 @@ import type { ChatEvent, ServiceEvent } from './normalizer';
 import type { Images } from '@/lib/images-schema';
 import type { CloudAgentSessionId } from './types';
 
+type CloudAgentStreamTicket = {
+  ticket: string;
+  /** Unix timestamp in seconds when the ticket expires. */
+  expiresAt?: number;
+};
+
+type CloudAgentStreamTicketResult = string | CloudAgentStreamTicket;
+
 /** Sink callbacks that a transport pushes typed events into. */
 type TransportSink = {
   onChatEvent: (event: ChatEvent) => void;
@@ -70,4 +78,11 @@ type CloudAgentApi = {
   }) => Promise<unknown>;
 };
 
-export type { TransportSink, Transport, TransportFactory, CloudAgentApi };
+export type {
+  CloudAgentApi,
+  CloudAgentStreamTicket,
+  CloudAgentStreamTicketResult,
+  TransportFactory,
+  TransportSink,
+  Transport,
+};

--- a/services/cloud-agent-next/src/auth.test.ts
+++ b/services/cloud-agent-next/src/auth.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import jwt from 'jsonwebtoken';
+import { validateStreamTicket } from './auth.js';
+
+const secret = 'test-secret';
+
+describe('validateStreamTicket', () => {
+  it('returns Ticket expired for expired stream tickets', () => {
+    const ticket = jwt.sign(
+      {
+        type: 'stream_ticket',
+        userId: 'user-1',
+        cloudAgentSessionId: 'session-1',
+      },
+      secret,
+      { algorithm: 'HS256', expiresIn: -1 }
+    );
+
+    expect(validateStreamTicket(ticket, secret)).toEqual({
+      success: false,
+      error: 'Ticket expired',
+    });
+  });
+
+  it('returns the payload for valid stream tickets', () => {
+    const ticket = jwt.sign(
+      {
+        type: 'stream_ticket',
+        userId: 'user-1',
+        cloudAgentSessionId: 'session-1',
+      },
+      secret,
+      { algorithm: 'HS256', expiresIn: '1 minute' }
+    );
+
+    expect(validateStreamTicket(ticket, secret)).toMatchObject({
+      success: true,
+      payload: {
+        type: 'stream_ticket',
+        userId: 'user-1',
+        cloudAgentSessionId: 'session-1',
+      },
+    });
+  });
+});

--- a/services/cloud-agent-next/src/server.test.ts
+++ b/services/cloud-agent-next/src/server.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import jwt from 'jsonwebtoken';
+
+vi.mock('./logger.js', () => {
+  const logger = {
+    setTags: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withFields: vi.fn(),
+  };
+  logger.withFields.mockReturnValue(logger);
+
+  return {
+    logger,
+    withLogTags: async (_tags: unknown, fn: () => Promise<void>) => fn(),
+  };
+});
+
+vi.mock('@cloudflare/sandbox', () => ({
+  Sandbox: class Sandbox {},
+}));
+
+vi.mock('./router.js', () => ({
+  appRouter: {},
+}));
+
+vi.mock('./callbacks/index.js', () => ({
+  createCallbackQueueConsumer: vi.fn(),
+}));
+
+vi.mock('./middleware/auth.js', () => ({
+  authMiddleware: vi.fn(),
+}));
+
+vi.mock('./middleware/balance.js', () => ({
+  balanceMiddleware: vi.fn(),
+}));
+
+vi.mock('./persistence/CloudAgentSession.js', () => ({
+  CloudAgentSession: class CloudAgentSession {},
+}));
+
+const { default: worker } = await import('./server.js');
+
+const secret = 'test-secret';
+
+type MockEnv = {
+  NEXTAUTH_SECRET: string;
+  CLOUD_AGENT_SESSION: {
+    idFromName: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+  };
+};
+
+function createEnv(): MockEnv {
+  return {
+    NEXTAUTH_SECRET: secret,
+    CLOUD_AGENT_SESSION: {
+      idFromName: vi.fn(),
+      get: vi.fn(),
+    },
+  };
+}
+
+describe('server /stream', () => {
+  it('returns Ticket expired before Durable Object lookup for expired tickets', async () => {
+    const ticket = jwt.sign(
+      {
+        type: 'stream_ticket',
+        userId: 'user-1',
+        cloudAgentSessionId: 'session-1',
+      },
+      secret,
+      { algorithm: 'HS256', expiresIn: -1 }
+    );
+    const env = createEnv();
+    const request = new Request(
+      `http://worker.test/stream?cloudAgentSessionId=session-1&ticket=${encodeURIComponent(ticket)}`,
+      {
+        headers: { Upgrade: 'websocket' },
+      }
+    );
+
+    const response = await worker.fetch(request, env);
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toBe('Ticket expired');
+    expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
+    expect(env.CLOUD_AGENT_SESSION.get).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Refresh cloud agent stream tickets before opening SDK WebSockets when the ticket is close to expiry, so reconnects do not immediately fail with expired auth.

