### PR TITLE
fix(kiloclaw): self-heal App DO flyAppName for pre-org-scoped instances

### DIFF
--- a/services/kiloclaw/src/durable-objects/kiloclaw-app.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-app.test.ts
@@ -441,6 +441,57 @@ describe('ensureEnvKey', () => {
 
     await expect(appDO.ensureEnvKey('user-2')).rejects.toThrow('ownerKey mismatch');
   });
+
+  it('adopts flyAppName from caller when App DO has none', async () => {
+    const storage = createFakeStorage();
+    const { appDO } = createAppDO(storage);
+
+    // First call without flyAppName — no Fly secret sync
+    const result1 = await appDO.ensureEnvKey('user-1');
+    expect(result1.secretsVersion).toBe(0);
+    expect(secretsClient.setAppSecret).not.toHaveBeenCalled();
+    expect(storage._store.get('flyAppName')).toBeUndefined();
+
+    vi.clearAllMocks();
+
+    // Second call passes flyAppName — App DO adopts it and syncs the Fly secret
+    const result2 = await appDO.ensureEnvKey('user-1', 'acct-adopted');
+    expect(result2.key).toBe(result1.key);
+    expect(result2.secretsVersion).toBe(1);
+    expect(storage._store.get('flyAppName')).toBe('acct-adopted');
+    expect(secretsClient.setAppSecret).toHaveBeenCalledWith(
+      { apiToken: 'test-token', appName: 'acct-adopted' },
+      'KILOCLAW_ENV_KEY',
+      result2.key
+    );
+  });
+
+  it('does not overwrite existing flyAppName with caller value', async () => {
+    const { appDO, storage } = createAppDO();
+    await appDO.ensureApp('user-1');
+    const existingAppName = storage._store.get('flyAppName');
+    vi.clearAllMocks();
+
+    const result = await appDO.ensureEnvKey('user-1', 'acct-different');
+
+    // flyAppName unchanged — the App DO already had one
+    expect(storage._store.get('flyAppName')).toBe(existingAppName);
+    expect(secretsClient.setAppSecret).toHaveBeenCalledWith(
+      expect.objectContaining({ appName: existingAppName }),
+      'KILOCLAW_ENV_KEY',
+      result.key
+    );
+  });
+
+  it('ignores undefined flyAppName param', async () => {
+    const storage = createFakeStorage();
+    const { appDO } = createAppDO(storage);
+
+    await appDO.ensureEnvKey('user-1', undefined);
+
+    expect(storage._store.get('flyAppName')).toBeUndefined();
+    expect(secretsClient.setAppSecret).not.toHaveBeenCalled();
+  });
 });
 
 describe('getEnvKey', () => {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-app.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-app.ts
@@ -204,8 +204,17 @@ export class KiloClawApp extends DurableObject<KiloClawEnv> {
    * Called by Instance DO at machine start time. This ensures every provider can
    * bootstrap encrypted env vars, while legacy Fly apps still get their Fly secret
    * synced on first start.
+   *
+   * @param ownerKey - The App DO owner key (userId or instanceId).
+   * @param flyAppName - Optional Fly app name from the Instance DO. If the App DO
+   *   doesn't have a flyAppName yet (e.g., instance provisioned before per-instance
+   *   Fly apps existed), it adopts this value so it can sync the env key to the
+   *   correct Fly app secret store.
    */
-  async ensureEnvKey(ownerKey: string): Promise<{ key: string; secretsVersion: number }> {
+  async ensureEnvKey(
+    ownerKey: string,
+    flyAppName?: string
+  ): Promise<{ key: string; secretsVersion: number }> {
     await this.loadState();
 
     if (this.userId && this.userId !== ownerKey) {
@@ -215,6 +224,16 @@ export class KiloClawApp extends DurableObject<KiloClawEnv> {
     if (!this.userId) {
       this.userId = ownerKey;
       await this.ctx.storage.put({ userId: ownerKey } satisfies Partial<AppState>);
+    }
+
+    // Adopt flyAppName from the Instance DO if we don't have one yet.
+    // This self-heals instances provisioned before per-instance Fly apps existed,
+    // where the App DO was created by ensureEnvKey (not ensureApp) and never
+    // learned the Fly app name.
+    if (!this.flyAppName && flyAppName) {
+      this.flyAppName = flyAppName;
+      await this.ctx.storage.put({ flyAppName } satisfies Partial<AppState>);
+      console.log('[AppDO] Adopted flyAppName from Instance DO:', flyAppName);
     }
 
     // Persist key before any async I/O so interleaved calls reuse the same key.

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
@@ -187,9 +187,15 @@ export async function buildUserEnvVars(
 
   // Get the env encryption key from the App DO, creating it if needed.
   // Instance-keyed DOs get per-instance apps, legacy DOs get per-user apps.
+  // Pass the Instance DO's known flyAppName so the App DO can adopt it if needed
+  // (self-heals instances provisioned before per-instance Fly apps existed).
   const appKey = getAppKey({ userId: state.userId, sandboxId: state.sandboxId });
   const appStub = env.KILOCLAW_APP.get(env.KILOCLAW_APP.idFromName(appKey));
-  const { key: envKey, secretsVersion } = await appStub.ensureEnvKey(appKey);
+  const knownFlyAppName =
+    (state.providerState?.provider === 'fly' ? state.providerState.appName : null) ??
+    state.flyAppName ??
+    undefined;
+  const { key: envKey, secretsVersion } = await appStub.ensureEnvKey(appKey, knownFlyAppName);
 
   // Encrypt sensitive values and prefix their names with KILOCLAW_ENC_
   const result: Record<string, string> = { ...plainEnv };

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
@@ -211,7 +211,10 @@ async function reconcileApiKeyExpiry(
 
     const appKey = getAppKey({ userId, sandboxId: state.sandboxId });
     const appStub = env.KILOCLAW_APP.get(env.KILOCLAW_APP.idFromName(appKey));
-    const knownFlyAppName = flyConfig.appName;
+    const knownFlyAppName =
+      (state.providerState?.provider === 'fly' ? state.providerState.appName : null) ??
+      state.flyAppName ??
+      undefined;
     const { key: envKey, secretsVersion } = await appStub.ensureEnvKey(appKey, knownFlyAppName);
     updatedEnv[`${ENCRYPTED_ENV_PREFIX}KILOCODE_API_KEY`] = encryptEnvValue(envKey, freshKey.token);
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
@@ -211,7 +211,8 @@ async function reconcileApiKeyExpiry(
 
     const appKey = getAppKey({ userId, sandboxId: state.sandboxId });
     const appStub = env.KILOCLAW_APP.get(env.KILOCLAW_APP.idFromName(appKey));
-    const { key: envKey, secretsVersion } = await appStub.ensureEnvKey(appKey);
+    const knownFlyAppName = flyConfig.appName;
+    const { key: envKey, secretsVersion } = await appStub.ensureEnvKey(appKey, knownFlyAppName);
     updatedEnv[`${ENCRYPTED_ENV_PREFIX}KILOCODE_API_KEY`] = encryptEnvValue(envKey, freshKey.token);
 
     await fly.updateMachine(


### PR DESCRIPTION
## Summary

Fixes a bug where instances provisioned on 3/31/2026 (between the instance-keyed identity PR and the per-instance Fly apps PR) fail to decrypt `KILOCLAW_ENC_*` env vars on newly provisioned hosts (e.g. we do a volume move or underlying fly host failure).

**Root cause:** After the org-scoped PR deployed, `getAppKey()` started returning `instanceId` for `ki_`-prefixed sandboxIds, routing `ensureEnvKey()` to a new App DO that was never initialized via `ensureApp()`. The App DO we're troubleshooting had `flyAppName: null`, so `ensureEnvKey()` generated an encryption key but never called `setAppSecret()` to push it to the Fly app. The encrypted env vars used the new key, but the Fly secret store still had the old key from the original userId-keyed App DO — causing AES-256-GCM decryption failures at boot.

**Fix:** `ensureEnvKey()` now accepts an optional `flyAppName` parameter. Both `buildUserEnvVars()` and `reconcileApiKeyExpiry()` pass the Instance DO's known Fly app name through. If the App DO has `flyAppName: null`, it adopts the passed value and persists it, allowing `setAppSecret()` to sync the key. This self-heals on the next stop+start cycle with no manual intervention needed.

## Verification

- [x] `pnpm --filter kiloclaw typecheck` — passes
- [x] `pnpm --filter kiloclaw test` — all 1322 tests pass
- [x] `pnpm format` — clean
- [x] Confirmed root cause via new admin "Env Key Diagnostics" card (#2481): affected instance showed `App DO Fly App Name: null (no Fly secret sync!)` 

## Visual Changes

N/A

## Reviewer Notes

- The `!this.flyAppName && flyAppName` guard ensures adoption is a one-time operation — an App DO that already has a `flyAppName` (from `ensureApp()`) will never overwrite it with the caller's value.
- Only `ki_`-prefixed instances provisioned before `f0b191ef3` (4/1/2026) are affected. Legacy instances are unaffected because `getAppKey()` returns `userId`, matching the original App DO.
