### PR TITLE
feat(claw): add copy button to destroy instance confirmation dialog

### DIFF
--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -639,10 +639,10 @@ function DestroyInstanceDialog({
           </div>
 
           <div className="space-y-2">
-            <div className="flex items-center gap-1.5 text-sm font-medium">
+            <div className="flex flex-wrap items-center gap-1.5 text-sm font-medium">
               <Label htmlFor="destroy-instance-confirmation">Type</Label>
-              <span className="bg-muted inline-flex items-center gap-1.5 rounded border border-border/50 py-0.5 pr-1 pl-2 select-text">
-                <code>{primaryConfirmation}</code>
+              <span className="bg-muted inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border/50 py-0.5 pr-1 pl-2 select-text">
+                <code className="break-all">{primaryConfirmation}</code>
                 <button
                   type="button"
                   className="text-muted-foreground hover:text-foreground inline-flex cursor-pointer items-center rounded p-0.5 transition-colors"

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -565,6 +565,7 @@ function DestroyInstanceDialog({
   onConfirm: () => void;
 }) {
   const [confirmation, setConfirmation] = useState('');
+  const [copied, setCopied] = useState(false);
   const { displayName, sandboxId, instanceKind, confirmationOptions, primaryConfirmation } =
     useMemo(
       () => getDestroyConfirmationContext({ status, organizationName }),
@@ -573,11 +574,22 @@ function DestroyInstanceDialog({
   const confirmationMatches =
     confirmationOptions.length > 0 && confirmationOptions.includes(confirmation.trim());
 
+  function handleCopyConfirmation() {
+    if (!primaryConfirmation) return;
+    void navigator.clipboard.writeText(primaryConfirmation);
+    setCopied(true);
+  }
+
   useEffect(() => {
     if (!open) {
       setConfirmation('');
+      setCopied(false);
+      return;
     }
-  }, [open]);
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [open, copied]);
 
   return (
     <Dialog open={open} onOpenChange={isPending ? () => {} : onOpenChange}>
@@ -627,13 +639,25 @@ function DestroyInstanceDialog({
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="destroy-instance-confirmation">
-              Type{' '}
-              <code className="bg-muted rounded px-1 py-0.5 select-text">
-                {primaryConfirmation}
-              </code>{' '}
-              to confirm
-            </Label>
+            <div className="flex items-center gap-1.5 text-sm font-medium">
+              <Label htmlFor="destroy-instance-confirmation">Type</Label>
+              <span className="bg-muted inline-flex items-center gap-1.5 rounded border border-border/50 py-0.5 pr-1 pl-2 select-text">
+                <code>{primaryConfirmation}</code>
+                <button
+                  type="button"
+                  className="text-muted-foreground hover:text-foreground inline-flex cursor-pointer items-center rounded p-0.5 transition-colors"
+                  onClick={handleCopyConfirmation}
+                  aria-label="Copy confirmation string"
+                >
+                  {copied ? (
+                    <Check className="h-3.5 w-3.5 text-green-500" />
+                  ) : (
+                    <Copy className="h-3.5 w-3.5" />
+                  )}
+                </button>
+              </span>
+              <Label htmlFor="destroy-instance-confirmation">to confirm</Label>
+            </div>
             <Input
               id="destroy-instance-confirmation"
               value={confirmation}


### PR DESCRIPTION
## Summary

Adds an inline copy button next to the confirmation string in the destroy instance dialog, so users can quickly copy the string to their clipboard instead of manually selecting and copying it.

- Confirmation string and copy icon are wrapped in a single bordered pill element (`bg-muted` + subtle `border-border/50`) for visual cohesion
- The confirmation string sits outside the `<Label>` element so double-click text selection works without the input stealing focus
- Copy state timeout is managed via `useEffect` with proper cleanup to avoid stale `setCopied` calls after dialog close

## Verification

- [x] `pnpm typecheck` passes
- [x] `pnpm format` passes
- [x] Manually verified copy button works in both org and personal instance destroy dialogs
- [x] Manually verified double-click text selection works on the confirmation string
- [x] Manually verified clicking "Type" / "to confirm" labels still focuses the input

## Visual Changes

**Before:** Confirmation string displayed as plain inline text within the label with no copy affordance.

**After:** Confirmation string displayed in a bordered pill with an inline copy icon button. Double-click to select text works correctly.

<img width="2694" height="1211" alt="Screenshot-2026-04-15-at-17 01 33@2x" src="https://github.com/user-attachments/assets/2712981f-e424-43a5-818b-ac3f45bdca5f" />



> Visual evidence to be attached in PR comments.

## Reviewer Notes

- Follows the same clipboard pattern used by `GoogleAccountCard` and `InboundEmailCard` in the same file
- The `<Label>` was split into two separate `<Label htmlFor>` elements ("Type" and "to confirm") flanking the confirmation pill — this preserves label→input focus behavior on those words while keeping the pill itself free from label click interference