### PR TITLE
fix(admin): make admin CLI runs manageable and attributable

### DIFF
--- a/apps/web/src/app/admin/components/KiloclawCliRuns/KiloclawCliRunsTab.tsx
+++ b/apps/web/src/app/admin/components/KiloclawCliRuns/KiloclawCliRunsTab.tsx
@@ -256,7 +256,10 @@ function RunDetail({
 }) {
   const trpc = useTRPC();
   const { data, isLoading } = useQuery(
-    trpc.admin.kiloclawInstances.getCliRunOutput.queryOptions({ runId: run.id })
+    trpc.admin.kiloclawInstances.getCliRunOutput.queryOptions({
+      userId: run.user_id,
+      runId: run.id,
+    })
   );
   const output = data?.output ?? null;
 

--- a/apps/web/src/lib/kiloclaw/cli-runs.test.ts
+++ b/apps/web/src/lib/kiloclaw/cli-runs.test.ts
@@ -55,7 +55,12 @@ async function getRunStatus(runId: string) {
 async function getRunRow(runId: string) {
   const [row] = await db
     .select({
+      user_id: kiloclaw_cli_runs.user_id,
+      instance_id: kiloclaw_cli_runs.instance_id,
+      initiated_by_admin_id: kiloclaw_cli_runs.initiated_by_admin_id,
+      prompt: kiloclaw_cli_runs.prompt,
       status: kiloclaw_cli_runs.status,
+      started_at: kiloclaw_cli_runs.started_at,
       completed_at: kiloclaw_cli_runs.completed_at,
       output: kiloclaw_cli_runs.output,
       exit_code: kiloclaw_cli_runs.exit_code,
@@ -70,9 +75,65 @@ async function getRunRow(runId: string) {
 
   return {
     ...row,
+    started_at: row.started_at ? new Date(row.started_at).toISOString() : null,
     completed_at: row.completed_at ? new Date(row.completed_at).toISOString() : null,
   };
 }
+
+describe('createCliRun', () => {
+  it('creates a user-started running CLI run and returns its id', async () => {
+    const user = await insertTestUser();
+    const instanceId = await createTestInstance(user.id);
+    const startedAt = '2026-04-12T12:00:00.000Z';
+
+    const runId = await createCliRun({
+      userId: user.id,
+      instanceId,
+      prompt: 'user-started run',
+      startedAt,
+      initiatedByAdminId: null,
+    });
+
+    await expect(getRunRow(runId)).resolves.toMatchObject({
+      user_id: user.id,
+      instance_id: instanceId,
+      initiated_by_admin_id: null,
+      prompt: 'user-started run',
+      status: 'running',
+      started_at: startedAt,
+      completed_at: null,
+      output: null,
+      exit_code: null,
+    });
+  });
+
+  it('stores the initiating admin for admin-started CLI runs', async () => {
+    const user = await insertTestUser();
+    const admin = await insertTestUser({ is_admin: true });
+    const instanceId = await createTestInstance(user.id);
+    const startedAt = '2026-04-12T12:00:00.000Z';
+
+    const runId = await createCliRun({
+      userId: user.id,
+      instanceId,
+      prompt: 'admin-started run',
+      startedAt,
+      initiatedByAdminId: admin.id,
+    });
+
+    await expect(getRunRow(runId)).resolves.toMatchObject({
+      user_id: user.id,
+      instance_id: instanceId,
+      initiated_by_admin_id: admin.id,
+      prompt: 'admin-started run',
+      status: 'running',
+      started_at: startedAt,
+      completed_at: null,
+      output: null,
+      exit_code: null,
+    });
+  });
+});
 
 describe('cancelCliRun', () => {
   it('persists terminal controller status without calling cancel when the run already finished', async () => {

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -3,24 +3,41 @@ import { insertTestUser } from '@/tests/helpers/user.helper';
 import type { User } from '@kilocode/db/schema';
 import { db } from '@/lib/drizzle';
 import {
+  kilocode_users,
   kiloclaw_admin_audit_logs,
+  kiloclaw_cli_runs,
   kiloclaw_inbound_email_aliases,
   kiloclaw_inbound_email_reserved_aliases,
   kiloclaw_instances,
 } from '@kilocode/db/schema';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { TRPCError } from '@trpc/server';
 import { UpstreamApiError } from '@/lib/trpc/init';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const mockGetDebugStatus: jest.Mock<any, any> = jest.fn();
 const mockDestroyFlyMachine: jest.Mock<any, any> = jest.fn();
+const mockGetKiloCliRunStatus: jest.Mock<any, any> = jest.fn();
+const mockCancelKiloCliRun: jest.Mock<any, any> = jest.fn();
 const mockStartKiloCliRun: jest.Mock<any, any> = jest.fn();
+
+function mockKiloClawInternalClient() {
+  const { KiloClawInternalClient } = jest.requireMock('@/lib/kiloclaw/kiloclaw-internal-client');
+  KiloClawInternalClient.mockImplementation(() => ({
+    getDebugStatus: mockGetDebugStatus,
+    destroyFlyMachine: mockDestroyFlyMachine,
+    getKiloCliRunStatus: mockGetKiloCliRunStatus,
+    cancelKiloCliRun: mockCancelKiloCliRun,
+    startKiloCliRun: mockStartKiloCliRun,
+  }));
+}
 
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => ({
   KiloClawInternalClient: jest.fn().mockImplementation(() => ({
     getDebugStatus: mockGetDebugStatus,
     destroyFlyMachine: mockDestroyFlyMachine,
+    getKiloCliRunStatus: mockGetKiloCliRunStatus,
+    cancelKiloCliRun: mockCancelKiloCliRun,
     startKiloCliRun: mockStartKiloCliRun,
   })),
   KiloClawApiError: class KiloClawApiError extends Error {
@@ -37,6 +54,9 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => ({
 
 let regularUser: User;
 let adminUser: User;
+let cliRunUser: User;
+let cliRunInstanceId: string;
+let cliRunId: string;
 
 const testAppName = 'acct-abc123def456';
 const testMachineId = 'd8901e123456';
@@ -68,36 +88,64 @@ async function insertInboundEmailInstance() {
   return { instanceId, alias };
 }
 
-beforeAll(async () => {
+beforeEach(async () => {
   regularUser = await insertTestUser({
-    google_user_email: 'regular-destroy-machine@example.com',
+    google_user_email: `regular-destroy-machine-${Math.random()}@example.com`,
     is_admin: false,
   });
   adminUser = await insertTestUser({
-    google_user_email: 'admin-destroy-machine@admin.example.com',
+    google_user_email: `admin-destroy-machine-${Math.random()}@admin.example.com`,
     is_admin: true,
   });
-});
 
-beforeEach(async () => {
+  cliRunUser = await insertTestUser({
+    google_user_email: `admin-cli-run-target-${Math.random()}@example.com`,
+    is_admin: false,
+  });
+
+  const [instance] = await db
+    .insert(kiloclaw_instances)
+    .values({
+      id: crypto.randomUUID(),
+      user_id: cliRunUser.id,
+      sandbox_id: `ki_${crypto.randomUUID().replace(/-/g, '')}`,
+    })
+    .returning({ id: kiloclaw_instances.id });
+
+  cliRunInstanceId = instance.id;
+
+  const [run] = await db
+    .insert(kiloclaw_cli_runs)
+    .values({
+      user_id: cliRunUser.id,
+      instance_id: cliRunInstanceId,
+      prompt: 'older admin-target run',
+      status: 'running',
+      started_at: '2026-04-08T12:00:00.000Z',
+      initiated_by_admin_id: adminUser.id,
+    })
+    .returning({ id: kiloclaw_cli_runs.id });
+
+  cliRunId = run.id;
   mockGetDebugStatus.mockReset();
   mockDestroyFlyMachine.mockReset();
+  mockGetKiloCliRunStatus.mockReset();
+  mockCancelKiloCliRun.mockReset();
   mockStartKiloCliRun.mockReset();
-  // Clean audit logs between tests so counts are accurate
-  await db
-    .delete(kiloclaw_admin_audit_logs)
-    .where(eq(kiloclaw_admin_audit_logs.actor_id, adminUser.id));
+  mockKiloClawInternalClient();
 });
 
 /* eslint-disable drizzle/enforce-delete-with-where */
-afterAll(async () => {
-  try {
-    await db
-      .delete(kiloclaw_admin_audit_logs)
-      .where(eq(kiloclaw_admin_audit_logs.actor_id, adminUser.id));
-  } catch {
-    // Test DB may already be torn down
-  }
+afterEach(async () => {
+  const userIds = [regularUser.id, adminUser.id, cliRunUser.id];
+  await db
+    .delete(kiloclaw_admin_audit_logs)
+    .where(eq(kiloclaw_admin_audit_logs.actor_id, adminUser.id));
+  // Delete cli_runs before instances (cli_runs.instance_id FK → instances)
+  await db.delete(kiloclaw_cli_runs).where(inArray(kiloclaw_cli_runs.user_id, userIds));
+  // Deleting instances cascades to inbound email aliases
+  await db.delete(kiloclaw_instances).where(inArray(kiloclaw_instances.user_id, userIds));
+  await db.delete(kilocode_users).where(inArray(kilocode_users.id, userIds));
 });
 /* eslint-enable drizzle/enforce-delete-with-where */
 
@@ -258,6 +306,68 @@ describe('admin.kiloclawInstances.destroyFlyMachine', () => {
 });
 
 describe('admin.kiloclawInstances.startKiloCliRun', () => {
+  it('rejects an instance that belongs to a different user', async () => {
+    const targetUser = await insertTestUser({
+      google_user_email: `admin-cli-run-target-${Math.random()}@example.com`,
+      is_admin: false,
+    });
+    const otherUser = await insertTestUser({
+      google_user_email: `admin-cli-run-other-${Math.random()}@example.com`,
+      is_admin: false,
+    });
+    const instanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values({
+      id: instanceId,
+      user_id: targetUser.id,
+      sandbox_id: `ki_${instanceId.replace(/-/g, '')}`,
+    });
+
+    try {
+      const caller = await createCallerForUser(adminUser.id);
+      await expect(
+        caller.admin.kiloclawInstances.startKiloCliRun({
+          userId: otherUser.id,
+          instanceId,
+          prompt: 'test prompt',
+        })
+      ).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+        message: 'Instance not found',
+      });
+
+      expect(mockStartKiloCliRun).not.toHaveBeenCalled();
+    } finally {
+      await db.delete(kiloclaw_instances).where(eq(kiloclaw_instances.id, instanceId));
+    }
+  });
+
+  it('maps a missing active instance to tRPC NOT_FOUND', async () => {
+    await db
+      .update(kiloclaw_instances)
+      .set({ destroyed_at: '2026-04-08T12:02:00.000Z' })
+      .where(eq(kiloclaw_instances.id, cliRunInstanceId));
+
+    const caller = await createCallerForUser(adminUser.id);
+    try {
+      await caller.admin.kiloclawInstances.startKiloCliRun({
+        userId: cliRunUser.id,
+        prompt: 'test prompt',
+      });
+      throw new Error('Expected startKiloCliRun to reject');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TRPCError);
+      if (!(err instanceof TRPCError)) throw err;
+      expect(err.code).toBe('NOT_FOUND');
+      expect(err.message).toBe('Instance not found');
+      expect(err.cause).toBeInstanceOf(UpstreamApiError);
+      if (!(err.cause instanceof UpstreamApiError)) throw err;
+      expect(err.cause.upstreamCode).toBe('instance_not_found');
+    }
+
+    expect(mockStartKiloCliRun).not.toHaveBeenCalled();
+  });
+
   it('maps worker 409 to tRPC CONFLICT', async () => {
     const { KiloClawApiError } = jest.requireMock<{
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -265,19 +375,29 @@ describe('admin.kiloclawInstances.startKiloCliRun', () => {
     }>('@/lib/kiloclaw/kiloclaw-internal-client');
 
     mockStartKiloCliRun.mockRejectedValue(
-      new KiloClawApiError(409, JSON.stringify({ error: 'A CLI run is already in progress' }))
+      new KiloClawApiError(
+        409,
+        JSON.stringify({ error: 'A CLI run is already in progress', code: 'cli_run_in_progress' })
+      )
     );
 
     const caller = await createCallerForUser(adminUser.id);
-    await expect(
-      caller.admin.kiloclawInstances.startKiloCliRun({
-        userId: testUserId,
+    try {
+      await caller.admin.kiloclawInstances.startKiloCliRun({
+        userId: cliRunUser.id,
+        instanceId: cliRunInstanceId,
         prompt: 'test prompt',
-      })
-    ).rejects.toMatchObject({
-      code: 'CONFLICT',
-      message: 'A CLI run is already in progress',
-    });
+      });
+      throw new Error('Expected startKiloCliRun to reject');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TRPCError);
+      if (!(err instanceof TRPCError)) throw err;
+      expect(err.code).toBe('CONFLICT');
+      expect(err.message).toBe('A CLI run is already in progress');
+      expect(err.cause).toBeInstanceOf(UpstreamApiError);
+      if (!(err.cause instanceof UpstreamApiError)) throw err;
+      expect(err.cause.upstreamCode).toBe('cli_run_in_progress');
+    }
   });
 
   it('maps controller_route_unavailable to PRECONDITION_FAILED', async () => {
@@ -295,7 +415,8 @@ describe('admin.kiloclawInstances.startKiloCliRun', () => {
     const caller = await createCallerForUser(adminUser.id);
     await expect(
       caller.admin.kiloclawInstances.startKiloCliRun({
-        userId: testUserId,
+        userId: cliRunUser.id,
+        instanceId: cliRunInstanceId,
         prompt: 'test prompt',
       })
     ).rejects.toMatchObject({
@@ -305,7 +426,8 @@ describe('admin.kiloclawInstances.startKiloCliRun', () => {
 
     try {
       await caller.admin.kiloclawInstances.startKiloCliRun({
-        userId: testUserId,
+        userId: cliRunUser.id,
+        instanceId: cliRunInstanceId,
         prompt: 'test prompt',
       });
       throw new Error('Expected startKiloCliRun to reject');
@@ -316,6 +438,63 @@ describe('admin.kiloclawInstances.startKiloCliRun', () => {
       if (!(err.cause instanceof UpstreamApiError)) throw err;
       expect(err.cause.upstreamCode).toBe('controller_route_unavailable');
     }
+  });
+
+  it('creates a running row with admin attribution and writes start audit metadata on success', async () => {
+    mockStartKiloCliRun.mockResolvedValue({
+      startedAt: '2026-04-08T12:10:00.000Z',
+      status: 'running',
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.startKiloCliRun({
+      userId: cliRunUser.id,
+      instanceId: cliRunInstanceId,
+      prompt: 'new admin run',
+    });
+
+    expect(result).toMatchObject({
+      id: expect.any(String),
+      startedAt: '2026-04-08T12:10:00.000Z',
+      status: 'running',
+    });
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, result.id));
+
+    expect(row).toMatchObject({
+      user_id: cliRunUser.id,
+      instance_id: cliRunInstanceId,
+      initiated_by_admin_id: adminUser.id,
+      prompt: 'new admin run',
+      status: 'running',
+      started_at: '2026-04-08 12:10:00+00',
+      completed_at: null,
+      output: null,
+      exit_code: null,
+    });
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_admin_audit_logs)
+      .where(
+        and(
+          eq(kiloclaw_admin_audit_logs.actor_id, adminUser.id),
+          eq(kiloclaw_admin_audit_logs.action, 'kiloclaw.cli_run.start')
+        )
+      );
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]?.target_user_id).toBe(cliRunUser.id);
+    expect(logs[0]?.metadata).toEqual({
+      runId: result.id,
+      instanceId: cliRunInstanceId,
+      promptLength: 'new admin run'.length,
+    });
+
+    await db.delete(kiloclaw_cli_runs).where(eq(kiloclaw_cli_runs.id, result.id));
   });
 
   it('maps worker 409 with empty body to CONFLICT with fallback message', async () => {
@@ -329,13 +508,96 @@ describe('admin.kiloclawInstances.startKiloCliRun', () => {
     const caller = await createCallerForUser(adminUser.id);
     await expect(
       caller.admin.kiloclawInstances.startKiloCliRun({
-        userId: testUserId,
+        userId: cliRunUser.id,
+        instanceId: cliRunInstanceId,
         prompt: 'test prompt',
       })
     ).rejects.toMatchObject({
       code: 'CONFLICT',
       message: 'Failed to start kilo CLI run',
     });
+  });
+});
+
+describe('admin.kiloclawInstances.getKiloCliRunStatus', () => {
+  it('marks a running DB row failed when controller status belongs to a newer run', async () => {
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'completed',
+      output: 'newer admin run output',
+      exitCode: 0,
+      startedAt: '2026-04-08T12:05:00Z',
+      completedAt: '2026-04-08T12:06:00Z',
+      prompt: 'newer admin run',
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.getKiloCliRunStatus({
+      userId: cliRunUser.id,
+      instanceId: cliRunInstanceId,
+      runId: cliRunId,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.output).toContain('controller has moved on to a newer run');
+    expect(result.completedAt).not.toBeNull();
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, cliRunId));
+
+    expect(row.status).toBe('failed');
+    expect(row.output).toContain('controller has moved on to a newer run');
+    expect(row.completed_at).not.toBeNull();
+  });
+
+  it('marks a running DB row failed when the controller no longer has the run', async () => {
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: false,
+      status: null,
+      output: null,
+      exitCode: null,
+      startedAt: null,
+      completedAt: null,
+      prompt: null,
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.getKiloCliRunStatus({
+      userId: cliRunUser.id,
+      instanceId: cliRunInstanceId,
+      runId: cliRunId,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.output).toContain('controller no longer has an active CLI run');
+    expect(result.completedAt).not.toBeNull();
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, cliRunId));
+
+    expect(row.status).toBe('failed');
+    expect(row.output).toContain('controller no longer has an active CLI run');
+    expect(row.completed_at).not.toBeNull();
+  });
+
+  it('lists the initiating admin email for admin-started runs', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.listAllCliRuns({
+      offset: 0,
+      limit: 10,
+      initiatedBy: 'admin',
+      status: 'all',
+    });
+
+    const run = result.runs.find(row => row.id === cliRunId);
+
+    expect(run?.initiated_by_admin_id).toBe(adminUser.id);
+    expect(run?.initiated_by_admin_email).toBe(adminUser.google_user_email);
+    expect(run).not.toHaveProperty('initiated_by_admin_name');
   });
 });
 
@@ -395,5 +657,259 @@ describe('admin.kiloclawInstances inbound email controls', () => {
       );
     expect(logs).toHaveLength(1);
     expect(logs[0].metadata).toEqual({ instanceId, enabled: false });
+  });
+});
+
+describe('admin.kiloclawInstances.cancelKiloCliRun', () => {
+  async function getCancelAuditLogs() {
+    return db
+      .select()
+      .from(kiloclaw_admin_audit_logs)
+      .where(
+        and(
+          eq(kiloclaw_admin_audit_logs.actor_id, adminUser.id),
+          eq(kiloclaw_admin_audit_logs.action, 'kiloclaw.cli_run.cancel')
+        )
+      );
+  }
+
+  it('throws before calling the controller when the scoped CLI run row does not exist', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+
+    await expect(
+      caller.admin.kiloclawInstances.cancelKiloCliRun({
+        userId: cliRunUser.id,
+        instanceId: cliRunInstanceId,
+        runId: crypto.randomUUID(),
+      })
+    ).rejects.toThrow('CLI run not found');
+
+    expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
+    await expect(getCancelAuditLogs()).resolves.toHaveLength(0);
+  });
+
+  it('falls back to the run row when an explicit instance is missing', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const missingInstanceId = crypto.randomUUID();
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'running',
+      output: null,
+      exitCode: null,
+      startedAt: '2026-04-08T12:00:00.000Z',
+      completedAt: null,
+      prompt: 'older admin-target run',
+    });
+    mockCancelKiloCliRun.mockResolvedValue({ ok: true });
+
+    await expect(
+      caller.admin.kiloclawInstances.cancelKiloCliRun({
+        userId: cliRunUser.id,
+        instanceId: missingInstanceId,
+        runId: cliRunId,
+      })
+    ).resolves.toEqual({ ok: true });
+
+    expect(mockCancelKiloCliRun).toHaveBeenCalledWith(cliRunUser.id, cliRunInstanceId);
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, cliRunId));
+
+    expect(row.status).toBe('cancelled');
+    expect(row.completed_at).not.toBeNull();
+  });
+
+  it('throws before calling the controller when the run belongs to another instance', async () => {
+    const [otherInstance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        id: crypto.randomUUID(),
+        user_id: cliRunUser.id,
+        sandbox_id: `ki_${crypto.randomUUID().replace(/-/g, '')}`,
+      })
+      .returning({ id: kiloclaw_instances.id });
+
+    const caller = await createCallerForUser(adminUser.id);
+
+    try {
+      await expect(
+        caller.admin.kiloclawInstances.cancelKiloCliRun({
+          userId: cliRunUser.id,
+          instanceId: otherInstance.id,
+          runId: cliRunId,
+        })
+      ).rejects.toThrow('CLI run not found');
+
+      expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
+      await expect(getCancelAuditLogs()).resolves.toHaveLength(0);
+    } finally {
+      await db.delete(kiloclaw_instances).where(eq(kiloclaw_instances.id, otherInstance.id));
+    }
+  });
+
+  it('returns ok without calling the controller when the run is already terminal', async () => {
+    await db
+      .update(kiloclaw_cli_runs)
+      .set({
+        status: 'completed',
+        exit_code: 0,
+        output: 'done',
+        completed_at: '2026-04-08T12:01:00.000Z',
+      })
+      .where(eq(kiloclaw_cli_runs.id, cliRunId));
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.cancelKiloCliRun({
+        userId: cliRunUser.id,
+        instanceId: cliRunInstanceId,
+        runId: cliRunId,
+      })
+    ).resolves.toEqual({ ok: true });
+
+    expect(mockCancelKiloCliRun).not.toHaveBeenCalled();
+    await expect(getCancelAuditLogs()).resolves.toHaveLength(0);
+  });
+
+  it('does not write a cancel audit log when the controller cannot cancel the run', async () => {
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'running',
+      output: null,
+      exitCode: null,
+      startedAt: '2026-04-08T12:00:00.000Z',
+      completedAt: null,
+      prompt: 'older admin-target run',
+    });
+    mockCancelKiloCliRun.mockResolvedValue({ ok: false });
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.cancelKiloCliRun({
+        userId: cliRunUser.id,
+        instanceId: cliRunInstanceId,
+        runId: cliRunId,
+      })
+    ).resolves.toEqual({ ok: false });
+
+    await expect(getCancelAuditLogs()).resolves.toHaveLength(0);
+  });
+
+  it('calls the controller, marks the row cancelled, and writes audit metadata for a running run', async () => {
+    mockGetKiloCliRunStatus.mockResolvedValue({
+      hasRun: true,
+      status: 'running',
+      output: null,
+      exitCode: null,
+      startedAt: '2026-04-08T12:00:00.000Z',
+      completedAt: null,
+      prompt: 'older admin-target run',
+    });
+    mockCancelKiloCliRun.mockResolvedValue({ ok: true });
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.cancelKiloCliRun({
+        userId: cliRunUser.id,
+        instanceId: cliRunInstanceId,
+        runId: cliRunId,
+      })
+    ).resolves.toEqual({ ok: true });
+
+    expect(mockCancelKiloCliRun).toHaveBeenCalledWith(cliRunUser.id, cliRunInstanceId);
+
+    const [row] = await db
+      .select()
+      .from(kiloclaw_cli_runs)
+      .where(eq(kiloclaw_cli_runs.id, cliRunId));
+
+    expect(row.status).toBe('cancelled');
+    expect(row.completed_at).not.toBeNull();
+
+    const logs = await getCancelAuditLogs();
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].target_user_id).toBe(cliRunUser.id);
+    expect(logs[0].metadata).toEqual({
+      instanceId: cliRunInstanceId,
+      requestedInstanceId: cliRunInstanceId,
+      routerInstanceMissing: false,
+      runId: cliRunId,
+    });
+  });
+
+  it('mirrors cancelCliRun fallback lookup and best-effort audit when explicit instance is gone', async () => {
+    const [destroyedInstance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        id: crypto.randomUUID(),
+        user_id: cliRunUser.id,
+        sandbox_id: `ki_${crypto.randomUUID().replace(/-/g, '')}`,
+        destroyed_at: '2026-04-08T12:02:00.000Z',
+      })
+      .returning({ id: kiloclaw_instances.id });
+
+    const [staleRun] = await db
+      .insert(kiloclaw_cli_runs)
+      .values({
+        user_id: cliRunUser.id,
+        instance_id: destroyedInstance.id,
+        prompt: 'stale destroyed-instance run',
+        status: 'running',
+        started_at: '2026-04-08T12:00:00.000Z',
+        initiated_by_admin_id: adminUser.id,
+      })
+      .returning({ id: kiloclaw_cli_runs.id });
+
+    try {
+      mockGetKiloCliRunStatus.mockResolvedValue({
+        hasRun: true,
+        status: 'running',
+        output: null,
+        exitCode: null,
+        startedAt: '2026-04-08T12:00:00.000Z',
+        completedAt: null,
+        prompt: 'stale destroyed-instance run',
+      });
+      mockCancelKiloCliRun.mockResolvedValue({ ok: true });
+
+      const caller = await createCallerForUser(adminUser.id);
+      await expect(
+        caller.admin.kiloclawInstances.cancelKiloCliRun({
+          userId: cliRunUser.id,
+          instanceId: destroyedInstance.id,
+          runId: staleRun.id,
+        })
+      ).resolves.toEqual({ ok: true });
+
+      expect(mockCancelKiloCliRun).toHaveBeenCalledWith(cliRunUser.id, destroyedInstance.id);
+
+      const [row] = await db
+        .select()
+        .from(kiloclaw_cli_runs)
+        .where(eq(kiloclaw_cli_runs.id, staleRun.id));
+
+      expect(row.status).toBe('cancelled');
+      expect(row.completed_at).not.toBeNull();
+
+      const logs = await getCancelAuditLogs();
+
+      expect(logs).toHaveLength(1);
+      expect(logs[0].target_user_id).toBe(cliRunUser.id);
+      expect(logs[0].message).toBe('CLI run cancelled');
+      expect(logs[0].metadata).toEqual({
+        instanceId: null,
+        requestedInstanceId: destroyedInstance.id,
+        routerInstanceMissing: true,
+        runId: staleRun.id,
+      });
+    } finally {
+      /* eslint-disable drizzle/enforce-delete-with-where */
+      await db.delete(kiloclaw_cli_runs).where(eq(kiloclaw_cli_runs.id, staleRun.id));
+      await db.delete(kiloclaw_instances).where(eq(kiloclaw_instances.id, destroyedInstance.id));
+      /* eslint-enable drizzle/enforce-delete-with-where */
+    }
   });
 });

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -26,6 +26,7 @@ import {
   createKiloClawAdminAuditLog,
   listKiloClawAdminAuditLogs,
 } from '@/lib/kiloclaw/admin-audit-log';
+import { cancelCliRun, createCliRun, getCliRunStatus } from '@/lib/kiloclaw/cli-runs';
 import type {
   PlatformDebugStatusResponse,
   VolumeSnapshot,
@@ -37,6 +38,7 @@ import type {
 import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
 import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
+import { alias } from 'drizzle-orm/pg-core';
 import {
   eq,
   and,
@@ -52,6 +54,8 @@ import {
   lte,
   type SQL,
 } from 'drizzle-orm';
+
+const initiatingAdminUsers = alias(kilocode_users, 'initiating_admin_users');
 
 const ListInstancesSchema = z.object({
   offset: z.number().min(0).default(0),
@@ -152,6 +156,10 @@ function throwKiloclawAdminError(
     messageOverrides?: Partial<Record<number, string>>;
   }
 ): never {
+  if (err instanceof TRPCError) {
+    throw err;
+  }
+
   if (err instanceof KiloClawApiError) {
     const payload = getKiloclawApiErrorPayload(err, fallbackMessage);
     if (payload.code === 'controller_route_unavailable') {
@@ -168,7 +176,7 @@ function throwKiloclawAdminError(
       code:
         options?.statusCodeOverrides?.[err.statusCode] ?? kiloclawStatusToTrpcCode(err.statusCode),
       message: options?.messageOverrides?.[err.statusCode] ?? payload.message,
-      cause: err,
+      cause: payload.code ? new UpstreamApiError(payload.code) : err,
     });
   }
 
@@ -191,11 +199,26 @@ async function resolveInstance(userId: string, instanceId?: string) {
       throw new TRPCError({
         code: 'NOT_FOUND',
         message: `Instance ${instanceId} not found`,
+        cause: new UpstreamApiError('instance_not_found'),
       });
     }
     return instance;
   }
+
   return getActiveInstance(userId);
+}
+
+function assertInstanceBelongsToUser(
+  instance: Awaited<ReturnType<typeof resolveInstance>>,
+  userId: string
+): asserts instance is NonNullable<Awaited<ReturnType<typeof resolveInstance>>> {
+  if (!instance || instance.userId !== userId) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Instance not found',
+      cause: new UpstreamApiError('instance_not_found'),
+    });
+  }
 }
 
 export type AdminKiloclawInstance = {
@@ -643,29 +666,140 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         prompt: z.string().min(1).max(10_000),
       })
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ input, ctx }) => {
       const fallbackMessage = 'Failed to start kilo CLI run';
       try {
         const instance = await resolveInstance(input.userId, input.instanceId);
+        assertInstanceBelongsToUser(instance, input.userId);
         const client = new KiloClawInternalClient();
-        return await client.startKiloCliRun(input.userId, input.prompt, workerInstanceId(instance));
+        const result = await client.startKiloCliRun(
+          input.userId,
+          input.prompt,
+          workerInstanceId(instance)
+        );
+
+        const runId = await createCliRun({
+          userId: input.userId,
+          instanceId: instance.id,
+          prompt: input.prompt,
+          startedAt: result.startedAt,
+          initiatedByAdminId: ctx.user.id,
+        });
+
+        try {
+          await createKiloClawAdminAuditLog({
+            action: 'kiloclaw.cli_run.start',
+            actor_id: ctx.user.id,
+            actor_email: ctx.user.google_user_email,
+            actor_name: ctx.user.google_user_name,
+            target_user_id: input.userId,
+            message: `CLI run started on instance ${instance.id}`,
+            metadata: {
+              runId,
+              instanceId: instance.id,
+              promptLength: input.prompt.length,
+            },
+          });
+        } catch (auditErr) {
+          console.error('Failed to write audit log for startKiloCliRun:', auditErr);
+        }
+
+        return { ...result, id: runId };
       } catch (err) {
         console.error('Failed to start kilo CLI run for user:', input.userId, err);
         throwKiloclawAdminError(err, fallbackMessage);
       }
     }),
 
-  getKiloCliRunStatus: adminProcedure.input(GatewayProcessSchema).query(async ({ input }) => {
-    const fallbackMessage = 'Failed to get kilo CLI run status';
-    try {
-      const instance = await resolveInstance(input.userId, input.instanceId);
-      const client = new KiloClawInternalClient();
-      return await client.getKiloCliRunStatus(input.userId, workerInstanceId(instance));
-    } catch (err) {
-      console.error('Failed to get kilo CLI run status for user:', input.userId, err);
-      throwKiloclawAdminError(err, fallbackMessage);
-    }
-  }),
+  getKiloCliRunStatus: adminProcedure
+    .input(
+      z.object({
+        userId: z.string().min(1),
+        instanceId: z.uuid().optional(),
+        runId: z.uuid(),
+      })
+    )
+    .query(async ({ input }) => {
+      const fallbackMessage = 'Failed to get kilo CLI run status';
+      try {
+        const instance = input.instanceId
+          ? await getInstanceById(input.instanceId)
+          : await getActiveInstance(input.userId);
+        if (instance) {
+          assertInstanceBelongsToUser(instance, input.userId);
+        }
+
+        return getCliRunStatus({
+          runId: input.runId,
+          userId: input.userId,
+          instanceId: instance?.id ?? null,
+          workerInstanceId: workerInstanceId(instance),
+        });
+      } catch (err) {
+        console.error('Failed to get kilo CLI run status for user:', input.userId, err);
+        throwKiloclawAdminError(err, fallbackMessage);
+      }
+    }),
+
+  cancelKiloCliRun: adminProcedure
+    .input(
+      z.object({
+        userId: z.string().min(1),
+        instanceId: z.uuid().optional(),
+        runId: z.uuid(),
+      })
+    )
+    .mutation(async ({ input, ctx }) => {
+      const fallbackMessage = 'Failed to cancel kilo CLI run';
+      try {
+        const instance = input.instanceId
+          ? await getInstanceById(input.instanceId)
+          : await getActiveInstance(input.userId);
+        if (instance) {
+          assertInstanceBelongsToUser(instance, input.userId);
+        }
+        const result = await cancelCliRun({
+          runId: input.runId,
+          userId: input.userId,
+          instanceId: instance?.id ?? null,
+          workerInstanceId: workerInstanceId(instance),
+        });
+
+        if (!result.runFound) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'CLI run not found' });
+        }
+
+        if (result.cancelled) {
+          const resolvedInstanceId = instance?.id ?? null;
+          try {
+            await createKiloClawAdminAuditLog({
+              action: 'kiloclaw.cli_run.cancel',
+              actor_id: ctx.user.id,
+              actor_email: ctx.user.google_user_email,
+              actor_name: ctx.user.google_user_name,
+              target_user_id: input.userId,
+              message: 'CLI run cancelled',
+              metadata: {
+                instanceId: resolvedInstanceId,
+                requestedInstanceId: input.instanceId ?? null,
+                // Whether the router resolved an instance for the user. Note:
+                // even when true, cancelCliRun may still reach the controller
+                // via the run row's own instance_id.
+                routerInstanceMissing: !resolvedInstanceId,
+                runId: input.runId,
+              },
+            });
+          } catch (auditErr) {
+            console.error('Failed to write audit log for cancelKiloCliRun:', auditErr);
+          }
+        }
+
+        return { ok: result.ok };
+      } catch (err) {
+        console.error('Failed to cancel kilo CLI run for user:', input.userId, err);
+        throwKiloclawAdminError(err, fallbackMessage);
+      }
+    }),
 
   listKiloCliRuns: adminProcedure
     .input(z.object({ userId: z.string().min(1), limit: z.number().min(1).max(50).default(20) }))
@@ -687,14 +821,23 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         limit: z.number().min(1).max(100).default(25),
         search: z.string().optional(),
         status: z.enum(['all', 'running', 'completed', 'failed', 'cancelled']).default('all'),
+        initiatedBy: z.enum(['all', 'admin', 'user']).default('all'),
       })
     )
     .query(async ({ input }) => {
-      const { offset, limit, search, status } = input;
+      const { offset, limit, search, status, initiatedBy } = input;
       const conditions: SQL[] = [];
 
       if (status !== 'all') {
         conditions.push(eq(kiloclaw_cli_runs.status, status));
+      }
+
+      if (initiatedBy !== 'all') {
+        conditions.push(
+          initiatedBy === 'admin'
+            ? isNotNull(kiloclaw_cli_runs.initiated_by_admin_id)
+            : isNull(kiloclaw_cli_runs.initiated_by_admin_id)
+        );
       }
 
       const searchTerm = search?.trim();
@@ -716,6 +859,8 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
             id: kiloclaw_cli_runs.id,
             user_id: kiloclaw_cli_runs.user_id,
             user_email: kilocode_users.google_user_email,
+            initiated_by_admin_id: kiloclaw_cli_runs.initiated_by_admin_id,
+            initiated_by_admin_email: initiatingAdminUsers.google_user_email,
             prompt: kiloclaw_cli_runs.prompt,
             status: kiloclaw_cli_runs.status,
             exit_code: kiloclaw_cli_runs.exit_code,
@@ -724,6 +869,10 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
           })
           .from(kiloclaw_cli_runs)
           .leftJoin(kilocode_users, eq(kiloclaw_cli_runs.user_id, kilocode_users.id))
+          .leftJoin(
+            initiatingAdminUsers,
+            eq(kiloclaw_cli_runs.initiated_by_admin_id, initiatingAdminUsers.id)
+          )
           .where(where)
           .orderBy(desc(kiloclaw_cli_runs.started_at))
           .limit(limit)
@@ -744,12 +893,14 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     }),
 
   getCliRunOutput: adminProcedure
-    .input(z.object({ runId: z.string().min(1) }))
+    .input(z.object({ userId: z.string().min(1), runId: z.uuid() }))
     .query(async ({ input }) => {
       const [row] = await db
         .select({ output: kiloclaw_cli_runs.output })
         .from(kiloclaw_cli_runs)
-        .where(eq(kiloclaw_cli_runs.id, input.runId))
+        .where(
+          and(eq(kiloclaw_cli_runs.id, input.runId), eq(kiloclaw_cli_runs.user_id, input.userId))
+        )
         .limit(1);
 
       return { output: row?.output ?? null };

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -65,7 +65,7 @@ import { APP_URL } from '@/lib/constants';
 import { getAffiliateAttribution } from '@/lib/affiliate-attribution';
 import { buildAffiliateEventDedupeKey, enqueueAffiliateEventForUser } from '@/lib/affiliate-events';
 import { clawAccessProcedure } from '@/lib/kiloclaw/access-gate';
-import { cancelCliRun, getCliRunStatus } from '@/lib/kiloclaw/cli-runs';
+import { cancelCliRun, createCliRun, getCliRunStatus } from '@/lib/kiloclaw/cli-runs';
 import {
   getStripePriceIdForClawPlan,
   getStripePriceIdForClawPlanIntro,
@@ -2223,19 +2223,15 @@ export const kiloclawRouter = createTRPCRouter({
         throw err;
       }
 
-      // Persist the run in the database and return its ID
-      const [row] = await db
-        .insert(kiloclaw_cli_runs)
-        .values({
-          user_id: ctx.user.id,
-          instance_id: instance?.id ?? null,
-          prompt: input.prompt,
-          status: 'running',
-          started_at: result.startedAt,
-        })
-        .returning({ id: kiloclaw_cli_runs.id });
+      const runId = await createCliRun({
+        userId: ctx.user.id,
+        instanceId: instance?.id ?? null,
+        prompt: input.prompt,
+        startedAt: result.startedAt,
+        initiatedByAdminId: null,
+      });
 
-      return { ...result, id: row.id };
+      return { ...result, id: runId };
     }),
 
   getKiloCliRunStatus: clawAccessProcedure

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -215,9 +215,15 @@ describe('kiloclaw.startKiloCliRun error translation', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
       user_id: user.id,
+      instance_id: expect.any(String),
+      initiated_by_admin_id: null,
       prompt: 'fix the config',
       status: 'running',
+      completed_at: null,
+      output: null,
+      exit_code: null,
     });
+    expect(new Date(rows[0]!.started_at!).toISOString()).toBe(startedAt);
   });
 });
 
@@ -312,9 +318,14 @@ describe('organizations.kiloclaw.startKiloCliRun error translation', () => {
     expect(rows[0]).toMatchObject({
       user_id: user.id,
       instance_id: expect.any(String),
+      initiated_by_admin_id: null,
       prompt: 'fix the org config',
       status: 'running',
+      completed_at: null,
+      output: null,
+      exit_code: null,
     });
+    expect(new Date(rows[0]!.started_at!).toISOString()).toBe(startedAt);
   });
 });
 

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -27,7 +27,7 @@ import {
 } from '@kilocode/db/schema';
 import { and, eq, desc, sql } from 'drizzle-orm';
 import type { KiloClawDashboardStatus, KiloCodeConfigResponse } from '@/lib/kiloclaw/types';
-import { cancelCliRun, getCliRunStatus } from '@/lib/kiloclaw/cli-runs';
+import { cancelCliRun, createCliRun, getCliRunStatus } from '@/lib/kiloclaw/cli-runs';
 import { queryDiskUsage } from '@/lib/kiloclaw/disk-usage';
 import {
   cycleInboundEmailAddressForInstance,
@@ -1195,18 +1195,15 @@ export const organizationKiloclawRouter = createTRPCRouter({
         throw err;
       }
 
-      const [row] = await db
-        .insert(kiloclaw_cli_runs)
-        .values({
-          user_id: ctx.user.id,
-          instance_id: instance.id,
-          prompt: input.prompt,
-          status: 'running',
-          started_at: result.startedAt,
-        })
-        .returning({ id: kiloclaw_cli_runs.id });
+      const runId = await createCliRun({
+        userId: ctx.user.id,
+        instanceId: instance.id,
+        prompt: input.prompt,
+        startedAt: result.startedAt,
+        initiatedByAdminId: null,
+      });
 
-      return { ...result, id: row.id };
+      return { ...result, id: runId };
     }),
 
   getKiloCliRunStatus: organizationMemberProcedure


### PR DESCRIPTION
## Summary

Admin-initiated CLI runs were previously fire-and-forget. There was no database record, no way to check status or cancel, and no attribution back to the admin who started them. If something went wrong, the only option was to destroy the instance.

This PR gives admin CLI runs the same lifecycle as user-started runs by routing them through the shared `createCliRun` / `getCliRunStatus` / `cancelCliRun` helpers. Each run records which admin started it, and the admin list view can now filter by initiator. Start and cancel actions write audit logs with instance and run metadata.

Ownership checks prevent admins from accidentally operating on an instance that belongs to a different user than the one selected.

## Verification

- Not manually tested

## Visual Changes

N/A

## Reviewer Notes

- The reconciliation paths for stale runs (controller has moved on, instance destroyed) mirror the user-facing `cancelCliRun` fallback.
- Left join is intentionally omitted from the `listAllCliRuns` query on the CLI runs tab, as we do not support searching by admin initiator. 
- startKiloCliRun in the admin router creates the DB row after the controller run starts. This mirrors the other existing audit patterns in the file