### PR TITLE
fix(claw): prevent doctor dialog pre overflow from breaking layout

### DIFF
--- a/apps/web/src/app/(app)/claw/components/RunDoctorDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/RunDoctorDialog.tsx
@@ -77,7 +77,7 @@ export function RunDoctorDialog({
         )}
 
         {result && !isPending && (
-          <div className="space-y-3">
+          <div className="min-w-0 space-y-3">
             <div className="flex items-center gap-2">
               {result.success ? (
                 <CheckCircle2 className="h-4 w-4 text-emerald-400" />
@@ -88,7 +88,7 @@ export function RunDoctorDialog({
                 {result.success ? 'Executed successfully' : 'Issues detected'}
               </span>
             </div>
-            <div className="border-border bg-background max-h-[400px] overflow-auto rounded-md border">
+            <div className="border-border bg-background max-h-[400px] min-w-0 overflow-auto rounded-md border">
               {/* prettier-ignore */}
               <pre
                 className="p-3 text-xs leading-relaxed whitespace-pre"


### PR DESCRIPTION
## Summary

- The OpenClaw Doctor dialog's `<pre>` output (with `whitespace-pre`) was expanding beyond the dialog's `max-w-[750px]` because CSS grid items default to `min-width: auto`
- Added `min-w-0` to the result wrapper (grid item) and the scrollable container so `overflow-auto` constrains the content within the dialog bounds

## Verification

<img width="3338" height="1315" alt="Untitled-1" src="https://github.com/user-attachments/assets/00f1d7af-b1ba-4f3f-a202-f24adb755654" />

- Ran `pnpm typecheck` — passes
- Ran `pnpm format` — no changes needed

## Visual Changes

Before: the `<pre>` block with long CLI output lines pushes the dialog wider than the viewport, breaking the layout.
After: long lines are contained within the dialog and horizontally scrollable.

## Reviewer Notes

N/A