### PR TITLE
fix(claw): improve onboarding step transitions

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
@@ -17,7 +17,7 @@ import { ChannelPairingStepView } from './ChannelPairingStep';
 import { ChannelSelectionStepView } from './ChannelSelectionStep';
 import { ClawConfigServiceBanner } from './ClawConfigServiceBanner';
 import { ClawHeader } from './ClawHeader';
-import { ClawSetupCompleteStep } from './ClawOnboardingFlow';
+import { ClawSetupCompleteStep, ClawSetupErrorStep } from './ClawOnboardingFlow';
 import { CreateInstanceCardView } from './CreateInstanceCard';
 import { PermissionStep } from './PermissionStep';
 import { ProvisioningStepView } from './ProvisioningStep';
@@ -30,6 +30,7 @@ const FAKE_STEP_LABELS: Record<ClawOnboardingRenderStep, string> = {
   provisioning: 'Provisioning',
   pairing: 'Pairing',
   complete: 'Complete',
+  error: 'Error',
 };
 
 const fakeStatus = {
@@ -242,5 +243,7 @@ function renderFakeStep({
       );
     case 'complete':
       return <ClawSetupCompleteStep status={fakeStatus} gatewayReady basePath={basePath} />;
+    case 'error':
+      return <ClawSetupErrorStep basePath={basePath} />;
   }
 }

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
@@ -1,26 +1,13 @@
 import { describe, expect, test } from '@jest/globals';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import {
+  CLAW_ONBOARDING_ERROR_STATUSES,
+  CLAW_ONBOARDING_PROVISIONING_STATUSES,
   type ClawOnboardingFlowStateInput,
   getClawOnboardingFlowState,
   hasPopulatedStatus,
   isPairingChannel,
 } from './ClawOnboardingFlow.state';
-
-const machineStatuses = [
-  'provisioned',
-  'starting',
-  'restarting',
-  'recovering',
-  'running',
-  'stopped',
-  'destroying',
-  'restoring',
-] satisfies NonNullable<KiloClawDashboardStatus['status']>[];
-
-const waitingMachineStatuses = machineStatuses.filter(
-  status => status !== 'running' && status !== 'stopped'
-);
 
 function createStatus(status: KiloClawDashboardStatus['status']): KiloClawDashboardStatus {
   return {
@@ -191,7 +178,7 @@ describe('ClawOnboardingFlow state machine', () => {
     expect(getClawOnboardingFlowState(createInput()).totalSteps).toBe(5);
   });
 
-  test.each(waitingMachineStatuses)(
+  test.each(CLAW_ONBOARDING_PROVISIONING_STATUSES)(
     'renders the post-provisioning spinner while machine status is %s',
     status => {
       const state = getClawOnboardingFlowState(
@@ -206,27 +193,30 @@ describe('ClawOnboardingFlow state machine', () => {
     }
   );
 
-  test('renders an error when the instance is stopped', () => {
-    expect(
-      getClawOnboardingFlowState(
-        createInput({
-          mode: 'post-provisioning',
-          status: createStatus('stopped'),
-        })
-      ).renderStep
-    ).toBe('error');
-    expect(
-      getClawOnboardingFlowState(
-        createInput({
-          createSetupStarted: true,
-          onboardingStep: 'provisioning',
-          hasBotIdentity: true,
-          selectedPreset: 'always-ask',
-          status: createStatus('stopped'),
-        })
-      ).renderStep
-    ).toBe('error');
-  });
+  test.each(CLAW_ONBOARDING_ERROR_STATUSES)(
+    'renders an error when machine status is %s',
+    status => {
+      expect(
+        getClawOnboardingFlowState(
+          createInput({
+            mode: 'post-provisioning',
+            status: createStatus(status),
+          })
+        ).renderStep
+      ).toBe('error');
+      expect(
+        getClawOnboardingFlowState(
+          createInput({
+            createSetupStarted: true,
+            onboardingStep: 'provisioning',
+            hasBotIdentity: true,
+            selectedPreset: 'always-ask',
+            status: createStatus(status),
+          })
+        ).renderStep
+      ).toBe('error');
+    }
+  );
 
   test('renders create-instance when post-provisioning has no provisioned DO', () => {
     // status undefined — no DO state at all (e.g. credit enrollment created DB

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
@@ -18,7 +18,9 @@ const machineStatuses = [
   'restoring',
 ] satisfies NonNullable<KiloClawDashboardStatus['status']>[];
 
-const waitingMachineStatuses = machineStatuses.filter(status => status !== 'running');
+const waitingMachineStatuses = machineStatuses.filter(
+  status => status !== 'running' && status !== 'stopped'
+);
 
 function createStatus(status: KiloClawDashboardStatus['status']): KiloClawDashboardStatus {
   return {
@@ -98,15 +100,17 @@ describe('ClawOnboardingFlow state machine', () => {
     expect(state.instanceStatus).toBeNull();
   });
 
-  test('renders identity after provisioning has been requested', () => {
+  test('renders identity immediately after provisioning is requested before status is available', () => {
     const state = getClawOnboardingFlowState(
       createInput({
         createSetupStarted: true,
+        status: undefined,
       })
     );
 
     expect(state.renderStep).toBe('identity');
     expect(state.createSetupActive).toBe(true);
+    expect(state.instanceStatus).toBeNull();
   });
 
   test('keeps create setup active once an instance status exists', () => {
@@ -201,6 +205,28 @@ describe('ClawOnboardingFlow state machine', () => {
       expect(state.postProvisioningReady).toBe(false);
     }
   );
+
+  test('renders an error when the instance is stopped', () => {
+    expect(
+      getClawOnboardingFlowState(
+        createInput({
+          mode: 'post-provisioning',
+          status: createStatus('stopped'),
+        })
+      ).renderStep
+    ).toBe('error');
+    expect(
+      getClawOnboardingFlowState(
+        createInput({
+          createSetupStarted: true,
+          onboardingStep: 'provisioning',
+          hasBotIdentity: true,
+          selectedPreset: 'always-ask',
+          status: createStatus('stopped'),
+        })
+      ).renderStep
+    ).toBe('error');
+  });
 
   test('renders create-instance when post-provisioning has no provisioned DO', () => {
     // status undefined — no DO state at all (e.g. credit enrollment created DB

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
@@ -22,7 +22,8 @@ export type ClawOnboardingRenderStep =
   | 'channels'
   | 'provisioning'
   | 'pairing'
-  | 'complete';
+  | 'complete'
+  | 'error';
 
 export type PairingChannelId = 'telegram' | 'discord';
 
@@ -36,6 +37,7 @@ export const CLAW_ONBOARDING_FAKE_STEPS = [
   'provisioning',
   'pairing',
   'complete',
+  'error',
 ] satisfies ClawOnboardingRenderStep[];
 
 export function parseClawOnboardingFakeStep(value: string | null): ClawOnboardingRenderStep | null {
@@ -54,6 +56,7 @@ export type ClawOnboardingFlowStateInput = {
   hasBotIdentity: boolean;
   selectedChannelId: string | null;
   gatewayState?: GatewayProcessStatusResponse['state'] | null;
+  debugLogSource?: string;
 };
 
 export type ClawOnboardingFlowState = {
@@ -87,6 +90,7 @@ export function getClawOnboardingFlowState({
   hasBotIdentity,
   selectedChannelId,
   gatewayState,
+  debugLogSource = 'default',
 }: ClawOnboardingFlowStateInput): ClawOnboardingFlowState {
   const instanceStatus = hasPopulatedStatus(status) ? status : null;
   const isRunning = instanceStatus?.status === 'running';
@@ -97,18 +101,18 @@ export function getClawOnboardingFlowState({
     mode === 'create-first' && (createSetupStarted || instanceStatus !== null);
   const hasPairingStep = isPairingChannel(selectedChannelId);
   const totalSteps = hasPairingStep ? 6 : 5;
-
-  return {
-    renderStep: getRenderStep({
-      mode,
-      createSetupStarted,
-      instanceStatus,
-      postProvisioningReady,
-      onboardingStep,
-      selectedPreset,
-      hasBotIdentity,
-      hasPairingStep,
-    }),
+  const renderStepDecision = getRenderStepDecision({
+    mode,
+    createSetupStarted,
+    instanceStatus,
+    postProvisioningReady,
+    onboardingStep,
+    selectedPreset,
+    hasBotIdentity,
+    hasPairingStep,
+  });
+  const flowState = {
+    renderStep: renderStepDecision.renderStep,
     instanceStatus,
     isRunning,
     gatewayReady,
@@ -117,7 +121,30 @@ export function getClawOnboardingFlowState({
     postProvisioningReady,
     hasPairingStep,
     totalSteps,
-  };
+  } satisfies ClawOnboardingFlowState;
+
+  logClawOnboardingFlowStateDecision({
+    status,
+    mode,
+    createSetupStarted,
+    onboardingStep,
+    selectedPreset,
+    hasBotIdentity,
+    selectedChannelId,
+    gatewayState,
+    debugLogSource,
+    instanceStatus,
+    isRunning,
+    gatewayReady,
+    instanceRunning,
+    createSetupActive,
+    postProvisioningReady,
+    hasPairingStep,
+    totalSteps,
+    renderStepDecision,
+  });
+
+  return flowState;
 }
 
 type RenderStepInput = Pick<
@@ -129,7 +156,34 @@ type RenderStepInput = Pick<
   hasPairingStep: boolean;
 };
 
-function getRenderStep({
+type RenderStepDecision = {
+  renderStep: ClawOnboardingRenderStep;
+  reason: string;
+};
+
+type ClawOnboardingFlowDebugLogInput = ClawOnboardingFlowStateInput & {
+  debugLogSource: string;
+  instanceStatus: PopulatedClawStatus | null;
+  isRunning: boolean;
+  gatewayReady: boolean;
+  instanceRunning: boolean;
+  createSetupActive: boolean;
+  postProvisioningReady: boolean;
+  hasPairingStep: boolean;
+  totalSteps: number;
+  renderStepDecision: RenderStepDecision;
+};
+
+type ClawOnboardingFlowDebugSnapshot = {
+  input: string;
+  derived: string;
+  decision: string;
+  loggedAtMs: number;
+};
+
+const clawOnboardingFlowDebugSnapshots = new Map<string, ClawOnboardingFlowDebugSnapshot>();
+
+function getRenderStepDecision({
   mode,
   createSetupStarted,
   instanceStatus,
@@ -138,43 +192,177 @@ function getRenderStep({
   selectedPreset,
   hasBotIdentity,
   hasPairingStep,
-}: RenderStepInput): ClawOnboardingRenderStep {
+}: RenderStepInput): RenderStepDecision {
+  if (instanceStatus?.status === 'stopped') {
+    return {
+      renderStep: 'error',
+      reason: 'instance status is stopped, so setup cannot continue automatically',
+    };
+  }
+
   if (mode === 'post-provisioning') {
-    if (postProvisioningReady) return 'complete';
+    if (postProvisioningReady) {
+      return {
+        renderStep: 'complete',
+        reason: 'post-provisioning mode is ready because the instance status is running',
+      };
+    }
     // DB row + subscription exist but no DO provisioned yet (e.g. credit
     // enrollment created the billing records without triggering provision).
     // Show the onboarding entry point so the user can kick off provisioning.
-    if (!instanceStatus) return 'create-instance';
-    return 'provisioning';
+    if (!instanceStatus) {
+      return {
+        renderStep: 'create-instance',
+        reason: 'post-provisioning mode has no populated instance status yet',
+      };
+    }
+    return {
+      renderStep: 'provisioning',
+      reason: 'post-provisioning mode has an instance but it is not running yet',
+    };
   }
 
   if (instanceStatus === null && !createSetupStarted) {
-    return 'create-instance';
+    return {
+      renderStep: 'create-instance',
+      reason: 'create-first mode has no instance status and setup has not started',
+    };
   }
 
   if (onboardingStep === 'done') {
-    return 'complete';
+    return {
+      renderStep: 'complete',
+      reason: 'stored onboarding step is done',
+    };
   }
 
   if (onboardingStep === 'identity' || !hasBotIdentity) {
-    return 'identity';
+    return {
+      renderStep: 'identity',
+      reason: !hasBotIdentity
+        ? 'bot identity is missing, so identity is the earliest safe step'
+        : 'stored onboarding step is identity',
+    };
   }
 
   if (onboardingStep === 'permissions' || selectedPreset === null) {
-    return 'permissions';
+    return {
+      renderStep: 'permissions',
+      reason:
+        selectedPreset === null
+          ? 'exec preset is missing, so permissions is the earliest safe step'
+          : 'stored onboarding step is permissions',
+    };
   }
 
   if (onboardingStep === 'channels') {
-    return 'channels';
+    return {
+      renderStep: 'channels',
+      reason: 'stored onboarding step is channels',
+    };
   }
 
   if (onboardingStep === 'provisioning') {
-    return 'provisioning';
+    return {
+      renderStep: 'provisioning',
+      reason: 'stored onboarding step is provisioning',
+    };
   }
 
   if (onboardingStep === 'pairing' && hasPairingStep) {
-    return 'pairing';
+    return {
+      renderStep: 'pairing',
+      reason: 'stored onboarding step is pairing and the selected channel requires pairing',
+    };
   }
 
-  return 'complete';
+  return {
+    renderStep: 'complete',
+    reason: 'no earlier step matched, so the flow falls through to complete',
+  };
+}
+
+function logClawOnboardingFlowStateDecision({
+  status,
+  mode,
+  createSetupStarted,
+  onboardingStep,
+  selectedPreset,
+  hasBotIdentity,
+  selectedChannelId,
+  gatewayState,
+  debugLogSource,
+  instanceStatus,
+  isRunning,
+  gatewayReady,
+  instanceRunning,
+  createSetupActive,
+  postProvisioningReady,
+  hasPairingStep,
+  totalSteps,
+  renderStepDecision,
+}: ClawOnboardingFlowDebugLogInput): void {
+  if (typeof window === 'undefined') return;
+
+  const input = JSON.stringify(
+    {
+      mode,
+      createSetupStarted,
+      onboardingStep,
+      selectedPreset,
+      hasBotIdentity,
+      selectedChannelId,
+      gatewayState: gatewayState ?? null,
+      status: status?.status ?? null,
+      hasStatusResponse: status !== undefined,
+    },
+    null,
+    2
+  );
+  const derived = JSON.stringify(
+    {
+      instanceStatus: instanceStatus?.status ?? null,
+      isRunning,
+      gatewayReady,
+      instanceRunning,
+      createSetupActive,
+      postProvisioningReady,
+      hasPairingStep,
+      totalSteps,
+    },
+    null,
+    2
+  );
+  const decision = JSON.stringify(renderStepDecision, null, 2);
+  const previousSnapshot = clawOnboardingFlowDebugSnapshots.get(debugLogSource);
+  const inputChanged = previousSnapshot?.input !== input;
+  const derivedChanged = previousSnapshot?.derived !== derived;
+  const decisionChanged = previousSnapshot?.decision !== decision;
+
+  if (!inputChanged && !derivedChanged && !decisionChanged) return;
+
+  const loggedAtMs = window.performance.now();
+  const elapsedMs =
+    previousSnapshot === undefined ? null : loggedAtMs - previousSnapshot.loggedAtMs;
+  const changedSections =
+    previousSnapshot === undefined
+      ? 'initial'
+      : [
+          inputChanged ? 'input' : '',
+          derivedChanged ? 'derived' : '',
+          decisionChanged ? 'decision' : '',
+        ]
+          .filter(section => section !== '')
+          .join(', ');
+
+  clawOnboardingFlowDebugSnapshots.set(debugLogSource, {
+    input,
+    derived,
+    decision,
+    loggedAtMs,
+  });
+
+  console.debug(
+    `[ClawOnboardingFlow:${debugLogSource}] state decision at ${new Date().toISOString()} (${elapsedMs === null ? 'first log' : `+${elapsedMs.toFixed(1)}ms`}; changed: ${changedSections})\ninput:\n${input}\nderived:\n${derived}\ndecision:\n${decision}`
+  );
 }

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
@@ -40,6 +40,17 @@ export const CLAW_ONBOARDING_FAKE_STEPS = [
   'error',
 ] satisfies ClawOnboardingRenderStep[];
 
+export const CLAW_ONBOARDING_PROVISIONING_STATUSES = [
+  'provisioned',
+  'starting',
+  'restarting',
+  'recovering',
+  'destroying',
+  'restoring',
+] satisfies PopulatedClawStatus['status'][];
+
+export const CLAW_ONBOARDING_ERROR_STATUSES = ['stopped'] satisfies PopulatedClawStatus['status'][];
+
 export function parseClawOnboardingFakeStep(value: string | null): ClawOnboardingRenderStep | null {
   for (const step of CLAW_ONBOARDING_FAKE_STEPS) {
     if (value === step) return step;
@@ -79,6 +90,13 @@ export function hasPopulatedStatus(
 
 export function isPairingChannel(channelId: string | null): channelId is PairingChannelId {
   return channelId === 'telegram' || channelId === 'discord';
+}
+
+export function isClawOnboardingErrorStatus(status: PopulatedClawStatus['status']): boolean {
+  for (const errorStatus of CLAW_ONBOARDING_ERROR_STATUSES) {
+    if (status === errorStatus) return true;
+  }
+  return false;
 }
 
 export function getClawOnboardingFlowState({
@@ -193,10 +211,10 @@ function getRenderStepDecision({
   hasBotIdentity,
   hasPairingStep,
 }: RenderStepInput): RenderStepDecision {
-  if (instanceStatus?.status === 'stopped') {
+  if (instanceStatus && isClawOnboardingErrorStatus(instanceStatus.status)) {
     return {
       renderStep: 'error',
-      reason: 'instance status is stopped, so setup cannot continue automatically',
+      reason: `instance status is ${instanceStatus.status}, so setup cannot continue automatically`,
     };
   }
 

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -54,12 +54,14 @@ export function ClawOnboardingFlow({
   status,
   mode,
   organizationId,
+  createFlowStarted = false,
   onCreateFlowStarted,
   onCreateFlowFailed,
 }: {
   status: KiloClawDashboardStatus | undefined;
   mode: ClawOnboardingMode;
   organizationId?: string;
+  createFlowStarted?: boolean;
   onCreateFlowStarted?: () => void;
   onCreateFlowFailed?: () => void;
 }) {
@@ -68,6 +70,7 @@ export function ClawOnboardingFlow({
       <ClawOnboardingFlowInner
         status={status}
         mode={mode}
+        createFlowStarted={createFlowStarted}
         onCreateFlowStarted={onCreateFlowStarted}
         onCreateFlowFailed={onCreateFlowFailed}
       />
@@ -78,11 +81,13 @@ export function ClawOnboardingFlow({
 function ClawOnboardingFlowInner({
   status,
   mode,
+  createFlowStarted,
   onCreateFlowStarted,
   onCreateFlowFailed,
 }: {
   status: KiloClawDashboardStatus | undefined;
   mode: ClawOnboardingMode;
+  createFlowStarted: boolean;
   onCreateFlowStarted?: () => void;
   onCreateFlowFailed?: () => void;
 }) {
@@ -99,9 +104,10 @@ function ClawOnboardingFlowInner({
   const [botIdentity, setBotIdentity] = useState<BotIdentity | null>(null);
   const [channelTokens, setChannelTokens] = useState<Record<string, string> | null>(null);
   const [selectedChannelId, setSelectedChannelId] = useState<string | null>(null);
-  const [createSetupStarted, setCreateSetupStarted] = useState(false);
+  const [localCreateSetupStarted, setLocalCreateSetupStarted] = useState(false);
   const hasCapturedIdentityView = useRef(false);
   const hasCapturedDoneView = useRef(false);
+  const createSetupStarted = createFlowStarted || localCreateSetupStarted;
 
   const stateInput = {
     status,
@@ -115,6 +121,7 @@ function ClawOnboardingFlowInner({
   const preGatewayFlowState = getClawOnboardingFlowState({
     ...stateInput,
     gatewayState: null,
+    debugLogSource: 'pre-gateway',
   });
 
   const personalGateway = useKiloClawGatewayStatus(
@@ -128,6 +135,7 @@ function ClawOnboardingFlowInner({
   const flowState = getClawOnboardingFlowState({
     ...stateInput,
     gatewayState: gatewayStatus?.state ?? null,
+    debugLogSource: 'gateway',
   });
 
   const { data: isServiceDegraded } = useClawServiceDegraded();
@@ -160,13 +168,13 @@ function ClawOnboardingFlowInner({
   }, []);
 
   const handleCreateFlowStarted = useCallback(() => {
-    setCreateSetupStarted(true);
+    setLocalCreateSetupStarted(true);
     resetWizardSelections();
     onCreateFlowStarted?.();
   }, [onCreateFlowStarted, resetWizardSelections]);
 
   const handleCreateFlowFailed = useCallback(() => {
-    setCreateSetupStarted(false);
+    setLocalCreateSetupStarted(false);
     hasCapturedIdentityView.current = false;
     resetWizardSelections();
     onCreateFlowFailed?.();
@@ -304,6 +312,10 @@ function ClawOnboardingFlowInner({
     );
   }
 
+  function renderErrorStep() {
+    return <ClawSetupErrorStep basePath={basePath} />;
+  }
+
   function renderStepContent() {
     const renderStep = flowState.renderStep;
 
@@ -322,6 +334,8 @@ function ClawOnboardingFlowInner({
         return renderPairingStep();
       case 'complete':
         return renderCompleteStep();
+      case 'error':
+        return renderErrorStep();
       default:
         return assertNever(renderStep);
     }
@@ -364,6 +378,42 @@ function ClawOnboardingFlowInner({
         {renderStepContent()}
       </MaybeBillingWrapper>
     </div>
+  );
+}
+
+export function ClawSetupErrorStep({ basePath }: { basePath: string }) {
+  return (
+    <Card className="mt-6 overflow-hidden">
+      <CardContent className="flex flex-col items-center justify-center gap-6 pt-12">
+        <div className="flex h-20 w-20 items-center justify-center rounded-2xl border border-destructive/30 bg-destructive/10">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full border-2 border-destructive">
+            <TriangleAlert className="h-6 w-6 text-destructive" />
+          </div>
+        </div>
+
+        <div className="flex flex-col items-center gap-2">
+          <h2 className="text-2xl font-bold">Something went wrong</h2>
+          <p className="text-muted-foreground max-w-md text-center">
+            Your KiloClaw instance stopped during setup. Please reach out to support for help
+            getting it back online.
+          </p>
+        </div>
+
+        <div className="flex w-full flex-col gap-3">
+          <Button asChild variant="primary" className="w-full min-w-[180px] py-6 text-base">
+            <a href="https://kilo.ai/support" target="_blank" rel="noopener noreferrer">
+              Contact Support
+            </a>
+          </Button>
+          <Button asChild className="w-full py-6 text-base" variant="outline">
+            <Link href={basePath}>
+              <X className="mr-2 h-4 w-4" />
+              Close Wizard
+            </Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/apps/web/src/app/(app)/claw/new/ClawNewClient.tsx
+++ b/apps/web/src/app/(app)/claw/new/ClawNewClient.tsx
@@ -52,6 +52,7 @@ function ClawNewLoader({
       <ClawOnboardingFlow
         status={status}
         mode={mode}
+        createFlowStarted={createFlowStartedAt !== null}
         onCreateFlowStarted={onCreateFlowStarted}
         onCreateFlowFailed={onCreateFlowFailed}
       />
@@ -71,6 +72,7 @@ function ClawNewLoader({
     <ClawOnboardingWithBoundary
       statusQuery={statusQueryForBoundary}
       mode={mode}
+      createFlowStarted={createFlowStartedAt !== null}
       onCreateFlowStarted={onCreateFlowStarted}
     />
   );

--- a/apps/web/src/app/(app)/claw/new/ClawNewClient.tsx
+++ b/apps/web/src/app/(app)/claw/new/ClawNewClient.tsx
@@ -74,6 +74,7 @@ function ClawNewLoader({
       mode={mode}
       createFlowStarted={createFlowStartedAt !== null}
       onCreateFlowStarted={onCreateFlowStarted}
+      onCreateFlowFailed={onCreateFlowFailed}
     />
   );
 }

--- a/apps/web/src/app/(app)/organizations/[id]/claw/new/OrgClawNewClient.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/claw/new/OrgClawNewClient.tsx
@@ -53,6 +53,7 @@ function OrgClawNewLiveClient({ organizationId }: { organizationId: string }) {
         status={createStatus}
         mode="create-first"
         organizationId={organizationId}
+        createFlowStarted
         onCreateFlowStarted={onCreateFlowStarted}
         onCreateFlowFailed={onCreateFlowFailed}
       />
@@ -65,6 +66,7 @@ function OrgClawNewLiveClient({ organizationId }: { organizationId: string }) {
         statusQuery={statusQuery}
         mode="post-provisioning"
         organizationId={organizationId}
+        createFlowStarted={createFlowStartedAt !== null}
         onCreateFlowStarted={onCreateFlowStarted}
       />
     );
@@ -78,6 +80,7 @@ function OrgClawNewLiveClient({ organizationId }: { organizationId: string }) {
         statusQuery={{ data: undefined, isLoading: true, error: null }}
         mode="post-provisioning"
         organizationId={organizationId}
+        createFlowStarted={createFlowStartedAt !== null}
         onCreateFlowStarted={onCreateFlowStarted}
       />
     );
@@ -92,6 +95,7 @@ function OrgClawNewLiveClient({ organizationId }: { organizationId: string }) {
       statusQuery={{ ...statusQuery, data: settledStatus }}
       mode={mode}
       organizationId={organizationId}
+      createFlowStarted={createFlowStartedAt !== null}
       onCreateFlowStarted={onCreateFlowStarted}
     />
   );

--- a/apps/web/src/app/(app)/organizations/[id]/claw/new/OrgClawNewClient.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/claw/new/OrgClawNewClient.tsx
@@ -68,6 +68,7 @@ function OrgClawNewLiveClient({ organizationId }: { organizationId: string }) {
         organizationId={organizationId}
         createFlowStarted={createFlowStartedAt !== null}
         onCreateFlowStarted={onCreateFlowStarted}
+        onCreateFlowFailed={onCreateFlowFailed}
       />
     );
   }
@@ -82,6 +83,7 @@ function OrgClawNewLiveClient({ organizationId }: { organizationId: string }) {
         organizationId={organizationId}
         createFlowStarted={createFlowStartedAt !== null}
         onCreateFlowStarted={onCreateFlowStarted}
+        onCreateFlowFailed={onCreateFlowFailed}
       />
     );
   }
@@ -97,6 +99,7 @@ function OrgClawNewLiveClient({ organizationId }: { organizationId: string }) {
       organizationId={organizationId}
       createFlowStarted={createFlowStartedAt !== null}
       onCreateFlowStarted={onCreateFlowStarted}
+      onCreateFlowFailed={onCreateFlowFailed}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Add structured KiloClaw onboarding state-machine debug logs that only emit when input, derived state, or decision snapshots change.
- Advance create-first onboarding immediately after provisioning is requested, before status polling reports a starting instance.
- Route stopped instances to a support-oriented error screen instead of leaving users on the provisioning step.

## Visual Changes

<img width="902" height="852" alt="CleanShot 2026-04-16 at 11 09 59@2x" src="https://github.com/user-attachments/assets/25c1c821-ff83-4214-849a-de693d5c98ad" />

https://github.com/user-attachments/assets/41985d67-e25d-4802-bf6f-06ff81f25ccd
