### PR TITLE
feat(cron): add hourly cleanup for stale free_model_usage records

### DIFF
--- a/apps/web/src/app/api/cron/cleanup-free-model-usage/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-free-model-usage/route.test.ts
@@ -1,0 +1,129 @@
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/config.server', () => ({
+  CRON_SECRET: 'cron-secret',
+}));
+
+import { db, sql } from '@/lib/drizzle';
+import { free_model_usage } from '@kilocode/db/schema';
+import { GET } from './route';
+
+function daysAgo(days: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date.toISOString();
+}
+
+function makeRequest(headers?: Record<string, string>) {
+  return new NextRequest('http://localhost:3000/api/cron/cleanup-free-model-usage', {
+    method: 'GET',
+    headers,
+  });
+}
+
+async function insertUsageRecord(created_at: string, model = 'test-model', ip = '127.0.0.1') {
+  const [row] = await db
+    .insert(free_model_usage)
+    .values({ ip_address: ip, model, created_at })
+    .returning();
+  return row;
+}
+
+describe('GET /api/cron/cleanup-free-model-usage', () => {
+  beforeEach(async () => {
+    await db.delete(free_model_usage).where(sql`true`);
+  });
+
+  it('rejects requests without authorization header', async () => {
+    const response = await GET(makeRequest());
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+  });
+
+  it('rejects requests with wrong authorization header', async () => {
+    const response = await GET(makeRequest({ authorization: 'Bearer wrong-secret' }));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+  });
+
+  it('returns zero deleted when table is empty', async () => {
+    const response = await GET(makeRequest({ authorization: 'Bearer cron-secret' }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.deletedCount).toBe(0);
+    expect(body.iterations).toBe(1);
+    expect(body.cutoffDate).toEqual(expect.any(String));
+    expect(body.timestamp).toEqual(expect.any(String));
+  });
+
+  it('deletes records older than 7 days', async () => {
+    await insertUsageRecord(daysAgo(10));
+    await insertUsageRecord(daysAgo(8));
+    await insertUsageRecord(daysAgo(14));
+
+    const response = await GET(makeRequest({ authorization: 'Bearer cron-secret' }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.deletedCount).toBe(3);
+
+    const remaining = await db.select().from(free_model_usage);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('preserves records newer than 7 days', async () => {
+    await insertUsageRecord(daysAgo(1));
+    await insertUsageRecord(daysAgo(3));
+    await insertUsageRecord(new Date().toISOString());
+
+    const response = await GET(makeRequest({ authorization: 'Bearer cron-secret' }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.deletedCount).toBe(0);
+
+    const remaining = await db.select().from(free_model_usage);
+    expect(remaining).toHaveLength(3);
+  });
+
+  it('deletes only expired records and preserves recent ones', async () => {
+    await insertUsageRecord(daysAgo(10));
+    await insertUsageRecord(daysAgo(30));
+    const recent1 = await insertUsageRecord(daysAgo(1));
+    const recent2 = await insertUsageRecord(daysAgo(5));
+    const recent3 = await insertUsageRecord(new Date().toISOString());
+
+    const response = await GET(makeRequest({ authorization: 'Bearer cron-secret' }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.deletedCount).toBe(2);
+
+    const remaining = await db.select().from(free_model_usage);
+    expect(remaining).toHaveLength(3);
+
+    const remainingIds = remaining.map(r => r.id).sort();
+    const expectedIds = [recent1.id, recent2.id, recent3.id].sort();
+    expect(remainingIds).toEqual(expectedIds);
+  });
+
+  it('does not delete records right at the 7-day boundary', async () => {
+    // Record created exactly 6 days and 23 hours ago should be preserved
+    const almostExpired = await insertUsageRecord(daysAgo(6));
+    // Record created 7+ days ago should be deleted
+    await insertUsageRecord(daysAgo(8));
+
+    const response = await GET(makeRequest({ authorization: 'Bearer cron-secret' }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.deletedCount).toBe(1);
+
+    const remaining = await db.select().from(free_model_usage);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe(almostExpired.id);
+  });
+});

--- a/apps/web/src/app/api/cron/cleanup-free-model-usage/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-free-model-usage/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/drizzle';
 import { free_model_usage } from '@kilocode/db/schema';
-import { lt, inArray, sql } from 'drizzle-orm';
+import { lt, inArray } from 'drizzle-orm';
 import { CRON_SECRET } from '@/lib/config.server';
 
 const RETENTION_DAYS = 7;

--- a/apps/web/src/app/api/cron/cleanup-free-model-usage/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-free-model-usage/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/drizzle';
 import { free_model_usage } from '@kilocode/db/schema';
-import { lt, inArray } from 'drizzle-orm';
+import { and, asc, lt, lte } from 'drizzle-orm';
 import { CRON_SECRET } from '@/lib/config.server';
 
 const RETENTION_DAYS = 7;
@@ -29,16 +29,24 @@ export async function GET(request: Request) {
   let iterations = 0;
 
   for (let i = 0; i < MAX_ITERATIONS; i++) {
+    // Find the created_at of the BATCH_SIZE-th oldest expired row to use as a batch boundary.
+    // This avoids passing 50k IDs and lets the DELETE use the created_at index directly.
+    const boundary = await db
+      .select({ created_at: free_model_usage.created_at })
+      .from(free_model_usage)
+      .where(lt(free_model_usage.created_at, cutoffDate))
+      .orderBy(asc(free_model_usage.created_at))
+      .offset(BATCH_SIZE - 1)
+      .limit(1);
+
+    const batchCutoff = boundary.length > 0 ? boundary[0].created_at : cutoffDate;
+
     const result = await db
       .delete(free_model_usage)
       .where(
-        inArray(
-          free_model_usage.id,
-          db
-            .select({ id: free_model_usage.id })
-            .from(free_model_usage)
-            .where(lt(free_model_usage.created_at, cutoffDate))
-            .limit(BATCH_SIZE)
+        and(
+          lt(free_model_usage.created_at, cutoffDate),
+          lte(free_model_usage.created_at, batchCutoff)
         )
       );
 
@@ -46,7 +54,8 @@ export async function GET(request: Request) {
     totalDeleted += deleted;
     iterations++;
 
-    if (deleted < BATCH_SIZE) {
+    // If there was no boundary row, we've deleted everything below the cutoff
+    if (boundary.length === 0 || deleted === 0) {
       break;
     }
 

--- a/apps/web/src/app/api/cron/cleanup-free-model-usage/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-free-model-usage/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/drizzle';
+import { free_model_usage } from '@kilocode/db/schema';
+import { lt, inArray, sql } from 'drizzle-orm';
+import { CRON_SECRET } from '@/lib/config.server';
+
+const RETENTION_DAYS = 7;
+const BATCH_SIZE = 50_000;
+const MAX_ITERATIONS = 20;
+const PAUSE_BETWEEN_BATCHES_MS = 500;
+
+function getDaysAgo(days: number) {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date;
+}
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function GET(request: Request) {
+  if (!CRON_SECRET || request.headers.get('authorization') !== `Bearer ${CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const cutoffDate = getDaysAgo(RETENTION_DAYS).toISOString();
+  let totalDeleted = 0;
+  let iterations = 0;
+
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    const result = await db
+      .delete(free_model_usage)
+      .where(
+        inArray(
+          free_model_usage.id,
+          db
+            .select({ id: free_model_usage.id })
+            .from(free_model_usage)
+            .where(lt(free_model_usage.created_at, cutoffDate))
+            .limit(BATCH_SIZE)
+        )
+      );
+
+    const deleted = result.rowCount ?? 0;
+    totalDeleted += deleted;
+    iterations++;
+
+    if (deleted < BATCH_SIZE) {
+      break;
+    }
+
+    await sleep(PAUSE_BETWEEN_BATCHES_MS);
+  }
+
+  return NextResponse.json({
+    deletedCount: totalDeleted,
+    iterations,
+    cutoffDate,
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/apps/web/src/app/api/cron/cleanup-free-model-usage/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-free-model-usage/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/drizzle';
 import { free_model_usage } from '@kilocode/db/schema';
-import { and, asc, lt, lte } from 'drizzle-orm';
+import { asc, lt, lte } from 'drizzle-orm';
 import { CRON_SECRET } from '@/lib/config.server';
 
 const RETENTION_DAYS = 7;
@@ -39,23 +39,23 @@ export async function GET(request: Request) {
       .offset(BATCH_SIZE - 1)
       .limit(1);
 
-    const batchCutoff = boundary.length > 0 ? boundary[0].created_at : cutoffDate;
+    // No boundary row means fewer than BATCH_SIZE expired rows remain — this is the final batch
+    const isFinalBatch = boundary.length === 0;
+    const batchCutoff = isFinalBatch ? cutoffDate : boundary[0].created_at;
 
     const result = await db
       .delete(free_model_usage)
       .where(
-        and(
-          lt(free_model_usage.created_at, cutoffDate),
-          lte(free_model_usage.created_at, batchCutoff)
-        )
+        isFinalBatch
+          ? lt(free_model_usage.created_at, batchCutoff)
+          : lte(free_model_usage.created_at, batchCutoff)
       );
 
     const deleted = result.rowCount ?? 0;
     totalDeleted += deleted;
     iterations++;
 
-    // If there was no boundary row, we've deleted everything below the cutoff
-    if (boundary.length === 0 || deleted === 0) {
+    if (isFinalBatch || deleted === 0) {
       break;
     }
 

--- a/apps/web/src/app/api/cron/cleanup-free-model-usage/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-free-model-usage/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/drizzle';
 import { free_model_usage } from '@kilocode/db/schema';
-import { asc, lt, lte } from 'drizzle-orm';
+import { asc, lt } from 'drizzle-orm';
 import { CRON_SECRET } from '@/lib/config.server';
 
 const RETENTION_DAYS = 7;
@@ -30,7 +30,6 @@ export async function GET(request: Request) {
 
   for (let i = 0; i < MAX_ITERATIONS; i++) {
     // Find the created_at of the BATCH_SIZE-th oldest expired row to use as a batch boundary.
-    // This avoids passing 50k IDs and lets the DELETE use the created_at index directly.
     const boundary = await db
       .select({ created_at: free_model_usage.created_at })
       .from(free_model_usage)
@@ -39,23 +38,15 @@ export async function GET(request: Request) {
       .offset(BATCH_SIZE - 1)
       .limit(1);
 
-    // No boundary row means fewer than BATCH_SIZE expired rows remain — this is the final batch
-    const isFinalBatch = boundary.length === 0;
-    const batchCutoff = isFinalBatch ? cutoffDate : boundary[0].created_at;
+    const batchCutoff = boundary.length > 0 ? boundary[0].created_at : cutoffDate;
 
-    const result = await db
-      .delete(free_model_usage)
-      .where(
-        isFinalBatch
-          ? lt(free_model_usage.created_at, batchCutoff)
-          : lte(free_model_usage.created_at, batchCutoff)
-      );
+    const result = await db.delete(free_model_usage).where(lt(free_model_usage.created_at, batchCutoff));
 
     const deleted = result.rowCount ?? 0;
     totalDeleted += deleted;
     iterations++;
 
-    if (isFinalBatch || deleted === 0) {
+    if (boundary.length === 0 || deleted === 0) {
       break;
     }
 

--- a/apps/web/src/app/api/cron/cleanup-free-model-usage/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-free-model-usage/route.ts
@@ -40,7 +40,9 @@ export async function GET(request: Request) {
 
     const batchCutoff = boundary.length > 0 ? boundary[0].created_at : cutoffDate;
 
-    const result = await db.delete(free_model_usage).where(lt(free_model_usage.created_at, batchCutoff));
+    const result = await db
+      .delete(free_model_usage)
+      .where(lt(free_model_usage.created_at, batchCutoff));
 
     const deleted = result.rowCount ?? 0;
     totalDeleted += deleted;

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -47,6 +47,10 @@
     {
       "path": "/api/cron/exa-partition-maintenance",
       "schedule": "0 0 1 * *"
+    },
+    {
+      "path": "/api/cron/cleanup-free-model-usage",
+      "schedule": "0 * * * *"
     }
   ],
   "build": {


### PR DESCRIPTION
## Summary

Adds an hourly cron job that deletes `free_model_usage` records older than 7 days. The table receives ~165k inserts/hour for rate limiting, but records beyond the rate-limit window are dead weight. The cleanup runs in batches of 50k rows with 500ms pauses between iterations (capped at 20 iterations / 1M rows per run) to avoid long-running transactions and excessive DB load.

## Verification

- [x] `pnpm typecheck` passes
- [x] `pnpm format` applied
- [ ] No manual testing — this is a new cron endpoint that will be triggered by Vercel's cron scheduler. The batched delete pattern mirrors `cleanup-api-request-log` with added batching.

## Visual Changes

N/A

## Reviewer Notes

- On first deploy there will be a large backlog of old records. The 1M-per-run cap means it will take several hourly runs to clear the backlog rather than hammering the DB in one go.
- The `idx_free_model_usage_created_at` index supports the `WHERE created_at < cutoff` filter efficiently.
- The subquery uses `SELECT id ... LIMIT 50000` to scope each DELETE to a fixed batch size, since Drizzle doesn't support `DELETE ... LIMIT` directly.
