### PR TITLE
feat(users): populate normalized_email on user creation and show in admin

### DIFF
--- a/apps/web/src/app/admin/api/backfills/normalized-email/route.ts
+++ b/apps/web/src/app/admin/api/backfills/normalized-email/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from 'next/server';
+import { getUserFromAuth } from '@/lib/user.server';
+import { db } from '@/lib/drizzle';
+import { kilocode_users } from '@kilocode/db';
+import { isNull, count, sql } from 'drizzle-orm';
+import { normalizeEmail } from '@/lib/utils';
+
+export type NormalizedEmailCountsResponse = {
+  missing: number;
+};
+
+export type NormalizedEmailBackfillResponse = {
+  processed: number;
+  remaining: boolean;
+};
+
+export async function GET(): Promise<
+  NextResponse<NormalizedEmailCountsResponse | { error: string }>
+> {
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) return authFailedResponse;
+
+  const [result] = await db
+    .select({ count: count() })
+    .from(kilocode_users)
+    .where(isNull(kilocode_users.normalized_email));
+
+  return NextResponse.json({ missing: result?.count ?? 0 });
+}
+
+const BATCH_SIZE = 1000;
+const BATCHES_PER_REQUEST = 50;
+
+export async function POST(): Promise<
+  NextResponse<NormalizedEmailBackfillResponse | { error: string }>
+> {
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) return authFailedResponse;
+
+  let totalProcessed = 0;
+
+  for (let i = 0; i < BATCHES_PER_REQUEST; i++) {
+    const rows = await db
+      .select({ id: kilocode_users.id, google_user_email: kilocode_users.google_user_email })
+      .from(kilocode_users)
+      .where(isNull(kilocode_users.normalized_email))
+      .limit(BATCH_SIZE);
+
+    if (rows.length === 0) break;
+
+    const updates = rows.map(row => ({
+      id: row.id,
+      normalized_email: normalizeEmail(row.google_user_email),
+    }));
+
+    await db.execute(sql`
+      UPDATE ${kilocode_users}
+      SET normalized_email = email_updates.normalized_email
+      FROM (VALUES ${sql.join(
+        updates.map(u => sql`(${u.id}, ${u.normalized_email})`),
+        sql`, `
+      )}) AS email_updates(id, normalized_email)
+      WHERE ${kilocode_users.id} = email_updates.id
+    `);
+
+    totalProcessed += rows.length;
+
+    if (rows.length < BATCH_SIZE) break;
+  }
+
+  return NextResponse.json({
+    processed: totalProcessed,
+    remaining: totalProcessed === BATCH_SIZE * BATCHES_PER_REQUEST,
+  });
+}

--- a/apps/web/src/app/admin/backfills/page.tsx
+++ b/apps/web/src/app/admin/backfills/page.tsx
@@ -1,0 +1,34 @@
+import { SafetyIdentifiersBackfill } from '../components/SafetyIdentifiersBackfill';
+import { NormalizedEmailBackfill } from '../components/NormalizedEmailBackfill';
+import { SafetyIdentifierHashGenerator } from '../components/SafetyIdentifierHashGenerator';
+import AdminPage from '../components/AdminPage';
+import { BreadcrumbItem, BreadcrumbPage } from '@/components/ui/breadcrumb';
+
+const breadcrumbs = (
+  <>
+    <BreadcrumbItem>
+      <BreadcrumbPage>Backfills</BreadcrumbPage>
+    </BreadcrumbItem>
+  </>
+);
+
+export default function BackfillsPage() {
+  return (
+    <AdminPage breadcrumbs={breadcrumbs}>
+      <div className="flex w-full flex-col gap-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-bold">Normalized Email Backfill</h2>
+        </div>
+        <NormalizedEmailBackfill />
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-bold">Safety Identifier Backfill</h2>
+        </div>
+        <SafetyIdentifiersBackfill />
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-bold">Hash Generator</h2>
+        </div>
+        <SafetyIdentifierHashGenerator />
+      </div>
+    </AdminPage>
+  );
+}

--- a/apps/web/src/app/admin/components/AppSidebar.tsx
+++ b/apps/web/src/app/admin/components/AppSidebar.tsx
@@ -74,8 +74,8 @@ const userManagementItems: MenuItem[] = [
     icon: () => <Shield />,
   },
   {
-    title: () => 'Safety Identifiers',
-    url: '/admin/safety-identifiers',
+    title: () => 'Backfills',
+    url: '/admin/backfills',
     icon: () => <KeyRound />,
   },
 ];

--- a/apps/web/src/app/admin/components/NormalizedEmailBackfill.tsx
+++ b/apps/web/src/app/admin/components/NormalizedEmailBackfill.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import type {
+  NormalizedEmailCountsResponse,
+  NormalizedEmailBackfillResponse,
+} from '../api/backfills/normalized-email/route';
+
+type BatchLog = {
+  processed: number;
+  timestamp: Date;
+};
+
+export function NormalizedEmailBackfill() {
+  const [logs, setLogs] = useState<BatchLog[]>([]);
+  const queryClient = useQueryClient();
+
+  const { data: counts, isLoading } = useQuery<NormalizedEmailCountsResponse>({
+    queryKey: ['normalized-email-counts'],
+    queryFn: async () => {
+      const res = await fetch('/admin/api/backfills/normalized-email');
+      return res.json() as Promise<NormalizedEmailCountsResponse>;
+    },
+    refetchInterval: false,
+  });
+
+  const mutation = useMutation<NormalizedEmailBackfillResponse, Error>({
+    mutationFn: async () => {
+      const res = await fetch('/admin/api/backfills/normalized-email', { method: 'POST' });
+      if (!res.ok) {
+        const body = (await res.json()) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      return res.json() as Promise<NormalizedEmailBackfillResponse>;
+    },
+    onSuccess: data => {
+      setLogs(prev => [{ processed: data.processed, timestamp: new Date() }, ...prev]);
+      void queryClient.invalidateQueries({ queryKey: ['normalized-email-counts'] });
+    },
+  });
+
+  const isDone = counts?.missing === 0;
+
+  return (
+    <div className="space-y-6">
+      <p className="text-muted-foreground text-sm">
+        Backfill normalized emails for users missing the field. Normalization lowercases the
+        address, strips + aliases, and removes dots from Gmail local parts. Each click processes up
+        to 50 000 users. Click repeatedly until the counter reaches zero.
+      </p>
+
+      <div className="bg-background space-y-4 rounded-lg border p-6">
+        <div className="flex items-center gap-3">
+          <span className="font-medium">Users missing a normalized email</span>
+          {isLoading ? (
+            <Badge variant="secondary">Loading...</Badge>
+          ) : isDone ? (
+            <Badge variant="default" className="bg-green-600">
+              All filled
+            </Badge>
+          ) : (
+            <Badge variant="destructive">{(counts?.missing ?? 0).toLocaleString()} missing</Badge>
+          )}
+        </div>
+
+        {mutation.isError && (
+          <Alert variant="destructive">
+            <AlertDescription>{mutation.error.message}</AlertDescription>
+          </Alert>
+        )}
+
+        <Button
+          onClick={() => mutation.mutate()}
+          disabled={isLoading || isDone || mutation.isPending}
+          variant={isDone ? 'outline' : 'default'}
+        >
+          {mutation.isPending
+            ? 'Backfilling...'
+            : isDone
+              ? 'Nothing to do'
+              : 'Backfill next 50 000'}
+        </Button>
+      </div>
+
+      {logs.length > 0 && (
+        <div className="bg-background space-y-2 rounded-lg border p-4">
+          <h4 className="text-sm font-medium">Batch log</h4>
+          <div className="space-y-1 font-mono text-xs">
+            {logs.map((log, i) => (
+              <div key={i} className="text-muted-foreground flex gap-2">
+                <span className="shrink-0">{log.timestamp.toLocaleTimeString()}</span>
+                <span>processed {log.processed.toLocaleString()} users</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.tsx
@@ -105,6 +105,10 @@ export function UserAdminAccountInfo(user: UserAdminAccountInfoProps) {
           <Field label="Email">
             {user.google_user_email} <CopyTextButton text={user.google_user_email} />
           </Field>
+          <Field label="Normalized Email">
+            {user.normalized_email ?? <span className="text-muted-foreground">N/A</span>}
+            {user.normalized_email ? <CopyTextButton text={user.normalized_email} /> : null}
+          </Field>
           <Field label="Hosted Domain">
             {user.hosted_domain || 'N/A'}
             {user.hosted_domain ? <CopyTextButton text={user.hosted_domain} /> : null}

--- a/apps/web/src/app/admin/safety-identifiers/page.tsx
+++ b/apps/web/src/app/admin/safety-identifiers/page.tsx
@@ -1,29 +1,5 @@
-import { SafetyIdentifiersBackfill } from '../components/SafetyIdentifiersBackfill';
-import { SafetyIdentifierHashGenerator } from '../components/SafetyIdentifierHashGenerator';
-import AdminPage from '../components/AdminPage';
-import { BreadcrumbItem, BreadcrumbPage } from '@/components/ui/breadcrumb';
-
-const breadcrumbs = (
-  <>
-    <BreadcrumbItem>
-      <BreadcrumbPage>Safety Identifiers</BreadcrumbPage>
-    </BreadcrumbItem>
-  </>
-);
+import { redirect } from 'next/navigation';
 
 export default function SafetyIdentifiersPage() {
-  return (
-    <AdminPage breadcrumbs={breadcrumbs}>
-      <div className="flex w-full flex-col gap-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-2xl font-bold">Safety Identifier Backfill</h2>
-        </div>
-        <SafetyIdentifiersBackfill />
-        <div className="flex items-center justify-between">
-          <h2 className="text-2xl font-bold">Hash Generator</h2>
-        </div>
-        <SafetyIdentifierHashGenerator />
-      </div>
-    </AdminPage>
-  );
+  redirect('/admin/backfills');
 }

--- a/apps/web/src/lib/user.test.ts
+++ b/apps/web/src/lib/user.test.ts
@@ -104,6 +104,7 @@ describe('User', () => {
     it('should anonymize the user row and preserve it', async () => {
       const user = await insertTestUser({
         google_user_email: 'real-email@example.com',
+        normalized_email: 'real-email@example.com',
         google_user_name: 'Real Name',
         google_user_image_url: 'https://example.com/avatar.png',
         linkedin_url: 'https://linkedin.com/in/testuser',
@@ -119,6 +120,7 @@ describe('User', () => {
       const softDeleted = await findUserById(user.id);
       expect(softDeleted).toBeDefined();
       expect(softDeleted!.google_user_email).toBe(`deleted+${user.id}@deleted.invalid`);
+      expect(softDeleted!.normalized_email).toBeNull();
       expect(softDeleted!.google_user_name).toBe('Deleted User');
       expect(softDeleted!.google_user_image_url).toBe('');
       expect(softDeleted!.hosted_domain).toBeNull();

--- a/apps/web/src/lib/user.ts
+++ b/apps/web/src/lib/user.ts
@@ -77,6 +77,7 @@ import {
   generateOpenRouterUpstreamSafetyIdentifier,
   generateVercelDownstreamSafetyIdentifier,
 } from '@/lib/ai-gateway/providerHash';
+import { normalizeEmail } from '@/lib/utils';
 import { recordAffiliateAttributionAndQueueParentEvent } from '@/lib/affiliate-events';
 
 const workos = new WorkOS(WORKOS_API_KEY);
@@ -328,6 +329,7 @@ export async function createOrUpdateUser(
     stripe_customer_id: stripeCustomer.id,
     openrouter_upstream_safety_identifier: generateOpenRouterUpstreamSafetyIdentifier(newUserId),
     vercel_downstream_safety_identifier: generateVercelDownstreamSafetyIdentifier(newUserId),
+    normalized_email: normalizeEmail(args.google_user_email),
   } satisfies typeof kilocode_users.$inferInsert;
 
   const savedUser = await db.transaction(async tx => {
@@ -564,6 +566,7 @@ export async function softDeleteUser(userId: string) {
       .update(kilocode_users)
       .set({
         google_user_email: `deleted+${userId}@deleted.invalid`,
+        normalized_email: null,
         google_user_name: 'Deleted User',
         google_user_image_url: '',
         hosted_domain: null,

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -175,6 +175,34 @@ export function getLowerDomainFromEmail(email: string): string | null {
 }
 
 /**
+ * Normalizes an email address for duplicate detection.
+ * - Lowercases the entire address
+ * - Strips `+` aliases (e.g. `user+tag@example.com` → `user@example.com`)
+ * - For Gmail/Googlemail: removes dots from the local part
+ */
+export function normalizeEmail(email: string): string {
+  const trimmed = email.trim().toLowerCase();
+  const atIndex = trimmed.lastIndexOf('@');
+  if (atIndex === -1) return trimmed;
+
+  let local = trimmed.slice(0, atIndex);
+  const domain = trimmed.slice(atIndex + 1);
+
+  // Strip +alias suffix
+  const plusIndex = local.indexOf('+');
+  if (plusIndex !== -1) {
+    local = local.slice(0, plusIndex);
+  }
+
+  // Gmail ignores dots in the local part
+  if (domain === 'gmail.com' || domain === 'googlemail.com') {
+    local = local.replace(/\./g, '');
+  }
+
+  return `${local}@${domain}`;
+}
+
+/**
  * Converts the first character of a string to uppercase.
  * Note: This is NOT full title-casing (e.g., "hello world" → "Hello world", not "Hello World")
  */


### PR DESCRIPTION
## Summary

Populates the `normalized_email` column (added in #2418) for new users at creation time. The normalization function lowercases the address, strips `+` aliases, and removes dots from Gmail/Googlemail local parts. The normalized email is now visible in the admin user detail screen and is cleared during GDPR soft-delete.

## Verification

- `pnpm typecheck` — passes
- `pnpm format` — passes
- `pnpm test -- apps/web/src/lib/user.test.ts -t "softDeleteUser"` — passes (includes new `normalized_email` assertion)

## Visual Changes

<img width="3320" height="402" alt="CleanShot 2026-04-16 at 14 16 18@2x" src="https://github.com/user-attachments/assets/4481dfe4-b607-4ad5-b990-fefa066358fb" />
<img width="1254" height="1582" alt="CleanShot 2026-04-16 at 15 43 37@2x" src="https://github.com/user-attachments/assets/6c3db2db-9b36-49ba-b6c6-4c14d8279634" />

## Reviewer Notes

- This only affects new user creation. Existing users will retain `normalized_email: null` until a backfill is run separately.
- The `normalizeEmail` function lives in `utils.ts` next to the existing `getLowerDomainFromEmail` for discoverability.
