### PR TITLE
feat(admin): add account deduplication page

### DIFF
--- a/apps/web/src/app/admin/account-deduplication/page.tsx
+++ b/apps/web/src/app/admin/account-deduplication/page.tsx
@@ -1,0 +1,24 @@
+import { AccountDeduplicationTable } from '../components/AccountDeduplicationTable';
+import AdminPage from '../components/AdminPage';
+import { BreadcrumbItem, BreadcrumbPage } from '@/components/ui/breadcrumb';
+
+const breadcrumbs = (
+  <>
+    <BreadcrumbItem>
+      <BreadcrumbPage>Account Deduplication</BreadcrumbPage>
+    </BreadcrumbItem>
+  </>
+);
+
+export default function AccountDeduplicationPage() {
+  return (
+    <AdminPage breadcrumbs={breadcrumbs}>
+      <div className="flex w-full flex-col gap-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-bold">Account Deduplication</h2>
+        </div>
+        <AccountDeduplicationTable />
+      </div>
+    </AdminPage>
+  );
+}

--- a/apps/web/src/app/admin/api/account-deduplication/route.ts
+++ b/apps/web/src/app/admin/api/account-deduplication/route.ts
@@ -95,7 +95,8 @@ export async function GET(
   // Group users by normalized_email
   const groupMap = new Map<string, DuplicateUser[]>();
   for (const user of users) {
-    const key = user.normalized_email!;
+    const key = user.normalized_email;
+    if (!key) continue;
     const existing = groupMap.get(key);
     if (existing) {
       existing.push(user as DuplicateUser);

--- a/apps/web/src/app/admin/api/account-deduplication/route.ts
+++ b/apps/web/src/app/admin/api/account-deduplication/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { getUserFromAuth } from '@/lib/user.server';
+import { db } from '@/lib/drizzle';
+import { kilocode_users } from '@kilocode/db';
+import { sql, isNotNull, inArray } from 'drizzle-orm';
+
+type DuplicateUser = {
+  id: string;
+  google_user_email: string;
+  normalized_email: string;
+  google_user_name: string;
+  google_user_image_url: string;
+  created_at: string;
+  blocked_reason: string | null;
+  microdollars_used: number;
+  total_microdollars_acquired: number;
+};
+
+type DuplicateGroup = {
+  normalized_email: string;
+  users: DuplicateUser[];
+};
+
+export type AccountDeduplicationResponse = {
+  groups: DuplicateGroup[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+};
+
+export async function GET(
+  request: NextRequest
+): Promise<NextResponse<AccountDeduplicationResponse | { error: string }>> {
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) return authFailedResponse;
+
+  const searchParams = request.nextUrl.searchParams;
+  const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
+  const limit = Math.min(50, Math.max(1, parseInt(searchParams.get('limit') ?? '20', 10)));
+
+  // Count distinct normalized_email values that appear more than once
+  const countRows = await db
+    .select({ normalized_email: kilocode_users.normalized_email })
+    .from(kilocode_users)
+    .where(isNotNull(kilocode_users.normalized_email))
+    .groupBy(kilocode_users.normalized_email)
+    .having(sql`count(*) > 1`);
+
+  const total = countRows.length;
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  const offset = (page - 1) * limit;
+
+  // Get the paginated set of duplicate normalized_email values
+  const duplicateEmailRows = await db
+    .select({ normalized_email: kilocode_users.normalized_email })
+    .from(kilocode_users)
+    .where(isNotNull(kilocode_users.normalized_email))
+    .groupBy(kilocode_users.normalized_email)
+    .having(sql`count(*) > 1`)
+    .orderBy(kilocode_users.normalized_email)
+    .limit(limit)
+    .offset(offset);
+
+  if (duplicateEmailRows.length === 0) {
+    return NextResponse.json({
+      groups: [],
+      pagination: { page, limit, total, totalPages },
+    });
+  }
+
+  const emailValues = duplicateEmailRows
+    .map(row => row.normalized_email)
+    .filter((e): e is string => e !== null);
+
+  // Fetch all users for those normalized emails
+  const users = await db
+    .select({
+      id: kilocode_users.id,
+      google_user_email: kilocode_users.google_user_email,
+      normalized_email: kilocode_users.normalized_email,
+      google_user_name: kilocode_users.google_user_name,
+      google_user_image_url: kilocode_users.google_user_image_url,
+      created_at: kilocode_users.created_at,
+      blocked_reason: kilocode_users.blocked_reason,
+      microdollars_used: kilocode_users.microdollars_used,
+      total_microdollars_acquired: kilocode_users.total_microdollars_acquired,
+    })
+    .from(kilocode_users)
+    .where(inArray(kilocode_users.normalized_email, emailValues))
+    .orderBy(kilocode_users.normalized_email, kilocode_users.created_at);
+
+  // Group users by normalized_email
+  const groupMap = new Map<string, DuplicateUser[]>();
+  for (const user of users) {
+    const key = user.normalized_email!;
+    const existing = groupMap.get(key);
+    if (existing) {
+      existing.push(user as DuplicateUser);
+    } else {
+      groupMap.set(key, [user as DuplicateUser]);
+    }
+  }
+
+  const groups: DuplicateGroup[] = emailValues.map(email => ({
+    normalized_email: email,
+    users: groupMap.get(email) ?? [],
+  }));
+
+  return NextResponse.json({
+    groups,
+    pagination: { page, limit, total, totalPages },
+  });
+}

--- a/apps/web/src/app/admin/components/AccountDeduplicationTable.tsx
+++ b/apps/web/src/app/admin/components/AccountDeduplicationTable.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { formatRelativeTime, formatMicrodollars } from '@/lib/admin-utils';
+import type { AccountDeduplicationResponse } from '../api/account-deduplication/route';
+
+const PAGE_SIZE = 20;
+
+export function AccountDeduplicationTable() {
+  const [page, setPage] = useState(1);
+
+  const { data, isLoading } = useQuery<AccountDeduplicationResponse>({
+    queryKey: ['account-deduplication', page],
+    queryFn: async () => {
+      const res = await fetch(`/admin/api/account-deduplication?page=${page}&limit=${PAGE_SIZE}`);
+      return res.json() as Promise<AccountDeduplicationResponse>;
+    },
+  });
+
+  const pagination = data?.pagination;
+  const groups = data?.groups ?? [];
+  const hasNext = pagination ? page < pagination.totalPages : false;
+  const hasPrev = page > 1;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-muted-foreground text-sm">
+          Users sharing the same normalized email address. Each group may indicate duplicate
+          accounts.
+        </p>
+        {pagination && (
+          <Badge variant="secondary">
+            {pagination.total.toLocaleString()} duplicate group{pagination.total !== 1 ? 's' : ''}
+          </Badge>
+        )}
+      </div>
+
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Normalized Email</TableHead>
+              <TableHead>User</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead>Acquired</TableHead>
+              <TableHead>Used</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              Array.from({ length: 6 }).map((_, i) => (
+                <TableRow key={i}>
+                  {Array.from({ length: 7 }).map((_, j) => (
+                    <TableCell key={j}>
+                      <Skeleton className="h-4 w-24" />
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : groups.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} className="h-24 text-center">
+                  <p className="text-muted-foreground">No duplicate accounts found.</p>
+                </TableCell>
+              </TableRow>
+            ) : (
+              groups.map(group => (
+                <DuplicateGroupRows
+                  key={group.normalized_email}
+                  normalizedEmail={group.normalized_email}
+                  users={group.users}
+                />
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {pagination && pagination.totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-muted-foreground text-sm">
+            Page {pagination.page} of {pagination.totalPages}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!hasPrev}
+              onClick={() => setPage(p => p - 1)}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!hasNext}
+              onClick={() => setPage(p => p + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DuplicateGroupRows({
+  normalizedEmail,
+  users,
+}: {
+  normalizedEmail: string;
+  users: AccountDeduplicationResponse['groups'][number]['users'];
+}) {
+  return (
+    <>
+      {users.map((user, i) => (
+        <TableRow
+          key={user.id}
+          className={`${user.blocked_reason ? 'bg-red-950/30' : ''} ${i === users.length - 1 ? 'border-b-2 border-b-border' : ''}`}
+        >
+          {i === 0 ? (
+            <TableCell rowSpan={users.length} className="align-top font-mono text-xs">
+              {normalizedEmail}
+              <Badge variant="secondary" className="ml-2">
+                {users.length}
+              </Badge>
+            </TableCell>
+          ) : null}
+          <TableCell>
+            <div className="flex items-center gap-2">
+              <img
+                src={user.google_user_image_url}
+                alt=""
+                className="h-6 w-6 rounded-full"
+                onError={e => {
+                  (e.target as HTMLImageElement).src = '/default-avatar.svg';
+                }}
+              />
+              <a
+                href={`/admin/users/${encodeURIComponent(user.id)}`}
+                className="text-sm font-medium hover:underline"
+              >
+                {user.google_user_name}
+              </a>
+            </div>
+          </TableCell>
+          <TableCell>
+            <a
+              href={`/admin/users/${encodeURIComponent(user.id)}`}
+              className="text-sm hover:underline"
+            >
+              {user.google_user_email}
+            </a>
+          </TableCell>
+          <TableCell className="text-sm">{formatRelativeTime(user.created_at)}</TableCell>
+          <TableCell className="font-mono text-sm">
+            {formatMicrodollars(user.total_microdollars_acquired)}
+          </TableCell>
+          <TableCell className="font-mono text-sm">
+            {formatMicrodollars(user.microdollars_used)}
+          </TableCell>
+          <TableCell>
+            {user.blocked_reason ? (
+              <Badge variant="destructive">Blocked</Badge>
+            ) : (
+              <Badge variant="default" className="bg-green-600">
+                Active
+              </Badge>
+            )}
+          </TableCell>
+        </TableRow>
+      ))}
+    </>
+  );
+}

--- a/apps/web/src/app/admin/components/AppSidebar.tsx
+++ b/apps/web/src/app/admin/components/AppSidebar.tsx
@@ -21,6 +21,7 @@ import {
   Bell,
   Network,
   KeyRound,
+  Copy,
 } from 'lucide-react';
 import { useSession } from 'next-auth/react';
 import type { Session } from 'next-auth';
@@ -77,6 +78,11 @@ const userManagementItems: MenuItem[] = [
     title: () => 'Backfills',
     url: '/admin/backfills',
     icon: () => <KeyRound />,
+  },
+  {
+    title: () => 'Account Deduplication',
+    url: '/admin/account-deduplication',
+    icon: () => <Copy />,
   },
 ];
 


### PR DESCRIPTION
## Summary

Adds a new "Account Deduplication" admin page at `/admin/account-deduplication` that shows groups of users sharing the same `normalized_email`. This helps identify duplicate accounts created with Gmail dot tricks, `+` aliases, or different casing. Users are grouped by normalized email, paginated at the group level (so all users in a group always appear together), and each user name/email links directly to their admin detail page.

## Verification

- `pnpm typecheck` -- passes
- `pnpm format` -- passes

## Visual Changes

New sidebar entry "Account Deduplication" (with Copy icon) below "Safety Identifiers" in the User Management section. The page shows a table with groups of duplicate users, each with avatar, name, email, creation date, credits acquired/used, and blocked status.

## Reviewer Notes

- This PR depends on the `normalized_email` column added in #2418. It works with whatever values are currently populated -- groups only appear when 2+ users share the same non-null `normalized_email`.
- The count query fetches all duplicate group keys to get an accurate total. For an admin-only page this is acceptable; if the number of duplicate groups grows very large, it could be refactored to use a COUNT subquery via raw SQL.
- Pagination keeps entire groups together -- the `limit` applies to the number of groups, not individual users.
