### PR TITLE
refactor(kiloclaw): simplify env key admin diagnostics

### DIFF
--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -2273,23 +2273,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                 <DetailField label="Next Alarm">
                   {formatEpochTime(data.workerStatus.alarmScheduledAt)}
                 </DetailField>
-              </div>
-            ) : !data.workerStatusError ? (
-              <p className="text-muted-foreground text-sm">No worker status available</p>
-            ) : null}
-          </CardContent>
-        </Card>
 
-        {data.workerStatus && (
-          <Card>
-            <CardHeader>
-              <CardTitle>Env Key Diagnostics</CardTitle>
-              <CardDescription>
-                Encryption key state from the App DO — helps debug boot decryption failures
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                 <DetailField label="App DO Key">
                   <code className="text-xs">{data.workerStatus.envKeyAppDOKey ?? '—'}</code>
                 </DetailField>
@@ -2304,24 +2288,12 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                   )}
                 </DetailField>
 
-                <DetailField label="Instance DO Fly App Name">
-                  <code className="text-xs">{data.workerStatus.flyAppName ?? '—'}</code>
-                </DetailField>
-
                 <DetailField label="App DO envKeySet">
                   {data.workerStatus.envKeyAppDOKeySet === null
                     ? '—'
                     : data.workerStatus.envKeyAppDOKeySet
                       ? 'true'
                       : 'false'}
-                </DetailField>
-
-                <DetailField label="Env Key Fingerprint">
-                  {data.workerStatus.envKeyAppDOFingerprint ? (
-                    <code className="text-xs">{data.workerStatus.envKeyAppDOFingerprint}...</code>
-                  ) : (
-                    <span className="text-destructive text-xs font-medium">no key</span>
-                  )}
                 </DetailField>
 
                 {data.workerStatus.envKeyAppDOFlyAppName !== null &&
@@ -2348,9 +2320,11 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                     </div>
                   )}
               </div>
-            </CardContent>
-          </Card>
-        )}
+            ) : !data.workerStatusError ? (
+              <p className="text-muted-foreground text-sm">No worker status available</p>
+            ) : null}
+          </CardContent>
+        </Card>
 
         {data.workerStatus &&
           (data.workerStatus.lastStartErrorMessage ||

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -240,7 +240,6 @@ export type PlatformDebugStatusResponse = PlatformStatusResponse & {
   envKeyAppDOKey: string | null;
   envKeyAppDOFlyAppName: string | null;
   envKeyAppDOKeySet: boolean | null;
-  envKeyAppDOFingerprint: string | null;
 };
 
 export type CleanupRecoveryPreviousVolumeResponse = {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-app.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-app.ts
@@ -283,18 +283,15 @@ export class KiloClawApp extends DurableObject<KiloClawEnv> {
 
   /**
    * Return diagnostic info for the admin debug UI.
-   * Exposes enough to debug env key mismatches without leaking the full key.
    */
   async getDiagnostics(): Promise<{
     flyAppName: string | null;
     envKeySet: boolean;
-    envKeyFingerprint: string | null;
   }> {
     await this.loadState();
     return {
       flyAppName: this.flyAppName,
       envKeySet: this.envKeySet,
-      envKeyFingerprint: this.envKey ? this.envKey.slice(0, 8) : null,
     };
   }
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -2003,7 +2003,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     envKeyAppDOKey: string | null;
     envKeyAppDOFlyAppName: string | null;
     envKeyAppDOKeySet: boolean | null;
-    envKeyAppDOFingerprint: string | null;
   }> {
     await this.loadState();
     const alarmScheduledAt = await this.ctx.storage.getAlarm();
@@ -2012,7 +2011,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     let envKeyDiag: {
       flyAppName: string | null;
       envKeySet: boolean;
-      envKeyFingerprint: string | null;
     } | null = null;
     let envKeyAppDOKey: string | null = null;
     try {
@@ -2080,7 +2078,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       envKeyAppDOKey,
       envKeyAppDOFlyAppName: envKeyDiag?.flyAppName ?? null,
       envKeyAppDOKeySet: envKeyDiag?.envKeySet ?? null,
-      envKeyAppDOFingerprint: envKeyDiag?.envKeyFingerprint ?? null,
     };
   }
 


### PR DESCRIPTION
## Summary

- Remove the standalone "Env Key Diagnostics" card from the admin instance detail page.
- Move the useful fields (App DO Key, App DO Fly App Name, envKeySet, and the mismatch warning banners) into the existing "Live Worker Status" card where they belong.
- Remove the env key fingerprint field entirely — from the App DO `getDiagnostics()` return, the Instance DO `getDebugState()` return, the `PlatformDebugStatusResponse` type, and the UI.

## Verification

- [x] `pnpm --filter kiloclaw typecheck` — passes
- [x] `pnpm --filter web typecheck` — passes
- [x] `pnpm --filter kiloclaw test` — all 1346 tests pass
- [x] `pnpm format` — clean

## Visual Changes

| Before | After |
| ------ | ----- |
| Separate "Env Key Diagnostics" card with 5 fields + warnings | Fields folded into "Live Worker Status" card, fingerprint removed |

## Reviewer Notes

- Pure cleanup — no behavioral changes to the encryption or secret sync flow.
- The Start / Restart Errors card added in #2481 is kept as-is (it surfaces `lastStartErrorMessage` / `lastRestartErrorMessage` which were previously not rendered).