### PR TITLE
feat(admin): add min accounts filter to deduplication page

### DIFF
--- a/apps/web/src/app/admin/api/account-deduplication/route.ts
+++ b/apps/web/src/app/admin/api/account-deduplication/route.ts
@@ -41,10 +41,16 @@ export async function GET(
   const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
   const limit = Math.min(50, Math.max(1, parseInt(searchParams.get('limit') ?? '20', 10)));
   const minAccounts = Math.max(2, parseInt(searchParams.get('minAccounts') ?? '2', 10));
+  const hideAllBlocked = searchParams.get('hideAllBlocked') === 'true';
 
-  const havingClause = sql`count(*) >= ${minAccounts}`;
+  const havingClauses = [sql`count(*) >= ${minAccounts}`];
+  if (hideAllBlocked) {
+    // Exclude groups where every user is blocked
+    havingClauses.push(sql`count(*) FILTER (WHERE ${kilocode_users.blocked_reason} IS NULL) > 0`);
+  }
+  const havingClause = sql.join(havingClauses, sql` AND `);
 
-  // Count distinct normalized_email values that appear minAccounts or more times
+  // Count distinct normalized_email values that meet the filter criteria
   const countRows = await db
     .select({ normalized_email: kilocode_users.normalized_email })
     .from(kilocode_users)

--- a/apps/web/src/app/admin/api/account-deduplication/route.ts
+++ b/apps/web/src/app/admin/api/account-deduplication/route.ts
@@ -40,14 +40,17 @@ export async function GET(
   const searchParams = request.nextUrl.searchParams;
   const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
   const limit = Math.min(50, Math.max(1, parseInt(searchParams.get('limit') ?? '20', 10)));
+  const minAccounts = Math.max(2, parseInt(searchParams.get('minAccounts') ?? '2', 10));
 
-  // Count distinct normalized_email values that appear more than once
+  const havingClause = sql`count(*) >= ${minAccounts}`;
+
+  // Count distinct normalized_email values that appear minAccounts or more times
   const countRows = await db
     .select({ normalized_email: kilocode_users.normalized_email })
     .from(kilocode_users)
     .where(isNotNull(kilocode_users.normalized_email))
     .groupBy(kilocode_users.normalized_email)
-    .having(sql`count(*) > 1`);
+    .having(havingClause);
 
   const total = countRows.length;
   const totalPages = Math.max(1, Math.ceil(total / limit));
@@ -59,7 +62,7 @@ export async function GET(
     .from(kilocode_users)
     .where(isNotNull(kilocode_users.normalized_email))
     .groupBy(kilocode_users.normalized_email)
-    .having(sql`count(*) > 1`)
+    .having(havingClause)
     .orderBy(kilocode_users.normalized_email)
     .limit(limit)
     .offset(offset);

--- a/apps/web/src/app/admin/components/AccountDeduplicationTable.tsx
+++ b/apps/web/src/app/admin/components/AccountDeduplicationTable.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -24,13 +25,18 @@ const DEFAULT_MIN_ACCOUNTS = 2;
 export function AccountDeduplicationTable() {
   const [page, setPage] = useState(1);
   const [minAccounts, setMinAccounts] = useState(DEFAULT_MIN_ACCOUNTS);
+  const [hideAllBlocked, setHideAllBlocked] = useState(false);
 
   const { data, isLoading } = useQuery<AccountDeduplicationResponse>({
-    queryKey: ['account-deduplication', page, minAccounts],
+    queryKey: ['account-deduplication', page, minAccounts, hideAllBlocked],
     queryFn: async () => {
-      const res = await fetch(
-        `/admin/api/account-deduplication?page=${page}&limit=${PAGE_SIZE}&minAccounts=${minAccounts}`
-      );
+      const params = new URLSearchParams({
+        page: String(page),
+        limit: String(PAGE_SIZE),
+        minAccounts: String(minAccounts),
+        hideAllBlocked: String(hideAllBlocked),
+      });
+      const res = await fetch(`/admin/api/account-deduplication?${params}`);
       return res.json() as Promise<AccountDeduplicationResponse>;
     },
   });
@@ -54,7 +60,7 @@ export function AccountDeduplicationTable() {
         )}
       </div>
 
-      <div className="flex items-end gap-3">
+      <div className="flex items-end gap-4">
         <div className="space-y-1">
           <Label htmlFor="min-accounts">Min. accounts per email</Label>
           <Input
@@ -71,6 +77,19 @@ export function AccountDeduplicationTable() {
             }}
             className="w-28"
           />
+        </div>
+        <div className="flex items-center gap-2 pb-1">
+          <Checkbox
+            id="hide-all-blocked"
+            checked={hideAllBlocked}
+            onCheckedChange={checked => {
+              setHideAllBlocked(checked);
+              setPage(1);
+            }}
+          />
+          <Label htmlFor="hide-all-blocked" className="cursor-pointer text-sm font-normal">
+            Hide fully blocked groups
+          </Label>
         </div>
       </div>
 

--- a/apps/web/src/app/admin/components/AccountDeduplicationTable.tsx
+++ b/apps/web/src/app/admin/components/AccountDeduplicationTable.tsx
@@ -12,19 +12,25 @@ import {
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
 import { formatRelativeTime, formatMicrodollars } from '@/lib/admin-utils';
 import type { AccountDeduplicationResponse } from '../api/account-deduplication/route';
 
 const PAGE_SIZE = 20;
+const DEFAULT_MIN_ACCOUNTS = 2;
 
 export function AccountDeduplicationTable() {
   const [page, setPage] = useState(1);
+  const [minAccounts, setMinAccounts] = useState(DEFAULT_MIN_ACCOUNTS);
 
   const { data, isLoading } = useQuery<AccountDeduplicationResponse>({
-    queryKey: ['account-deduplication', page],
+    queryKey: ['account-deduplication', page, minAccounts],
     queryFn: async () => {
-      const res = await fetch(`/admin/api/account-deduplication?page=${page}&limit=${PAGE_SIZE}`);
+      const res = await fetch(
+        `/admin/api/account-deduplication?page=${page}&limit=${PAGE_SIZE}&minAccounts=${minAccounts}`
+      );
       return res.json() as Promise<AccountDeduplicationResponse>;
     },
   });
@@ -46,6 +52,26 @@ export function AccountDeduplicationTable() {
             {pagination.total.toLocaleString()} duplicate group{pagination.total !== 1 ? 's' : ''}
           </Badge>
         )}
+      </div>
+
+      <div className="flex items-end gap-3">
+        <div className="space-y-1">
+          <Label htmlFor="min-accounts">Min. accounts per email</Label>
+          <Input
+            id="min-accounts"
+            type="number"
+            min={2}
+            value={minAccounts}
+            onChange={e => {
+              const val = parseInt(e.target.value, 10);
+              if (val >= 2) {
+                setMinAccounts(val);
+                setPage(1);
+              }
+            }}
+            className="w-28"
+          />
+        </div>
       </div>
 
       <div className="rounded-lg border">


### PR DESCRIPTION
## Summary

Adds a "Min. accounts per email" filter to the account deduplication admin page. Defaults to 2 (same behavior as before). Increasing the value lets admins quickly find emails with higher concentrations of duplicate accounts, which are more likely to be fraud rings.

## Verification

- `pnpm typecheck` -- passes
- `pnpm lint` -- passes
- `pnpm format` -- passes

## Visual Changes

A labeled number input appears above the table. Changing the value resets to page 1 and re-fetches with the new threshold.

## Reviewer Notes

N/A
