### PR TITLE
fix(kiloclaw): route instance webhooks to the correct DO

### DIFF
--- a/services/kiloclaw/src/lib/instance-routing.ts
+++ b/services/kiloclaw/src/lib/instance-routing.ts
@@ -1,4 +1,4 @@
-import { getActivePersonalInstance, getWorkerDb } from '../db';
+import { getActivePersonalInstance, getInstanceById, getWorkerDb } from '../db';
 import { userIdFromSandboxId } from '../auth/sandbox-id';
 import {
   instanceIdFromSandboxId,
@@ -37,6 +37,18 @@ export async function resolveDoKeyForUser(
   if (!connectionString) return null;
 
   const instance = await getActivePersonalInstance(getWorkerDb(connectionString), userId);
+  if (!instance) return null;
+
+  return doKeyFromActiveInstance(instance);
+}
+
+export async function resolveDoKeyForInstance(
+  connectionString: string | undefined,
+  instanceId: string
+): Promise<string | null> {
+  if (!connectionString) return null;
+
+  const instance = await getInstanceById(getWorkerDb(connectionString), instanceId);
   if (!instance) return null;
 
   return doKeyFromActiveInstance(instance);

--- a/services/kiloclaw/src/routes/platform-legacy-routing.test.ts
+++ b/services/kiloclaw/src/routes/platform-legacy-routing.test.ts
@@ -12,12 +12,13 @@ vi.mock('../db', async importOriginal => {
     ...actual,
     getWorkerDb: vi.fn(() => ({})),
     getActivePersonalInstance: vi.fn(),
+    getInstanceById: vi.fn(),
   };
 });
 
 import { platform, resolveInstanceDoKey } from './platform';
 import { sandboxIdFromUserId } from '../auth/sandbox-id';
-import { getActivePersonalInstance } from '../db';
+import { getActivePersonalInstance, getInstanceById } from '../db';
 
 const currentUserId = '199e2b19-aa40-488d-9442-9a18a620ba68';
 const legacyDoKey = 'oauth/google:117453785559478190551';
@@ -153,5 +154,53 @@ describe('legacy platform DO routing', () => {
       `user:${currentUserId}`,
       '11111111-1111-4111-8111-111111111111'
     );
+  });
+});
+
+describe('resolveInstanceDoKey with instanceId', () => {
+  const env = {
+    HYPERDRIVE: { connectionString: 'postgresql://fake' },
+  } as never;
+  const instanceId = '11111111-1111-4111-8111-111111111111';
+  const newSandboxId = 'ki_11111111111141118111111111111111';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('translates the UUID to the legacy userId DO key when the instance row is legacy', async () => {
+    vi.mocked(getInstanceById).mockResolvedValue({
+      id: instanceId,
+      sandboxId: legacySandboxId,
+      userId: currentUserId,
+      orgId: null,
+      inboundEmailEnabled: false,
+    });
+
+    await expect(resolveInstanceDoKey(env, currentUserId, instanceId)).resolves.toBe(legacyDoKey);
+  });
+
+  it('returns the raw UUID when the instance row is instance-keyed', async () => {
+    vi.mocked(getInstanceById).mockResolvedValue({
+      id: instanceId,
+      sandboxId: newSandboxId,
+      userId: currentUserId,
+      orgId: null,
+      inboundEmailEnabled: false,
+    });
+
+    await expect(resolveInstanceDoKey(env, currentUserId, instanceId)).resolves.toBe(instanceId);
+  });
+
+  it('falls back to the raw UUID when the instance row is missing', async () => {
+    vi.mocked(getInstanceById).mockResolvedValue(null);
+
+    await expect(resolveInstanceDoKey(env, currentUserId, instanceId)).resolves.toBe(instanceId);
+  });
+
+  it('falls back to the raw UUID when the Hyperdrive lookup throws', async () => {
+    vi.mocked(getInstanceById).mockRejectedValue(new Error('hyperdrive down'));
+
+    await expect(resolveInstanceDoKey(env, currentUserId, instanceId)).resolves.toBe(instanceId);
   });
 });

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -35,7 +35,11 @@ import { deriveHttpEventName } from '../middleware/analytics';
 import { sendMessage } from '../stream-chat/client';
 import { assertAvailableProvider } from '../providers';
 import type { ProviderCapability } from '../providers/types';
-import { doKeyFromActiveInstance, resolveDoKeyForUser } from '../lib/instance-routing';
+import {
+  doKeyFromActiveInstance,
+  resolveDoKeyForInstance,
+  resolveDoKeyForUser,
+} from '../lib/instance-routing';
 import { getInstanceById, getWorkerDb } from '../db';
 import { kiloclaw_inbound_email_aliases } from '@kilocode/db/schema';
 import { and, eq, isNull } from 'drizzle-orm';
@@ -216,16 +220,32 @@ function setValidatedQueryUserId(c: Context<AppEnv>): string | null {
 /**
  * Resolve the DO key for a platform request.
  *
- * When instanceId is provided, it is always authoritative. Otherwise the
- * active Postgres row is the source of truth so legacy sandboxes continue to
- * route to the original userId-keyed DO after kilocode_users.id migrations.
+ * When instanceId is provided, the Postgres row is still consulted so legacy
+ * sandboxes (sandbox_id not starting with `ki_`) route to the original
+ * userId-keyed DO instead of a brand-new DO keyed by the row's UUID. If the
+ * lookup fails or the row is missing, we fall back to the raw UUID — correct
+ * for instance-keyed rows and a no-regression path for legacy rows.
  */
 export async function resolveInstanceDoKey(
   env: AppEnv['Bindings'],
   userId: string,
   instanceId?: string
 ): Promise<string> {
-  if (instanceId) return instanceId;
+  if (instanceId) {
+    try {
+      const resolved = await resolveDoKeyForInstance(env.HYPERDRIVE?.connectionString, instanceId);
+      if (resolved) return resolved;
+    } catch (err) {
+      console.warn(
+        '[platform] Failed to resolve DO key from instanceId, falling back to raw UUID',
+        {
+          instanceId,
+          error: err instanceof Error ? err.message : String(err),
+        }
+      );
+    }
+    return instanceId;
+  }
 
   try {
     return (await resolveDoKeyForUser(env.HYPERDRIVE?.connectionString, userId)) ?? userId;


### PR DESCRIPTION
## Summary                                                                   
                                                                               
 Webhook-triggered messages to KiloClaw Chat were failing with `404 "Stream Chat is not set up for this instance"` for every user whose instance pre dates the multi instance (personal vs org) migration.          
                                         
## Verification                                                              
                                                                          
 - [x] `pnpm --filter kiloclaw test` — all 1350 tests pass, including 4 new cases in `platform-legacy-routing.test.ts` covering: legacy sandbox + `instanceId` → userId DO key, `ki_` sandbox + `instanceId` → raw UUID, missing row → raw UUID fallback, Hyperdrive throws → raw UUID fallback.      
- [x] `pnpm --filter kiloclaw typecheck`, `lint`, `format:check` all clean.
- [ ] End-to-end webhook delivery against a legacy instance in dev — **not run locally**; needs a seeded legacy `kiloclaw_instances` row with a pre-provisioned Stream Chat DO at `idFromName(userId)`. Recommend verifying on dev before prod rollout per the acceptance criteria.                      
                                                                               
## Visual Changes                                                       
                                         
  N/A
     
## Reviewer Notes
                   
 - The legacy-aware branch runs on every `send-chat-message` (and any other caller that passes `instanceId`) — it adds one Hyperdrive-cached PK lookup per call. `getInstanceById` is already used elsewhere on this path (e.g. platform.ts:1904), so no new DB coupling.                                    
  - Fallback semantics are intentionally permissive: if the instance row is missing or Hyperdrive errors, we fall back to the raw UUID. That matches the prior behavior for post-migration rows and is strictly no-worse for legacy rows (same 404 they hit today).                                           