### PR TITLE
feat(admin): add copy-all-emails button to dedup groups

### DIFF
--- a/apps/web/src/app/admin/components/AccountDeduplicationTable.tsx
+++ b/apps/web/src/app/admin/components/AccountDeduplicationTable.tsx
@@ -18,6 +18,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
 import { formatRelativeTime, formatMicrodollars } from '@/lib/admin-utils';
+import { CopyTextButton } from '@/components/admin/CopyEmailButton';
 import type { AccountDeduplicationResponse } from '../api/account-deduplication/route';
 
 const PAGE_SIZE = 20;
@@ -198,10 +199,13 @@ function DuplicateGroupRows({
         >
           {i === 0 ? (
             <TableCell rowSpan={users.length} className="align-top font-mono text-xs">
-              {normalizedEmail}
-              <Badge variant="secondary" className="ml-2">
-                {users.length}
-              </Badge>
+              <div className="flex flex-col gap-1">
+                <span>{normalizedEmail}</span>
+                <div className="flex items-center gap-1">
+                  <Badge variant="secondary">{users.length}</Badge>
+                  <CopyTextButton text={users.map(u => u.google_user_email).join('\n')} showText />
+                </div>
+              </div>
             </TableCell>
           ) : null}
           <TableCell>


### PR DESCRIPTION
## Summary

Adds a copy button next to the group count badge in the Normalized Email column on the account deduplication page. Clicking it copies all emails in that group (newline-separated) to the clipboard. Uses the existing `CopyTextButton` component.

## Verification

- `pnpm typecheck` -- passes (pre-existing error in `resolution.ts` unrelated)
- `pnpm lint` -- passes
- `pnpm format` -- passes

## Visual Changes

Copy button with "Copy" text appears below the normalized email and count badge in each group row.

## Reviewer Notes

N/A
