### PR TITLE
feat(claw): replace Pylon default bubble with custom Support button

### DIFF
--- a/apps/web/src/app/(app)/claw/layout.tsx
+++ b/apps/web/src/app/(app)/claw/layout.tsx
@@ -8,8 +8,9 @@ export default async function ClawLayout({ children }: { children: React.ReactNo
   return (
     <>
       {children}
-      <PylonWidget />
-      <PylonSupportButton />
+      <PylonWidget>
+        <PylonSupportButton />
+      </PylonWidget>
     </>
   );
 }

--- a/apps/web/src/app/(app)/claw/layout.tsx
+++ b/apps/web/src/app/(app)/claw/layout.tsx
@@ -1,5 +1,6 @@
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { PylonWidget } from '@/components/pylon-widget';
+import { PylonSupportButton } from '@/components/pylon-support-button';
 import './claw-chat.css';
 
 export default async function ClawLayout({ children }: { children: React.ReactNode }) {
@@ -8,6 +9,7 @@ export default async function ClawLayout({ children }: { children: React.ReactNo
     <>
       {children}
       <PylonWidget />
+      <PylonSupportButton />
     </>
   );
 }

--- a/apps/web/src/components/pylon-support-button.tsx
+++ b/apps/web/src/components/pylon-support-button.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { CircleHelp } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { usePylonChat } from '@/components/pylon-widget';
+
+export function PylonSupportButton() {
+  const { toggle, unreadCount } = usePylonChat();
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={toggle}
+      className="fixed bottom-5 right-5 z-50 gap-1.5 rounded-full border-white/10 bg-black/60 py-2 pl-3 pr-4 text-white/80 shadow-lg backdrop-blur-sm hover:bg-white/10 hover:text-white"
+    >
+      <CircleHelp className="h-4 w-4" />
+      Support
+      {unreadCount > 0 && (
+        <span className="ml-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-red-500 px-1.5 text-[11px] font-semibold leading-none text-white">
+          {unreadCount}
+        </span>
+      )}
+    </Button>
+  );
+}

--- a/apps/web/src/components/pylon-widget.tsx
+++ b/apps/web/src/components/pylon-widget.tsx
@@ -1,15 +1,21 @@
 'use client';
 
-import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import Script from 'next/script';
 import { z } from 'zod';
 import { useUser } from '@/hooks/useUser';
 
+type PylonCommand = [command: string, ...args: unknown[]];
+type PylonQueue = ((command: string, ...args: unknown[]) => void) & {
+  q?: PylonCommand[];
+};
+
 declare global {
   interface Window {
-    Pylon?: (command: string, ...args: unknown[]) => void;
-    pylon?: { chat_settings: Record<string, unknown> };
+    Pylon?: PylonQueue;
+    pylon?: {
+      chat_settings?: Record<string, unknown>;
+    } & Record<string, unknown>;
   }
 }
 
@@ -18,14 +24,22 @@ const pylonIdentitySchema = z.object({
   name: z.string(),
   emailHash: z.string(),
 });
+
 type PylonIdentity = z.infer<typeof pylonIdentitySchema>;
 type PylonChatState = {
   unreadCount: number;
   isOpen: boolean;
 };
+type PylonWidgetProps = {
+  children?: React.ReactNode;
+};
+type PylonWidgetConfig = {
+  appId: string;
+  identity: PylonIdentity;
+};
 
-const serverSnapshot: PylonChatState = { unreadCount: 0, isOpen: false };
-const PYLON_BUBBLE_STYLE_ID = 'kilo-pylon-hide-bubble-style';
+const INITIAL_PYLON_CHAT_STATE: PylonChatState = { unreadCount: 0, isOpen: false };
+const PYLON_WIDGET_SCRIPT_ID = 'kilo-pylon-widget-script';
 const PYLON_BUBBLE_HIDDEN_CSS = `
 #pylon-chat-bubble,
 .PylonChat-bubbleFrameContainer {
@@ -34,6 +48,9 @@ const PYLON_BUBBLE_HIDDEN_CSS = `
   pointer-events: none !important;
 }
 `;
+
+let pylonChatState = INITIAL_PYLON_CHAT_STATE;
+const listeners = new Set<() => void>();
 
 async function fetchPylonIdentity(): Promise<PylonIdentity | null> {
   const res = await fetch('/api/pylon/identity');
@@ -46,91 +63,10 @@ async function fetchPylonIdentity(): Promise<PylonIdentity | null> {
   return pylonIdentitySchema.parse(await res.json());
 }
 
-function toInlineScriptValue(value: unknown) {
-  return JSON.stringify(value).replace(/</g, '\\u003c');
-}
-
-function buildPylonLoaderScript(appId: string, identity: PylonIdentity) {
-  const widgetSrc = `https://widget.usepylon.com/widget/${encodeURIComponent(appId)}`;
-
-  return `
-window.pylon = {
-  chat_settings: {
-    app_id: ${toInlineScriptValue(appId)},
-    email: ${toInlineScriptValue(identity.email)},
-    name: ${toInlineScriptValue(identity.name)},
-    email_hash: ${toInlineScriptValue(identity.emailHash)}
-  }
-};
-
-(function() {
-  var styleId = ${toInlineScriptValue(PYLON_BUBBLE_STYLE_ID)};
-  if (document.getElementById(styleId)) return;
-
-  var style = document.createElement("style");
-  style.id = styleId;
-  style.textContent = ${toInlineScriptValue(PYLON_BUBBLE_HIDDEN_CSS)};
-  document.head.appendChild(style);
-})();
-
-(function() {
-  var w = window;
-  var d = document;
-  var queue = function() { queue.e(arguments); };
-  queue.q = [];
-  queue.e = function(args) { queue.q.push(args); };
-  w.Pylon = queue;
-
-  var load = function() {
-    var script = d.createElement("script");
-    script.type = "text/javascript";
-    script.async = true;
-    script.src = ${toInlineScriptValue(widgetSrc)};
-
-    var firstScript = d.getElementsByTagName("script")[0];
-    if (firstScript && firstScript.parentNode) firstScript.parentNode.insertBefore(script, firstScript);
-    else (d.head || d.body || d.documentElement).appendChild(script);
-  };
-
-  if (d.readyState === "complete") load();
-  else if (w.addEventListener) w.addEventListener("load", load, false);
-})();
-  `.trim();
-}
-
-// ── Shared state (singleton, lives outside React) ────────────────────────────
-let pylonState = serverSnapshot;
-const listeners = new Set<() => void>();
-
-function notify() {
-  for (const cb of listeners) cb();
-}
-
-function setPylonState(next: Partial<PylonChatState>) {
-  const updated = { ...pylonState, ...next };
-  if (updated.unreadCount !== pylonState.unreadCount || updated.isOpen !== pylonState.isOpen) {
-    pylonState = updated;
-    notify();
-  }
-}
-
-function getSnapshot() {
-  return pylonState;
-}
-
-function subscribe(cb: () => void) {
-  listeners.add(cb);
-  return () => {
-    listeners.delete(cb);
-  };
-}
-
-// ── PylonWidget: loads the script, hides default bubble ──────────────────────
-export function PylonWidget() {
+function usePylonWidgetConfig(): PylonWidgetConfig | null {
   const appId = process.env.NEXT_PUBLIC_PYLON_APP_ID;
   const { data: user } = useUser();
 
-  // Keyed by user.id so logout/login in the same tab gets a fresh identity.
   const { data: identity } = useQuery({
     queryKey: ['pylon-identity', user?.id],
     queryFn: fetchPylonIdentity,
@@ -138,41 +74,135 @@ export function PylonWidget() {
     staleTime: 5 * 60 * 1000,
   });
 
-  // Register Pylon callbacks once the widget is ready.
-  useEffect(() => {
-    if (!identity) return;
+  return appId && identity ? { appId, identity } : null;
+}
 
-    const handleShow = () => setPylonState({ isOpen: true });
-    const handleHide = () => setPylonState({ isOpen: false });
+function setPylonChatState(next: Partial<PylonChatState>) {
+  const updated = { ...pylonChatState, ...next };
+  if (
+    updated.unreadCount !== pylonChatState.unreadCount ||
+    updated.isOpen !== pylonChatState.isOpen
+  ) {
+    pylonChatState = updated;
+    for (const listener of listeners) {
+      listener();
+    }
+  }
+}
+
+function getPylonChatSnapshot() {
+  return pylonChatState;
+}
+
+function subscribeToPylonChat(cb: () => void) {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+function configurePylonChatSettings(appId: string, identity: PylonIdentity) {
+  const currentPylon = window.pylon;
+  const currentChatSettings = currentPylon?.chat_settings;
+
+  window.pylon = {
+    ...currentPylon,
+    chat_settings: {
+      ...currentChatSettings,
+      app_id: appId,
+      email: identity.email,
+      name: identity.name,
+      email_hash: identity.emailHash,
+    },
+  };
+}
+
+function ensurePylonQueue() {
+  if (window.Pylon) {
+    return;
+  }
+
+  const queuedCommands: PylonCommand[] = [];
+  const queue: PylonQueue = (command, ...args) => {
+    queuedCommands.push([command, ...args]);
+  };
+  queue.q = queuedCommands;
+  window.Pylon = queue;
+}
+
+function ensurePylonScript(appId: string) {
+  const widgetSrc = `https://widget.usepylon.com/widget/${encodeURIComponent(appId)}`;
+  if (
+    document.getElementById(PYLON_WIDGET_SCRIPT_ID) ||
+    document.querySelector(`script[src="${widgetSrc}"]`)
+  ) {
+    return;
+  }
+
+  const script = document.createElement('script');
+  script.id = PYLON_WIDGET_SCRIPT_ID;
+  script.type = 'text/javascript';
+  script.async = true;
+  script.src = widgetSrc;
+  (document.head ?? document.body ?? document.documentElement).appendChild(script);
+}
+
+function bootstrapPylon(appId: string, identity: PylonIdentity) {
+  configurePylonChatSettings(appId, identity);
+  ensurePylonQueue();
+  ensurePylonScript(appId);
+}
+
+export function PylonWidget({ children }: PylonWidgetProps) {
+  const config = usePylonWidgetConfig();
+  const [isBootstrapped, setIsBootstrapped] = useState(false);
+
+  useEffect(() => {
+    if (!config) {
+      setIsBootstrapped(false);
+      setPylonChatState(INITIAL_PYLON_CHAT_STATE);
+      return;
+    }
+
+    bootstrapPylon(config.appId, config.identity);
+
+    const handleShow = () => setPylonChatState({ isOpen: true });
+    const handleHide = () => setPylonChatState({ isOpen: false });
     const handleUnreadCountChange = (count: unknown) =>
-      setPylonState({ unreadCount: typeof count === 'number' ? count : 0 });
+      setPylonChatState({ unreadCount: typeof count === 'number' ? count : 0 });
 
     window.Pylon?.('onShow', handleShow);
     window.Pylon?.('onHide', handleHide);
     window.Pylon?.('onChangeUnreadMessagesCount', handleUnreadCountChange);
+    setIsBootstrapped(true);
 
     return () => {
       window.Pylon?.('onShow', null);
       window.Pylon?.('onHide', null);
       window.Pylon?.('onChangeUnreadMessagesCount', null);
-      setPylonState(serverSnapshot);
+      setPylonChatState(INITIAL_PYLON_CHAT_STATE);
+      setIsBootstrapped(false);
     };
-  }, [identity]);
+  }, [config?.appId, config?.identity.email, config?.identity.emailHash, config?.identity.name]);
 
-  if (!appId || !identity) {
+  if (!config) {
     return null;
   }
 
   return (
-    <Script id="pylon-chat" strategy="afterInteractive">
-      {buildPylonLoaderScript(appId, identity)}
-    </Script>
+    <>
+      <style dangerouslySetInnerHTML={{ __html: PYLON_BUBBLE_HIDDEN_CSS }} />
+      {isBootstrapped ? children : null}
+    </>
   );
 }
 
-// ── usePylonChat: hook for custom trigger buttons ────────────────────────────
 export function usePylonChat() {
-  const state = useSyncExternalStore(subscribe, getSnapshot, () => serverSnapshot);
+  const state = useSyncExternalStore(
+    subscribeToPylonChat,
+    getPylonChatSnapshot,
+    () => INITIAL_PYLON_CHAT_STATE
+  );
 
   const toggle = useCallback(() => {
     window.Pylon?.(state.isOpen ? 'hide' : 'show');

--- a/apps/web/src/components/pylon-widget.tsx
+++ b/apps/web/src/components/pylon-widget.tsx
@@ -1,9 +1,17 @@
 'use client';
 
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import Script from 'next/script';
 import { z } from 'zod';
 import { useUser } from '@/hooks/useUser';
+
+declare global {
+  interface Window {
+    Pylon?: (command: string, ...args: unknown[]) => void;
+    pylon?: { chat_settings: Record<string, unknown> };
+  }
+}
 
 const pylonIdentitySchema = z.object({
   email: z.string(),
@@ -11,6 +19,21 @@ const pylonIdentitySchema = z.object({
   emailHash: z.string(),
 });
 type PylonIdentity = z.infer<typeof pylonIdentitySchema>;
+type PylonChatState = {
+  unreadCount: number;
+  isOpen: boolean;
+};
+
+const serverSnapshot: PylonChatState = { unreadCount: 0, isOpen: false };
+const PYLON_BUBBLE_STYLE_ID = 'kilo-pylon-hide-bubble-style';
+const PYLON_BUBBLE_HIDDEN_CSS = `
+#pylon-chat-bubble,
+.PylonChat-bubbleFrameContainer {
+  display: none !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
+}
+`;
 
 async function fetchPylonIdentity(): Promise<PylonIdentity | null> {
   const res = await fetch('/api/pylon/identity');
@@ -23,12 +46,91 @@ async function fetchPylonIdentity(): Promise<PylonIdentity | null> {
   return pylonIdentitySchema.parse(await res.json());
 }
 
+function toInlineScriptValue(value: unknown) {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+function buildPylonLoaderScript(appId: string, identity: PylonIdentity) {
+  const widgetSrc = `https://widget.usepylon.com/widget/${encodeURIComponent(appId)}`;
+
+  return `
+window.pylon = {
+  chat_settings: {
+    app_id: ${toInlineScriptValue(appId)},
+    email: ${toInlineScriptValue(identity.email)},
+    name: ${toInlineScriptValue(identity.name)},
+    email_hash: ${toInlineScriptValue(identity.emailHash)}
+  }
+};
+
+(function() {
+  var styleId = ${toInlineScriptValue(PYLON_BUBBLE_STYLE_ID)};
+  if (document.getElementById(styleId)) return;
+
+  var style = document.createElement("style");
+  style.id = styleId;
+  style.textContent = ${toInlineScriptValue(PYLON_BUBBLE_HIDDEN_CSS)};
+  document.head.appendChild(style);
+})();
+
+(function() {
+  var w = window;
+  var d = document;
+  var queue = function() { queue.e(arguments); };
+  queue.q = [];
+  queue.e = function(args) { queue.q.push(args); };
+  w.Pylon = queue;
+
+  var load = function() {
+    var script = d.createElement("script");
+    script.type = "text/javascript";
+    script.async = true;
+    script.src = ${toInlineScriptValue(widgetSrc)};
+
+    var firstScript = d.getElementsByTagName("script")[0];
+    if (firstScript && firstScript.parentNode) firstScript.parentNode.insertBefore(script, firstScript);
+    else (d.head || d.body || d.documentElement).appendChild(script);
+  };
+
+  if (d.readyState === "complete") load();
+  else if (w.addEventListener) w.addEventListener("load", load, false);
+})();
+  `.trim();
+}
+
+// ── Shared state (singleton, lives outside React) ────────────────────────────
+let pylonState = serverSnapshot;
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const cb of listeners) cb();
+}
+
+function setPylonState(next: Partial<PylonChatState>) {
+  const updated = { ...pylonState, ...next };
+  if (updated.unreadCount !== pylonState.unreadCount || updated.isOpen !== pylonState.isOpen) {
+    pylonState = updated;
+    notify();
+  }
+}
+
+function getSnapshot() {
+  return pylonState;
+}
+
+function subscribe(cb: () => void) {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+// ── PylonWidget: loads the script, hides default bubble ──────────────────────
 export function PylonWidget() {
   const appId = process.env.NEXT_PUBLIC_PYLON_APP_ID;
   const { data: user } = useUser();
 
-  // Key by user.id so logout/login in the same tab can't serve a previous
-  // user's signed identity payload from cache.
+  // Keyed by user.id so logout/login in the same tab gets a fresh identity.
   const { data: identity } = useQuery({
     queryKey: ['pylon-identity', user?.id],
     queryFn: fetchPylonIdentity,
@@ -36,19 +138,45 @@ export function PylonWidget() {
     staleTime: 5 * 60 * 1000,
   });
 
+  // Register Pylon callbacks once the widget is ready.
+  useEffect(() => {
+    if (!identity) return;
+
+    const handleShow = () => setPylonState({ isOpen: true });
+    const handleHide = () => setPylonState({ isOpen: false });
+    const handleUnreadCountChange = (count: unknown) =>
+      setPylonState({ unreadCount: typeof count === 'number' ? count : 0 });
+
+    window.Pylon?.('onShow', handleShow);
+    window.Pylon?.('onHide', handleHide);
+    window.Pylon?.('onChangeUnreadMessagesCount', handleUnreadCountChange);
+
+    return () => {
+      window.Pylon?.('onShow', null);
+      window.Pylon?.('onHide', null);
+      window.Pylon?.('onChangeUnreadMessagesCount', null);
+      setPylonState(serverSnapshot);
+    };
+  }, [identity]);
+
   if (!appId || !identity) {
     return null;
   }
 
-  const safeJson = (value: unknown) => JSON.stringify(value).replace(/</g, '\\u003c');
-  const safeAppId = encodeURIComponent(appId);
-  // Single inline script: assign chat_settings, then run Pylon loader IIFE.
-  // Combining guarantees settings are in place before the widget script loads.
-  const script = `window.pylon = { chat_settings: { app_id: ${safeJson(appId)}, email: ${safeJson(identity.email)}, name: ${safeJson(identity.name)}, email_hash: ${safeJson(identity.emailHash)} } };(function(){var e=window;var t=document;var n=function(){n.e(arguments)};n.q=[];n.e=function(e){n.q.push(e)};e.Pylon=n;var r=function(){var e=t.createElement("script");e.setAttribute("type","text/javascript");e.setAttribute("async","true");e.setAttribute("src","https://widget.usepylon.com/widget/${safeAppId}");var n=t.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};if(t.readyState==="complete"){r()}else if(e.addEventListener){e.addEventListener("load",r,false)}})();`;
-
   return (
     <Script id="pylon-chat" strategy="afterInteractive">
-      {script}
+      {buildPylonLoaderScript(appId, identity)}
     </Script>
   );
+}
+
+// ── usePylonChat: hook for custom trigger buttons ────────────────────────────
+export function usePylonChat() {
+  const state = useSyncExternalStore(subscribe, getSnapshot, () => serverSnapshot);
+
+  const toggle = useCallback(() => {
+    window.Pylon?.(state.isOpen ? 'hide' : 'show');
+  }, [state.isOpen]);
+
+  return { toggle, unreadCount: state.unreadCount, isOpen: state.isOpen };
 }


### PR DESCRIPTION
## Summary

Replace Pylon's default chat bubble on `/claw/*` pages with a custom `Support` button that opens and closes the Pylon chat window, shows unread count, and keeps the default launcher hidden.

This follow-up addresses the review feedback on the first implementation:
- Move the Pylon bootstrap out of a large inline script string into explicit client-side helpers in `pylon-widget.tsx`
- Scope the bubble-hiding CSS to the `/claw` layout lifecycle so it does not leak into the rest of the app after a user leaves `/claw/*`
- Render `PylonSupportButton` only when Pylon is actually configured and bootstrapped for the current user, so the UI does not show a dead toggle when the app ID or identity is unavailable
- Keep the widget state in a small external store used by `usePylonChat()` for `toggle`, `isOpen`, and `unreadCount`

## Verification

- `pnpm format`
- `pnpm --filter web typecheck`
- `pnpm dev:restart nextjs`
- Manual browser sanity check of the Pylon bootstrap flow: no default Pylon bubble on load, open, or close; custom trigger remains gated to `/claw/*`

## Visual Changes

<img width="496" height="486" alt="ezgif-1fb29e0fd3af240c" src="https://github.com/user-attachments/assets/fc4f5207-4e8f-4af4-918b-1ed609ccc2ad" />

## Reviewer Notes

- Root cause: Pylon's launcher is not controlled by our Tailwind pipeline, and the previous fix hid it via a globally injected style that persisted beyond `/claw/*`
- The bubble-hiding CSS now mounts with `PylonWidget` and disappears when the claw layout unmounts
- The custom button now renders as a child of `PylonWidget`, so it only appears when the widget bootstrap has valid app/user configuration
- The Pylon vendor script is deduped by both script id and `src` to avoid duplicate loads during client transitions or re-renders
