### PR TITLE
chore(kiloclaw): bump OpenClaw to 2026.4.9

### DIFF
--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -49,22 +49,7 @@ RUN npm install -g pnpm
 # Patch: bump model discovery timeout from 5s to 60s — shared-cpu machines
 # under boot load routinely need 27-35s for the first TLS+fetch to complete.
 # Remove this sed patch once openclaw exposes a configurable timeout.
-# Workaround: openclaw@2026.4.5 is missing bundled channel plugin runtime deps
-# that were removed in the "move bundled extension deps to plugin packages" refactor
-# and re-added in openclaw@2026.4.9 via "mirror bundled channel deps at root (#63065)".
-# Install them globally so openclaw can resolve them at runtime.
-# Remove this block when upgrading to openclaw >= 2026.4.9.
-RUN npm install -g \
-    @buape/carbon@0.14.0 \
-    @grammyjs/runner@^2.0.3 \
-    @grammyjs/transformer-throttler@^1.2.1 \
-    @larksuiteoapi/node-sdk@^1.60.0 \
-    @slack/bolt@^4.6.0 \
-    @slack/web-api@^7.15.0 \
-    grammy@^1.42.0 \
-    https-proxy-agent@^9.0.0 \
-    opusscript@^0.1.1
-RUN npm install -g openclaw@2026.4.5 \
+RUN npm install -g openclaw@2026.4.9 \
     && OC_DIST=/usr/local/lib/node_modules/openclaw/dist \
     && FOUND_FILES=$(find "$OC_DIST" -name 'provider-models-*.js' | wc -l | tr -d ' ') \
     && if [ "$FOUND_FILES" -eq 0 ]; then echo "ERROR: provider-models-*.js not found in openclaw dist" >&2; exit 1; fi \


### PR DESCRIPTION
## Summary

Bumps the OpenClaw pin in the KiloClaw Docker image to v2026.4.9 and removes the temporary workaround.

## Verification

- Reviewed all changelog entries for 4.7, 4.8, 4.9
- Confirmed against the npm registry that `openclaw@2026.4.9`'s root `dependencies` include all 9 previously-workaround-installed packages.
- Manual testing of Stream Chat, Telegram, Slack, Discord, Cron, WebUI for personal instance.
- Manual testing of Web UI for org

## Visual Changes

N/A

## Reviewer Notes
see https://github.com/Kilo-Org/KiloClaw-Version-Upgrade-Artifacts/tree/main/history