### PR TITLE
feat(admin): add backfill to block users on blacklisted domains

### DIFF
--- a/apps/web/src/app/admin/api/backfills/block-blacklisted-domains/route.ts
+++ b/apps/web/src/app/admin/api/backfills/block-blacklisted-domains/route.ts
@@ -11,13 +11,10 @@ const BLACKLIST_DOMAINS = blacklistDomainsEnv
   : [];
 
 function blacklistedDomainConditions() {
-  const conditions = BLACKLIST_DOMAINS.map(
-    domain =>
-      or(
-        sql`lower(${kilocode_users.google_user_email}) LIKE ${`%@${domain.toLowerCase()}`}`,
-        sql`lower(${kilocode_users.google_user_email}) LIKE ${`%.${domain.toLowerCase()}`}`
-      )!
-  );
+  const conditions = BLACKLIST_DOMAINS.flatMap(domain => [
+    sql`lower(${kilocode_users.google_user_email}) LIKE ${`%@${domain.toLowerCase()}`}`,
+    sql`lower(${kilocode_users.google_user_email}) LIKE ${`%.${domain.toLowerCase()}`}`,
+  ]);
   return or(...conditions);
 }
 

--- a/apps/web/src/app/admin/api/backfills/block-blacklisted-domains/route.ts
+++ b/apps/web/src/app/admin/api/backfills/block-blacklisted-domains/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server';
+import { getUserFromAuth } from '@/lib/user.server';
+import { db } from '@/lib/drizzle';
+import { kilocode_users } from '@kilocode/db';
+import { and, count, isNull, or, sql } from 'drizzle-orm';
+import { getEnvVariable } from '@/lib/dotenvx';
+
+const blacklistDomainsEnv = getEnvVariable('BLACKLIST_DOMAINS');
+const BLACKLIST_DOMAINS = blacklistDomainsEnv
+  ? blacklistDomainsEnv.split('|').map((domain: string) => domain.trim())
+  : [];
+
+function blacklistedDomainConditions() {
+  const conditions = BLACKLIST_DOMAINS.map(
+    domain =>
+      or(
+        sql`lower(${kilocode_users.google_user_email}) LIKE ${`%@${domain.toLowerCase()}`}`,
+        sql`lower(${kilocode_users.google_user_email}) LIKE ${`%.${domain.toLowerCase()}`}`
+      )!
+  );
+  return or(...conditions);
+}
+
+export type BlockBlacklistedDomainsCountsResponse = {
+  unblocked: number;
+};
+
+export type BlockBlacklistedDomainsBackfillResponse = {
+  processed: number;
+  remaining: boolean;
+};
+
+export async function GET(): Promise<
+  NextResponse<BlockBlacklistedDomainsCountsResponse | { error: string }>
+> {
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) return authFailedResponse;
+
+  if (BLACKLIST_DOMAINS.length === 0) {
+    return NextResponse.json({ unblocked: 0 });
+  }
+
+  const [result] = await db
+    .select({ count: count() })
+    .from(kilocode_users)
+    .where(and(isNull(kilocode_users.blocked_reason), blacklistedDomainConditions()));
+
+  return NextResponse.json({ unblocked: result?.count ?? 0 });
+}
+
+const BATCH_SIZE = 1000;
+const BATCHES_PER_REQUEST = 50;
+const BLOCKED_REASON = 'domainblocked';
+
+export async function POST(): Promise<
+  NextResponse<BlockBlacklistedDomainsBackfillResponse | { error: string }>
+> {
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) return authFailedResponse;
+
+  if (BLACKLIST_DOMAINS.length === 0) {
+    return NextResponse.json({ processed: 0, remaining: false });
+  }
+
+  let totalProcessed = 0;
+
+  for (let i = 0; i < BATCHES_PER_REQUEST; i++) {
+    const rows = await db
+      .select({ id: kilocode_users.id })
+      .from(kilocode_users)
+      .where(and(isNull(kilocode_users.blocked_reason), blacklistedDomainConditions()))
+      .limit(BATCH_SIZE);
+
+    if (rows.length === 0) break;
+
+    await db
+      .update(kilocode_users)
+      .set({ blocked_reason: BLOCKED_REASON })
+      .where(
+        and(
+          sql`${kilocode_users.id} IN (${sql.join(
+            rows.map(r => sql`${r.id}`),
+            sql`, `
+          )})`,
+          isNull(kilocode_users.blocked_reason)
+        )
+      );
+
+    totalProcessed += rows.length;
+
+    if (rows.length < BATCH_SIZE) break;
+  }
+
+  return NextResponse.json({
+    processed: totalProcessed,
+    remaining: totalProcessed === BATCH_SIZE * BATCHES_PER_REQUEST,
+  });
+}

--- a/apps/web/src/app/admin/backfills/page.tsx
+++ b/apps/web/src/app/admin/backfills/page.tsx
@@ -1,5 +1,6 @@
 import { SafetyIdentifiersBackfill } from '../components/SafetyIdentifiersBackfill';
 import { NormalizedEmailBackfill } from '../components/NormalizedEmailBackfill';
+import { BlockBlacklistedDomainsBackfill } from '../components/BlockBlacklistedDomainsBackfill';
 import { SafetyIdentifierHashGenerator } from '../components/SafetyIdentifierHashGenerator';
 import AdminPage from '../components/AdminPage';
 import { BreadcrumbItem, BreadcrumbPage } from '@/components/ui/breadcrumb';
@@ -20,6 +21,10 @@ export default function BackfillsPage() {
           <h2 className="text-2xl font-bold">Normalized Email Backfill</h2>
         </div>
         <NormalizedEmailBackfill />
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-bold">Block Blacklisted Domains</h2>
+        </div>
+        <BlockBlacklistedDomainsBackfill />
         <div className="flex items-center justify-between">
           <h2 className="text-2xl font-bold">Safety Identifier Backfill</h2>
         </div>

--- a/apps/web/src/app/admin/components/BlockBlacklistedDomainsBackfill.tsx
+++ b/apps/web/src/app/admin/components/BlockBlacklistedDomainsBackfill.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import type {
+  BlockBlacklistedDomainsCountsResponse,
+  BlockBlacklistedDomainsBackfillResponse,
+} from '../api/backfills/block-blacklisted-domains/route';
+
+type BatchLog = {
+  processed: number;
+  timestamp: Date;
+};
+
+export function BlockBlacklistedDomainsBackfill() {
+  const [logs, setLogs] = useState<BatchLog[]>([]);
+  const queryClient = useQueryClient();
+
+  const { data: counts, isLoading } = useQuery<BlockBlacklistedDomainsCountsResponse>({
+    queryKey: ['block-blacklisted-domains-counts'],
+    queryFn: async () => {
+      const res = await fetch('/admin/api/backfills/block-blacklisted-domains');
+      return res.json() as Promise<BlockBlacklistedDomainsCountsResponse>;
+    },
+    refetchInterval: false,
+  });
+
+  const mutation = useMutation<BlockBlacklistedDomainsBackfillResponse, Error>({
+    mutationFn: async () => {
+      const res = await fetch('/admin/api/backfills/block-blacklisted-domains', {
+        method: 'POST',
+      });
+      if (!res.ok) {
+        const body = (await res.json()) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      return res.json() as Promise<BlockBlacklistedDomainsBackfillResponse>;
+    },
+    onSuccess: data => {
+      setLogs(prev => [{ processed: data.processed, timestamp: new Date() }, ...prev]);
+      void queryClient.invalidateQueries({
+        queryKey: ['block-blacklisted-domains-counts'],
+      });
+    },
+  });
+
+  const isDone = counts?.unblocked === 0;
+
+  return (
+    <div className="space-y-6">
+      <p className="text-muted-foreground text-sm">
+        Block users whose email matches a blacklisted domain but who don&apos;t yet have a
+        blocked_reason set. Each click processes up to 50 000 users. Click repeatedly until the
+        counter reaches zero.
+      </p>
+
+      <div className="bg-background space-y-4 rounded-lg border p-6">
+        <div className="flex items-center gap-3">
+          <span className="font-medium">Unblocked users on blacklisted domains</span>
+          {isLoading ? (
+            <Badge variant="secondary">Loading...</Badge>
+          ) : isDone ? (
+            <Badge variant="default" className="bg-green-600">
+              All blocked
+            </Badge>
+          ) : (
+            <Badge variant="destructive">
+              {(counts?.unblocked ?? 0).toLocaleString()} unblocked
+            </Badge>
+          )}
+        </div>
+
+        {mutation.isError && (
+          <Alert variant="destructive">
+            <AlertDescription>{mutation.error.message}</AlertDescription>
+          </Alert>
+        )}
+
+        <Button
+          onClick={() => mutation.mutate()}
+          disabled={isLoading || isDone || mutation.isPending}
+          variant={isDone ? 'outline' : 'default'}
+        >
+          {mutation.isPending ? 'Blocking...' : isDone ? 'Nothing to do' : 'Block next 50 000'}
+        </Button>
+      </div>
+
+      {logs.length > 0 && (
+        <div className="bg-background space-y-2 rounded-lg border p-4">
+          <h4 className="text-sm font-medium">Batch log</h4>
+          <div className="space-y-1 font-mono text-xs">
+            {logs.map((log, i) => (
+              <div key={i} className="text-muted-foreground flex gap-2">
+                <span className="shrink-0">{log.timestamp.toLocaleTimeString()}</span>
+                <span>blocked {log.processed.toLocaleString()} users</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds an admin backfill API route at `/admin/api/backfills/block-blacklisted-domains` that sets `blocked_reason = 'domainblocked'` on users whose email matches a `BLACKLIST_DOMAINS` entry but who don't already have a `blocked_reason` set.
- GET returns the count of unblocked users on blacklisted domains; POST processes them in batches (1000 users × 50 batches per request).
- Follows the same pattern as the existing `normalized-email` backfill route.

## Verification

- [x] Typecheck passes (pre-existing errors only, none from this change)
- [x] Formatted with `pnpm format`
- [ ] Not manually tested against a live database — the route is admin-only and idempotent

## Visual Changes

N/A

## Reviewer Notes

- The `blocked_reason` value `'domainblocked'` matches the convention used by the prior backfill script (`d2025-08-29-backfill-domainblocked-users.ts`).
- The UPDATE includes a redundant `isNull(blocked_reason)` guard to avoid race conditions with concurrent blocks.
- Uses `or()` with `!` on each condition — this is safe because `or()` with two SQL conditions always returns a defined value; however if the linter flags it, it can be restructured.
