### PR TITLE
feat(web): serve kilo-extended CLI config schema at /config.json

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -65,10 +65,8 @@ const nextConfig = {
     return {
       beforeFiles: globalApiRewrites,
       afterFiles: [
-        {
-          source: '/config.json',
-          destination: 'https://opencode.ai/config.json',
-        },
+        // /config.json is handled by src/app/config.json/route.ts which merges
+        // Kilo-specific schema additions on top of the upstream opencode schema.
         // PostHog reverse proxy rewrites — specific routes MUST come before the catch-all
         {
           source: '/ingest/static/:path*',

--- a/apps/web/src/app/config.json/extras.ts
+++ b/apps/web/src/app/config.json/extras.ts
@@ -1,0 +1,82 @@
+/**
+ * Kilo-specific additions and overrides for the CLI config JSON Schema.
+ *
+ * Keep these entries in sync with the zod schema in
+ * packages/opencode/src/config/config.ts in the kilocode repo (grep for
+ * `kilocode_change` markers). If this list drifts from the zod schema, users
+ * of `$schema: https://app.kilo.ai/config.json` will see spurious
+ * "unknown property" warnings for Kilo-only keys.
+ *
+ * To add a new key:
+ *   1. Add the zod field with a `kilocode_change` marker in the CLI repo.
+ *   2. Run `bun --bun packages/opencode/script/schema.ts /tmp/kilo.json` in
+ *      the CLI repo, then `jq '.properties.<new_key>' /tmp/kilo.json` to get
+ *      the exact JSON schema shape.
+ *   3. Paste that shape into the right bucket below:
+ *        - Top-level: `top`
+ *        - New primary agent: `agents`
+ *        - Under `experimental`: `experimental`
+ *        - Anywhere else nested: add a new bucket here AND extend the merge
+ *          logic in `./route.ts` to overlay that section.
+ *   4. Add an assertion to `apps/web/src/tests/cli-config-schema.test.ts`.
+ */
+
+const MODEL_REF = 'https://models.dev/model-schema.json#/$defs/Model';
+
+const nullableModel = {
+  anyOf: [{ $ref: MODEL_REF, type: 'string' }, { type: 'null' }],
+};
+
+const agentConfig = {
+  ref: 'AgentConfig',
+  type: 'object',
+  properties: { model: nullableModel },
+  additionalProperties: {},
+} as const;
+
+export const kiloExtras = {
+  top: {
+    model: {
+      description: 'Model to use in the format of provider/model, eg anthropic/claude-2',
+      ...nullableModel,
+    },
+    small_model: {
+      description:
+        'Small model to use for tasks like title generation in the format of provider/model',
+      ...nullableModel,
+    },
+    remote_control: {
+      description:
+        'Enable remote control of sessions via Kilo Cloud. Equivalent to running /remote on startup.',
+      type: 'boolean',
+    },
+    commit_message: {
+      description: 'Configuration for AI-generated commit messages',
+      type: 'object',
+      properties: {
+        prompt: {
+          description:
+            'Custom system prompt for AI commit message generation. When set, replaces the default conventional commits prompt entirely.',
+          type: 'string',
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  agents: {
+    ask: agentConfig,
+    debug: agentConfig,
+    orchestrator: agentConfig,
+  },
+  experimental: {
+    codebase_search: {
+      description: 'Enable AI-powered codebase search',
+      type: 'boolean',
+    },
+    openTelemetry: {
+      description: 'Enable telemetry. Set to false to opt-out.',
+      default: true,
+      type: 'boolean',
+    },
+  },
+} as const;

--- a/apps/web/src/app/config.json/route.ts
+++ b/apps/web/src/app/config.json/route.ts
@@ -1,78 +1,17 @@
 import { NextResponse } from 'next/server';
+import { kiloExtras } from './extras';
 
 /**
  * Serves the Kilo CLI config JSON Schema at `app.kilo.ai/config.json`.
  *
- * Fetches the upstream opencode schema at request time and merges Kilo-specific
- * additions/overrides on top. Keep the extras below in sync with the zod schema
- * in packages/opencode/src/config/config.ts in the kilocode repo (grep for
- * `kilocode_change` markers).
- *
- * If this list drifts from the zod schema, users of `$schema: https://app.kilo.ai/config.json`
- * will see spurious "unknown property" warnings for Kilo-only keys.
+ * Fetches the upstream opencode schema at request time and overlays Kilo's
+ * additions/overrides (see `./extras.ts`). Cached at the CDN edge for 1 hour
+ * with stale-while-revalidate, so the actual upstream fetch happens at most
+ * once per hour per region.
  */
 
 const UPSTREAM = 'https://opencode.ai/config.json';
-const MODEL_REF = 'https://models.dev/model-schema.json#/$defs/Model';
 const CACHE_SECONDS = 60 * 60; // 1 hour
-
-const nullableModel = {
-  anyOf: [{ $ref: MODEL_REF, type: 'string' }, { type: 'null' }],
-};
-
-const agentConfigExtras = {
-  ref: 'AgentConfig',
-  type: 'object',
-  properties: { model: nullableModel },
-  additionalProperties: {},
-} as const;
-
-const kiloExtras = {
-  top: {
-    model: {
-      description: 'Model to use in the format of provider/model, eg anthropic/claude-2',
-      ...nullableModel,
-    },
-    small_model: {
-      description:
-        'Small model to use for tasks like title generation in the format of provider/model',
-      ...nullableModel,
-    },
-    remote_control: {
-      description:
-        'Enable remote control of sessions via Kilo Cloud. Equivalent to running /remote on startup.',
-      type: 'boolean',
-    },
-    commit_message: {
-      description: 'Configuration for AI-generated commit messages',
-      type: 'object',
-      properties: {
-        prompt: {
-          description:
-            'Custom system prompt for AI commit message generation. When set, replaces the default conventional commits prompt entirely.',
-          type: 'string',
-        },
-      },
-      additionalProperties: false,
-    },
-  },
-  agents: {
-    ask: agentConfigExtras,
-    debug: agentConfigExtras,
-    orchestrator: agentConfigExtras,
-  },
-  experimental: {
-    codebase_search: {
-      description: 'Enable AI-powered codebase search',
-      type: 'boolean',
-    },
-    openTelemetry: {
-      description: 'Enable telemetry. Set to false to opt-out.',
-      default: true,
-      type: 'boolean',
-    },
-  },
-} as const;
 
 export type Schema = Record<string, unknown>;
 

--- a/apps/web/src/app/config.json/route.ts
+++ b/apps/web/src/app/config.json/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Serves the Kilo CLI config JSON Schema at `app.kilo.ai/config.json`.
+ *
+ * Fetches the upstream opencode schema at request time and merges Kilo-specific
+ * additions/overrides on top. Keep the extras below in sync with the zod schema
+ * in packages/opencode/src/config/config.ts in the kilocode repo (grep for
+ * `kilocode_change` markers).
+ *
+ * If this list drifts from the zod schema, users of `$schema: https://app.kilo.ai/config.json`
+ * will see spurious "unknown property" warnings for Kilo-only keys.
+ */
+
+const UPSTREAM = 'https://opencode.ai/config.json';
+const MODEL_REF = 'https://models.dev/model-schema.json#/$defs/Model';
+const CACHE_SECONDS = 60 * 60; // 1 hour
+
+const nullableModel = {
+  anyOf: [{ $ref: MODEL_REF, type: 'string' }, { type: 'null' }],
+};
+
+const agentConfigExtras = {
+  ref: 'AgentConfig',
+  type: 'object',
+  properties: { model: nullableModel },
+  additionalProperties: {},
+} as const;
+
+const kiloExtras = {
+  top: {
+    model: {
+      description: 'Model to use in the format of provider/model, eg anthropic/claude-2',
+      ...nullableModel,
+    },
+    small_model: {
+      description:
+        'Small model to use for tasks like title generation in the format of provider/model',
+      ...nullableModel,
+    },
+    remote_control: {
+      description:
+        'Enable remote control of sessions via Kilo Cloud. Equivalent to running /remote on startup.',
+      type: 'boolean',
+    },
+    commit_message: {
+      description: 'Configuration for AI-generated commit messages',
+      type: 'object',
+      properties: {
+        prompt: {
+          description:
+            'Custom system prompt for AI commit message generation. When set, replaces the default conventional commits prompt entirely.',
+          type: 'string',
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  agents: {
+    ask: agentConfigExtras,
+    debug: agentConfigExtras,
+    orchestrator: agentConfigExtras,
+  },
+  experimental: {
+    codebase_search: {
+      description: 'Enable AI-powered codebase search',
+      type: 'boolean',
+    },
+    openTelemetry: {
+      description: 'Enable telemetry. Set to false to opt-out.',
+      default: true,
+      type: 'boolean',
+    },
+  },
+} as const;
+
+export type Schema = Record<string, unknown>;
+
+function isObject(value: unknown): value is Schema {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function merge(schema: Schema): Schema {
+  const properties = isObject(schema.properties) ? { ...schema.properties } : {};
+  Object.assign(properties, kiloExtras.top);
+
+  const agent = isObject(properties.agent) ? { ...properties.agent } : {};
+  agent.properties = {
+    ...(isObject(agent.properties) ? agent.properties : {}),
+    ...kiloExtras.agents,
+  };
+  properties.agent = agent;
+
+  const experimental = isObject(properties.experimental) ? { ...properties.experimental } : {};
+  experimental.properties = {
+    ...(isObject(experimental.properties) ? experimental.properties : {}),
+    ...kiloExtras.experimental,
+  };
+  properties.experimental = experimental;
+
+  return { ...schema, properties };
+}
+
+export async function GET() {
+  const res = await fetch(UPSTREAM, { next: { revalidate: CACHE_SECONDS } });
+  if (!res.ok) {
+    return NextResponse.json(
+      { error: `upstream ${UPSTREAM} returned ${res.status}` },
+      { status: 502 }
+    );
+  }
+  const upstream = (await res.json()) as Schema;
+  const merged = merge(upstream);
+
+  return NextResponse.json(merged, {
+    headers: {
+      'cache-control': `public, max-age=0, s-maxage=${CACHE_SECONDS}, stale-while-revalidate=${CACHE_SECONDS}`,
+      'access-control-allow-origin': '*',
+    },
+  });
+}

--- a/apps/web/src/tests/cli-config-schema.test.ts
+++ b/apps/web/src/tests/cli-config-schema.test.ts
@@ -1,0 +1,69 @@
+import { merge, type Schema } from '@/app/config.json/route';
+
+const upstream: Schema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  ref: 'Config',
+  type: 'object',
+  properties: {
+    agent: {
+      type: 'object',
+      properties: {
+        build: { ref: 'AgentConfig', type: 'object', properties: {} },
+        plan: { ref: 'AgentConfig', type: 'object', properties: {} },
+      },
+    },
+    experimental: {
+      type: 'object',
+      properties: {
+        batch_tool: { type: 'boolean' },
+      },
+    },
+    model: {
+      $ref: 'https://models.dev/model-schema.json#/$defs/Model',
+      type: 'string',
+    },
+  },
+};
+
+describe('kilo config.json schema merge', () => {
+  const out = merge(upstream);
+  const props = out.properties as Record<string, unknown>;
+
+  test('adds kilo-only top-level keys', () => {
+    expect(props.commit_message).toBeDefined();
+    expect(props.remote_control).toBeDefined();
+  });
+
+  test('commit_message has a prompt string property', () => {
+    const cm = props.commit_message as { properties: { prompt: unknown } };
+    expect(cm.properties.prompt).toEqual(expect.objectContaining({ type: 'string' }));
+  });
+
+  test('allows null on model and small_model', () => {
+    const model = props.model as { anyOf: Array<{ type?: string }> };
+    expect(model.anyOf.some(m => m.type === 'null')).toBe(true);
+    const small = props.small_model as { anyOf: Array<{ type?: string }> };
+    expect(small.anyOf.some(m => m.type === 'null')).toBe(true);
+  });
+
+  test('adds kilo primary agents', () => {
+    const agent = props.agent as { properties: Record<string, unknown> };
+    expect(agent.properties.ask).toBeDefined();
+    expect(agent.properties.debug).toBeDefined();
+    expect(agent.properties.orchestrator).toBeDefined();
+    expect(agent.properties.build).toBeDefined(); // upstream key preserved
+  });
+
+  test('adds kilo experimental keys without dropping upstream', () => {
+    const exp = props.experimental as { properties: Record<string, unknown> };
+    expect(exp.properties.codebase_search).toBeDefined();
+    expect(exp.properties.openTelemetry).toBeDefined();
+    expect(exp.properties.batch_tool).toBeDefined(); // upstream key preserved
+  });
+
+  test('preserves upstream root-level keys', () => {
+    expect(out.$schema).toBe(upstream.$schema);
+    expect(out.ref).toBe('Config');
+    expect(out.type).toBe('object');
+  });
+});


### PR DESCRIPTION
## Summary

`app.kilo.ai/config.json` currently proxies verbatim to `opencode.ai/config.json`, so `kilo.json` files that reference it flag Kilo-only keys (`commit_message`, `remote_control`, etc.) as unknown properties. This replaces the upstream-only rewrite with a Next.js route that fetches the opencode schema and merges Kilo-specific additions on top.

Kilo extras merged in (mirrors `kilocode_change` markers in `packages/opencode/src/config/config.ts` in the kilo CLI repo):
- Top-level: `commit_message`, `remote_control`
- `model` / `small_model` made nullable
- `agent.properties`: `ask`, `debug`, `orchestrator` primary agents
- `experimental.properties`: `codebase_search`, `openTelemetry`

When a new `kilocode_change` top-level or nested property is added to the zod schema, the `kiloExtras` const in the new route file must be updated to match; the file header comment documents this.

## Verification

- `pnpm --filter web test` — 6/6 tests pass (`apps/web/src/tests/cli-config-schema.test.ts`)
- `pnpm -w exec oxlint` — 0 warnings, 0 errors on new files
- `pnpm exec oxfmt` — formatted
- `pnpm run typecheck` — same error count as `main` (79, pre-existing, unrelated)
- Offline diff of merged result vs the CLI-generated `schema.json` — top-level keys, `experimental.properties`, and `agent.properties` all match exactly