### PR TITLE
fix: resolve typecheck errors in resolution.ts and CLI run test

### DIFF
--- a/apps/web/src/lib/kilo-auto/resolution.ts
+++ b/apps/web/src/lib/kilo-auto/resolution.ts
@@ -91,11 +91,9 @@ export async function applyResolvedAutoModel(
   }
   if (resolved.verbosity) {
     if (request.kind === 'messages') {
-      // Anthropic's output_config.effort doesn't support 'xhigh'; map it to 'max'
-      const effort = resolved.verbosity === 'xhigh' ? 'max' : resolved.verbosity;
       request.body.output_config = {
         ...request.body.output_config,
-        effort,
+        effort: resolved.verbosity,
       };
     } else if (request.kind === 'responses') {
       request.body.text = {

--- a/apps/web/src/lib/kilo-auto/resolution.ts
+++ b/apps/web/src/lib/kilo-auto/resolution.ts
@@ -91,9 +91,11 @@ export async function applyResolvedAutoModel(
   }
   if (resolved.verbosity) {
     if (request.kind === 'messages') {
+      // Anthropic's output_config.effort doesn't support 'xhigh'; map it to 'high'
+      const effort = resolved.verbosity === 'xhigh' ? 'high' : resolved.verbosity;
       request.body.output_config = {
         ...request.body.output_config,
-        effort: resolved.verbosity,
+        effort,
       };
     } else if (request.kind === 'responses') {
       request.body.text = {

--- a/apps/web/src/lib/kilo-auto/resolution.ts
+++ b/apps/web/src/lib/kilo-auto/resolution.ts
@@ -91,8 +91,8 @@ export async function applyResolvedAutoModel(
   }
   if (resolved.verbosity) {
     if (request.kind === 'messages') {
-      // Anthropic's output_config.effort doesn't support 'xhigh'; map it to 'high'
-      const effort = resolved.verbosity === 'xhigh' ? 'high' : resolved.verbosity;
+      // Anthropic's output_config.effort doesn't support 'xhigh'; map it to 'max'
+      const effort = resolved.verbosity === 'xhigh' ? 'max' : resolved.verbosity;
       request.body.output_config = {
         ...request.body.output_config,
         effort,

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -540,8 +540,8 @@ describe('organizations.kiloclaw.listKiloCliRuns', () => {
 
 describe('CLI run cross-instance isolation', () => {
   it('org runs are not visible via personal listKiloCliRuns', async () => {
-    await grantKiloClawAccess(user.id);
     const personalInstanceId = await createPersonalInstance(user.id);
+    await grantKiloClawAccess(user.id, personalInstanceId);
     org = await createOrganization('Isolation Org', user.id);
     const orgInstanceId = await createOrgInstance(user.id, org.id);
 
@@ -575,8 +575,8 @@ describe('CLI run cross-instance isolation', () => {
   });
 
   it('org run status is not accessible from the personal getKiloCliRunStatus route', async () => {
-    await grantKiloClawAccess(user.id);
-    await createPersonalInstance(user.id);
+    const personalInstanceId = await createPersonalInstance(user.id);
+    await grantKiloClawAccess(user.id, personalInstanceId);
     org = await createOrganization('Isolation Org 2', user.id);
     const orgInstanceId = await createOrgInstance(user.id, org.id);
 


### PR DESCRIPTION
## Summary

Fixes two typecheck errors on main:

1. **`resolution.ts:96`** — The installed `@anthropic-ai/sdk` was stuck at `0.78.0` (stale `node_modules`) despite the lockfile specifying `0.90.0`. The older version's types didn't include `'xhigh'` in `output_config.effort`, causing a type error when assigning `resolved.verbosity`. The Anthropic API [does support `xhigh` effort](https://docs.anthropic.com/en/docs/build-with-claude/effort) (added for Claude Opus 4.7). Resolved by refreshing the dependency — no code workaround needed.

2. **`kiloclaw-start-kilo-cli-run.test.ts:543,578`** — [PR #2482](https://github.com/Kilo-Org/cloud/pull/2482) changed `grantKiloClawAccess` to require `(userId, instanceId)` but missed updating two call sites in the cross-instance isolation tests. Fixed by creating the personal instance first and passing its ID.

## Verification

- [x] `pnpm typecheck` passes with zero errors
- [x] `pnpm format` applied

## Visual Changes

N/A

## Reviewer Notes

- The first error appeared to be a code issue but was actually a stale dependency. The `xhigh` effort level is [natively supported by the Anthropic API](https://docs.anthropic.com/en/docs/build-with-claude/effort) and by SDK `0.90.0`. CI should resolve correctly since it does a clean install.
- If CI still fails on the effort type, the lockfile may need regenerating with `pnpm install --force`.
