### PR TITLE
fix(kiloclaw): preserve customizer in recovery config

### DIFF
--- a/.specs/kiloclaw-controller.md
+++ b/.specs/kiloclaw-controller.md
@@ -345,10 +345,12 @@ patches to `openclaw.json`. The patches MUST include:
     restore. MUST be preserved on subsequent boots.
 11. Exec policy: host `gateway`, security `allowlist`, ask `on-miss`.
 12. Browser: enabled, headless, noSandbox.
-13. Channel configuration from `TELEGRAM_BOT_TOKEN`,
+13. KiloClaw customizer plugin: load path and entry MUST be present;
+    when `plugins.allow` exists, it MUST include `kiloclaw-customizer`.
+14. Channel configuration from `TELEGRAM_BOT_TOKEN`,
     `DISCORD_BOT_TOKEN`, `SLACK_BOT_TOKEN`/`SLACK_APP_TOKEN`, with
     corresponding plugin enablement.
-14. Hooks configuration from `KILOCLAW_HOOKS_TOKEN`: enabled,
+15. Hooks configuration from `KILOCLAW_HOOKS_TOKEN`: enabled,
     token, inbound email mapping. When Gmail credentials are present, the
     gmail preset MUST also be enabled.
 

--- a/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
+++ b/apps/web/src/routers/kiloclaw-start-kilo-cli-run.test.ts
@@ -540,8 +540,8 @@ describe('organizations.kiloclaw.listKiloCliRuns', () => {
 
 describe('CLI run cross-instance isolation', () => {
   it('org runs are not visible via personal listKiloCliRuns', async () => {
-    await grantKiloClawAccess(user.id);
     const personalInstanceId = await createPersonalInstance(user.id);
+    await grantKiloClawAccess(user.id, personalInstanceId);
     org = await createOrganization('Isolation Org', user.id);
     const orgInstanceId = await createOrgInstance(user.id, org.id);
 
@@ -575,8 +575,8 @@ describe('CLI run cross-instance isolation', () => {
   });
 
   it('org run status is not accessible from the personal getKiloCliRunStatus route', async () => {
-    await grantKiloClawAccess(user.id);
-    await createPersonalInstance(user.id);
+    const personalInstanceId = await createPersonalInstance(user.id);
+    await grantKiloClawAccess(user.id, personalInstanceId);
     org = await createOrganization('Isolation Org 2', user.id);
     const orgInstanceId = await createOrgInstance(user.id, org.id);
 

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -615,6 +615,18 @@ describe('generateBaseConfig', () => {
     expect(paths.filter(p => p === pluginPath)).toHaveLength(1);
   });
 
+  it('adds KiloClaw customizer to an existing plugin allowlist', () => {
+    const existing = JSON.stringify({
+      plugins: {
+        allow: ['openclaw-channel-streamchat', 'telegram', 'kilocode', 'browser'],
+      },
+    });
+    const { deps } = fakeDeps(existing);
+    const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);
+
+    expect(config.plugins.allow).toContain('kiloclaw-customizer');
+  });
+
   it('configures Telegram channel', () => {
     const { deps } = fakeDeps();
     const env = { ...minimalEnv(), TELEGRAM_BOT_TOKEN: 'tg-token-123' };

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -325,6 +325,12 @@ export function generateBaseConfig(
   if (!(config.plugins.load.paths as string[]).includes(KILOCLAW_CUSTOMIZER_PLUGIN_PATH)) {
     (config.plugins.load.paths as string[]).push(KILOCLAW_CUSTOMIZER_PLUGIN_PATH);
   }
+  if (
+    Array.isArray(config.plugins.allow) &&
+    !config.plugins.allow.includes(KILOCLAW_CUSTOMIZER_PLUGIN_ID)
+  ) {
+    config.plugins.allow.push(KILOCLAW_CUSTOMIZER_PLUGIN_ID);
+  }
   config.plugins.entries = config.plugins.entries ?? {};
   config.plugins.entries[KILOCLAW_CUSTOMIZER_PLUGIN_ID] =
     config.plugins.entries[KILOCLAW_CUSTOMIZER_PLUGIN_ID] ?? {};

--- a/services/kiloclaw/controller/src/routes/kilo-cli-run.test.ts
+++ b/services/kiloclaw/controller/src/routes/kilo-cli-run.test.ts
@@ -54,6 +54,13 @@ describe('buildRunPrompt', () => {
     expect(result).toContain('/root/clawd/');
     expect(result).toContain('/_kilo/health');
   });
+
+  it('instructs recovery agents to preserve the KiloClaw customizer plugin', () => {
+    const result = buildRunPrompt('fix plugin warnings');
+    expect(result).toContain('kiloclaw-customizer');
+    expect(result).toContain('Do NOT remove');
+    expect(result).toContain('adding `"kiloclaw-customizer"` to `plugins.allow`');
+  });
 });
 
 describe('/_kilo/cli-run routes', () => {

--- a/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
+++ b/services/kiloclaw/controller/src/routes/kilo-cli-run.ts
@@ -49,13 +49,19 @@ The OpenClaw gateway process listens on \`127.0.0.1:3001\` (loopback), managed b
 - Gateway readiness: \`curl -sf http://127.0.0.1:3001/ready\`
 - Controller state: \`curl -sf http://127.0.0.1:18789/_kilo/health\`
 - Process check: \`ps aux | grep openclaw\`
-- Validate config JSON: \`cat /root/.openclaw/openclaw.json | jq .\`
+- Validate config JSON without printing secrets: \`jq empty /root/.openclaw/openclaw.json\`
 - Logs are NOT written to disk — they go to stdout/stderr (Fly log aggregation). The user may paste log excerpts in the task description below.
 - Run \`openclaw doctor\` to check for common issues.
 
+## Managed KiloClaw Config
+
+- The \`kiloclaw-customizer\` plugin is required and maintained by KiloClaw. Do NOT remove \`/usr/local/lib/node_modules/@kiloclaw/kiloclaw-customizer\` from \`plugins.load.paths\` and do NOT remove \`plugins.entries.kiloclaw-customizer\`.
+- If \`openclaw doctor\` says \`kiloclaw-customizer\` is disabled because it is not in the allowlist, fix the allowlist by adding \`"kiloclaw-customizer"\` to \`plugins.allow\` instead of removing the plugin config.
+- Do not print or summarize secret values from \`openclaw.json\` such as tokens, API keys, auth headers, cookies, or channel credentials.
+
 ## How to Fix
 
-- Edit \`/root/.openclaw/openclaw.json\` to correct config issues.
+- Edit \`/root/.openclaw/openclaw.json\` to correct config issues, preserving managed KiloClaw plugin entries.
 - After config changes, restart the gateway: \`kill -USR1 $(pgrep -f "openclaw gateway")\`
 - The supervisor auto-restarts the gateway on crashes with exponential backoff.
 - If the gateway process is missing entirely, the supervisor will respawn it.


### PR DESCRIPTION
## Summary

I was looking at a customer's Kilo CLI run and noticed the following in the logs:

```
The `kiloclaw-customizer` plugin config should be removed since the plugin is not in the allowlist. Let me fix that:
→ Read ../.openclaw/openclaw.json
The `kiloclaw-customizer` is in `load.paths` but not in the `allow` list, causing a config inconsistency. I'll remove it:

← Edit ../.openclaw/openclaw.json
Index: /root/.openclaw/openclaw.json
===================================================================
--- /root/.openclaw/openclaw.json
+++ /root/.openclaw/openclaw.json
@@ -129,10 +129,9 @@
 ],
 "load": {
   "paths": [
     "/usr/local/lib/node_modules/@wunderchat/openclaw-channel-streamchat",
-    "/usr/local/lib/node_modules/openclaw/dist/extensions/telegram",
-    "/usr/local/lib/node_modules/@kiloclaw/kiloclaw-customizer"
+    "/usr/local/lib/node_modules/openclaw/dist/extensions/telegram"
   ]
 },
 "entries": {
   "telegram": {


← Edit ../.openclaw/openclaw.json
Index: /root/.openclaw/openclaw.json
===================================================================
--- /root/.openclaw/openclaw.json
+++ /root/.openclaw/openclaw.json
@@ -144,16 +144,8 @@
         "enabled": true
       },
       "browser": {
         "enabled": true
-      },
-      "kiloclaw-customizer": {
-        "enabled": true,
-        "config": {
-          "webSearch": {
-            "enabled": true
-          }
-        }
       }
     }
   }
 }
\ No newline at end of file


Now let me restart the gateway and verify:
```

This PR fixes this issue and makes sure that Kilo never disables its own plugin.
