### PR TITLE
ci: notify Slack when CI fails on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,3 +369,61 @@ jobs:
 
       - name: Run tests
         run: pnpm --filter ${{ matrix.workspace.name }} test
+
+  notify-main-failure:
+    if: ${{ always() && github.ref == 'refs/heads/main' && contains(join(needs.*.result, ','), 'failure') }}
+    needs:
+      [
+        typecheck,
+        lint,
+        format-check,
+        drizzle-check,
+        test,
+        build,
+        cloud-agent,
+        cloud-agent-next,
+        workspace-tests,
+      ]
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 5
+    steps:
+      - name: Notify Slack
+        continue-on-error: true
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.DEPLOY_NOTIFY_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":red_circle: CI failed on main"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Commit:*\n<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|`${{ github.sha }}`>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Author:*\n${{ github.actor }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                    }
+                  ]
+                }
+              ]
+            }


### PR DESCRIPTION
## Summary

Adds a Slack notification when CI fails on `main`. This catches semantic merge conflicts (e.g. two PRs pass CI individually but break when merged together) that currently go unnoticed until the next PR fails.

The new `notify-main-failure` job runs after all CI jobs, only on the `main` branch, and only when at least one job failed. It uses the same `DEPLOY_NOTIFY_SLACK_WEBHOOK_URL` webhook and `slackapi/slack-github-action` already used by the KiloClaw deploy workflow.

## Verification

- Reviewed the existing Slack notification pattern in `deploy-kiloclaw.yml` and matched the action version, webhook secret, and Block Kit payload format.
- Verified the `if` condition uses `always()` so skipped jobs (conditional on path changes) don't prevent the notification job from running.

## Visual Changes

N/A

## Reviewer Notes

- The `DEPLOY_NOTIFY_SLACK_WEBHOOK_URL` secret is already configured in the repo — no new secrets needed.
- The job uses `continue-on-error: true` so a Slack API failure won't mark the workflow as failed.
- Skipped jobs (e.g. `test` when no backend files changed) report `skipped`, not `failure`, so they won't trigger the notification.
