### PR TITLE
feat(admin): store blacklisted domains in Redis for instant updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,3 +369,61 @@ jobs:
 
       - name: Run tests
         run: pnpm --filter ${{ matrix.workspace.name }} test
+
+  notify-main-failure:
+    if: ${{ always() && github.ref == 'refs/heads/main' && contains(join(needs.*.result, ','), 'failure') }}
+    needs:
+      [
+        typecheck,
+        lint,
+        format-check,
+        drizzle-check,
+        test,
+        build,
+        cloud-agent,
+        cloud-agent-next,
+        workspace-tests,
+      ]
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 5
+    steps:
+      - name: Notify Slack
+        continue-on-error: true
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.DEPLOY_NOTIFY_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":red_circle: CI failed on main"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Commit:*\n<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|`${{ github.sha }}`>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Author:*\n${{ github.actor }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                    }
+                  ]
+                }
+              ]
+            }

--- a/apps/web/src/app/admin/api/abuse/blacklisted-domains/route.ts
+++ b/apps/web/src/app/admin/api/abuse/blacklisted-domains/route.ts
@@ -3,12 +3,7 @@ import { db } from '@/lib/drizzle';
 import { kilocode_users } from '@kilocode/db/schema';
 import { sql, count, or } from 'drizzle-orm';
 import { getUserFromAuth } from '@/lib/user.server';
-import { getEnvVariable } from '@/lib/dotenvx';
-
-const blacklistDomainsEnv = getEnvVariable('BLACKLIST_DOMAINS');
-const BLACKLIST_DOMAINS = blacklistDomainsEnv
-  ? blacklistDomainsEnv.split('|').map((domain: string) => domain.trim())
-  : [];
+import { getBlacklistedDomains } from '@/lib/blacklist-domains-config';
 
 export async function GET() {
   const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
@@ -17,6 +12,8 @@ export async function GET() {
   }
 
   try {
+    const BLACKLIST_DOMAINS = await getBlacklistedDomains();
+
     // Get counts for each blacklisted domain
     const domainCounts = await Promise.all(
       BLACKLIST_DOMAINS.map(async domain => {

--- a/apps/web/src/app/admin/api/users/route.ts
+++ b/apps/web/src/app/admin/api/users/route.ts
@@ -207,18 +207,20 @@ export async function GET(
     // Calculate pagination metadata
     const totalPages = Math.ceil(totalUserCount / limit);
 
-    const usersWithPaymentStatus: UserTableProps[] = users.map(user => ({
-      ...user,
-      paymentMethodStatus: describePaymentMethods(
-        paymentMethodsByUserId[user.id] || [],
-        user,
-        usersWithValidationCredits.has(user.id)
-      ),
-      admin_notes: notesByUserId.get(user.id)?.map(o => ({ ...o, admin_kilo_user: null })) || [],
-      is_blacklisted_by_domain: isUserBlacklistedByDomain({
-        google_user_email: user.google_user_email,
-      }),
-    }));
+    const usersWithPaymentStatus: UserTableProps[] = await Promise.all(
+      users.map(async user => ({
+        ...user,
+        paymentMethodStatus: describePaymentMethods(
+          paymentMethodsByUserId[user.id] || [],
+          user,
+          usersWithValidationCredits.has(user.id)
+        ),
+        admin_notes: notesByUserId.get(user.id)?.map(o => ({ ...o, admin_kilo_user: null })) || [],
+        is_blacklisted_by_domain: await isUserBlacklistedByDomain({
+          google_user_email: user.google_user_email,
+        }),
+      }))
+    );
 
     const response: UsersApiResponse = {
       users: usersWithPaymentStatus,

--- a/apps/web/src/app/admin/components/BlacklistedDomains.tsx
+++ b/apps/web/src/app/admin/components/BlacklistedDomains.tsx
@@ -1,76 +1,59 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { toast } from 'sonner';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
-import { Shield, Users } from 'lucide-react';
-
-type DomainData = {
-  domain: string;
-  blockedCount: number;
-};
-
-type BlacklistedDomainsData = {
-  domains: DomainData[];
-  totalDomains: number;
-  totalBlockedUsers: number;
-};
+import { Shield } from 'lucide-react';
 
 export function BlacklistedDomains() {
-  const [data, setData] = useState<BlacklistedDomainsData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery(trpc.admin.blacklistDomains.get.queryOptions());
+
+  const [inputValue, setInputValue] = useState('');
+  const [hasChanges, setHasChanges] = useState(false);
 
   useEffect(() => {
-    async function fetchData() {
-      try {
-        const response = await fetch('/admin/api/abuse/blacklisted-domains');
-        if (!response.ok) {
-          throw new Error('Failed to fetch blacklisted domains');
-        }
-        const result = await response.json();
-        setData(result);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'An error occurred');
-      } finally {
-        setLoading(false);
-      }
+    if (data) {
+      setInputValue(data.domains.join('\n'));
+      setHasChanges(false);
     }
+  }, [data]);
 
-    void fetchData();
-  }, []);
+  const mutation = useMutation(
+    trpc.admin.blacklistDomains.set.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.blacklistDomains.get.queryKey(),
+        });
+        toast.success('Blacklisted domains updated');
+      },
+      onError: error => {
+        toast.error(error.message || 'Failed to update');
+      },
+    })
+  );
 
-  if (loading) {
-    return (
-      <Card>
-        <CardContent className="pt-6">
-          <div className="text-muted-foreground text-center">Loading blacklisted domains...</div>
-        </CardContent>
-      </Card>
-    );
+  function handleSave() {
+    const domains = inputValue
+      .split('\n')
+      .map(line => line.trim().toLowerCase())
+      .filter(Boolean);
+
+    mutation.mutate({ domains });
   }
 
-  if (error) {
-    return (
-      <Card>
-        <CardContent className="pt-6">
-          <div className="text-destructive text-center">Error: {error}</div>
-        </CardContent>
-      </Card>
-    );
+  if (isLoading) {
+    return <div className="text-muted-foreground py-8 text-sm">Loading...</div>;
   }
 
-  if (!data) {
-    return null;
-  }
+  const domainCount = data?.domains.length ?? 0;
 
   return (
     <Card>
@@ -81,62 +64,45 @@ export function BlacklistedDomains() {
               <Shield className="h-5 w-5" />
               Blacklisted Domains
             </CardTitle>
-            <CardDescription>Email domains that are blocked from registration</CardDescription>
+            <CardDescription>
+              Email domains that are blocked from registration and access. Enter one domain per
+              line. Subdomains are automatically blocked (e.g. blocking example.com also blocks
+              sub.example.com).
+            </CardDescription>
           </div>
-          <div className="flex gap-4 text-sm">
-            <div className="flex items-center gap-2">
-              <Badge variant="secondary" className="px-3 py-1">
-                {data.totalDomains} domains
-              </Badge>
-            </div>
-            <div className="flex items-center gap-2">
-              <Badge variant="destructive" className="px-3 py-1">
-                <Users className="mr-1 h-3 w-3" />
-                {data.totalBlockedUsers.toLocaleString()} blocked users
-              </Badge>
-            </div>
-          </div>
+          <Badge variant="secondary" className="px-3 py-1">
+            {domainCount} {domainCount === 1 ? 'domain' : 'domains'}
+          </Badge>
         </div>
       </CardHeader>
-      <CardContent>
-        {data.domains.length === 0 ? (
-          <div className="text-muted-foreground py-8 text-center">
-            No blacklisted domains configured
-          </div>
-        ) : (
-          <div className="rounded-md border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Domain</TableHead>
-                  <TableHead className="text-right">Blocked Users</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {data.domains.map(domain => (
-                  <TableRow key={domain.domain}>
-                    <TableCell className="font-medium">
-                      <code className="bg-muted rounded px-2 py-1 text-sm">{domain.domain}</code>
-                    </TableCell>
-                    <TableCell className="text-right">
-                      {domain.blockedCount > 0 ? (
-                        <Badge variant={domain.blockedCount > 100 ? 'destructive' : 'secondary'}>
-                          {domain.blockedCount.toLocaleString()}
-                        </Badge>
-                      ) : (
-                        <span className="text-muted-foreground">0</span>
-                      )}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-        )}
-        <div className="text-muted-foreground mt-4 text-xs">
+      <CardContent className="flex flex-col gap-4">
+        <Textarea
+          placeholder={'example.com\nspam.org\nmalicious.net'}
+          value={inputValue}
+          onChange={e => {
+            setInputValue(e.target.value);
+            setHasChanges(true);
+          }}
+          rows={15}
+          className="font-mono text-sm"
+        />
+
+        <div className="flex items-center gap-3">
+          <Button onClick={handleSave} disabled={mutation.isPending || !hasChanges} size="sm">
+            {mutation.isPending ? 'Saving...' : 'Save'}
+          </Button>
+          {data?.updated_by_email && (
+            <span className="text-muted-foreground text-sm">
+              Last updated by {data.updated_by_email}
+              {data.updated_at && <> at {new Date(data.updated_at).toLocaleString()}</>}
+            </span>
+          )}
+        </div>
+
+        <div className="text-muted-foreground text-xs">
           <p>
-            Domains are matched against email addresses using both @domain and .domain patterns.
-            This list is configured via the BLACKLIST_DOMAINS environment variable.
+            Domains are stored in Redis for instant updates. Changes take effect immediately without
+            a deploy. The BLACKLIST_DOMAINS env var is used as a fallback if Redis has no data.
           </p>
         </div>
       </CardContent>

--- a/apps/web/src/app/admin/components/BlacklistedDomains.tsx
+++ b/apps/web/src/app/admin/components/BlacklistedDomains.tsx
@@ -41,9 +41,10 @@ export function BlacklistedDomains() {
   );
 
   function handleSave() {
+    // Support both newline and pipe-separated input (e.g. pasting from the env var)
     const domains = inputValue
-      .split('\n')
-      .map(line => line.trim().toLowerCase())
+      .split(/[\n|]/)
+      .map(part => part.trim().toLowerCase())
       .filter(Boolean);
 
     mutation.mutate({ domains });
@@ -65,9 +66,9 @@ export function BlacklistedDomains() {
               Blacklisted Domains
             </CardTitle>
             <CardDescription>
-              Email domains that are blocked from registration and access. Enter one domain per
-              line. Subdomains are automatically blocked (e.g. blocking example.com also blocks
-              sub.example.com).
+              Email domains that are blocked from registration and access. Enter one domain per line
+              (or paste a pipe-separated list). Subdomains are automatically blocked (e.g. blocking
+              example.com also blocks sub.example.com).
             </CardDescription>
           </div>
           <Badge variant="secondary" className="px-3 py-1">

--- a/apps/web/src/app/admin/components/BlacklistedDomains.tsx
+++ b/apps/web/src/app/admin/components/BlacklistedDomains.tsx
@@ -8,13 +8,24 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
-import { Shield } from 'lucide-react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Shield, Users } from 'lucide-react';
 
 export function BlacklistedDomains() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
   const { data, isLoading } = useQuery(trpc.admin.blacklistDomains.get.queryOptions());
+  const { data: stats, isLoading: statsLoading } = useQuery(
+    trpc.admin.blacklistDomains.stats.queryOptions()
+  );
 
   const [inputValue, setInputValue] = useState('');
   const [hasChanges, setHasChanges] = useState(false);
@@ -31,6 +42,9 @@ export function BlacklistedDomains() {
       onSuccess: () => {
         void queryClient.invalidateQueries({
           queryKey: trpc.admin.blacklistDomains.get.queryKey(),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.blacklistDomains.stats.queryKey(),
         });
         toast.success('Blacklisted domains updated');
       },
@@ -57,56 +71,116 @@ export function BlacklistedDomains() {
   const domainCount = data?.domains.length ?? 0;
 
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <div>
-            <CardTitle className="flex items-center gap-2">
-              <Shield className="h-5 w-5" />
-              Blacklisted Domains
-            </CardTitle>
-            <CardDescription>
-              Email domains that are blocked from registration and access. Enter one domain per line
-              (or paste a pipe-separated list). Subdomains are automatically blocked (e.g. blocking
-              example.com also blocks sub.example.com).
-            </CardDescription>
+    <div className="flex flex-col gap-6">
+      {/* Editor card */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle className="flex items-center gap-2">
+                <Shield className="h-5 w-5" />
+                Blacklisted Domains
+              </CardTitle>
+              <CardDescription>
+                Email domains that are blocked from registration and access. Enter one domain per
+                line (or paste a pipe-separated list). Subdomains are automatically blocked (e.g.
+                blocking example.com also blocks sub.example.com).
+              </CardDescription>
+            </div>
+            <div className="flex gap-4 text-sm">
+              <Badge variant="secondary" className="px-3 py-1">
+                {domainCount} {domainCount === 1 ? 'domain' : 'domains'}
+              </Badge>
+              {stats && (
+                <Badge variant="destructive" className="px-3 py-1">
+                  <Users className="mr-1 h-3 w-3" />
+                  {stats.totalBlockedUsers.toLocaleString()} blocked users
+                </Badge>
+              )}
+            </div>
           </div>
-          <Badge variant="secondary" className="px-3 py-1">
-            {domainCount} {domainCount === 1 ? 'domain' : 'domains'}
-          </Badge>
-        </div>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4">
-        <Textarea
-          placeholder={'example.com\nspam.org\nmalicious.net'}
-          value={inputValue}
-          onChange={e => {
-            setInputValue(e.target.value);
-            setHasChanges(true);
-          }}
-          rows={15}
-          className="font-mono text-sm"
-        />
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <Textarea
+            placeholder={'example.com\nspam.org\nmalicious.net'}
+            value={inputValue}
+            onChange={e => {
+              setInputValue(e.target.value);
+              setHasChanges(true);
+            }}
+            rows={15}
+            className="font-mono text-sm"
+          />
 
-        <div className="flex items-center gap-3">
-          <Button onClick={handleSave} disabled={mutation.isPending || !hasChanges} size="sm">
-            {mutation.isPending ? 'Saving...' : 'Save'}
-          </Button>
-          {data?.updated_by_email && (
-            <span className="text-muted-foreground text-sm">
-              Last updated by {data.updated_by_email}
-              {data.updated_at && <> at {new Date(data.updated_at).toLocaleString()}</>}
-            </span>
+          <div className="flex items-center gap-3">
+            <Button onClick={handleSave} disabled={mutation.isPending || !hasChanges} size="sm">
+              {mutation.isPending ? 'Saving...' : 'Save'}
+            </Button>
+            {data?.updated_by_email && (
+              <span className="text-muted-foreground text-sm">
+                Last updated by {data.updated_by_email}
+                {data.updated_at && <> at {new Date(data.updated_at).toLocaleString()}</>}
+              </span>
+            )}
+          </div>
+
+          <div className="text-muted-foreground text-xs">
+            <p>
+              Domains are stored in Redis for instant updates. Changes take effect immediately
+              without a deploy. The BLACKLIST_DOMAINS env var is used as a fallback if Redis has no
+              data.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Stats table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Blocked Users by Domain</CardTitle>
+          <CardDescription>
+            Number of registered users matching each blacklisted domain
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {statsLoading ? (
+            <div className="text-muted-foreground py-8 text-center text-sm">Loading stats...</div>
+          ) : !stats || stats.domains.length === 0 ? (
+            <div className="text-muted-foreground py-8 text-center">
+              No blacklisted domains configured
+            </div>
+          ) : (
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Domain</TableHead>
+                    <TableHead className="text-right">Blocked Users</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {stats.domains.map(domain => (
+                    <TableRow key={domain.domain}>
+                      <TableCell className="font-medium">
+                        <code className="bg-muted rounded px-2 py-1 text-sm">{domain.domain}</code>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {domain.blockedCount > 0 ? (
+                          <Badge variant={domain.blockedCount > 100 ? 'destructive' : 'secondary'}>
+                            {domain.blockedCount.toLocaleString()}
+                          </Badge>
+                        ) : (
+                          <span className="text-muted-foreground">0</span>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
           )}
-        </div>
-
-        <div className="text-muted-foreground text-xs">
-          <p>
-            Domains are stored in Redis for instant updates. Changes take effect immediately without
-            a deploy. The BLACKLIST_DOMAINS env var is used as a fallback if Redis has no data.
-          </p>
-        </div>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/apps/web/src/app/admin/users/[id]/page.tsx
+++ b/apps/web/src/app/admin/users/[id]/page.tsx
@@ -87,7 +87,7 @@ async function getUserData(userId: string): Promise<UserDetailProps | null> {
     ),
     creditInfo,
     admin_notes: notesWithAdmin,
-    is_blacklisted_by_domain: isUserBlacklistedByDomain({
+    is_blacklisted_by_domain: await isUserBlacklistedByDomain({
       google_user_email: user.google_user_email,
     }),
     organization_memberships: organizationMemberships,

--- a/apps/web/src/app/api/auth/magic-link/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/route.ts
@@ -6,7 +6,7 @@ import { verifyTurnstileJWT } from '@/lib/auth/verify-turnstile-jwt';
 import * as z from 'zod';
 import { findUserByEmail } from '@/lib/user';
 import { validateMagicLinkSignupEmail } from '@/lib/schemas/email';
-import { isEmailBlacklistedByDomain, isBlockedTLD } from '@/lib/user.server';
+import { isEmailBlacklistedByDomainAsync, isBlockedTLD } from '@/lib/user.server';
 
 const requestSchema = z.object({
   email: z.string().email(),
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
     return turnstileResult.response;
   }
 
-  if (isEmailBlacklistedByDomain(email)) {
+  if (await isEmailBlacklistedByDomainAsync(email)) {
     return NextResponse.json({ success: false, error: 'BLOCKED' }, { status: 403 });
   }
 

--- a/apps/web/src/lib/blacklist-domains-config.ts
+++ b/apps/web/src/lib/blacklist-domains-config.ts
@@ -1,3 +1,4 @@
+import 'server-only';
 import * as z from 'zod';
 import { redisGet } from '@/lib/redis';
 import { getEnvVariable } from '@/lib/dotenvx';

--- a/apps/web/src/lib/blacklist-domains-config.ts
+++ b/apps/web/src/lib/blacklist-domains-config.ts
@@ -1,6 +1,7 @@
 import * as z from 'zod';
 import { redisGet } from '@/lib/redis';
 import { getEnvVariable } from '@/lib/dotenvx';
+import { createCachedFetch } from '@/lib/cached-fetch';
 
 export const BLACKLIST_DOMAINS_REDIS_KEY = 'admin:blacklisted-domains';
 
@@ -24,24 +25,7 @@ export const BlacklistDomainsInputSchema = z.object({
   domains: z.array(z.string().min(1).trim()),
 });
 
-/**
- * Reads blacklisted domains from Redis, falling back to the BLACKLIST_DOMAINS env var.
- * Returns a plain string array of domains.
- */
-export async function getBlacklistedDomains(): Promise<string[]> {
-  try {
-    const raw = await redisGet(BLACKLIST_DOMAINS_REDIS_KEY);
-    if (raw) {
-      const parsed = BlacklistDomainsConfigSchema.parse(JSON.parse(raw));
-      if (parsed.domains.length > 0) {
-        return parsed.domains;
-      }
-    }
-  } catch {
-    // Fall through to env var
-  }
-
-  // Fallback to env var
+function getEnvFallbackDomains(): string[] {
   const envVal = getEnvVariable('BLACKLIST_DOMAINS');
   return envVal
     ? envVal
@@ -50,3 +34,23 @@ export async function getBlacklistedDomains(): Promise<string[]> {
         .filter(Boolean)
     : [];
 }
+
+/**
+ * Reads blacklisted domains from Redis, falling back to the BLACKLIST_DOMAINS env var.
+ * Cached in-process for 10 seconds (stale-while-revalidate) to avoid hitting Redis on
+ * every auth check.
+ */
+export const getBlacklistedDomains = createCachedFetch(
+  async (): Promise<string[]> => {
+    const raw = await redisGet(BLACKLIST_DOMAINS_REDIS_KEY);
+    if (raw) {
+      const parsed = BlacklistDomainsConfigSchema.parse(JSON.parse(raw));
+      if (parsed.domains.length > 0) {
+        return parsed.domains;
+      }
+    }
+    return getEnvFallbackDomains();
+  },
+  10_000,
+  getEnvFallbackDomains()
+);

--- a/apps/web/src/lib/blacklist-domains-config.ts
+++ b/apps/web/src/lib/blacklist-domains-config.ts
@@ -1,0 +1,52 @@
+import * as z from 'zod';
+import { redisGet } from '@/lib/redis';
+import { getEnvVariable } from '@/lib/dotenvx';
+
+export const BLACKLIST_DOMAINS_REDIS_KEY = 'admin:blacklisted-domains';
+
+export const BlacklistDomainsConfigSchema = z.object({
+  domains: z.array(z.string()),
+  updated_at: z.string().nullable(),
+  updated_by: z.string().nullable(),
+  updated_by_email: z.string().nullable(),
+});
+
+export type BlacklistDomainsConfig = z.infer<typeof BlacklistDomainsConfigSchema>;
+
+export const DEFAULT_BLACKLIST_DOMAINS_CONFIG: BlacklistDomainsConfig = {
+  domains: [],
+  updated_at: null,
+  updated_by: null,
+  updated_by_email: null,
+};
+
+export const BlacklistDomainsInputSchema = z.object({
+  domains: z.array(z.string().min(1).trim()),
+});
+
+/**
+ * Reads blacklisted domains from Redis, falling back to the BLACKLIST_DOMAINS env var.
+ * Returns a plain string array of domains.
+ */
+export async function getBlacklistedDomains(): Promise<string[]> {
+  try {
+    const raw = await redisGet(BLACKLIST_DOMAINS_REDIS_KEY);
+    if (raw) {
+      const parsed = BlacklistDomainsConfigSchema.parse(JSON.parse(raw));
+      if (parsed.domains.length > 0) {
+        return parsed.domains;
+      }
+    }
+  } catch {
+    // Fall through to env var
+  }
+
+  // Fallback to env var
+  const envVal = getEnvVariable('BLACKLIST_DOMAINS');
+  return envVal
+    ? envVal
+        .split('|')
+        .map((d: string) => d.trim())
+        .filter(Boolean)
+    : [];
+}

--- a/apps/web/src/lib/user.server.ts
+++ b/apps/web/src/lib/user.server.ts
@@ -93,8 +93,10 @@ export type TurnstileJwtPayload = {
 
 const warnInSentry = sentryLogger('user.server', 'warning');
 
+import { getBlacklistedDomains } from '@/lib/blacklist-domains-config';
+
 const blacklistDomainsEnv = getEnvVariable('BLACKLIST_DOMAINS');
-const BLACKLIST_DOMAINS = blacklistDomainsEnv
+const BLACKLIST_DOMAINS_FROM_ENV = blacklistDomainsEnv
   ? blacklistDomainsEnv.split('|').map((domain: string) => domain.trim())
   : [];
 
@@ -561,7 +563,7 @@ const authOptions: NextAuthOptions = {
           return redirectUrlForCode('USER-NOT-FOUND', accountInfo.google_user_email);
         }
 
-        if (isEmailBlacklistedByDomain(accountInfo.google_user_email)) {
+        if (await isEmailBlacklistedByDomainAsync(accountInfo.google_user_email)) {
           sentryLogger('auth', 'warning')(
             `SECURITY: Blacklisted: ${accountInfo.google_user_email}`,
             accountInfo
@@ -918,7 +920,7 @@ async function validateUserAuthorization(
 ): Promise<GetAuthResponse> {
   if (!user) {
     return authError(401, 'User not found', kiloUserId);
-  } else if (isUserBlacklistedByDomain(user)) {
+  } else if (await isUserBlacklistedByDomain(user)) {
     return authError(403, 'Access denied (R0)', kiloUserId);
   } else if (!opts.DANGEROUS_allowBlockedUsers && user.blocked_reason) {
     return report_blocked_user(kiloUserId);
@@ -948,18 +950,27 @@ async function validateUserAuthorization(
   };
 }
 
-export const isUserBlacklistedByDomain = (existingUser: Pick<User, 'google_user_email'>) =>
-  isEmailBlacklistedByDomain(existingUser.google_user_email);
+export async function isUserBlacklistedByDomain(
+  existingUser: Pick<User, 'google_user_email'>
+): Promise<boolean> {
+  const domains = await getBlacklistedDomains();
+  return isEmailBlacklistedByDomain(existingUser.google_user_email, domains);
+}
 
 export const isEmailBlacklistedByDomain = (
   email: string,
-  blacklisted_domains = BLACKLIST_DOMAINS
+  blacklisted_domains: string[] | undefined = BLACKLIST_DOMAINS_FROM_ENV
 ) =>
   blacklisted_domains?.some(
     domain =>
       email.toLowerCase().endsWith('@' + domain.toLowerCase()) ||
       email.toLowerCase().endsWith('.' + domain.toLowerCase())
   );
+
+export async function isEmailBlacklistedByDomainAsync(email: string): Promise<boolean> {
+  const domains = await getBlacklistedDomains();
+  return !!isEmailBlacklistedByDomain(email, domains);
+}
 
 export const isBlockedTLD = (email: string, blacklisted_tlds = BLACKLIST_TLDS) =>
   blacklisted_tlds.some(tld => email.toLowerCase().endsWith(tld));

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -35,6 +35,7 @@ import { adminGastownRouter } from '@/routers/admin/gastown-router';
 import { extendClawTrialRouter } from '@/routers/admin/extend-claw-trial-router';
 import { adminCustomLlmRouter } from '@/routers/admin/custom-llm-router';
 import { adminGatewayConfigRouter } from '@/routers/admin/gateway-config-router';
+import { adminBlacklistDomainsRouter } from '@/routers/admin/blacklist-domains-router';
 import { adminWebhookTriggersRouter } from '@/routers/admin-webhook-triggers-router';
 import { adminAlertingRouter } from '@/routers/admin-alerting-router';
 import { adminBotRequestsRouter } from '@/routers/admin-bot-requests-router';
@@ -1563,4 +1564,5 @@ export const adminRouter = createTRPCRouter({
   extendClawTrial: extendClawTrialRouter,
   customLlm: adminCustomLlmRouter,
   gatewayConfig: adminGatewayConfigRouter,
+  blacklistDomains: adminBlacklistDomainsRouter,
 });

--- a/apps/web/src/routers/admin/blacklist-domains-router.ts
+++ b/apps/web/src/routers/admin/blacklist-domains-router.ts
@@ -1,0 +1,48 @@
+import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
+import { redisGet, redisSet } from '@/lib/redis';
+import {
+  BLACKLIST_DOMAINS_REDIS_KEY,
+  BlacklistDomainsConfigSchema,
+  BlacklistDomainsInputSchema,
+  DEFAULT_BLACKLIST_DOMAINS_CONFIG,
+} from '@/lib/blacklist-domains-config';
+import type { BlacklistDomainsConfig } from '@/lib/blacklist-domains-config';
+import { TRPCError } from '@trpc/server';
+
+async function readConfig(): Promise<BlacklistDomainsConfig> {
+  try {
+    const raw = await redisGet(BLACKLIST_DOMAINS_REDIS_KEY);
+    if (!raw) return DEFAULT_BLACKLIST_DOMAINS_CONFIG;
+    return BlacklistDomainsConfigSchema.parse(JSON.parse(raw));
+  } catch {
+    return DEFAULT_BLACKLIST_DOMAINS_CONFIG;
+  }
+}
+
+export const adminBlacklistDomainsRouter = createTRPCRouter({
+  get: adminProcedure.query(async () => {
+    return readConfig();
+  }),
+
+  set: adminProcedure.input(BlacklistDomainsInputSchema).mutation(async ({ input, ctx }) => {
+    // Deduplicate and normalize domains
+    const normalizedDomains = [
+      ...new Set(input.domains.map(d => d.toLowerCase().trim()).filter(Boolean)),
+    ];
+
+    const config: BlacklistDomainsConfig = {
+      domains: normalizedDomains,
+      updated_at: new Date().toISOString(),
+      updated_by: ctx.user.id,
+      updated_by_email: ctx.user.google_user_email,
+    };
+    const written = await redisSet(BLACKLIST_DOMAINS_REDIS_KEY, JSON.stringify(config));
+    if (!written) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Redis is not configured — cannot save blacklisted domains',
+      });
+    }
+    return config;
+  }),
+});

--- a/apps/web/src/routers/admin/blacklist-domains-router.ts
+++ b/apps/web/src/routers/admin/blacklist-domains-router.ts
@@ -5,9 +5,13 @@ import {
   BlacklistDomainsConfigSchema,
   BlacklistDomainsInputSchema,
   DEFAULT_BLACKLIST_DOMAINS_CONFIG,
+  getBlacklistedDomains,
 } from '@/lib/blacklist-domains-config';
 import type { BlacklistDomainsConfig } from '@/lib/blacklist-domains-config';
 import { TRPCError } from '@trpc/server';
+import { db } from '@/lib/drizzle';
+import { kilocode_users } from '@kilocode/db/schema';
+import { sql, count, or } from 'drizzle-orm';
 
 async function readConfig(): Promise<BlacklistDomainsConfig> {
   try {
@@ -44,5 +48,33 @@ export const adminBlacklistDomainsRouter = createTRPCRouter({
       });
     }
     return config;
+  }),
+
+  stats: adminProcedure.query(async () => {
+    const domains = await getBlacklistedDomains();
+
+    const domainCounts = await Promise.all(
+      domains.map(async domain => {
+        const conditions = or(
+          sql`lower(${kilocode_users.google_user_email}) LIKE ${`%@${domain.toLowerCase()}`}`,
+          sql`lower(${kilocode_users.google_user_email}) LIKE ${`%.${domain.toLowerCase()}`}`
+        );
+
+        const result = await db.select({ count: count() }).from(kilocode_users).where(conditions);
+
+        return {
+          domain,
+          blockedCount: result[0]?.count ?? 0,
+        };
+      })
+    );
+
+    domainCounts.sort((a, b) => b.blockedCount - a.blockedCount);
+
+    return {
+      domains: domainCounts,
+      totalDomains: domains.length,
+      totalBlockedUsers: domainCounts.reduce((sum, d) => sum + d.blockedCount, 0),
+    };
   }),
 });


### PR DESCRIPTION
## Summary

Moves the blacklisted domains list from the `BLACKLIST_DOMAINS` env var to Redis, so domains can be added/removed instantly from the admin UI without a deploy.

- New `blacklist-domains-config.ts` defines the Redis key, Zod schemas, and a `getBlacklistedDomains()` getter that reads from Redis with env var fallback
- New tRPC router (`admin.blacklistDomains.get`/`.set`) for reading and writing the domain list, with deduplication and case normalization
- `isUserBlacklistedByDomain` is now async (reads from Redis); added `isEmailBlacklistedByDomainAsync` for callers that previously used the sync version without an explicit domain list
- The sync `isEmailBlacklistedByDomain` is unchanged — tests and the backfill script that pass explicit domain arrays still work identically
- The admin `/admin/blacklisted-domains` page now uses a textarea (one domain per line) backed by tRPC instead of a read-only table fetched from a REST endpoint
- The REST endpoint at `/admin/api/abuse/blacklisted-domains` also reads from Redis now

## Verification

- [x] `pnpm typecheck` passes
- [x] `pnpm format` applied
- [x] All 42 existing `user.server.test.ts` tests pass
- [ ] Not manually tested in browser (no dev server running)

## Visual Changes

N/A (admin page layout change from read-only table to editable textarea)

## Reviewer Notes

- The env var `BLACKLIST_DOMAINS` is kept as a fallback: if Redis has no data (empty array or key missing), the env var is used. This means existing deployments continue working until someone saves domains via the admin UI.
- On the hot auth path (`validateUserAuthorization`), this adds a Redis read per request. Redis reads are sub-millisecond and already used on this path for gateway routing config.
- The backfill script (`d2025-08-29-backfill-domainblocked-users.ts`) is unaffected — it passes an explicit domain list from the env var.
