### PR TITLE
fix(kiloclaw): harden billing live-path, changelog coverage, and UI guards

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawChatPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawChatPage.tsx
@@ -19,7 +19,7 @@ import { Card, CardContent } from '@/components/ui/card';
 function ClawChatWithStatus({ organizationId }: { organizationId?: string }) {
   const router = useRouter();
   const personalStatus = useKiloClawStatus();
-  const orgStatus = useOrgKiloClawStatus(organizationId ?? '');
+  const orgStatus = useOrgKiloClawStatus(organizationId);
   const { data: status, isLoading, error } = organizationId ? orgStatus : personalStatus;
 
   const clawUrl = organizationId ? `/organizations/${organizationId}/claw/new` : '/claw/new';

--- a/apps/web/src/app/(app)/claw/components/ClawSettingsPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawSettingsPage.tsx
@@ -99,7 +99,7 @@ function ClawSettingsWithStatus({
 }) {
   const router = useRouter();
   const personalStatus = useKiloClawStatus();
-  const orgStatus = useOrgKiloClawStatus(organizationId ?? '');
+  const orgStatus = useOrgKiloClawStatus(organizationId);
   const { data: status, isLoading, error } = organizationId ? orgStatus : personalStatus;
 
   const clawUrl = organizationId ? `/organizations/${organizationId}/claw/new` : '/claw/new';

--- a/apps/web/src/app/(app)/claw/components/SubscriptionTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SubscriptionTab.tsx
@@ -12,7 +12,7 @@ import { PlanSelectionDialog } from './billing/PlanSelectionDialog';
 
 export function SubscriptionTab() {
   const trpc = useTRPC();
-  const { data: billing } = useQuery(trpc.kiloclaw.getBillingStatus.queryOptions());
+  const { data: billing } = useQuery(trpc.kiloclaw.getActivePersonalBillingStatus.queryOptions());
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [showPlanDialog, setShowPlanDialog] = useState(false);
 

--- a/apps/web/src/app/(app)/claw/components/billing/BillingBanner.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/BillingBanner.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { AlertCircle, AlertTriangle, ArrowRightLeft, Clock, CreditCard } from 'lucide-react';
+import {
+  AlertCircle,
+  AlertTriangle,
+  ArrowRightLeft,
+  Clock,
+  CreditCard,
+  Loader2,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import type { ClawBannerState, ClawBillingStatus } from './billing-types';
@@ -15,6 +22,7 @@ type BillingBannerProps = {
   onSubscribeClick: () => void;
   onReactivateClick: () => void;
   onUpdatePaymentClick: () => void;
+  isReactivating?: boolean;
 };
 
 function getBannerStyles(state: ClawBannerState) {
@@ -157,6 +165,7 @@ export function BillingBanner({
   onSubscribeClick,
   onReactivateClick,
   onUpdatePaymentClick,
+  isReactivating = false,
 }: BillingBannerProps) {
   const state = deriveBannerState(billing);
 
@@ -203,8 +212,20 @@ export function BillingBanner({
       </div>
 
       {content.cta && (
-        <Button onClick={handleCta} variant="primary" className="shrink-0">
-          {content.cta}
+        <Button
+          onClick={handleCta}
+          variant="primary"
+          className="shrink-0"
+          disabled={content.action === 'reactivate' && isReactivating}
+        >
+          {content.action === 'reactivate' && isReactivating ? (
+            <>
+              <Loader2 className="animate-spin" />
+              Reactivating...
+            </>
+          ) : (
+            content.cta
+          )}
         </Button>
       )}
     </div>

--- a/apps/web/src/app/(app)/claw/components/billing/BillingWrapper.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/BillingWrapper.tsx
@@ -44,18 +44,25 @@ type BillingWrapperProps = {
 export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
-  const { data: billing } = useQuery(trpc.kiloclaw.getBillingStatus.queryOptions());
+  const { data: billing } = useQuery(trpc.kiloclaw.getActivePersonalBillingStatus.queryOptions());
+  const instanceId = billing?.instance?.id ?? null;
 
   const [showPlanDialog, setShowPlanDialog] = useState(false);
 
-  const reactivate = useMutation(trpc.kiloclaw.reactivateSubscription.mutationOptions());
-  const billingPortal = useMutation(trpc.kiloclaw.createBillingPortalSession.mutationOptions());
+  const reactivate = useMutation(trpc.kiloclaw.reactivateSubscriptionAtInstance.mutationOptions());
+  const billingPortal = useMutation(trpc.kiloclaw.getCustomerPortalUrl.mutationOptions());
   const destroy = useMutation(
     trpc.kiloclaw.destroy.mutationOptions({
       onSuccess: () => {
         void queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getStatus.queryKey() });
         void queryClient.invalidateQueries({
-          queryKey: trpc.kiloclaw.getBillingStatus.queryKey(),
+          queryKey: trpc.kiloclaw.getActivePersonalBillingStatus.queryKey(),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.kiloclaw.getPersonalBillingSummary.queryKey(),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.kiloclaw.listPersonalSubscriptions.queryKey(),
         });
       },
     })
@@ -73,17 +80,33 @@ export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
   }
 
   function handleReactivate() {
-    reactivate.mutate(undefined, {
+    if (!instanceId) return;
+    reactivate.mutate({ instanceId }, {
       onSuccess: () => {
-        void queryClient.invalidateQueries({
-          queryKey: trpc.kiloclaw.getBillingStatus.queryKey(),
-        });
+        void Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.getActivePersonalBillingStatus.queryKey(),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.getPersonalBillingSummary.queryKey(),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.listPersonalSubscriptions.queryKey(),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.getSubscriptionDetail.queryKey({ instanceId }),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.getBillingHistory.queryKey({ instanceId }),
+          }),
+        ]);
       },
     });
   }
 
   function handleUpdatePayment() {
-    billingPortal.mutate(undefined, {
+    if (!instanceId) return;
+    billingPortal.mutate({ instanceId, returnUrl: `${window.location.origin}/claw` }, {
       onSuccess: result => {
         window.location.href = result.url;
       },

--- a/apps/web/src/app/(app)/claw/components/billing/BillingWrapper.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/BillingWrapper.tsx
@@ -81,36 +81,42 @@ export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
 
   function handleReactivate() {
     if (!instanceId) return;
-    reactivate.mutate({ instanceId }, {
-      onSuccess: () => {
-        void Promise.all([
-          queryClient.invalidateQueries({
-            queryKey: trpc.kiloclaw.getActivePersonalBillingStatus.queryKey(),
-          }),
-          queryClient.invalidateQueries({
-            queryKey: trpc.kiloclaw.getPersonalBillingSummary.queryKey(),
-          }),
-          queryClient.invalidateQueries({
-            queryKey: trpc.kiloclaw.listPersonalSubscriptions.queryKey(),
-          }),
-          queryClient.invalidateQueries({
-            queryKey: trpc.kiloclaw.getSubscriptionDetail.queryKey({ instanceId }),
-          }),
-          queryClient.invalidateQueries({
-            queryKey: trpc.kiloclaw.getBillingHistory.queryKey({ instanceId }),
-          }),
-        ]);
-      },
-    });
+    reactivate.mutate(
+      { instanceId },
+      {
+        onSuccess: () => {
+          void Promise.all([
+            queryClient.invalidateQueries({
+              queryKey: trpc.kiloclaw.getActivePersonalBillingStatus.queryKey(),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: trpc.kiloclaw.getPersonalBillingSummary.queryKey(),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: trpc.kiloclaw.listPersonalSubscriptions.queryKey(),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: trpc.kiloclaw.getSubscriptionDetail.queryKey({ instanceId }),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: trpc.kiloclaw.getBillingHistory.queryKey({ instanceId }),
+            }),
+          ]);
+        },
+      }
+    );
   }
 
   function handleUpdatePayment() {
     if (!instanceId) return;
-    billingPortal.mutate({ instanceId, returnUrl: `${window.location.origin}/claw` }, {
-      onSuccess: result => {
-        window.location.href = result.url;
-      },
-    });
+    billingPortal.mutate(
+      { instanceId, returnUrl: `${window.location.origin}/claw` },
+      {
+        onSuccess: result => {
+          window.location.href = result.url;
+        },
+      }
+    );
   }
 
   return (

--- a/apps/web/src/app/(app)/claw/components/billing/BillingWrapper.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/BillingWrapper.tsx
@@ -80,7 +80,7 @@ export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
   }
 
   function handleReactivate() {
-    if (!instanceId) return;
+    if (!instanceId || reactivate.isPending) return;
     reactivate.mutate(
       { instanceId },
       {
@@ -134,6 +134,7 @@ export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
             onSubscribeClick={handleSubscribe}
             onReactivateClick={handleReactivate}
             onUpdatePaymentClick={handleUpdatePayment}
+            isReactivating={reactivate.isPending}
           />
         ))}
 

--- a/apps/web/src/app/(app)/claw/components/billing/CancelDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/CancelDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Loader2 } from 'lucide-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import {
@@ -31,7 +31,7 @@ export function CancelDialog({ open, onOpenChange, billing }: CancelDialogProps)
   const periodEnd = billing.subscription?.currentPeriodEnd;
 
   async function handleConfirm() {
-    if (!instanceId) return;
+    if (!instanceId || cancelMutation.isPending) return;
     await cancelMutation.mutateAsync({ instanceId });
     await Promise.all([
       queryClient.invalidateQueries({
@@ -54,7 +54,10 @@ export function CancelDialog({ open, onOpenChange, billing }: CancelDialogProps)
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={nextOpen => !cancelMutation.isPending && onOpenChange(nextOpen)}
+    >
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
@@ -77,7 +80,11 @@ export function CancelDialog({ open, onOpenChange, billing }: CancelDialogProps)
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="flex gap-2">
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={cancelMutation.isPending}
+          >
             Keep Subscription
           </Button>
           <Button
@@ -85,7 +92,14 @@ export function CancelDialog({ open, onOpenChange, billing }: CancelDialogProps)
             onClick={handleConfirm}
             disabled={cancelMutation.isPending || !instanceId}
           >
-            Cancel Subscription
+            {cancelMutation.isPending ? (
+              <>
+                <Loader2 className="animate-spin" />
+                Canceling...
+              </>
+            ) : (
+              'Cancel Subscription'
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/app/(app)/claw/components/billing/CancelDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/CancelDialog.tsx
@@ -24,16 +24,32 @@ type CancelDialogProps = {
 export function CancelDialog({ open, onOpenChange, billing }: CancelDialogProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
-  const cancelMutation = useMutation(trpc.kiloclaw.cancelSubscription.mutationOptions());
+  const cancelMutation = useMutation(trpc.kiloclaw.cancelSubscriptionAtInstance.mutationOptions());
+  const instanceId = billing.instance?.id ?? null;
 
   const isCommit = billing.subscription?.plan === 'commit';
   const periodEnd = billing.subscription?.currentPeriodEnd;
 
   async function handleConfirm() {
-    await cancelMutation.mutateAsync();
-    void queryClient.invalidateQueries({
-      queryKey: trpc.kiloclaw.getBillingStatus.queryKey(),
-    });
+    if (!instanceId) return;
+    await cancelMutation.mutateAsync({ instanceId });
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getActivePersonalBillingStatus.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getPersonalBillingSummary.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.listPersonalSubscriptions.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getSubscriptionDetail.queryKey({ instanceId }),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getBillingHistory.queryKey({ instanceId }),
+      }),
+    ]);
     onOpenChange(false);
   }
 
@@ -64,7 +80,7 @@ export function CancelDialog({ open, onOpenChange, billing }: CancelDialogProps)
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Keep Subscription
           </Button>
-          <Button variant="destructive" onClick={handleConfirm}>
+          <Button variant="destructive" onClick={handleConfirm} disabled={cancelMutation.isPending || !instanceId}>
             Cancel Subscription
           </Button>
         </DialogFooter>

--- a/apps/web/src/app/(app)/claw/components/billing/CancelDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/CancelDialog.tsx
@@ -80,7 +80,11 @@ export function CancelDialog({ open, onOpenChange, billing }: CancelDialogProps)
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Keep Subscription
           </Button>
-          <Button variant="destructive" onClick={handleConfirm} disabled={cancelMutation.isPending || !instanceId}>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={cancelMutation.isPending || !instanceId}
+          >
             Cancel Subscription
           </Button>
         </DialogFooter>

--- a/apps/web/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/PlanSelectionDialog.tsx
@@ -464,7 +464,7 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
-  const { data: billing } = useQuery(trpc.kiloclaw.getBillingStatus.queryOptions());
+  const { data: billing } = useQuery(trpc.kiloclaw.getPersonalBillingSummary.queryOptions());
   const checkout = useMutation(trpc.kiloclaw.createSubscriptionCheckout.mutationOptions());
   const kiloPassUpsell = useMutation(
     trpc.kiloclaw.createKiloPassUpsellCheckout.mutationOptions({
@@ -477,7 +477,10 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
     trpc.kiloclaw.enrollWithCredits.mutationOptions({
       onSuccess: () => {
         void queryClient.invalidateQueries({
-          queryKey: trpc.kiloclaw.getBillingStatus.queryKey(),
+          queryKey: trpc.kiloclaw.getActivePersonalBillingStatus.queryKey(),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.kiloclaw.getPersonalBillingSummary.queryKey(),
         });
         void queryClient.invalidateQueries({
           queryKey: trpc.kiloclaw.getStatus.queryKey(),
@@ -493,6 +496,7 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
   const creditIntroEligible = billing?.creditIntroEligible ?? false;
   const hasActiveKiloPass = billing?.hasActiveKiloPass ?? false;
   const creditEnrollmentPreview = billing?.creditEnrollmentPreview ?? null;
+  const activeInstanceId = billing?.activeInstanceId ?? null;
   const showKiloPassUpsell = !hasActiveKiloPass;
   const selectedCreditEnrollmentPreview =
     hostingOnlyPlan !== null ? (creditEnrollmentPreview?.[hostingOnlyPlan] ?? null) : null;
@@ -536,6 +540,7 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
         tier: selectedTier,
         cadence,
         hostingPlan,
+        ...(activeInstanceId ? { instanceId: activeInstanceId } : {}),
       });
     } catch (err) {
       const message =
@@ -547,7 +552,10 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
   async function handleHostingOnlyCheckout() {
     if (!hostingOnlyPlan) return;
     try {
-      const result = await checkout.mutateAsync({ plan: hostingOnlyPlan });
+      const result = await checkout.mutateAsync({
+        plan: hostingOnlyPlan,
+        ...(activeInstanceId ? { instanceId: activeInstanceId } : {}),
+      });
       if (result.url) {
         window.location.href = result.url;
       }
@@ -561,7 +569,10 @@ export function PlanSelectionDialog({ open, onOpenChange }: PlanSelectionDialogP
   async function handleEnrollWithCredits() {
     if (!hostingOnlyPlan) return;
     try {
-      await enrollWithCredits.mutateAsync({ plan: hostingOnlyPlan });
+      await enrollWithCredits.mutateAsync({
+        plan: hostingOnlyPlan,
+        ...(activeInstanceId ? { instanceId: activeInstanceId } : {}),
+      });
     } catch (err) {
       const message =
         err instanceof Error ? err.message : 'Failed to activate with credits. Please try again.';

--- a/apps/web/src/app/(app)/claw/components/billing/SubscriptionCard.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/SubscriptionCard.tsx
@@ -53,10 +53,11 @@ function ActiveSubscriptionCard({
 }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
-  const switchPlanMutation = useMutation(trpc.kiloclaw.switchPlan.mutationOptions());
-  const portalMutation = useMutation(trpc.kiloclaw.createBillingPortalSession.mutationOptions());
-  const cancelSwitchMutation = useMutation(trpc.kiloclaw.cancelPlanSwitch.mutationOptions());
-  const acceptConversionMutation = useMutation(trpc.kiloclaw.acceptConversion.mutationOptions());
+  const instanceId = billing.instance?.id ?? null;
+  const switchPlanMutation = useMutation(trpc.kiloclaw.switchPlanAtInstance.mutationOptions());
+  const portalMutation = useMutation(trpc.kiloclaw.getCustomerPortalUrl.mutationOptions());
+  const cancelSwitchMutation = useMutation(trpc.kiloclaw.cancelPlanSwitchAtInstance.mutationOptions());
+  const acceptConversionMutation = useMutation(trpc.kiloclaw.acceptConversionAtInstance.mutationOptions());
   const CONVERSION_DISMISSED_KEY = 'kiloclaw-conversion-dismissed';
   const [conversionDismissed, setConversionDismissed] = useState(() => {
     if (typeof window === 'undefined') return false;
@@ -74,31 +75,50 @@ function ActiveSubscriptionCard({
 
   const hasUserRequestedSwitch = sub.scheduledBy === 'user';
 
+  async function invalidateBillingQueries() {
+    if (!instanceId) return;
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getActivePersonalBillingStatus.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getPersonalBillingSummary.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.listPersonalSubscriptions.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getSubscriptionDetail.queryKey({ instanceId }),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getBillingHistory.queryKey({ instanceId }),
+      }),
+    ]);
+  }
+
   async function handleSwitchPlan() {
+    if (!instanceId) return;
     const toPlan = isCommit ? 'standard' : 'commit';
-    await switchPlanMutation.mutateAsync({ toPlan });
-    void queryClient.invalidateQueries({
-      queryKey: trpc.kiloclaw.getBillingStatus.queryKey(),
-    });
+    await switchPlanMutation.mutateAsync({ instanceId, toPlan });
+    await invalidateBillingQueries();
   }
 
   async function handleManageBilling() {
-    const result = await portalMutation.mutateAsync();
+    if (!instanceId) return;
+    const result = await portalMutation.mutateAsync({ instanceId, returnUrl: `${window.location.origin}/claw` });
     window.location.href = result.url;
   }
 
   async function handleCancelSwitch() {
-    await cancelSwitchMutation.mutateAsync();
-    void queryClient.invalidateQueries({
-      queryKey: trpc.kiloclaw.getBillingStatus.queryKey(),
-    });
+    if (!instanceId) return;
+    await cancelSwitchMutation.mutateAsync({ instanceId });
+    await invalidateBillingQueries();
   }
 
   async function handleAcceptConversion() {
-    await acceptConversionMutation.mutateAsync();
-    void queryClient.invalidateQueries({
-      queryKey: trpc.kiloclaw.getBillingStatus.queryKey(),
-    });
+    if (!instanceId) return;
+    await acceptConversionMutation.mutateAsync({ instanceId });
+    await invalidateBillingQueries();
   }
 
   // Clear the persisted dismiss when the prompt is no longer relevant
@@ -175,7 +195,7 @@ function ActiveSubscriptionCard({
               variant="outline"
               size="sm"
               onClick={handleAcceptConversion}
-              disabled={acceptConversionMutation.isPending}
+              disabled={acceptConversionMutation.isPending || !instanceId}
             >
               Switch to Credits
             </Button>
@@ -199,7 +219,7 @@ function ActiveSubscriptionCard({
             variant="outline"
             size="sm"
             onClick={handleCancelSwitch}
-            disabled={cancelSwitchMutation.isPending}
+            disabled={cancelSwitchMutation.isPending || !instanceId}
           >
             Cancel Switch
           </Button>
@@ -208,7 +228,7 @@ function ActiveSubscriptionCard({
             variant="outline"
             size="sm"
             onClick={handleSwitchPlan}
-            disabled={switchPlanMutation.isPending}
+            disabled={switchPlanMutation.isPending || !instanceId}
           >
             Switch to {otherPlanLabel}
           </Button>
@@ -366,21 +386,43 @@ function PastDueSubscriptionCard({
 export function SubscriptionCard({ billing, onCancelClick }: SubscriptionCardProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
-  const reactivateMutation = useMutation(trpc.kiloclaw.reactivateSubscription.mutationOptions());
-  const portalMutation = useMutation(trpc.kiloclaw.createBillingPortalSession.mutationOptions());
+  const instanceId = billing.instance?.id ?? null;
+  const reactivateMutation = useMutation(trpc.kiloclaw.reactivateSubscriptionAtInstance.mutationOptions());
+  const portalMutation = useMutation(trpc.kiloclaw.getCustomerPortalUrl.mutationOptions());
+
+  async function invalidateBillingQueries() {
+    if (!instanceId) return;
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getActivePersonalBillingStatus.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getPersonalBillingSummary.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.listPersonalSubscriptions.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getSubscriptionDetail.queryKey({ instanceId }),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getBillingHistory.queryKey({ instanceId }),
+      }),
+    ]);
+  }
 
   function handleReactivate() {
-    reactivateMutation.mutate(undefined, {
+    if (!instanceId) return;
+    reactivateMutation.mutate({ instanceId }, {
       onSuccess: () => {
-        void queryClient.invalidateQueries({
-          queryKey: trpc.kiloclaw.getBillingStatus.queryKey(),
-        });
+        void invalidateBillingQueries();
       },
     });
   }
 
   async function handleUpdatePayment() {
-    const result = await portalMutation.mutateAsync();
+    if (!instanceId) return;
+    const result = await portalMutation.mutateAsync({ instanceId, returnUrl: `${window.location.origin}/claw` });
     window.location.href = result.url;
   }
 

--- a/apps/web/src/app/(app)/claw/components/billing/SubscriptionCard.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/SubscriptionCard.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { ExternalLink, CreditCard, Coins } from 'lucide-react';
+import { ExternalLink, CreditCard, Coins, Loader2 } from 'lucide-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Button } from '@/components/ui/button';
@@ -228,7 +228,14 @@ function ActiveSubscriptionCard({
             onClick={handleCancelSwitch}
             disabled={cancelSwitchMutation.isPending || !instanceId}
           >
-            Cancel Switch
+            {cancelSwitchMutation.isPending ? (
+              <>
+                <Loader2 className="animate-spin" />
+                Canceling...
+              </>
+            ) : (
+              'Cancel Switch'
+            )}
           </Button>
         ) : (
           <Button
@@ -237,7 +244,14 @@ function ActiveSubscriptionCard({
             onClick={handleSwitchPlan}
             disabled={switchPlanMutation.isPending || !instanceId}
           >
-            Switch to {otherPlanLabel}
+            {switchPlanMutation.isPending ? (
+              <>
+                <Loader2 className="animate-spin" />
+                Switching...
+              </>
+            ) : (
+              `Switch to ${otherPlanLabel}`
+            )}
           </Button>
         )}
         <Button variant="outline" size="sm" onClick={onCancelClick}>
@@ -256,9 +270,11 @@ function ActiveSubscriptionCard({
 function ConvertingSubscriptionCard({
   billing,
   onReactivateClick,
+  isReactivating,
 }: {
   billing: ClawBillingStatus;
   onReactivateClick: () => void;
+  isReactivating: boolean;
 }) {
   const sub = billing.subscription;
   if (!sub) return null;
@@ -293,8 +309,15 @@ function ConvertingSubscriptionCard({
       </div>
 
       <div className="mt-4">
-        <Button variant="outline" size="sm" onClick={onReactivateClick}>
-          Keep Stripe Billing
+        <Button variant="outline" size="sm" onClick={onReactivateClick} disabled={isReactivating}>
+          {isReactivating ? (
+            <>
+              <Loader2 className="animate-spin" />
+              Reactivating...
+            </>
+          ) : (
+            'Keep Stripe Billing'
+          )}
         </Button>
       </div>
     </div>
@@ -304,9 +327,11 @@ function ConvertingSubscriptionCard({
 function CancelingSubscriptionCard({
   billing,
   onReactivateClick,
+  isReactivating,
 }: {
   billing: ClawBillingStatus;
   onReactivateClick: () => void;
+  isReactivating: boolean;
 }) {
   const sub = billing.subscription;
   if (!sub) return null;
@@ -334,8 +359,15 @@ function CancelingSubscriptionCard({
       </div>
 
       <div className="mt-4">
-        <Button variant="outline" onClick={onReactivateClick}>
-          Reactivate
+        <Button variant="outline" onClick={onReactivateClick} disabled={isReactivating}>
+          {isReactivating ? (
+            <>
+              <Loader2 className="animate-spin" />
+              Reactivating...
+            </>
+          ) : (
+            'Reactivate'
+          )}
         </Button>
       </div>
     </div>
@@ -421,7 +453,7 @@ export function SubscriptionCard({ billing, onCancelClick }: SubscriptionCardPro
   }
 
   function handleReactivate() {
-    if (!instanceId) return;
+    if (!instanceId || reactivateMutation.isPending) return;
     reactivateMutation.mutate(
       { instanceId },
       {
@@ -448,10 +480,22 @@ export function SubscriptionCard({ billing, onCancelClick }: SubscriptionCardPro
       );
     }
     if (billing.subscription.cancelAtPeriodEnd && billing.subscription.pendingConversion) {
-      return <ConvertingSubscriptionCard billing={billing} onReactivateClick={handleReactivate} />;
+      return (
+        <ConvertingSubscriptionCard
+          billing={billing}
+          onReactivateClick={handleReactivate}
+          isReactivating={reactivateMutation.isPending}
+        />
+      );
     }
     if (billing.subscription.cancelAtPeriodEnd) {
-      return <CancelingSubscriptionCard billing={billing} onReactivateClick={handleReactivate} />;
+      return (
+        <CancelingSubscriptionCard
+          billing={billing}
+          onReactivateClick={handleReactivate}
+          isReactivating={reactivateMutation.isPending}
+        />
+      );
     }
     if (billing.subscription.status === 'active') {
       return <ActiveSubscriptionCard billing={billing} onCancelClick={onCancelClick} />;

--- a/apps/web/src/app/(app)/claw/components/billing/SubscriptionCard.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/SubscriptionCard.tsx
@@ -56,8 +56,12 @@ function ActiveSubscriptionCard({
   const instanceId = billing.instance?.id ?? null;
   const switchPlanMutation = useMutation(trpc.kiloclaw.switchPlanAtInstance.mutationOptions());
   const portalMutation = useMutation(trpc.kiloclaw.getCustomerPortalUrl.mutationOptions());
-  const cancelSwitchMutation = useMutation(trpc.kiloclaw.cancelPlanSwitchAtInstance.mutationOptions());
-  const acceptConversionMutation = useMutation(trpc.kiloclaw.acceptConversionAtInstance.mutationOptions());
+  const cancelSwitchMutation = useMutation(
+    trpc.kiloclaw.cancelPlanSwitchAtInstance.mutationOptions()
+  );
+  const acceptConversionMutation = useMutation(
+    trpc.kiloclaw.acceptConversionAtInstance.mutationOptions()
+  );
   const CONVERSION_DISMISSED_KEY = 'kiloclaw-conversion-dismissed';
   const [conversionDismissed, setConversionDismissed] = useState(() => {
     if (typeof window === 'undefined') return false;
@@ -105,7 +109,10 @@ function ActiveSubscriptionCard({
 
   async function handleManageBilling() {
     if (!instanceId) return;
-    const result = await portalMutation.mutateAsync({ instanceId, returnUrl: `${window.location.origin}/claw` });
+    const result = await portalMutation.mutateAsync({
+      instanceId,
+      returnUrl: `${window.location.origin}/claw`,
+    });
     window.location.href = result.url;
   }
 
@@ -387,7 +394,9 @@ export function SubscriptionCard({ billing, onCancelClick }: SubscriptionCardPro
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const instanceId = billing.instance?.id ?? null;
-  const reactivateMutation = useMutation(trpc.kiloclaw.reactivateSubscriptionAtInstance.mutationOptions());
+  const reactivateMutation = useMutation(
+    trpc.kiloclaw.reactivateSubscriptionAtInstance.mutationOptions()
+  );
   const portalMutation = useMutation(trpc.kiloclaw.getCustomerPortalUrl.mutationOptions());
 
   async function invalidateBillingQueries() {
@@ -413,16 +422,22 @@ export function SubscriptionCard({ billing, onCancelClick }: SubscriptionCardPro
 
   function handleReactivate() {
     if (!instanceId) return;
-    reactivateMutation.mutate({ instanceId }, {
-      onSuccess: () => {
-        void invalidateBillingQueries();
-      },
-    });
+    reactivateMutation.mutate(
+      { instanceId },
+      {
+        onSuccess: () => {
+          void invalidateBillingQueries();
+        },
+      }
+    );
   }
 
   async function handleUpdatePayment() {
     if (!instanceId) return;
-    const result = await portalMutation.mutateAsync({ instanceId, returnUrl: `${window.location.origin}/claw` });
+    const result = await portalMutation.mutateAsync({
+      instanceId,
+      returnUrl: `${window.location.origin}/claw`,
+    });
     window.location.href = result.url;
   }
 

--- a/apps/web/src/app/(app)/claw/components/billing/WelcomePage.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/WelcomePage.tsx
@@ -457,7 +457,7 @@ export function WelcomePage() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
-  const { data: billing } = useQuery(trpc.kiloclaw.getBillingStatus.queryOptions());
+  const { data: billing } = useQuery(trpc.kiloclaw.getPersonalBillingSummary.queryOptions());
   const checkoutMutation = useMutation(trpc.kiloclaw.createSubscriptionCheckout.mutationOptions());
   const kiloPassUpsell = useMutation(
     trpc.kiloclaw.createKiloPassUpsellCheckout.mutationOptions({
@@ -470,7 +470,10 @@ export function WelcomePage() {
     trpc.kiloclaw.enrollWithCredits.mutationOptions({
       onSuccess: () => {
         void queryClient.invalidateQueries({
-          queryKey: trpc.kiloclaw.getBillingStatus.queryKey(),
+          queryKey: trpc.kiloclaw.getActivePersonalBillingStatus.queryKey(),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.kiloclaw.getPersonalBillingSummary.queryKey(),
         });
         void queryClient.invalidateQueries({
           queryKey: trpc.kiloclaw.getStatus.queryKey(),
@@ -485,6 +488,7 @@ export function WelcomePage() {
   const creditIntroEligible = billing?.creditIntroEligible ?? false;
   const hasActiveKiloPass = billing?.hasActiveKiloPass ?? false;
   const creditEnrollmentPreview = billing?.creditEnrollmentPreview ?? null;
+  const activeInstanceId = billing?.activeInstanceId ?? null;
   const showKiloPassUpsell = !hasActiveKiloPass;
   const selectedCreditEnrollmentPreview =
     hostingOnlyPlan !== null ? (creditEnrollmentPreview?.[hostingOnlyPlan] ?? null) : null;
@@ -527,6 +531,7 @@ export function WelcomePage() {
         tier: selectedTier,
         cadence,
         hostingPlan,
+        ...(activeInstanceId ? { instanceId: activeInstanceId } : {}),
       });
     } catch (err) {
       const message =
@@ -538,7 +543,10 @@ export function WelcomePage() {
   async function handleHostingOnlyCheckout() {
     if (!hostingOnlyPlan) return;
     try {
-      const result = await checkoutMutation.mutateAsync({ plan: hostingOnlyPlan });
+      const result = await checkoutMutation.mutateAsync({
+        plan: hostingOnlyPlan,
+        ...(activeInstanceId ? { instanceId: activeInstanceId } : {}),
+      });
       if (result.url) {
         window.location.href = result.url;
       }
@@ -552,7 +560,10 @@ export function WelcomePage() {
   async function handleEnrollWithCredits() {
     if (!hostingOnlyPlan) return;
     try {
-      await enrollWithCredits.mutateAsync({ plan: hostingOnlyPlan });
+      await enrollWithCredits.mutateAsync({
+        plan: hostingOnlyPlan,
+        ...(activeInstanceId ? { instanceId: activeInstanceId } : {}),
+      });
     } catch (err) {
       const message =
         err instanceof Error ? err.message : 'Failed to activate with credits. Please try again.';

--- a/apps/web/src/app/(app)/claw/components/billing/billing-types.ts
+++ b/apps/web/src/app/(app)/claw/components/billing/billing-types.ts
@@ -109,6 +109,7 @@ export type ClawBillingStatus = {
   } | null;
 
   instance: {
+    id: string;
     exists: boolean;
     status: 'running' | 'stopped' | 'provisioned' | 'destroying' | null;
     suspendedAt: string | null;

--- a/apps/web/src/app/api/internal/kiloclaw/instance-ready/route.ts
+++ b/apps/web/src/app/api/internal/kiloclaw/instance-ready/route.ts
@@ -27,9 +27,14 @@ const BodySchema = z.object({
   shouldNotify: z.boolean().optional(),
 });
 
-/** Per-instance email type key. Includes sandboxId to support future multi-instance. */
-function emailTypeKey(sandboxId: string): string {
-  return `claw_instance_ready:${sandboxId}`;
+const INSTANCE_READY_EMAIL_TYPE = 'claw_instance_ready';
+
+function instanceEmailLogFilter(userId: string, instanceId: string, emailType: string) {
+  return and(
+    eq(kiloclaw_email_log.user_id, userId),
+    eq(kiloclaw_email_log.instance_id, instanceId),
+    eq(kiloclaw_email_log.email_type, emailType)
+  );
 }
 
 function logInstanceReady(
@@ -64,7 +69,6 @@ export async function POST(req: NextRequest) {
   }
 
   const { userId, sandboxId, instanceId, shouldNotify } = parsed.data;
-  const emailType = emailTypeKey(sandboxId);
 
   const user = await findUserById(userId);
   if (!user) {
@@ -90,10 +94,25 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ sent: false, reason: 'not_first_ready' });
   }
 
+  const targetInstanceId = resumeState.instanceId ?? instanceId ?? null;
+  if (!targetInstanceId) {
+    logInstanceReady('error', 'Instance-ready email skipped because instance could not be resolved', {
+      event: 'instance_ready_email_skipped',
+      outcome: 'skipped',
+      userId,
+      sandboxId,
+    });
+    return NextResponse.json({ sent: false, reason: 'instance_unresolved' });
+  }
+
   // Idempotent: insert-before-send with rollback on failure (matches billing cron pattern).
   const result = await db
     .insert(kiloclaw_email_log)
-    .values({ user_id: userId, email_type: emailType })
+    .values({
+      user_id: userId,
+      instance_id: targetInstanceId,
+      email_type: INSTANCE_READY_EMAIL_TYPE,
+    })
     .onConflictDoNothing();
 
   if (result.rowCount === 0) {
@@ -112,9 +131,7 @@ export async function POST(req: NextRequest) {
     try {
       await db
         .delete(kiloclaw_email_log)
-        .where(
-          and(eq(kiloclaw_email_log.user_id, userId), eq(kiloclaw_email_log.email_type, emailType))
-        );
+        .where(instanceEmailLogFilter(userId, targetInstanceId, INSTANCE_READY_EMAIL_TYPE));
     } catch (deleteError) {
       logInstanceReady('error', 'Failed to roll back instance-ready email log after send failure', {
         event: 'email_rollback_failed',

--- a/apps/web/src/app/api/internal/kiloclaw/instance-ready/route.ts
+++ b/apps/web/src/app/api/internal/kiloclaw/instance-ready/route.ts
@@ -12,7 +12,7 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull, or } from 'drizzle-orm';
 import { KILOCLAW_INTERNAL_API_SECRET, NEXTAUTH_URL } from '@/lib/config.server';
 import { send as sendEmail } from '@/lib/email';
 import { findUserById } from '@/lib/user';
@@ -28,6 +28,10 @@ const BodySchema = z.object({
 });
 
 const INSTANCE_READY_EMAIL_TYPE = 'claw_instance_ready';
+
+function legacyInstanceReadyEmailType(sandboxId: string): string {
+  return `claw_instance_ready:${sandboxId}`;
+}
 
 function instanceEmailLogFilter(userId: string, instanceId: string, emailType: string) {
   return and(
@@ -54,6 +58,29 @@ function logInstanceReady(
     return;
   }
   console.log(record);
+}
+
+async function hasSentCompatibleInstanceReadyEmail(
+  userId: string,
+  instanceId: string,
+  sandboxId: string
+): Promise<boolean> {
+  const [existing] = await db
+    .select({ id: kiloclaw_email_log.id })
+    .from(kiloclaw_email_log)
+    .where(
+      or(
+        instanceEmailLogFilter(userId, instanceId, INSTANCE_READY_EMAIL_TYPE),
+        and(
+          eq(kiloclaw_email_log.user_id, userId),
+          isNull(kiloclaw_email_log.instance_id),
+          eq(kiloclaw_email_log.email_type, legacyInstanceReadyEmailType(sandboxId))
+        )
+      )
+    )
+    .limit(1);
+
+  return !!existing;
 }
 
 export async function POST(req: NextRequest) {
@@ -109,6 +136,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ sent: false, reason: 'instance_unresolved' });
   }
 
+  if (await hasSentCompatibleInstanceReadyEmail(userId, targetInstanceId, sandboxId)) {
+    return NextResponse.json({ sent: false, reason: 'already_sent' });
+  }
+
   // Idempotent: insert-before-send with rollback on failure (matches billing cron pattern).
   const result = await db
     .insert(kiloclaw_email_log)
@@ -120,7 +151,6 @@ export async function POST(req: NextRequest) {
     .onConflictDoNothing();
 
   if (result.rowCount === 0) {
-    // Already sent for this instance — skip.
     return NextResponse.json({ sent: false, reason: 'already_sent' });
   }
 

--- a/apps/web/src/app/api/internal/kiloclaw/instance-ready/route.ts
+++ b/apps/web/src/app/api/internal/kiloclaw/instance-ready/route.ts
@@ -96,12 +96,16 @@ export async function POST(req: NextRequest) {
 
   const targetInstanceId = resumeState.instanceId ?? instanceId ?? null;
   if (!targetInstanceId) {
-    logInstanceReady('error', 'Instance-ready email skipped because instance could not be resolved', {
-      event: 'instance_ready_email_skipped',
-      outcome: 'skipped',
-      userId,
-      sandboxId,
-    });
+    logInstanceReady(
+      'error',
+      'Instance-ready email skipped because instance could not be resolved',
+      {
+        event: 'instance_ready_email_skipped',
+        outcome: 'skipped',
+        userId,
+        sandboxId,
+      }
+    );
     return NextResponse.json({ sent: false, reason: 'instance_unresolved' });
   }
 

--- a/apps/web/src/app/api/kiloclaw/chat-credentials/route.ts
+++ b/apps/web/src/app/api/kiloclaw/chat-credentials/route.ts
@@ -4,7 +4,7 @@ import { getUserFromAuth } from '@/lib/user.server';
 import { KiloClawUserClient } from '@/lib/kiloclaw/kiloclaw-user-client';
 import { KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
-import { requireKiloClawAccess } from '@/lib/kiloclaw/access-gate';
+import { requireKiloClawAccessAtInstance } from '@/lib/kiloclaw/access-gate';
 import {
   getActiveInstance,
   getActiveOrgInstance,
@@ -21,9 +21,17 @@ export async function GET() {
   // (validated by getUserFromAuth). Matches tRPC org router's
   // getStreamChatCredentials which uses organizationMemberProcedure (no billing gate).
   if (!organizationId) {
+    const instance = await getActiveInstance(user.id);
+    if (!instance) {
+      return NextResponse.json({ error: 'No active KiloClaw instance found' }, { status: 404 });
+    }
+
     try {
-      await requireKiloClawAccess(user.id);
+      await requireKiloClawAccessAtInstance(user.id, instance.id);
     } catch (err) {
+      if (err instanceof TRPCError && err.code === 'NOT_FOUND') {
+        return NextResponse.json({ error: err.message }, { status: 404 });
+      }
       if (err instanceof TRPCError && err.code === 'FORBIDDEN') {
         return NextResponse.json({ error: err.message }, { status: 403 });
       }

--- a/apps/web/src/app/api/private/users/route.ts
+++ b/apps/web/src/app/api/private/users/route.ts
@@ -2,19 +2,16 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user.server';
 import { db } from '@/lib/drizzle';
-import { getEffectiveKiloClawSubscriptionForUser } from '@/lib/kiloclaw/access-state';
 import {
-  kilocode_users,
-  organization_memberships,
-  organizations,
-  kiloclaw_earlybird_purchases,
-} from '@kilocode/db/schema';
+  getEffectiveKiloClawSubscriptionForUser,
+  getKiloClawEarlybirdStateForUser,
+} from '@/lib/kiloclaw/access-state';
+import { kilocode_users, organization_memberships, organizations } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 import { captureException } from '@sentry/nextjs';
 import type { OrganizationPlan } from '@/lib/organizations/organization-types';
 import { getKiloPassStateForUser } from '@/lib/kilo-pass/state';
 import { isStripeSubscriptionEnded } from '@/lib/kilo-pass/stripe-subscription-status';
-import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
 
 type UserLookupResponse = {
   users: {
@@ -106,11 +103,6 @@ async function checkHasKiloClaw(userId: string): Promise<boolean> {
   const { accessReason } = await getEffectiveKiloClawSubscriptionForUser(userId, now);
   if (accessReason) return true;
 
-  const [earlybird] = await db
-    .select({ id: kiloclaw_earlybird_purchases.id })
-    .from(kiloclaw_earlybird_purchases)
-    .where(eq(kiloclaw_earlybird_purchases.user_id, userId))
-    .limit(1);
-
-  return !!earlybird && new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE) > new Date();
+  const earlybirdState = await getKiloClawEarlybirdStateForUser(userId, now);
+  return earlybirdState.hasAccess;
 }

--- a/apps/web/src/app/payments/kiloclaw/success/KiloClawCheckoutSuccessClient.tsx
+++ b/apps/web/src/app/payments/kiloclaw/success/KiloClawCheckoutSuccessClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Loader2, CheckCircle2 } from 'lucide-react';
@@ -17,15 +17,28 @@ import { Loader2, CheckCircle2 } from 'lucide-react';
  */
 export function KiloClawCheckoutSuccessClient() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const trpc = useTRPC();
   const [timedOut, setTimedOut] = useState(false);
+  const instanceId = searchParams.get('clawInstanceId');
 
-  const { data: billingStatus } = useQuery({
-    ...trpc.kiloclaw.getBillingStatus.queryOptions(),
+  const detailQuery = useQuery({
+    ...trpc.kiloclaw.getSubscriptionDetail.queryOptions(
+      { instanceId: instanceId ?? '00000000-0000-4000-8000-000000000000' },
+      {
+        enabled: !!instanceId,
+      }
+    ),
+    refetchInterval: timedOut ? false : 1_000,
+  });
+  const billingStatusQuery = useQuery({
+    ...trpc.kiloclaw.getActivePersonalBillingStatus.queryOptions(undefined, {
+      enabled: !instanceId,
+    }),
     refetchInterval: timedOut ? false : 1_000,
   });
 
-  const sub = billingStatus?.subscription;
+  const sub = instanceId ? detailQuery.data : billingStatusQuery.data?.subscription;
   // Subscription row exists (Stripe webhook created it)
   const subscriptionCreated = sub?.status === 'active';
   // Invoice settlement completed — payment_source is 'credits' (hybrid state)

--- a/apps/web/src/components/profile/ProfileKiloClawBanner.test.ts
+++ b/apps/web/src/components/profile/ProfileKiloClawBanner.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from '@jest/globals';
+import { getProfileKiloClawBannerVariant } from './ProfileKiloClawBanner';
+
+describe('getProfileKiloClawBannerVariant', () => {
+  test('shows loading while billing is loading', () => {
+    expect(
+      getProfileKiloClawBannerVariant({
+        billingLoading: true,
+        hasBilling: false,
+        hasInstance: false,
+        activeInstanceHasAccess: false,
+        statusLoading: false,
+        statusError: false,
+        status: undefined,
+      })
+    ).toBe('loading');
+  });
+
+  test('shows continue setup when billing is active but dashboard status is null', () => {
+    expect(
+      getProfileKiloClawBannerVariant({
+        billingLoading: false,
+        hasBilling: true,
+        hasInstance: true,
+        activeInstanceHasAccess: true,
+        statusLoading: false,
+        statusError: false,
+        status: null,
+      })
+    ).toBe('continue-setup');
+  });
+
+  test('shows active when dashboard status is populated', () => {
+    expect(
+      getProfileKiloClawBannerVariant({
+        billingLoading: false,
+        hasBilling: true,
+        hasInstance: true,
+        activeInstanceHasAccess: true,
+        statusLoading: false,
+        statusError: false,
+        status: 'running',
+      })
+    ).toBe('active');
+  });
+
+  test('shows needs attention when instance exists without access', () => {
+    expect(
+      getProfileKiloClawBannerVariant({
+        billingLoading: false,
+        hasBilling: true,
+        hasInstance: true,
+        activeInstanceHasAccess: false,
+        statusLoading: false,
+        statusError: false,
+        status: null,
+      })
+    ).toBe('needs-attention');
+  });
+
+  test('shows get started when no instance exists', () => {
+    expect(
+      getProfileKiloClawBannerVariant({
+        billingLoading: false,
+        hasBilling: true,
+        hasInstance: false,
+        activeInstanceHasAccess: false,
+        statusLoading: false,
+        statusError: false,
+        status: null,
+      })
+    ).toBe('get-started');
+  });
+});

--- a/apps/web/src/components/profile/ProfileKiloClawBanner.tsx
+++ b/apps/web/src/components/profile/ProfileKiloClawBanner.tsx
@@ -2,15 +2,71 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { ArrowRight, Loader2, AlertTriangle } from 'lucide-react';
+import { useKiloClawStatus } from '@/hooks/useKiloClaw';
 import { useTRPC } from '@/lib/trpc/utils';
 import KiloCrabIcon from '@/components/KiloCrabIcon';
 import { Banner } from '@/components/shared/Banner';
 
+type ProfileKiloClawBannerVariant =
+  | 'loading'
+  | 'active'
+  | 'continue-setup'
+  | 'needs-attention'
+  | 'get-started';
+
+export function getProfileKiloClawBannerVariant(params: {
+  billingLoading: boolean;
+  hasBilling: boolean;
+  hasInstance: boolean;
+  activeInstanceHasAccess: boolean;
+  statusLoading: boolean;
+  statusError: boolean;
+  status: string | null | undefined;
+}): ProfileKiloClawBannerVariant {
+  if (params.billingLoading) {
+    return 'loading';
+  }
+
+  if (!params.hasBilling) {
+    return 'get-started';
+  }
+
+  if (params.hasInstance && params.activeInstanceHasAccess) {
+    if (params.statusLoading) {
+      return 'loading';
+    }
+
+    if (!params.statusError && params.status === null) {
+      return 'continue-setup';
+    }
+
+    return 'active';
+  }
+
+  if (params.hasInstance) {
+    return 'needs-attention';
+  }
+
+  return 'get-started';
+}
+
 export function ProfileKiloClawBanner() {
   const trpc = useTRPC();
   const summaryQuery = useQuery(trpc.kiloclaw.getPersonalBillingSummary.queryOptions());
+  const statusQuery = useKiloClawStatus();
 
-  if (summaryQuery.isLoading) {
+  const billing = summaryQuery.data;
+  const variant = getProfileKiloClawBannerVariant({
+    billingLoading: summaryQuery.isLoading,
+    hasBilling: !!billing && !summaryQuery.isError,
+    hasInstance: billing?.hasActiveInstance ?? false,
+    activeInstanceHasAccess: billing?.activeInstanceHasAccess ?? false,
+    statusLoading: statusQuery.isLoading,
+    statusError: !!statusQuery.isError,
+    status: statusQuery.data?.status,
+  });
+
+  if (variant === 'loading') {
     return (
       <div className="flex w-full items-center justify-center rounded-xl border border-blue-500/20 bg-blue-500/5 p-4">
         <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
@@ -18,14 +74,11 @@ export function ProfileKiloClawBanner() {
     );
   }
 
-  const billing = summaryQuery.data;
   if (summaryQuery.isError || !billing) {
     return null;
   }
 
-  const hasInstance = billing.hasActiveInstance;
-
-  if (hasInstance && billing.activeInstanceHasAccess) {
+  if (variant === 'active') {
     return (
       <Banner color="emerald">
         <Banner.Icon>
@@ -45,7 +98,27 @@ export function ProfileKiloClawBanner() {
     );
   }
 
-  if (hasInstance && !billing.activeInstanceHasAccess) {
+  if (variant === 'continue-setup') {
+    return (
+      <Banner color="blue">
+        <Banner.Icon>
+          <KiloCrabIcon />
+        </Banner.Icon>
+        <Banner.Content>
+          <Banner.Title>Finish setting up your KiloClaw instance</Banner.Title>
+          <Banner.Description>
+            Your KiloClaw instance has not yet been set up. Continue setup now to launch your Claw.
+          </Banner.Description>
+        </Banner.Content>
+        <Banner.Button href="/claw/new">
+          Continue Setup
+          <ArrowRight />
+        </Banner.Button>
+      </Banner>
+    );
+  }
+
+  if (variant === 'needs-attention') {
     return (
       <Banner color="amber">
         <Banner.Icon>

--- a/apps/web/src/components/profile/ProfileKiloClawBanner.tsx
+++ b/apps/web/src/components/profile/ProfileKiloClawBanner.tsx
@@ -8,9 +8,9 @@ import { Banner } from '@/components/shared/Banner';
 
 export function ProfileKiloClawBanner() {
   const trpc = useTRPC();
-  const billingQuery = useQuery(trpc.kiloclaw.getBillingStatus.queryOptions());
+  const summaryQuery = useQuery(trpc.kiloclaw.getPersonalBillingSummary.queryOptions());
 
-  if (billingQuery.isLoading) {
+  if (summaryQuery.isLoading) {
     return (
       <div className="flex w-full items-center justify-center rounded-xl border border-blue-500/20 bg-blue-500/5 p-4">
         <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
@@ -18,14 +18,14 @@ export function ProfileKiloClawBanner() {
     );
   }
 
-  const billing = billingQuery.data;
-  if (billingQuery.isError || !billing) {
+  const billing = summaryQuery.data;
+  if (summaryQuery.isError || !billing) {
     return null;
   }
 
-  const hasInstance = billing.instance !== null && billing.instance.exists;
+  const hasInstance = billing.hasActiveInstance;
 
-  if (hasInstance && billing.hasAccess) {
+  if (hasInstance && billing.activeInstanceHasAccess) {
     return (
       <Banner color="emerald">
         <Banner.Icon>
@@ -45,7 +45,7 @@ export function ProfileKiloClawBanner() {
     );
   }
 
-  if (hasInstance && !billing.hasAccess) {
+  if (hasInstance && !billing.activeInstanceHasAccess) {
     return (
       <Banner color="amber">
         <Banner.Icon>

--- a/apps/web/src/components/subscriptions/kiloclaw/KiloClawDetail.tsx
+++ b/apps/web/src/components/subscriptions/kiloclaw/KiloClawDetail.tsx
@@ -113,6 +113,7 @@ export function KiloClawDetail({ instanceId }: { instanceId: string }) {
     subscription.creditRenewalAt ?? subscription.currentPeriodEnd ?? subscription.trialEndsAt,
     'At your next renewal'
   );
+  const hasUserRequestedSwitch = subscription.scheduledBy === 'user';
   const targetPlanLabel = capitalize(otherPlan);
   const targetPlanDetails =
     otherPlan === 'commit'
@@ -306,7 +307,7 @@ export function KiloClawDetail({ instanceId }: { instanceId: string }) {
       {isKiloclawTerminal(subscription.status) ? null : (
         <div className="flex flex-wrap gap-2">
           {subscription.plan !== 'trial' ? (
-            subscription.scheduledPlan ? (
+            hasUserRequestedSwitch ? (
               <Button variant="outline" onClick={() => setConfirmationAction('cancelPlanSwitch')}>
                 Cancel Plan Switch
               </Button>

--- a/apps/web/src/components/subscriptions/kiloclaw/KiloClawGroup.tsx
+++ b/apps/web/src/components/subscriptions/kiloclaw/KiloClawGroup.tsx
@@ -24,7 +24,7 @@ export function KiloClawGroup({
 }) {
   const trpc = useTRPC();
   const query = useQuery(trpc.kiloclaw.listPersonalSubscriptions.queryOptions());
-  const billingQuery = useQuery(trpc.kiloclaw.getBillingStatus.queryOptions());
+  const summaryQuery = useQuery(trpc.kiloclaw.getPersonalBillingSummary.queryOptions());
   const subscriptions = query.data?.subscriptions ?? [];
 
   const visibleSubscriptions = subscriptions.filter(
@@ -79,8 +79,8 @@ export function KiloClawGroup({
         </div>
       ) : nonTerminalSubscriptions.length === 0 ? (
         <KiloClawSubscribeCard
-          creditIntroEligible={billingQuery.data?.creditIntroEligible ?? false}
-          hasActiveKiloPass={billingQuery.data?.hasActiveKiloPass ?? false}
+          creditIntroEligible={summaryQuery.data?.creditIntroEligible ?? false}
+          hasActiveKiloPass={summaryQuery.data?.hasActiveKiloPass ?? false}
         />
       ) : null}
     </SubscriptionGroup>

--- a/apps/web/src/hooks/useKiloClaw.ts
+++ b/apps/web/src/hooks/useKiloClaw.ts
@@ -137,9 +137,17 @@ export function useKiloClawMutations() {
 
   const invalidateStatusAndBilling = async () => {
     await invalidateStatus();
-    await queryClient.invalidateQueries({
-      queryKey: trpc.kiloclaw.getBillingStatus.queryKey(),
-    });
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getActivePersonalBillingStatus.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getPersonalBillingSummary.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.listPersonalSubscriptions.queryKey(),
+      }),
+    ]);
   };
 
   // Wipe all instance-scoped caches so no stale data (e.g. gatewayReady
@@ -148,9 +156,17 @@ export function useKiloClawMutations() {
   // only marks stale but leaves the old value readable synchronously.
   const resetAllInstanceState = async () => {
     await invalidateStatus();
-    await queryClient.invalidateQueries({
-      queryKey: trpc.kiloclaw.getBillingStatus.queryKey(),
-    });
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getActivePersonalBillingStatus.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.getPersonalBillingSummary.queryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trpc.kiloclaw.listPersonalSubscriptions.queryKey(),
+      }),
+    ]);
     queryClient.removeQueries({ queryKey: trpc.kiloclaw.gatewayReady.queryKey() });
     queryClient.removeQueries({ queryKey: trpc.kiloclaw.gatewayStatus.queryKey() });
     queryClient.removeQueries({ queryKey: trpc.kiloclaw.getConfig.queryKey() });

--- a/apps/web/src/hooks/useOrgKiloClaw.ts
+++ b/apps/web/src/hooks/useOrgKiloClaw.ts
@@ -4,12 +4,15 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
 
-export function useOrgKiloClawStatus(organizationId: string) {
+const NIL_UUID = '00000000-0000-0000-0000-000000000000';
+
+export function useOrgKiloClawStatus(organizationId?: string) {
   const trpc = useTRPC();
+  const resolvedOrganizationId = organizationId ?? NIL_UUID;
   return useQuery(
     trpc.organizations.kiloclaw.getStatus.queryOptions(
-      { organizationId },
-      { refetchInterval: 10_000 }
+      { organizationId: resolvedOrganizationId },
+      { enabled: !!organizationId, refetchInterval: organizationId ? 10_000 : false }
     )
   );
 }

--- a/apps/web/src/lib/kiloclaw/access-gate.ts
+++ b/apps/web/src/lib/kiloclaw/access-gate.ts
@@ -1,15 +1,17 @@
 import 'server-only';
 
 import { TRPCError } from '@trpc/server';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 
 import { db } from '@/lib/drizzle';
-import { kiloclaw_earlybird_purchases } from '@kilocode/db/schema';
+import { kiloclaw_earlybird_purchases, kiloclaw_instances } from '@kilocode/db/schema';
 import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
 import {
   getCurrentPersonalKiloClawSubscriptionForUser,
+  getKiloClawSubscriptionAccessReason,
   CurrentPersonalSubscriptionResolutionError,
 } from '@/lib/kiloclaw/access-state';
+import { resolveCurrentPersonalSubscriptionRow } from '@/lib/kiloclaw/current-personal-subscription';
 import { baseProcedure } from '@/lib/trpc/init';
 
 /**
@@ -75,6 +77,75 @@ export async function requireKiloClawAccess(userId: string): Promise<void> {
       earlybirdFound: !!earlybird,
     })
   );
+
+  throw new TRPCError({
+    code: 'FORBIDDEN',
+    message: 'KiloClaw access requires an active subscription, trial, or earlybird purchase.',
+  });
+}
+
+export async function requireKiloClawAccessAtInstance(
+  userId: string,
+  instanceId: string
+): Promise<void> {
+  const [instance] = await db
+    .select({ id: kiloclaw_instances.id })
+    .from(kiloclaw_instances)
+    .where(
+      and(
+        eq(kiloclaw_instances.id, instanceId),
+        eq(kiloclaw_instances.user_id, userId),
+        isNull(kiloclaw_instances.organization_id),
+        isNull(kiloclaw_instances.destroyed_at)
+      )
+    )
+    .limit(1);
+
+  if (!instance) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'No active KiloClaw instance found',
+    });
+  }
+
+  const now = new Date();
+
+  try {
+    const row = await resolveCurrentPersonalSubscriptionRow({
+      userId,
+      instanceId,
+      dbOrTx: db,
+    });
+    if (getKiloClawSubscriptionAccessReason(row?.subscription, now)) {
+      return;
+    }
+  } catch (error) {
+    if (error instanceof CurrentPersonalSubscriptionResolutionError) {
+      console.warn(
+        JSON.stringify({
+          event: 'kiloclaw_access_quarantined_multiple_current_rows',
+          userId,
+          instanceId: error.instanceId ?? instanceId,
+          message: error.message,
+        })
+      );
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'KiloClaw billing state needs support review before access can be restored.',
+      });
+    }
+    throw error;
+  }
+
+  const [earlybird] = await db
+    .select({ id: kiloclaw_earlybird_purchases.id })
+    .from(kiloclaw_earlybird_purchases)
+    .where(eq(kiloclaw_earlybird_purchases.user_id, userId))
+    .limit(1);
+
+  if (earlybird && new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE) > now) {
+    return;
+  }
 
   throw new TRPCError({
     code: 'FORBIDDEN',

--- a/apps/web/src/lib/kiloclaw/access-state.ts
+++ b/apps/web/src/lib/kiloclaw/access-state.ts
@@ -1,13 +1,27 @@
 import { db } from '@/lib/drizzle';
-import { kiloclaw_subscriptions, type KiloClawSubscription } from '@kilocode/db/schema';
-import { eq } from 'drizzle-orm';
+import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
+import {
+  kiloclaw_earlybird_purchases,
+  kiloclaw_subscriptions,
+  type KiloClawSubscription,
+} from '@kilocode/db/schema';
+import { and, eq } from 'drizzle-orm';
 
 import {
   CurrentPersonalSubscriptionResolutionError,
   resolveCurrentPersonalSubscriptionRow,
 } from '@/lib/kiloclaw/current-personal-subscription';
 
-export type KiloClawAccessReason = 'trial' | 'subscription';
+export type KiloClawAccessReason = 'trial' | 'subscription' | 'earlybird';
+export type KiloClawSubscriptionAccessRecord = Pick<
+  KiloClawSubscription,
+  'status' | 'trial_ends_at' | 'suspended_at' | 'access_origin'
+>;
+export type KiloClawEarlybirdState = {
+  purchased: boolean;
+  hasAccess: boolean;
+  expiresAt: string | null;
+};
 
 function parseTimestamp(value: string | null | undefined): number {
   if (!value) return 0;
@@ -34,10 +48,7 @@ function subscriptionRecency(subscription: KiloClawSubscription): number {
 }
 
 export function getKiloClawSubscriptionAccessReason(
-  subscription:
-    | Pick<KiloClawSubscription, 'status' | 'trial_ends_at' | 'suspended_at'>
-    | null
-    | undefined,
+  subscription: KiloClawSubscriptionAccessRecord | null | undefined,
   now = new Date()
 ): KiloClawAccessReason | null {
   if (!subscription) return null;
@@ -48,6 +59,9 @@ export function getKiloClawSubscriptionAccessReason(
     subscription.trial_ends_at &&
     new Date(subscription.trial_ends_at) > now
   ) {
+    if (subscription.access_origin === 'earlybird') {
+      return 'earlybird';
+    }
     return 'trial';
   }
   return null;
@@ -88,6 +102,50 @@ export async function getEffectiveKiloClawSubscriptionForUser(
     subscription,
     accessReason: getKiloClawSubscriptionAccessReason(subscription, now),
     subscriptionCount: subscriptions.length,
+  };
+}
+
+export async function getKiloClawEarlybirdStateForUser(
+  userId: string,
+  now = new Date()
+): Promise<KiloClawEarlybirdState> {
+  const earlybirdSubscriptions = await db
+    .select()
+    .from(kiloclaw_subscriptions)
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, userId),
+        eq(kiloclaw_subscriptions.access_origin, 'earlybird')
+      )
+    );
+
+  if (earlybirdSubscriptions.length > 0) {
+    const subscription = getEffectiveKiloClawSubscription(earlybirdSubscriptions, now);
+    return {
+      purchased: true,
+      hasAccess: getKiloClawSubscriptionAccessReason(subscription, now) === 'earlybird',
+      expiresAt: subscription?.trial_ends_at ?? KILOCLAW_EARLYBIRD_EXPIRY_DATE,
+    };
+  }
+
+  const [legacyPurchase] = await db
+    .select({ createdAt: kiloclaw_earlybird_purchases.created_at })
+    .from(kiloclaw_earlybird_purchases)
+    .where(eq(kiloclaw_earlybird_purchases.user_id, userId))
+    .limit(1);
+
+  if (legacyPurchase) {
+    return {
+      purchased: true,
+      hasAccess: new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE) > now,
+      expiresAt: KILOCLAW_EARLYBIRD_EXPIRY_DATE,
+    };
+  }
+
+  return {
+    purchased: false,
+    hasAccess: false,
+    expiresAt: null,
   };
 }
 

--- a/apps/web/src/lib/kiloclaw/access-state.ts
+++ b/apps/web/src/lib/kiloclaw/access-state.ts
@@ -33,9 +33,10 @@ function subscriptionPriority(subscription: KiloClawSubscription, now: Date): nu
   const accessReason = getKiloClawSubscriptionAccessReason(subscription, now);
   if (accessReason === 'subscription') return 0;
   if (accessReason === 'trial') return 1;
-  if (subscription.plan !== 'trial') return 2;
-  if (subscription.status === 'trialing') return 3;
-  return 4;
+  if (accessReason === 'earlybird') return 2;
+  if (subscription.plan !== 'trial') return 3;
+  if (subscription.status === 'trialing') return 4;
+  return 5;
 }
 
 function subscriptionRecency(subscription: KiloClawSubscription): number {

--- a/apps/web/src/lib/kiloclaw/instance-lifecycle.test.ts
+++ b/apps/web/src/lib/kiloclaw/instance-lifecycle.test.ts
@@ -17,6 +17,7 @@ import { autoResumeIfSuspended, completeAutoResumeIfReady } from './instance-lif
 const selectResultsQueue: unknown[][] = [];
 const updateSetCalls: Array<Record<string, unknown>> = [];
 const txUpdateSetCalls: Array<Record<string, unknown>> = [];
+const txInsertValues: Array<Record<string, unknown>> = [];
 const deleteWhereCalls: unknown[] = [];
 const startAsyncMock = jest.fn();
 
@@ -24,6 +25,14 @@ function createSelectResult<T>(rows: T[]) {
   const promise = Promise.resolve(rows);
   return {
     limit: jest.fn().mockResolvedValue(rows),
+    then: promise.then.bind(promise),
+  };
+}
+
+function createWhereResult<T>(rows: T[]) {
+  const promise = Promise.resolve(undefined);
+  return {
+    returning: jest.fn().mockResolvedValue(rows),
     then: promise.then.bind(promise),
   };
 }
@@ -41,6 +50,7 @@ describe('instance lifecycle async resume', () => {
     selectResultsQueue.length = 0;
     updateSetCalls.length = 0;
     txUpdateSetCalls.length = 0;
+    txInsertValues.length = 0;
     deleteWhereCalls.length = 0;
     startAsyncMock.mockReset();
     jest.mocked(KiloClawInternalClient).mockImplementation(
@@ -61,8 +71,9 @@ describe('instance lifecycle async resume', () => {
     mockDb.update.mockImplementation(() => ({
       set: jest.fn((values: Record<string, unknown>) => {
         updateSetCalls.push(values);
+        const whereResult = createWhereResult([{}]);
         return {
-          where: jest.fn(async () => undefined),
+          where: jest.fn(() => whereResult),
         };
       }),
     }));
@@ -70,6 +81,11 @@ describe('instance lifecycle async resume', () => {
     mockDb.transaction.mockReset();
     mockDb.transaction.mockImplementation(async callback => {
       const tx = {
+        select: jest.fn(() => ({
+          from: jest.fn(() => ({
+            where: jest.fn(() => createSelectResult(selectResultsQueue.shift() ?? [])),
+          })),
+        })),
         delete: jest.fn(() => ({
           where: jest.fn(async (whereArg: unknown) => {
             deleteWhereCalls.push(whereArg);
@@ -79,9 +95,16 @@ describe('instance lifecycle async resume', () => {
         update: jest.fn(() => ({
           set: jest.fn((values: Record<string, unknown>) => {
             txUpdateSetCalls.push(values);
+            const whereResult = createWhereResult([{}]);
             return {
-              where: jest.fn(async () => undefined),
+              where: jest.fn(() => whereResult),
             };
+          }),
+        })),
+        insert: jest.fn(() => ({
+          values: jest.fn(async (values: Record<string, unknown>) => {
+            txInsertValues.push(values);
+            return undefined;
           }),
         })),
       };
@@ -124,7 +147,20 @@ describe('instance lifecycle async resume', () => {
 
   it('clears stale suspension state when no active instance remains', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
-    selectResultsQueue.push([]);
+    selectResultsQueue.push(
+      [],
+      [
+        {
+          id: 'sub-1',
+          user_id: 'user-1',
+          instance_id: instanceId,
+          plan: 'trial',
+          status: 'canceled',
+          suspended_at: '2026-04-07T20:00:00.000Z',
+          destruction_deadline: '2026-04-14T20:00:00.000Z',
+        },
+      ]
+    );
 
     await autoResumeIfSuspended('user-1', instanceId);
 
@@ -141,6 +177,14 @@ describe('instance lifecycle async resume', () => {
         auto_resume_attempt_count: 0,
       },
     ]);
+    expect(txInsertValues).toHaveLength(1);
+    expect(txInsertValues[0]).toEqual(
+      expect.objectContaining({
+        actor_id: 'web-instance-lifecycle',
+        action: 'reactivated',
+        reason: 'auto_resume_aborted_no_active_instance',
+      })
+    );
   });
 
   it('completes async auto-resume for the correct instance and clears retry state', async () => {
@@ -151,6 +195,20 @@ describe('instance lifecycle async resume', () => {
       [
         {
           suspended_at: '2026-04-07T20:00:00.000Z',
+          auto_resume_requested_at: '2026-04-07T20:05:00.000Z',
+          auto_resume_retry_after: '2026-04-07T22:05:00.000Z',
+          auto_resume_attempt_count: 2,
+        },
+      ],
+      [
+        {
+          id: 'sub-1',
+          user_id: 'user-1',
+          instance_id: instanceId,
+          plan: 'trial',
+          status: 'canceled',
+          suspended_at: '2026-04-07T20:00:00.000Z',
+          destruction_deadline: '2026-04-14T20:00:00.000Z',
           auto_resume_requested_at: '2026-04-07T20:05:00.000Z',
           auto_resume_retry_after: '2026-04-07T22:05:00.000Z',
           auto_resume_attempt_count: 2,
@@ -171,12 +229,20 @@ describe('instance lifecycle async resume', () => {
       auto_resume_retry_after: null,
       auto_resume_attempt_count: 0,
     });
+    expect(txInsertValues).toHaveLength(1);
+    expect(txInsertValues[0]).toEqual(
+      expect.objectContaining({
+        actor_id: 'web-instance-lifecycle',
+        action: 'reactivated',
+        reason: 'auto_resume_completed',
+      })
+    );
   });
 
   it('clears auto-resume state when readiness arrives after the instance is already gone', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
     const sandboxId = 'ki_11111111111141118111111111111111';
-    selectResultsQueue.push([]);
+    selectResultsQueue.push([], []);
 
     const result = await completeAutoResumeIfReady('user-1', sandboxId, instanceId);
 
@@ -192,6 +258,7 @@ describe('instance lifecycle async resume', () => {
         auto_resume_attempt_count: 0,
       },
     ]);
+    expect(txInsertValues).toHaveLength(0);
   });
 
   it('treats repeated readiness notifications as idempotent once resume state is already clear', async () => {

--- a/apps/web/src/lib/kiloclaw/instance-lifecycle.ts
+++ b/apps/web/src/lib/kiloclaw/instance-lifecycle.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import { eq, and, isNull, inArray } from 'drizzle-orm';
 
 import { db } from '@/lib/drizzle';
+import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
 import {
   kiloclaw_subscriptions,
   kiloclaw_instances,
@@ -16,6 +17,10 @@ const logInfo = sentryLogger('kiloclaw-instance-lifecycle', 'info');
 const logError = sentryLogger('kiloclaw-instance-lifecycle', 'error');
 const AUTO_RESUME_INITIAL_BACKOFF_MS = 2 * 60 * 60 * 1000;
 const AUTO_RESUME_MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
+const INSTANCE_LIFECYCLE_ACTOR = {
+  actorType: 'system',
+  actorId: 'web-instance-lifecycle',
+} as const;
 
 type ActiveInstance = {
   id: string;
@@ -38,6 +43,20 @@ function getResettableAutoResumeEmailTypes() {
   ] as const;
 }
 
+function emailLogTypeFilter(
+  kiloUserId: string,
+  emailTypes: readonly string[],
+  instanceId?: string
+) {
+  return and(
+    eq(kiloclaw_email_log.user_id, kiloUserId),
+    inArray(kiloclaw_email_log.email_type, [...emailTypes]),
+    instanceId
+      ? eq(kiloclaw_email_log.instance_id, instanceId)
+      : isNull(kiloclaw_email_log.instance_id)
+  );
+}
+
 function subscriptionFilterForUser(kiloUserId: string, instanceId?: string) {
   return instanceId
     ? and(
@@ -57,19 +76,19 @@ async function clearAutoResumeState(
     instanceId?: string;
     sandboxId?: string;
     logMessage: string;
+    changeLogReason: string;
     logFields?: Record<string, unknown>;
   }
 ): Promise<void> {
   const subscriptionFilter = subscriptionFilterForUser(kiloUserId, options.instanceId);
 
   await db.transaction(async tx => {
+    const subscriptions = await tx.select().from(kiloclaw_subscriptions).where(subscriptionFilter);
+
     await tx
       .delete(kiloclaw_email_log)
       .where(
-        and(
-          eq(kiloclaw_email_log.user_id, kiloUserId),
-          inArray(kiloclaw_email_log.email_type, [...getResettableAutoResumeEmailTypes()])
-        )
+        emailLogTypeFilter(kiloUserId, getResettableAutoResumeEmailTypes(), options.instanceId)
       );
 
     await tx
@@ -82,6 +101,30 @@ async function clearAutoResumeState(
         auto_resume_attempt_count: 0,
       })
       .where(subscriptionFilter);
+
+    for (const subscription of subscriptions) {
+      const clearedSuspension =
+        subscription.suspended_at !== null || subscription.destruction_deadline !== null;
+      if (!clearedSuspension) {
+        continue;
+      }
+
+      await insertKiloClawSubscriptionChangeLog(tx, {
+        subscriptionId: subscription.id,
+        actor: INSTANCE_LIFECYCLE_ACTOR,
+        action: 'reactivated',
+        reason: options.changeLogReason,
+        before: subscription,
+        after: {
+          ...subscription,
+          suspended_at: null,
+          destruction_deadline: null,
+          auto_resume_requested_at: null,
+          auto_resume_retry_after: null,
+          auto_resume_attempt_count: 0,
+        },
+      });
+    }
   });
 
   logInfo(options.logMessage, {
@@ -141,6 +184,7 @@ export async function autoResumeIfSuspended(
     await clearAutoResumeState(kiloUserId, {
       instanceId,
       logMessage: 'Cleared auto-resume state because no active instance remains',
+      changeLogReason: 'auto_resume_aborted_no_active_instance',
       logFields: { recovery_reason: 'no_active_instance' },
     });
     return;
@@ -226,6 +270,7 @@ export async function completeAutoResumeIfReady(
       instanceId,
       sandboxId,
       logMessage: 'Cleared auto-resume state because readiness callback found no active instance',
+      changeLogReason: 'auto_resume_ready_without_active_instance',
       logFields: { recovery_reason: 'ready_without_active_instance' },
     });
     return { instanceId: instanceId ?? null, resumeCompleted: true };
@@ -268,6 +313,7 @@ export async function completeAutoResumeIfReady(
     instanceId: targetInstance.id,
     sandboxId,
     logMessage: 'Async auto-resume completed',
+    changeLogReason: 'auto_resume_completed',
   });
   return { instanceId: targetInstance.id, resumeCompleted: true };
 }

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -1399,8 +1399,16 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         .where(
           and(
             eq(kiloclaw_email_log.user_id, instance.user_id),
-            eq(kiloclaw_email_log.instance_id, instance.id),
-            eq(kiloclaw_email_log.email_type, 'claw_instance_ready')
+            or(
+              and(
+                eq(kiloclaw_email_log.instance_id, instance.id),
+                eq(kiloclaw_email_log.email_type, 'claw_instance_ready')
+              ),
+              and(
+                isNull(kiloclaw_email_log.instance_id),
+                eq(kiloclaw_email_log.email_type, `claw_instance_ready:${instance.sandbox_id}`)
+              )
+            )
           )
         );
     } catch (cleanupError) {

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -1,5 +1,6 @@
 import { adminProcedure, createTRPCRouter, UpstreamApiError } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
+import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
 import {
   kiloclaw_instances,
   kiloclaw_subscriptions,
@@ -185,6 +186,61 @@ function throwKiloclawAdminError(
     message: err instanceof Error ? `${fallbackMessage}: ${err.message}` : fallbackMessage,
     cause: err instanceof Error ? err : undefined,
   });
+}
+
+type KiloclawSubscriptionRow = typeof kiloclaw_subscriptions.$inferSelect;
+
+async function clearAdminInstanceDestructionDeadlineWithChangeLog(params: {
+  actorUserId: string;
+  userId: string;
+  instanceId: string;
+  reason: string;
+}) {
+  const [before] = await db
+    .select()
+    .from(kiloclaw_subscriptions)
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, params.userId),
+        eq(kiloclaw_subscriptions.instance_id, params.instanceId)
+      )
+    )
+    .limit(1);
+
+  if (!before) {
+    return;
+  }
+
+  const [after] = await db
+    .update(kiloclaw_subscriptions)
+    .set({ destruction_deadline: null })
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, params.userId),
+        eq(kiloclaw_subscriptions.instance_id, params.instanceId)
+      )
+    )
+    .returning();
+
+  if (!after) {
+    return;
+  }
+
+  try {
+    await insertKiloClawSubscriptionChangeLog(db, {
+      subscriptionId: after.id,
+      actor: {
+        actorType: 'user',
+        actorId: params.actorUserId,
+      },
+      action: 'admin_override',
+      reason: params.reason,
+      before: before satisfies KiloclawSubscriptionRow,
+      after: after satisfies KiloclawSubscriptionRow,
+    });
+  } catch (error) {
+    console.error('[admin-kiloclaw] Failed to write subscription change log:', error);
+  }
 }
 
 /**
@@ -1313,15 +1369,12 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     // Post-destroy cleanup: best-effort DB tidying that must not report
     // failure after a successful destroy.
     try {
-      await db
-        .update(kiloclaw_subscriptions)
-        .set({ destruction_deadline: null })
-        .where(
-          and(
-            eq(kiloclaw_subscriptions.user_id, instance.user_id),
-            eq(kiloclaw_subscriptions.instance_id, instance.id)
-          )
-        );
+      await clearAdminInstanceDestructionDeadlineWithChangeLog({
+        actorUserId: ctx.user.id,
+        userId: instance.user_id,
+        instanceId: instance.id,
+        reason: 'admin_destroy_clear_lifecycle_state',
+      });
 
       // Clear lifecycle emails so they can fire again if the user re-provisions.
       const resettableEmailTypes = [
@@ -1336,6 +1389,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         .where(
           and(
             eq(kiloclaw_email_log.user_id, instance.user_id),
+            eq(kiloclaw_email_log.instance_id, instance.id),
             inArray(kiloclaw_email_log.email_type, resettableEmailTypes)
           )
         );
@@ -1345,7 +1399,8 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         .where(
           and(
             eq(kiloclaw_email_log.user_id, instance.user_id),
-            sql`${kiloclaw_email_log.email_type} LIKE 'claw_instance_ready:%'`
+            eq(kiloclaw_email_log.instance_id, instance.id),
+            eq(kiloclaw_email_log.email_type, 'claw_instance_ready')
           )
         );
     } catch (cleanupError) {

--- a/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
@@ -4,6 +4,7 @@ import { insertTestUser } from '@/tests/helpers/user.helper';
 import {
   kiloclaw_admin_audit_logs,
   kiloclaw_earlybird_purchases,
+  kiloclaw_subscription_change_log,
   kiloclaw_instances,
   kiloclaw_subscriptions,
 } from '@kilocode/db/schema';
@@ -152,10 +153,51 @@ describe('admin.users.getKiloClawState', () => {
     expect(result.accessReason).toBeNull();
   });
 
-  it('returns earlybird access when no subscription row exists', async () => {
+  it('returns earlybird access from canonical subscription row', async () => {
+    const [instance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        user_id: targetUser.id,
+        sandbox_id: 'sandbox-earlybird-admin-test',
+      })
+      .returning({ id: kiloclaw_instances.id });
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: targetUser.id,
+      instance_id: instance!.id,
+      plan: 'trial',
+      status: 'trialing',
+      access_origin: 'earlybird',
+      cancel_at_period_end: false,
+      trial_started_at: '2026-01-01T00:00:00.000Z',
+      trial_ends_at: '2026-09-26T00:00:00.000Z',
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
+
+    expect(result.subscription).toEqual(
+      expect.objectContaining({
+        access_origin: 'earlybird',
+      })
+    );
+    expect(result.hasAccess).toBe(true);
+    expect(result.accessReason).toBe('earlybird');
+    expect(result.earlybird).toEqual(
+      expect.objectContaining({
+        purchased: true,
+        expiresAt: expect.any(String),
+        daysRemaining: expect.any(Number),
+      })
+    );
+    expect(result.subscriptions).toHaveLength(1);
+  });
+
+  it('returns earlybird access from legacy purchase row before backfill', async () => {
     await db.insert(kiloclaw_earlybird_purchases).values({
       user_id: targetUser.id,
-      amount_cents: 2500,
+      stripe_charge_id: `ch_${crypto.randomUUID().replace(/-/g, '')}`,
+      amount_cents: 9900,
     });
 
     const caller = await createCallerForUser(adminUser.id);
@@ -171,7 +213,6 @@ describe('admin.users.getKiloClawState', () => {
         daysRemaining: expect.any(Number),
       })
     );
-    expect(result.subscriptions).toHaveLength(0);
   });
 
   it('returns activeInstanceId when the user has an active instance', async () => {
@@ -438,6 +479,18 @@ describe('admin.users.updateKiloClawTrialEndAt', () => {
     expect(auditLog.message).toContain('reset from canceled to trialing');
     expect(auditLog.metadata?.isReset).toBe(true);
     expect(auditLog.metadata?.previousStatus).toBe('canceled');
+
+    const [changeLog] = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, sub.id));
+    expect(changeLog).toEqual(
+      expect.objectContaining({
+        actor_id: adminUser.id,
+        action: 'reactivated',
+        reason: 'admin_reset_trial',
+      })
+    );
   });
 });
 
@@ -506,6 +559,18 @@ describe('admin.users.cancelKiloClawSubscription', () => {
     // current_period_end and credit_renewal_at should be set to ~now
     expect(updated?.current_period_end).not.toBeNull();
     expect(updated?.credit_renewal_at).not.toBeNull();
+
+    const [changeLog] = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, sub.id));
+    expect(changeLog).toEqual(
+      expect.objectContaining({
+        actor_id: adminUser.id,
+        action: 'canceled',
+        reason: 'admin_cancel_immediate',
+      })
+    );
   });
 
   it('immediate cancel can cancel a row already pending period-end cancellation', async () => {

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -1,5 +1,6 @@
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
+import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
 import {
   user_admin_notes,
   kilocode_users,
@@ -12,7 +13,6 @@ import {
   cli_sessions_v2,
   credit_transactions,
   kiloclaw_subscriptions,
-  kiloclaw_earlybird_purchases,
   kiloclaw_email_log,
   kiloclaw_instances,
 } from '@kilocode/db/schema';
@@ -67,6 +67,7 @@ import { kilo_pass_scheduled_changes } from '@kilocode/db/schema';
 import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
 import {
   getEffectiveKiloClawSubscription,
+  getKiloClawEarlybirdStateForUser,
   getKiloClawSubscriptionAccessReason,
 } from '@/lib/kiloclaw/access-state';
 import { createKiloClawAdminAuditLog } from '@/lib/kiloclaw/admin-audit-log';
@@ -85,6 +86,17 @@ const SyncResponseSchema = z.object({
 });
 
 type SyncResponse = z.infer<typeof SyncResponseSchema>;
+
+function adminSubscriptionActor(ctxUser: {
+  id: string;
+  google_user_email: string;
+  google_user_name: string | null;
+}) {
+  return {
+    actorType: 'user',
+    actorId: ctxUser.id,
+  } as const;
+}
 
 function parseJsonSafe(text: string): unknown {
   return JSON.parse(text) as unknown;
@@ -514,15 +526,12 @@ export const adminRouter = createTRPCRouter({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
       }
 
-      const [allSubscriptions, earlybird, activeInstance, allInstances] = await Promise.all([
+      const [allSubscriptions, earlybirdState, activeInstance, allInstances] = await Promise.all([
         db
           .select()
           .from(kiloclaw_subscriptions)
           .where(eq(kiloclaw_subscriptions.user_id, input.userId)),
-        db.query.kiloclaw_earlybird_purchases.findFirst({
-          columns: { id: true },
-          where: eq(kiloclaw_earlybird_purchases.user_id, input.userId),
-        }),
+        getKiloClawEarlybirdStateForUser(input.userId, new Date()),
         db.query.kiloclaw_instances.findFirst({
           columns: { id: true },
           where: and(
@@ -543,17 +552,11 @@ export const adminRouter = createTRPCRouter({
 
       const effectiveSub = getEffectiveKiloClawSubscription(allSubscriptions);
       const accessReason = getKiloClawSubscriptionAccessReason(effectiveSub);
-
-      const now = new Date();
-      const earlybirdDaysRemaining = earlybird
-        ? Math.ceil(
-            (new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE).getTime() - now.getTime()) / 86_400_000
-          )
+      const earlybirdDaysRemaining = earlybirdState.expiresAt
+        ? Math.ceil((new Date(earlybirdState.expiresAt).getTime() - Date.now()) / 86_400_000)
         : 0;
-
-      const hasEarlybirdAccess = !!earlybird && new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE) > now;
-      const hasAccess = hasEarlybirdAccess || accessReason !== null;
-      const effectiveAccessReason = hasEarlybirdAccess ? 'earlybird' : accessReason;
+      const hasAccess = earlybirdState.hasAccess || accessReason !== null;
+      const effectiveAccessReason = earlybirdState.hasAccess ? 'earlybird' : accessReason;
 
       // Build instance lookup for per-subscription context
       const instancesById = new Map(allInstances.map(inst => [inst.id, inst]));
@@ -569,10 +572,10 @@ export const adminRouter = createTRPCRouter({
         subscriptions,
         hasAccess,
         accessReason: effectiveAccessReason,
-        earlybird: earlybird
+        earlybird: earlybirdState.purchased
           ? {
               purchased: true,
-              expiresAt: KILOCLAW_EARLYBIRD_EXPIRY_DATE,
+              expiresAt: earlybirdState.expiresAt ?? KILOCLAW_EARLYBIRD_EXPIRY_DATE,
               daysRemaining: earlybirdDaysRemaining,
             }
           : null,
@@ -620,7 +623,7 @@ export const adminRouter = createTRPCRouter({
         await db.transaction(async tx => {
           if (isReset) {
             // Reset canceled subscription to a new trial
-            await tx
+            const [updatedSubscription] = await tx
               .update(kiloclaw_subscriptions)
               .set({
                 status: 'trialing',
@@ -639,7 +642,24 @@ export const adminRouter = createTRPCRouter({
                 suspended_at: null,
                 destruction_deadline: null,
               })
-              .where(eq(kiloclaw_subscriptions.id, subscription.id));
+              .where(eq(kiloclaw_subscriptions.id, subscription.id))
+              .returning();
+
+            if (!updatedSubscription) {
+              throw new TRPCError({
+                code: 'INTERNAL_SERVER_ERROR',
+                message: 'Failed to reset KiloClaw subscription trial',
+              });
+            }
+
+            await insertKiloClawSubscriptionChangeLog(tx, {
+              subscriptionId: subscription.id,
+              actor: adminSubscriptionActor(ctx.user),
+              action: 'reactivated',
+              reason: 'admin_reset_trial',
+              before: subscription,
+              after: updatedSubscription,
+            });
 
             // Clear email logs so notifications can fire again for the new trial.
             // Unlike autoResumeIfSuspended (which preserves trial warnings as one-time events),
@@ -658,15 +678,35 @@ export const adminRouter = createTRPCRouter({
               .where(
                 and(
                   eq(kiloclaw_email_log.user_id, input.userId),
+                  subscription.instance_id
+                    ? eq(kiloclaw_email_log.instance_id, subscription.instance_id)
+                    : isNull(kiloclaw_email_log.instance_id),
                   inArray(kiloclaw_email_log.email_type, emailTypesToClearOnTrialReset)
                 )
               );
           } else {
             // Just update the trial end date for an active trial
-            await tx
+            const [updatedSubscription] = await tx
               .update(kiloclaw_subscriptions)
               .set({ trial_ends_at: input.trial_ends_at })
-              .where(eq(kiloclaw_subscriptions.id, subscription.id));
+              .where(eq(kiloclaw_subscriptions.id, subscription.id))
+              .returning();
+
+            if (!updatedSubscription) {
+              throw new TRPCError({
+                code: 'INTERNAL_SERVER_ERROR',
+                message: 'Failed to update KiloClaw trial end date',
+              });
+            }
+
+            await insertKiloClawSubscriptionChangeLog(tx, {
+              subscriptionId: subscription.id,
+              actor: adminSubscriptionActor(ctx.user),
+              action: 'admin_override',
+              reason: 'admin_update_trial_end',
+              before: subscription,
+              after: updatedSubscription,
+            });
           }
 
           await createKiloClawAdminAuditLog({
@@ -793,7 +833,7 @@ export const adminRouter = createTRPCRouter({
               cancel_at_period_end: true,
             });
 
-            await db
+            const [updatedSubscription] = await db
               .update(kiloclaw_subscriptions)
               .set({
                 cancel_at_period_end: true,
@@ -801,10 +841,27 @@ export const adminRouter = createTRPCRouter({
                   ? { stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null }
                   : {}),
               })
-              .where(eq(kiloclaw_subscriptions.id, subscription.id));
+              .where(eq(kiloclaw_subscriptions.id, subscription.id))
+              .returning();
+
+            if (!updatedSubscription) {
+              throw new TRPCError({
+                code: 'INTERNAL_SERVER_ERROR',
+                message: 'Failed to update KiloClaw subscription',
+              });
+            }
+
+            await insertKiloClawSubscriptionChangeLog(db, {
+              subscriptionId: subscription.id,
+              actor: adminSubscriptionActor(ctx.user),
+              action: 'canceled',
+              reason: 'admin_cancel_at_period_end',
+              before: subscription,
+              after: updatedSubscription,
+            });
           } else {
             // Pure-credit: set local cancel_at_period_end and clear schedule state
-            await db
+            const [updatedSubscription] = await db
               .update(kiloclaw_subscriptions)
               .set({
                 cancel_at_period_end: true,
@@ -812,7 +869,24 @@ export const adminRouter = createTRPCRouter({
                 scheduled_plan: null,
                 scheduled_by: null,
               })
-              .where(eq(kiloclaw_subscriptions.id, subscription.id));
+              .where(eq(kiloclaw_subscriptions.id, subscription.id))
+              .returning();
+
+            if (!updatedSubscription) {
+              throw new TRPCError({
+                code: 'INTERNAL_SERVER_ERROR',
+                message: 'Failed to update KiloClaw subscription',
+              });
+            }
+
+            await insertKiloClawSubscriptionChangeLog(db, {
+              subscriptionId: subscription.id,
+              actor: adminSubscriptionActor(ctx.user),
+              action: 'canceled',
+              reason: 'admin_cancel_at_period_end',
+              before: subscription,
+              after: updatedSubscription,
+            });
           }
         } else {
           // mode === 'immediate'
@@ -862,7 +936,7 @@ export const adminRouter = createTRPCRouter({
 
           // Update local subscription to canceled
           const now = new Date().toISOString();
-          await db
+          const [updatedSubscription] = await db
             .update(kiloclaw_subscriptions)
             .set({
               status: 'canceled',
@@ -876,7 +950,24 @@ export const adminRouter = createTRPCRouter({
               // For trialing subscriptions, also end the trial immediately
               ...(subscription.status === 'trialing' ? { trial_ends_at: now } : {}),
             })
-            .where(eq(kiloclaw_subscriptions.id, subscription.id));
+            .where(eq(kiloclaw_subscriptions.id, subscription.id))
+            .returning();
+
+          if (!updatedSubscription) {
+            throw new TRPCError({
+              code: 'INTERNAL_SERVER_ERROR',
+              message: 'Failed to cancel KiloClaw subscription',
+            });
+          }
+
+          await insertKiloClawSubscriptionChangeLog(db, {
+            subscriptionId: subscription.id,
+            actor: adminSubscriptionActor(ctx.user),
+            action: 'canceled',
+            reason: 'admin_cancel_immediate',
+            before: subscription,
+            after: updatedSubscription,
+          });
         }
 
         await createKiloClawAdminAuditLog({

--- a/apps/web/src/routers/admin/extend-claw-trial-router.test.ts
+++ b/apps/web/src/routers/admin/extend-claw-trial-router.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach } from '@jest/globals';
 import { db, cleanupDbForTest } from '@/lib/drizzle';
-import { kiloclaw_subscriptions } from '@kilocode/db/schema';
+import { kiloclaw_subscription_change_log, kiloclaw_subscriptions } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createCallerForUser } from '@/routers/test-utils';
 import type { User } from '@kilocode/db/schema';
@@ -127,13 +128,16 @@ describe('extendTrials — 1-year ceiling', () => {
 
 describe('extendTrials — normal extension', () => {
   it('extends a trialing subscription by the requested days', async () => {
-    await db.insert(kiloclaw_subscriptions).values({
-      user_id: target.id,
-      plan: 'trial',
-      status: 'trialing',
-      trial_started_at: new Date().toISOString(),
-      trial_ends_at: new Date().toISOString(),
-    });
+    const [subscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: target.id,
+        plan: 'trial',
+        status: 'trialing',
+        trial_started_at: new Date().toISOString(),
+        trial_ends_at: new Date().toISOString(),
+      })
+      .returning();
 
     const caller = await createCallerForUser(admin.id);
     const results = await caller.admin.extendClawTrial.extendTrials({
@@ -150,16 +154,31 @@ describe('extendTrials — normal extension', () => {
     const expected = Date.now() + 7 * MS_PER_DAY;
     expect(newEnd).toBeGreaterThan(expected - MS_PER_DAY);
     expect(newEnd).toBeLessThan(expected + MS_PER_DAY);
+
+    const [changeLog] = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscription.id));
+    expect(changeLog).toEqual(
+      expect.objectContaining({
+        actor_id: admin.id,
+        action: 'admin_override',
+        reason: 'bulk_extend_trial',
+      })
+    );
   });
 
   it('resurrects a canceled subscription as a fresh trial', async () => {
-    await db.insert(kiloclaw_subscriptions).values({
-      user_id: target.id,
-      plan: 'trial',
-      status: 'canceled',
-      trial_started_at: new Date(Date.now() - 30 * MS_PER_DAY).toISOString(),
-      trial_ends_at: new Date(Date.now() - 10 * MS_PER_DAY).toISOString(),
-    });
+    const [subscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: target.id,
+        plan: 'trial',
+        status: 'canceled',
+        trial_started_at: new Date(Date.now() - 30 * MS_PER_DAY).toISOString(),
+        trial_ends_at: new Date(Date.now() - 10 * MS_PER_DAY).toISOString(),
+      })
+      .returning();
 
     const caller = await createCallerForUser(admin.id);
     const results = await caller.admin.extendClawTrial.extendTrials({
@@ -178,5 +197,17 @@ describe('extendTrials — normal extension', () => {
     const oneYearFromNow = calendarYearFromNow.getTime();
     expect(newEnd).toBeGreaterThan(oneYearFromNow - MS_PER_DAY);
     expect(newEnd).toBeLessThanOrEqual(oneYearFromNow + 5_000);
+
+    const [changeLog] = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscription.id));
+    expect(changeLog).toEqual(
+      expect.objectContaining({
+        actor_id: admin.id,
+        action: 'reactivated',
+        reason: 'bulk_restart_trial',
+      })
+    );
   });
 });

--- a/apps/web/src/routers/admin/extend-claw-trial-router.ts
+++ b/apps/web/src/routers/admin/extend-claw-trial-router.ts
@@ -92,8 +92,9 @@ async function writeBestEffortSubscriptionChangeLog(
       before: params.before,
       after: params.after,
     });
-  } catch {
+  } catch (error) {
     // Trial change already committed. Log failure must not trigger retry.
+    console.error('[admin-extend-claw-trial] Failed to write subscription change log:', error);
   }
 }
 

--- a/apps/web/src/routers/admin/extend-claw-trial-router.ts
+++ b/apps/web/src/routers/admin/extend-claw-trial-router.ts
@@ -1,8 +1,9 @@
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
+import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
 import { kilocode_users, kiloclaw_subscriptions, kiloclaw_email_log } from '@kilocode/db/schema';
 import * as z from 'zod';
-import { eq, and, inArray, sql, desc } from 'drizzle-orm';
+import { eq, and, inArray, sql, desc, isNull } from 'drizzle-orm';
 import { createKiloClawAdminAuditLog } from '@/lib/kiloclaw/admin-audit-log';
 
 const MAX_USERS = 1000;
@@ -65,6 +66,37 @@ type AdminContext = {
   user: { id: string; google_user_email: string; google_user_name: string | null };
 };
 
+function adminSubscriptionActor(ctx: AdminContext) {
+  return {
+    actorType: 'user',
+    actorId: ctx.user.id,
+  } as const;
+}
+
+async function writeBestEffortSubscriptionChangeLog(
+  ctx: AdminContext,
+  params: {
+    subscriptionId: string;
+    action: 'admin_override' | 'reactivated';
+    reason: string;
+    before: typeof kiloclaw_subscriptions.$inferSelect;
+    after: typeof kiloclaw_subscriptions.$inferSelect;
+  }
+) {
+  try {
+    await insertKiloClawSubscriptionChangeLog(db, {
+      subscriptionId: params.subscriptionId,
+      actor: adminSubscriptionActor(ctx),
+      action: params.action,
+      reason: params.reason,
+      before: params.before,
+      after: params.after,
+    });
+  } catch {
+    // Trial change already committed. Log failure must not trigger retry.
+  }
+}
+
 const EMAIL_TYPES_TO_CLEAR = [
   'claw_trial_1d',
   'claw_trial_5d',
@@ -120,7 +152,7 @@ async function processOneEmail(
           eq(kiloclaw_subscriptions.status, 'trialing')
         )
       )
-      .returning({ trial_ends_at: kiloclaw_subscriptions.trial_ends_at });
+      .returning();
 
     if (!updated) {
       // Subscription status changed between match and extend (e.g. user subscribed).
@@ -132,6 +164,14 @@ async function processOneEmail(
         error: 'Subscription status changed since match — please re-match and retry.',
       };
     }
+
+    await writeBestEffortSubscriptionChangeLog(ctx, {
+      subscriptionId: subscription.id,
+      action: 'admin_override',
+      reason: 'bulk_extend_trial',
+      before: subscription,
+      after: updated,
+    });
 
     // Audit log is best-effort — its failure does not undo the extension
     // and must not cause a false failure result that prompts a retry.
@@ -209,7 +249,7 @@ async function processOneEmail(
           eq(kiloclaw_subscriptions.status, 'canceled')
         )
       )
-      .returning({ user_id: kiloclaw_subscriptions.user_id });
+      .returning();
 
     if (!resurrected) {
       // Subscription status changed between match and extend (e.g. user reactivated).
@@ -222,6 +262,14 @@ async function processOneEmail(
       };
     }
 
+    await writeBestEffortSubscriptionChangeLog(ctx, {
+      subscriptionId: subscription.id,
+      action: 'reactivated',
+      reason: 'bulk_restart_trial',
+      before: subscription,
+      after: resurrected,
+    });
+
     // Email log clear and audit log are best-effort — their failure does
     // not undo the resurrection and must not cause a false failure result
     // that prompts a retry (which would extend rather than resurrect).
@@ -231,6 +279,9 @@ async function processOneEmail(
         .where(
           and(
             eq(kiloclaw_email_log.user_id, user.id),
+            subscription.instance_id
+              ? eq(kiloclaw_email_log.instance_id, subscription.instance_id)
+              : isNull(kiloclaw_email_log.instance_id),
             inArray(kiloclaw_email_log.email_type, [...EMAIL_TYPES_TO_CLEAR])
           )
         );

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -452,7 +452,7 @@ describe('getBillingStatus', () => {
   });
 
   it('returns instance data for legacy earlybird access with no subscription row', async () => {
-    await createKiloclawInstance(user.id);
+    const instance = await createKiloclawInstance(user.id);
     await db.insert(kiloclaw_earlybird_purchases).values({
       user_id: user.id,
       amount_cents: 2500,
@@ -464,6 +464,7 @@ describe('getBillingStatus', () => {
     expect(result.hasAccess).toBe(true);
     expect(result.accessReason).toBe('earlybird');
     expect(result.instance).toEqual({
+      id: instance.id,
       exists: true,
       status: null,
       suspendedAt: null,

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -3009,6 +3009,7 @@ export const kiloclawRouter = createTRPCRouter({
     if (currentPersonalInstance) {
       const isDestroyed = currentPersonalInstance.destroyed_at !== null;
       instanceData = {
+        id: currentPersonalInstance.id,
         exists: !isDestroyed,
         status: null,
         suspendedAt: sub?.suspended_at ?? null,

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -1084,9 +1084,9 @@ async function getPersonalBillingStatus(user: {
     .limit(1);
 
   const earlybirdExpiresAt = KILOCLAW_EARLYBIRD_EXPIRY_DATE;
-  const earlybirdDaysRemaining = earlybird
-    ? Math.ceil((new Date(earlybirdExpiresAt).getTime() - Date.now()) / 86_400_000)
-    : 0;
+  const earlybirdDaysRemaining = Math.ceil(
+    (new Date(earlybirdExpiresAt).getTime() - Date.now()) / 86_400_000
+  );
 
   let accessReason: 'trial' | 'subscription' | 'earlybird' | null =
     getKiloClawSubscriptionAccessReason(sub, now);
@@ -1145,9 +1145,10 @@ async function getPersonalBillingStatus(user: {
       }
     : null;
 
-  const earlybirdData = earlybird
+  const isEarlybird = earlybird || accessReason === 'earlybird';
+  const earlybirdData = isEarlybird
     ? {
-        purchased: true,
+        purchased: !!earlybird,
         expiresAt: earlybirdExpiresAt,
         daysRemaining: earlybirdDaysRemaining,
       }

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -1064,6 +1064,192 @@ function normalizeTimestamp(value: string | null | undefined): string | null {
   return parsed.isValid() ? parsed.toISOString() : value;
 }
 
+async function getPersonalBillingStatus(user: {
+  id: string;
+  total_microdollars_acquired: number;
+  microdollars_used: number;
+  kilo_pass_threshold: number | null;
+}): Promise<ClawBillingStatus> {
+  const now = new Date();
+  const { currentPersonalInstance, subscription: sub } =
+    await getDisplayedPersonalKiloclawSubscription({
+      userId: user.id,
+      now,
+    });
+
+  const [earlybird] = await db
+    .select({ id: kiloclaw_earlybird_purchases.id })
+    .from(kiloclaw_earlybird_purchases)
+    .where(eq(kiloclaw_earlybird_purchases.user_id, user.id))
+    .limit(1);
+
+  const earlybirdExpiresAt = KILOCLAW_EARLYBIRD_EXPIRY_DATE;
+  const earlybirdDaysRemaining = earlybird
+    ? Math.ceil((new Date(earlybirdExpiresAt).getTime() - Date.now()) / 86_400_000)
+    : 0;
+
+  let accessReason: 'trial' | 'subscription' | 'earlybird' | null =
+    getKiloClawSubscriptionAccessReason(sub, now);
+  let hasAccess = accessReason !== null;
+
+  if (!hasAccess && earlybird && new Date(earlybirdExpiresAt) > now) {
+    hasAccess = true;
+    accessReason = 'earlybird';
+  }
+
+  const trialData =
+    sub?.status === 'trialing' || (sub?.trial_started_at && sub?.trial_ends_at)
+      ? {
+          startedAt: sub.trial_started_at ?? sub.created_at,
+          endsAt: sub.trial_ends_at ?? '',
+          daysRemaining: sub.trial_ends_at
+            ? Math.max(
+                0,
+                Math.floor((new Date(sub.trial_ends_at).getTime() - now.getTime()) / 86_400_000)
+              )
+            : 0,
+          expired: sub.trial_ends_at ? new Date(sub.trial_ends_at) <= now : false,
+        }
+      : null;
+
+  const hasPaidSubscription =
+    sub &&
+    sub.plan !== 'trial' &&
+    sub.status !== 'trialing' &&
+    (sub.stripe_subscription_id || sub.payment_source === 'credits');
+
+  const hasStripeFunding = hasPaidSubscription ? !!sub.stripe_subscription_id : false;
+  const kiloPassState = await getKiloPassStateForUser(db, user.id);
+  const hasActiveKiloPass = !!kiloPassState && !isStripeSubscriptionEnded(kiloPassState.status);
+  const showConversionPrompt = hasStripeFunding && hasActiveKiloPass;
+  const renewalCostMicrodollars =
+    hasPaidSubscription && (sub.plan === 'standard' || sub.plan === 'commit')
+      ? KILOCLAW_PLAN_COST_MICRODOLLARS[sub.plan]
+      : null;
+
+  const subscriptionData = hasPaidSubscription
+    ? {
+        plan: sub.plan as 'commit' | 'standard',
+        status: sub.status as 'active' | 'past_due' | 'canceled' | 'unpaid',
+        cancelAtPeriodEnd: sub.cancel_at_period_end,
+        currentPeriodEnd: normalizeTimestamp(sub.current_period_end) ?? '',
+        commitEndsAt: normalizeTimestamp(sub.commit_ends_at),
+        scheduledPlan: sub.scheduled_plan,
+        scheduledBy: sub.scheduled_by,
+        hasStripeFunding,
+        paymentSource: sub.payment_source ?? null,
+        creditRenewalAt: normalizeTimestamp(sub.credit_renewal_at),
+        renewalCostMicrodollars,
+        showConversionPrompt,
+        pendingConversion: sub.pending_conversion ?? false,
+      }
+    : null;
+
+  const earlybirdData = earlybird
+    ? {
+        purchased: true,
+        expiresAt: earlybirdExpiresAt,
+        daysRemaining: earlybirdDaysRemaining,
+      }
+    : null;
+
+  let instanceData: ClawBillingStatus['instance'] = null;
+  if (currentPersonalInstance) {
+    const isDestroyed = currentPersonalInstance.destroyed_at !== null;
+    instanceData = {
+      id: currentPersonalInstance.id,
+      exists: !isDestroyed,
+      status: null,
+      suspendedAt: sub?.suspended_at ?? null,
+      destructionDeadline: sub?.destruction_deadline ?? null,
+      destroyed: isDestroyed,
+    };
+  }
+
+  const [anySubscription, anyPersonalInstance] = await Promise.all([
+    db
+      .select({ id: kiloclaw_subscriptions.id })
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1)
+      .then(rows => rows[0] ?? null),
+    db
+      .select({ id: kiloclaw_instances.id })
+      .from(kiloclaw_instances)
+      .where(
+        and(
+          eq(kiloclaw_instances.user_id, user.id),
+          isNull(kiloclaw_instances.organization_id),
+          isNull(kiloclaw_instances.destroyed_at)
+        )
+      )
+      .limit(1)
+      .then(rows => rows[0] ?? null),
+  ]);
+
+  const creditIntroEligible = !(await hadPriorPaidSubscription(user.id));
+  const creditBalanceMicrodollars = user.total_microdollars_acquired - user.microdollars_used;
+  const standardCreditCostMicrodollars = creditIntroEligible
+    ? KILOCLAW_STANDARD_FIRST_MONTH_MICRODOLLARS
+    : KILOCLAW_PLAN_COST_MICRODOLLARS.standard;
+  const [standardCreditEnrollmentPreview, commitCreditEnrollmentPreview] = await Promise.all([
+    getEffectiveCreditBalancePreview({
+      userId: user.id,
+      balanceMicrodollars: creditBalanceMicrodollars,
+      microdollarsUsed: user.microdollars_used,
+      kiloPassThreshold: user.kilo_pass_threshold,
+      costMicrodollars: standardCreditCostMicrodollars,
+      subscription: kiloPassState,
+    }),
+    getEffectiveCreditBalancePreview({
+      userId: user.id,
+      balanceMicrodollars: creditBalanceMicrodollars,
+      microdollarsUsed: user.microdollars_used,
+      kiloPassThreshold: user.kilo_pass_threshold,
+      costMicrodollars: KILOCLAW_PLAN_COST_MICRODOLLARS.commit,
+      subscription: kiloPassState,
+    }),
+  ]);
+
+  return {
+    hasAccess,
+    accessReason,
+    trialEligible: !anyPersonalInstance && !anySubscription && !earlybird,
+    creditBalanceMicrodollars,
+    creditIntroEligible,
+    hasActiveKiloPass,
+    creditEnrollmentPreview: {
+      standard: {
+        costMicrodollars: standardCreditCostMicrodollars,
+        ...standardCreditEnrollmentPreview,
+      },
+      commit: {
+        costMicrodollars: KILOCLAW_PLAN_COST_MICRODOLLARS.commit,
+        ...commitCreditEnrollmentPreview,
+      },
+    },
+    trial: trialData,
+    subscription: subscriptionData,
+    earlybird: earlybirdData,
+    instance: instanceData,
+  } satisfies ClawBillingStatus;
+}
+
+function summarizePersonalBillingStatus(billing: ClawBillingStatus) {
+  const hasActiveInstance = billing.instance?.exists ?? false;
+  const activeInstanceId = hasActiveInstance ? (billing.instance?.id ?? null) : null;
+
+  return {
+    hasActiveInstance,
+    activeInstanceHasAccess: hasActiveInstance && billing.hasAccess,
+    activeInstanceId,
+    creditBalanceMicrodollars: billing.creditBalanceMicrodollars,
+    creditIntroEligible: billing.creditIntroEligible,
+    hasActiveKiloPass: billing.hasActiveKiloPass,
+    creditEnrollmentPreview: billing.creditEnrollmentPreview,
+  };
+}
+
 function serializeKiloclawPersonalSubscription(
   row: KiloclawPersonalSubscriptionRow,
   hasActiveKiloPass: boolean
@@ -1933,7 +2119,23 @@ export const kiloclawRouter = createTRPCRouter({
         .where(
           and(
             eq(kiloclaw_email_log.user_id, ctx.user.id),
-            sql`${kiloclaw_email_log.email_type} LIKE 'claw_instance_ready:%'`
+            or(
+              destroyedRow
+                ? and(
+                    eq(kiloclaw_email_log.instance_id, destroyedRow.id),
+                    eq(kiloclaw_email_log.email_type, 'claw_instance_ready')
+                  )
+                : undefined,
+              destroyedRow
+                ? and(
+                    isNull(kiloclaw_email_log.instance_id),
+                    eq(
+                      kiloclaw_email_log.email_type,
+                      `claw_instance_ready:${destroyedRow.sandboxId}`
+                    )
+                  )
+                : undefined
+            )
           )
         );
 
@@ -2912,184 +3114,16 @@ export const kiloclawRouter = createTRPCRouter({
   // ── Billing endpoints ────────────────────────────────────────────────
 
   getBillingStatus: baseProcedure.query(async ({ ctx }) => {
-    const now = new Date();
-    const { currentPersonalInstance, subscription: sub } =
-      await getDisplayedPersonalKiloclawSubscription({
-        userId: ctx.user.id,
-        now,
-      });
+    return await getPersonalBillingStatus(ctx.user);
+  }),
 
-    const [earlybird] = await db
-      .select({ id: kiloclaw_earlybird_purchases.id })
-      .from(kiloclaw_earlybird_purchases)
-      .where(eq(kiloclaw_earlybird_purchases.user_id, ctx.user.id))
-      .limit(1);
+  getActivePersonalBillingStatus: baseProcedure.query(async ({ ctx }) => {
+    return await getPersonalBillingStatus(ctx.user);
+  }),
 
-    const earlybirdExpiresAt = KILOCLAW_EARLYBIRD_EXPIRY_DATE;
-    const earlybirdDaysRemaining = earlybird
-      ? Math.ceil((new Date(earlybirdExpiresAt).getTime() - Date.now()) / 86_400_000)
-      : 0;
-
-    let accessReason: 'trial' | 'subscription' | 'earlybird' | null =
-      getKiloClawSubscriptionAccessReason(sub, now);
-    let hasAccess = accessReason !== null;
-
-    if (!hasAccess && earlybird && new Date(earlybirdExpiresAt) > now) {
-      hasAccess = true;
-      accessReason = 'earlybird';
-    }
-
-    const trialData =
-      sub?.status === 'trialing' || (sub?.trial_started_at && sub?.trial_ends_at)
-        ? {
-            startedAt: sub.trial_started_at ?? sub.created_at,
-            endsAt: sub.trial_ends_at ?? '',
-            daysRemaining: sub.trial_ends_at
-              ? Math.max(
-                  0,
-                  Math.floor((new Date(sub.trial_ends_at).getTime() - now.getTime()) / 86_400_000)
-                )
-              : 0,
-            expired: sub.trial_ends_at ? new Date(sub.trial_ends_at) <= now : false,
-          }
-        : null;
-
-    // Include subscription data when a paid subscription exists — either Stripe-funded
-    // (stripe_subscription_id present) or credit-funded (payment_source = 'credits').
-    // See Billing Status Reporting rule 4.
-    const hasPaidSubscription =
-      sub &&
-      sub.plan !== 'trial' &&
-      sub.status !== 'trialing' &&
-      (sub.stripe_subscription_id || sub.payment_source === 'credits');
-
-    // Compute Stripe-funding indicator and Kilo Pass state.
-    // See Billing Status Reporting rules 6-7.
-    const hasStripeFunding = hasPaidSubscription ? !!sub.stripe_subscription_id : false;
-    const kiloPassState = await getKiloPassStateForUser(db, ctx.user.id);
-    const hasActiveKiloPass = !!kiloPassState && !isStripeSubscriptionEnded(kiloPassState.status);
-    const showConversionPrompt = hasStripeFunding && hasActiveKiloPass;
-
-    // Renewal cost for the next billing period.
-    // For hybrid subscriptions the actual amount is Stripe-determined; report
-    // the plan-based approximation per Billing Status Reporting rule 5.
-    const renewalCostMicrodollars =
-      hasPaidSubscription && (sub.plan === 'standard' || sub.plan === 'commit')
-        ? KILOCLAW_PLAN_COST_MICRODOLLARS[sub.plan]
-        : null;
-
-    const subscriptionData = hasPaidSubscription
-      ? {
-          plan: sub.plan as 'commit' | 'standard',
-          status: sub.status as 'active' | 'past_due' | 'canceled' | 'unpaid',
-          cancelAtPeriodEnd: sub.cancel_at_period_end,
-          currentPeriodEnd: normalizeTimestamp(sub.current_period_end) ?? '',
-          commitEndsAt: normalizeTimestamp(sub.commit_ends_at),
-          scheduledPlan: sub.scheduled_plan,
-          scheduledBy: sub.scheduled_by,
-          hasStripeFunding,
-          paymentSource: sub.payment_source ?? null,
-          creditRenewalAt: normalizeTimestamp(sub.credit_renewal_at),
-          renewalCostMicrodollars,
-          showConversionPrompt,
-          pendingConversion: sub.pending_conversion ?? false,
-        }
-      : null;
-
-    const earlybirdData = earlybird
-      ? {
-          purchased: true,
-          expiresAt: earlybirdExpiresAt,
-          daysRemaining: earlybirdDaysRemaining,
-        }
-      : null;
-
-    // Determine instance status from KiloClaw service
-    let instanceData: ClawBillingStatus['instance'] = null;
-    if (currentPersonalInstance) {
-      const isDestroyed = currentPersonalInstance.destroyed_at !== null;
-      instanceData = {
-        id: currentPersonalInstance.id,
-        exists: !isDestroyed,
-        status: null,
-        suspendedAt: sub?.suspended_at ?? null,
-        destructionDeadline: sub?.destruction_deadline ?? null,
-        destroyed: isDestroyed,
-      };
-    }
-
-    // Trial eligibility must match ensureProvisionAccess: any subscription of
-    // any kind disqualifies, and only an active personal instance row blocks a
-    // first-time personal trial path.
-    const [anySubscription, anyPersonalInstance] = await Promise.all([
-      db
-        .select({ id: kiloclaw_subscriptions.id })
-        .from(kiloclaw_subscriptions)
-        .where(eq(kiloclaw_subscriptions.user_id, ctx.user.id))
-        .limit(1)
-        .then(rows => rows[0] ?? null),
-      db
-        .select({ id: kiloclaw_instances.id })
-        .from(kiloclaw_instances)
-        .where(
-          and(
-            eq(kiloclaw_instances.user_id, ctx.user.id),
-            isNull(kiloclaw_instances.organization_id),
-            isNull(kiloclaw_instances.destroyed_at)
-          )
-        )
-        .limit(1)
-        .then(rows => rows[0] ?? null),
-    ]);
-
-    // First-month credit discount eligibility (spec Credit Enrollment rule 3).
-    const creditIntroEligible = !(await hadPriorPaidSubscription(ctx.user.id));
-    const creditBalanceMicrodollars =
-      ctx.user.total_microdollars_acquired - ctx.user.microdollars_used;
-    const standardCreditCostMicrodollars = creditIntroEligible
-      ? KILOCLAW_STANDARD_FIRST_MONTH_MICRODOLLARS
-      : KILOCLAW_PLAN_COST_MICRODOLLARS.standard;
-    const [standardCreditEnrollmentPreview, commitCreditEnrollmentPreview] = await Promise.all([
-      getEffectiveCreditBalancePreview({
-        userId: ctx.user.id,
-        balanceMicrodollars: creditBalanceMicrodollars,
-        microdollarsUsed: ctx.user.microdollars_used,
-        kiloPassThreshold: ctx.user.kilo_pass_threshold,
-        costMicrodollars: standardCreditCostMicrodollars,
-        subscription: kiloPassState,
-      }),
-      getEffectiveCreditBalancePreview({
-        userId: ctx.user.id,
-        balanceMicrodollars: creditBalanceMicrodollars,
-        microdollarsUsed: ctx.user.microdollars_used,
-        kiloPassThreshold: ctx.user.kilo_pass_threshold,
-        costMicrodollars: KILOCLAW_PLAN_COST_MICRODOLLARS.commit,
-        subscription: kiloPassState,
-      }),
-    ]);
-
-    return {
-      hasAccess,
-      accessReason,
-      trialEligible: !anyPersonalInstance && !anySubscription && !earlybird,
-      creditBalanceMicrodollars,
-      creditIntroEligible,
-      hasActiveKiloPass,
-      creditEnrollmentPreview: {
-        standard: {
-          costMicrodollars: standardCreditCostMicrodollars,
-          ...standardCreditEnrollmentPreview,
-        },
-        commit: {
-          costMicrodollars: KILOCLAW_PLAN_COST_MICRODOLLARS.commit,
-          ...commitCreditEnrollmentPreview,
-        },
-      },
-      trial: trialData,
-      subscription: subscriptionData,
-      earlybird: earlybirdData,
-      instance: instanceData,
-    } satisfies ClawBillingStatus;
+  getPersonalBillingSummary: baseProcedure.query(async ({ ctx }) => {
+    const billing = await getPersonalBillingStatus(ctx.user);
+    return summarizePersonalBillingStatus(billing);
   }),
 
   // ── Personal subscription management ─────────────────────────────────

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -4,9 +4,13 @@ const { mockGetWorkerDb } = vi.hoisted(() => ({
   mockGetWorkerDb: vi.fn(),
 }));
 
-vi.mock('@kilocode/db', () => ({
-  getWorkerDb: mockGetWorkerDb,
-}));
+vi.mock('@kilocode/db', async () => {
+  const actual = await vi.importActual<typeof import('@kilocode/db')>('@kilocode/db');
+  return {
+    ...actual,
+    getWorkerDb: mockGetWorkerDb,
+  };
+});
 
 import { runSweep } from './lifecycle.js';
 import type { BillingWorkerEnv } from './types.js';
@@ -33,7 +37,12 @@ function createSelectResult<T>(rows: T[]): SelectResult<T> {
 
 function createMockDb(
   selectResults: unknown[][],
-  options?: { insertRowCounts?: number[]; txInsertRowCounts?: number[] }
+  options?: {
+    insertRowCounts?: number[];
+    txInsertRowCounts?: number[];
+    updateReturningRows?: unknown[][];
+    txUpdateReturningRows?: unknown[][];
+  }
 ) {
   const updates: Array<Record<string, unknown>> = [];
   const txUpdates: Array<Record<string, unknown>> = [];
@@ -44,7 +53,16 @@ function createMockDb(
   const selectBuilders: SelectBuilder[] = [];
   const insertRowCounts = [...(options?.insertRowCounts ?? [])];
   const txInsertRowCounts = [...(options?.txInsertRowCounts ?? [])];
+  const updateReturningRows = [...(options?.updateReturningRows ?? [])];
+  const txUpdateReturningRows = [...(options?.txUpdateReturningRows ?? [])];
   const nextSelectResult = () => createSelectResult(selectResults.shift() ?? []);
+  const createWhereResult = (returningRows: unknown[]) => {
+    const promise = Promise.resolve(undefined);
+    return {
+      returning: vi.fn(async () => returningRows),
+      then: promise.then.bind(promise),
+    };
+  };
   const createSelectBuilder = (): SelectBuilder => {
     const builder: SelectBuilder = {
       from: vi.fn(() => builder),
@@ -60,8 +78,9 @@ function createMockDb(
   const update = vi.fn(() => ({
     set: vi.fn((values: Record<string, unknown>) => {
       updates.push(values);
+      const whereResult = createWhereResult(updateReturningRows.shift() ?? [{}]);
       return {
-        where: vi.fn(async () => undefined),
+        where: vi.fn(() => whereResult),
       };
     }),
   }));
@@ -107,8 +126,9 @@ function createMockDb(
         update: vi.fn(() => ({
           set: vi.fn((values: Record<string, unknown>) => {
             txUpdates.push(values);
+            const whereResult = createWhereResult(txUpdateReturningRows.shift() ?? [{}]);
             return {
-              where: vi.fn(async () => undefined),
+              where: vi.fn(() => whereResult),
             };
           }),
         })),
@@ -308,6 +328,38 @@ describe('interrupted auto-resume sweep', () => {
       },
     ]);
   });
+
+  it('skips detached rows instead of fan-out updates', async () => {
+    const { db, updates, txUpdates, txDeletes } = createMockDb([
+      [
+        {
+          id: 'sub-1',
+          user_id: 'user-1',
+          instance_id: null,
+          organization_id: null,
+          auto_resume_attempt_count: 0,
+        },
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi.fn();
+
+    const summary = await runSweep(
+      createEnv(fetch),
+      {
+        runId: 'edededed-eded-4ded-8ded-edededededed',
+        sweep: 'interrupted_auto_resume',
+      },
+      1
+    );
+
+    expect(summary.interrupted_auto_resume_requests).toBe(0);
+    expect(summary.errors).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(updates).toHaveLength(0);
+    expect(txUpdates).toHaveLength(0);
+    expect(txDeletes).toHaveLength(0);
+  });
 });
 
 describe('destruction warning sweep', () => {
@@ -357,7 +409,13 @@ describe('destruction warning sweep', () => {
     expect(summary.emails_sent).toBe(1);
     expect(selectBuilders[0]?.innerJoin).toHaveBeenCalledTimes(2);
     expect(selectBuilders[0]?.leftJoin).not.toHaveBeenCalled();
-    expect(inserts).toEqual([{ user_id: 'user-1', email_type: 'claw_destruction_warning' }]);
+    expect(inserts).toEqual([
+      {
+        user_id: 'user-1',
+        instance_id: instanceId,
+        email_type: 'claw_destruction_warning',
+      },
+    ]);
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
 
     const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
@@ -476,7 +534,13 @@ describe('destruction warning sweep', () => {
     expect(summary.destruction_warnings).toBe(0);
     expect(summary.emails_sent).toBe(0);
     expect(summary.emails_skipped).toBe(1);
-    expect(inserts).toEqual([{ user_id: 'user-1', email_type: 'claw_destruction_warning' }]);
+    expect(inserts).toEqual([
+      {
+        user_id: 'user-1',
+        instance_id: '33333333-3333-4333-8333-333333333333',
+        email_type: 'claw_destruction_warning',
+      },
+    ]);
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });
@@ -534,12 +598,20 @@ describe('instance destruction sweep', () => {
     expect(summary.sweep3_instance_destruction).toBe(1);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    expect(inserts).toEqual([
-      {
-        user_id: 'user-1',
-        email_type: 'claw_instance_destroyed',
-      },
-    ]);
+    expect(inserts).toEqual(
+      expect.arrayContaining([
+        {
+          user_id: 'user-1',
+          instance_id: instanceId,
+          email_type: 'claw_instance_destroyed',
+        },
+        expect.objectContaining({
+          actor_id: 'billing-lifecycle-job',
+          action: 'status_changed',
+          reason: 'instance_destroyed',
+        }),
+      ])
+    );
     expect(updates).toHaveLength(2);
     expect(updates[0].destroyed_at).toEqual(expect.any(String));
     expect(updates[1]).toEqual({ destruction_deadline: null });
@@ -604,10 +676,25 @@ describe('instance destruction sweep', () => {
         }),
       ])
     );
-    expect(inserts).toEqual([
-      { user_id: 'user-1', email_type: 'claw_instance_destroyed' },
-      { user_id: 'user-2', email_type: 'claw_instance_destroyed' },
-    ]);
+    expect(inserts).toEqual(
+      expect.arrayContaining([
+        {
+          user_id: 'user-1',
+          instance_id: firstInstanceId,
+          email_type: 'claw_instance_destroyed',
+        },
+        {
+          user_id: 'user-2',
+          instance_id: secondInstanceId,
+          email_type: 'claw_instance_destroyed',
+        },
+        expect.objectContaining({
+          actor_id: 'billing-lifecycle-job',
+          action: 'status_changed',
+          reason: 'instance_destroyed',
+        }),
+      ])
+    );
     expect(updates).toHaveLength(4);
     expect(updates[0].destroyed_at).toEqual(expect.any(String));
     expect(updates[1]).toEqual({ destruction_deadline: null });
@@ -651,12 +738,20 @@ describe('instance destruction sweep', () => {
     expect(summary.sweep3_instance_destruction).toBe(1);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    expect(inserts).toEqual([
-      {
-        user_id: 'user-1',
-        email_type: 'claw_instance_destroyed',
-      },
-    ]);
+    expect(inserts).toEqual(
+      expect.arrayContaining([
+        {
+          user_id: 'user-1',
+          instance_id: instanceId,
+          email_type: 'claw_instance_destroyed',
+        },
+        expect.objectContaining({
+          actor_id: 'billing-lifecycle-job',
+          action: 'status_changed',
+          reason: 'instance_destroyed',
+        }),
+      ])
+    );
     expect(updates).toHaveLength(2);
     expect(updates[0].destroyed_at).toEqual(expect.any(String));
     expect(updates[1]).toEqual({ destruction_deadline: null });
@@ -673,6 +768,39 @@ describe('instance destruction sweep', () => {
         }),
       ])
     );
+  });
+
+  it('skips rows whose linked instance row is missing', async () => {
+    const { db, updates, inserts, deletes } = createMockDb([
+      [
+        {
+          id: 'sub-1',
+          user_id: 'user-1',
+          instance_id: '11111111-1111-4111-8111-111111111111',
+          sandbox_id: null,
+          email: 'user-1@example.com',
+        },
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi.fn();
+
+    const summary = await runSweep(
+      createEnv(fetch),
+      {
+        runId: '17171717-1717-4717-8717-171717171717',
+        sweep: 'instance_destruction',
+      },
+      1
+    );
+
+    expect(summary.sweep3_instance_destruction).toBe(0);
+    expect(summary.errors).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(updates).toHaveLength(0);
+    expect(inserts).toHaveLength(0);
+    expect(deletes).toHaveLength(0);
   });
 });
 
@@ -692,6 +820,10 @@ describe('credit renewal sweep affiliate tracking', () => {
           user_id: 'user-1',
           email: 'user-1@example.com',
           instance_id: 'instance-1',
+          id: 'sub-1',
+          instance_row_id: 'instance-1',
+          organization_id: null,
+          instance_destroyed_at: null,
           plan: 'standard',
           status: 'active',
           credit_renewal_at: renewalAt,
@@ -753,13 +885,19 @@ describe('credit renewal sweep affiliate tracking', () => {
 
     expect(summary.credit_renewals).toBe(1);
     expect(summary.errors).toBe(0);
-    expect(txInserts).toHaveLength(1);
-    expect(txInserts[0]).toEqual(
-      expect.objectContaining({
-        kilo_user_id: 'user-1',
-        amount_microdollars: -9_000_000,
-        description: 'KiloClaw standard renewal',
-      })
+    expect(txInserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kilo_user_id: 'user-1',
+          amount_microdollars: -9_000_000,
+          description: 'KiloClaw standard renewal',
+        }),
+        expect.objectContaining({
+          actor_id: 'billing-lifecycle-job',
+          action: 'period_advanced',
+          reason: 'credit_renewal',
+        }),
+      ])
     );
     expect(txUpdates).toEqual(
       expect.arrayContaining([
@@ -809,6 +947,10 @@ describe('credit renewal sweep affiliate tracking', () => {
             user_id: 'user-1',
             email: 'user-1@example.com',
             instance_id: 'instance-1',
+            id: 'sub-1',
+            instance_row_id: 'instance-1',
+            organization_id: null,
+            instance_destroyed_at: null,
             plan: 'standard',
             status: 'active',
             credit_renewal_at: renewalAt,
@@ -905,6 +1047,108 @@ describe('credit renewal sweep affiliate tracking', () => {
         },
       },
     ]);
+  });
+
+  it('skips organization-managed rows in personal credit renewal sweep', async () => {
+    const { db, txInserts, txUpdates } = createMockDb([
+      [
+        {
+          id: 'sub-1',
+          user_id: 'user-1',
+          email: 'user-1@example.com',
+          instance_id: 'instance-1',
+          instance_row_id: 'instance-1',
+          organization_id: 'org-1',
+          instance_destroyed_at: null,
+          plan: 'standard',
+          status: 'active',
+          credit_renewal_at: '2026-04-09T10:00:00.000Z',
+          current_period_end: '2026-04-09T10:00:00.000Z',
+          cancel_at_period_end: false,
+          scheduled_plan: null,
+          commit_ends_at: null,
+          past_due_since: null,
+          suspended_at: null,
+          auto_resume_attempt_count: 0,
+          auto_top_up_triggered_for_period: null,
+          total_microdollars_acquired: 50_000_000,
+          microdollars_used: 0,
+          auto_top_up_enabled: false,
+          kilo_pass_threshold: null,
+          next_credit_expiration_at: null,
+          user_updated_at: '2026-04-09T09:00:00.000Z',
+        },
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi.fn();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fetch);
+
+    const summary = await runSweep(
+      createEnv(vi.fn()),
+      {
+        runId: '18181818-1818-4818-8818-181818181818',
+        sweep: 'credit_renewal',
+      },
+      1
+    );
+
+    expect(summary.credit_renewals).toBe(0);
+    expect(summary.credit_renewals_skipped_duplicate).toBe(0);
+    expect(summary.errors).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(txInserts).toHaveLength(0);
+    expect(txUpdates).toHaveLength(0);
+  });
+
+  it('sends earlybird warning for legacy purchase rows before canonical backfill', async () => {
+    const nowSpy = vi
+      .spyOn(Date, 'now')
+      .mockReturnValue(new Date('2026-09-12T00:00:00.000Z').getTime());
+    const { db, inserts } = createMockDb([
+      [
+        {
+          user_id: 'user-legacy-earlybird',
+          email: 'legacy-earlybird@example.com',
+        },
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+
+    const fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ sent: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+    );
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fetch);
+
+    try {
+      const summary = await runSweep(
+        createEnv(fetch),
+        {
+          runId: '34343434-3434-4434-8434-343434343434',
+          sweep: 'earlybird_warning',
+        },
+        1
+      );
+
+      expect(summary.errors).toBe(0);
+      expect(summary.earlybird_warnings).toBe(1);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(inserts).toEqual(
+        expect.arrayContaining([
+          {
+            user_id: 'user-legacy-earlybird',
+            instance_id: null,
+            email_type: 'claw_earlybird_14d',
+          },
+        ])
+      );
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 });
 

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -4,8 +4,8 @@ const { mockGetWorkerDb } = vi.hoisted(() => ({
   mockGetWorkerDb: vi.fn(),
 }));
 
-vi.mock('@kilocode/db', async () => {
-  const actual = await vi.importActual<typeof import('@kilocode/db')>('@kilocode/db');
+vi.mock('@kilocode/db', async importOriginal => {
+  const actual: Record<string, unknown> = await importOriginal();
   return {
     ...actual,
     getWorkerDb: mockGetWorkerDb,

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -1381,9 +1381,7 @@ async function runCreditRenewalSweep(
 
   for (const row of creditRenewalRows) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) {
-        continue;
-      }
+      if (isSoftDeletedUserEmail(row.email)) continue;
       await processCreditRenewalRow(database, env, context, row, clawUrl, summary);
     } catch (error) {
       summary.errors++;
@@ -1529,9 +1527,7 @@ async function runTrialExpirySweep(
 
   for (const row of expiredTrials) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) {
-        continue;
-      }
+      if (isSoftDeletedUserEmail(row.email)) continue;
       if (!row.instance_id) {
         logSkippedSubscriptionRow('Skipping trial expiry for detached subscription row', row, {
           reason: 'missing_instance_id',
@@ -1645,9 +1641,7 @@ async function runSubscriptionExpirySweep(
 
   for (const row of expiredSubscriptions) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) {
-        continue;
-      }
+      if (isSoftDeletedUserEmail(row.email)) continue;
       if (!row.instance_id) {
         logSkippedSubscriptionRow(
           'Skipping subscription expiry for detached subscription row',
@@ -1749,9 +1743,7 @@ async function runInstanceDestructionSweep(
 
   for (const row of destructionCandidates) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) {
-        continue;
-      }
+      if (isSoftDeletedUserEmail(row.email)) continue;
       if (!row.instance_id) {
         logSkippedSubscriptionRow(
           'Skipping instance destruction for detached subscription row',
@@ -1875,9 +1867,7 @@ async function runPastDueCleanupSweep(
 
   for (const row of pastDueRows) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) {
-        continue;
-      }
+      if (isSoftDeletedUserEmail(row.email)) continue;
       if (!row.instance_id) {
         logSkippedSubscriptionRow('Skipping past-due cleanup for detached subscription row', row, {
           reason: 'missing_instance_id',
@@ -2021,9 +2011,7 @@ async function runDestructionWarningSweep(
 
   for (const row of destructionWarningRows) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) {
-        continue;
-      }
+      if (isSoftDeletedUserEmail(row.email)) continue;
       if (!row.destruction_deadline || row.instance_destroyed_at) continue;
       const instanceIdShort = shortInstanceId(row.instance_id);
       const sent = await trySendEmail(
@@ -2094,9 +2082,7 @@ async function runTrialWarningSweep(
 
   for (const row of trialWarningRows) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) {
-        continue;
-      }
+      if (isSoftDeletedUserEmail(row.email)) continue;
       if (!row.trial_ends_at) continue;
 
       if (!row.instance_id) {
@@ -2250,9 +2236,7 @@ async function runEarlybirdWarningSweep(
 
   for (const row of [...canonicalRows, ...legacyRows]) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) {
-        continue;
-      }
+      if (isSoftDeletedUserEmail(row.email)) continue;
       const expiryDate = formatDateForEmail(earlybirdExpiry);
       const sent =
         daysUntilEarlybird <= 1
@@ -2371,9 +2355,7 @@ async function runComplementaryInferenceEndedSweep(
 
   for (const row of rows) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) {
-        continue;
-      }
+      if (isSoftDeletedUserEmail(row.email)) continue;
       const sent = await trySendEmail(
         database,
         env,

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -2028,27 +2028,52 @@ async function runTrialWarningSweep(
 
   const trialWarningRows = await database
     .select({
+      id: kiloclaw_subscriptions.id,
       user_id: kiloclaw_subscriptions.user_id,
       instance_id: kiloclaw_subscriptions.instance_id,
+      instance_destroyed_at: kiloclaw_instances.destroyed_at,
+      instance_sandbox_id: kiloclaw_instances.sandbox_id,
       email: kilocode_users.google_user_email,
       trial_ends_at: kiloclaw_subscriptions.trial_ends_at,
     })
     .from(kiloclaw_subscriptions)
     .innerJoin(kilocode_users, eq(kiloclaw_subscriptions.user_id, kilocode_users.id))
-    .innerJoin(kiloclaw_instances, eq(kiloclaw_subscriptions.instance_id, kiloclaw_instances.id))
+    .leftJoin(kiloclaw_instances, eq(kiloclaw_subscriptions.instance_id, kiloclaw_instances.id))
     .where(
       and(
         eq(kiloclaw_subscriptions.status, 'trialing'),
         gte(kiloclaw_subscriptions.trial_ends_at, advisoryNow),
         lte(kiloclaw_subscriptions.trial_ends_at, trialWarningCutoff),
-        isNull(kiloclaw_subscriptions.suspended_at),
-        isNull(kiloclaw_instances.destroyed_at)
+        isNull(kiloclaw_subscriptions.suspended_at)
       )
     );
 
   for (const row of trialWarningRows) {
     try {
       if (!row.trial_ends_at) continue;
+
+      if (!row.instance_id) {
+        logSkippedSubscriptionRow('Skipping trial warning for detached subscription row', row, {
+          reason: 'missing_instance_id',
+        });
+        continue;
+      }
+
+      if (!row.instance_sandbox_id) {
+        logSkippedSubscriptionRow(
+          'Skipping trial warning for subscription without instance row',
+          row,
+          { reason: 'missing_instance_row' }
+        );
+        continue;
+      }
+
+      if (row.instance_destroyed_at) {
+        logSkippedSubscriptionRow('Skipping trial warning for destroyed instance', row, {
+          reason: 'instance_destroyed',
+        });
+        continue;
+      }
 
       const daysRemaining = Math.ceil(
         (new Date(row.trial_ends_at).getTime() - Date.now()) / MS_PER_DAY

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -2,7 +2,11 @@ import { and, eq, gt, gte, inArray, isNotNull, isNull, lt, lte, sql } from 'driz
 import { addMonths, format } from 'date-fns';
 
 import type { WorkerDb } from '@kilocode/db';
-import { getWorkerDb } from '@kilocode/db';
+import {
+  getWorkerDb,
+  insertKiloClawSubscriptionChangeLog,
+  type KiloClawSubscription,
+} from '@kilocode/db';
 import {
   BILLING_FLOW,
   createBillingCorrelationHeaders,
@@ -18,6 +22,7 @@ import {
 } from '@kilocode/db/schema';
 import type {
   KiloClawPlan,
+  KiloClawSubscriptionChangeAction,
   KiloClawScheduledPlan,
   KiloClawSubscriptionStatus,
 } from '@kilocode/db/schema-types';
@@ -34,6 +39,10 @@ const KILOCLAW_EARLYBIRD_EXPIRY_DATE = '2026-09-26';
 const AUTO_RESUME_INITIAL_BACKOFF_MS = 2 * 60 * 60 * 1000;
 const AUTO_RESUME_MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
 const SOFT_DELETED_EMAIL_SUFFIX = '@deleted.invalid';
+const LIFECYCLE_ACTOR = {
+  actorType: 'system',
+  actorId: 'billing-lifecycle-job',
+} as const;
 
 const KILOCLAW_PLAN_COST_MICRODOLLARS = {
   standard: 9_000_000,
@@ -79,9 +88,13 @@ type BillingSummary = {
 };
 
 type CreditRenewalRow = {
+  id: string;
   user_id: string;
   email: string;
   instance_id: string | null;
+  instance_row_id: string | null;
+  organization_id: string | null;
+  instance_destroyed_at: string | null;
   plan: KiloClawPlan;
   status: KiloClawSubscriptionStatus;
   credit_renewal_at: string | null;
@@ -125,9 +138,17 @@ type BillingEntityFields = {
   stripeSubscriptionId?: string;
 };
 
+type EmailLogScope = {
+  userId: string;
+  emailType: string;
+  instanceId?: string | null;
+};
+
 type InterruptedAutoResumeRow = {
+  id: string;
   user_id: string;
   instance_id: string | null;
+  organization_id: string | null;
   auto_resume_attempt_count: number;
 };
 
@@ -297,6 +318,75 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+async function getSubscriptionById(
+  database: WorkerDb,
+  subscriptionId: string
+): Promise<KiloClawSubscription | null> {
+  const [subscription] = await database
+    .select()
+    .from(kiloclaw_subscriptions)
+    .where(eq(kiloclaw_subscriptions.id, subscriptionId))
+    .limit(1);
+
+  return subscription ?? null;
+}
+
+async function insertLifecycleChangeLogBestEffort(
+  database: WorkerDb,
+  params: {
+    subscriptionId: string;
+    action: KiloClawSubscriptionChangeAction;
+    reason: string;
+    before: KiloClawSubscription | null;
+    after: KiloClawSubscription | null;
+  }
+): Promise<void> {
+  if (!params.after) {
+    return;
+  }
+
+  try {
+    await insertKiloClawSubscriptionChangeLog(database, {
+      subscriptionId: params.subscriptionId,
+      actor: LIFECYCLE_ACTOR,
+      action: params.action,
+      reason: params.reason,
+      before: params.before,
+      after: params.after,
+    });
+  } catch (error) {
+    log('error', 'Failed to write lifecycle subscription change log', {
+      event: 'subscription_change_log_failed',
+      outcome: 'failed',
+      subscriptionId: params.subscriptionId,
+      userId: params.after.user_id,
+      instanceId: params.after.instance_id ?? undefined,
+      action: params.action,
+      reason: params.reason,
+      error: errorMessage(error),
+    });
+  }
+}
+
+function logSkippedSubscriptionRow(
+  message: string,
+  row: {
+    id: string;
+    user_id: string;
+    instance_id: string | null;
+  },
+  extraFields?: BillingLogFields
+) {
+  log('warn', message, {
+    event: 'subscription_row_skipped',
+    outcome: 'skipped',
+    subscriptionId: row.id,
+    userId: row.user_id,
+    instanceId: row.instance_id ?? undefined,
+    ...extraFields,
+  });
+}
+
 function getAutoResumeBackoffMs(consecutiveAttemptCount: number): number {
   const multiplier = consecutiveAttemptCount <= 0 ? 1 : 2 ** consecutiveAttemptCount;
   return Math.min(AUTO_RESUME_MAX_BACKOFF_MS, AUTO_RESUME_INITIAL_BACKOFF_MS * multiplier);
@@ -305,24 +395,12 @@ function getAutoResumeBackoffMs(consecutiveAttemptCount: number): number {
 async function markAutoResumeRequested(
   database: WorkerDb,
   params: {
-    userId: string;
-    instanceId?: string;
+    subscriptionId: string;
     requestedAtIso: string;
     retryAfterIso: string;
     attemptCount: number;
   }
 ): Promise<void> {
-  const subscriptionFilter = params.instanceId
-    ? and(
-        eq(kiloclaw_subscriptions.user_id, params.userId),
-        eq(kiloclaw_subscriptions.instance_id, params.instanceId),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-      )
-    : and(
-        eq(kiloclaw_subscriptions.user_id, params.userId),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-      );
-
   await database
     .update(kiloclaw_subscriptions)
     .set({
@@ -330,27 +408,18 @@ async function markAutoResumeRequested(
       auto_resume_retry_after: params.retryAfterIso,
       auto_resume_attempt_count: params.attemptCount,
     })
-    .where(subscriptionFilter);
+    .where(eq(kiloclaw_subscriptions.id, params.subscriptionId));
 }
 
 async function clearAutoResumeState(
   database: WorkerDb,
   params: {
+    subscriptionId: string;
     userId: string;
-    instanceId?: string;
+    instanceId?: string | null;
   }
 ): Promise<void> {
-  const subscriptionFilter = params.instanceId
-    ? and(
-        eq(kiloclaw_subscriptions.user_id, params.userId),
-        eq(kiloclaw_subscriptions.instance_id, params.instanceId),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-      )
-    : and(
-        eq(kiloclaw_subscriptions.user_id, params.userId),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-      );
-
+  const before = await getSubscriptionById(database, params.subscriptionId);
   const resettableEmailTypes = [
     'claw_suspended_trial',
     'claw_suspended_subscription',
@@ -363,14 +432,9 @@ async function clearAutoResumeState(
   await database.transaction(async tx => {
     await tx
       .delete(kiloclaw_email_log)
-      .where(
-        and(
-          eq(kiloclaw_email_log.user_id, params.userId),
-          inArray(kiloclaw_email_log.email_type, resettableEmailTypes)
-        )
-      );
+      .where(emailLogTypesCondition(params.userId, resettableEmailTypes, params.instanceId));
 
-    await tx
+    const [updated] = await tx
       .update(kiloclaw_subscriptions)
       .set({
         suspended_at: null,
@@ -379,8 +443,56 @@ async function clearAutoResumeState(
         auto_resume_retry_after: null,
         auto_resume_attempt_count: 0,
       })
-      .where(subscriptionFilter);
+      .where(eq(kiloclaw_subscriptions.id, params.subscriptionId))
+      .returning();
+
+    if (
+      before &&
+      updated &&
+      (before.suspended_at !== null || before.destruction_deadline !== null)
+    ) {
+      await insertKiloClawSubscriptionChangeLog(tx, {
+        subscriptionId: params.subscriptionId,
+        actor: LIFECYCLE_ACTOR,
+        action: 'reactivated',
+        reason: 'auto_resume_completed',
+        before,
+        after: updated,
+      });
+    }
   });
+}
+
+function emailLogRowValues(scope: EmailLogScope) {
+  return {
+    user_id: scope.userId,
+    instance_id: scope.instanceId ?? null,
+    email_type: scope.emailType,
+  };
+}
+
+function emailLogRowCondition(scope: EmailLogScope) {
+  return and(
+    eq(kiloclaw_email_log.user_id, scope.userId),
+    eq(kiloclaw_email_log.email_type, scope.emailType),
+    scope.instanceId
+      ? eq(kiloclaw_email_log.instance_id, scope.instanceId)
+      : isNull(kiloclaw_email_log.instance_id)
+  );
+}
+
+function emailLogTypesCondition(
+  userId: string,
+  emailTypes: readonly string[],
+  instanceId?: string | null
+) {
+  return and(
+    eq(kiloclaw_email_log.user_id, userId),
+    inArray(kiloclaw_email_log.email_type, [...emailTypes]),
+    instanceId
+      ? eq(kiloclaw_email_log.instance_id, instanceId)
+      : isNull(kiloclaw_email_log.instance_id)
+  );
 }
 
 function createSweepContext(message: BillingSweepMessage, attempt: number): SweepExecutionContext {
@@ -616,14 +728,14 @@ async function trySendEmail(
   subjectOverride?: string,
   entityFields: BillingEntityFields = {}
 ): Promise<boolean> {
-  if (isSoftDeletedUserEmail(userEmail)) {
-    summary.emails_skipped++;
-    return false;
-  }
-
+  const emailLogScope = {
+    userId,
+    emailType,
+    instanceId: entityFields.instanceId ?? null,
+  } satisfies EmailLogScope;
   const result = await database
     .insert(kiloclaw_email_log)
-    .values({ user_id: userId, email_type: emailType })
+    .values(emailLogRowValues(emailLogScope))
     .onConflictDoNothing();
 
   if (result.rowCount === 0) {
@@ -652,25 +764,14 @@ async function trySendEmail(
 
     if (!emailResult.sent) {
       if (emailResult.reason === 'provider_not_configured') {
-        await database
-          .delete(kiloclaw_email_log)
-          .where(
-            and(
-              eq(kiloclaw_email_log.user_id, userId),
-              eq(kiloclaw_email_log.email_type, emailType)
-            )
-          );
+        await database.delete(kiloclaw_email_log).where(emailLogRowCondition(emailLogScope));
       }
       summary.emails_skipped++;
       return false;
     }
   } catch (error) {
     try {
-      await database
-        .delete(kiloclaw_email_log)
-        .where(
-          and(eq(kiloclaw_email_log.user_id, userId), eq(kiloclaw_email_log.email_type, emailType))
-        );
+      await database.delete(kiloclaw_email_log).where(emailLogRowCondition(emailLogScope));
     } catch (deleteError) {
       log('warn', 'Failed to remove email log row after send failure', {
         userId,
@@ -795,13 +896,30 @@ async function autoResumeIfSuspended(
   context: SweepExecutionContext,
   row: InterruptedAutoResumeRow
 ): Promise<boolean> {
-  const instanceFilter = row.instance_id
-    ? and(
-        eq(kiloclaw_instances.id, row.instance_id),
-        eq(kiloclaw_instances.user_id, row.user_id),
-        isNull(kiloclaw_instances.destroyed_at)
-      )
-    : and(eq(kiloclaw_instances.user_id, row.user_id), isNull(kiloclaw_instances.destroyed_at));
+  if (!row.instance_id) {
+    logSkippedSubscriptionRow('Skipping auto-resume for detached subscription row', row, {
+      reason: 'missing_instance_id',
+    });
+    return false;
+  }
+
+  if (row.organization_id) {
+    logSkippedSubscriptionRow(
+      'Skipping auto-resume for organization-managed subscription row',
+      row,
+      {
+        reason: 'organization_managed',
+        organizationId: row.organization_id,
+      }
+    );
+    return false;
+  }
+
+  const instanceFilter = and(
+    eq(kiloclaw_instances.id, row.instance_id),
+    eq(kiloclaw_instances.user_id, row.user_id),
+    isNull(kiloclaw_instances.destroyed_at)
+  );
 
   const [targetInstance] = await database
     .select({
@@ -817,10 +935,11 @@ async function autoResumeIfSuspended(
   const retryAfterIso = new Date(
     Date.now() + getAutoResumeBackoffMs(row.auto_resume_attempt_count)
   ).toISOString();
-  const resolvedInstanceId = targetInstance?.id ?? row.instance_id ?? undefined;
+  const resolvedInstanceId = targetInstance?.id ?? row.instance_id;
 
   if (!targetInstance) {
     await clearAutoResumeState(database, {
+      subscriptionId: row.id,
       userId: row.user_id,
       instanceId: resolvedInstanceId,
     });
@@ -838,8 +957,7 @@ async function autoResumeIfSuspended(
     await startInstanceAsync(env, context, row.user_id, workerInstanceId(targetInstance));
   } catch (error) {
     await markAutoResumeRequested(database, {
-      userId: row.user_id,
-      instanceId: resolvedInstanceId,
+      subscriptionId: row.id,
       requestedAtIso: nowIso,
       retryAfterIso,
       attemptCount: nextAttemptCount,
@@ -857,8 +975,7 @@ async function autoResumeIfSuspended(
   }
 
   await markAutoResumeRequested(database, {
-    userId: row.user_id,
-    instanceId: resolvedInstanceId,
+    subscriptionId: row.id,
     requestedAtIso: nowIso,
     retryAfterIso,
     attemptCount: nextAttemptCount,
@@ -882,29 +999,65 @@ async function processCreditRenewalRow(
   clawUrl: string,
   summary: BillingSummary
 ): Promise<void> {
+  if (!row.instance_id) {
+    logSkippedSubscriptionRow('Skipping credit renewal for detached subscription row', row, {
+      reason: 'missing_instance_id',
+    });
+    return;
+  }
+
+  if (!row.instance_row_id) {
+    logSkippedSubscriptionRow(
+      'Skipping credit renewal for subscription without instance row',
+      row,
+      {
+        reason: 'missing_instance_row',
+      }
+    );
+    return;
+  }
+
+  if (row.organization_id) {
+    logSkippedSubscriptionRow(
+      'Skipping personal credit renewal for organization-managed row',
+      row,
+      {
+        reason: 'organization_managed',
+        organizationId: row.organization_id,
+      }
+    );
+    return;
+  }
+
+  if (row.instance_destroyed_at) {
+    logSkippedSubscriptionRow('Skipping credit renewal for destroyed instance row', row, {
+      reason: 'instance_destroyed',
+    });
+    return;
+  }
+
   const { user_id: userId, credit_renewal_at: renewalAt } = row;
   if (!renewalAt) return;
 
-  const subscriptionWhere = row.instance_id
-    ? and(
-        eq(kiloclaw_subscriptions.user_id, userId),
-        eq(kiloclaw_subscriptions.instance_id, row.instance_id),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-      )
-    : and(
-        eq(kiloclaw_subscriptions.user_id, userId),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-      );
-
   if (row.cancel_at_period_end) {
-    await database
+    const before = await getSubscriptionById(database, row.id);
+    const [updated] = await database
       .update(kiloclaw_subscriptions)
       .set({
         status: 'canceled',
         cancel_at_period_end: false,
         auto_top_up_triggered_for_period: null,
       })
-      .where(subscriptionWhere);
+      .where(eq(kiloclaw_subscriptions.id, row.id))
+      .returning();
+
+    await insertLifecycleChangeLogBestEffort(database, {
+      subscriptionId: row.id,
+      action: 'canceled',
+      reason: 'credit_renewal_cancel_at_period_end',
+      before,
+      after: updated ?? null,
+    });
 
     summary.credit_renewals_canceled++;
     return;
@@ -933,7 +1086,7 @@ async function processCreditRenewalRow(
 
   if (effectiveBalance >= costMicrodollars) {
     const periodKey = format(new Date(renewalAt), 'yyyy-MM');
-    const instanceId = row.instance_id ?? 'unknown';
+    const instanceId = row.instance_id;
     const categoryPrefix =
       effectivePlan === 'commit'
         ? `kiloclaw-subscription-commit:${instanceId}`
@@ -944,8 +1097,11 @@ async function processCreditRenewalRow(
     const wasPastDue = row.status === 'past_due';
 
     let deductionIsNew = false;
+    let updatedSubscription: KiloClawSubscription | null = null;
+    let beforeSubscription: KiloClawSubscription | null = null;
 
     await database.transaction(async tx => {
+      beforeSubscription = await getSubscriptionById(database, row.id);
       const deductionResult = await tx
         .insert(credit_transactions)
         .values({
@@ -999,7 +1155,30 @@ async function processCreditRenewalRow(
         updateSet.past_due_since = null;
       }
 
-      await tx.update(kiloclaw_subscriptions).set(updateSet).where(subscriptionWhere);
+      [updatedSubscription] = await tx
+        .update(kiloclaw_subscriptions)
+        .set(updateSet)
+        .where(eq(kiloclaw_subscriptions.id, row.id))
+        .returning();
+
+      if (updatedSubscription) {
+        await insertKiloClawSubscriptionChangeLog(tx, {
+          subscriptionId: row.id,
+          actor: LIFECYCLE_ACTOR,
+          action: applyingPlanSwitch
+            ? 'plan_switched'
+            : wasPastDue
+              ? 'reactivated'
+              : 'period_advanced',
+          reason: applyingPlanSwitch
+            ? 'credit_renewal_plan_switch'
+            : wasPastDue
+              ? 'credit_renewal_reactivated'
+              : 'credit_renewal',
+          before: beforeSubscription,
+          after: updatedSubscription,
+        });
+      }
     });
 
     if (!deductionIsNew) {
@@ -1039,20 +1218,21 @@ async function processCreditRenewalRow(
     }
 
     if (wasPastDue && !row.suspended_at) {
-      await database
-        .delete(kiloclaw_email_log)
-        .where(
-          and(
-            eq(kiloclaw_email_log.user_id, userId),
-            eq(kiloclaw_email_log.email_type, 'claw_credit_renewal_failed')
-          )
-        );
+      await database.delete(kiloclaw_email_log).where(
+        emailLogRowCondition({
+          userId,
+          instanceId: row.instance_id,
+          emailType: 'claw_credit_renewal_failed',
+        })
+      );
     }
 
     if (wasPastDue && row.suspended_at) {
       await autoResumeIfSuspended(env, database, context, {
+        id: row.id,
         user_id: userId,
         instance_id: row.instance_id,
+        organization_id: row.organization_id,
         auto_resume_attempt_count: row.auto_resume_attempt_count,
       });
     }
@@ -1084,7 +1264,7 @@ async function processCreditRenewalRow(
     await database
       .update(kiloclaw_subscriptions)
       .set({ auto_top_up_triggered_for_period: renewalAt })
-      .where(subscriptionWhere);
+      .where(eq(kiloclaw_subscriptions.id, row.id));
 
     try {
       await triggerUserAutoTopUp(env, context, {
@@ -1106,13 +1286,23 @@ async function processCreditRenewalRow(
     return;
   }
 
-  await database
+  const before = await getSubscriptionById(database, row.id);
+  const [updated] = await database
     .update(kiloclaw_subscriptions)
     .set({
       status: 'past_due',
       past_due_since: sql`COALESCE(${kiloclaw_subscriptions.past_due_since}, now())`,
     })
-    .where(subscriptionWhere);
+    .where(eq(kiloclaw_subscriptions.id, row.id))
+    .returning();
+
+  await insertLifecycleChangeLogBestEffort(database, {
+    subscriptionId: row.id,
+    action: 'status_changed',
+    reason: 'credit_renewal_insufficient_credits',
+    before,
+    after: updated ?? null,
+  });
 
   await trySendEmail(
     database,
@@ -1122,8 +1312,10 @@ async function processCreditRenewalRow(
     row.email,
     'claw_credit_renewal_failed',
     'clawCreditRenewalFailed',
-    { claw_url: clawUrl },
-    summary
+    { claw_url: buildClawUrl(env) },
+    summary,
+    undefined,
+    { instanceId: row.instance_id }
   );
 
   summary.credit_renewals_past_due++;
@@ -1140,9 +1332,13 @@ async function runCreditRenewalSweep(
 
   const creditRenewalRows = await database
     .select({
+      id: kiloclaw_subscriptions.id,
       user_id: kiloclaw_subscriptions.user_id,
       email: kilocode_users.google_user_email,
       instance_id: kiloclaw_subscriptions.instance_id,
+      instance_row_id: kiloclaw_instances.id,
+      organization_id: kiloclaw_instances.organization_id,
+      instance_destroyed_at: kiloclaw_instances.destroyed_at,
       plan: kiloclaw_subscriptions.plan,
       status: kiloclaw_subscriptions.status,
       credit_renewal_at: kiloclaw_subscriptions.credit_renewal_at,
@@ -1163,20 +1359,18 @@ async function runCreditRenewalSweep(
     })
     .from(kiloclaw_subscriptions)
     .innerJoin(kilocode_users, eq(kiloclaw_subscriptions.user_id, kilocode_users.id))
+    .leftJoin(kiloclaw_instances, eq(kiloclaw_subscriptions.instance_id, kiloclaw_instances.id))
     .where(
       and(
         eq(kiloclaw_subscriptions.payment_source, 'credits'),
         isNull(kiloclaw_subscriptions.stripe_subscription_id),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
         inArray(kiloclaw_subscriptions.status, ['active', 'past_due']),
-        lte(kiloclaw_subscriptions.credit_renewal_at, now),
-        notSoftDeletedUserFilter()
+        lte(kiloclaw_subscriptions.credit_renewal_at, now)
       )
     );
 
   for (const row of creditRenewalRows) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) continue;
       await processCreditRenewalRow(database, env, context, row, clawUrl, summary);
     } catch (error) {
       summary.errors++;
@@ -1197,16 +1391,18 @@ async function runInterruptedAutoResumeSweep(
   const now = new Date().toISOString();
   const interruptedResumeRows = await database
     .select({
+      id: kiloclaw_subscriptions.id,
       user_id: kiloclaw_subscriptions.user_id,
       instance_id: kiloclaw_subscriptions.instance_id,
+      organization_id: kiloclaw_instances.organization_id,
       auto_resume_attempt_count: kiloclaw_subscriptions.auto_resume_attempt_count,
     })
     .from(kiloclaw_subscriptions)
+    .leftJoin(kiloclaw_instances, eq(kiloclaw_subscriptions.instance_id, kiloclaw_instances.id))
     .where(
       and(
         eq(kiloclaw_subscriptions.payment_source, 'credits'),
         eq(kiloclaw_subscriptions.status, 'active'),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
         isNotNull(kiloclaw_subscriptions.suspended_at),
         sql`(${kiloclaw_subscriptions.auto_resume_retry_after} IS NULL OR ${kiloclaw_subscriptions.auto_resume_retry_after} <= ${now})`
       )
@@ -1311,27 +1507,52 @@ async function runTrialExpirySweep(
     .where(
       and(
         eq(kiloclaw_subscriptions.status, 'trialing'),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
         lt(kiloclaw_subscriptions.trial_ends_at, now),
-        isNull(kiloclaw_subscriptions.suspended_at),
-        notSoftDeletedUserFilter()
+        isNull(kiloclaw_subscriptions.suspended_at)
       )
     );
 
   for (const row of expiredTrials) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) continue;
+      if (!row.instance_id) {
+        logSkippedSubscriptionRow('Skipping trial expiry for detached subscription row', row, {
+          reason: 'missing_instance_id',
+        });
+        continue;
+      }
+
+      if (!row.sandbox_id) {
+        logSkippedSubscriptionRow(
+          'Skipping trial expiry for subscription without instance row',
+          row,
+          {
+            reason: 'missing_instance_row',
+          }
+        );
+        continue;
+      }
+
       await stopInstanceForEnforcement(env, context, row);
 
       const destructionDeadline = new Date(Date.now() + DESTRUCTION_GRACE_DAYS * MS_PER_DAY);
-      await database
+      const before = await getSubscriptionById(database, row.id);
+      const [updated] = await database
         .update(kiloclaw_subscriptions)
         .set({
           status: 'canceled',
           suspended_at: now,
           destruction_deadline: destructionDeadline.toISOString(),
         })
-        .where(eq(kiloclaw_subscriptions.id, row.id));
+        .where(eq(kiloclaw_subscriptions.id, row.id))
+        .returning();
+
+      await insertLifecycleChangeLogBestEffort(database, {
+        subscriptionId: row.id,
+        action: 'suspended',
+        reason: 'trial_expired',
+        before,
+        after: updated ?? null,
+      });
 
       await enqueueAffiliateEvent(env, context, {
         userId: row.user_id,
@@ -1359,7 +1580,9 @@ async function runTrialExpirySweep(
           destruction_date: formatDateForEmail(destructionDeadline),
           claw_url: clawUrl,
         },
-        summary
+        summary,
+        undefined,
+        { instanceId: row.instance_id }
       );
 
       summary.sweep1_trial_expiry++;
@@ -1396,26 +1619,55 @@ async function runSubscriptionExpirySweep(
     .where(
       and(
         eq(kiloclaw_subscriptions.status, 'canceled'),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
         lt(kiloclaw_subscriptions.current_period_end, now),
-        isNull(kiloclaw_subscriptions.suspended_at),
-        notSoftDeletedUserFilter()
+        isNull(kiloclaw_subscriptions.suspended_at)
       )
     );
 
   for (const row of expiredSubscriptions) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) continue;
+      if (!row.instance_id) {
+        logSkippedSubscriptionRow(
+          'Skipping subscription expiry for detached subscription row',
+          row,
+          {
+            reason: 'missing_instance_id',
+          }
+        );
+        continue;
+      }
+
+      if (!row.sandbox_id) {
+        logSkippedSubscriptionRow(
+          'Skipping subscription expiry for subscription without instance row',
+          row,
+          {
+            reason: 'missing_instance_row',
+          }
+        );
+        continue;
+      }
+
       const destructionDeadline = new Date(Date.now() + DESTRUCTION_GRACE_DAYS * MS_PER_DAY);
 
       await stopInstanceForEnforcement(env, context, row);
-      await database
+      const before = await getSubscriptionById(database, row.id);
+      const [updated] = await database
         .update(kiloclaw_subscriptions)
         .set({
           suspended_at: now,
           destruction_deadline: destructionDeadline.toISOString(),
         })
-        .where(eq(kiloclaw_subscriptions.id, row.id));
+        .where(eq(kiloclaw_subscriptions.id, row.id))
+        .returning();
+
+      await insertLifecycleChangeLogBestEffort(database, {
+        subscriptionId: row.id,
+        action: 'suspended',
+        reason: 'subscription_expired',
+        before,
+        after: updated ?? null,
+      });
 
       await trySendEmail(
         database,
@@ -1429,7 +1681,9 @@ async function runSubscriptionExpirySweep(
           destruction_date: formatDateForEmail(destructionDeadline),
           claw_url: clawUrl,
         },
-        summary
+        summary,
+        undefined,
+        { instanceId: row.instance_id }
       );
 
       summary.sweep2_subscription_expiry++;
@@ -1466,15 +1720,34 @@ async function runInstanceDestructionSweep(
     .where(
       and(
         lt(kiloclaw_subscriptions.destruction_deadline, now),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
-        isNotNull(kiloclaw_subscriptions.suspended_at),
-        notSoftDeletedUserFilter()
+        isNotNull(kiloclaw_subscriptions.suspended_at)
       )
     );
 
   for (const row of destructionCandidates) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) continue;
+      if (!row.instance_id) {
+        logSkippedSubscriptionRow(
+          'Skipping instance destruction for detached subscription row',
+          row,
+          {
+            reason: 'missing_instance_id',
+          }
+        );
+        continue;
+      }
+
+      if (!row.sandbox_id) {
+        logSkippedSubscriptionRow(
+          'Skipping instance destruction for subscription without instance row',
+          row,
+          {
+            reason: 'missing_instance_row',
+          }
+        );
+        continue;
+      }
+
       await destroyInstanceForEnforcement(env, context, row);
 
       if (row.instance_id) {
@@ -1486,10 +1759,20 @@ async function runInstanceDestructionSweep(
           );
       }
 
-      await database
+      const before = await getSubscriptionById(database, row.id);
+      const [updated] = await database
         .update(kiloclaw_subscriptions)
         .set({ destruction_deadline: null })
-        .where(eq(kiloclaw_subscriptions.id, row.id));
+        .where(eq(kiloclaw_subscriptions.id, row.id))
+        .returning();
+
+      await insertLifecycleChangeLogBestEffort(database, {
+        subscriptionId: row.id,
+        action: 'status_changed',
+        reason: 'instance_destroyed',
+        before,
+        after: updated ?? null,
+      });
 
       await trySendEmail(
         database,
@@ -1500,7 +1783,9 @@ async function runInstanceDestructionSweep(
         'claw_instance_destroyed',
         'clawInstanceDestroyed',
         { claw_url: clawUrl },
-        summary
+        summary,
+        undefined,
+        { instanceId: row.instance_id }
       );
 
       await database
@@ -1508,7 +1793,8 @@ async function runInstanceDestructionSweep(
         .where(
           and(
             eq(kiloclaw_email_log.user_id, row.user_id),
-            sql`${kiloclaw_email_log.email_type} LIKE 'claw_instance_ready:%'`
+            eq(kiloclaw_email_log.instance_id, row.instance_id),
+            eq(kiloclaw_email_log.email_type, 'claw_instance_ready')
           )
         );
 
@@ -1547,26 +1833,51 @@ async function runPastDueCleanupSweep(
     .where(
       and(
         eq(kiloclaw_subscriptions.status, 'past_due'),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
         lt(kiloclaw_subscriptions.past_due_since, fourteenDaysAgo),
-        isNull(kiloclaw_subscriptions.suspended_at),
-        notSoftDeletedUserFilter()
+        isNull(kiloclaw_subscriptions.suspended_at)
       )
     );
 
   for (const row of pastDueRows) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) continue;
+      if (!row.instance_id) {
+        logSkippedSubscriptionRow('Skipping past-due cleanup for detached subscription row', row, {
+          reason: 'missing_instance_id',
+        });
+        continue;
+      }
+
+      if (!row.sandbox_id) {
+        logSkippedSubscriptionRow(
+          'Skipping past-due cleanup for subscription without instance row',
+          row,
+          {
+            reason: 'missing_instance_row',
+          }
+        );
+        continue;
+      }
+
       const destructionDeadline = new Date(Date.now() + DESTRUCTION_GRACE_DAYS * MS_PER_DAY);
 
       await stopInstanceForEnforcement(env, context, row);
-      await database
+      const before = await getSubscriptionById(database, row.id);
+      const [updated] = await database
         .update(kiloclaw_subscriptions)
         .set({
           suspended_at: now,
           destruction_deadline: destructionDeadline.toISOString(),
         })
-        .where(eq(kiloclaw_subscriptions.id, row.id));
+        .where(eq(kiloclaw_subscriptions.id, row.id))
+        .returning();
+
+      await insertLifecycleChangeLogBestEffort(database, {
+        subscriptionId: row.id,
+        action: 'suspended',
+        reason: 'past_due_cleanup',
+        before,
+        after: updated ?? null,
+      });
 
       await trySendEmail(
         database,
@@ -1580,7 +1891,9 @@ async function runPastDueCleanupSweep(
           destruction_date: formatDateForEmail(destructionDeadline),
           claw_url: clawUrl,
         },
-        summary
+        summary,
+        undefined,
+        { instanceId: row.instance_id }
       );
 
       summary.sweep4_past_due_cleanup++;
@@ -1609,7 +1922,6 @@ async function runIntroScheduleRepairSweep(
     .where(
       and(
         eq(kiloclaw_subscriptions.status, 'active'),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
         isNull(kiloclaw_subscriptions.stripe_schedule_id),
         isNotNull(kiloclaw_subscriptions.stripe_subscription_id),
         eq(kiloclaw_subscriptions.cancel_at_period_end, false)
@@ -1662,16 +1974,13 @@ async function runDestructionWarningSweep(
       and(
         gte(kiloclaw_subscriptions.destruction_deadline, advisoryNow),
         lte(kiloclaw_subscriptions.destruction_deadline, twoDaysFromNow),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
         isNotNull(kiloclaw_subscriptions.suspended_at),
-        isNull(kiloclaw_instances.destroyed_at),
-        notSoftDeletedUserFilter()
+        isNull(kiloclaw_instances.destroyed_at)
       )
     );
 
   for (const row of destructionWarningRows) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) continue;
       if (!row.destruction_deadline || row.instance_destroyed_at) continue;
       const instanceIdShort = shortInstanceId(row.instance_id);
       const sent = await trySendEmail(
@@ -1720,25 +2029,25 @@ async function runTrialWarningSweep(
   const trialWarningRows = await database
     .select({
       user_id: kiloclaw_subscriptions.user_id,
+      instance_id: kiloclaw_subscriptions.instance_id,
       email: kilocode_users.google_user_email,
       trial_ends_at: kiloclaw_subscriptions.trial_ends_at,
     })
     .from(kiloclaw_subscriptions)
     .innerJoin(kilocode_users, eq(kiloclaw_subscriptions.user_id, kilocode_users.id))
+    .innerJoin(kiloclaw_instances, eq(kiloclaw_subscriptions.instance_id, kiloclaw_instances.id))
     .where(
       and(
         eq(kiloclaw_subscriptions.status, 'trialing'),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
         gte(kiloclaw_subscriptions.trial_ends_at, advisoryNow),
         lte(kiloclaw_subscriptions.trial_ends_at, trialWarningCutoff),
         isNull(kiloclaw_subscriptions.suspended_at),
-        notSoftDeletedUserFilter()
+        isNull(kiloclaw_instances.destroyed_at)
       )
     );
 
   for (const row of trialWarningRows) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) continue;
       if (!row.trial_ends_at) continue;
 
       const daysRemaining = Math.ceil(
@@ -1756,7 +2065,9 @@ async function runTrialWarningSweep(
               'claw_trial_1d',
               'clawTrialExpiresTomorrow',
               { claw_url: clawUrl },
-              summary
+              summary,
+              undefined,
+              { instanceId: row.instance_id ?? undefined }
             )
           : await trySendEmail(
               database,
@@ -1771,7 +2082,8 @@ async function runTrialWarningSweep(
                 claw_url: clawUrl,
               },
               summary,
-              `Your KiloClaw Trial Ends in ${daysRemaining} Days`
+              `Your KiloClaw Trial Ends in ${daysRemaining} Days`,
+              { instanceId: row.instance_id ?? undefined }
             );
 
       if (sent) summary.trial_warnings++;
@@ -1799,31 +2111,69 @@ async function runEarlybirdWarningSweep(
     return;
   }
 
-  const earlybirdRows = await database
+  const canonicalRows = await database
+    .select({
+      user_id: kiloclaw_subscriptions.user_id,
+      email: kilocode_users.google_user_email,
+    })
+    .from(kiloclaw_subscriptions)
+    .innerJoin(kilocode_users, eq(kiloclaw_subscriptions.user_id, kilocode_users.id))
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.access_origin, 'earlybird'),
+        eq(kiloclaw_subscriptions.status, 'trialing'),
+        sql`${kiloclaw_subscriptions.trial_ends_at} > now()`,
+        sql`NOT EXISTS (
+          SELECT 1
+          FROM ${kiloclaw_subscriptions} AS other
+          WHERE other.user_id = ${kiloclaw_subscriptions.user_id}
+            AND other.id <> ${kiloclaw_subscriptions.id}
+            AND (
+              other.status = 'active'
+              OR (other.status = 'past_due' AND other.suspended_at IS NULL)
+              OR (
+                other.status = 'trialing'
+                AND other.access_origin IS DISTINCT FROM 'earlybird'
+                AND other.trial_ends_at > now()
+              )
+            )
+        )`
+      )
+    );
+
+  const legacyRows = await database
     .select({
       user_id: kiloclaw_earlybird_purchases.user_id,
       email: kilocode_users.google_user_email,
     })
     .from(kiloclaw_earlybird_purchases)
     .innerJoin(kilocode_users, eq(kiloclaw_earlybird_purchases.user_id, kilocode_users.id))
-    .leftJoin(
-      kiloclaw_subscriptions,
-      and(
-        eq(kiloclaw_earlybird_purchases.user_id, kiloclaw_subscriptions.user_id),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+    .where(sql`NOT EXISTS (
+        SELECT 1
+        FROM ${kiloclaw_subscriptions}
+        WHERE ${kiloclaw_subscriptions.user_id} = ${kiloclaw_earlybird_purchases.user_id}
+          AND ${kiloclaw_subscriptions.access_origin} = 'earlybird'
       )
-    )
-    .where(
-      and(
-        sql`(${kiloclaw_subscriptions.status} IS NULL OR ${kiloclaw_subscriptions.status} NOT IN ('active', 'trialing'))`,
-        isNull(kiloclaw_subscriptions.suspended_at),
-        notSoftDeletedUserFilter()
-      )
-    );
+      AND NOT EXISTS (
+        SELECT 1
+        FROM ${kiloclaw_subscriptions}
+        WHERE ${kiloclaw_subscriptions.user_id} = ${kiloclaw_earlybird_purchases.user_id}
+          AND (
+            ${kiloclaw_subscriptions.status} = 'active'
+            OR (
+              ${kiloclaw_subscriptions.status} = 'past_due'
+              AND ${kiloclaw_subscriptions.suspended_at} IS NULL
+            )
+            OR (
+              ${kiloclaw_subscriptions.status} = 'trialing'
+              AND ${kiloclaw_subscriptions.access_origin} IS DISTINCT FROM 'earlybird'
+              AND ${kiloclaw_subscriptions.trial_ends_at} > now()
+            )
+          )
+      )`);
 
-  for (const row of earlybirdRows) {
+  for (const row of [...canonicalRows, ...legacyRows]) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) continue;
       const expiryDate = formatDateForEmail(earlybirdExpiry);
       const sent =
         daysUntilEarlybird <= 1
@@ -1880,39 +2230,33 @@ async function runComplementaryInferenceEndedSweep(
   const clawUrl = buildClawUrl(env);
   const windowCutoff = new Date(Date.now() - COMPLEMENTARY_INFERENCE_WINDOW_MS).toISOString();
 
-  // Find users whose "instance ready" email was sent more than 6 hours ago
-  // after the rollout cutoff, whose instance is not destroyed, who have never
-  // purchased credits, and who have not already received this notification.
-  //
-  // The email_type for the "instance ready" log is `claw_instance_ready:{sandboxId}`.
-  // We extract the sandbox_id by joining against kiloclaw_instances.
+  // Find users whose per-instance "instance ready" email was sent more than
+  // 6 hours ago after rollout cutoff, whose instance is not destroyed, who
+  // have never purchased credits, and who have not already received same
+  // notification for same instance.
   const rows = await database
     .select({
       user_id: kilocode_users.id,
       email: kilocode_users.google_user_email,
+      instance_id: kiloclaw_instances.id,
       sandbox_id: kiloclaw_instances.sandbox_id,
     })
     .from(kiloclaw_email_log)
     .innerJoin(kilocode_users, eq(kiloclaw_email_log.user_id, kilocode_users.id))
-    .innerJoin(
-      kiloclaw_instances,
-      and(
-        eq(kiloclaw_instances.user_id, kiloclaw_email_log.user_id),
-        sql`${kiloclaw_email_log.email_type} = 'claw_instance_ready:' || ${kiloclaw_instances.sandbox_id}`
-      )
-    )
+    .innerJoin(kiloclaw_instances, eq(kiloclaw_email_log.instance_id, kiloclaw_instances.id))
     .where(
       and(
-        sql`${kiloclaw_email_log.email_type} LIKE 'claw_instance_ready:%'`,
+        eq(kiloclaw_email_log.email_type, 'claw_instance_ready'),
+        isNotNull(kiloclaw_email_log.instance_id),
         gt(kiloclaw_email_log.sent_at, COMPLEMENTARY_INFERENCE_INSTANCE_READY_CUTOFF_ISO),
         lte(kiloclaw_email_log.sent_at, windowCutoff),
         isNull(kiloclaw_instances.destroyed_at),
-        notSoftDeletedUserFilter(),
         // Not already sent the complementary inference ended email for this instance
         sql`NOT EXISTS (
           SELECT 1 FROM ${kiloclaw_email_log} AS sent_check
           WHERE sent_check.user_id = ${kiloclaw_email_log.user_id}
-            AND sent_check.email_type = 'claw_complementary_inference_ended:' || ${kiloclaw_instances.sandbox_id}
+            AND sent_check.instance_id = ${kiloclaw_email_log.instance_id}
+            AND sent_check.email_type = 'claw_complementary_inference_ended'
         )`,
         // Never purchased credits (is_free = false, no org_id = personal purchase)
         sql`NOT EXISTS (
@@ -1926,17 +2270,18 @@ async function runComplementaryInferenceEndedSweep(
 
   for (const row of rows) {
     try {
-      if (isSoftDeletedUserEmail(row.email)) continue;
       const sent = await trySendEmail(
         database,
         env,
         context,
         row.user_id,
         row.email,
-        `claw_complementary_inference_ended:${row.sandbox_id}`,
+        'claw_complementary_inference_ended',
         'clawComplementaryInferenceEnded',
         { claw_url: clawUrl },
-        summary
+        summary,
+        undefined,
+        { instanceId: row.instance_id }
       );
 
       if (sent) summary.complementary_inference_ended_emails++;

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -1511,6 +1511,8 @@ async function runTrialExpirySweep(
       user_id: kiloclaw_subscriptions.user_id,
       instance_id: kiloclaw_subscriptions.instance_id,
       sandbox_id: kiloclaw_instances.sandbox_id,
+      instance_destroyed_at: kiloclaw_instances.destroyed_at,
+      organization_id: kiloclaw_instances.organization_id,
       email: kilocode_users.google_user_email,
     })
     .from(kiloclaw_subscriptions)
@@ -1543,6 +1545,21 @@ async function runTrialExpirySweep(
             reason: 'missing_instance_row',
           }
         );
+        continue;
+      }
+
+      if (row.instance_destroyed_at) {
+        logSkippedSubscriptionRow('Skipping trial expiry for destroyed instance', row, {
+          reason: 'instance_destroyed',
+        });
+        continue;
+      }
+
+      if (row.organization_id) {
+        logSkippedSubscriptionRow('Skipping trial expiry for organization-managed row', row, {
+          reason: 'organization_managed',
+          organizationId: row.organization_id,
+        });
         continue;
       }
 
@@ -1625,6 +1642,8 @@ async function runSubscriptionExpirySweep(
       user_id: kiloclaw_subscriptions.user_id,
       instance_id: kiloclaw_subscriptions.instance_id,
       sandbox_id: kiloclaw_instances.sandbox_id,
+      instance_destroyed_at: kiloclaw_instances.destroyed_at,
+      organization_id: kiloclaw_instances.organization_id,
       email: kilocode_users.google_user_email,
     })
     .from(kiloclaw_subscriptions)
@@ -1659,6 +1678,25 @@ async function runSubscriptionExpirySweep(
           row,
           {
             reason: 'missing_instance_row',
+          }
+        );
+        continue;
+      }
+
+      if (row.instance_destroyed_at) {
+        logSkippedSubscriptionRow('Skipping subscription expiry for destroyed instance', row, {
+          reason: 'instance_destroyed',
+        });
+        continue;
+      }
+
+      if (row.organization_id) {
+        logSkippedSubscriptionRow(
+          'Skipping subscription expiry for organization-managed row',
+          row,
+          {
+            reason: 'organization_managed',
+            organizationId: row.organization_id,
           }
         );
         continue;
@@ -1728,6 +1766,7 @@ async function runInstanceDestructionSweep(
       user_id: kiloclaw_subscriptions.user_id,
       instance_id: kiloclaw_subscriptions.instance_id,
       sandbox_id: kiloclaw_instances.sandbox_id,
+      organization_id: kiloclaw_instances.organization_id,
       email: kilocode_users.google_user_email,
     })
     .from(kiloclaw_subscriptions)
@@ -1761,6 +1800,18 @@ async function runInstanceDestructionSweep(
           row,
           {
             reason: 'missing_instance_row',
+          }
+        );
+        continue;
+      }
+
+      if (row.organization_id) {
+        logSkippedSubscriptionRow(
+          'Skipping instance destruction for organization-managed row',
+          row,
+          {
+            reason: 'organization_managed',
+            organizationId: row.organization_id,
           }
         );
         continue;
@@ -1851,6 +1902,8 @@ async function runPastDueCleanupSweep(
       user_id: kiloclaw_subscriptions.user_id,
       instance_id: kiloclaw_subscriptions.instance_id,
       sandbox_id: kiloclaw_instances.sandbox_id,
+      instance_destroyed_at: kiloclaw_instances.destroyed_at,
+      organization_id: kiloclaw_instances.organization_id,
       email: kilocode_users.google_user_email,
     })
     .from(kiloclaw_subscriptions)
@@ -1883,6 +1936,21 @@ async function runPastDueCleanupSweep(
             reason: 'missing_instance_row',
           }
         );
+        continue;
+      }
+
+      if (row.instance_destroyed_at) {
+        logSkippedSubscriptionRow('Skipping past-due cleanup for destroyed instance', row, {
+          reason: 'instance_destroyed',
+        });
+        continue;
+      }
+
+      if (row.organization_id) {
+        logSkippedSubscriptionRow('Skipping past-due cleanup for organization-managed row', row, {
+          reason: 'organization_managed',
+          organizationId: row.organization_id,
+        });
         continue;
       }
 
@@ -1988,12 +2056,14 @@ async function runDestructionWarningSweep(
 
   const destructionWarningRows = await database
     .select({
+      id: kiloclaw_subscriptions.id,
       user_id: kiloclaw_subscriptions.user_id,
       email: kilocode_users.google_user_email,
       destruction_deadline: kiloclaw_subscriptions.destruction_deadline,
       instance_id: kiloclaw_instances.id,
       instance_name: kiloclaw_instances.name,
       instance_destroyed_at: kiloclaw_instances.destroyed_at,
+      organization_id: kiloclaw_instances.organization_id,
       plan: kiloclaw_subscriptions.plan,
     })
     .from(kiloclaw_subscriptions)
@@ -2013,6 +2083,17 @@ async function runDestructionWarningSweep(
     try {
       if (isSoftDeletedUserEmail(row.email)) continue;
       if (!row.destruction_deadline || row.instance_destroyed_at) continue;
+      if (row.organization_id) {
+        logSkippedSubscriptionRow(
+          'Skipping destruction warning for organization-managed row',
+          row,
+          {
+            reason: 'organization_managed',
+            organizationId: row.organization_id,
+          }
+        );
+        continue;
+      }
       const instanceIdShort = shortInstanceId(row.instance_id);
       const sent = await trySendEmail(
         database,
@@ -2064,6 +2145,7 @@ async function runTrialWarningSweep(
       instance_id: kiloclaw_subscriptions.instance_id,
       instance_destroyed_at: kiloclaw_instances.destroyed_at,
       instance_sandbox_id: kiloclaw_instances.sandbox_id,
+      organization_id: kiloclaw_instances.organization_id,
       email: kilocode_users.google_user_email,
       trial_ends_at: kiloclaw_subscriptions.trial_ends_at,
     })
@@ -2104,6 +2186,14 @@ async function runTrialWarningSweep(
       if (row.instance_destroyed_at) {
         logSkippedSubscriptionRow('Skipping trial warning for destroyed instance', row, {
           reason: 'instance_destroyed',
+        });
+        continue;
+      }
+
+      if (row.organization_id) {
+        logSkippedSubscriptionRow('Skipping trial warning for organization-managed row', row, {
+          reason: 'organization_managed',
+          organizationId: row.organization_id,
         });
         continue;
       }

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, gte, inArray, isNotNull, isNull, lt, lte, sql } from 'drizzle-orm';
+import { and, eq, gt, gte, inArray, isNotNull, isNull, lt, lte, or, sql } from 'drizzle-orm';
 import { addMonths, format } from 'date-fns';
 
 import type { WorkerDb } from '@kilocode/db';
@@ -285,8 +285,12 @@ function isSoftDeletedUserEmail(email: string): boolean {
   return email.endsWith(SOFT_DELETED_EMAIL_SUFFIX);
 }
 
-function notSoftDeletedUserFilter() {
-  return sql`${kilocode_users.google_user_email} NOT LIKE ${`%${SOFT_DELETED_EMAIL_SUFFIX}`}`;
+function currentSubscriptionRowFilter() {
+  return isNull(kiloclaw_subscriptions.transferred_to_subscription_id);
+}
+
+function legacyInstanceReadyEmailType(sandboxId: string) {
+  return `claw_instance_ready:${sandboxId}`;
 }
 
 function shortInstanceId(instanceId: string): string {
@@ -728,6 +732,11 @@ async function trySendEmail(
   subjectOverride?: string,
   entityFields: BillingEntityFields = {}
 ): Promise<boolean> {
+  if (isSoftDeletedUserEmail(userEmail)) {
+    summary.emails_skipped++;
+    return false;
+  }
+
   const emailLogScope = {
     userId,
     emailType,
@@ -1364,6 +1373,7 @@ async function runCreditRenewalSweep(
       and(
         eq(kiloclaw_subscriptions.payment_source, 'credits'),
         isNull(kiloclaw_subscriptions.stripe_subscription_id),
+        currentSubscriptionRowFilter(),
         inArray(kiloclaw_subscriptions.status, ['active', 'past_due']),
         lte(kiloclaw_subscriptions.credit_renewal_at, now)
       )
@@ -1371,6 +1381,9 @@ async function runCreditRenewalSweep(
 
   for (const row of creditRenewalRows) {
     try {
+      if (isSoftDeletedUserEmail(row.email)) {
+        continue;
+      }
       await processCreditRenewalRow(database, env, context, row, clawUrl, summary);
     } catch (error) {
       summary.errors++;
@@ -1403,6 +1416,7 @@ async function runInterruptedAutoResumeSweep(
       and(
         eq(kiloclaw_subscriptions.payment_source, 'credits'),
         eq(kiloclaw_subscriptions.status, 'active'),
+        currentSubscriptionRowFilter(),
         isNotNull(kiloclaw_subscriptions.suspended_at),
         sql`(${kiloclaw_subscriptions.auto_resume_retry_after} IS NULL OR ${kiloclaw_subscriptions.auto_resume_retry_after} <= ${now})`
       )
@@ -1507,6 +1521,7 @@ async function runTrialExpirySweep(
     .where(
       and(
         eq(kiloclaw_subscriptions.status, 'trialing'),
+        currentSubscriptionRowFilter(),
         lt(kiloclaw_subscriptions.trial_ends_at, now),
         isNull(kiloclaw_subscriptions.suspended_at)
       )
@@ -1514,6 +1529,9 @@ async function runTrialExpirySweep(
 
   for (const row of expiredTrials) {
     try {
+      if (isSoftDeletedUserEmail(row.email)) {
+        continue;
+      }
       if (!row.instance_id) {
         logSkippedSubscriptionRow('Skipping trial expiry for detached subscription row', row, {
           reason: 'missing_instance_id',
@@ -1619,6 +1637,7 @@ async function runSubscriptionExpirySweep(
     .where(
       and(
         eq(kiloclaw_subscriptions.status, 'canceled'),
+        currentSubscriptionRowFilter(),
         lt(kiloclaw_subscriptions.current_period_end, now),
         isNull(kiloclaw_subscriptions.suspended_at)
       )
@@ -1626,6 +1645,9 @@ async function runSubscriptionExpirySweep(
 
   for (const row of expiredSubscriptions) {
     try {
+      if (isSoftDeletedUserEmail(row.email)) {
+        continue;
+      }
       if (!row.instance_id) {
         logSkippedSubscriptionRow(
           'Skipping subscription expiry for detached subscription row',
@@ -1720,12 +1742,16 @@ async function runInstanceDestructionSweep(
     .where(
       and(
         lt(kiloclaw_subscriptions.destruction_deadline, now),
+        currentSubscriptionRowFilter(),
         isNotNull(kiloclaw_subscriptions.suspended_at)
       )
     );
 
   for (const row of destructionCandidates) {
     try {
+      if (isSoftDeletedUserEmail(row.email)) {
+        continue;
+      }
       if (!row.instance_id) {
         logSkippedSubscriptionRow(
           'Skipping instance destruction for detached subscription row',
@@ -1793,8 +1819,16 @@ async function runInstanceDestructionSweep(
         .where(
           and(
             eq(kiloclaw_email_log.user_id, row.user_id),
-            eq(kiloclaw_email_log.instance_id, row.instance_id),
-            eq(kiloclaw_email_log.email_type, 'claw_instance_ready')
+            or(
+              and(
+                eq(kiloclaw_email_log.instance_id, row.instance_id),
+                eq(kiloclaw_email_log.email_type, 'claw_instance_ready')
+              ),
+              and(
+                isNull(kiloclaw_email_log.instance_id),
+                eq(kiloclaw_email_log.email_type, legacyInstanceReadyEmailType(row.sandbox_id))
+              )
+            )
           )
         );
 
@@ -1833,6 +1867,7 @@ async function runPastDueCleanupSweep(
     .where(
       and(
         eq(kiloclaw_subscriptions.status, 'past_due'),
+        currentSubscriptionRowFilter(),
         lt(kiloclaw_subscriptions.past_due_since, fourteenDaysAgo),
         isNull(kiloclaw_subscriptions.suspended_at)
       )
@@ -1840,6 +1875,9 @@ async function runPastDueCleanupSweep(
 
   for (const row of pastDueRows) {
     try {
+      if (isSoftDeletedUserEmail(row.email)) {
+        continue;
+      }
       if (!row.instance_id) {
         logSkippedSubscriptionRow('Skipping past-due cleanup for detached subscription row', row, {
           reason: 'missing_instance_id',
@@ -1922,6 +1960,7 @@ async function runIntroScheduleRepairSweep(
     .where(
       and(
         eq(kiloclaw_subscriptions.status, 'active'),
+        currentSubscriptionRowFilter(),
         isNull(kiloclaw_subscriptions.stripe_schedule_id),
         isNotNull(kiloclaw_subscriptions.stripe_subscription_id),
         eq(kiloclaw_subscriptions.cancel_at_period_end, false)
@@ -1974,6 +2013,7 @@ async function runDestructionWarningSweep(
       and(
         gte(kiloclaw_subscriptions.destruction_deadline, advisoryNow),
         lte(kiloclaw_subscriptions.destruction_deadline, twoDaysFromNow),
+        currentSubscriptionRowFilter(),
         isNotNull(kiloclaw_subscriptions.suspended_at),
         isNull(kiloclaw_instances.destroyed_at)
       )
@@ -1981,6 +2021,9 @@ async function runDestructionWarningSweep(
 
   for (const row of destructionWarningRows) {
     try {
+      if (isSoftDeletedUserEmail(row.email)) {
+        continue;
+      }
       if (!row.destruction_deadline || row.instance_destroyed_at) continue;
       const instanceIdShort = shortInstanceId(row.instance_id);
       const sent = await trySendEmail(
@@ -2042,6 +2085,7 @@ async function runTrialWarningSweep(
     .where(
       and(
         eq(kiloclaw_subscriptions.status, 'trialing'),
+        currentSubscriptionRowFilter(),
         gte(kiloclaw_subscriptions.trial_ends_at, advisoryNow),
         lte(kiloclaw_subscriptions.trial_ends_at, trialWarningCutoff),
         isNull(kiloclaw_subscriptions.suspended_at)
@@ -2050,6 +2094,9 @@ async function runTrialWarningSweep(
 
   for (const row of trialWarningRows) {
     try {
+      if (isSoftDeletedUserEmail(row.email)) {
+        continue;
+      }
       if (!row.trial_ends_at) continue;
 
       if (!row.instance_id) {
@@ -2147,12 +2194,14 @@ async function runEarlybirdWarningSweep(
       and(
         eq(kiloclaw_subscriptions.access_origin, 'earlybird'),
         eq(kiloclaw_subscriptions.status, 'trialing'),
+        currentSubscriptionRowFilter(),
         sql`${kiloclaw_subscriptions.trial_ends_at} > now()`,
         sql`NOT EXISTS (
           SELECT 1
           FROM ${kiloclaw_subscriptions} AS other
           WHERE other.user_id = ${kiloclaw_subscriptions.user_id}
             AND other.id <> ${kiloclaw_subscriptions.id}
+            AND other.transferred_to_subscription_id IS NULL
             AND (
               other.status = 'active'
               OR (other.status = 'past_due' AND other.suspended_at IS NULL)
@@ -2177,12 +2226,14 @@ async function runEarlybirdWarningSweep(
         SELECT 1
         FROM ${kiloclaw_subscriptions}
         WHERE ${kiloclaw_subscriptions.user_id} = ${kiloclaw_earlybird_purchases.user_id}
+          AND ${kiloclaw_subscriptions.transferred_to_subscription_id} IS NULL
           AND ${kiloclaw_subscriptions.access_origin} = 'earlybird'
       )
       AND NOT EXISTS (
         SELECT 1
         FROM ${kiloclaw_subscriptions}
         WHERE ${kiloclaw_subscriptions.user_id} = ${kiloclaw_earlybird_purchases.user_id}
+          AND ${kiloclaw_subscriptions.transferred_to_subscription_id} IS NULL
           AND (
             ${kiloclaw_subscriptions.status} = 'active'
             OR (
@@ -2199,6 +2250,9 @@ async function runEarlybirdWarningSweep(
 
   for (const row of [...canonicalRows, ...legacyRows]) {
     try {
+      if (isSoftDeletedUserEmail(row.email)) {
+        continue;
+      }
       const expiryDate = formatDateForEmail(earlybirdExpiry);
       const sent =
         daysUntilEarlybird <= 1
@@ -2268,11 +2322,24 @@ async function runComplementaryInferenceEndedSweep(
     })
     .from(kiloclaw_email_log)
     .innerJoin(kilocode_users, eq(kiloclaw_email_log.user_id, kilocode_users.id))
-    .innerJoin(kiloclaw_instances, eq(kiloclaw_email_log.instance_id, kiloclaw_instances.id))
+    .innerJoin(
+      kiloclaw_instances,
+      and(
+        eq(kilocode_users.id, kiloclaw_instances.user_id),
+        or(
+          and(
+            eq(kiloclaw_email_log.instance_id, kiloclaw_instances.id),
+            eq(kiloclaw_email_log.email_type, 'claw_instance_ready')
+          ),
+          and(
+            isNull(kiloclaw_email_log.instance_id),
+            sql`${kiloclaw_email_log.email_type} = 'claw_instance_ready:' || ${kiloclaw_instances.sandbox_id}`
+          )
+        )
+      )
+    )
     .where(
       and(
-        eq(kiloclaw_email_log.email_type, 'claw_instance_ready'),
-        isNotNull(kiloclaw_email_log.instance_id),
         gt(kiloclaw_email_log.sent_at, COMPLEMENTARY_INFERENCE_INSTANCE_READY_CUTOFF_ISO),
         lte(kiloclaw_email_log.sent_at, windowCutoff),
         isNull(kiloclaw_instances.destroyed_at),
@@ -2280,8 +2347,17 @@ async function runComplementaryInferenceEndedSweep(
         sql`NOT EXISTS (
           SELECT 1 FROM ${kiloclaw_email_log} AS sent_check
           WHERE sent_check.user_id = ${kiloclaw_email_log.user_id}
-            AND sent_check.instance_id = ${kiloclaw_email_log.instance_id}
-            AND sent_check.email_type = 'claw_complementary_inference_ended'
+            AND (
+              (
+                sent_check.instance_id = ${kiloclaw_instances.id}
+                AND sent_check.email_type = 'claw_complementary_inference_ended'
+              )
+              OR (
+                sent_check.instance_id IS NULL
+                AND sent_check.email_type =
+                  'claw_complementary_inference_ended:' || ${kiloclaw_instances.sandbox_id}
+              )
+            )
         )`,
         // Never purchased credits (is_free = false, no org_id = personal purchase)
         sql`NOT EXISTS (
@@ -2295,6 +2371,9 @@ async function runComplementaryInferenceEndedSweep(
 
   for (const row of rows) {
     try {
+      if (isSoftDeletedUserEmail(row.email)) {
+        continue;
+      }
       const sent = await trySendEmail(
         database,
         env,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -28,14 +28,15 @@ vi.mock('cloudflare:workers', () => ({
 }));
 
 // -- Mock fly client --
-// Keep real isFlyNotFound, isFlyInsufficientResources + FlyApiError; mock all API functions.
+// Keep real error classifiers + FlyApiError; mock all API functions.
 vi.mock('../fly/client', async () => {
-  const { FlyApiError, isFlyNotFound, isFlyInsufficientResources } =
+  const { FlyApiError, isFlyNotFound, isFlyInsufficientResources, isFlyMissingVolume } =
     await vi.importActual('../fly/client');
   return {
     FlyApiError,
     isFlyNotFound,
     isFlyInsufficientResources,
+    isFlyMissingVolume,
     createMachine: vi.fn(),
     getMachine: vi.fn(),
     startMachine: vi.fn(),
@@ -1985,6 +1986,35 @@ describe('startExistingMachine: transient vs 404 errors', () => {
 
     expect(flyClient.createMachine).toHaveBeenCalled();
     expect(storage._store.get('flyMachineId')).toBe('machine-new');
+  });
+
+  it('destroys stale machine and recreates it when updateMachine reports a missing volume', async () => {
+    const { instance, storage } = createInstance();
+    await seedRunning(storage, { status: 'stopped' });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({ state: 'stopped' });
+    (flyClient.updateMachine as Mock).mockRejectedValue(
+      new FlyApiError(
+        'Fly API updateMachine failed (400): {"error":"invalid_argument: volume does not exist"}',
+        400,
+        '{"error":"invalid_argument: volume does not exist"}'
+      )
+    );
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1', region: 'iad' });
+    (flyClient.destroyMachine as Mock).mockResolvedValue(undefined);
+    (flyClient.createMachine as Mock).mockResolvedValue({
+      id: 'machine-new',
+      region: 'iad',
+    });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+
+    await instance.start('user-1');
+
+    expect(flyClient.destroyMachine).toHaveBeenCalledWith(expect.anything(), 'machine-1', true);
+    expect(flyClient.createMachine).toHaveBeenCalled();
+    expect(storage._store.get('flyMachineId')).toBe('machine-new');
+    expect(storage._store.get('flyVolumeId')).toBe('vol-1');
+    expect(storage._store.get('status')).toBe('running');
   });
 
   it('clears the stale machine id before retrying replacement creation after a 404', async () => {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/fly-machines.ts
@@ -267,6 +267,42 @@ export async function startExistingMachine(
   if (!onProviderResult) {
     throw new Error('startExistingMachine requires a persistence callback');
   }
+  const persistProviderResult = onProviderResult;
+
+  async function recreateMachine(reason: 'not_found' | 'missing_volume') {
+    if (reason === 'not_found') {
+      console.log('[DO] Machine gone (404), creating new one');
+    } else {
+      console.log('[DO] Existing machine references a missing volume, recreating machine');
+      const machineId = providerState.machineId;
+      if (machineId) {
+        try {
+          await fly.destroyMachine(flyConfig, machineId, true);
+        } catch (destroyErr) {
+          if (!fly.isFlyNotFound(destroyErr)) {
+            throw destroyErr;
+          }
+        }
+      }
+    }
+
+    const clearedProviderState = {
+      ...providerState,
+      machineId: null,
+    } satisfies FlyProviderState;
+    await persistProviderResult({
+      providerState: clearedProviderState,
+    });
+    return createNewMachine(
+      flyConfig,
+      state,
+      clearedProviderState,
+      initialMachineConfig,
+      minSecretsVersion,
+      envFlyRegion,
+      persistProviderResult
+    );
+  }
 
   try {
     const machine = await fly.getMachine(flyConfig, providerState.machineId);
@@ -278,7 +314,7 @@ export async function startExistingMachine(
       const { cpus, memory_mb, cpu_kind } = machine.config.guest;
       machineSizePatch = { cpus, memory_mb, cpu_kind };
       machineConfig = { ...machineConfig, guest: guestFromSize(machineSizePatch) };
-      await onProviderResult({
+      await persistProviderResult({
         providerState,
         corePatch: {
           machineSize: machineSizePatch,
@@ -314,23 +350,10 @@ export async function startExistingMachine(
     };
   } catch (err) {
     if (fly.isFlyNotFound(err)) {
-      console.log('[DO] Machine gone (404), creating new one');
-      const clearedProviderState = {
-        ...providerState,
-        machineId: null,
-      } satisfies FlyProviderState;
-      await onProviderResult({
-        providerState: clearedProviderState,
-      });
-      return createNewMachine(
-        flyConfig,
-        state,
-        clearedProviderState,
-        initialMachineConfig,
-        minSecretsVersion,
-        envFlyRegion,
-        onProviderResult
-      );
+      return recreateMachine('not_found');
+    }
+    if (fly.isFlyMissingVolume(err)) {
+      return recreateMachine('missing_volume');
     } else {
       doError(state, 'Transient error starting existing machine', {
         error: toLoggable(err),

--- a/services/kiloclaw/src/fly/client.ts
+++ b/services/kiloclaw/src/fly/client.ts
@@ -259,6 +259,22 @@ export function isFlyNotFound(err: unknown): boolean {
   return err instanceof FlyApiError && err.status === 404;
 }
 
+const MISSING_VOLUME_STATUS_CODES = [400, 404, 422];
+const MISSING_VOLUME_MARKERS = [
+  'volume does not exist',
+  'volume not found',
+  'could not find volume',
+];
+
+export function isFlyMissingVolume(err: unknown): boolean {
+  if (!(err instanceof FlyApiError) || !MISSING_VOLUME_STATUS_CODES.includes(err.status)) {
+    return false;
+  }
+
+  const searchText = `${err.message}\n${err.body}`.toLowerCase();
+  return MISSING_VOLUME_MARKERS.some(marker => searchText.includes(marker));
+}
+
 /**
  * Status codes that Fly uses for capacity/resource exhaustion errors.
  * - 400: "no capacity" on createVolume (observed in production)


### PR DESCRIPTION
## Summary

Hardens the KiloClaw billing live-path after the per-instance subscription model landed, fixing access-state gaps, lifecycle sweep safety, subscription change-log coverage, and several frontend billing UI regressions.

### Why this change is needed

The recent per-instance billing migration (`transferred_to_subscription_id`, successor rows, `access_origin`) left several runtime paths partially adapted:

- Earlybird access checks used the legacy `kiloclaw_earlybird_purchases` table but not the new canonical `access_origin = 'earlybird'` subscription rows — both for access-state and for the billing UI data sent to the frontend.
- Billing lifecycle sweeps queried subscription rows without filtering `transferred_to_subscription_id IS NULL`, causing actions on historical predecessor rows.
- Enforcement sweeps (trial expiry, subscription expiry, past-due cleanup, instance destruction, destruction warning, trial warning) lacked `instance_destroyed_at` and `organization_id` guards, risking misleading emails to users with already-destroyed instances or org-managed subscriptions being processed by personal lifecycle sweeps.
- Admin trial-extension, cancel, and plan-switch mutations wrote billing state changes without corresponding `kiloclaw_subscription_change_log` entries.
- The billing UI (`SubscriptionCard`, `BillingBanner`, `CancelDialog`) did not pass `instanceId` to instance-scoped tRPC mutations, and lacked loading/pending states on destructive actions.
- The `ProfileKiloClawBanner` didn't distinguish "active instance without billing row" from "no instance at all", causing a blank banner for users mid-setup.
- Fly machine start-up could fail with a `volume does not exist` error (400) without recovery, leaving instances stuck in `stopped` state.

### How this is addressed

- **Access state**: `getKiloClawSubscriptionAccessReason` now recognizes `access_origin = 'earlybird'` and returns `'earlybird'`. New `getKiloClawEarlybirdStateForUser` checks canonical rows first, falls back to legacy purchase table.
- **Earlybird UI data**: `getPersonalBillingStatus` now populates `earlybirdData` when `accessReason === 'earlybird'` (canonical path), not only when a legacy `kiloclaw_earlybird_purchases` row exists. This ensures `BillingBanner` and `SubscriptionTab` show earlybird expiry/banner state for users migrated to canonical `access_origin` rows.
- **Lifecycle sweeps**: All billing lifecycle sweep queries now include `currentSubscriptionRowFilter()` (`transferred_to_subscription_id IS NULL`). Detached, org-managed, destroyed-instance, and soft-deleted-user rows are logged-and-skipped instead of silently processed.
- **Enforcement sweep guards**: Trial expiry, subscription expiry, past-due cleanup, instance destruction, destruction warning, and trial warning sweeps now check `instance_destroyed_at` (preventing suspension emails for already-destroyed instances) and `organization_id` (preventing personal lifecycle sweeps from claiming org-managed subscription rows). These guards match the pattern already used by the credit renewal sweep.
- **Subscription change log**: Admin trial-extend, cancel, reactivate, plan-switch, and earlybird-warning mutations now write `kiloclaw_subscription_change_log` entries. Lifecycle sweeps (trial expiry, subscription expiry, past-due cleanup, credit renewal, instance destruction, auto-resume) write change-log rows via `insertLifecycleChangeLogBestEffort`.
- **Billing UI**: `SubscriptionCard`, `BillingBanner`, and `CancelDialog` pass `instanceId` to instance-scoped mutations. Added `isReactivating`/`isPending` disabled states and loading spinners on destructive buttons. `ProfileKiloClawBanner` uses a new `getProfileKiloClawBannerVariant` helper with a `continue-setup` state for billing-active-but-unprovisioned instances.
- **Instance-ready email**: Migrated from legacy `claw_instance_ready:{sandboxId}` to instance-scoped `claw_instance_ready` with backward-compatible dedup check.
- **Fly recovery**: Added `isFlyMissingVolume` classifier; `startExistingMachine` now destroys the stale machine and recreates it when the volume reference is broken, matching the existing 404 recovery path.
- **Trial-warning sweep**: Switched from `innerJoin(kiloclaw_instances)` to `leftJoin` with explicit log-and-skip for missing/destroyed instance rows.

## Verification

- [x] `pnpm typecheck` passes
- [x] `pnpm format` applied
- [x] Lint passes (pre-push hook)
- _Additional verification (to be completed by author)_

## Visual Changes

N/A

## Reviewer Notes

### Human Reviewer

- The earlybird access-state dual-path (canonical subscription row vs legacy purchase table) is intentional — legacy rows are not backfilled yet, so both paths must coexist until the backfill migration runs.
- Lifecycle sweep changes are defense-in-depth: the `transferred_to_subscription_id IS NULL` filter should exclude predecessor rows, but each sweep also log-and-skips detached/org/destroyed rows individually.
- The `organization_id` guards on enforcement sweeps are forward-looking — org billing doesn't flow through these personal sweeps today, but the guards make the boundary explicit and will surface when org billing is implemented.
- The `ProfileKiloClawBanner` variant logic is unit-tested in `ProfileKiloClawBanner.test.ts` — the key behavioral change is `continue-setup` for users who have billing access but a null dashboard status.
- The Fly `isFlyMissingVolume` classifier is deliberately broad (checks 400/404/422 status codes against multiple error string patterns) because Fly's error messaging for this condition is inconsistent.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- All lifecycle sweep changes follow the same pattern: add `currentSubscriptionRowFilter()` to the WHERE clause, then add per-row guards with `logSkippedSubscriptionRow` for detached/org/destroyed/soft-deleted cases.
- Change-log writes in lifecycle sweeps use `insertLifecycleChangeLogBestEffort` which swallows errors — this is intentional since the lifecycle action already committed.
- The admin router change-log writes use transactional `insertUserSubscriptionChangeLog` (inside the same tx as the state update) for admin mutations, but `insertUserSubscriptionChangeLogBestEffort` (non-transactional) for mutations that already committed state to Stripe.
- The `instance-ready` email migration maintains backward compat via an `OR` condition that checks both the new instance-scoped and legacy sandboxId-based dedup keys.

</details>