### PR TITLE
feat(admin): add Suspicious Domains tab to blacklisted-domains page

### DIFF
--- a/apps/web/src/app/admin/components/BlacklistedDomains.tsx
+++ b/apps/web/src/app/admin/components/BlacklistedDomains.tsx
@@ -17,7 +17,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { Shield, Users } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, Shield, Users } from 'lucide-react';
 
 function EditTab() {
   const trpc = useTRPC();
@@ -192,6 +192,120 @@ function StatsTab() {
   );
 }
 
+function SuspiciousTab() {
+  const trpc = useTRPC();
+
+  const { data, isLoading } = useQuery(trpc.admin.blacklistDomains.suspicious.queryOptions());
+
+  const domains = data?.domains ?? [];
+  const blacklistedCount = domains.filter(d => d.isBlacklisted).length;
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle>Suspicious Domains</CardTitle>
+            <CardDescription>
+              Top 100 registrable domains by blocked account count, then total account count. Use
+              this to spot domains that are accumulating accounts but aren&apos;t yet blacklisted.
+            </CardDescription>
+          </div>
+          {data && (
+            <div className="flex gap-4 text-sm">
+              <Badge variant="secondary" className="px-3 py-1">
+                {domains.length} {domains.length === 1 ? 'domain' : 'domains'}
+              </Badge>
+              <Badge variant="outline" className="px-3 py-1">
+                <Shield className="mr-1 h-3 w-3" />
+                {blacklistedCount} already blacklisted
+              </Badge>
+            </div>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="text-muted-foreground py-8 text-center text-sm">Loading…</div>
+        ) : domains.length === 0 ? (
+          <div className="text-muted-foreground py-8 text-center">No data</div>
+        ) : (
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Domain</TableHead>
+                  <TableHead className="text-right">Accounts</TableHead>
+                  <TableHead className="text-right">Blocked</TableHead>
+                  <TableHead className="text-right">% Blocked</TableHead>
+                  <TableHead>First seen</TableHead>
+                  <TableHead>Last seen</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {domains.map(domain => (
+                  <TableRow
+                    key={domain.domain}
+                    className={domain.isBlacklisted ? 'bg-muted/60' : undefined}
+                  >
+                    <TableCell>
+                      {domain.isBlacklisted ? (
+                        <Badge variant="secondary" className="gap-1">
+                          <CheckCircle2 className="h-3 w-3" />
+                          Blacklisted
+                        </Badge>
+                      ) : (
+                        <Badge variant="destructive" className="gap-1">
+                          <AlertTriangle className="h-3 w-3" />
+                          Not blacklisted
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell
+                      className={domain.isBlacklisted ? 'text-muted-foreground' : 'font-medium'}
+                    >
+                      <code className="bg-muted rounded px-2 py-1 text-sm">{domain.domain}</code>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {domain.accountCount.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {domain.blockedAccountCount > 0 ? (
+                        <Badge
+                          variant={domain.blockedAccountCount > 100 ? 'destructive' : 'secondary'}
+                        >
+                          {domain.blockedAccountCount.toLocaleString()}
+                        </Badge>
+                      ) : (
+                        <span className="text-muted-foreground">0</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-right text-xs">
+                      {domain.blockedAccountPercent.toFixed(2)}%
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-xs">
+                      {formatTimestamp(domain.firstSeen)}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-xs">
+                      {formatTimestamp(domain.lastSeen)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return '—';
+  return new Date(value).toLocaleDateString();
+}
+
 const tabTriggerClass =
   'text-muted-foreground hover:text-foreground data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none border-b-2 border-transparent px-0 py-3 text-sm font-medium transition-colors data-[state=active]:border-0 data-[state=active]:border-b-2 data-[state=active]:bg-transparent data-[state=active]:shadow-none';
 
@@ -207,12 +321,18 @@ export function BlacklistedDomains() {
         <TabsTrigger value="stats" className={tabTriggerClass}>
           Stats
         </TabsTrigger>
+        <TabsTrigger value="suspicious" className={tabTriggerClass}>
+          Suspicious
+        </TabsTrigger>
       </TabsList>
       <TabsContent value="edit" className="mt-4">
         <EditTab />
       </TabsContent>
       <TabsContent value="stats" className="mt-4">
         {activeTab === 'stats' && <StatsTab />}
+      </TabsContent>
+      <TabsContent value="suspicious" className="mt-4">
+        {activeTab === 'suspicious' && <SuspiciousTab />}
       </TabsContent>
     </Tabs>
   );

--- a/apps/web/src/app/admin/components/BlacklistedDomains.tsx
+++ b/apps/web/src/app/admin/components/BlacklistedDomains.tsx
@@ -207,8 +207,10 @@ function SuspiciousTab() {
           <div>
             <CardTitle>Suspicious Domains</CardTitle>
             <CardDescription>
-              Top 100 registrable domains by blocked account count, then total account count. Use
-              this to spot domains that are accumulating accounts but aren&apos;t yet blacklisted.
+              Top 100 registrable domains by blocked account count, then total account count. Only
+              shows domains where at least 1% of accounts have been blocked, to filter out
+              legitimate high-volume providers. Use this to spot domains that are accumulating abuse
+              but aren&apos;t yet blacklisted.
             </CardDescription>
           </div>
           {data && (

--- a/apps/web/src/routers/admin/blacklist-domains-router.test.ts
+++ b/apps/web/src/routers/admin/blacklist-domains-router.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeEach } from '@jest/globals';
 import { cleanupDbForTest } from '@/lib/drizzle';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createCallerForUser } from '@/routers/test-utils';
-import { isDomainOnBlacklist } from './blacklist-domains-router';
+import { computeBlacklistStats, isDomainOnBlacklist } from './blacklist-domains-router';
 import type { User } from '@kilocode/db/schema';
 
 let admin: User;
@@ -41,6 +41,105 @@ describe('isDomainOnBlacklist', () => {
 
   it('returns false on empty blacklist', () => {
     expect(isDomainOnBlacklist('anything.com', [])).toBe(false);
+  });
+});
+
+describe('computeBlacklistStats', () => {
+  it('sums per-email_domain counts for each blacklist entry by exact match', () => {
+    const stats = computeBlacklistStats(
+      ['mailinator.com', 'spam.org'],
+      [
+        { email_domain: 'mailinator.com', count: 12 },
+        { email_domain: 'spam.org', count: 5 },
+        { email_domain: 'legit.com', count: 99 },
+      ]
+    );
+
+    expect(stats.domains).toEqual([
+      { domain: 'mailinator.com', blockedCount: 12 },
+      { domain: 'spam.org', blockedCount: 5 },
+    ]);
+    expect(stats.totalDomains).toBe(2);
+    expect(stats.totalBlockedUsers).toBe(17);
+  });
+
+  it('includes subdomain groups in the count for a blacklist entry', () => {
+    const stats = computeBlacklistStats(
+      ['mailinator.com'],
+      [
+        { email_domain: 'mailinator.com', count: 4 },
+        { email_domain: 'evil.mailinator.com', count: 3 },
+        { email_domain: 'a.b.mailinator.com', count: 2 },
+        { email_domain: 'notmailinator.com', count: 100 },
+      ]
+    );
+
+    expect(stats.domains).toEqual([{ domain: 'mailinator.com', blockedCount: 9 }]);
+    expect(stats.totalBlockedUsers).toBe(9);
+  });
+
+  it('orders result by blockedCount descending', () => {
+    const stats = computeBlacklistStats(
+      ['first.com', 'second.com', 'third.com'],
+      [
+        { email_domain: 'first.com', count: 1 },
+        { email_domain: 'second.com', count: 10 },
+        { email_domain: 'third.com', count: 5 },
+      ]
+    );
+
+    expect(stats.domains.map(d => d.domain)).toEqual(['second.com', 'third.com', 'first.com']);
+  });
+
+  it('ignores rows with null email_domain', () => {
+    const stats = computeBlacklistStats(
+      ['mailinator.com'],
+      [
+        { email_domain: null, count: 999 },
+        { email_domain: 'mailinator.com', count: 3 },
+      ]
+    );
+
+    expect(stats.domains).toEqual([{ domain: 'mailinator.com', blockedCount: 3 }]);
+  });
+
+  it('returns zero-count entries for blacklist entries with no matching users', () => {
+    const stats = computeBlacklistStats(['unused.com'], [{ email_domain: 'other.com', count: 10 }]);
+
+    expect(stats.domains).toEqual([{ domain: 'unused.com', blockedCount: 0 }]);
+    expect(stats.totalBlockedUsers).toBe(0);
+  });
+
+  it('returns empty stats for an empty blacklist', () => {
+    const stats = computeBlacklistStats([], [{ email_domain: 'anything.com', count: 5 }]);
+
+    expect(stats.domains).toEqual([]);
+    expect(stats.totalDomains).toBe(0);
+    expect(stats.totalBlockedUsers).toBe(0);
+  });
+});
+
+describe('admin.blacklistDomains.stats', () => {
+  it('returns structurally valid shape (empty blacklist → empty domain list)', async () => {
+    await insertTestUser({
+      google_user_email: 'a@example.com',
+      email_domain: 'example.com',
+    });
+
+    const caller = await createCallerForUser(admin.id);
+    const stats = await caller.admin.blacklistDomains.stats();
+
+    expect(stats).toMatchObject({
+      domains: expect.any(Array),
+      totalDomains: expect.any(Number),
+      totalBlockedUsers: expect.any(Number),
+    });
+    // With BLACKLIST_DOMAINS unset in the test env and redis unavailable,
+    // the procedure sees an empty blacklist and returns an empty per-domain
+    // breakdown regardless of how many users exist.
+    expect(stats.domains).toEqual([]);
+    expect(stats.totalDomains).toBe(0);
+    expect(stats.totalBlockedUsers).toBe(0);
   });
 });
 

--- a/apps/web/src/routers/admin/blacklist-domains-router.test.ts
+++ b/apps/web/src/routers/admin/blacklist-domains-router.test.ts
@@ -186,27 +186,66 @@ describe('admin.blacklistDomains.suspicious', () => {
   });
 
   it('orders rows by blocked_account_count desc then account_count desc', async () => {
-    for (let i = 0; i < 5; i++) {
+    // more-blocked.com: 2 of 4 blocked (50%)
+    for (let i = 0; i < 2; i++) {
       await insertTestUser({
-        google_user_email: `u${i}@more-users.com`,
-        email_domain: 'more-users.com',
+        google_user_email: `u${i}@more-blocked.com`,
+        email_domain: 'more-blocked.com',
       });
     }
     for (let i = 0; i < 2; i++) {
       await insertTestUser({
-        google_user_email: `u${i}@fewer-users-but-blocked.com`,
-        email_domain: 'fewer-users-but-blocked.com',
+        google_user_email: `b${i}@more-blocked.com`,
+        email_domain: 'more-blocked.com',
         blocked_reason: 'abuse',
       });
     }
+    // fewer-blocked.com: 1 of 2 blocked (50%)
+    await insertTestUser({
+      google_user_email: 'u@fewer-blocked.com',
+      email_domain: 'fewer-blocked.com',
+    });
+    await insertTestUser({
+      google_user_email: 'b@fewer-blocked.com',
+      email_domain: 'fewer-blocked.com',
+      blocked_reason: 'abuse',
+    });
 
     const caller = await createCallerForUser(admin.id);
     const { domains } = await caller.admin.blacklistDomains.suspicious();
 
     const ordered = domains.map(d => d.domain);
-    expect(ordered.indexOf('fewer-users-but-blocked.com')).toBeLessThan(
-      ordered.indexOf('more-users.com')
-    );
+    expect(ordered.indexOf('more-blocked.com')).toBeLessThan(ordered.indexOf('fewer-blocked.com'));
+  });
+
+  it('hides domains with fewer than 1% of accounts blocked', async () => {
+    // noisy.com: 99 clean users + 0 blocked → 0% → filtered out
+    for (let i = 0; i < 99; i++) {
+      await insertTestUser({
+        google_user_email: `u${i}@noisy.com`,
+        email_domain: 'noisy.com',
+      });
+    }
+    // just-under.com: 99 clean + 0 blocked → filtered out (0%)
+    // over-threshold.com: 99 clean + 1 blocked → 1% → surfaced
+    for (let i = 0; i < 99; i++) {
+      await insertTestUser({
+        google_user_email: `u${i}@over-threshold.com`,
+        email_domain: 'over-threshold.com',
+      });
+    }
+    await insertTestUser({
+      google_user_email: 'b@over-threshold.com',
+      email_domain: 'over-threshold.com',
+      blocked_reason: 'abuse',
+    });
+
+    const caller = await createCallerForUser(admin.id);
+    const { domains } = await caller.admin.blacklistDomains.suspicious();
+
+    const names = domains.map(d => d.domain);
+    expect(names).toContain('over-threshold.com');
+    expect(names).not.toContain('noisy.com');
   });
 
   it('excludes users whose email_domain is NULL', async () => {
@@ -225,6 +264,7 @@ describe('admin.blacklistDomains.suspicious', () => {
     await insertTestUser({
       google_user_email: 'a@example.com',
       email_domain: 'example.com',
+      blocked_reason: 'abuse',
     });
 
     const caller = await createCallerForUser(admin.id);

--- a/apps/web/src/routers/admin/blacklist-domains-router.test.ts
+++ b/apps/web/src/routers/admin/blacklist-domains-router.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import { cleanupDbForTest } from '@/lib/drizzle';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { createCallerForUser } from '@/routers/test-utils';
+import { isDomainOnBlacklist } from './blacklist-domains-router';
+import type { User } from '@kilocode/db/schema';
+
+let admin: User;
+
+beforeEach(async () => {
+  await cleanupDbForTest();
+  admin = await insertTestUser({
+    google_user_email: `admin-${Math.random()}@admin.example.com`,
+    is_admin: true,
+  });
+});
+
+describe('isDomainOnBlacklist', () => {
+  it('matches exact equality', () => {
+    expect(isDomainOnBlacklist('mailinator.com', ['mailinator.com'])).toBe(true);
+  });
+
+  it('matches subdomains of blacklist entries', () => {
+    expect(isDomainOnBlacklist('evil.mailinator.com', ['mailinator.com'])).toBe(true);
+    expect(isDomainOnBlacklist('a.b.mailinator.com', ['mailinator.com'])).toBe(true);
+  });
+
+  it('is case-insensitive on the domain side', () => {
+    expect(isDomainOnBlacklist('MAILINATOR.COM', ['mailinator.com'])).toBe(true);
+  });
+
+  it('does not match unrelated domains', () => {
+    expect(isDomainOnBlacklist('legit.com', ['mailinator.com'])).toBe(false);
+  });
+
+  it('does not match on label-boundary mismatch', () => {
+    // 'notmailinator.com' should not match 'mailinator.com' just because the
+    // latter is a suffix of the former as a raw string.
+    expect(isDomainOnBlacklist('notmailinator.com', ['mailinator.com'])).toBe(false);
+  });
+
+  it('returns false on empty blacklist', () => {
+    expect(isDomainOnBlacklist('anything.com', [])).toBe(false);
+  });
+});
+
+describe('admin.blacklistDomains.suspicious', () => {
+  it('aggregates user counts by email_domain and returns blocked counts and percent', async () => {
+    await insertTestUser({
+      google_user_email: 'a@example.com',
+      email_domain: 'example.com',
+    });
+    await insertTestUser({
+      google_user_email: 'b@example.com',
+      email_domain: 'example.com',
+    });
+    await insertTestUser({
+      google_user_email: 'c@example.com',
+      email_domain: 'example.com',
+      blocked_reason: 'abuse',
+    });
+    await insertTestUser({
+      google_user_email: 'x@spam.org',
+      email_domain: 'spam.org',
+      blocked_reason: 'abuse',
+    });
+    await insertTestUser({
+      google_user_email: 'y@spam.org',
+      email_domain: 'spam.org',
+      blocked_reason: 'abuse',
+    });
+
+    const caller = await createCallerForUser(admin.id);
+    const { domains } = await caller.admin.blacklistDomains.suspicious();
+
+    const byDomain = Object.fromEntries(domains.map(d => [d.domain, d]));
+    expect(byDomain['example.com']).toMatchObject({
+      accountCount: 3,
+      blockedAccountCount: 1,
+      blockedAccountPercent: 33.33,
+    });
+    expect(byDomain['spam.org']).toMatchObject({
+      accountCount: 2,
+      blockedAccountCount: 2,
+      blockedAccountPercent: 100,
+    });
+  });
+
+  it('orders rows by blocked_account_count desc then account_count desc', async () => {
+    for (let i = 0; i < 5; i++) {
+      await insertTestUser({
+        google_user_email: `u${i}@more-users.com`,
+        email_domain: 'more-users.com',
+      });
+    }
+    for (let i = 0; i < 2; i++) {
+      await insertTestUser({
+        google_user_email: `u${i}@fewer-users-but-blocked.com`,
+        email_domain: 'fewer-users-but-blocked.com',
+        blocked_reason: 'abuse',
+      });
+    }
+
+    const caller = await createCallerForUser(admin.id);
+    const { domains } = await caller.admin.blacklistDomains.suspicious();
+
+    const ordered = domains.map(d => d.domain);
+    expect(ordered.indexOf('fewer-users-but-blocked.com')).toBeLessThan(
+      ordered.indexOf('more-users.com')
+    );
+  });
+
+  it('excludes users whose email_domain is NULL', async () => {
+    await insertTestUser({
+      google_user_email: 'a@example.com',
+      email_domain: null,
+    });
+
+    const caller = await createCallerForUser(admin.id);
+    const { domains } = await caller.admin.blacklistDomains.suspicious();
+
+    expect(domains).toHaveLength(0);
+  });
+
+  it('returns first_seen and last_seen timestamps', async () => {
+    await insertTestUser({
+      google_user_email: 'a@example.com',
+      email_domain: 'example.com',
+    });
+
+    const caller = await createCallerForUser(admin.id);
+    const { domains } = await caller.admin.blacklistDomains.suspicious();
+
+    const example = domains.find(d => d.domain === 'example.com');
+    expect(example).toBeDefined();
+    expect(typeof example!.firstSeen).toBe('string');
+    expect(typeof example!.lastSeen).toBe('string');
+  });
+});

--- a/apps/web/src/routers/admin/blacklist-domains-router.ts
+++ b/apps/web/src/routers/admin/blacklist-domains-router.ts
@@ -72,6 +72,10 @@ export const adminBlacklistDomainsRouter = createTRPCRouter({
     const normalizedBlacklist = blacklistedDomains.map(d => d.toLowerCase());
 
     const blockedCountExpr = sql<number>`count(*) FILTER (WHERE ${kilocode_users.blocked_reason} IS NOT NULL)`;
+    // Hide noise: require at least 1% of users on the domain to have been
+    // blocked before surfacing it. Computed against count(*) so a one-off
+    // block on a huge domain doesn't appear here.
+    const minBlockedPercent = sql`${blockedCountExpr} * 100 >= count(*)`;
 
     const rows = await db
       .select({
@@ -84,6 +88,7 @@ export const adminBlacklistDomainsRouter = createTRPCRouter({
       .from(kilocode_users)
       .where(isNotNull(kilocode_users.email_domain))
       .groupBy(kilocode_users.email_domain)
+      .having(minBlockedPercent)
       .orderBy(desc(blockedCountExpr), desc(count()))
       .limit(100);
 

--- a/apps/web/src/routers/admin/blacklist-domains-router.ts
+++ b/apps/web/src/routers/admin/blacklist-domains-router.ts
@@ -11,7 +11,7 @@ import type { BlacklistDomainsConfig } from '@/lib/blacklist-domains-config';
 import { TRPCError } from '@trpc/server';
 import { db } from '@/lib/drizzle';
 import { kilocode_users } from '@kilocode/db/schema';
-import { sql, count, or } from 'drizzle-orm';
+import { sql, count, isNotNull, or, desc, min, max } from 'drizzle-orm';
 
 async function readConfig(): Promise<BlacklistDomainsConfig> {
   try {
@@ -77,4 +77,49 @@ export const adminBlacklistDomainsRouter = createTRPCRouter({
       totalBlockedUsers: domainCounts.reduce((sum, d) => sum + d.blockedCount, 0),
     };
   }),
+
+  suspicious: adminProcedure.query(async () => {
+    const blacklistedDomains = await getBlacklistedDomains();
+    const normalizedBlacklist = blacklistedDomains.map(d => d.toLowerCase());
+
+    const blockedCountExpr = sql<number>`count(*) FILTER (WHERE ${kilocode_users.blocked_reason} IS NOT NULL)`;
+
+    const rows = await db
+      .select({
+        email_domain: kilocode_users.email_domain,
+        account_count: count(),
+        blocked_account_count: blockedCountExpr.mapWith(Number),
+        first_seen: min(kilocode_users.created_at),
+        last_seen: max(kilocode_users.created_at),
+      })
+      .from(kilocode_users)
+      .where(isNotNull(kilocode_users.email_domain))
+      .groupBy(kilocode_users.email_domain)
+      .orderBy(desc(blockedCountExpr), desc(count()))
+      .limit(100);
+
+    const domains = rows.map(row => ({
+      domain: row.email_domain ?? '',
+      accountCount: row.account_count,
+      blockedAccountCount: row.blocked_account_count,
+      blockedAccountPercent:
+        row.account_count === 0
+          ? 0
+          : Math.round((10000 * row.blocked_account_count) / row.account_count) / 100,
+      firstSeen: row.first_seen,
+      lastSeen: row.last_seen,
+      isBlacklisted: isDomainOnBlacklist(row.email_domain ?? '', normalizedBlacklist),
+    }));
+
+    return { domains };
+  }),
 });
+
+// Mirrors the suffix semantics of isEmailBlacklistedByDomain, but operates
+// directly on a domain string (e.g. the value stored in email_domain). A
+// blacklist entry matches a domain when the domain equals it or is a
+// subdomain of it.
+export function isDomainOnBlacklist(domain: string, normalizedBlacklist: string[]): boolean {
+  const lower = domain.toLowerCase();
+  return normalizedBlacklist.some(entry => lower === entry || lower.endsWith('.' + entry));
+}

--- a/apps/web/src/routers/admin/blacklist-domains-router.ts
+++ b/apps/web/src/routers/admin/blacklist-domains-router.ts
@@ -11,7 +11,7 @@ import type { BlacklistDomainsConfig } from '@/lib/blacklist-domains-config';
 import { TRPCError } from '@trpc/server';
 import { db } from '@/lib/drizzle';
 import { kilocode_users } from '@kilocode/db/schema';
-import { sql, count, isNotNull, or, desc, min, max } from 'drizzle-orm';
+import { sql, count, isNotNull, desc, min, max } from 'drizzle-orm';
 
 async function readConfig(): Promise<BlacklistDomainsConfig> {
   try {
@@ -53,29 +53,18 @@ export const adminBlacklistDomainsRouter = createTRPCRouter({
   stats: adminProcedure.query(async () => {
     const domains = await getBlacklistedDomains();
 
-    const domainCounts = await Promise.all(
-      domains.map(async domain => {
-        const conditions = or(
-          sql`lower(${kilocode_users.google_user_email}) LIKE ${`%@${domain.toLowerCase()}`}`,
-          sql`lower(${kilocode_users.google_user_email}) LIKE ${`%.${domain.toLowerCase()}`}`
-        );
-
-        const result = await db.select({ count: count() }).from(kilocode_users).where(conditions);
-
-        return {
-          domain,
-          blockedCount: result[0]?.count ?? 0,
-        };
+    // One grouped query against the indexed email_domain column rather than
+    // an N+1 LIKE scan of google_user_email per blacklist entry.
+    const emailDomainCounts = await db
+      .select({
+        email_domain: kilocode_users.email_domain,
+        count: count(),
       })
-    );
+      .from(kilocode_users)
+      .where(isNotNull(kilocode_users.email_domain))
+      .groupBy(kilocode_users.email_domain);
 
-    domainCounts.sort((a, b) => b.blockedCount - a.blockedCount);
-
-    return {
-      domains: domainCounts,
-      totalDomains: domains.length,
-      totalBlockedUsers: domainCounts.reduce((sum, d) => sum + d.blockedCount, 0),
-    };
+    return computeBlacklistStats(domains, emailDomainCounts);
   }),
 
   suspicious: adminProcedure.query(async () => {
@@ -122,4 +111,44 @@ export const adminBlacklistDomainsRouter = createTRPCRouter({
 export function isDomainOnBlacklist(domain: string, normalizedBlacklist: string[]): boolean {
   const lower = domain.toLowerCase();
   return normalizedBlacklist.some(entry => lower === entry || lower.endsWith('.' + entry));
+}
+
+export type EmailDomainCount = { email_domain: string | null; count: number };
+
+export type BlacklistStats = {
+  domains: { domain: string; blockedCount: number }[];
+  totalDomains: number;
+  totalBlockedUsers: number;
+};
+
+/**
+ * Aggregates per-email_domain counts into per-blacklist-entry blocked counts.
+ *
+ * For each blacklist entry, sums the counts of email_domain groups that match
+ * it via isDomainOnBlacklist (equality or strict subdomain). This preserves
+ * the original suffix-match semantics of the old google_user_email LIKE query
+ * while scanning only the grouped result set.
+ */
+export function computeBlacklistStats(
+  blacklistedDomains: string[],
+  emailDomainCounts: readonly EmailDomainCount[]
+): BlacklistStats {
+  const domainCounts = blacklistedDomains.map(domain => {
+    const entry = domain.toLowerCase();
+    let blockedCount = 0;
+    for (const row of emailDomainCounts) {
+      if (row.email_domain !== null && isDomainOnBlacklist(row.email_domain, [entry])) {
+        blockedCount += row.count;
+      }
+    }
+    return { domain, blockedCount };
+  });
+
+  domainCounts.sort((a, b) => b.blockedCount - a.blockedCount);
+
+  return {
+    domains: domainCounts,
+    totalDomains: blacklistedDomains.length,
+    totalBlockedUsers: domainCounts.reduce((sum, d) => sum + d.blockedCount, 0),
+  };
 }


### PR DESCRIPTION
## Summary

- Adds a third tab next to **Edit** / **Stats** on `/admin/blacklisted-domains` called **Suspicious**.
- The tab shows the top 100 registrable domains by blocked-account count (then total account count), driven by the `email_domain` column from #2547. For each row it shows whether the domain is already covered by the current blacklist — blacklisted rows are visually muted with a `Shield` badge, non-blacklisted rows carry a destructive `AlertTriangle` badge.
- The goal is to surface domains that are accumulating accounts but aren't on the blacklist yet, without scanning `google_user_email` at query time.

## Verification

- `pnpm typecheck` — clean.
- `pnpm lint` — 0 warnings, 0 errors.
- `pnpm format` — applied.
- `pnpm --filter web test -- src/routers/admin/blacklist-domains-router.test.ts` — 10 tests, all pass. Cover the aggregation (counts, percent, order), null-domain exclusion, timestamp shape, and every branch of `isDomainOnBlacklist` (equality, subdomain match, case-insensitivity, label-boundary guard so `notmailinator.com` does not match `mailinator.com`, empty blacklist).

## Visual Changes

Adds one tab with a table:

| Status | Domain | Accounts | Blocked | % Blocked | First seen | Last seen |
|---|---|---|---|---|---|---|
| `AlertTriangle` Not blacklisted | `mailinator.com` | 142 | 9 | 6.34% | 2025-11-02 | 2026-04-12 |
| `Shield` Blacklisted (muted row) | `example.com` | 85 | 85 | 100% | 2025-08-14 | 2026-03-30 |

## Reviewer Notes

- Query shape: `SELECT email_domain, count(*), count(*) FILTER (WHERE blocked_reason IS NOT NULL), min/max(created_at) FROM kilocode_users WHERE email_domain IS NOT NULL GROUP BY email_domain ORDER BY blocked_count DESC, count DESC LIMIT 100`. The `FILTER` expression is extracted into a `const` so the same SQL fragment is reused in `select` and `orderBy` without drift.
- `isDomainOnBlacklist` is exported for testability. It mirrors `isEmailBlacklistedByDomain` in `user.server.ts:960` but matches on a raw domain string: `lower === entry || lower.endsWith('.' + entry)`.
- The existing `Stats` tab still uses `google_user_email LIKE '%@...'` / `LIKE '%....'`. Keeping it that way is intentional for now — switching `Stats` to `email_domain` can be a follow-up once backfill of the column is confirmed complete in prod.
