### PR TITLE
feat(security-advisor): suppress KiloClaw mitigated findings

### DIFF
--- a/apps/web/src/lib/security-advisor/__tests__/report-generator.test.ts
+++ b/apps/web/src/lib/security-advisor/__tests__/report-generator.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from '@jest/globals';
 import { generateSecurityReport } from '../report-generator';
 import type { AuditFinding, SecurityAdvisorRequest } from '../schemas';
 import type { LoadedSecurityAdvisorContent } from '../content-loader';
+import { KILOCLAW_MITIGATED_CHECKS } from '../kiloclaw-mitigations';
 
 /**
  * Build a test fixture that mirrors the seeded DB content.
@@ -439,6 +440,107 @@ describe('generateSecurityReport', () => {
       });
 
       expect(report.findings[0]!.risk).toBe('Review this finding: Something was reported');
+    });
+  });
+
+  describe('KiloClaw-mitigated finding suppression', () => {
+    // The list lives in kiloclaw-mitigations.ts. These tests guard filtering
+    // BEHAVIOR (dropped from rendered findings, not counted in grade,
+    // disclosure note rendered) — test inputs are derived from the live
+    // KILOCLAW_MITIGATED_CHECKS map so adding or removing entries doesn't
+    // silently break assertions here.
+    const MITIGATED_IDS = Array.from(KILOCLAW_MITIGATED_CHECKS.keys());
+    const MITIGATED_EXAMPLE = MITIGATED_IDS[0]!;
+    const NOT_MITIGATED_EXAMPLE = 'tools.exec.security_full_configured';
+
+    function auditWith(checkIds: string[]): SecurityAdvisorRequest['audit'] {
+      return {
+        ts: 1,
+        summary: { critical: 0, warn: checkIds.length, info: 0 },
+        findings: checkIds.map((id, i) => ({
+          checkId: id,
+          severity: 'warn' as const,
+          title: `t${i}`,
+          detail: `d${i}`,
+          remediation: null,
+        })),
+      };
+    }
+
+    it('drops mitigated findings on KiloClaw and excludes them from the grade', () => {
+      const content = buildTestContent();
+      const report = generateSecurityReport({
+        audit: auditWith([MITIGATED_EXAMPLE, NOT_MITIGATED_EXAMPLE]),
+        isKiloClaw: true,
+        content,
+      });
+
+      // Only the non-mitigated finding survives into the rendered findings.
+      expect(report.findings).toHaveLength(1);
+      expect(report.findings[0]!.checkId).toBe(NOT_MITIGATED_EXAMPLE);
+
+      // Grade is computed on the filtered count (1 warn, not 2).
+      expect(report.score).toBe(96);
+      expect(report.grade).toBe('A');
+    });
+
+    it('keeps the same finding visible on self-hosted OpenClaw', () => {
+      const content = buildTestContent();
+      const report = generateSecurityReport({
+        audit: auditWith([MITIGATED_EXAMPLE, NOT_MITIGATED_EXAMPLE]),
+        isKiloClaw: false,
+        content,
+      });
+
+      // Nothing is suppressed for OpenClaw — both findings are real issues there.
+      expect(report.findings).toHaveLength(2);
+      expect(report.markdown).not.toContain('hidden');
+      expect(report.score).toBe(92);
+    });
+
+    it('renders a disclosure note when any findings are suppressed', () => {
+      const content = buildTestContent();
+      const report = generateSecurityReport({
+        audit: auditWith([MITIGATED_EXAMPLE, NOT_MITIGATED_EXAMPLE]),
+        isKiloClaw: true,
+        content,
+      });
+
+      // Plural-aware message, references external mitigation, not silent.
+      expect(report.markdown).toContain('1 additional finding hidden');
+      expect(report.markdown).toContain("KiloClaw's managed infrastructure");
+      expect(report.markdown).toContain('Not counted toward the grade');
+    });
+
+    it('pluralizes the disclosure note correctly for multiple suppressions', () => {
+      // Guard: this test specifically exercises the plural branch, so it
+      // requires >=2 entries in the live list. If the list ever shrinks to
+      // 1, fail loudly here with a clear pointer rather than silently
+      // asserting against the wrong message.
+      expect(MITIGATED_IDS.length).toBeGreaterThanOrEqual(2);
+
+      const content = buildTestContent();
+      const report = generateSecurityReport({
+        audit: auditWith(MITIGATED_IDS),
+        isKiloClaw: true,
+        content,
+      });
+
+      expect(report.markdown).toContain(`${MITIGATED_IDS.length} additional findings hidden`);
+      expect(report.findings).toHaveLength(0);
+      expect(report.grade).toBe('A'); // All findings suppressed → clean 100.
+    });
+
+    it('omits the disclosure note entirely when nothing was suppressed', () => {
+      const content = buildTestContent();
+      const report = generateSecurityReport({
+        audit: auditWith([NOT_MITIGATED_EXAMPLE]),
+        isKiloClaw: true,
+        content,
+      });
+
+      expect(report.markdown).not.toContain('hidden');
+      expect(report.markdown).not.toContain('additional finding');
     });
   });
 

--- a/apps/web/src/lib/security-advisor/kiloclaw-mitigations.ts
+++ b/apps/web/src/lib/security-advisor/kiloclaw-mitigations.ts
@@ -1,0 +1,83 @@
+/**
+ * KiloClaw-mitigated checkIds — false positives on the KiloClaw platform.
+ *
+ * When a security advisor report originates from a KiloClaw-hosted instance
+ * (source.platform === 'kiloclaw'), the following findings are suppressed
+ * BEFORE the report is rendered AND BEFORE the grade is computed. They still
+ * appear in raw audit data, but the user never sees them and they do not
+ * count against the overall score.
+ *
+ * Why suppress rather than just annotate? Each of these findings is a genuine
+ * issue on a generic self-hosted OpenClaw instance — the OpenClaw audit tool
+ * detects them correctly. On KiloClaw they are mitigated by infrastructure
+ * the audit tool cannot see from inside the gateway process: Fly.io's edge
+ * proxy, Fly's private network between edge and gateway, and product design
+ * choices that intentionally scope certain settings. The gateway auditor
+ * legitimately cannot tell the difference between "unsafe config, exposed to
+ * the internet" and "unsafe-looking config, fronted by a managed proxy on a
+ * private network." We have that external context and the audit doesn't, so
+ * we filter.
+ *
+ * This repo is public. The rationale for each suppression is documented
+ * inline below and surfaced to the end user via a short note in the report
+ * ("N findings hidden: mitigated externally by KiloClaw's infrastructure…")
+ * so nothing is silently swept under the rug.
+ *
+ * Keep this list minimal. Only add a checkId here when the mitigation is
+ * genuinely external and architectural, not when it's merely inconvenient
+ * to explain. A finding that reflects a real operator choice (e.g.
+ * `tools.exec.security_full_configured` when someone opts into `full` trust)
+ * must stay visible and affect the grade regardless of platform.
+ */
+export const KILOCLAW_MITIGATED_CHECKS: ReadonlyMap<string, string> = new Map([
+  [
+    'gateway.trusted_proxies_missing',
+    // Gateway is bound loopback-only on KiloClaw. Fly's edge proxy sits at
+    // the network boundary in front of the machine, not behind the gateway
+    // process. The gateway therefore never receives X-Forwarded-For headers
+    // from an external caller — there is no proxy-spoofing path to close.
+    // The finding assumes a standard reverse-proxy deployment topology that
+    // does not apply.
+    'Gateway runs on loopback only; Fly edge terminates at the network boundary, not behind the gateway.',
+  ],
+  [
+    'gateway.control_ui.insecure_auth',
+    // `allowInsecureAuth=true` is set when AUTO_APPROVE_DEVICES=true on
+    // KiloClaw's provisioning flow. In the KiloClaw deployment model TLS
+    // terminates at the Fly edge; the hop between edge and the gateway
+    // rides Fly's private network, not the public internet. The credential
+    // never crosses an untrusted link, so the "plaintext auth in transit"
+    // risk that this check guards against does not exist here.
+    "TLS terminates at the Fly edge; the edge-to-gateway hop is on Fly's private network.",
+  ],
+  [
+    'config.insecure_or_dangerous_flags',
+    // This is a meta-check that fires because of `allowInsecureAuth` above.
+    // On KiloClaw it surfaces the same architectural choice twice in the
+    // report. Suppressing it here avoids the duplicate; if a different
+    // dangerous flag ever shows up and also happens to be mitigated, that
+    // flag's own specific checkId would need its own entry here with its
+    // own rationale.
+    'Fires because of gateway.control_ui.insecure_auth above; same architectural choice, suppressed to avoid a duplicate finding.',
+  ],
+  [
+    'plugins.tools_reachable_permissive_policy',
+    // KiloClaw's product experience (Telegram, Discord, Slack, web-search
+    // bots, etc.) intentionally allows plugin-provided tools from the
+    // default agent profile — that's how bots invoke their capabilities.
+    // Restricting the default profile to block plugin tools would break
+    // the core bot workflow. This is a deliberate product design choice,
+    // not a misconfiguration.
+    'Default profile intentionally reaches plugin tools so bots (Telegram/Discord/Slack/web-search) can invoke their capabilities.',
+  ],
+]);
+
+/**
+ * True if `checkId` is in the KiloClaw-mitigated list. The caller is
+ * responsible for only invoking this when the scan actually originated
+ * from a KiloClaw-hosted instance — the same findings are real issues on
+ * self-hosted OpenClaw and must NOT be filtered there.
+ */
+export function isKiloClawMitigated(checkId: string): boolean {
+  return KILOCLAW_MITIGATED_CHECKS.has(checkId);
+}

--- a/apps/web/src/lib/security-advisor/report-generator.ts
+++ b/apps/web/src/lib/security-advisor/report-generator.ts
@@ -8,6 +8,7 @@ import type {
   ReportGrade,
 } from './schemas';
 import { findCoverageForCheckId, type LoadedSecurityAdvisorContent } from './content-loader';
+import { isKiloClawMitigated } from './kiloclaw-mitigations';
 
 // --- Grading ---
 
@@ -59,7 +60,15 @@ interface GeneratedReport {
 export function generateSecurityReport(options: GenerateReportOptions): GeneratedReport {
   const { audit, publicIp, isKiloClaw, content } = options;
 
-  const findings = audit.findings.map(f => mapFinding(f, isKiloClaw, content));
+  // On KiloClaw, drop findings that are architecturally mitigated by the
+  // managed infrastructure before grading + rendering. See
+  // kiloclaw-mitigations.ts for the list and rationale per checkId.
+  const activeRawFindings = isKiloClaw
+    ? audit.findings.filter(f => !isKiloClawMitigated(f.checkId))
+    : audit.findings;
+  const suppressedCount = audit.findings.length - activeRawFindings.length;
+
+  const findings = activeRawFindings.map(f => mapFinding(f, isKiloClaw, content));
   const recommendations = generateRecommendations(findings, content);
 
   // Count passed deep-scan checks. Only deep scan results have a clear pass/fail
@@ -72,7 +81,8 @@ export function generateSecurityReport(options: GenerateReportOptions): Generate
 
   // Recompute severity counts from server-mapped findings, not client-reported
   // summary. Server may have overridden severity for known checkIds, so the
-  // client's counts can't be trusted.
+  // client's counts can't be trusted. These counts reflect findings the user
+  // actually sees (post-suppression) so they align with the rendered report.
   const summary = {
     critical: findings.filter(f => f.severity === 'critical').length,
     warn: findings.filter(f => f.severity === 'warn').length,
@@ -90,6 +100,7 @@ export function generateSecurityReport(options: GenerateReportOptions): Generate
     grade,
     publicIp,
     isKiloClaw,
+    suppressedCount,
     content,
   });
 
@@ -230,11 +241,23 @@ interface RenderOptions {
   grade: ReportGrade;
   publicIp?: string;
   isKiloClaw: boolean;
+  /** How many findings were dropped by KiloClaw-mitigation filtering. 0 on OpenClaw. */
+  suppressedCount: number;
   content: LoadedSecurityAdvisorContent;
 }
 
 function renderMarkdown(opts: RenderOptions): string {
-  const { findings, recommendations, summary, score, grade, publicIp, isKiloClaw, content } = opts;
+  const {
+    findings,
+    recommendations,
+    summary,
+    score,
+    grade,
+    publicIp,
+    isKiloClaw,
+    suppressedCount,
+    content,
+  } = opts;
   const get = (key: string, fallback: string) => getContent(content, key, fallback);
   const lines: string[] = [];
 
@@ -267,6 +290,18 @@ function renderMarkdown(opts: RenderOptions): string {
   }
   lines.push(parts.join(' | '));
   lines.push('');
+
+  // KiloClaw-mitigation disclosure: when findings have been suppressed because
+  // KiloClaw's managed infrastructure already mitigates them externally, tell
+  // the user instead of silently hiding them. See kiloclaw-mitigations.ts for
+  // the full list + per-finding rationale.
+  if (suppressedCount > 0) {
+    const noun = suppressedCount === 1 ? 'finding' : 'findings';
+    lines.push(
+      `_${suppressedCount} additional ${noun} hidden: KiloClaw's managed infrastructure mitigates ${suppressedCount === 1 ? 'it' : 'them'} externally via controls the in-gateway audit cannot detect (edge TLS, private networking, product-scoped tool policies). Not counted toward the grade._`
+    );
+    lines.push('');
+  }
 
   if (publicIp) {
     lines.push(`**Public IP:** \`${publicIp}\``);


### PR DESCRIPTION
## Summary

On KiloClaw instances, four OpenClaw audit findings represent risks that are mitigated externally by KiloClaw's managed infrastructure in ways the in gateway auditor cannot see:

    - gateway.trusted_proxies_missing
    - gateway.control_ui.insecure_auth
    - config.insecure_or_dangerous_flags
    - plugins.tools_reachable_permissive_policy

The plugin still reports these for transparency, but server side, suppress them with a note as to why. For full transparency.

## Verification

- [x] Linters
- [x] local e2e testing

## Visual Changes

The report may now include a small note such as the following
```
2 additional findings hidden: KiloClaw's managed infrastructure mitigates them externally via controls the 
in-gateway audit cannot detect (edge TLS, private networking, product-scoped tool policies). Not counted toward the grade.
```


## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
