### PR TITLE
feat(kiloclaw): add subscription alignment tooling

### DIFF
--- a/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
@@ -67,7 +67,7 @@ describe('kiloclaw-subscription-alignment script', () => {
       throw new Error('Expected canonical subscription row');
     }
 
-    await run('apply-duplicates');
+    await run('apply-duplicates', '--confirm-sandboxes-destroyed');
 
     const [olderInstance, canonicalInstance] = await db
       .select()
@@ -383,7 +383,7 @@ describe('kiloclaw-subscription-alignment script', () => {
     );
   });
 
-  it('backfills baseline snapshot for subscription that has only mutation logs', async () => {
+  it('backfills baseline from earliest mutation before_state to preserve audit replay', async () => {
     const user = await insertTestUser({
       google_user_email: 'mutation-only-logs@example.com',
     });
@@ -395,13 +395,15 @@ describe('kiloclaw-subscription-alignment script', () => {
       sandbox_id: `ki_${instanceId.replaceAll('-', '')}`,
     });
 
+    // Current state is a post-past_due row; the subscription's initial state
+    // (captured in the earliest mutation's before_state) was still trialing.
     const [subscription] = await db
       .insert(kiloclaw_subscriptions)
       .values({
         user_id: user.id,
         instance_id: instanceId,
         plan: 'trial',
-        status: 'trialing',
+        status: 'past_due',
         cancel_at_period_end: false,
         trial_started_at: '2026-04-01T00:00:00.000Z',
         trial_ends_at: '2026-04-08T00:00:00.000Z',
@@ -412,15 +414,15 @@ describe('kiloclaw-subscription-alignment script', () => {
       throw new Error('Expected subscription row');
     }
 
-    // Simulate a legacy subscription created before changelog rollout whose only
-    // log entries are post-creation mutations (before_state is non-null).
+    const initialState = { ...subscription, status: 'trialing' };
     await db.insert(kiloclaw_subscription_change_log).values({
       subscription_id: subscription.id,
       actor_type: 'system',
       actor_id: 'legacy-mutator',
       action: 'status_changed',
       reason: 'legacy_mutation',
-      before_state: { ...subscription, status: 'trialing' },
+      created_at: '2026-04-05T00:00:00.000Z',
+      before_state: initialState,
       after_state: { ...subscription, status: 'past_due' },
     });
 
@@ -437,8 +439,13 @@ describe('kiloclaw-subscription-alignment script', () => {
     expect(baselineLog).toEqual(
       expect.objectContaining({
         action: 'backfilled',
-        reason: 'baseline_subscription_snapshot',
+        reason: 'baseline_subscription_snapshot_from_earliest_mutation',
       })
+    );
+    // Baseline after_state MUST match the earliest mutation's before_state
+    // (the true initial state) NOT the current post-mutation row state.
+    expect(baselineLog?.after_state).toEqual(
+      expect.objectContaining({ id: subscription.id, status: 'trialing' })
     );
 
     // Running again should be a no-op because a baseline now exists.
@@ -448,5 +455,184 @@ describe('kiloclaw-subscription-alignment script', () => {
       .from(kiloclaw_subscription_change_log)
       .where(eq(kiloclaw_subscription_change_log.subscription_id, subscription.id));
     expect(changeLogsAfterRerun.filter(log => log.before_state === null)).toHaveLength(1);
+  });
+
+  it('stamps personal bootstrap trial with 7-day duration, not org 14-day', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'personal-trial-7d@example.com',
+    });
+    const instanceId = crypto.randomUUID();
+    const instanceCreatedAt = '2026-04-10T00:00:00.000Z';
+
+    await db.insert(kiloclaw_instances).values({
+      id: instanceId,
+      user_id: user.id,
+      sandbox_id: `ki_${instanceId.replaceAll('-', '')}`,
+      created_at: instanceCreatedAt,
+    });
+
+    await run('apply-missing-personal');
+
+    const [subscription] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.instance_id, instanceId));
+
+    if (!subscription) {
+      throw new Error('Expected bootstrapped trial row');
+    }
+
+    expect(subscription.plan).toBe('trial');
+    if (!subscription.trial_started_at || !subscription.trial_ends_at) {
+      throw new Error('Expected trial_started_at and trial_ends_at');
+    }
+    // 7 days duration. 14 would indicate the bug where org trial constant leaks
+    // into the personal bootstrap path.
+    const trialDurationMs =
+      new Date(subscription.trial_ends_at).getTime() -
+      new Date(subscription.trial_started_at).getTime();
+    const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+    expect(trialDurationMs).toBe(sevenDaysMs);
+  });
+
+  it('refuses to reassign destroyed sub when user already has live personal subscription', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'two-personal-guard@example.com',
+    });
+
+    const destroyedInstanceId = crypto.randomUUID();
+    const liveInstanceId = crypto.randomUUID();
+    const missingInstanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: destroyedInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${destroyedInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-03-01T00:00:00.000Z',
+        destroyed_at: '2026-03-15T00:00:00.000Z',
+      },
+      {
+        id: liveInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${liveInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-03-20T00:00:00.000Z',
+      },
+      {
+        id: missingInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${missingInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+      },
+    ]);
+
+    // Destroyed instance has an access-granting legacy sub (would normally
+    // trigger reassign_destroyed for the missing row).
+    const [destroyedSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: destroyedInstanceId,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'stripe',
+        cancel_at_period_end: false,
+        created_at: '2026-03-01T00:00:00.000Z',
+        updated_at: '2026-03-01T00:00:00.000Z',
+      })
+      .returning();
+
+    // Live instance already holds the user's current personal sub.
+    const [liveSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: liveInstanceId,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'stripe',
+        cancel_at_period_end: false,
+        created_at: '2026-03-20T00:00:00.000Z',
+        updated_at: '2026-03-20T00:00:00.000Z',
+      })
+      .returning();
+
+    if (!destroyedSub || !liveSub) {
+      throw new Error('Expected seed subscription rows');
+    }
+
+    await run('apply-missing-personal');
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .orderBy(kiloclaw_subscriptions.created_at);
+
+    // MUST remain 2 rows; creating a successor on missingInstanceId would
+    // yield two current personal subs for one user (spec violation).
+    expect(subscriptions).toHaveLength(2);
+    expect(subscriptions.map(s => s.id).sort()).toEqual([destroyedSub.id, liveSub.id].sort());
+
+    const destroyedAfter = subscriptions.find(s => s.id === destroyedSub.id);
+    const liveAfter = subscriptions.find(s => s.id === liveSub.id);
+
+    expect(destroyedAfter?.transferred_to_subscription_id).toBeNull();
+    expect(destroyedAfter?.status).toBe('active');
+    expect(liveAfter?.transferred_to_subscription_id).toBeNull();
+    expect(liveAfter?.status).toBe('active');
+  });
+
+  it('refuses to write destroyed_at for duplicates without --confirm-sandboxes-destroyed flag', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'no-confirm-flag@example.com',
+    });
+    const emptyOlderInstanceId = crypto.randomUUID();
+    const canonicalInstanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: emptyOlderInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${emptyOlderInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+      },
+      {
+        id: canonicalInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${canonicalInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-02T00:00:00.000Z',
+      },
+    ]);
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: canonicalInstanceId,
+      plan: 'standard',
+      status: 'active',
+      payment_source: 'stripe',
+      cancel_at_period_end: false,
+      created_at: '2026-04-02T00:00:00.000Z',
+      updated_at: '2026-04-02T00:00:00.000Z',
+    });
+
+    await run('apply-duplicates');
+
+    const instances = await db
+      .select()
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.user_id, user.id));
+
+    // Neither instance touched without the confirm flag — operator must
+    // externally verify sandbox teardown first.
+    expect(instances.every(instance => instance.destroyed_at === null)).toBe(true);
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+
+    // No terminal replacement inserted either.
+    expect(subscriptions).toHaveLength(1);
   });
 });

--- a/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
@@ -757,4 +757,62 @@ describe('kiloclaw-subscription-alignment script', () => {
       .where(eq(kiloclaw_subscriptions.instance_id, canonicalInstanceId));
     expect(canonicalAttached).toHaveLength(0);
   });
+
+  it('backfills every active org orphan as managed-active regardless of seats/purchase', async () => {
+    // Org billing has not rolled out. Every org instance gets managed-active
+    // access as a free trial until paid org billing ships. Verifies that the
+    // classifier ignores require_seats, oss_sponsorship_tier,
+    // suppress_trial_messaging, and latest seat purchase status.
+    const user = await insertTestUser({
+      google_user_email: 'org-free-trial@example.com',
+    });
+    // require_seats=true + no active purchase would historically have
+    // produced a trial row. Must now produce managed-active.
+    const org = await createTestOrganization('test-org-free-trial', user.id, 0, {}, true);
+
+    const orgInstanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values({
+      id: orgInstanceId,
+      user_id: user.id,
+      organization_id: org.id,
+      sandbox_id: `ki_${orgInstanceId.replaceAll('-', '')}`,
+      created_at: '2026-04-01T00:00:00.000Z',
+    });
+
+    await run('apply-org');
+
+    const [subscription] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.instance_id, orgInstanceId));
+
+    if (!subscription) {
+      throw new Error('Expected subscription row for org instance');
+    }
+
+    expect(subscription).toEqual(
+      expect.objectContaining({
+        user_id: user.id,
+        instance_id: orgInstanceId,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+      })
+    );
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscription.id));
+
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'backfilled',
+          reason: 'apply_org_backfill_active_standard_credits',
+        }),
+      ])
+    );
+  });
 });

--- a/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
+import { createTestOrganization } from '@/tests/helpers/organization.helper';
 
 describe('kiloclaw-subscription-alignment script', () => {
   beforeEach(async () => {
@@ -26,29 +27,33 @@ describe('kiloclaw-subscription-alignment script', () => {
       google_user_email: 'duplicate-align@example.com',
     });
 
+    // Canonical = instance that already holds the subscription, even though it is
+    // the newer of the two. Destroying the live-subscription instance and wiring
+    // the row onto a stale empty one would be user-visibly wrong, so the script
+    // prefers "has subscription" over "oldest" when choosing canonical.
+    const emptyOlderInstanceId = crypto.randomUUID();
     const canonicalInstanceId = crypto.randomUUID();
-    const duplicateInstanceId = crypto.randomUUID();
 
     await db.insert(kiloclaw_instances).values([
+      {
+        id: emptyOlderInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${emptyOlderInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+      },
       {
         id: canonicalInstanceId,
         user_id: user.id,
         sandbox_id: `ki_${canonicalInstanceId.replaceAll('-', '')}`,
-        created_at: '2026-04-01T00:00:00.000Z',
-      },
-      {
-        id: duplicateInstanceId,
-        user_id: user.id,
-        sandbox_id: `ki_${duplicateInstanceId.replaceAll('-', '')}`,
         created_at: '2026-04-02T00:00:00.000Z',
       },
     ]);
 
-    const [duplicateSubscription] = await db
+    const [canonicalSubscription] = await db
       .insert(kiloclaw_subscriptions)
       .values({
         user_id: user.id,
-        instance_id: duplicateInstanceId,
+        instance_id: canonicalInstanceId,
         plan: 'standard',
         status: 'active',
         payment_source: 'stripe',
@@ -58,21 +63,22 @@ describe('kiloclaw-subscription-alignment script', () => {
       })
       .returning();
 
-    if (!duplicateSubscription) {
-      throw new Error('Expected duplicate subscription row');
+    if (!canonicalSubscription) {
+      throw new Error('Expected canonical subscription row');
     }
 
     await run('apply-duplicates');
 
-    const [canonicalInstance, duplicateInstance] = await db
+    const [olderInstance, canonicalInstance] = await db
       .select()
       .from(kiloclaw_instances)
       .where(eq(kiloclaw_instances.user_id, user.id))
       .orderBy(kiloclaw_instances.created_at);
 
+    expect(olderInstance?.id).toBe(emptyOlderInstanceId);
     expect(canonicalInstance?.id).toBe(canonicalInstanceId);
-    expect(duplicateInstance?.id).toBe(duplicateInstanceId);
-    expect(duplicateInstance?.destroyed_at).not.toBeNull();
+    expect(olderInstance?.destroyed_at).not.toBeNull();
+    expect(canonicalInstance?.destroyed_at).toBeNull();
 
     const subscriptions = await db
       .select()
@@ -82,41 +88,27 @@ describe('kiloclaw-subscription-alignment script', () => {
 
     expect(subscriptions).toHaveLength(2);
 
-    const reassigned = subscriptions.find(
-      subscription => subscription.id === duplicateSubscription.id
+    const retainedCanonical = subscriptions.find(
+      subscription => subscription.id === canonicalSubscription.id
     );
     const replacement = subscriptions.find(
       subscription =>
-        subscription.id !== duplicateSubscription.id &&
-        subscription.instance_id === duplicateInstanceId
+        subscription.id !== canonicalSubscription.id &&
+        subscription.instance_id === emptyOlderInstanceId
     );
 
     if (!replacement) {
-      throw new Error('Expected replacement terminal subscription row');
+      throw new Error('Expected replacement terminal subscription row on the destroyed duplicate');
     }
 
-    expect(reassigned?.instance_id).toBe(canonicalInstanceId);
+    expect(retainedCanonical?.instance_id).toBe(canonicalInstanceId);
     expect(replacement).toEqual(
       expect.objectContaining({
         user_id: user.id,
-        instance_id: duplicateInstanceId,
+        instance_id: emptyOlderInstanceId,
         plan: 'trial',
         status: 'canceled',
       })
-    );
-
-    const changeLogs = await db
-      .select()
-      .from(kiloclaw_subscription_change_log)
-      .where(eq(kiloclaw_subscription_change_log.subscription_id, duplicateSubscription.id));
-
-    expect(changeLogs).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          action: 'reassigned',
-          reason: 'apply_duplicate_active_reassign_to_canonical',
-        }),
-      ])
     );
 
     const replacementLogs = await db
@@ -132,6 +124,16 @@ describe('kiloclaw-subscription-alignment script', () => {
         }),
       ])
     );
+
+    // No reassignment should have happened because canonical already had the sub.
+    const canonicalSubLogs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, canonicalSubscription.id));
+
+    expect(
+      canonicalSubLogs.find(log => log.reason === 'apply_duplicate_active_reassign_to_canonical')
+    ).toBeUndefined();
   });
 
   it('backfills missing baseline changelog rows once', async () => {
@@ -190,5 +192,261 @@ describe('kiloclaw-subscription-alignment script', () => {
         status: 'trialing',
       })
     );
+  });
+
+  it('transfers reassign-destroyed subscription via successor pattern preserving predecessor history', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'reassign-destroyed@example.com',
+    });
+
+    const destroyedInstanceId = crypto.randomUUID();
+    const activeInstanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: destroyedInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${destroyedInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-03-01T00:00:00.000Z',
+        destroyed_at: '2026-03-15T00:00:00.000Z',
+      },
+      {
+        id: activeInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${activeInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+      },
+    ]);
+
+    const [predecessorSubscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: destroyedInstanceId,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'stripe',
+        cancel_at_period_end: false,
+        stripe_subscription_id: 'sub_reassign_test',
+        created_at: '2026-03-01T00:00:00.000Z',
+        updated_at: '2026-03-01T00:00:00.000Z',
+      })
+      .returning();
+
+    if (!predecessorSubscription) {
+      throw new Error('Expected predecessor subscription row');
+    }
+
+    await run('apply-missing-personal');
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .orderBy(kiloclaw_subscriptions.created_at, kiloclaw_subscriptions.id);
+
+    expect(subscriptions).toHaveLength(2);
+
+    const predecessorAfter = subscriptions.find(
+      subscription => subscription.id === predecessorSubscription.id
+    );
+    const successor = subscriptions.find(
+      subscription => subscription.id !== predecessorSubscription.id
+    );
+
+    if (!successor) {
+      throw new Error('Expected successor subscription row');
+    }
+
+    // Predecessor stays pinned to destroyed instance and is marked transferred.
+    expect(predecessorAfter?.instance_id).toBe(destroyedInstanceId);
+    expect(predecessorAfter?.status).toBe('canceled');
+    expect(predecessorAfter?.transferred_to_subscription_id).toBe(successor.id);
+    expect(predecessorAfter?.stripe_subscription_id).toBeNull();
+    expect(predecessorAfter?.payment_source).toBe('credits');
+
+    // Successor is a new row on the active instance, inheriting plan+stripe ownership.
+    expect(successor.instance_id).toBe(activeInstanceId);
+    expect(successor.status).toBe('active');
+    expect(successor.plan).toBe('standard');
+    expect(successor.stripe_subscription_id).toBe('sub_reassign_test');
+    expect(successor.transferred_to_subscription_id).toBeNull();
+
+    const predecessorLogs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, predecessorSubscription.id));
+
+    expect(predecessorLogs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'reassigned',
+          reason: 'apply_missing_personal_reassign_destroyed_predecessor',
+        }),
+      ])
+    );
+
+    const successorLogs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, successor.id));
+
+    expect(successorLogs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'backfilled',
+          reason: 'apply_missing_personal_reassign_destroyed_successor',
+        }),
+      ])
+    );
+  });
+
+  it('does not bootstrap trial or earlybird rows for destroyed personal instances', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroyed-bootstrap@example.com',
+    });
+    const destroyedInstanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values({
+      id: destroyedInstanceId,
+      user_id: user.id,
+      sandbox_id: `ki_${destroyedInstanceId.replaceAll('-', '')}`,
+      created_at: '2026-04-01T00:00:00.000Z',
+      destroyed_at: '2026-04-02T00:00:00.000Z',
+    });
+
+    await run('apply-missing-personal');
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+
+    expect(subscriptions).toHaveLength(0);
+  });
+
+  it('bootstraps personal trial even when user has org-context subscription', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'org-sub-holder@example.com',
+    });
+    const org = await createTestOrganization('test-org', user.id, 0);
+
+    const orgInstanceId = crypto.randomUUID();
+    const personalInstanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: orgInstanceId,
+        user_id: user.id,
+        organization_id: org.id,
+        sandbox_id: `ki_${orgInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-03-01T00:00:00.000Z',
+      },
+      {
+        id: personalInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${personalInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+      },
+    ]);
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: orgInstanceId,
+      plan: 'standard',
+      status: 'active',
+      payment_source: 'credits',
+      cancel_at_period_end: false,
+      created_at: '2026-03-01T00:00:00.000Z',
+      updated_at: '2026-03-01T00:00:00.000Z',
+    });
+
+    await run('apply-missing-personal');
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .orderBy(kiloclaw_subscriptions.created_at);
+
+    expect(subscriptions).toHaveLength(2);
+    const personalSub = subscriptions.find(s => s.instance_id === personalInstanceId);
+    const orgSub = subscriptions.find(s => s.instance_id === orgInstanceId);
+
+    expect(orgSub?.status).toBe('active');
+    expect(personalSub).toEqual(
+      expect.objectContaining({
+        user_id: user.id,
+        instance_id: personalInstanceId,
+        plan: 'trial',
+      })
+    );
+  });
+
+  it('backfills baseline snapshot for subscription that has only mutation logs', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'mutation-only-logs@example.com',
+    });
+    const instanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values({
+      id: instanceId,
+      user_id: user.id,
+      sandbox_id: `ki_${instanceId.replaceAll('-', '')}`,
+    });
+
+    const [subscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: instanceId,
+        plan: 'trial',
+        status: 'trialing',
+        cancel_at_period_end: false,
+        trial_started_at: '2026-04-01T00:00:00.000Z',
+        trial_ends_at: '2026-04-08T00:00:00.000Z',
+      })
+      .returning();
+
+    if (!subscription) {
+      throw new Error('Expected subscription row');
+    }
+
+    // Simulate a legacy subscription created before changelog rollout whose only
+    // log entries are post-creation mutations (before_state is non-null).
+    await db.insert(kiloclaw_subscription_change_log).values({
+      subscription_id: subscription.id,
+      actor_type: 'system',
+      actor_id: 'legacy-mutator',
+      action: 'status_changed',
+      reason: 'legacy_mutation',
+      before_state: { ...subscription, status: 'trialing' },
+      after_state: { ...subscription, status: 'past_due' },
+    });
+
+    await run('apply-changelog-baseline');
+
+    const changeLogs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscription.id))
+      .orderBy(kiloclaw_subscription_change_log.created_at);
+
+    const baselineLog = changeLogs.find(log => log.before_state === null);
+    expect(baselineLog).toBeDefined();
+    expect(baselineLog).toEqual(
+      expect.objectContaining({
+        action: 'backfilled',
+        reason: 'baseline_subscription_snapshot',
+      })
+    );
+
+    // Running again should be a no-op because a baseline now exists.
+    await run('apply-changelog-baseline');
+    const changeLogsAfterRerun = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscription.id));
+    expect(changeLogsAfterRerun.filter(log => log.before_state === null)).toHaveLength(1);
   });
 });

--- a/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
@@ -301,9 +301,9 @@ describe('kiloclaw-subscription-alignment script', () => {
     );
   });
 
-  it('does not bootstrap trial or earlybird rows for destroyed personal instances', async () => {
+  it('backfills canceled terminal row for destroyed personal instance missing a sub row', async () => {
     const user = await insertTestUser({
-      google_user_email: 'destroyed-bootstrap@example.com',
+      google_user_email: 'destroyed-terminal@example.com',
     });
     const destroyedInstanceId = crypto.randomUUID();
 
@@ -322,7 +322,44 @@ describe('kiloclaw-subscription-alignment script', () => {
       .from(kiloclaw_subscriptions)
       .where(eq(kiloclaw_subscriptions.user_id, user.id));
 
-    expect(subscriptions).toHaveLength(0);
+    // Destroyed missing-row instances get a terminal canceled trial row so
+    // apply-missing-personal can clean up after admin-panel destroys.
+    expect(subscriptions).toHaveLength(1);
+    const terminal = subscriptions[0];
+    expect(terminal).toEqual(
+      expect.objectContaining({
+        user_id: user.id,
+        instance_id: destroyedInstanceId,
+        plan: 'trial',
+        status: 'canceled',
+        payment_source: null,
+      })
+    );
+    if (!terminal) {
+      throw new Error('Expected terminal subscription row');
+    }
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, terminal.id));
+
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'backfilled',
+          reason: 'apply_missing_personal_backfill_destroyed_terminal',
+        }),
+      ])
+    );
+
+    // Second run is a no-op.
+    await run('apply-missing-personal');
+    const subscriptionsAfterRerun = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+    expect(subscriptionsAfterRerun).toHaveLength(1);
   });
 
   it('bootstraps personal trial even when user has org-context subscription', async () => {
@@ -634,5 +671,90 @@ describe('kiloclaw-subscription-alignment script', () => {
 
     // No terminal replacement inserted either.
     expect(subscriptions).toHaveLength(1);
+  });
+
+  it('ignores transferred-out rows when picking duplicate reassign targets', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'duplicate-transferred@example.com',
+    });
+
+    // Canonical instance C has zero current subscriptions.
+    // Duplicate instance D holds only a transferred-out predecessor (history).
+    // The script MUST NOT treat D's historical row as a live sub; moving it
+    // onto C would occupy the unique instance_id slot with a dead row and
+    // wedge future repair.
+    const canonicalInstanceId = crypto.randomUUID();
+    const duplicateInstanceId = crypto.randomUUID();
+    const transferredSuccessorId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: canonicalInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${canonicalInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+      },
+      {
+        id: duplicateInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${duplicateInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-02T00:00:00.000Z',
+      },
+    ]);
+
+    // A live successor elsewhere (detached for this test — point is only that
+    // it's referenced by transferred_to_subscription_id). Insert it detached
+    // then reference it from the predecessor on the duplicate instance.
+    const [successor] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        id: transferredSuccessorId,
+        user_id: user.id,
+        instance_id: null,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'stripe',
+        cancel_at_period_end: false,
+        created_at: '2026-03-20T00:00:00.000Z',
+        updated_at: '2026-03-20T00:00:00.000Z',
+      })
+      .returning();
+
+    const [predecessor] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: duplicateInstanceId,
+        plan: 'standard',
+        status: 'canceled',
+        payment_source: 'credits',
+        cancel_at_period_end: false,
+        transferred_to_subscription_id: successor?.id,
+        created_at: '2026-03-01T00:00:00.000Z',
+        updated_at: '2026-03-20T00:00:00.000Z',
+      })
+      .returning();
+
+    if (!predecessor || !successor) {
+      throw new Error('Expected seed subscription rows');
+    }
+
+    await run('apply-duplicates', '--confirm-sandboxes-destroyed');
+
+    const predecessorAfter = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, predecessor.id));
+
+    // Predecessor MUST stay pinned to duplicateInstanceId (not moved to canonical).
+    expect(predecessorAfter[0]?.instance_id).toBe(duplicateInstanceId);
+    expect(predecessorAfter[0]?.transferred_to_subscription_id).toBe(successor.id);
+
+    // Canonical still has no attached sub.
+    const canonicalAttached = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.instance_id, canonicalInstanceId));
+    expect(canonicalAttached).toHaveLength(0);
   });
 });

--- a/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { cleanupDbForTest, db } from '@/lib/drizzle';
+import { run } from '@/scripts/db/kiloclaw-subscription-alignment';
+import {
+  kiloclaw_instances,
+  kiloclaw_subscription_change_log,
+  kiloclaw_subscriptions,
+} from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+
+describe('kiloclaw-subscription-alignment script', () => {
+  beforeEach(async () => {
+    await cleanupDbForTest();
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    jest.spyOn(console, 'table').mockImplementation(() => undefined);
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('reassigns duplicate active personal subscription to canonical instance and destroys duplicate', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'duplicate-align@example.com',
+    });
+
+    const canonicalInstanceId = crypto.randomUUID();
+    const duplicateInstanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: canonicalInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${canonicalInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+      },
+      {
+        id: duplicateInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${duplicateInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-02T00:00:00.000Z',
+      },
+    ]);
+
+    const [duplicateSubscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: duplicateInstanceId,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'stripe',
+        cancel_at_period_end: false,
+        created_at: '2026-04-02T00:00:00.000Z',
+        updated_at: '2026-04-02T00:00:00.000Z',
+      })
+      .returning();
+
+    if (!duplicateSubscription) {
+      throw new Error('Expected duplicate subscription row');
+    }
+
+    await run('apply-duplicates');
+
+    const [canonicalInstance, duplicateInstance] = await db
+      .select()
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.user_id, user.id))
+      .orderBy(kiloclaw_instances.created_at);
+
+    expect(canonicalInstance?.id).toBe(canonicalInstanceId);
+    expect(duplicateInstance?.id).toBe(duplicateInstanceId);
+    expect(duplicateInstance?.destroyed_at).not.toBeNull();
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .orderBy(kiloclaw_subscriptions.created_at, kiloclaw_subscriptions.id);
+
+    expect(subscriptions).toHaveLength(2);
+
+    const reassigned = subscriptions.find(
+      subscription => subscription.id === duplicateSubscription.id
+    );
+    const replacement = subscriptions.find(
+      subscription =>
+        subscription.id !== duplicateSubscription.id &&
+        subscription.instance_id === duplicateInstanceId
+    );
+
+    if (!replacement) {
+      throw new Error('Expected replacement terminal subscription row');
+    }
+
+    expect(reassigned?.instance_id).toBe(canonicalInstanceId);
+    expect(replacement).toEqual(
+      expect.objectContaining({
+        user_id: user.id,
+        instance_id: duplicateInstanceId,
+        plan: 'trial',
+        status: 'canceled',
+      })
+    );
+
+    const changeLogs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, duplicateSubscription.id));
+
+    expect(changeLogs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'reassigned',
+          reason: 'apply_duplicate_active_reassign_to_canonical',
+        }),
+      ])
+    );
+
+    const replacementLogs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, replacement.id));
+
+    expect(replacementLogs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'backfilled',
+          reason: 'apply_duplicate_active_backfill_personal_terminal',
+        }),
+      ])
+    );
+  });
+
+  it('backfills missing baseline changelog rows once', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'baseline-log@example.com',
+    });
+    const instanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values({
+      id: instanceId,
+      user_id: user.id,
+      sandbox_id: `ki_${instanceId.replaceAll('-', '')}`,
+    });
+
+    const [subscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: instanceId,
+        plan: 'trial',
+        status: 'trialing',
+        cancel_at_period_end: false,
+        trial_started_at: '2026-04-01T00:00:00.000Z',
+        trial_ends_at: '2026-04-08T00:00:00.000Z',
+      })
+      .returning();
+
+    if (!subscription) {
+      throw new Error('Expected baseline subscription row');
+    }
+
+    await run('apply-changelog-baseline');
+    await run('apply-changelog-baseline');
+
+    const changeLogs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscription.id));
+
+    expect(changeLogs).toHaveLength(1);
+    expect(changeLogs[0]).toEqual(
+      expect.objectContaining({
+        action: 'backfilled',
+        actor_type: 'system',
+        actor_id: 'kiloclaw-subscription-alignment',
+        reason: 'baseline_subscription_snapshot',
+      })
+    );
+    expect(changeLogs[0]?.before_state).toBeNull();
+    expect(changeLogs[0]?.after_state).toEqual(
+      expect.objectContaining({
+        id: subscription.id,
+        user_id: user.id,
+        instance_id: instanceId,
+        plan: 'trial',
+        status: 'trialing',
+      })
+    );
+  });
+});

--- a/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
@@ -815,4 +815,117 @@ describe('kiloclaw-subscription-alignment script', () => {
       ])
     );
   });
+
+  it('destroys duplicate instance whose only sub is a transferred predecessor', async () => {
+    // Builder filters transferred rows from subscriptionsByInstanceId; the
+    // apply existence checks must match. An instance holding only a
+    // transferred-out predecessor has 0 current subs → builder classifies it
+    // as a backfill_destroy_duplicate_personal target. Before this fix, the
+    // apply existence check counted the transferred row as present and
+    // silently skipped — leaving preview and apply forever disagreeing.
+    const user = await insertTestUser({
+      google_user_email: 'duplicate-with-transferred@example.com',
+    });
+
+    const canonicalInstanceId = crypto.randomUUID();
+    const duplicateInstanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: canonicalInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${canonicalInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+      },
+      {
+        id: duplicateInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${duplicateInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-02T00:00:00.000Z',
+      },
+    ]);
+
+    // Canonical has a live current sub.
+    const [canonicalSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: canonicalInstanceId,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'stripe',
+        cancel_at_period_end: false,
+        created_at: '2026-04-01T00:00:00.000Z',
+        updated_at: '2026-04-01T00:00:00.000Z',
+      })
+      .returning();
+
+    // Successor elsewhere (detached) so transferred_to points at a real row.
+    const [successor] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: null,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'stripe',
+        cancel_at_period_end: false,
+        created_at: '2026-03-10T00:00:00.000Z',
+        updated_at: '2026-03-10T00:00:00.000Z',
+      })
+      .returning();
+
+    // Duplicate instance ONLY holds a transferred predecessor — runtime-invisible.
+    const [duplicatePredecessor] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: duplicateInstanceId,
+        plan: 'standard',
+        status: 'canceled',
+        payment_source: 'credits',
+        cancel_at_period_end: false,
+        transferred_to_subscription_id: successor?.id,
+        created_at: '2026-03-15T00:00:00.000Z',
+        updated_at: '2026-03-15T00:00:00.000Z',
+      })
+      .returning();
+
+    if (!canonicalSub || !successor || !duplicatePredecessor) {
+      throw new Error('Expected seed subscription rows');
+    }
+
+    await run('apply-duplicates', '--confirm-sandboxes-destroyed');
+
+    // Duplicate instance MUST have been destroyed with a canceled terminal
+    // row inserted. Before the fix, apply silently skipped because the
+    // existence check counted the transferred predecessor.
+    const [duplicateInstanceAfter] = await db
+      .select()
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.id, duplicateInstanceId));
+    expect(duplicateInstanceAfter?.destroyed_at).not.toBeNull();
+
+    const duplicateRows = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.instance_id, duplicateInstanceId));
+
+    // The transferred predecessor already satisfies the "every instance has
+    // a sub row" invariant. The partial-unique index on instance_id prevents
+    // inserting another row into that slot, so apply-duplicates destroys
+    // the instance but skips the terminal insert — leaving the predecessor
+    // in place.
+    expect(duplicateRows).toHaveLength(1);
+    const predecessorAfter = duplicateRows[0];
+    expect(predecessorAfter?.id).toBe(duplicatePredecessor.id);
+    expect(predecessorAfter?.transferred_to_subscription_id).toBe(successor.id);
+
+    // Canonical instance untouched.
+    const canonicalSubAfter = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, canonicalSub.id));
+    expect(canonicalSubAfter[0]?.instance_id).toBe(canonicalInstanceId);
+  });
 });

--- a/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
+++ b/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
@@ -1,0 +1,1823 @@
+/**
+ * Audit and backfill KiloClaw subscription drift.
+ *
+ * Usage:
+ *   pnpm script db kiloclaw-subscription-alignment
+ *   pnpm script db kiloclaw-subscription-alignment audit
+ *   pnpm script db kiloclaw-subscription-alignment repair-detached
+ *   pnpm script db kiloclaw-subscription-alignment preview-missing-personal
+ *   pnpm script db kiloclaw-subscription-alignment apply-missing-personal
+ *   pnpm script db kiloclaw-subscription-alignment preview-duplicates
+ *   pnpm script db kiloclaw-subscription-alignment apply-duplicates
+ *   pnpm script db kiloclaw-subscription-alignment preview-org
+ *   pnpm script db kiloclaw-subscription-alignment apply-org
+ *   pnpm script db kiloclaw-subscription-alignment preview-changelog-baseline
+ *   pnpm script db kiloclaw-subscription-alignment apply-changelog-baseline
+ */
+
+import { and, desc, eq, inArray, isNull, notExists, sql } from 'drizzle-orm';
+
+import { TRIAL_DURATION_DAYS } from '@/lib/constants';
+import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
+import { db } from '@/lib/drizzle';
+import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
+import {
+  kiloclaw_earlybird_purchases,
+  kiloclaw_instances,
+  kiloclaw_subscription_change_log,
+  kiloclaw_subscriptions,
+  organizations,
+  organization_seats_purchases,
+  type KiloClawSubscription,
+  type Organization,
+  type OrganizationSeatsPurchase,
+} from '@kilocode/db/schema';
+
+type Mode =
+  | 'audit'
+  | 'repair-detached'
+  | 'preview-missing-personal'
+  | 'apply-missing-personal'
+  | 'preview-duplicates'
+  | 'apply-duplicates'
+  | 'preview-org'
+  | 'apply-org'
+  | 'preview-changelog-baseline'
+  | 'apply-changelog-baseline';
+
+type PersonalInstanceWithoutRow = {
+  instanceId: string;
+  userId: string;
+  sandboxId: string;
+  createdAt: string;
+  destroyedAt: string | null;
+};
+
+type OrgInstanceWithoutRow = {
+  instanceId: string;
+  userId: string;
+  organizationId: string | null;
+  instanceCreatedAt: string;
+  organizationCreatedAt: string;
+  freeTrialEndAt: string | null;
+  requireSeats: boolean;
+  settings: Organization['settings'];
+  destroyedAt: string | null;
+};
+
+type DetachedSubscriptionAuditRow = {
+  subscriptionId: string;
+  userId: string;
+  status: string;
+  plan: string;
+  suspendedAt: string | null;
+  trialEndsAt: string | null;
+  createdAt: string;
+  detachedRowCount: number;
+  activePersonalInstanceCount: number;
+  linkedPersonalSubscriptionCount: number;
+  targetInstanceId: string | null;
+};
+
+type MissingPersonalBackfillAction =
+  | 'adopt_detached_access_row'
+  | 'reassign_destroyed_access_row'
+  | 'bootstrap_trial_row'
+  | 'backfill_earlybird_row'
+  | 'manual_review';
+
+type MissingPersonalCandidate = {
+  action: MissingPersonalBackfillAction;
+  instanceId: string;
+  userId: string;
+  sandboxId: string;
+  instanceCreatedAt: string;
+  instanceDestroyedAt: string | null;
+  earlybirdPurchaseCreatedAt: string | null;
+  hasEarlybird: boolean;
+  totalSubscriptionCount: number;
+  detachedTotalCount: number;
+  detachedAccessCount: number;
+  linkedPersonalTotalCount: number;
+  linkedDestroyedTotalCount: number;
+  linkedDestroyedAccessCount: number;
+  targetSubscriptionId: string | null;
+};
+
+type OrgBackfillAction =
+  | 'backfill_active_standard_credits'
+  | 'backfill_trial'
+  | 'backfill_destroyed_standard_credits'
+  | 'backfill_destroyed_trial';
+
+type OrgBackfillCandidate = {
+  action: OrgBackfillAction;
+  instanceId: string;
+  userId: string;
+  organizationId: string;
+  instanceCreatedAt: string;
+  organizationCreatedAt: string;
+  freeTrialEndAt: string | null;
+  requireSeats: boolean;
+  latestPurchaseStatus: OrganizationSeatsPurchase['subscription_status'] | null;
+  destroyedAt: string | null;
+};
+
+type ActiveInstanceContextRow = {
+  instanceId: string;
+  userId: string;
+  organizationId: string | null;
+  sandboxId: string;
+  createdAt: string;
+};
+
+type DuplicateActiveInstanceAction =
+  | 'backfill_destroy_duplicate_personal'
+  | 'backfill_destroy_duplicate_org'
+  | 'reassign_to_canonical_and_destroy_duplicate'
+  | 'manual_review';
+
+type DuplicateActiveInstanceCandidate = {
+  action: DuplicateActiveInstanceAction;
+  contextType: 'personal' | 'organization';
+  userId: string;
+  organizationId: string | null;
+  canonicalInstanceId: string;
+  canonicalCreatedAt: string;
+  duplicateInstanceId: string;
+  duplicateSandboxId: string;
+  duplicateCreatedAt: string;
+  canonicalSubscriptionCount: number;
+  duplicateSubscriptionCount: number;
+  targetSubscriptionId: string | null;
+  organizationCreatedAt: string | null;
+  freeTrialEndAt: string | null;
+  requireSeats: boolean | null;
+  organizationSettings: Organization['settings'] | null;
+  latestPurchaseStatus: OrganizationSeatsPurchase['subscription_status'] | null;
+};
+
+type MissingChangelogBaselineRow = KiloClawSubscription;
+
+const ALIGNMENT_SCRIPT_ACTOR = {
+  actorType: 'system',
+  actorId: 'kiloclaw-subscription-alignment',
+} as const;
+
+function isAccessGrantingSubscription(
+  row: Pick<KiloClawSubscription, 'status' | 'suspended_at' | 'trial_ends_at'>,
+  now: Date
+): boolean {
+  if (row.status === 'active') return true;
+  if (row.status === 'past_due' && !row.suspended_at) return true;
+  if (row.status === 'trialing' && row.trial_ends_at) {
+    return new Date(row.trial_ends_at).getTime() > now.getTime();
+  }
+  return false;
+}
+
+function isAccessGrantingRow(row: DetachedSubscriptionAuditRow, now: Date): boolean {
+  if (row.status === 'active') return true;
+  if (row.status === 'past_due' && !row.suspendedAt) return true;
+  if (row.status === 'trialing' && row.trialEndsAt) {
+    return new Date(row.trialEndsAt).getTime() > now.getTime();
+  }
+  return false;
+}
+
+function getTrialEndsAt(startedAt: string): string {
+  return new Date(
+    new Date(startedAt).getTime() + TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000
+  ).toISOString();
+}
+
+function getEarlybirdEndsAt(): string {
+  return new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE).toISOString();
+}
+
+function getOrganizationManagedActiveAccess(params: {
+  organization: Pick<Organization, 'require_seats' | 'settings'>;
+  latestPurchase: Pick<OrganizationSeatsPurchase, 'subscription_status'> | null;
+}): boolean {
+  return (
+    params.latestPurchase?.subscription_status === 'active' ||
+    !params.organization.require_seats ||
+    params.organization.settings.oss_sponsorship_tier != null ||
+    !!params.organization.settings.suppress_trial_messaging
+  );
+}
+
+function printSection<T>(label: string, rows: T[]) {
+  console.log(`\n${label}: ${rows.length}`);
+  if (rows.length === 0) return;
+  console.table(rows.slice(0, 25));
+  if (rows.length > 25) {
+    console.log(`... truncated ${rows.length - 25} more row(s)`);
+  }
+}
+
+async function insertAlignmentChangeLog(params: {
+  subscriptionId: string;
+  action: 'backfilled' | 'reassigned';
+  reason: string;
+  before: KiloClawSubscription | null;
+  after: KiloClawSubscription | null;
+}) {
+  if (!params.after) {
+    return;
+  }
+
+  try {
+    await insertKiloClawSubscriptionChangeLog(db, {
+      subscriptionId: params.subscriptionId,
+      actor: ALIGNMENT_SCRIPT_ACTOR,
+      action: params.action,
+      reason: params.reason,
+      before: params.before,
+      after: params.after,
+    });
+  } catch (error) {
+    console.error('Failed to write alignment change log', {
+      subscriptionId: params.subscriptionId,
+      action: params.action,
+      reason: params.reason,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function listPersonalInstancesWithoutRows(): Promise<PersonalInstanceWithoutRow[]> {
+  return await db
+    .select({
+      instanceId: kiloclaw_instances.id,
+      userId: kiloclaw_instances.user_id,
+      sandboxId: kiloclaw_instances.sandbox_id,
+      createdAt: kiloclaw_instances.created_at,
+      destroyedAt: kiloclaw_instances.destroyed_at,
+    })
+    .from(kiloclaw_instances)
+    .leftJoin(kiloclaw_subscriptions, eq(kiloclaw_subscriptions.instance_id, kiloclaw_instances.id))
+    .where(and(isNull(kiloclaw_instances.organization_id), isNull(kiloclaw_subscriptions.id)))
+    .orderBy(desc(kiloclaw_instances.created_at));
+}
+
+async function listOrgInstancesWithoutRows(): Promise<OrgInstanceWithoutRow[]> {
+  return await db
+    .select({
+      instanceId: kiloclaw_instances.id,
+      userId: kiloclaw_instances.user_id,
+      organizationId: kiloclaw_instances.organization_id,
+      instanceCreatedAt: kiloclaw_instances.created_at,
+      organizationCreatedAt: organizations.created_at,
+      freeTrialEndAt: organizations.free_trial_end_at,
+      requireSeats: organizations.require_seats,
+      settings: organizations.settings,
+      destroyedAt: kiloclaw_instances.destroyed_at,
+    })
+    .from(kiloclaw_instances)
+    .innerJoin(organizations, eq(organizations.id, kiloclaw_instances.organization_id))
+    .leftJoin(kiloclaw_subscriptions, eq(kiloclaw_subscriptions.instance_id, kiloclaw_instances.id))
+    .where(isNull(kiloclaw_subscriptions.id))
+    .orderBy(desc(kiloclaw_instances.created_at));
+}
+
+async function listDetachedSubscriptions(): Promise<DetachedSubscriptionAuditRow[]> {
+  return await db
+    .select({
+      subscriptionId: kiloclaw_subscriptions.id,
+      userId: kiloclaw_subscriptions.user_id,
+      status: kiloclaw_subscriptions.status,
+      plan: kiloclaw_subscriptions.plan,
+      suspendedAt: kiloclaw_subscriptions.suspended_at,
+      trialEndsAt: kiloclaw_subscriptions.trial_ends_at,
+      createdAt: kiloclaw_subscriptions.created_at,
+      detachedRowCount: sql<number>`(
+        SELECT count(*)::int
+        FROM ${kiloclaw_subscriptions} AS detached
+        WHERE detached.user_id = ${kiloclaw_subscriptions.user_id}
+          AND detached.instance_id IS NULL
+      )`,
+      activePersonalInstanceCount: sql<number>`(
+        SELECT count(*)::int
+        FROM ${kiloclaw_instances} AS active_instance
+        WHERE active_instance.user_id = ${kiloclaw_subscriptions.user_id}
+          AND active_instance.organization_id IS NULL
+          AND active_instance.destroyed_at IS NULL
+      )`,
+      linkedPersonalSubscriptionCount: sql<number>`(
+        SELECT count(*)::int
+        FROM ${kiloclaw_subscriptions} AS linked_sub
+        INNER JOIN ${kiloclaw_instances} AS linked_instance
+          ON linked_instance.id = linked_sub.instance_id
+        WHERE linked_sub.user_id = ${kiloclaw_subscriptions.user_id}
+          AND linked_instance.organization_id IS NULL
+          AND linked_instance.destroyed_at IS NULL
+      )`,
+      targetInstanceId: sql<string | null>`(
+        SELECT active_instance.id
+        FROM ${kiloclaw_instances} AS active_instance
+        WHERE active_instance.user_id = ${kiloclaw_subscriptions.user_id}
+          AND active_instance.organization_id IS NULL
+          AND active_instance.destroyed_at IS NULL
+        ORDER BY active_instance.created_at DESC
+        LIMIT 1
+      )`,
+    })
+    .from(kiloclaw_subscriptions)
+    .where(isNull(kiloclaw_subscriptions.instance_id))
+    .orderBy(desc(kiloclaw_subscriptions.created_at));
+}
+
+function summarizeDetachedRows(rows: DetachedSubscriptionAuditRow[]) {
+  const now = new Date();
+  const repairable = rows.filter(
+    row =>
+      row.detachedRowCount === 1 &&
+      row.activePersonalInstanceCount === 1 &&
+      row.linkedPersonalSubscriptionCount === 0 &&
+      !!row.targetInstanceId &&
+      isAccessGrantingRow(row, now)
+  );
+  const quarantined = rows.filter(
+    row => !repairable.some(candidate => candidate.subscriptionId === row.subscriptionId)
+  );
+
+  return { repairable, quarantined };
+}
+
+async function getSubscriptionsForUsers(userIds: string[]) {
+  if (userIds.length === 0) return [];
+  return await db
+    .select()
+    .from(kiloclaw_subscriptions)
+    .where(inArray(kiloclaw_subscriptions.user_id, userIds));
+}
+
+async function getSubscriptionsForInstances(instanceIds: string[]) {
+  if (instanceIds.length === 0) return [];
+  return await db
+    .select()
+    .from(kiloclaw_subscriptions)
+    .where(inArray(kiloclaw_subscriptions.instance_id, instanceIds));
+}
+
+async function getPersonalInstancesForUsers(userIds: string[]) {
+  if (userIds.length === 0) return [];
+  return await db
+    .select({
+      id: kiloclaw_instances.id,
+      userId: kiloclaw_instances.user_id,
+      destroyedAt: kiloclaw_instances.destroyed_at,
+    })
+    .from(kiloclaw_instances)
+    .where(
+      and(inArray(kiloclaw_instances.user_id, userIds), isNull(kiloclaw_instances.organization_id))
+    );
+}
+
+async function getEarlybirdPurchases(userIds: string[]) {
+  if (userIds.length === 0) return [];
+  return await db
+    .select({
+      userId: kiloclaw_earlybird_purchases.user_id,
+      createdAt: kiloclaw_earlybird_purchases.created_at,
+    })
+    .from(kiloclaw_earlybird_purchases)
+    .where(inArray(kiloclaw_earlybird_purchases.user_id, userIds));
+}
+
+function groupByUser<T extends { user_id: string }>(rows: T[]) {
+  const grouped = new Map<string, T[]>();
+  for (const row of rows) {
+    const existing = grouped.get(row.user_id);
+    if (existing) {
+      existing.push(row);
+    } else {
+      grouped.set(row.user_id, [row]);
+    }
+  }
+  return grouped;
+}
+
+async function buildMissingPersonalCandidates(): Promise<MissingPersonalCandidate[]> {
+  const missingRows = await listPersonalInstancesWithoutRows();
+  const userIds = [...new Set(missingRows.map(row => row.userId))];
+  const [subscriptions, personalInstances, earlybirdPurchases] = await Promise.all([
+    getSubscriptionsForUsers(userIds),
+    getPersonalInstancesForUsers(userIds),
+    getEarlybirdPurchases(userIds),
+  ]);
+
+  const subscriptionsByUser = groupByUser(subscriptions);
+  const personalInstancesById = new Map(personalInstances.map(row => [row.id, row]));
+  const earlybirdPurchaseByUser = new Map(
+    earlybirdPurchases.map(row => [row.userId, row.createdAt])
+  );
+  const now = new Date();
+
+  return missingRows.map(row => {
+    const userSubscriptions = subscriptionsByUser.get(row.userId) ?? [];
+    const detachedRows = userSubscriptions.filter(
+      subscription => subscription.instance_id === null
+    );
+    const detachedAccessRows = detachedRows.filter(subscription =>
+      isAccessGrantingSubscription(subscription, now)
+    );
+    const linkedPersonalRows = userSubscriptions.filter(subscription => {
+      if (!subscription.instance_id) return false;
+      return personalInstancesById.has(subscription.instance_id);
+    });
+    const linkedDestroyedRows = linkedPersonalRows.filter(subscription => {
+      const instanceId = subscription.instance_id;
+      if (!instanceId) {
+        return false;
+      }
+      const instance = personalInstancesById.get(instanceId);
+      return !!instance?.destroyedAt;
+    });
+    const linkedDestroyedAccessRows = linkedDestroyedRows.filter(subscription =>
+      isAccessGrantingSubscription(subscription, now)
+    );
+
+    let action: MissingPersonalBackfillAction = 'manual_review';
+    let targetSubscriptionId: string | null = null;
+    const earlybirdPurchaseCreatedAt = earlybirdPurchaseByUser.get(row.userId) ?? null;
+
+    if (
+      !row.destroyedAt &&
+      detachedRows.length === 1 &&
+      detachedAccessRows.length === 1 &&
+      linkedPersonalRows.length === 0
+    ) {
+      action = 'adopt_detached_access_row';
+      targetSubscriptionId = detachedAccessRows[0]?.id ?? null;
+    } else if (
+      !row.destroyedAt &&
+      detachedRows.length === 0 &&
+      linkedDestroyedRows.length === 1 &&
+      linkedDestroyedAccessRows.length === 1
+    ) {
+      action = 'reassign_destroyed_access_row';
+      targetSubscriptionId = linkedDestroyedAccessRows[0]?.id ?? null;
+    } else if (userSubscriptions.length === 0 && earlybirdPurchaseCreatedAt) {
+      action = 'backfill_earlybird_row';
+    } else if (userSubscriptions.length === 0 && !earlybirdPurchaseCreatedAt) {
+      action = 'bootstrap_trial_row';
+    }
+
+    return {
+      action,
+      instanceId: row.instanceId,
+      userId: row.userId,
+      sandboxId: row.sandboxId,
+      instanceCreatedAt: row.createdAt,
+      instanceDestroyedAt: row.destroyedAt,
+      earlybirdPurchaseCreatedAt,
+      hasEarlybird: !!earlybirdPurchaseCreatedAt,
+      totalSubscriptionCount: userSubscriptions.length,
+      detachedTotalCount: detachedRows.length,
+      detachedAccessCount: detachedAccessRows.length,
+      linkedPersonalTotalCount: linkedPersonalRows.length,
+      linkedDestroyedTotalCount: linkedDestroyedRows.length,
+      linkedDestroyedAccessCount: linkedDestroyedAccessRows.length,
+      targetSubscriptionId,
+    };
+  });
+}
+
+async function getLatestSeatPurchases(orgIds: string[]) {
+  if (orgIds.length === 0) return [];
+  return await db
+    .select({
+      organizationId: organization_seats_purchases.organization_id,
+      subscriptionStatus: organization_seats_purchases.subscription_status,
+      createdAt: organization_seats_purchases.created_at,
+    })
+    .from(organization_seats_purchases)
+    .where(inArray(organization_seats_purchases.organization_id, orgIds))
+    .orderBy(
+      organization_seats_purchases.organization_id,
+      desc(organization_seats_purchases.created_at)
+    );
+}
+
+async function getOrganizationsByIds(orgIds: string[]) {
+  if (orgIds.length === 0) return [];
+  return await db
+    .select({
+      id: organizations.id,
+      createdAt: organizations.created_at,
+      freeTrialEndAt: organizations.free_trial_end_at,
+      requireSeats: organizations.require_seats,
+      settings: organizations.settings,
+    })
+    .from(organizations)
+    .where(inArray(organizations.id, orgIds));
+}
+
+async function listActiveInstancesByContext(): Promise<ActiveInstanceContextRow[]> {
+  return await db
+    .select({
+      instanceId: kiloclaw_instances.id,
+      userId: kiloclaw_instances.user_id,
+      organizationId: kiloclaw_instances.organization_id,
+      sandboxId: kiloclaw_instances.sandbox_id,
+      createdAt: kiloclaw_instances.created_at,
+    })
+    .from(kiloclaw_instances)
+    .where(isNull(kiloclaw_instances.destroyed_at))
+    .orderBy(
+      kiloclaw_instances.user_id,
+      sql`coalesce(${kiloclaw_instances.organization_id}::text, 'personal')`,
+      kiloclaw_instances.created_at
+    );
+}
+
+async function buildDuplicateActiveInstanceCandidates(): Promise<
+  DuplicateActiveInstanceCandidate[]
+> {
+  const activeInstances = await listActiveInstancesByContext();
+  const grouped = new Map<string, ActiveInstanceContextRow[]>();
+
+  for (const row of activeInstances) {
+    const key = `${row.userId}:${row.organizationId ?? 'personal'}`;
+    const existing = grouped.get(key);
+    if (existing) {
+      existing.push(row);
+    } else {
+      grouped.set(key, [row]);
+    }
+  }
+
+  const duplicateRows = [...grouped.values()].flatMap(rows =>
+    rows.length > 1 ? rows.slice(1) : []
+  );
+  const canonicalRows = [...grouped.values()]
+    .filter(rows => rows.length > 1)
+    .map(rows => rows[0])
+    .filter((row): row is ActiveInstanceContextRow => !!row);
+
+  const instanceIds = [
+    ...new Set([
+      ...duplicateRows.map(row => row.instanceId),
+      ...canonicalRows.map(row => row.instanceId),
+    ]),
+  ];
+  const orgIds = [
+    ...new Set(
+      duplicateRows
+        .map(row => row.organizationId)
+        .filter((organizationId): organizationId is string => typeof organizationId === 'string')
+    ),
+  ];
+
+  const [subscriptions, orgRows, purchases] = await Promise.all([
+    getSubscriptionsForInstances(instanceIds),
+    getOrganizationsByIds(orgIds),
+    getLatestSeatPurchases(orgIds),
+  ]);
+
+  const subscriptionsByInstanceId = new Map<string, KiloClawSubscription[]>();
+  for (const subscription of subscriptions) {
+    const instanceId = subscription.instance_id;
+    if (!instanceId) {
+      continue;
+    }
+    const existing = subscriptionsByInstanceId.get(instanceId);
+    if (existing) {
+      existing.push(subscription);
+    } else {
+      subscriptionsByInstanceId.set(instanceId, [subscription]);
+    }
+  }
+
+  const organizationById = new Map(orgRows.map(row => [row.id, row]));
+  const latestPurchaseByOrgId = new Map<
+    string,
+    Pick<OrganizationSeatsPurchase, 'subscription_status'>
+  >();
+  for (const purchase of purchases) {
+    if (!latestPurchaseByOrgId.has(purchase.organizationId)) {
+      latestPurchaseByOrgId.set(purchase.organizationId, {
+        subscription_status: purchase.subscriptionStatus,
+      });
+    }
+  }
+
+  const candidates: DuplicateActiveInstanceCandidate[] = [];
+  for (const rows of grouped.values()) {
+    if (rows.length <= 1) {
+      continue;
+    }
+
+    const canonical = rows[0];
+    if (!canonical) {
+      continue;
+    }
+    const canonicalSubscriptions = subscriptionsByInstanceId.get(canonical.instanceId) ?? [];
+
+    for (const duplicate of rows.slice(1)) {
+      const duplicateSubscriptions = subscriptionsByInstanceId.get(duplicate.instanceId) ?? [];
+      const organizationRow =
+        typeof duplicate.organizationId === 'string'
+          ? (organizationById.get(duplicate.organizationId) ?? null)
+          : null;
+      const latestPurchase =
+        typeof duplicate.organizationId === 'string'
+          ? (latestPurchaseByOrgId.get(duplicate.organizationId) ?? null)
+          : null;
+
+      let action: DuplicateActiveInstanceAction = 'manual_review';
+      let targetSubscriptionId: string | null = null;
+
+      if (duplicateSubscriptions.length === 0) {
+        action =
+          duplicate.organizationId === null
+            ? 'backfill_destroy_duplicate_personal'
+            : 'backfill_destroy_duplicate_org';
+      } else if (duplicateSubscriptions.length === 1 && canonicalSubscriptions.length === 0) {
+        action = 'reassign_to_canonical_and_destroy_duplicate';
+        targetSubscriptionId = duplicateSubscriptions[0]?.id ?? null;
+      }
+
+      candidates.push({
+        action,
+        contextType: duplicate.organizationId === null ? 'personal' : 'organization',
+        userId: duplicate.userId,
+        organizationId: duplicate.organizationId,
+        canonicalInstanceId: canonical.instanceId,
+        canonicalCreatedAt: canonical.createdAt,
+        duplicateInstanceId: duplicate.instanceId,
+        duplicateSandboxId: duplicate.sandboxId,
+        duplicateCreatedAt: duplicate.createdAt,
+        canonicalSubscriptionCount: canonicalSubscriptions.length,
+        duplicateSubscriptionCount: duplicateSubscriptions.length,
+        targetSubscriptionId,
+        organizationCreatedAt: organizationRow?.createdAt ?? null,
+        freeTrialEndAt: organizationRow?.freeTrialEndAt ?? null,
+        requireSeats: organizationRow?.requireSeats ?? null,
+        organizationSettings: organizationRow?.settings ?? null,
+        latestPurchaseStatus: latestPurchase?.subscription_status ?? null,
+      });
+    }
+  }
+
+  return candidates;
+}
+
+async function buildOrgBackfillCandidates(): Promise<OrgBackfillCandidate[]> {
+  const missingRows = await listOrgInstancesWithoutRows();
+  const orgIds = [
+    ...new Set(
+      missingRows
+        .map(row => row.organizationId)
+        .filter((organizationId): organizationId is string => !!organizationId)
+    ),
+  ];
+  const purchases = await getLatestSeatPurchases(orgIds);
+  const latestPurchaseByOrgId = new Map<
+    string,
+    Pick<OrganizationSeatsPurchase, 'subscription_status'>
+  >();
+
+  for (const purchase of purchases) {
+    if (!latestPurchaseByOrgId.has(purchase.organizationId)) {
+      latestPurchaseByOrgId.set(purchase.organizationId, {
+        subscription_status: purchase.subscriptionStatus,
+      });
+    }
+  }
+
+  return missingRows
+    .filter(
+      (row): row is typeof row & { organizationId: string } =>
+        typeof row.organizationId === 'string'
+    )
+    .map(row => {
+      const latestPurchase = latestPurchaseByOrgId.get(row.organizationId) ?? null;
+      const hasManagedActiveAccess = getOrganizationManagedActiveAccess({
+        organization: {
+          require_seats: row.requireSeats,
+          settings: row.settings,
+        },
+        latestPurchase,
+      });
+      const action = row.destroyedAt
+        ? hasManagedActiveAccess
+          ? 'backfill_destroyed_standard_credits'
+          : 'backfill_destroyed_trial'
+        : hasManagedActiveAccess
+          ? 'backfill_active_standard_credits'
+          : 'backfill_trial';
+
+      return {
+        action,
+        instanceId: row.instanceId,
+        userId: row.userId,
+        organizationId: row.organizationId,
+        instanceCreatedAt: row.instanceCreatedAt,
+        organizationCreatedAt: row.organizationCreatedAt,
+        freeTrialEndAt: row.freeTrialEndAt,
+        requireSeats: row.requireSeats,
+        latestPurchaseStatus: latestPurchase?.subscription_status ?? null,
+        destroyedAt: row.destroyedAt,
+      };
+    });
+}
+
+function summarizeMissingPersonalCandidates(rows: MissingPersonalCandidate[]) {
+  return Object.entries(
+    rows.reduce<Record<MissingPersonalBackfillAction, number>>(
+      (acc, row) => {
+        acc[row.action] += 1;
+        return acc;
+      },
+      {
+        adopt_detached_access_row: 0,
+        reassign_destroyed_access_row: 0,
+        bootstrap_trial_row: 0,
+        backfill_earlybird_row: 0,
+        manual_review: 0,
+      }
+    )
+  ).map(([action, count]) => ({ action, count }));
+}
+
+function summarizeOrgBackfillCandidates(rows: OrgBackfillCandidate[]) {
+  return Object.entries(
+    rows.reduce<Record<OrgBackfillAction, number>>(
+      (acc, row) => {
+        acc[row.action] += 1;
+        return acc;
+      },
+      {
+        backfill_active_standard_credits: 0,
+        backfill_trial: 0,
+        backfill_destroyed_standard_credits: 0,
+        backfill_destroyed_trial: 0,
+      }
+    )
+  ).map(([action, count]) => ({ action, count }));
+}
+
+function summarizeDuplicateActiveInstanceCandidates(rows: DuplicateActiveInstanceCandidate[]) {
+  return Object.entries(
+    rows.reduce<Record<DuplicateActiveInstanceAction, number>>(
+      (acc, row) => {
+        acc[row.action] += 1;
+        return acc;
+      },
+      {
+        backfill_destroy_duplicate_personal: 0,
+        backfill_destroy_duplicate_org: 0,
+        reassign_to_canonical_and_destroy_duplicate: 0,
+        manual_review: 0,
+      }
+    )
+  ).map(([action, count]) => ({ action, count }));
+}
+
+async function listSubscriptionsMissingBaselineChangeLog(): Promise<MissingChangelogBaselineRow[]> {
+  return await db
+    .select()
+    .from(kiloclaw_subscriptions)
+    .where(
+      notExists(
+        db
+          .select({ id: kiloclaw_subscription_change_log.id })
+          .from(kiloclaw_subscription_change_log)
+          .where(eq(kiloclaw_subscription_change_log.subscription_id, kiloclaw_subscriptions.id))
+      )
+    )
+    .orderBy(desc(kiloclaw_subscriptions.created_at));
+}
+
+async function previewChangelogBaselineBackfill() {
+  const rows = await listSubscriptionsMissingBaselineChangeLog();
+  printSection(
+    'Subscriptions missing baseline change log',
+    rows.map(row => ({
+      subscriptionId: row.id,
+      userId: row.user_id,
+      instanceId: row.instance_id,
+      plan: row.plan,
+      status: row.status,
+      accessOrigin: row.access_origin,
+      createdAt: row.created_at,
+    }))
+  );
+}
+
+async function applyChangelogBaselineBackfill() {
+  const rows = await listSubscriptionsMissingBaselineChangeLog();
+  let inserted = 0;
+
+  for (const row of rows) {
+    const [existingLog] = await db
+      .select({ id: kiloclaw_subscription_change_log.id })
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, row.id))
+      .limit(1);
+
+    if (existingLog) {
+      continue;
+    }
+
+    await insertAlignmentChangeLog({
+      subscriptionId: row.id,
+      action: 'backfilled',
+      reason: 'baseline_subscription_snapshot',
+      before: null,
+      after: row,
+    });
+    inserted += 1;
+  }
+
+  console.log('\nChangelog baseline backfill results');
+  console.table([{ action: 'backfilled', count: inserted }]);
+}
+
+async function previewMissingPersonalBackfill() {
+  const rows = await buildMissingPersonalCandidates();
+  printSection('Missing personal backfill action counts', summarizeMissingPersonalCandidates(rows));
+  printSection(
+    'Missing personal rows safe to adopt detached access row',
+    rows
+      .filter(row => row.action === 'adopt_detached_access_row')
+      .map(row => ({
+        instanceId: row.instanceId,
+        userId: row.userId,
+        sandboxId: row.sandboxId,
+        instanceDestroyedAt: row.instanceDestroyedAt,
+        targetSubscriptionId: row.targetSubscriptionId,
+        instanceCreatedAt: row.instanceCreatedAt,
+      }))
+  );
+  printSection(
+    'Missing personal rows safe to reassign destroyed access row',
+    rows
+      .filter(row => row.action === 'reassign_destroyed_access_row')
+      .map(row => ({
+        instanceId: row.instanceId,
+        userId: row.userId,
+        sandboxId: row.sandboxId,
+        instanceDestroyedAt: row.instanceDestroyedAt,
+        targetSubscriptionId: row.targetSubscriptionId,
+        instanceCreatedAt: row.instanceCreatedAt,
+      }))
+  );
+  printSection(
+    'Missing personal rows safe to bootstrap trial row',
+    rows
+      .filter(row => row.action === 'bootstrap_trial_row')
+      .map(row => ({
+        instanceId: row.instanceId,
+        userId: row.userId,
+        sandboxId: row.sandboxId,
+        instanceDestroyedAt: row.instanceDestroyedAt,
+        trialEndsAt: getTrialEndsAt(row.instanceCreatedAt),
+        instanceCreatedAt: row.instanceCreatedAt,
+      }))
+  );
+  printSection(
+    'Missing personal rows safe to backfill earlybird row',
+    rows
+      .filter(row => row.action === 'backfill_earlybird_row')
+      .map(row => ({
+        instanceId: row.instanceId,
+        userId: row.userId,
+        sandboxId: row.sandboxId,
+        instanceDestroyedAt: row.instanceDestroyedAt,
+        earlybirdPurchaseCreatedAt: row.earlybirdPurchaseCreatedAt,
+        trialEndsAt: getEarlybirdEndsAt(),
+        instanceCreatedAt: row.instanceCreatedAt,
+      }))
+  );
+  printSection(
+    'Missing personal rows left for manual review',
+    rows
+      .filter(row => row.action === 'manual_review')
+      .map(row => ({
+        instanceId: row.instanceId,
+        userId: row.userId,
+        sandboxId: row.sandboxId,
+        instanceDestroyedAt: row.instanceDestroyedAt,
+        earlybirdPurchaseCreatedAt: row.earlybirdPurchaseCreatedAt,
+        totalSubscriptionCount: row.totalSubscriptionCount,
+        detachedTotalCount: row.detachedTotalCount,
+        detachedAccessCount: row.detachedAccessCount,
+        linkedPersonalTotalCount: row.linkedPersonalTotalCount,
+        linkedDestroyedTotalCount: row.linkedDestroyedTotalCount,
+        linkedDestroyedAccessCount: row.linkedDestroyedAccessCount,
+        hasEarlybird: row.hasEarlybird,
+      }))
+  );
+}
+
+async function previewOrgBackfill() {
+  const rows = await buildOrgBackfillCandidates();
+  printSection('Org backfill action counts', summarizeOrgBackfillCandidates(rows));
+  printSection(
+    'Org rows to backfill as active standard credits',
+    rows
+      .filter(row => row.action === 'backfill_active_standard_credits')
+      .map(row => ({
+        instanceId: row.instanceId,
+        organizationId: row.organizationId,
+        userId: row.userId,
+        latestPurchaseStatus: row.latestPurchaseStatus,
+        requireSeats: row.requireSeats,
+        destroyedAt: row.destroyedAt,
+        instanceCreatedAt: row.instanceCreatedAt,
+      }))
+  );
+  printSection(
+    'Org rows to backfill as active trial rows',
+    rows
+      .filter(row => row.action === 'backfill_trial')
+      .map(row => ({
+        instanceId: row.instanceId,
+        organizationId: row.organizationId,
+        userId: row.userId,
+        latestPurchaseStatus: row.latestPurchaseStatus,
+        requireSeats: row.requireSeats,
+        destroyedAt: row.destroyedAt,
+        trialStartedAt: row.organizationCreatedAt,
+        trialEndsAt: row.freeTrialEndAt ?? getTrialEndsAt(row.organizationCreatedAt),
+      }))
+  );
+  printSection(
+    'Org rows to backfill as destroyed standard credits',
+    rows
+      .filter(row => row.action === 'backfill_destroyed_standard_credits')
+      .map(row => ({
+        instanceId: row.instanceId,
+        organizationId: row.organizationId,
+        userId: row.userId,
+        latestPurchaseStatus: row.latestPurchaseStatus,
+        requireSeats: row.requireSeats,
+        destroyedAt: row.destroyedAt,
+        instanceCreatedAt: row.instanceCreatedAt,
+      }))
+  );
+  printSection(
+    'Org rows to backfill as destroyed trial rows',
+    rows
+      .filter(row => row.action === 'backfill_destroyed_trial')
+      .map(row => ({
+        instanceId: row.instanceId,
+        organizationId: row.organizationId,
+        userId: row.userId,
+        latestPurchaseStatus: row.latestPurchaseStatus,
+        requireSeats: row.requireSeats,
+        destroyedAt: row.destroyedAt,
+        trialStartedAt: row.organizationCreatedAt,
+        trialEndsAt: row.freeTrialEndAt ?? getTrialEndsAt(row.organizationCreatedAt),
+      }))
+  );
+}
+
+async function previewDuplicateActiveInstances() {
+  const rows = await buildDuplicateActiveInstanceCandidates();
+  printSection(
+    'Duplicate active instance action counts',
+    summarizeDuplicateActiveInstanceCandidates(rows)
+  );
+  printSection(
+    'Duplicate active personal instances safe to backfill and destroy',
+    rows
+      .filter(row => row.action === 'backfill_destroy_duplicate_personal')
+      .map(row => ({
+        userId: row.userId,
+        canonicalInstanceId: row.canonicalInstanceId,
+        duplicateInstanceId: row.duplicateInstanceId,
+        duplicateSandboxId: row.duplicateSandboxId,
+        canonicalSubscriptionCount: row.canonicalSubscriptionCount,
+        duplicateCreatedAt: row.duplicateCreatedAt,
+      }))
+  );
+  printSection(
+    'Duplicate active org instances safe to backfill and destroy',
+    rows
+      .filter(row => row.action === 'backfill_destroy_duplicate_org')
+      .map(row => ({
+        userId: row.userId,
+        organizationId: row.organizationId,
+        canonicalInstanceId: row.canonicalInstanceId,
+        duplicateInstanceId: row.duplicateInstanceId,
+        duplicateSandboxId: row.duplicateSandboxId,
+        latestPurchaseStatus: row.latestPurchaseStatus,
+        requireSeats: row.requireSeats,
+        duplicateCreatedAt: row.duplicateCreatedAt,
+      }))
+  );
+  printSection(
+    'Duplicate active instances safe to reassign to canonical and destroy',
+    rows
+      .filter(row => row.action === 'reassign_to_canonical_and_destroy_duplicate')
+      .map(row => ({
+        userId: row.userId,
+        organizationId: row.organizationId,
+        canonicalInstanceId: row.canonicalInstanceId,
+        duplicateInstanceId: row.duplicateInstanceId,
+        targetSubscriptionId: row.targetSubscriptionId,
+        canonicalSubscriptionCount: row.canonicalSubscriptionCount,
+        duplicateSubscriptionCount: row.duplicateSubscriptionCount,
+      }))
+  );
+  printSection(
+    'Duplicate active instances left for manual review',
+    rows
+      .filter(row => row.action === 'manual_review')
+      .map(row => ({
+        userId: row.userId,
+        organizationId: row.organizationId,
+        canonicalInstanceId: row.canonicalInstanceId,
+        duplicateInstanceId: row.duplicateInstanceId,
+        canonicalSubscriptionCount: row.canonicalSubscriptionCount,
+        duplicateSubscriptionCount: row.duplicateSubscriptionCount,
+        targetSubscriptionId: row.targetSubscriptionId,
+      }))
+  );
+}
+
+async function insertDuplicateTerminalSubscription(
+  row: DuplicateActiveInstanceCandidate
+): Promise<KiloClawSubscription | null> {
+  if (row.contextType === 'personal') {
+    const [inserted] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: row.userId,
+        instance_id: row.duplicateInstanceId,
+        plan: 'trial',
+        status: 'canceled',
+        payment_source: null,
+        cancel_at_period_end: false,
+        trial_started_at: row.duplicateCreatedAt,
+        trial_ends_at: getTrialEndsAt(row.duplicateCreatedAt),
+        created_at: row.duplicateCreatedAt,
+        updated_at: row.duplicateCreatedAt,
+      })
+      .returning();
+    return inserted ?? null;
+  }
+
+  if (
+    !row.organizationId ||
+    row.organizationCreatedAt === null ||
+    row.requireSeats === null ||
+    row.organizationSettings === null
+  ) {
+    return null;
+  }
+
+  const hasManagedActiveAccess = getOrganizationManagedActiveAccess({
+    organization: {
+      require_seats: row.requireSeats,
+      settings: row.organizationSettings,
+    },
+    latestPurchase: row.latestPurchaseStatus
+      ? { subscription_status: row.latestPurchaseStatus }
+      : null,
+  });
+
+  const [inserted] = await db
+    .insert(kiloclaw_subscriptions)
+    .values(
+      hasManagedActiveAccess
+        ? {
+            user_id: row.userId,
+            instance_id: row.duplicateInstanceId,
+            plan: 'standard',
+            status: 'canceled',
+            payment_source: 'credits',
+            cancel_at_period_end: false,
+            created_at: row.duplicateCreatedAt,
+            updated_at: row.duplicateCreatedAt,
+          }
+        : {
+            user_id: row.userId,
+            instance_id: row.duplicateInstanceId,
+            plan: 'trial',
+            status: 'canceled',
+            payment_source: null,
+            cancel_at_period_end: false,
+            trial_started_at: row.organizationCreatedAt,
+            trial_ends_at: row.freeTrialEndAt ?? getTrialEndsAt(row.organizationCreatedAt),
+            created_at: row.duplicateCreatedAt,
+            updated_at: row.duplicateCreatedAt,
+          }
+    )
+    .returning();
+
+  return inserted ?? null;
+}
+
+async function markDuplicateInstanceDestroyed(instanceId: string): Promise<boolean> {
+  const destroyedAt = new Date().toISOString();
+  const rows = await db
+    .update(kiloclaw_instances)
+    .set({ destroyed_at: destroyedAt })
+    .where(and(eq(kiloclaw_instances.id, instanceId), isNull(kiloclaw_instances.destroyed_at)))
+    .returning({ id: kiloclaw_instances.id });
+
+  return rows.length > 0;
+}
+
+async function applyDuplicateActiveInstances() {
+  const rows = await buildDuplicateActiveInstanceCandidates();
+  let personalDestroyed = 0;
+  let orgDestroyed = 0;
+  let reassigned = 0;
+  const skipped: Array<{
+    duplicateInstanceId: string;
+    canonicalInstanceId: string;
+    userId: string;
+    action: string;
+  }> = [];
+
+  for (const row of rows) {
+    if (
+      row.action !== 'backfill_destroy_duplicate_personal' &&
+      row.action !== 'backfill_destroy_duplicate_org' &&
+      row.action !== 'reassign_to_canonical_and_destroy_duplicate'
+    ) {
+      continue;
+    }
+
+    const [canonicalExisting, duplicateExisting] = await Promise.all([
+      db
+        .select()
+        .from(kiloclaw_subscriptions)
+        .where(eq(kiloclaw_subscriptions.instance_id, row.canonicalInstanceId)),
+      db
+        .select()
+        .from(kiloclaw_subscriptions)
+        .where(eq(kiloclaw_subscriptions.instance_id, row.duplicateInstanceId)),
+    ]);
+
+    if (
+      row.action === 'reassign_to_canonical_and_destroy_duplicate' &&
+      (!row.targetSubscriptionId || canonicalExisting.length > 0 || duplicateExisting.length !== 1)
+    ) {
+      skipped.push({
+        duplicateInstanceId: row.duplicateInstanceId,
+        canonicalInstanceId: row.canonicalInstanceId,
+        userId: row.userId,
+        action: row.action,
+      });
+      continue;
+    }
+
+    if (
+      (row.action === 'backfill_destroy_duplicate_personal' ||
+        row.action === 'backfill_destroy_duplicate_org') &&
+      duplicateExisting.length > 0
+    ) {
+      skipped.push({
+        duplicateInstanceId: row.duplicateInstanceId,
+        canonicalInstanceId: row.canonicalInstanceId,
+        userId: row.userId,
+        action: row.action,
+      });
+      continue;
+    }
+
+    if (row.action === 'reassign_to_canonical_and_destroy_duplicate') {
+      const before = duplicateExisting[0] ?? null;
+      if (!before || before.id !== row.targetSubscriptionId) {
+        skipped.push({
+          duplicateInstanceId: row.duplicateInstanceId,
+          canonicalInstanceId: row.canonicalInstanceId,
+          userId: row.userId,
+          action: row.action,
+        });
+        continue;
+      }
+
+      const [updated] = await db
+        .update(kiloclaw_subscriptions)
+        .set({ instance_id: row.canonicalInstanceId })
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.id, row.targetSubscriptionId),
+            eq(kiloclaw_subscriptions.instance_id, row.duplicateInstanceId)
+          )
+        )
+        .returning();
+
+      if (!updated) {
+        skipped.push({
+          duplicateInstanceId: row.duplicateInstanceId,
+          canonicalInstanceId: row.canonicalInstanceId,
+          userId: row.userId,
+          action: row.action,
+        });
+        continue;
+      }
+
+      await insertAlignmentChangeLog({
+        subscriptionId: updated.id,
+        action: 'reassigned',
+        reason: 'apply_duplicate_active_reassign_to_canonical',
+        before,
+        after: updated,
+      });
+      reassigned += 1;
+    }
+
+    const replacement = await insertDuplicateTerminalSubscription(row);
+    if (!replacement) {
+      skipped.push({
+        duplicateInstanceId: row.duplicateInstanceId,
+        canonicalInstanceId: row.canonicalInstanceId,
+        userId: row.userId,
+        action: row.action,
+      });
+      continue;
+    }
+
+    await insertAlignmentChangeLog({
+      subscriptionId: replacement.id,
+      action: 'backfilled',
+      reason:
+        row.contextType === 'personal'
+          ? 'apply_duplicate_active_backfill_personal_terminal'
+          : 'apply_duplicate_active_backfill_org_terminal',
+      before: null,
+      after: replacement,
+    });
+
+    const destroyed = await markDuplicateInstanceDestroyed(row.duplicateInstanceId);
+    if (!destroyed) {
+      skipped.push({
+        duplicateInstanceId: row.duplicateInstanceId,
+        canonicalInstanceId: row.canonicalInstanceId,
+        userId: row.userId,
+        action: row.action,
+      });
+      continue;
+    }
+
+    if (row.contextType === 'personal') {
+      personalDestroyed += 1;
+    } else {
+      orgDestroyed += 1;
+    }
+  }
+
+  console.log('\nDuplicate active instance apply results');
+  console.table([
+    { action: 'backfill_destroy_duplicate_personal', count: personalDestroyed },
+    { action: 'backfill_destroy_duplicate_org', count: orgDestroyed },
+    { action: 'reassign_to_canonical_and_destroy_duplicate', count: reassigned },
+    { action: 'skipped', count: skipped.length },
+  ]);
+  printSection('Duplicate active instances skipped during apply', skipped);
+}
+
+async function applyMissingPersonalBackfill() {
+  const rows = await buildMissingPersonalCandidates();
+  let adopted = 0;
+  let reassigned = 0;
+  let bootstrapped = 0;
+  let earlybirdBackfilled = 0;
+  const skipped: Array<{ instanceId: string; userId: string; action: string }> = [];
+
+  for (const row of rows) {
+    if (row.action === 'adopt_detached_access_row') {
+      if (!row.targetSubscriptionId) {
+        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
+        continue;
+      }
+
+      const result = await db
+        .select()
+        .from(kiloclaw_subscriptions)
+        .where(eq(kiloclaw_subscriptions.id, row.targetSubscriptionId))
+        .limit(1);
+      const before = result[0] ?? null;
+      const updated = await db
+        .update(kiloclaw_subscriptions)
+        .set({ instance_id: row.instanceId })
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.id, row.targetSubscriptionId),
+            isNull(kiloclaw_subscriptions.instance_id)
+          )
+        )
+        .returning();
+      const updatedRow = updated[0] ?? null;
+
+      if (before && updatedRow) {
+        await insertAlignmentChangeLog({
+          subscriptionId: updatedRow.id,
+          action: 'reassigned',
+          reason: 'apply_missing_personal_adopt_detached',
+          before,
+          after: updatedRow,
+        });
+        adopted += 1;
+      } else {
+        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
+      }
+      continue;
+    }
+
+    if (row.action === 'reassign_destroyed_access_row') {
+      if (!row.targetSubscriptionId) {
+        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
+        continue;
+      }
+
+      const existing = await db
+        .select({ id: kiloclaw_subscriptions.id })
+        .from(kiloclaw_subscriptions)
+        .where(eq(kiloclaw_subscriptions.instance_id, row.instanceId))
+        .limit(1);
+      if (existing.length > 0) {
+        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
+        continue;
+      }
+
+      const [before] = await db
+        .select()
+        .from(kiloclaw_subscriptions)
+        .where(eq(kiloclaw_subscriptions.id, row.targetSubscriptionId))
+        .limit(1);
+      const updated = await db
+        .update(kiloclaw_subscriptions)
+        .set({ instance_id: row.instanceId })
+        .where(eq(kiloclaw_subscriptions.id, row.targetSubscriptionId))
+        .returning();
+      const updatedRow = updated[0] ?? null;
+
+      if (before && updatedRow) {
+        await insertAlignmentChangeLog({
+          subscriptionId: updatedRow.id,
+          action: 'reassigned',
+          reason: 'apply_missing_personal_reassign_destroyed',
+          before,
+          after: updatedRow,
+        });
+        reassigned += 1;
+      } else {
+        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
+      }
+      continue;
+    }
+
+    if (row.action === 'bootstrap_trial_row') {
+      const [existingForInstance, existingForUser] = await Promise.all([
+        db
+          .select({ id: kiloclaw_subscriptions.id })
+          .from(kiloclaw_subscriptions)
+          .where(eq(kiloclaw_subscriptions.instance_id, row.instanceId))
+          .limit(1),
+        db
+          .select({ id: kiloclaw_subscriptions.id })
+          .from(kiloclaw_subscriptions)
+          .where(eq(kiloclaw_subscriptions.user_id, row.userId))
+          .limit(1),
+      ]);
+
+      if (existingForInstance.length > 0 || existingForUser.length > 0) {
+        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
+        continue;
+      }
+
+      const trialEndsAt = getTrialEndsAt(row.instanceCreatedAt);
+      const [inserted] = await db
+        .insert(kiloclaw_subscriptions)
+        .values({
+          user_id: row.userId,
+          instance_id: row.instanceId,
+          plan: 'trial',
+          status: new Date(trialEndsAt).getTime() > Date.now() ? 'trialing' : 'canceled',
+          payment_source: null,
+          cancel_at_period_end: false,
+          trial_started_at: row.instanceCreatedAt,
+          trial_ends_at: trialEndsAt,
+          created_at: row.instanceCreatedAt,
+          updated_at: row.instanceCreatedAt,
+        })
+        .returning();
+
+      if (inserted) {
+        await insertAlignmentChangeLog({
+          subscriptionId: inserted.id,
+          action: 'backfilled',
+          reason: 'apply_missing_personal_bootstrap_trial',
+          before: null,
+          after: inserted,
+        });
+        bootstrapped += 1;
+      } else {
+        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
+      }
+      continue;
+    }
+
+    if (row.action === 'backfill_earlybird_row') {
+      const [existingForInstance, existingForUser, earlybirdPurchase] = await Promise.all([
+        db
+          .select({ id: kiloclaw_subscriptions.id })
+          .from(kiloclaw_subscriptions)
+          .where(eq(kiloclaw_subscriptions.instance_id, row.instanceId))
+          .limit(1),
+        db
+          .select({ id: kiloclaw_subscriptions.id })
+          .from(kiloclaw_subscriptions)
+          .where(eq(kiloclaw_subscriptions.user_id, row.userId))
+          .limit(1),
+        db
+          .select({ createdAt: kiloclaw_earlybird_purchases.created_at })
+          .from(kiloclaw_earlybird_purchases)
+          .where(eq(kiloclaw_earlybird_purchases.user_id, row.userId))
+          .limit(1),
+      ]);
+
+      if (
+        existingForInstance.length > 0 ||
+        existingForUser.length > 0 ||
+        earlybirdPurchase.length === 0
+      ) {
+        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
+        continue;
+      }
+
+      const trialEndsAt = getEarlybirdEndsAt();
+      const purchase = earlybirdPurchase[0];
+      if (!purchase) {
+        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
+        continue;
+      }
+      const [inserted] = await db
+        .insert(kiloclaw_subscriptions)
+        .values({
+          user_id: row.userId,
+          instance_id: row.instanceId,
+          access_origin: 'earlybird',
+          plan: 'trial',
+          status: new Date(trialEndsAt).getTime() > Date.now() ? 'trialing' : 'canceled',
+          payment_source: null,
+          cancel_at_period_end: false,
+          trial_started_at: purchase.createdAt,
+          trial_ends_at: trialEndsAt,
+          created_at: row.instanceCreatedAt,
+          updated_at: row.instanceCreatedAt,
+        })
+        .returning();
+
+      if (inserted) {
+        await insertAlignmentChangeLog({
+          subscriptionId: inserted.id,
+          action: 'backfilled',
+          reason: 'apply_missing_personal_backfill_earlybird',
+          before: null,
+          after: inserted,
+        });
+        earlybirdBackfilled += 1;
+      } else {
+        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
+      }
+    }
+  }
+
+  console.log('\nMissing personal backfill results');
+  console.table([
+    { action: 'adopt_detached_access_row', count: adopted },
+    { action: 'reassign_destroyed_access_row', count: reassigned },
+    { action: 'bootstrap_trial_row', count: bootstrapped },
+    { action: 'backfill_earlybird_row', count: earlybirdBackfilled },
+    { action: 'skipped', count: skipped.length },
+  ]);
+  printSection('Missing personal rows skipped during apply', skipped);
+}
+
+async function applyOrgBackfill() {
+  const rows = await buildOrgBackfillCandidates();
+  let activeStandardCredits = 0;
+  let activeTrialRows = 0;
+  let destroyedStandardCredits = 0;
+  let destroyedTrialRows = 0;
+  const skipped: Array<{
+    instanceId: string;
+    organizationId: string;
+    userId: string;
+    action: string;
+  }> = [];
+
+  for (const row of rows) {
+    const existing = await db
+      .select({ id: kiloclaw_subscriptions.id })
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.instance_id, row.instanceId))
+      .limit(1);
+    if (existing.length > 0) {
+      skipped.push({
+        instanceId: row.instanceId,
+        organizationId: row.organizationId,
+        userId: row.userId,
+        action: row.action,
+      });
+      continue;
+    }
+
+    const trialEndsAt = row.freeTrialEndAt ?? getTrialEndsAt(row.organizationCreatedAt);
+    const trialStatus = new Date(trialEndsAt).getTime() > Date.now() ? 'trialing' : 'canceled';
+    const [inserted] = await db
+      .insert(kiloclaw_subscriptions)
+      .values(
+        row.action === 'backfill_active_standard_credits'
+          ? {
+              user_id: row.userId,
+              instance_id: row.instanceId,
+              plan: 'standard',
+              status: 'active',
+              payment_source: 'credits',
+              cancel_at_period_end: false,
+              created_at: row.instanceCreatedAt,
+              updated_at: row.instanceCreatedAt,
+            }
+          : row.action === 'backfill_destroyed_standard_credits'
+            ? {
+                user_id: row.userId,
+                instance_id: row.instanceId,
+                plan: 'standard',
+                status: 'canceled',
+                payment_source: 'credits',
+                cancel_at_period_end: false,
+                created_at: row.instanceCreatedAt,
+                updated_at: row.instanceCreatedAt,
+              }
+            : {
+                user_id: row.userId,
+                instance_id: row.instanceId,
+                plan: 'trial',
+                status: row.action === 'backfill_destroyed_trial' ? 'canceled' : trialStatus,
+                payment_source: null,
+                cancel_at_period_end: false,
+                trial_started_at: row.organizationCreatedAt,
+                trial_ends_at: trialEndsAt,
+                created_at: row.instanceCreatedAt,
+                updated_at: row.instanceCreatedAt,
+              }
+      )
+      .returning();
+
+    if (!inserted) {
+      skipped.push({
+        instanceId: row.instanceId,
+        organizationId: row.organizationId,
+        userId: row.userId,
+        action: row.action,
+      });
+      continue;
+    }
+
+    if (row.action === 'backfill_active_standard_credits') {
+      await insertAlignmentChangeLog({
+        subscriptionId: inserted.id,
+        action: 'backfilled',
+        reason: 'apply_org_backfill_active_standard_credits',
+        before: null,
+        after: inserted,
+      });
+      activeStandardCredits += 1;
+    } else if (row.action === 'backfill_trial') {
+      await insertAlignmentChangeLog({
+        subscriptionId: inserted.id,
+        action: 'backfilled',
+        reason: 'apply_org_backfill_trial',
+        before: null,
+        after: inserted,
+      });
+      activeTrialRows += 1;
+    } else if (row.action === 'backfill_destroyed_standard_credits') {
+      await insertAlignmentChangeLog({
+        subscriptionId: inserted.id,
+        action: 'backfilled',
+        reason: 'apply_org_backfill_destroyed_standard_credits',
+        before: null,
+        after: inserted,
+      });
+      destroyedStandardCredits += 1;
+    } else {
+      await insertAlignmentChangeLog({
+        subscriptionId: inserted.id,
+        action: 'backfilled',
+        reason: 'apply_org_backfill_destroyed_trial',
+        before: null,
+        after: inserted,
+      });
+      destroyedTrialRows += 1;
+    }
+  }
+
+  console.log('\nOrg backfill results');
+  console.table([
+    { action: 'backfill_active_standard_credits', count: activeStandardCredits },
+    { action: 'backfill_trial', count: activeTrialRows },
+    { action: 'backfill_destroyed_standard_credits', count: destroyedStandardCredits },
+    { action: 'backfill_destroyed_trial', count: destroyedTrialRows },
+    { action: 'skipped', count: skipped.length },
+  ]);
+  printSection('Org rows skipped during apply', skipped);
+}
+
+function parseMode(inputMode?: string): Mode {
+  const mode = inputMode ?? 'audit';
+  switch (mode) {
+    case 'audit':
+    case 'repair-detached':
+    case 'preview-missing-personal':
+    case 'apply-missing-personal':
+    case 'preview-duplicates':
+    case 'apply-duplicates':
+    case 'preview-org':
+    case 'apply-org':
+    case 'preview-changelog-baseline':
+    case 'apply-changelog-baseline':
+      return mode;
+    default:
+      throw new Error(`Unsupported mode: ${inputMode}`);
+  }
+}
+
+export async function run(inputMode?: string) {
+  const mode = parseMode(inputMode);
+
+  if (mode === 'preview-missing-personal') {
+    console.log(`Mode: ${mode}`);
+    await previewMissingPersonalBackfill();
+    return;
+  }
+
+  if (mode === 'apply-missing-personal') {
+    console.log(`Mode: ${mode}`);
+    await applyMissingPersonalBackfill();
+    return;
+  }
+
+  if (mode === 'preview-duplicates') {
+    console.log(`Mode: ${mode}`);
+    await previewDuplicateActiveInstances();
+    return;
+  }
+
+  if (mode === 'apply-duplicates') {
+    console.log(`Mode: ${mode}`);
+    await applyDuplicateActiveInstances();
+    return;
+  }
+
+  if (mode === 'preview-org') {
+    console.log(`Mode: ${mode}`);
+    await previewOrgBackfill();
+    return;
+  }
+
+  if (mode === 'apply-org') {
+    console.log(`Mode: ${mode}`);
+    await applyOrgBackfill();
+    return;
+  }
+
+  if (mode === 'preview-changelog-baseline') {
+    console.log(`Mode: ${mode}`);
+    await previewChangelogBaselineBackfill();
+    return;
+  }
+
+  if (mode === 'apply-changelog-baseline') {
+    console.log(`Mode: ${mode}`);
+    await applyChangelogBaselineBackfill();
+    return;
+  }
+
+  const [
+    personalRowsWithoutSubscriptions,
+    personalCandidates,
+    duplicateCandidates,
+    orgCandidates,
+    detachedRows,
+    missingChangelogRows,
+  ] = await Promise.all([
+    listPersonalInstancesWithoutRows(),
+    buildMissingPersonalCandidates(),
+    buildDuplicateActiveInstanceCandidates(),
+    buildOrgBackfillCandidates(),
+    listDetachedSubscriptions(),
+    listSubscriptionsMissingBaselineChangeLog(),
+  ]);
+  const { repairable, quarantined } = summarizeDetachedRows(detachedRows);
+
+  console.log(`Mode: ${mode}`);
+  printSection(
+    'Active personal instances without linked subscription row',
+    personalRowsWithoutSubscriptions.filter(row => !row.destroyedAt)
+  );
+  printSection(
+    'Destroyed personal instances without linked subscription row',
+    personalRowsWithoutSubscriptions.filter(row => !!row.destroyedAt)
+  );
+  printSection(
+    'Personal missing-row backfill action counts',
+    summarizeMissingPersonalCandidates(personalCandidates)
+  );
+  printSection(
+    'Duplicate active instance action counts',
+    summarizeDuplicateActiveInstanceCandidates(duplicateCandidates)
+  );
+  printSection(
+    'Active org instances without linked subscription row',
+    orgCandidates.filter(
+      row => row.action === 'backfill_active_standard_credits' || row.action === 'backfill_trial'
+    )
+  );
+  printSection(
+    'Destroyed org instances without linked subscription row',
+    orgCandidates.filter(
+      row =>
+        row.action === 'backfill_destroyed_standard_credits' ||
+        row.action === 'backfill_destroyed_trial'
+    )
+  );
+  printSection(
+    'Org missing-row backfill action counts',
+    summarizeOrgBackfillCandidates(orgCandidates)
+  );
+  printSection(
+    'Detached subscriptions safe to adopt',
+    repairable.map(row => ({
+      subscriptionId: row.subscriptionId,
+      userId: row.userId,
+      status: row.status,
+      plan: row.plan,
+      targetInstanceId: row.targetInstanceId,
+    }))
+  );
+  printSection(
+    'Detached subscriptions quarantined',
+    quarantined.map(row => ({
+      subscriptionId: row.subscriptionId,
+      userId: row.userId,
+      status: row.status,
+      plan: row.plan,
+      detachedRowCount: row.detachedRowCount,
+      activePersonalInstanceCount: row.activePersonalInstanceCount,
+      linkedPersonalSubscriptionCount: row.linkedPersonalSubscriptionCount,
+      targetInstanceId: row.targetInstanceId,
+    }))
+  );
+  printSection(
+    'Subscriptions missing baseline change log',
+    missingChangelogRows.map(row => ({
+      subscriptionId: row.id,
+      userId: row.user_id,
+      instanceId: row.instance_id,
+      plan: row.plan,
+      status: row.status,
+      accessOrigin: row.access_origin,
+    }))
+  );
+
+  if (mode !== 'repair-detached') {
+    return;
+  }
+
+  let repaired = 0;
+  for (const row of repairable) {
+    if (!row.targetInstanceId) continue;
+    const [before] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, row.subscriptionId))
+      .limit(1);
+    const updated = await db
+      .update(kiloclaw_subscriptions)
+      .set({ instance_id: row.targetInstanceId })
+      .where(
+        and(
+          eq(kiloclaw_subscriptions.id, row.subscriptionId),
+          isNull(kiloclaw_subscriptions.instance_id)
+        )
+      )
+      .returning();
+    const updatedRow = updated[0] ?? null;
+    if (before && updatedRow) {
+      await insertAlignmentChangeLog({
+        subscriptionId: updatedRow.id,
+        action: 'reassigned',
+        reason: 'repair_detached_subscription',
+        before,
+        after: updatedRow,
+      });
+      repaired += 1;
+    }
+  }
+
+  console.log(`\nDetached subscriptions repaired: ${repaired}`);
+}

--- a/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
+++ b/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
@@ -15,11 +15,11 @@
  *   pnpm script db kiloclaw-subscription-alignment apply-changelog-baseline
  */
 
-import { and, desc, eq, inArray, isNull, notExists, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, notExists, or, sql } from 'drizzle-orm';
 
 import { TRIAL_DURATION_DAYS } from '@/lib/constants';
 import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
-import { db } from '@/lib/drizzle';
+import { db, type DrizzleTransaction } from '@/lib/drizzle';
 import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
 import {
   kiloclaw_earlybird_purchases,
@@ -32,6 +32,8 @@ import {
   type Organization,
   type OrganizationSeatsPurchase,
 } from '@kilocode/db/schema';
+
+type DbOrTx = typeof db | DrizzleTransaction;
 
 type Mode =
   | 'audit'
@@ -96,6 +98,7 @@ type MissingPersonalCandidate = {
   earlybirdPurchaseCreatedAt: string | null;
   hasEarlybird: boolean;
   totalSubscriptionCount: number;
+  personalContextSubscriptionCount: number;
   detachedTotalCount: number;
   detachedAccessCount: number;
   linkedPersonalTotalCount: number;
@@ -216,34 +219,53 @@ function printSection<T>(label: string, rows: T[]) {
   }
 }
 
-async function insertAlignmentChangeLog(params: {
-  subscriptionId: string;
-  action: 'backfilled' | 'reassigned';
-  reason: string;
-  before: KiloClawSubscription | null;
-  after: KiloClawSubscription | null;
-}) {
+function describeError(error: unknown): string {
+  return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+}
+
+async function insertAlignmentChangeLog(
+  writer: DbOrTx,
+  params: {
+    subscriptionId: string;
+    action: 'backfilled' | 'reassigned';
+    reason: string;
+    before: KiloClawSubscription | null;
+    after: KiloClawSubscription | null;
+  }
+) {
   if (!params.after) {
     return;
   }
 
-  try {
-    await insertKiloClawSubscriptionChangeLog(db, {
-      subscriptionId: params.subscriptionId,
-      actor: ALIGNMENT_SCRIPT_ACTOR,
-      action: params.action,
-      reason: params.reason,
-      before: params.before,
-      after: params.after,
-    });
-  } catch (error) {
-    console.error('Failed to write alignment change log', {
-      subscriptionId: params.subscriptionId,
-      action: params.action,
-      reason: params.reason,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
+  await insertKiloClawSubscriptionChangeLog(writer, {
+    subscriptionId: params.subscriptionId,
+    actor: ALIGNMENT_SCRIPT_ACTOR,
+    action: params.action,
+    reason: params.reason,
+    before: params.before,
+    after: params.after,
+  });
+}
+
+async function personalContextSubscriptionExistsForUser(
+  executor: DbOrTx,
+  userId: string
+): Promise<boolean> {
+  // Personal-context = detached (no instance) or attached to a personal instance
+  // (no organization). Excludes org-context subscriptions so they don't block
+  // personal backfill decisions.
+  const rows = await executor
+    .select({ id: kiloclaw_subscriptions.id })
+    .from(kiloclaw_subscriptions)
+    .leftJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, userId),
+        or(isNull(kiloclaw_subscriptions.instance_id), isNull(kiloclaw_instances.organization_id))
+      )
+    )
+    .limit(1);
+  return rows.length > 0;
 }
 
 async function listPersonalInstancesWithoutRows(): Promise<PersonalInstanceWithoutRow[]> {
@@ -438,6 +460,10 @@ async function buildMissingPersonalCandidates(): Promise<MissingPersonalCandidat
     const linkedDestroyedAccessRows = linkedDestroyedRows.filter(subscription =>
       isAccessGrantingSubscription(subscription, now)
     );
+    // Personal-context subscriptions: rows linked to a personal instance OR detached
+    // (ambiguous, but treated as personal-intended by the adopt_detached path).
+    // Org-context subs are intentionally excluded so they don't block personal backfill.
+    const personalContextSubscriptionCount = linkedPersonalRows.length + detachedRows.length;
 
     let action: MissingPersonalBackfillAction = 'manual_review';
     let targetSubscriptionId: string | null = null;
@@ -459,9 +485,17 @@ async function buildMissingPersonalCandidates(): Promise<MissingPersonalCandidat
     ) {
       action = 'reassign_destroyed_access_row';
       targetSubscriptionId = linkedDestroyedAccessRows[0]?.id ?? null;
-    } else if (userSubscriptions.length === 0 && earlybirdPurchaseCreatedAt) {
+    } else if (
+      !row.destroyedAt &&
+      personalContextSubscriptionCount === 0 &&
+      earlybirdPurchaseCreatedAt
+    ) {
       action = 'backfill_earlybird_row';
-    } else if (userSubscriptions.length === 0 && !earlybirdPurchaseCreatedAt) {
+    } else if (
+      !row.destroyedAt &&
+      personalContextSubscriptionCount === 0 &&
+      !earlybirdPurchaseCreatedAt
+    ) {
       action = 'bootstrap_trial_row';
     }
 
@@ -475,6 +509,7 @@ async function buildMissingPersonalCandidates(): Promise<MissingPersonalCandidat
       earlybirdPurchaseCreatedAt,
       hasEarlybird: !!earlybirdPurchaseCreatedAt,
       totalSubscriptionCount: userSubscriptions.length,
+      personalContextSubscriptionCount,
       detachedTotalCount: detachedRows.length,
       detachedAccessCount: detachedAccessRows.length,
       linkedPersonalTotalCount: linkedPersonalRows.length,
@@ -549,30 +584,20 @@ async function buildDuplicateActiveInstanceCandidates(): Promise<
     }
   }
 
-  const duplicateRows = [...grouped.values()].flatMap(rows =>
-    rows.length > 1 ? rows.slice(1) : []
-  );
-  const canonicalRows = [...grouped.values()]
-    .filter(rows => rows.length > 1)
-    .map(rows => rows[0])
-    .filter((row): row is ActiveInstanceContextRow => !!row);
-
-  const instanceIds = [
-    ...new Set([
-      ...duplicateRows.map(row => row.instanceId),
-      ...canonicalRows.map(row => row.instanceId),
-    ]),
+  const duplicateGroups = [...grouped.values()].filter(rows => rows.length > 1);
+  const allDuplicateGroupInstanceIds = [
+    ...new Set(duplicateGroups.flatMap(rows => rows.map(row => row.instanceId))),
   ];
   const orgIds = [
     ...new Set(
-      duplicateRows
-        .map(row => row.organizationId)
+      duplicateGroups
+        .flatMap(rows => rows.map(row => row.organizationId))
         .filter((organizationId): organizationId is string => typeof organizationId === 'string')
     ),
   ];
 
   const [subscriptions, orgRows, purchases] = await Promise.all([
-    getSubscriptionsForInstances(instanceIds),
+    getSubscriptionsForInstances(allDuplicateGroupInstanceIds),
     getOrganizationsByIds(orgIds),
     getLatestSeatPurchases(orgIds),
   ]);
@@ -605,18 +630,22 @@ async function buildDuplicateActiveInstanceCandidates(): Promise<
   }
 
   const candidates: DuplicateActiveInstanceCandidate[] = [];
-  for (const rows of grouped.values()) {
-    if (rows.length <= 1) {
-      continue;
-    }
+  for (const rows of duplicateGroups) {
+    // Canonical = instance with the most subscriptions. Tiebreak: oldest created_at.
+    // Input rows are already ordered by created_at ASC, so stable sort preserves tiebreak.
+    const sortedByPreference = [...rows].sort((a, b) => {
+      const aCount = subscriptionsByInstanceId.get(a.instanceId)?.length ?? 0;
+      const bCount = subscriptionsByInstanceId.get(b.instanceId)?.length ?? 0;
+      return bCount - aCount;
+    });
 
-    const canonical = rows[0];
+    const canonical = sortedByPreference[0];
     if (!canonical) {
       continue;
     }
     const canonicalSubscriptions = subscriptionsByInstanceId.get(canonical.instanceId) ?? [];
 
-    for (const duplicate of rows.slice(1)) {
+    for (const duplicate of sortedByPreference.slice(1)) {
       const duplicateSubscriptions = subscriptionsByInstanceId.get(duplicate.instanceId) ?? [];
       const organizationRow =
         typeof duplicate.organizationId === 'string'
@@ -777,6 +806,10 @@ function summarizeDuplicateActiveInstanceCandidates(rows: DuplicateActiveInstanc
   ).map(([action, count]) => ({ action, count }));
 }
 
+// A "baseline" entry is any change-log row with before_state IS NULL — i.e. an
+// action=created/backfilled snapshot that establishes the subscription's initial
+// state. A subscription is missing its baseline if no such entry exists, even if
+// it has later mutation logs (which always carry a before_state).
 async function listSubscriptionsMissingBaselineChangeLog(): Promise<MissingChangelogBaselineRow[]> {
   return await db
     .select()
@@ -786,10 +819,32 @@ async function listSubscriptionsMissingBaselineChangeLog(): Promise<MissingChang
         db
           .select({ id: kiloclaw_subscription_change_log.id })
           .from(kiloclaw_subscription_change_log)
-          .where(eq(kiloclaw_subscription_change_log.subscription_id, kiloclaw_subscriptions.id))
+          .where(
+            and(
+              eq(kiloclaw_subscription_change_log.subscription_id, kiloclaw_subscriptions.id),
+              isNull(kiloclaw_subscription_change_log.before_state)
+            )
+          )
       )
     )
     .orderBy(desc(kiloclaw_subscriptions.created_at));
+}
+
+async function hasBaselineChangeLogEntry(
+  executor: DbOrTx,
+  subscriptionId: string
+): Promise<boolean> {
+  const rows = await executor
+    .select({ id: kiloclaw_subscription_change_log.id })
+    .from(kiloclaw_subscription_change_log)
+    .where(
+      and(
+        eq(kiloclaw_subscription_change_log.subscription_id, subscriptionId),
+        isNull(kiloclaw_subscription_change_log.before_state)
+      )
+    )
+    .limit(1);
+  return rows.length > 0;
 }
 
 async function previewChangelogBaselineBackfill() {
@@ -811,30 +866,48 @@ async function previewChangelogBaselineBackfill() {
 async function applyChangelogBaselineBackfill() {
   const rows = await listSubscriptionsMissingBaselineChangeLog();
   let inserted = 0;
+  const failures: Array<{ subscriptionId: string; userId: string; error: string }> = [];
 
   for (const row of rows) {
-    const [existingLog] = await db
-      .select({ id: kiloclaw_subscription_change_log.id })
-      .from(kiloclaw_subscription_change_log)
-      .where(eq(kiloclaw_subscription_change_log.subscription_id, row.id))
-      .limit(1);
+    try {
+      const wrote = await db.transaction(async tx => {
+        if (await hasBaselineChangeLogEntry(tx, row.id)) {
+          return false;
+        }
 
-    if (existingLog) {
-      continue;
+        await insertAlignmentChangeLog(tx, {
+          subscriptionId: row.id,
+          action: 'backfilled',
+          reason: 'baseline_subscription_snapshot',
+          before: null,
+          after: row,
+        });
+        return true;
+      });
+
+      if (wrote) {
+        inserted += 1;
+      }
+    } catch (error) {
+      console.error('Changelog baseline backfill row failed', {
+        subscriptionId: row.id,
+        userId: row.user_id,
+        error: describeError(error),
+      });
+      failures.push({
+        subscriptionId: row.id,
+        userId: row.user_id,
+        error: describeError(error),
+      });
     }
-
-    await insertAlignmentChangeLog({
-      subscriptionId: row.id,
-      action: 'backfilled',
-      reason: 'baseline_subscription_snapshot',
-      before: null,
-      after: row,
-    });
-    inserted += 1;
   }
 
   console.log('\nChangelog baseline backfill results');
-  console.table([{ action: 'backfilled', count: inserted }]);
+  console.table([
+    { action: 'backfilled', count: inserted },
+    { action: 'failed', count: failures.length },
+  ]);
+  printSection('Changelog baseline rows that failed to backfill', failures);
 }
 
 async function previewMissingPersonalBackfill() {
@@ -904,6 +977,7 @@ async function previewMissingPersonalBackfill() {
         instanceDestroyedAt: row.instanceDestroyedAt,
         earlybirdPurchaseCreatedAt: row.earlybirdPurchaseCreatedAt,
         totalSubscriptionCount: row.totalSubscriptionCount,
+        personalContextSubscriptionCount: row.personalContextSubscriptionCount,
         detachedTotalCount: row.detachedTotalCount,
         detachedAccessCount: row.detachedAccessCount,
         linkedPersonalTotalCount: row.linkedPersonalTotalCount,
@@ -1042,10 +1116,11 @@ async function previewDuplicateActiveInstances() {
 }
 
 async function insertDuplicateTerminalSubscription(
+  tx: DbOrTx,
   row: DuplicateActiveInstanceCandidate
 ): Promise<KiloClawSubscription | null> {
   if (row.contextType === 'personal') {
-    const [inserted] = await db
+    const [inserted] = await tx
       .insert(kiloclaw_subscriptions)
       .values({
         user_id: row.userId,
@@ -1082,7 +1157,7 @@ async function insertDuplicateTerminalSubscription(
       : null,
   });
 
-  const [inserted] = await db
+  const [inserted] = await tx
     .insert(kiloclaw_subscriptions)
     .values(
       hasManagedActiveAccess
@@ -1114,15 +1189,105 @@ async function insertDuplicateTerminalSubscription(
   return inserted ?? null;
 }
 
-async function markDuplicateInstanceDestroyed(instanceId: string): Promise<boolean> {
+async function markDuplicateInstanceDestroyed(tx: DbOrTx, instanceId: string): Promise<boolean> {
   const destroyedAt = new Date().toISOString();
-  const rows = await db
+  const rows = await tx
     .update(kiloclaw_instances)
     .set({ destroyed_at: destroyedAt })
     .where(and(eq(kiloclaw_instances.id, instanceId), isNull(kiloclaw_instances.destroyed_at)))
     .returning({ id: kiloclaw_instances.id });
 
   return rows.length > 0;
+}
+
+type DuplicateApplyOutcome = 'personal_destroyed' | 'org_destroyed' | 'reassigned' | 'skipped';
+
+async function applyDuplicateActiveInstanceRow(
+  row: DuplicateActiveInstanceCandidate
+): Promise<DuplicateApplyOutcome> {
+  return await db.transaction(async tx => {
+    const [canonicalExisting, duplicateExisting] = await Promise.all([
+      tx
+        .select()
+        .from(kiloclaw_subscriptions)
+        .where(eq(kiloclaw_subscriptions.instance_id, row.canonicalInstanceId)),
+      tx
+        .select()
+        .from(kiloclaw_subscriptions)
+        .where(eq(kiloclaw_subscriptions.instance_id, row.duplicateInstanceId)),
+    ]);
+
+    if (
+      row.action === 'reassign_to_canonical_and_destroy_duplicate' &&
+      (!row.targetSubscriptionId || canonicalExisting.length > 0 || duplicateExisting.length !== 1)
+    ) {
+      return 'skipped';
+    }
+
+    if (
+      (row.action === 'backfill_destroy_duplicate_personal' ||
+        row.action === 'backfill_destroy_duplicate_org') &&
+      duplicateExisting.length > 0
+    ) {
+      return 'skipped';
+    }
+
+    if (row.action === 'reassign_to_canonical_and_destroy_duplicate') {
+      const before = duplicateExisting[0] ?? null;
+      if (!before || before.id !== row.targetSubscriptionId) {
+        return 'skipped';
+      }
+
+      const [updated] = await tx
+        .update(kiloclaw_subscriptions)
+        .set({ instance_id: row.canonicalInstanceId })
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.id, row.targetSubscriptionId),
+            eq(kiloclaw_subscriptions.instance_id, row.duplicateInstanceId)
+          )
+        )
+        .returning();
+
+      if (!updated) {
+        return 'skipped';
+      }
+
+      await insertAlignmentChangeLog(tx, {
+        subscriptionId: updated.id,
+        action: 'reassigned',
+        reason: 'apply_duplicate_active_reassign_to_canonical',
+        before,
+        after: updated,
+      });
+    }
+
+    const destroyed = await markDuplicateInstanceDestroyed(tx, row.duplicateInstanceId);
+    if (!destroyed) {
+      return 'skipped';
+    }
+
+    const replacement = await insertDuplicateTerminalSubscription(tx, row);
+    if (!replacement) {
+      return 'skipped';
+    }
+
+    await insertAlignmentChangeLog(tx, {
+      subscriptionId: replacement.id,
+      action: 'backfilled',
+      reason:
+        row.contextType === 'personal'
+          ? 'apply_duplicate_active_backfill_personal_terminal'
+          : 'apply_duplicate_active_backfill_org_terminal',
+      before: null,
+      after: replacement,
+    });
+
+    if (row.action === 'reassign_to_canonical_and_destroy_duplicate') {
+      return 'reassigned';
+    }
+    return row.contextType === 'personal' ? 'personal_destroyed' : 'org_destroyed';
+  });
 }
 
 async function applyDuplicateActiveInstances() {
@@ -1135,6 +1300,7 @@ async function applyDuplicateActiveInstances() {
     canonicalInstanceId: string;
     userId: string;
     action: string;
+    error?: string;
   }> = [];
 
   for (const row of rows) {
@@ -1146,124 +1312,45 @@ async function applyDuplicateActiveInstances() {
       continue;
     }
 
-    const [canonicalExisting, duplicateExisting] = await Promise.all([
-      db
-        .select()
-        .from(kiloclaw_subscriptions)
-        .where(eq(kiloclaw_subscriptions.instance_id, row.canonicalInstanceId)),
-      db
-        .select()
-        .from(kiloclaw_subscriptions)
-        .where(eq(kiloclaw_subscriptions.instance_id, row.duplicateInstanceId)),
-    ]);
-
-    if (
-      row.action === 'reassign_to_canonical_and_destroy_duplicate' &&
-      (!row.targetSubscriptionId || canonicalExisting.length > 0 || duplicateExisting.length !== 1)
-    ) {
+    let outcome: DuplicateApplyOutcome;
+    try {
+      outcome = await applyDuplicateActiveInstanceRow(row);
+    } catch (error) {
+      console.error('Duplicate active instance apply row failed', {
+        duplicateInstanceId: row.duplicateInstanceId,
+        canonicalInstanceId: row.canonicalInstanceId,
+        userId: row.userId,
+        action: row.action,
+        error: describeError(error),
+      });
       skipped.push({
         duplicateInstanceId: row.duplicateInstanceId,
         canonicalInstanceId: row.canonicalInstanceId,
         userId: row.userId,
         action: row.action,
+        error: describeError(error),
       });
       continue;
     }
 
-    if (
-      (row.action === 'backfill_destroy_duplicate_personal' ||
-        row.action === 'backfill_destroy_duplicate_org') &&
-      duplicateExisting.length > 0
-    ) {
-      skipped.push({
-        duplicateInstanceId: row.duplicateInstanceId,
-        canonicalInstanceId: row.canonicalInstanceId,
-        userId: row.userId,
-        action: row.action,
-      });
-      continue;
-    }
-
-    if (row.action === 'reassign_to_canonical_and_destroy_duplicate') {
-      const before = duplicateExisting[0] ?? null;
-      if (!before || before.id !== row.targetSubscriptionId) {
+    switch (outcome) {
+      case 'personal_destroyed':
+        personalDestroyed += 1;
+        break;
+      case 'org_destroyed':
+        orgDestroyed += 1;
+        break;
+      case 'reassigned':
+        reassigned += 1;
+        break;
+      case 'skipped':
         skipped.push({
           duplicateInstanceId: row.duplicateInstanceId,
           canonicalInstanceId: row.canonicalInstanceId,
           userId: row.userId,
           action: row.action,
         });
-        continue;
-      }
-
-      const [updated] = await db
-        .update(kiloclaw_subscriptions)
-        .set({ instance_id: row.canonicalInstanceId })
-        .where(
-          and(
-            eq(kiloclaw_subscriptions.id, row.targetSubscriptionId),
-            eq(kiloclaw_subscriptions.instance_id, row.duplicateInstanceId)
-          )
-        )
-        .returning();
-
-      if (!updated) {
-        skipped.push({
-          duplicateInstanceId: row.duplicateInstanceId,
-          canonicalInstanceId: row.canonicalInstanceId,
-          userId: row.userId,
-          action: row.action,
-        });
-        continue;
-      }
-
-      await insertAlignmentChangeLog({
-        subscriptionId: updated.id,
-        action: 'reassigned',
-        reason: 'apply_duplicate_active_reassign_to_canonical',
-        before,
-        after: updated,
-      });
-      reassigned += 1;
-    }
-
-    const replacement = await insertDuplicateTerminalSubscription(row);
-    if (!replacement) {
-      skipped.push({
-        duplicateInstanceId: row.duplicateInstanceId,
-        canonicalInstanceId: row.canonicalInstanceId,
-        userId: row.userId,
-        action: row.action,
-      });
-      continue;
-    }
-
-    await insertAlignmentChangeLog({
-      subscriptionId: replacement.id,
-      action: 'backfilled',
-      reason:
-        row.contextType === 'personal'
-          ? 'apply_duplicate_active_backfill_personal_terminal'
-          : 'apply_duplicate_active_backfill_org_terminal',
-      before: null,
-      after: replacement,
-    });
-
-    const destroyed = await markDuplicateInstanceDestroyed(row.duplicateInstanceId);
-    if (!destroyed) {
-      skipped.push({
-        duplicateInstanceId: row.duplicateInstanceId,
-        canonicalInstanceId: row.canonicalInstanceId,
-        userId: row.userId,
-        action: row.action,
-      });
-      continue;
-    }
-
-    if (row.contextType === 'personal') {
-      personalDestroyed += 1;
-    } else {
-      orgDestroyed += 1;
+        break;
     }
   }
 
@@ -1277,28 +1364,33 @@ async function applyDuplicateActiveInstances() {
   printSection('Duplicate active instances skipped during apply', skipped);
 }
 
-async function applyMissingPersonalBackfill() {
-  const rows = await buildMissingPersonalCandidates();
-  let adopted = 0;
-  let reassigned = 0;
-  let bootstrapped = 0;
-  let earlybirdBackfilled = 0;
-  const skipped: Array<{ instanceId: string; userId: string; action: string }> = [];
+type MissingPersonalOutcome =
+  | 'adopted'
+  | 'reassigned'
+  | 'bootstrapped'
+  | 'earlybird_backfilled'
+  | 'skipped'
+  | 'no_op';
 
-  for (const row of rows) {
+async function applyMissingPersonalBackfillRow(
+  row: MissingPersonalCandidate
+): Promise<MissingPersonalOutcome> {
+  if (row.action === 'manual_review') {
+    return 'no_op';
+  }
+  return await db.transaction(async tx => {
     if (row.action === 'adopt_detached_access_row') {
       if (!row.targetSubscriptionId) {
-        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
-        continue;
+        return 'skipped';
       }
 
-      const result = await db
+      const result = await tx
         .select()
         .from(kiloclaw_subscriptions)
         .where(eq(kiloclaw_subscriptions.id, row.targetSubscriptionId))
         .limit(1);
       const before = result[0] ?? null;
-      const updated = await db
+      const updated = await tx
         .update(kiloclaw_subscriptions)
         .set({ instance_id: row.instanceId })
         .where(
@@ -1310,85 +1402,172 @@ async function applyMissingPersonalBackfill() {
         .returning();
       const updatedRow = updated[0] ?? null;
 
-      if (before && updatedRow) {
-        await insertAlignmentChangeLog({
-          subscriptionId: updatedRow.id,
-          action: 'reassigned',
-          reason: 'apply_missing_personal_adopt_detached',
-          before,
-          after: updatedRow,
-        });
-        adopted += 1;
-      } else {
-        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
+      if (!before || !updatedRow) {
+        return 'skipped';
       }
-      continue;
+
+      await insertAlignmentChangeLog(tx, {
+        subscriptionId: updatedRow.id,
+        action: 'reassigned',
+        reason: 'apply_missing_personal_adopt_detached',
+        before,
+        after: updatedRow,
+      });
+      return 'adopted';
     }
 
     if (row.action === 'reassign_destroyed_access_row') {
       if (!row.targetSubscriptionId) {
-        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
-        continue;
+        return 'skipped';
       }
 
-      const existing = await db
+      const existing = await tx
         .select({ id: kiloclaw_subscriptions.id })
         .from(kiloclaw_subscriptions)
         .where(eq(kiloclaw_subscriptions.instance_id, row.instanceId))
         .limit(1);
       if (existing.length > 0) {
-        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
-        continue;
+        return 'skipped';
       }
 
-      const [before] = await db
+      const [before] = await tx
         .select()
         .from(kiloclaw_subscriptions)
-        .where(eq(kiloclaw_subscriptions.id, row.targetSubscriptionId))
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.id, row.targetSubscriptionId),
+            isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+          )
+        )
         .limit(1);
-      const updated = await db
-        .update(kiloclaw_subscriptions)
-        .set({ instance_id: row.instanceId })
-        .where(eq(kiloclaw_subscriptions.id, row.targetSubscriptionId))
-        .returning();
-      const updatedRow = updated[0] ?? null;
 
-      if (before && updatedRow) {
-        await insertAlignmentChangeLog({
-          subscriptionId: updatedRow.id,
-          action: 'reassigned',
-          reason: 'apply_missing_personal_reassign_destroyed',
-          before,
-          after: updatedRow,
-        });
-        reassigned += 1;
-      } else {
-        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
+      if (!before) {
+        return 'skipped';
       }
-      continue;
+
+      // Successor pattern: mirror createSuccessorPersonalSubscription in
+      // services/kiloclaw-billing/src/bootstrap.ts. Create new row on the active
+      // instance, mark the destroyed-instance row canceled + transferred_to. This
+      // preserves history on the destroyed instance and keeps future audits clean.
+      const [insertedSuccessor] = await tx
+        .insert(kiloclaw_subscriptions)
+        .values({
+          user_id: before.user_id,
+          instance_id: row.instanceId,
+          access_origin: before.access_origin,
+          payment_source: before.payment_source,
+          plan: before.plan,
+          scheduled_plan: before.scheduled_plan,
+          scheduled_by: before.scheduled_by,
+          status: before.status,
+          cancel_at_period_end: before.cancel_at_period_end,
+          pending_conversion: before.pending_conversion,
+          trial_started_at: before.trial_started_at,
+          trial_ends_at: before.trial_ends_at,
+          current_period_start: before.current_period_start,
+          current_period_end: before.current_period_end,
+          credit_renewal_at: before.credit_renewal_at,
+          commit_ends_at: before.commit_ends_at,
+          past_due_since: before.past_due_since,
+          suspended_at: before.suspended_at,
+          destruction_deadline: before.destruction_deadline,
+          auto_resume_requested_at: before.auto_resume_requested_at,
+          auto_resume_retry_after: before.auto_resume_retry_after,
+          auto_resume_attempt_count: before.auto_resume_attempt_count,
+          auto_top_up_triggered_for_period: before.auto_top_up_triggered_for_period,
+        })
+        .returning();
+
+      if (!insertedSuccessor) {
+        return 'skipped';
+      }
+
+      const [predecessor] = await tx
+        .update(kiloclaw_subscriptions)
+        .set({
+          status: 'canceled',
+          transferred_to_subscription_id: insertedSuccessor.id,
+          payment_source: 'credits',
+          stripe_subscription_id: null,
+          stripe_schedule_id: null,
+          credit_renewal_at: null,
+          cancel_at_period_end: false,
+          pending_conversion: false,
+          scheduled_plan: null,
+          scheduled_by: null,
+          auto_resume_requested_at: null,
+          auto_resume_retry_after: null,
+          auto_resume_attempt_count: 0,
+          auto_top_up_triggered_for_period: null,
+          destruction_deadline: null,
+        })
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.id, before.id),
+            isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+          )
+        )
+        .returning();
+
+      if (!predecessor) {
+        return 'skipped';
+      }
+
+      const successor =
+        before.stripe_subscription_id || before.stripe_schedule_id
+          ? ((
+              await tx
+                .update(kiloclaw_subscriptions)
+                .set({
+                  stripe_subscription_id: before.stripe_subscription_id,
+                  stripe_schedule_id: before.stripe_schedule_id,
+                })
+                .where(eq(kiloclaw_subscriptions.id, insertedSuccessor.id))
+                .returning()
+            )[0] ?? null)
+          : insertedSuccessor;
+
+      if (!successor) {
+        return 'skipped';
+      }
+
+      await insertAlignmentChangeLog(tx, {
+        subscriptionId: predecessor.id,
+        action: 'reassigned',
+        reason: 'apply_missing_personal_reassign_destroyed_predecessor',
+        before,
+        after: predecessor,
+      });
+      await insertAlignmentChangeLog(tx, {
+        subscriptionId: successor.id,
+        action: 'backfilled',
+        reason: 'apply_missing_personal_reassign_destroyed_successor',
+        before: null,
+        after: successor,
+      });
+      return 'reassigned';
     }
 
     if (row.action === 'bootstrap_trial_row') {
-      const [existingForInstance, existingForUser] = await Promise.all([
-        db
+      if (row.instanceDestroyedAt) {
+        return 'skipped';
+      }
+
+      const [existingForInstance, hasPersonalForUser] = await Promise.all([
+        tx
           .select({ id: kiloclaw_subscriptions.id })
           .from(kiloclaw_subscriptions)
           .where(eq(kiloclaw_subscriptions.instance_id, row.instanceId))
           .limit(1),
-        db
-          .select({ id: kiloclaw_subscriptions.id })
-          .from(kiloclaw_subscriptions)
-          .where(eq(kiloclaw_subscriptions.user_id, row.userId))
-          .limit(1),
+        personalContextSubscriptionExistsForUser(tx, row.userId),
       ]);
 
-      if (existingForInstance.length > 0 || existingForUser.length > 0) {
-        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
-        continue;
+      if (existingForInstance.length > 0 || hasPersonalForUser) {
+        return 'skipped';
       }
 
       const trialEndsAt = getTrialEndsAt(row.instanceCreatedAt);
-      const [inserted] = await db
+      const [inserted] = await tx
         .insert(kiloclaw_subscriptions)
         .values({
           user_id: row.userId,
@@ -1404,56 +1583,49 @@ async function applyMissingPersonalBackfill() {
         })
         .returning();
 
-      if (inserted) {
-        await insertAlignmentChangeLog({
-          subscriptionId: inserted.id,
-          action: 'backfilled',
-          reason: 'apply_missing_personal_bootstrap_trial',
-          before: null,
-          after: inserted,
-        });
-        bootstrapped += 1;
-      } else {
-        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
+      if (!inserted) {
+        return 'skipped';
       }
-      continue;
+
+      await insertAlignmentChangeLog(tx, {
+        subscriptionId: inserted.id,
+        action: 'backfilled',
+        reason: 'apply_missing_personal_bootstrap_trial',
+        before: null,
+        after: inserted,
+      });
+      return 'bootstrapped';
     }
 
     if (row.action === 'backfill_earlybird_row') {
-      const [existingForInstance, existingForUser, earlybirdPurchase] = await Promise.all([
-        db
+      if (row.instanceDestroyedAt) {
+        return 'skipped';
+      }
+
+      const [existingForInstance, hasPersonalForUser, earlybirdPurchase] = await Promise.all([
+        tx
           .select({ id: kiloclaw_subscriptions.id })
           .from(kiloclaw_subscriptions)
           .where(eq(kiloclaw_subscriptions.instance_id, row.instanceId))
           .limit(1),
-        db
-          .select({ id: kiloclaw_subscriptions.id })
-          .from(kiloclaw_subscriptions)
-          .where(eq(kiloclaw_subscriptions.user_id, row.userId))
-          .limit(1),
-        db
+        personalContextSubscriptionExistsForUser(tx, row.userId),
+        tx
           .select({ createdAt: kiloclaw_earlybird_purchases.created_at })
           .from(kiloclaw_earlybird_purchases)
           .where(eq(kiloclaw_earlybird_purchases.user_id, row.userId))
           .limit(1),
       ]);
 
-      if (
-        existingForInstance.length > 0 ||
-        existingForUser.length > 0 ||
-        earlybirdPurchase.length === 0
-      ) {
-        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
-        continue;
+      if (existingForInstance.length > 0 || hasPersonalForUser || earlybirdPurchase.length === 0) {
+        return 'skipped';
       }
 
-      const trialEndsAt = getEarlybirdEndsAt();
       const purchase = earlybirdPurchase[0];
       if (!purchase) {
-        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
-        continue;
+        return 'skipped';
       }
-      const [inserted] = await db
+      const trialEndsAt = getEarlybirdEndsAt();
+      const [inserted] = await tx
         .insert(kiloclaw_subscriptions)
         .values({
           user_id: row.userId,
@@ -1470,18 +1642,75 @@ async function applyMissingPersonalBackfill() {
         })
         .returning();
 
-      if (inserted) {
-        await insertAlignmentChangeLog({
-          subscriptionId: inserted.id,
-          action: 'backfilled',
-          reason: 'apply_missing_personal_backfill_earlybird',
-          before: null,
-          after: inserted,
-        });
-        earlybirdBackfilled += 1;
-      } else {
-        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
+      if (!inserted) {
+        return 'skipped';
       }
+
+      await insertAlignmentChangeLog(tx, {
+        subscriptionId: inserted.id,
+        action: 'backfilled',
+        reason: 'apply_missing_personal_backfill_earlybird',
+        before: null,
+        after: inserted,
+      });
+      return 'earlybird_backfilled';
+    }
+
+    return 'no_op';
+  });
+}
+
+async function applyMissingPersonalBackfill() {
+  const rows = await buildMissingPersonalCandidates();
+  let adopted = 0;
+  let reassigned = 0;
+  let bootstrapped = 0;
+  let earlybirdBackfilled = 0;
+  const skipped: Array<{
+    instanceId: string;
+    userId: string;
+    action: string;
+    error?: string;
+  }> = [];
+
+  for (const row of rows) {
+    let outcome: MissingPersonalOutcome;
+    try {
+      outcome = await applyMissingPersonalBackfillRow(row);
+    } catch (error) {
+      console.error('Missing personal backfill row failed', {
+        instanceId: row.instanceId,
+        userId: row.userId,
+        action: row.action,
+        error: describeError(error),
+      });
+      skipped.push({
+        instanceId: row.instanceId,
+        userId: row.userId,
+        action: row.action,
+        error: describeError(error),
+      });
+      continue;
+    }
+
+    switch (outcome) {
+      case 'adopted':
+        adopted += 1;
+        break;
+      case 'reassigned':
+        reassigned += 1;
+        break;
+      case 'bootstrapped':
+        bootstrapped += 1;
+        break;
+      case 'earlybird_backfilled':
+        earlybirdBackfilled += 1;
+        break;
+      case 'skipped':
+        skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
+        break;
+      case 'no_op':
+        break;
     }
   }
 
@@ -1496,38 +1725,29 @@ async function applyMissingPersonalBackfill() {
   printSection('Missing personal rows skipped during apply', skipped);
 }
 
-async function applyOrgBackfill() {
-  const rows = await buildOrgBackfillCandidates();
-  let activeStandardCredits = 0;
-  let activeTrialRows = 0;
-  let destroyedStandardCredits = 0;
-  let destroyedTrialRows = 0;
-  const skipped: Array<{
-    instanceId: string;
-    organizationId: string;
-    userId: string;
-    action: string;
-  }> = [];
+type OrgApplyOutcome = OrgBackfillAction | 'skipped';
 
-  for (const row of rows) {
-    const existing = await db
+const ORG_BACKFILL_REASON: Record<OrgBackfillAction, string> = {
+  backfill_active_standard_credits: 'apply_org_backfill_active_standard_credits',
+  backfill_trial: 'apply_org_backfill_trial',
+  backfill_destroyed_standard_credits: 'apply_org_backfill_destroyed_standard_credits',
+  backfill_destroyed_trial: 'apply_org_backfill_destroyed_trial',
+};
+
+async function applyOrgBackfillRow(row: OrgBackfillCandidate): Promise<OrgApplyOutcome> {
+  return await db.transaction(async tx => {
+    const existing = await tx
       .select({ id: kiloclaw_subscriptions.id })
       .from(kiloclaw_subscriptions)
       .where(eq(kiloclaw_subscriptions.instance_id, row.instanceId))
       .limit(1);
     if (existing.length > 0) {
-      skipped.push({
-        instanceId: row.instanceId,
-        organizationId: row.organizationId,
-        userId: row.userId,
-        action: row.action,
-      });
-      continue;
+      return 'skipped';
     }
 
     const trialEndsAt = row.freeTrialEndAt ?? getTrialEndsAt(row.organizationCreatedAt);
     const trialStatus = new Date(trialEndsAt).getTime() > Date.now() ? 'trialing' : 'canceled';
-    const [inserted] = await db
+    const [inserted] = await tx
       .insert(kiloclaw_subscriptions)
       .values(
         row.action === 'backfill_active_standard_credits'
@@ -1568,60 +1788,79 @@ async function applyOrgBackfill() {
       .returning();
 
     if (!inserted) {
+      return 'skipped';
+    }
+
+    await insertAlignmentChangeLog(tx, {
+      subscriptionId: inserted.id,
+      action: 'backfilled',
+      reason: ORG_BACKFILL_REASON[row.action],
+      before: null,
+      after: inserted,
+    });
+    return row.action;
+  });
+}
+
+async function applyOrgBackfill() {
+  const rows = await buildOrgBackfillCandidates();
+  const counts: Record<OrgBackfillAction, number> = {
+    backfill_active_standard_credits: 0,
+    backfill_trial: 0,
+    backfill_destroyed_standard_credits: 0,
+    backfill_destroyed_trial: 0,
+  };
+  const skipped: Array<{
+    instanceId: string;
+    organizationId: string;
+    userId: string;
+    action: string;
+    error?: string;
+  }> = [];
+
+  for (const row of rows) {
+    let outcome: OrgApplyOutcome;
+    try {
+      outcome = await applyOrgBackfillRow(row);
+    } catch (error) {
+      console.error('Org backfill row failed', {
+        instanceId: row.instanceId,
+        organizationId: row.organizationId,
+        userId: row.userId,
+        action: row.action,
+        error: describeError(error),
+      });
+      skipped.push({
+        instanceId: row.instanceId,
+        organizationId: row.organizationId,
+        userId: row.userId,
+        action: row.action,
+        error: describeError(error),
+      });
+      continue;
+    }
+
+    if (outcome === 'skipped') {
       skipped.push({
         instanceId: row.instanceId,
         organizationId: row.organizationId,
         userId: row.userId,
         action: row.action,
       });
-      continue;
-    }
-
-    if (row.action === 'backfill_active_standard_credits') {
-      await insertAlignmentChangeLog({
-        subscriptionId: inserted.id,
-        action: 'backfilled',
-        reason: 'apply_org_backfill_active_standard_credits',
-        before: null,
-        after: inserted,
-      });
-      activeStandardCredits += 1;
-    } else if (row.action === 'backfill_trial') {
-      await insertAlignmentChangeLog({
-        subscriptionId: inserted.id,
-        action: 'backfilled',
-        reason: 'apply_org_backfill_trial',
-        before: null,
-        after: inserted,
-      });
-      activeTrialRows += 1;
-    } else if (row.action === 'backfill_destroyed_standard_credits') {
-      await insertAlignmentChangeLog({
-        subscriptionId: inserted.id,
-        action: 'backfilled',
-        reason: 'apply_org_backfill_destroyed_standard_credits',
-        before: null,
-        after: inserted,
-      });
-      destroyedStandardCredits += 1;
     } else {
-      await insertAlignmentChangeLog({
-        subscriptionId: inserted.id,
-        action: 'backfilled',
-        reason: 'apply_org_backfill_destroyed_trial',
-        before: null,
-        after: inserted,
-      });
-      destroyedTrialRows += 1;
+      counts[outcome] += 1;
     }
   }
 
   console.log('\nOrg backfill results');
   console.table([
-    { action: 'backfill_active_standard_credits', count: activeStandardCredits },
-    { action: 'backfill_trial', count: activeTrialRows },
-    { action: 'backfill_destroyed_standard_credits', count: destroyedStandardCredits },
-    { action: 'backfill_destroyed_trial', count: destroyedTrialRows },
+    { action: 'backfill_active_standard_credits', count: counts.backfill_active_standard_credits },
+    { action: 'backfill_trial', count: counts.backfill_trial },
+    {
+      action: 'backfill_destroyed_standard_credits',
+      count: counts.backfill_destroyed_standard_credits,
+    },
+    { action: 'backfill_destroyed_trial', count: counts.backfill_destroyed_trial },
     { action: 'skipped', count: skipped.length },
   ]);
   printSection('Org rows skipped during apply', skipped);
@@ -1646,56 +1885,27 @@ function parseMode(inputMode?: string): Mode {
   }
 }
 
+const singleModeHandlers: Partial<Record<Mode, () => Promise<void>>> = {
+  'preview-missing-personal': previewMissingPersonalBackfill,
+  'apply-missing-personal': applyMissingPersonalBackfill,
+  'preview-duplicates': previewDuplicateActiveInstances,
+  'apply-duplicates': applyDuplicateActiveInstances,
+  'preview-org': previewOrgBackfill,
+  'apply-org': applyOrgBackfill,
+  'preview-changelog-baseline': previewChangelogBaselineBackfill,
+  'apply-changelog-baseline': applyChangelogBaselineBackfill,
+};
+
 export async function run(inputMode?: string) {
   const mode = parseMode(inputMode);
 
-  if (mode === 'preview-missing-personal') {
+  const handler = singleModeHandlers[mode];
+  if (handler) {
     console.log(`Mode: ${mode}`);
-    await previewMissingPersonalBackfill();
+    await handler();
     return;
   }
-
-  if (mode === 'apply-missing-personal') {
-    console.log(`Mode: ${mode}`);
-    await applyMissingPersonalBackfill();
-    return;
-  }
-
-  if (mode === 'preview-duplicates') {
-    console.log(`Mode: ${mode}`);
-    await previewDuplicateActiveInstances();
-    return;
-  }
-
-  if (mode === 'apply-duplicates') {
-    console.log(`Mode: ${mode}`);
-    await applyDuplicateActiveInstances();
-    return;
-  }
-
-  if (mode === 'preview-org') {
-    console.log(`Mode: ${mode}`);
-    await previewOrgBackfill();
-    return;
-  }
-
-  if (mode === 'apply-org') {
-    console.log(`Mode: ${mode}`);
-    await applyOrgBackfill();
-    return;
-  }
-
-  if (mode === 'preview-changelog-baseline') {
-    console.log(`Mode: ${mode}`);
-    await previewChangelogBaselineBackfill();
-    return;
-  }
-
-  if (mode === 'apply-changelog-baseline') {
-    console.log(`Mode: ${mode}`);
-    await applyChangelogBaselineBackfill();
-    return;
-  }
+  // Fall through: 'audit' and 'repair-detached' share the full summary output.
 
   const [
     personalRowsWithoutSubscriptions,
@@ -1789,35 +1999,59 @@ export async function run(inputMode?: string) {
   }
 
   let repaired = 0;
+  const failures: Array<{ subscriptionId: string; userId: string; error: string }> = [];
   for (const row of repairable) {
     if (!row.targetInstanceId) continue;
-    const [before] = await db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.id, row.subscriptionId))
-      .limit(1);
-    const updated = await db
-      .update(kiloclaw_subscriptions)
-      .set({ instance_id: row.targetInstanceId })
-      .where(
-        and(
-          eq(kiloclaw_subscriptions.id, row.subscriptionId),
-          isNull(kiloclaw_subscriptions.instance_id)
-        )
-      )
-      .returning();
-    const updatedRow = updated[0] ?? null;
-    if (before && updatedRow) {
-      await insertAlignmentChangeLog({
-        subscriptionId: updatedRow.id,
-        action: 'reassigned',
-        reason: 'repair_detached_subscription',
-        before,
-        after: updatedRow,
+    const targetInstanceId = row.targetInstanceId;
+    try {
+      const didRepair = await db.transaction(async tx => {
+        const [before] = await tx
+          .select()
+          .from(kiloclaw_subscriptions)
+          .where(eq(kiloclaw_subscriptions.id, row.subscriptionId))
+          .limit(1);
+        const updated = await tx
+          .update(kiloclaw_subscriptions)
+          .set({ instance_id: targetInstanceId })
+          .where(
+            and(
+              eq(kiloclaw_subscriptions.id, row.subscriptionId),
+              isNull(kiloclaw_subscriptions.instance_id)
+            )
+          )
+          .returning();
+        const updatedRow = updated[0] ?? null;
+        if (!before || !updatedRow) {
+          return false;
+        }
+        await insertAlignmentChangeLog(tx, {
+          subscriptionId: updatedRow.id,
+          action: 'reassigned',
+          reason: 'repair_detached_subscription',
+          before,
+          after: updatedRow,
+        });
+        return true;
       });
-      repaired += 1;
+      if (didRepair) {
+        repaired += 1;
+      }
+    } catch (error) {
+      console.error('Detached subscription repair row failed', {
+        subscriptionId: row.subscriptionId,
+        userId: row.userId,
+        error: describeError(error),
+      });
+      failures.push({
+        subscriptionId: row.subscriptionId,
+        userId: row.userId,
+        error: describeError(error),
+      });
     }
   }
 
   console.log(`\nDetached subscriptions repaired: ${repaired}`);
+  if (failures.length > 0) {
+    printSection('Detached subscriptions that failed to repair', failures);
+  }
 }

--- a/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
+++ b/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
@@ -17,8 +17,17 @@
  * Flags:
  *   --confirm-sandboxes-destroyed   Required for apply-duplicates to write
  *     destroyed_at. Operators MUST first tear down the underlying sandbox
- *     resources via the admin panel. Without this flag, apply-duplicates
- *     prints a manifest of duplicate sandbox IDs and exits without writes.
+ *     resource out-of-band (provider-level teardown that does NOT mutate
+ *     kiloclaw_instances — the admin panel destroy flow writes destroyed_at
+ *     itself and would hide the row from apply-duplicates). Without this
+ *     flag, apply-duplicates prints a manifest of duplicate sandbox IDs and
+ *     exits without writes.
+ *
+ * Admin-panel workflow (recommended): operators destroy duplicate sandboxes
+ * via the admin panel, which sets destroyed_at and tears down the resource.
+ * Then apply-missing-personal picks up the now-destroyed instances via the
+ * backfill_destroyed_terminal_personal path and inserts canceled terminal
+ * subscription rows — no --confirm-sandboxes-destroyed flag required.
  */
 
 import { and, asc, desc, eq, inArray, isNull, notExists, or, sql } from 'drizzle-orm';
@@ -95,6 +104,7 @@ type MissingPersonalBackfillAction =
   | 'reassign_destroyed_access_row'
   | 'bootstrap_trial_row'
   | 'backfill_earlybird_row'
+  | 'backfill_destroyed_terminal_personal'
   | 'manual_review';
 
 type MissingPersonalCandidate = {
@@ -557,6 +567,13 @@ async function buildMissingPersonalCandidates(): Promise<MissingPersonalCandidat
       !earlybirdPurchaseCreatedAt
     ) {
       action = 'bootstrap_trial_row';
+    } else if (row.destroyedAt) {
+      // Destroyed personal instance without a sub row. Insert a canceled
+      // terminal trial row to satisfy the "every instance has a sub row"
+      // invariant. Mirrors the org-side backfill_destroyed_trial path and
+      // closes the admin-panel-destroy wedge where destroyed_at is written
+      // before apply-duplicates sees the row.
+      action = 'backfill_destroyed_terminal_personal';
     }
 
     return {
@@ -662,10 +679,16 @@ async function buildDuplicateActiveInstanceCandidates(): Promise<
     getLatestSeatPurchases(orgIds),
   ]);
 
+  // Transferred-out rows are history (predecessor in a successor chain).
+  // Runtime resolvers in lib/kiloclaw/current-personal-subscription.ts ignore
+  // them, so they MUST NOT count toward duplicate-instance sub counts nor be
+  // eligible as a targetSubscriptionId for reassignment: moving a transferred
+  // row onto the canonical instance would occupy the instance_id unique slot
+  // without providing a live sub, wedging future repair.
   const subscriptionsByInstanceId = new Map<string, KiloClawSubscription[]>();
   for (const subscription of subscriptions) {
     const instanceId = subscription.instance_id;
-    if (!instanceId) {
+    if (!instanceId || subscription.transferred_to_subscription_id !== null) {
       continue;
     }
     const existing = subscriptionsByInstanceId.get(instanceId);
@@ -826,6 +849,7 @@ function summarizeMissingPersonalCandidates(rows: MissingPersonalCandidate[]) {
         reassign_destroyed_access_row: 0,
         bootstrap_trial_row: 0,
         backfill_earlybird_row: 0,
+        backfill_destroyed_terminal_personal: 0,
         manual_review: 0,
       }
     )
@@ -1059,6 +1083,18 @@ async function previewMissingPersonalBackfill() {
         earlybirdPurchaseCreatedAt: row.earlybirdPurchaseCreatedAt,
         trialEndsAt: getEarlybirdEndsAt(),
         instanceCreatedAt: row.instanceCreatedAt,
+      }))
+  );
+  printSection(
+    'Missing personal rows safe to backfill terminal canceled row (destroyed instance)',
+    rows
+      .filter(row => row.action === 'backfill_destroyed_terminal_personal')
+      .map(row => ({
+        instanceId: row.instanceId,
+        userId: row.userId,
+        sandboxId: row.sandboxId,
+        instanceCreatedAt: row.instanceCreatedAt,
+        instanceDestroyedAt: row.instanceDestroyedAt,
       }))
   );
   printSection(
@@ -1328,6 +1364,8 @@ async function applyDuplicateActiveInstanceRow(
       return 'skipped';
     }
 
+    let didReassign = false;
+
     if (row.action === 'reassign_to_canonical_and_destroy_duplicate') {
       const before = duplicateExisting[0] ?? null;
       if (!before || before.id !== row.targetSubscriptionId) {
@@ -1346,8 +1384,16 @@ async function applyDuplicateActiveInstanceRow(
         .returning();
 
       if (!updated) {
+        // UPDATE matched zero rows — no mutation, safe to skip.
         return 'skipped';
       }
+
+      // ---- MUTATION BARRIER ----
+      // Past this point the sub has been moved off the duplicate. Any later
+      // failure MUST throw so drizzle rolls the tx back; returning 'skipped'
+      // would leave the canonical instance with the sub but the duplicate
+      // without its terminal replacement, violating one-row-per-instance.
+      didReassign = true;
 
       await insertAlignmentChangeLog(tx, {
         subscriptionId: updated.id,
@@ -1360,12 +1406,19 @@ async function applyDuplicateActiveInstanceRow(
 
     const destroyed = await markDuplicateInstanceDestroyed(tx, row.duplicateInstanceId);
     if (!destroyed) {
+      if (didReassign) {
+        throw new Error(
+          `apply-duplicates: duplicate instance ${row.duplicateInstanceId} destroy marker lost race after reassigning sub to ${row.canonicalInstanceId}; rolling back`
+        );
+      }
       return 'skipped';
     }
 
     const replacement = await insertDuplicateTerminalSubscription(tx, row);
     if (!replacement) {
-      return 'skipped';
+      throw new Error(
+        `apply-duplicates: failed to insert terminal subscription for duplicate instance ${row.duplicateInstanceId} after marking destroyed; rolling back`
+      );
     }
 
     await insertAlignmentChangeLog(tx, {
@@ -1506,6 +1559,7 @@ type MissingPersonalOutcome =
   | 'reassigned'
   | 'bootstrapped'
   | 'earlybird_backfilled'
+  | 'destroyed_terminal_backfilled'
   | 'skipped'
   | 'no_op';
 
@@ -1620,8 +1674,15 @@ async function applyMissingPersonalBackfillRow(
         .returning();
 
       if (!insertedSuccessor) {
+        // INSERT returned nothing — no mutation, safe to skip.
         return 'skipped';
       }
+
+      // ---- MUTATION BARRIER ----
+      // Past this point the successor row exists in the tx. Any downstream
+      // failure MUST throw so drizzle rolls the tx back; returning 'skipped'
+      // would commit the orphan successor and violate the single-current-row
+      // invariant.
 
       const [predecessor] = await tx
         .update(kiloclaw_subscriptions)
@@ -1651,7 +1712,9 @@ async function applyMissingPersonalBackfillRow(
         .returning();
 
       if (!predecessor) {
-        return 'skipped';
+        throw new Error(
+          `reassign_destroyed_access_row: predecessor ${before.id} was transferred concurrently after successor ${insertedSuccessor.id} was inserted; rolling back successor`
+        );
       }
 
       const successor =
@@ -1669,7 +1732,9 @@ async function applyMissingPersonalBackfillRow(
           : insertedSuccessor;
 
       if (!successor) {
-        return 'skipped';
+        throw new Error(
+          `reassign_destroyed_access_row: successor ${insertedSuccessor.id} disappeared during stripe re-attach`
+        );
       }
 
       await insertAlignmentChangeLog(tx, {
@@ -1797,6 +1862,55 @@ async function applyMissingPersonalBackfillRow(
       return 'earlybird_backfilled';
     }
 
+    if (row.action === 'backfill_destroyed_terminal_personal') {
+      if (!row.instanceDestroyedAt) {
+        // Candidate classification guarantees destroyedAt. If the instance
+        // was un-destroyed between preview and apply, fall out; the next
+        // audit run will reclassify.
+        return 'skipped';
+      }
+
+      const existingForInstance = await tx
+        .select({ id: kiloclaw_subscriptions.id })
+        .from(kiloclaw_subscriptions)
+        .where(eq(kiloclaw_subscriptions.instance_id, row.instanceId))
+        .limit(1);
+
+      if (existingForInstance.length > 0) {
+        return 'skipped';
+      }
+
+      const trialEndsAt = getPersonalTrialEndsAt(row.instanceCreatedAt);
+      const [inserted] = await tx
+        .insert(kiloclaw_subscriptions)
+        .values({
+          user_id: row.userId,
+          instance_id: row.instanceId,
+          plan: 'trial',
+          status: 'canceled',
+          payment_source: null,
+          cancel_at_period_end: false,
+          trial_started_at: row.instanceCreatedAt,
+          trial_ends_at: trialEndsAt,
+          created_at: row.instanceCreatedAt,
+          updated_at: row.instanceCreatedAt,
+        })
+        .returning();
+
+      if (!inserted) {
+        return 'skipped';
+      }
+
+      await insertAlignmentChangeLog(tx, {
+        subscriptionId: inserted.id,
+        action: 'backfilled',
+        reason: 'apply_missing_personal_backfill_destroyed_terminal',
+        before: null,
+        after: inserted,
+      });
+      return 'destroyed_terminal_backfilled';
+    }
+
     return 'no_op';
   });
 }
@@ -1807,6 +1921,7 @@ async function applyMissingPersonalBackfill() {
   let reassigned = 0;
   let bootstrapped = 0;
   let earlybirdBackfilled = 0;
+  let destroyedTerminalBackfilled = 0;
   const skipped: Array<{
     instanceId: string;
     userId: string;
@@ -1847,6 +1962,9 @@ async function applyMissingPersonalBackfill() {
       case 'earlybird_backfilled':
         earlybirdBackfilled += 1;
         break;
+      case 'destroyed_terminal_backfilled':
+        destroyedTerminalBackfilled += 1;
+        break;
       case 'skipped':
         skipped.push({ instanceId: row.instanceId, userId: row.userId, action: row.action });
         break;
@@ -1861,6 +1979,7 @@ async function applyMissingPersonalBackfill() {
     { action: 'reassign_destroyed_access_row', count: reassigned },
     { action: 'bootstrap_trial_row', count: bootstrapped },
     { action: 'backfill_earlybird_row', count: earlybirdBackfilled },
+    { action: 'backfill_destroyed_terminal_personal', count: destroyedTerminalBackfilled },
     { action: 'skipped', count: skipped.length },
   ]);
   printSection('Missing personal rows skipped during apply', skipped);

--- a/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
+++ b/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
@@ -8,17 +8,26 @@
  *   pnpm script db kiloclaw-subscription-alignment preview-missing-personal
  *   pnpm script db kiloclaw-subscription-alignment apply-missing-personal
  *   pnpm script db kiloclaw-subscription-alignment preview-duplicates
- *   pnpm script db kiloclaw-subscription-alignment apply-duplicates
+ *   pnpm script db kiloclaw-subscription-alignment apply-duplicates [--confirm-sandboxes-destroyed]
  *   pnpm script db kiloclaw-subscription-alignment preview-org
  *   pnpm script db kiloclaw-subscription-alignment apply-org
  *   pnpm script db kiloclaw-subscription-alignment preview-changelog-baseline
  *   pnpm script db kiloclaw-subscription-alignment apply-changelog-baseline
+ *
+ * Flags:
+ *   --confirm-sandboxes-destroyed   Required for apply-duplicates to write
+ *     destroyed_at. Operators MUST first tear down the underlying sandbox
+ *     resources via the admin panel. Without this flag, apply-duplicates
+ *     prints a manifest of duplicate sandbox IDs and exits without writes.
  */
 
-import { and, desc, eq, inArray, isNull, notExists, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull, notExists, or, sql } from 'drizzle-orm';
 
 import { TRIAL_DURATION_DAYS } from '@/lib/constants';
-import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
+import {
+  KILOCLAW_EARLYBIRD_EXPIRY_DATE,
+  KILOCLAW_TRIAL_DURATION_DAYS,
+} from '@/lib/kiloclaw/constants';
 import { db, type DrizzleTransaction } from '@/lib/drizzle';
 import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
 import {
@@ -188,7 +197,16 @@ function isAccessGrantingRow(row: DetachedSubscriptionAuditRow, now: Date): bool
   return false;
 }
 
-function getTrialEndsAt(startedAt: string): string {
+// Personal KiloClaw trials are 7 days (KILOCLAW_TRIAL_DURATION_DAYS, billing spec
+// Trials rule 2). Organization trials are 14 days (TRIAL_DURATION_DAYS). These
+// MUST NOT be unified — using 14 for personal rows grants extra free access.
+function getPersonalTrialEndsAt(startedAt: string): string {
+  return new Date(
+    new Date(startedAt).getTime() + KILOCLAW_TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000
+  ).toISOString();
+}
+
+function getOrganizationTrialEndsAt(startedAt: string): string {
   return new Date(
     new Date(startedAt).getTime() + TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000
   ).toISOString();
@@ -253,7 +271,8 @@ async function personalContextSubscriptionExistsForUser(
 ): Promise<boolean> {
   // Personal-context = detached (no instance) or attached to a personal instance
   // (no organization). Excludes org-context subscriptions so they don't block
-  // personal backfill decisions.
+  // personal backfill decisions. Transferred-out predecessors are history and
+  // MUST be excluded — a canceled/transferred row is not a current subscription.
   const rows = await executor
     .select({ id: kiloclaw_subscriptions.id })
     .from(kiloclaw_subscriptions)
@@ -261,7 +280,32 @@ async function personalContextSubscriptionExistsForUser(
     .where(
       and(
         eq(kiloclaw_subscriptions.user_id, userId),
+        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
         or(isNull(kiloclaw_subscriptions.instance_id), isNull(kiloclaw_instances.organization_id))
+      )
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+async function liveCurrentPersonalSubscriptionExistsForUser(
+  executor: DbOrTx,
+  userId: string
+): Promise<boolean> {
+  // Live-current = non-transferred row attached to a non-destroyed personal
+  // instance. Used to guard reassign-destroyed apply: if the user already has
+  // a live personal subscription we MUST NOT create a successor on the missing
+  // instance (would yield two current personal rows for one user).
+  const rows = await executor
+    .select({ id: kiloclaw_subscriptions.id })
+    .from(kiloclaw_subscriptions)
+    .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, userId),
+        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
+        isNull(kiloclaw_instances.organization_id),
+        isNull(kiloclaw_instances.destroyed_at)
       )
     )
     .limit(1);
@@ -438,7 +482,12 @@ async function buildMissingPersonalCandidates(): Promise<MissingPersonalCandidat
   const now = new Date();
 
   return missingRows.map(row => {
-    const userSubscriptions = subscriptionsByUser.get(row.userId) ?? [];
+    // Transferred-out rows are history (predecessor of a successor chain). They
+    // do not count against the "at most one current personal row per user" invariant
+    // and MUST NOT be considered candidates for further reassignment.
+    const userSubscriptions = (subscriptionsByUser.get(row.userId) ?? []).filter(
+      subscription => subscription.transferred_to_subscription_id === null
+    );
     const detachedRows = userSubscriptions.filter(
       subscription => subscription.instance_id === null
     );
@@ -460,6 +509,16 @@ async function buildMissingPersonalCandidates(): Promise<MissingPersonalCandidat
     const linkedDestroyedAccessRows = linkedDestroyedRows.filter(subscription =>
       isAccessGrantingSubscription(subscription, now)
     );
+    // Live-current personal rows: on a non-destroyed instance and not transferred.
+    // If any exist, the user already has a current personal subscription and we
+    // MUST NOT insert a successor on the missing instance (would violate the
+    // "at most one current personal row per user" invariant from the billing spec).
+    const liveCurrentPersonalRows = linkedPersonalRows.filter(subscription => {
+      const instanceId = subscription.instance_id;
+      if (!instanceId) return false;
+      const instance = personalInstancesById.get(instanceId);
+      return !!instance && !instance.destroyedAt;
+    });
     // Personal-context subscriptions: rows linked to a personal instance OR detached
     // (ambiguous, but treated as personal-intended by the adopt_detached path).
     // Org-context subs are intentionally excluded so they don't block personal backfill.
@@ -480,6 +539,7 @@ async function buildMissingPersonalCandidates(): Promise<MissingPersonalCandidat
     } else if (
       !row.destroyedAt &&
       detachedRows.length === 0 &&
+      liveCurrentPersonalRows.length === 0 &&
       linkedDestroyedRows.length === 1 &&
       linkedDestroyedAccessRows.length === 1
     ) {
@@ -865,14 +925,46 @@ async function previewChangelogBaselineBackfill() {
 
 async function applyChangelogBaselineBackfill() {
   const rows = await listSubscriptionsMissingBaselineChangeLog();
-  let inserted = 0;
+  let insertedFromCurrent = 0;
+  let insertedFromMutation = 0;
   const failures: Array<{ subscriptionId: string; userId: string; error: string }> = [];
 
   for (const row of rows) {
     try {
-      const wrote = await db.transaction(async tx => {
+      const result = await db.transaction(async tx => {
         if (await hasBaselineChangeLogEntry(tx, row.id)) {
-          return false;
+          return 'skipped' as const;
+        }
+
+        // When prior mutation logs exist, the oldest row's before_state holds
+        // the subscription's true initial state (captured before the first
+        // mutation was applied). Using it as the fabricated baseline's
+        // after_state preserves audit-replay integrity: replaying
+        // baseline -> mutation1 -> mutation2 ... reaches the current row.
+        // Falling back to the current row would inject a no-op delta before
+        // the first mutation and desync replay forever.
+        const [earliestMutation] = await tx
+          .select({
+            beforeState: kiloclaw_subscription_change_log.before_state,
+          })
+          .from(kiloclaw_subscription_change_log)
+          .where(eq(kiloclaw_subscription_change_log.subscription_id, row.id))
+          .orderBy(asc(kiloclaw_subscription_change_log.created_at))
+          .limit(1);
+
+        const inheritedBaseline = earliestMutation?.beforeState ?? null;
+
+        if (inheritedBaseline) {
+          await tx.insert(kiloclaw_subscription_change_log).values({
+            subscription_id: row.id,
+            actor_type: ALIGNMENT_SCRIPT_ACTOR.actorType,
+            actor_id: ALIGNMENT_SCRIPT_ACTOR.actorId,
+            action: 'backfilled',
+            reason: 'baseline_subscription_snapshot_from_earliest_mutation',
+            before_state: null,
+            after_state: inheritedBaseline,
+          });
+          return 'from_mutation' as const;
         }
 
         await insertAlignmentChangeLog(tx, {
@@ -882,11 +974,13 @@ async function applyChangelogBaselineBackfill() {
           before: null,
           after: row,
         });
-        return true;
+        return 'from_current' as const;
       });
 
-      if (wrote) {
-        inserted += 1;
+      if (result === 'from_mutation') {
+        insertedFromMutation += 1;
+      } else if (result === 'from_current') {
+        insertedFromCurrent += 1;
       }
     } catch (error) {
       console.error('Changelog baseline backfill row failed', {
@@ -904,7 +998,8 @@ async function applyChangelogBaselineBackfill() {
 
   console.log('\nChangelog baseline backfill results');
   console.table([
-    { action: 'backfilled', count: inserted },
+    { action: 'backfilled_from_current_state', count: insertedFromCurrent },
+    { action: 'backfilled_from_earliest_mutation', count: insertedFromMutation },
     { action: 'failed', count: failures.length },
   ]);
   printSection('Changelog baseline rows that failed to backfill', failures);
@@ -948,7 +1043,7 @@ async function previewMissingPersonalBackfill() {
         userId: row.userId,
         sandboxId: row.sandboxId,
         instanceDestroyedAt: row.instanceDestroyedAt,
-        trialEndsAt: getTrialEndsAt(row.instanceCreatedAt),
+        trialEndsAt: getPersonalTrialEndsAt(row.instanceCreatedAt),
         instanceCreatedAt: row.instanceCreatedAt,
       }))
   );
@@ -1017,7 +1112,7 @@ async function previewOrgBackfill() {
         requireSeats: row.requireSeats,
         destroyedAt: row.destroyedAt,
         trialStartedAt: row.organizationCreatedAt,
-        trialEndsAt: row.freeTrialEndAt ?? getTrialEndsAt(row.organizationCreatedAt),
+        trialEndsAt: row.freeTrialEndAt ?? getOrganizationTrialEndsAt(row.organizationCreatedAt),
       }))
   );
   printSection(
@@ -1046,7 +1141,7 @@ async function previewOrgBackfill() {
         requireSeats: row.requireSeats,
         destroyedAt: row.destroyedAt,
         trialStartedAt: row.organizationCreatedAt,
-        trialEndsAt: row.freeTrialEndAt ?? getTrialEndsAt(row.organizationCreatedAt),
+        trialEndsAt: row.freeTrialEndAt ?? getOrganizationTrialEndsAt(row.organizationCreatedAt),
       }))
   );
 }
@@ -1130,7 +1225,7 @@ async function insertDuplicateTerminalSubscription(
         payment_source: null,
         cancel_at_period_end: false,
         trial_started_at: row.duplicateCreatedAt,
-        trial_ends_at: getTrialEndsAt(row.duplicateCreatedAt),
+        trial_ends_at: getPersonalTrialEndsAt(row.duplicateCreatedAt),
         created_at: row.duplicateCreatedAt,
         updated_at: row.duplicateCreatedAt,
       })
@@ -1179,7 +1274,8 @@ async function insertDuplicateTerminalSubscription(
             payment_source: null,
             cancel_at_period_end: false,
             trial_started_at: row.organizationCreatedAt,
-            trial_ends_at: row.freeTrialEndAt ?? getTrialEndsAt(row.organizationCreatedAt),
+            trial_ends_at:
+              row.freeTrialEndAt ?? getOrganizationTrialEndsAt(row.organizationCreatedAt),
             created_at: row.duplicateCreatedAt,
             updated_at: row.duplicateCreatedAt,
           }
@@ -1290,7 +1386,7 @@ async function applyDuplicateActiveInstanceRow(
   });
 }
 
-async function applyDuplicateActiveInstances() {
+async function applyDuplicateActiveInstances(options: ApplyOptions) {
   const rows = await buildDuplicateActiveInstanceCandidates();
   let personalDestroyed = 0;
   let orgDestroyed = 0;
@@ -1302,6 +1398,47 @@ async function applyDuplicateActiveInstances() {
     action: string;
     error?: string;
   }> = [];
+  const manualTeardown: Array<{
+    duplicateInstanceId: string;
+    duplicateSandboxId: string;
+    userId: string;
+    action: string;
+  }> = [];
+
+  // Writing destroyed_at without destroying the underlying sandbox would make
+  // an active sandbox invisible to lifecycle/access checks while it keeps
+  // consuming resources. The canonical destroy flow (kiloclaw-router.ts
+  // destroy procedure) always calls KiloClawInternalClient().destroy() and
+  // rolls back on failure; we can't safely mirror that from a batch script.
+  // Operators MUST confirm each duplicate sandbox has already been torn down
+  // out-of-band before we mark its DB row destroyed.
+  if (!options.confirmSandboxesDestroyed) {
+    for (const row of rows) {
+      if (
+        row.action === 'backfill_destroy_duplicate_personal' ||
+        row.action === 'backfill_destroy_duplicate_org' ||
+        row.action === 'reassign_to_canonical_and_destroy_duplicate'
+      ) {
+        manualTeardown.push({
+          duplicateInstanceId: row.duplicateInstanceId,
+          duplicateSandboxId: row.duplicateSandboxId,
+          userId: row.userId,
+          action: row.action,
+        });
+      }
+    }
+    console.log(
+      '\nRefusing to mark duplicate instances destroyed without external sandbox teardown confirmation.'
+    );
+    console.log(
+      'Operators MUST destroy each sandbox below via the admin panel (or confirm it is already gone),'
+    );
+    console.log(
+      'then re-run with --confirm-sandboxes-destroyed to write destroyed_at and insert terminal rows.'
+    );
+    printSection('Duplicate sandboxes requiring manual teardown first', manualTeardown);
+    return;
+  }
 
   for (const row of rows) {
     if (
@@ -1421,12 +1558,16 @@ async function applyMissingPersonalBackfillRow(
         return 'skipped';
       }
 
-      const existing = await tx
-        .select({ id: kiloclaw_subscriptions.id })
-        .from(kiloclaw_subscriptions)
-        .where(eq(kiloclaw_subscriptions.instance_id, row.instanceId))
-        .limit(1);
-      if (existing.length > 0) {
+      const [existing, hasLiveCurrent] = await Promise.all([
+        tx
+          .select({ id: kiloclaw_subscriptions.id })
+          .from(kiloclaw_subscriptions)
+          .where(eq(kiloclaw_subscriptions.instance_id, row.instanceId))
+          .limit(1),
+        liveCurrentPersonalSubscriptionExistsForUser(tx, row.userId),
+      ]);
+
+      if (existing.length > 0 || hasLiveCurrent) {
         return 'skipped';
       }
 
@@ -1566,7 +1707,7 @@ async function applyMissingPersonalBackfillRow(
         return 'skipped';
       }
 
-      const trialEndsAt = getTrialEndsAt(row.instanceCreatedAt);
+      const trialEndsAt = getPersonalTrialEndsAt(row.instanceCreatedAt);
       const [inserted] = await tx
         .insert(kiloclaw_subscriptions)
         .values({
@@ -1745,7 +1886,7 @@ async function applyOrgBackfillRow(row: OrgBackfillCandidate): Promise<OrgApplyO
       return 'skipped';
     }
 
-    const trialEndsAt = row.freeTrialEndAt ?? getTrialEndsAt(row.organizationCreatedAt);
+    const trialEndsAt = row.freeTrialEndAt ?? getOrganizationTrialEndsAt(row.organizationCreatedAt);
     const trialStatus = new Date(trialEndsAt).getTime() > Date.now() ? 'trialing' : 'canceled';
     const [inserted] = await tx
       .insert(kiloclaw_subscriptions)
@@ -1866,6 +2007,10 @@ async function applyOrgBackfill() {
   printSection('Org rows skipped during apply', skipped);
 }
 
+type ApplyOptions = {
+  confirmSandboxesDestroyed: boolean;
+};
+
 function parseMode(inputMode?: string): Mode {
   const mode = inputMode ?? 'audit';
   switch (mode) {
@@ -1885,7 +2030,15 @@ function parseMode(inputMode?: string): Mode {
   }
 }
 
-const singleModeHandlers: Partial<Record<Mode, () => Promise<void>>> = {
+function parseApplyOptions(args: string[]): ApplyOptions {
+  return {
+    confirmSandboxesDestroyed: args.includes('--confirm-sandboxes-destroyed'),
+  };
+}
+
+type ModeHandler = (options: ApplyOptions) => Promise<void>;
+
+const singleModeHandlers: Partial<Record<Mode, ModeHandler>> = {
   'preview-missing-personal': previewMissingPersonalBackfill,
   'apply-missing-personal': applyMissingPersonalBackfill,
   'preview-duplicates': previewDuplicateActiveInstances,
@@ -1896,13 +2049,15 @@ const singleModeHandlers: Partial<Record<Mode, () => Promise<void>>> = {
   'apply-changelog-baseline': applyChangelogBaselineBackfill,
 };
 
-export async function run(inputMode?: string) {
+export async function run(...args: string[]) {
+  const inputMode = args[0];
   const mode = parseMode(inputMode);
+  const options = parseApplyOptions(args.slice(1));
 
   const handler = singleModeHandlers[mode];
   if (handler) {
     console.log(`Mode: ${mode}`);
-    await handler();
+    await handler(options);
     return;
   }
   // Fall through: 'audit' and 'repair-detached' share the full summary output.

--- a/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
+++ b/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
@@ -226,16 +226,16 @@ function getEarlybirdEndsAt(): string {
   return new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE).toISOString();
 }
 
-function getOrganizationManagedActiveAccess(params: {
+// Org billing has not rolled out yet. Every org instance gets managed-active
+// access as a free trial until paid org billing ships. When billing rolls out,
+// restore the spec-defined classifier (active seat purchase || !require_seats
+// || oss_sponsorship_tier || suppress_trial_messaging) and keep this aligned
+// with services/kiloclaw-billing/src/bootstrap.ts.
+function getOrganizationManagedActiveAccess(_params: {
   organization: Pick<Organization, 'require_seats' | 'settings'>;
   latestPurchase: Pick<OrganizationSeatsPurchase, 'subscription_status'> | null;
 }): boolean {
-  return (
-    params.latestPurchase?.subscription_status === 'active' ||
-    !params.organization.require_seats ||
-    params.organization.settings.oss_sponsorship_tier != null ||
-    !!params.organization.settings.suppress_trial_messaging
-  );
+  return true;
 }
 
 function printSection<T>(label: string, rows: T[]) {

--- a/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
+++ b/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
@@ -1338,15 +1338,31 @@ async function applyDuplicateActiveInstanceRow(
   row: DuplicateActiveInstanceCandidate
 ): Promise<DuplicateApplyOutcome> {
   return await db.transaction(async tx => {
+    // Filter transferred-out predecessor rows to match the candidate builder
+    // (subscriptionsByInstanceId at buildDuplicateActiveInstanceCandidates).
+    // Otherwise a canonical instance holding only a historical transferred
+    // predecessor would block reassignment forever: preview classifies the
+    // duplicate as safe, apply sees the transferred row as a current sub and
+    // skips. Same applies to duplicate counts.
     const [canonicalExisting, duplicateExisting] = await Promise.all([
       tx
         .select()
         .from(kiloclaw_subscriptions)
-        .where(eq(kiloclaw_subscriptions.instance_id, row.canonicalInstanceId)),
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.instance_id, row.canonicalInstanceId),
+            isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+          )
+        ),
       tx
         .select()
         .from(kiloclaw_subscriptions)
-        .where(eq(kiloclaw_subscriptions.instance_id, row.duplicateInstanceId)),
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.instance_id, row.duplicateInstanceId),
+            isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+          )
+        ),
     ]);
 
     if (
@@ -1414,23 +1430,36 @@ async function applyDuplicateActiveInstanceRow(
       return 'skipped';
     }
 
-    const replacement = await insertDuplicateTerminalSubscription(tx, row);
-    if (!replacement) {
-      throw new Error(
-        `apply-duplicates: failed to insert terminal subscription for duplicate instance ${row.duplicateInstanceId} after marking destroyed; rolling back`
-      );
-    }
+    // If the duplicate's instance_id slot is already occupied (e.g. by a
+    // transferred predecessor), the UQ_kiloclaw_subscriptions_instance partial
+    // unique prevents inserting another row. A transferred predecessor
+    // already satisfies the "every instance has a sub row" invariant, so
+    // skip the terminal insert in that case.
+    const anyRowOnDuplicate = await tx
+      .select({ id: kiloclaw_subscriptions.id })
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.instance_id, row.duplicateInstanceId))
+      .limit(1);
 
-    await insertAlignmentChangeLog(tx, {
-      subscriptionId: replacement.id,
-      action: 'backfilled',
-      reason:
-        row.contextType === 'personal'
-          ? 'apply_duplicate_active_backfill_personal_terminal'
-          : 'apply_duplicate_active_backfill_org_terminal',
-      before: null,
-      after: replacement,
-    });
+    if (anyRowOnDuplicate.length === 0) {
+      const replacement = await insertDuplicateTerminalSubscription(tx, row);
+      if (!replacement) {
+        throw new Error(
+          `apply-duplicates: failed to insert terminal subscription for duplicate instance ${row.duplicateInstanceId} after marking destroyed; rolling back`
+        );
+      }
+
+      await insertAlignmentChangeLog(tx, {
+        subscriptionId: replacement.id,
+        action: 'backfilled',
+        reason:
+          row.contextType === 'personal'
+            ? 'apply_duplicate_active_backfill_personal_terminal'
+            : 'apply_duplicate_active_backfill_org_terminal',
+        before: null,
+        after: replacement,
+      });
+    }
 
     if (row.action === 'reassign_to_canonical_and_destroy_duplicate') {
       return 'reassigned';
@@ -1612,11 +1641,19 @@ async function applyMissingPersonalBackfillRow(
         return 'skipped';
       }
 
+      // Only current (non-transferred) rows block reassignment. A transferred
+      // predecessor on this instance is runtime-invisible and must not block
+      // the successor insert.
       const [existing, hasLiveCurrent] = await Promise.all([
         tx
           .select({ id: kiloclaw_subscriptions.id })
           .from(kiloclaw_subscriptions)
-          .where(eq(kiloclaw_subscriptions.instance_id, row.instanceId))
+          .where(
+            and(
+              eq(kiloclaw_subscriptions.instance_id, row.instanceId),
+              isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+            )
+          )
           .limit(1),
         liveCurrentPersonalSubscriptionExistsForUser(tx, row.userId),
       ]);
@@ -1759,11 +1796,18 @@ async function applyMissingPersonalBackfillRow(
         return 'skipped';
       }
 
+      // Only current (non-transferred) rows block bootstrap. Transferred
+      // predecessor on this instance is runtime-invisible.
       const [existingForInstance, hasPersonalForUser] = await Promise.all([
         tx
           .select({ id: kiloclaw_subscriptions.id })
           .from(kiloclaw_subscriptions)
-          .where(eq(kiloclaw_subscriptions.instance_id, row.instanceId))
+          .where(
+            and(
+              eq(kiloclaw_subscriptions.instance_id, row.instanceId),
+              isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+            )
+          )
           .limit(1),
         personalContextSubscriptionExistsForUser(tx, row.userId),
       ]);
@@ -1808,11 +1852,18 @@ async function applyMissingPersonalBackfillRow(
         return 'skipped';
       }
 
+      // Only current (non-transferred) rows block earlybird backfill.
+      // Transferred predecessor on this instance is runtime-invisible.
       const [existingForInstance, hasPersonalForUser, earlybirdPurchase] = await Promise.all([
         tx
           .select({ id: kiloclaw_subscriptions.id })
           .from(kiloclaw_subscriptions)
-          .where(eq(kiloclaw_subscriptions.instance_id, row.instanceId))
+          .where(
+            and(
+              eq(kiloclaw_subscriptions.instance_id, row.instanceId),
+              isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+            )
+          )
           .limit(1),
         personalContextSubscriptionExistsForUser(tx, row.userId),
         tx

--- a/services/kiloclaw-billing/src/bootstrap.ts
+++ b/services/kiloclaw-billing/src/bootstrap.ts
@@ -162,11 +162,12 @@ async function bootstrapOrganizationSubscription(
     throw new Error('Organization not found during subscription bootstrap');
   }
 
-  const hasManagedActiveAccess =
-    latestSeatPurchase?.subscriptionStatus === 'active' ||
-    !organization.requireSeats ||
-    organization.settings.oss_sponsorship_tier != null ||
-    !!organization.settings.suppress_trial_messaging;
+  // Org billing has not rolled out yet. Every org instance gets managed-active
+  // access as a free trial until paid org billing ships. When billing rolls
+  // out, restore the spec-defined classifier (active seat purchase ||
+  // !requireSeats || oss_sponsorship_tier || suppress_trial_messaging) and
+  // keep it aligned with apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts.
+  const hasManagedActiveAccess = true;
 
   logger
     .withFields({


### PR DESCRIPTION
## Summary
Ships an offline script that audits and repairs drift between `kiloclaw_instances` and `kiloclaw_subscriptions` so every instance has exactly one subscription row with a correct change-log history, and grants managed-active access to all org instances as a free trial until paid org billing ships.

### Why this change is needed
Production data has accumulated several classes of drift that violate the datamodel spec (`.specs/kiloclaw-datamodel.md` rules 4–6) and break the billing spec's "at most one current personal subscription per user" invariant:

- Instances without subscription rows (early-bird users, legacy creates, destroyed duplicates). **409 active org-context instances currently in this state → users reporting lockouts.**
- Duplicate active instances per user per context where only one should exist.
- Detached subscription rows with a null `instance_id` that should be repaired or quarantined.
- Subscriptions missing the baseline change-log entry required for audit replay.
- Org instances lacking the correct shape for the current access policy.

These drifts cannot be resolved by runtime code because resolution depends on user-specific history (earlybird purchase, destroyed predecessors, concurrent org subs, etc.) and needs auditable, transactional one-off fixes.

Separately: org billing has not rolled out yet, and every org instance should get access during the transition. The old 4-way classifier (active seat purchase || `!require_seats` || `oss_sponsorship_tier` || `suppress_trial_messaging`) produced `trial` rows for orgs with `require_seats=true` and no active purchase — which is most orgs right now — leaving them locked out.

### How this is addressed
- New `pnpm script db kiloclaw-subscription-alignment [mode]` tool with 10 modes: read-only `audit` (default), `repair-detached`, plus preview/apply pairs for missing-personal, duplicates, org, and changelog-baseline.
- Every apply mode runs per-row in a `db.transaction`; post-mutation failures throw so partial state is rolled back. One bad row cannot wedge the run — it lands in a skipped manifest and execution continues.
- Missing-personal classifier produces 5 resolutions: adopt detached, reassign-destroyed via the successor pattern (mirrors `createSuccessorPersonalSubscription`), bootstrap 7-day trial, backfill earlybird row, or insert a canceled terminal row for already-destroyed instances.
- Duplicate handling picks canonical = instance with most subscriptions (tiebreak oldest). Writes to `destroyed_at` are gated behind `--confirm-sandboxes-destroyed` so a running sandbox cannot be hidden from lifecycle checks.
- **Org classifier collapsed to "managed-active for every non-destroyed org instance."** Both the alignment script and `services/kiloclaw-billing/src/bootstrap.ts` now write `{plan: 'standard', status: 'active', payment_source: 'credits'}` for all org orphans and all newly-created org instances. When paid org billing ships, restore the spec-defined classifier in both files.
- Changelog baseline backfill inherits `after_state` from the earliest mutation's `before_state` when prior mutation logs exist, preserving audit replay integrity.
- Every mutation writes a `kiloclaw_subscription_change_log` entry (action `backfilled` or `reassigned`, actor `system/kiloclaw-subscription-alignment`, distinct `reason` per path).
- No schema changes; no other production code paths touched.

## Execution Plan — Bringing Production DB Into the Right Shape

Run the sequence below from a machine with `POSTGRES_SCRIPT_URL` pointing at production (or a prod snapshot). All `apply-*` modes are transactional per-row; one bad row does not abort the run.

### 0. Prerequisites

```bash
# Confirm env is pointed at the right DB
echo "$POSTGRES_SCRIPT_URL" | sed 's/:[^:@]*@/:***@/'

# Pull dependencies
pnpm install
```

### 1. Audit (read-only, no writes)

```bash
pnpm script db kiloclaw-subscription-alignment audit
```

Prints counts for every drift category. Save the output — you'll compare against it after each apply step to confirm rows moved in the expected direction.

Expected scale (as of this PR):
- **Missing personal rows**: TBD — run to see
- **Missing org rows**: 409 active + 104 destroyed = 513
- **Duplicate active instances**: TBD
- **Detached subscriptions**: TBD
- **Subscriptions missing baseline changelog**: TBD

### 2. Backfill missing personal rows

```bash
pnpm script db kiloclaw-subscription-alignment preview-missing-personal
# Review: counts per action (adopt / reassign-destroyed / bootstrap-trial / earlybird / destroyed-terminal / manual-review)
pnpm script db kiloclaw-subscription-alignment apply-missing-personal
```

Resolutions:
- **adopt_detached_access_row** — detached sub row attaches to the personal instance.
- **reassign_destroyed_access_row** — successor pattern: inserts new current sub on the active instance, marks the destroyed-instance predecessor `canceled + transferred_to_subscription_id`.
- **bootstrap_trial_row** — 7-day trial for users with no sub and no earlybird purchase.
- **backfill_earlybird_row** — earlybird access row for early-bird purchasers.
- **backfill_destroyed_terminal_personal** — canceled terminal row for destroyed personal instances missing a sub. Satisfies "every instance has a sub row" invariant.
- **manual_review** — ambiguous cases (multiple detached access rows, multiple destroyed access rows, etc.). Investigate individually.

### 3. Backfill missing org rows (unlocks the 409 locked-out users)

```bash
pnpm script db kiloclaw-subscription-alignment preview-org
# Confirm counts — active instances → backfill_active_standard_credits,
# destroyed instances → backfill_destroyed_standard_credits
pnpm script db kiloclaw-subscription-alignment apply-org
```

Because the classifier now returns `true` unconditionally, every non-destroyed org instance gets `{plan: 'standard', status: 'active', payment_source: 'credits'}`. Every destroyed org instance gets the same shape with `status: 'canceled'` as terminal cleanup.

### 4. Repair detached subscriptions

```bash
pnpm script db kiloclaw-subscription-alignment repair-detached
```

Re-links unambiguous detached rows (null `instance_id`) to the owning instance.

### 5. Resolve duplicate active instances

Two sub-workflows, pick one:

**5a. Recommended — admin-panel destroy first, then run apply-missing-personal/apply-org.** Operator destroys the duplicate sandbox via the admin panel (which writes `destroyed_at` via the existing `destroy` tRPC). Then:

```bash
# Destroyed duplicate personal instances → pick up via backfill_destroyed_terminal_personal
pnpm script db kiloclaw-subscription-alignment apply-missing-personal

# Destroyed duplicate org instances → pick up via backfill_destroyed_standard_credits
pnpm script db kiloclaw-subscription-alignment apply-org
```

No flag required — already-destroyed instances are handled by the normal backfill paths.

**5b. Fallback — out-of-band sandbox teardown already completed.** If the sandbox resource has been torn down via provider-level tooling (not the admin panel) and you need the script to write `destroyed_at` + terminal rows:

```bash
pnpm script db kiloclaw-subscription-alignment preview-duplicates
# Review duplicate groups and canonical selection
pnpm script db kiloclaw-subscription-alignment apply-duplicates --confirm-sandboxes-destroyed
```

**Do not run 5b** unless the sandbox is verifiably gone. Without the flag, the script prints a manifest and exits without writes.

### 6. Backfill changelog baselines

```bash
pnpm script db kiloclaw-subscription-alignment preview-changelog-baseline
pnpm script db kiloclaw-subscription-alignment apply-changelog-baseline
```

Writes a `before_state IS NULL` baseline row for every subscription missing one. When prior mutation logs exist, the baseline's `after_state` inherits from the earliest mutation's `before_state` (preserves audit replay). Otherwise, snapshots the current row.

### 7. Final audit

```bash
pnpm script db kiloclaw-subscription-alignment audit
```

All drift counters should be zero (or contain only `manual_review` entries requiring operator attention). Compare to step 1 output.

### Rollback

Every apply mode writes a `kiloclaw_subscription_change_log` entry per mutation with `actor_id='kiloclaw-subscription-alignment'`. If something goes wrong, queries against the change log identify exactly which rows the script touched and what the prior state was:

```sql
SELECT * FROM kiloclaw_subscription_change_log
WHERE actor_id = 'kiloclaw-subscription-alignment'
ORDER BY created_at DESC;
```

A bespoke rollback SQL would be needed to reverse a specific apply — the script itself does not implement undo.

## Human Verification
- **Spec alignment** — Verified against `.specs/kiloclaw-datamodel.md` (rules 1–18, 21) and `.specs/kiloclaw-billing.md` Trials rule 2 (7-day personal trial). No rule violations. Org classifier is explicitly a transitional state; spec classifier remains documented in-code for restoration when billing ships.
- **Code evaluations** — Five iterative review rounds performed (general correctness, self-review after fixes, externally-provided findings, partial-state/rollback review, and user-reported lockout investigation). All findings addressed across 4 fix commits on top of the initial feat commit, plus the managed-active commit.
- **Tests verified** — `pnpm --filter web test src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts` passes all 11 integration tests against a real postgres instance. `pnpm --filter kiloclaw-billing test` passes all 35 billing worker tests.

<details>
<summary>Manual testing performed</summary>

1. Per-action happy path: duplicate reassign+destroy, reassign-destroyed successor pattern, destroyed-terminal backfill, mutation-only-logs baseline inheritance, org-context does not block personal bootstrap.
2. Guard paths: live-current sub blocks reassign-destroyed, `--confirm-sandboxes-destroyed` flag gates duplicate writes, transferred-out rows excluded from duplicate targets.
3. Idempotency: re-running each apply mode is a no-op after a successful run.
4. 7-day vs 14-day trial: personal bootstrap produces 7-day `trial_ends_at` regardless of org trial constant.
5. Org free-trial: org instance with `require_seats=true` and no purchase produces `plan=standard, status=active, payment_source=credits` (not a trial row).

</details>

- _Additional verification (to be completed by author)_

## Visual Changes
N/A

## Reviewer Notes
### Human Reviewer
- **New tool with destructive write modes.** `apply-*` modes mutate billing data. Default mode is read-only `audit`; all writes are transactional and per-row-isolated, but a reviewer should confirm the default workflow before anyone runs apply against production.
- **Org classifier change is transitional.** `hasManagedActiveAccess = true` in both `services/kiloclaw-billing/src/bootstrap.ts` and the alignment script. The pre-existing 4-way classifier is documented in a comment for restoration when paid org billing ships. These two files MUST stay aligned — do not restore the classifier in only one place.
- **`apply-duplicates --confirm-sandboxes-destroyed` flag convention.** The recommended workflow is admin-panel-first (operator destroys the sandbox via existing `destroy` tRPC which sets `destroyed_at`), then `apply-missing-personal` / `apply-org` picks up the now-destroyed row and inserts the appropriate terminal row. The `apply-duplicates` flag is the fallback when teardown has already happened out-of-band.
- **Canonical selection heuristic.** Duplicate handling picks the instance with more subscriptions, tiebreaking on oldest `created_at`. Rejected alternative: unconditionally pick oldest. Rationale: if a live subscription exists, it already points at the "winning" instance; moving the live sub to a stale empty instance would be user-visibly wrong.
- **Reassign-destroyed uses the successor pattern, not in-place UPDATE.** Mirrors `createSuccessorPersonalSubscription` in `services/kiloclaw-billing/src/bootstrap.ts`. Preserves predecessor history on the destroyed instance.
- **Assumptions to validate**: (a) runtime resolvers in `lib/kiloclaw/current-personal-subscription.ts` reliably filter `transferred_to_subscription_id IS NOT NULL`; (b) `UQ_kiloclaw_subscriptions_instance` is partial unique on non-null `instance_id`; (c) `kiloclaw_subscription_change_log.created_at` uses `defaultNow()` so we do not pass it from the app; (d) `backfilled` and `reassigned` action labels are in the enum (`packages/db/src/schema-types.ts:174`).

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- **Scope**: new script + matching integration test file + two-line classifier change in `services/kiloclaw-billing/src/bootstrap.ts`. Zero schema changes.
- **Per-row atomicity**: each apply row runs inside `db.transaction`. After the first mutating statement in a tx, all subsequent skip conditions `throw` rather than `return 'skipped'` so Drizzle rolls back. Look for the "MUTATION BARRIER" comments in `applyDuplicateActiveInstanceRow` and the reassign-destroyed path.
- **Change log discipline**: every mutation pairs with a `insertAlignmentChangeLog` call inside the same tx. Failures propagate (no swallowed errors), so a log-write failure rolls back the mutation per datamodel spec rule 15.
- **Guards against double-current-row**: `liveCurrentPersonalSubscriptionExistsForUser` and `personalContextSubscriptionExistsForUser` both filter `transferred_to_subscription_id IS NULL` + exclude org-context subs. Called in candidate builder AND re-called inside each apply tx so concurrent races cannot slip past.
- **Duplicate candidate builder filters transferred predecessors** from `subscriptionsByInstanceId` population. Without this, moving a transferred row onto canonical would occupy the unique `instance_id` slot with a dead row.
- **Baseline backfill uses earliest-mutation `before_state` when mutation logs exist**. Falls back to current row only when no prior logs. Preserves replay invariant: `baseline.after_state → mutation1.diff → ...` reaches the current row.
- **Trial duration**: `getPersonalTrialEndsAt` (7d, `KILOCLAW_TRIAL_DURATION_DAYS`) vs `getOrganizationTrialEndsAt` (14d, `TRIAL_DURATION_DAYS`). Personal spec is stricter; do not unify. Note: org trial helper still exists but the classifier never routes to trial in this PR — kept for when billing ships.
- **Mode dispatch**: `singleModeHandlers` table (typed `Partial<Record<Mode, ModeHandler>>`). `audit` and `repair-detached` fall through to the summary output block by design.
- **No mocks in web tests** — all tests hit a real postgres instance started via `docker compose`. Assertions check DB state, not call spies.
- **Specs followed**: `.specs/kiloclaw-datamodel.md` rules 1–18, 21; `.specs/kiloclaw-billing.md` Trials rule 2.

</details>