### PR TITLE
fix(web): pass websocketBaseUrl to Cloud Agent session manager

### DIFF
--- a/apps/web/src/components/cloud-agent-next/CloudAgentProvider.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudAgentProvider.tsx
@@ -13,7 +13,7 @@ import {
   type KiloSessionId,
   type CloudAgentSessionId,
 } from '@/lib/cloud-agent-sdk';
-import { SESSION_INGEST_WS_URL } from '@/lib/constants';
+import { CLOUD_AGENT_NEXT_WS_URL, SESSION_INGEST_WS_URL } from '@/lib/constants';
 import type { AgentMode } from './types';
 import { usePostHog } from 'posthog-js/react';
 
@@ -115,6 +115,8 @@ export function CloudAgentProvider({ children, organizationId }: CloudAgentProvi
       },
 
       cliWebsocketUrl: SESSION_INGEST_WS_URL ? `${SESSION_INGEST_WS_URL}/api/user/web` : undefined,
+
+      websocketBaseUrl: CLOUD_AGENT_NEXT_WS_URL,
 
       lifecycleHooks: createBrowserLifecycleHooks(),
 


### PR DESCRIPTION
## Summary

- Regression from #2417: `createCloudAgentTransport` no longer falls back to `CLOUD_AGENT_NEXT_WS_URL` internally, and `session.ts` now throws when `config.websocketBaseUrl` is missing. The web `CloudAgentProvider` never passed it explicitly, so every Cloud Agent session fails with `CloudAgentSession websocketBaseUrl is required for Cloud Agent sessions`.
- Forward `CLOUD_AGENT_NEXT_WS_URL` from `@/lib/constants` into `createSessionManager`, matching how mobile forwards its own `CLOUD_AGENT_WS_URL`.
- App-builder is unaffected — its streaming path (`project-manager/sessions/v2/streaming.ts`) reads `CLOUD_AGENT_NEXT_WS_URL` directly and does not go through the SDK session manager.

## Verification

- [x] `pnpm --filter web typecheck`
- [x] `pnpm format`

## Visual Changes

N/A

## Reviewer Notes

Small one-line fix. The SDK contract change in #2417 was intentional (mobile needs an explicit URL); this just restores the value on the web caller.