### PR TITLE
refactor(claw): polish BotIdentityStep onboarding card

### DIFF
--- a/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, Shuffle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { OnboardingStepView } from './OnboardingStepView';
@@ -10,24 +10,11 @@ import { cn } from '@/lib/utils';
 
 const NAME_SUGGESTIONS = ['Aria', 'Echo', 'Nova', 'Rex', 'Sage', 'Iris', 'Orion', 'Pixel'];
 
-const EMOJI_OPTIONS = [
-  '🤖',
-  '🐱',
-  '🐙',
-  '🦁',
-  '⚡',
-  '🌙',
-  '🍥',
-  '🔥',
-  '🦄',
-  '🧠',
-  '🐉',
-  '✨',
-  '🌊',
-  '🎪',
-  '🦋',
-  '💎',
-];
+const EMOJI_OPTIONS = ['🤖', '👾', '🧠', '⚡', '🔮', '🔥', '🐉', '✨', '🌙'];
+
+function pickRandom<T>(items: readonly T[]): T {
+  return items[Math.floor(Math.random() * items.length)];
+}
 
 type NaturePreset = {
   id: string;
@@ -78,6 +65,12 @@ export function BotIdentityStep({
   const activeEmoji = customEmoji || selectedEmoji;
   const nature = NATURE_PRESETS.find(n => n.id === selectedNatureId) ?? NATURE_PRESETS[0];
 
+  function handleShuffle() {
+    setBotName(pickRandom(NAME_SUGGESTIONS));
+    setSelectedEmoji(pickRandom(EMOJI_OPTIONS));
+    setCustomEmoji('');
+  }
+
   function handleContinue() {
     onContinue({
       botName: botName.trim() || 'KiloClaw',
@@ -96,16 +89,28 @@ export function BotIdentityStep({
       showProvisioningBanner={!instanceRunning}
       contentClassName="gap-6"
     >
-      {/* Name */}
+      <div className="border-border bg-muted/30 flex items-center gap-3 rounded-lg border p-4">
+        <span className="text-2xl">{activeEmoji}</span>
+        <div className="min-w-0 flex-1">
+          <p className="text-foreground font-medium">{botName || 'Your bot'}</p>
+          <p className="text-muted-foreground text-sm">{nature.label}</p>
+        </div>
+        <button
+          type="button"
+          onClick={handleShuffle}
+          aria-label="Shuffle name and emoji"
+          className="border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground flex h-9 w-9 shrink-0 items-center justify-center rounded-md border transition-colors"
+        >
+          <Shuffle className="h-4 w-4" />
+        </button>
+      </div>
+
       <div className="space-y-3">
-        <h3 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
-          What should we call it?
-        </h3>
         <Input
           value={botName}
           onChange={e => setBotName(e.target.value)}
           maxLength={80}
-          placeholder="e.g. Aria, Sage, Nova..."
+          placeholder="Name your bot"
         />
         <div className="flex flex-wrap gap-2">
           {NAME_SUGGESTIONS.map(name => (
@@ -115,7 +120,7 @@ export function BotIdentityStep({
               className={cn(
                 'rounded-full border px-3 py-1 text-sm transition-colors',
                 botName === name
-                  ? 'border-blue-500 bg-blue-500/10 text-blue-400'
+                  ? 'border-brand-primary bg-brand-primary/10 text-brand-primary'
                   : 'border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground'
               )}
               onClick={() => setBotName(name)}
@@ -126,20 +131,16 @@ export function BotIdentityStep({
         </div>
       </div>
 
-      {/* Emoji picker */}
       <div className="space-y-3">
-        <h3 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
-          Pick a signature emoji
-        </h3>
-        <div className="grid grid-cols-8 gap-2">
+        <div className="flex flex-wrap gap-3">
           {EMOJI_OPTIONS.map(emoji => (
             <button
               key={emoji}
               type="button"
               className={cn(
-                'flex h-12 items-center justify-center rounded-lg border text-xl transition-colors',
+                'flex h-14 w-14 items-center justify-center rounded-lg border text-2xl transition-colors',
                 selectedEmoji === emoji && !customEmoji
-                  ? 'border-blue-500 bg-blue-500/10'
+                  ? 'border-brand-primary bg-brand-primary/10'
                   : 'border-border hover:border-foreground/30 hover:bg-muted/50'
               )}
               onClick={() => {
@@ -161,45 +162,27 @@ export function BotIdentityStep({
         />
       </div>
 
-      {/* Nature */}
-      <div className="space-y-3">
-        <h3 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
-          What kind of creature is it?
-        </h3>
-        <div className="grid gap-3 md:grid-cols-2">
-          {NATURE_PRESETS.map(preset => (
-            <button
-              key={preset.id}
-              type="button"
-              className={cn(
-                'flex items-center gap-3 rounded-lg border p-4 text-left transition-colors',
-                selectedNatureId === preset.id
-                  ? 'border-blue-500 bg-blue-500/10'
-                  : 'border-border hover:border-foreground/30 hover:bg-muted/50'
-              )}
-              onClick={() => setSelectedNatureId(preset.id)}
-            >
-              <span className="text-2xl">{preset.emoji}</span>
-              <div>
-                <p className="text-foreground font-medium">{preset.label}</p>
-                <p className="text-muted-foreground text-sm">{preset.vibe}</p>
-              </div>
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* Preview */}
-      <div className="border-border bg-muted/30 flex items-center gap-3 rounded-lg border p-4">
-        <span className="text-2xl">{activeEmoji}</span>
-        <div>
-          <p className="text-foreground font-medium">{botName || 'Your bot'}</p>
-          <p className="text-muted-foreground text-sm">{nature.label}</p>
-        </div>
+      <div className="flex flex-wrap gap-2">
+        {NATURE_PRESETS.map(preset => (
+          <button
+            key={preset.id}
+            type="button"
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors',
+              selectedNatureId === preset.id
+                ? 'border-brand-primary bg-brand-primary/10 text-brand-primary'
+                : 'border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+            )}
+            onClick={() => setSelectedNatureId(preset.id)}
+          >
+            <span>{preset.emoji}</span>
+            {preset.label}
+          </button>
+        ))}
       </div>
 
       <Button
-        className="w-full bg-emerald-600 py-6 text-base text-white hover:bg-emerald-700"
+        className="bg-brand-primary hover:bg-brand-primary/90 w-full py-6 text-base text-black"
         onClick={handleContinue}
       >
         Continue

--- a/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
@@ -68,9 +68,15 @@ export function BotIdentityStep({
   const [selectedEmoji, setSelectedEmoji] = useState('🤖');
   const [selectedNatureId, setSelectedNatureId] = useState('ai-assistant');
   const [isShuffling, setIsShuffling] = useState(false);
+  const [nameAnimKey, setNameAnimKey] = useState(0);
   const reducedMotion = useReducedMotion();
 
   const nature = NATURE_PRESETS.find(n => n.id === selectedNatureId) ?? NATURE_PRESETS[0];
+
+  function selectBotName(name: string) {
+    setBotName(name);
+    setNameAnimKey(k => k + 1);
+  }
 
   async function handleShuffle() {
     if (isShuffling) return;
@@ -78,6 +84,7 @@ export function BotIdentityStep({
       setBotName(pickRandom(NAME_SUGGESTIONS));
       setSelectedEmoji(pickRandom(EMOJI_OPTIONS));
       setSelectedNatureId(pickRandom(NATURE_PRESETS).id);
+      setNameAnimKey(k => k + 1);
       return;
     }
     setIsShuffling(true);
@@ -85,11 +92,13 @@ export function BotIdentityStep({
       setBotName(pickRandom(NAME_SUGGESTIONS));
       setSelectedEmoji(pickRandom(EMOJI_OPTIONS));
       setSelectedNatureId(pickRandom(NATURE_PRESETS).id);
+      setNameAnimKey(k => k + 1);
       await new Promise(resolve => setTimeout(resolve, SHUFFLE_INTERVAL_MS));
     }
     setBotName(pickRandom(NAME_SUGGESTIONS));
     setSelectedEmoji(pickRandom(EMOJI_OPTIONS));
     setSelectedNatureId(pickRandom(NATURE_PRESETS).id);
+    setNameAnimKey(k => k + 1);
     setIsShuffling(false);
   }
 
@@ -118,6 +127,15 @@ export function BotIdentityStep({
               aria-hidden
               className="pointer-events-none absolute inset-0"
               style={{
+                background:
+                  'radial-gradient(circle at 50% 42%, var(--brand-primary) 0%, transparent 55%)',
+                opacity: 0.12,
+              }}
+            />
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0"
+              style={{
                 backgroundImage: `linear-gradient(var(--muted-foreground) 1px, transparent 1px), linear-gradient(90deg, var(--muted-foreground) 1px, transparent 1px)`,
                 backgroundSize: '28px 28px',
                 maskImage: 'radial-gradient(circle at 50% 50%, black 25%, transparent 75%)',
@@ -125,7 +143,7 @@ export function BotIdentityStep({
                 opacity: 0.22,
               }}
             />
-            <div className="relative flex h-24 w-24 items-center justify-center">
+            <div aria-hidden className="relative flex h-24 w-24 items-center justify-center">
               <AnimatePresence mode="popLayout" initial={false}>
                 <motion.span
                   key={selectedEmoji}
@@ -133,7 +151,7 @@ export function BotIdentityStep({
                   animate={{ scale: 1, opacity: 1, rotate: 0 }}
                   exit={{ scale: 0.85, opacity: 0, rotate: 8 }}
                   transition={{ type: 'spring', stiffness: 380, damping: 26 }}
-                  className="text-7xl leading-none"
+                  className="block text-7xl leading-none"
                 >
                   {selectedEmoji}
                 </motion.span>
@@ -142,13 +160,13 @@ export function BotIdentityStep({
             <div className="relative flex min-h-[3.5rem] flex-col items-center gap-1">
               <AnimatePresence mode="popLayout" initial={false}>
                 <motion.p
-                  key={botName || 'empty'}
+                  key={nameAnimKey}
                   initial={{ y: 4, opacity: 0 }}
                   animate={{ y: 0, opacity: 1 }}
                   exit={{ y: -4, opacity: 0 }}
                   transition={TEXT_SWAP_EASE}
                   className={cn(
-                    'text-xl font-semibold',
+                    'text-2xl font-bold tracking-tight',
                     botName ? 'text-foreground' : 'text-muted-foreground italic'
                   )}
                 >
@@ -156,16 +174,17 @@ export function BotIdentityStep({
                 </motion.p>
               </AnimatePresence>
               <AnimatePresence mode="popLayout" initial={false}>
-                <motion.p
-                  key={nature.label}
+                <motion.div
+                  key={nature.id}
                   initial={{ y: 4, opacity: 0 }}
                   animate={{ y: 0, opacity: 1 }}
                   exit={{ y: -4, opacity: 0 }}
                   transition={TEXT_SWAP_EASE}
-                  className="text-muted-foreground text-sm"
+                  className="flex flex-col items-center gap-0.5"
                 >
-                  {nature.label}
-                </motion.p>
+                  <p className="text-muted-foreground text-sm font-medium">{nature.label}</p>
+                  <p className="text-muted-foreground/80 text-xs">{nature.vibe}</p>
+                </motion.div>
               </AnimatePresence>
             </div>
           </div>
@@ -177,14 +196,17 @@ export function BotIdentityStep({
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.97 }}
             transition={TAP_EASE}
-            className="bg-card border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 absolute bottom-0 left-1/2 flex h-11 w-11 -translate-x-1/2 translate-y-1/2 cursor-pointer items-center justify-center rounded-full border shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+            className="bg-card border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 focus-visible:ring-brand-primary/60 absolute bottom-0 left-1/2 flex h-11 w-11 -translate-x-1/2 translate-y-1/2 cursor-pointer items-center justify-center rounded-full border shadow-sm transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
           >
             <Shuffle className="h-4 w-4" />
           </motion.button>
         </div>
 
         <div className="flex flex-col gap-6">
-          <div className="space-y-3">
+          <section className="space-y-3">
+            <h3 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+              Name
+            </h3>
             <Input
               value={botName}
               onChange={e => setBotName(e.target.value)}
@@ -200,61 +222,77 @@ export function BotIdentityStep({
                   whileTap={{ scale: 0.97 }}
                   transition={TAP_EASE}
                   className={cn(
-                    'cursor-pointer rounded-full border px-3 py-1 text-sm transition-colors',
+                    'focus-visible:ring-brand-primary/60 cursor-pointer rounded-full border px-3 py-1 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none',
                     botName === name
                       ? 'border-brand-primary bg-brand-primary/10 text-brand-primary'
                       : 'border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground'
                   )}
-                  onClick={() => setBotName(name)}
+                  onClick={() => selectBotName(name)}
                 >
                   {name}
                 </motion.button>
               ))}
             </div>
-          </div>
+          </section>
 
-          <div className="flex flex-wrap gap-3">
-            {EMOJI_OPTIONS.map(emoji => (
-              <motion.button
-                key={emoji}
-                type="button"
-                whileHover={{ scale: 1.05, y: -1 }}
-                whileTap={{ scale: 0.97 }}
-                transition={TAP_EASE}
-                className={cn(
-                  'flex h-14 w-14 cursor-pointer items-center justify-center rounded-lg border text-2xl transition-colors',
-                  selectedEmoji === emoji
-                    ? 'border-brand-primary bg-brand-primary/10'
-                    : 'border-border hover:border-foreground/30 hover:bg-muted/50'
-                )}
-                onClick={() => setSelectedEmoji(emoji)}
-              >
-                {emoji}
-              </motion.button>
-            ))}
-          </div>
+          <section className="space-y-3">
+            <h3 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+              Avatar
+            </h3>
+            <div className="flex flex-wrap gap-3">
+              {EMOJI_OPTIONS.map(emoji => (
+                <motion.button
+                  key={emoji}
+                  type="button"
+                  aria-label={`Select ${emoji} as avatar`}
+                  aria-pressed={selectedEmoji === emoji}
+                  whileHover={{ scale: 1.05, y: -1 }}
+                  whileTap={{ scale: 0.97 }}
+                  transition={TAP_EASE}
+                  className={cn(
+                    'focus-visible:ring-brand-primary/60 flex h-14 w-14 cursor-pointer items-center justify-center rounded-lg border text-2xl transition-colors focus-visible:ring-2 focus-visible:outline-none',
+                    selectedEmoji === emoji
+                      ? 'border-brand-primary bg-brand-primary/10'
+                      : 'border-border hover:border-foreground/30 hover:bg-muted/50'
+                  )}
+                  onClick={() => setSelectedEmoji(emoji)}
+                >
+                  {emoji}
+                </motion.button>
+              ))}
+            </div>
+          </section>
 
-          <div className="flex flex-wrap gap-2">
-            {NATURE_PRESETS.map(preset => (
-              <motion.button
-                key={preset.id}
-                type="button"
-                whileHover={{ scale: 1.03 }}
-                whileTap={{ scale: 0.97 }}
-                transition={TAP_EASE}
-                className={cn(
-                  'inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors',
-                  selectedNatureId === preset.id
-                    ? 'border-brand-primary bg-brand-primary/10 text-brand-primary'
-                    : 'border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground'
-                )}
-                onClick={() => setSelectedNatureId(preset.id)}
-              >
-                <span>{preset.emoji}</span>
-                {preset.label}
-              </motion.button>
-            ))}
-          </div>
+          <section className="space-y-3">
+            <div className="flex items-baseline gap-2">
+              <h3 className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+                Personality
+              </h3>
+              <span className="text-muted-foreground/80 text-xs">Shapes how it talks</span>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {NATURE_PRESETS.map(preset => (
+                <motion.button
+                  key={preset.id}
+                  type="button"
+                  aria-pressed={selectedNatureId === preset.id}
+                  whileHover={{ scale: 1.03 }}
+                  whileTap={{ scale: 0.97 }}
+                  transition={TAP_EASE}
+                  className={cn(
+                    'focus-visible:ring-brand-primary/60 inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none',
+                    selectedNatureId === preset.id
+                      ? 'border-brand-primary bg-brand-primary/10 text-brand-primary'
+                      : 'border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+                  )}
+                  onClick={() => setSelectedNatureId(preset.id)}
+                >
+                  <span aria-hidden>{preset.emoji}</span>
+                  {preset.label}
+                </motion.button>
+              ))}
+            </div>
+          </section>
         </div>
       </div>
 

--- a/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
@@ -2,11 +2,18 @@
 
 import { useState } from 'react';
 import { ChevronRight, Shuffle } from 'lucide-react';
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { OnboardingStepView } from './OnboardingStepView';
 import type { BotIdentity } from './claw.types';
 import { cn } from '@/lib/utils';
+
+const SHUFFLE_STEPS = 4;
+const SHUFFLE_INTERVAL_MS = 90;
+const EASE_OUT_QUART = [0.22, 1, 0.36, 1] as const;
+const TAP_EASE = { duration: 0.12, ease: EASE_OUT_QUART } as const;
+const TEXT_SWAP_EASE = { duration: 0.18, ease: EASE_OUT_QUART } as const;
 
 const NAME_SUGGESTIONS = ['Aria', 'Echo', 'Nova', 'Rex', 'Sage', 'Iris', 'Orion', 'Pixel'];
 
@@ -59,22 +66,37 @@ export function BotIdentityStep({
 }) {
   const [botName, setBotName] = useState('');
   const [selectedEmoji, setSelectedEmoji] = useState('🤖');
-  const [customEmoji, setCustomEmoji] = useState('');
   const [selectedNatureId, setSelectedNatureId] = useState('ai-assistant');
+  const [isShuffling, setIsShuffling] = useState(false);
+  const reducedMotion = useReducedMotion();
 
-  const activeEmoji = customEmoji || selectedEmoji;
   const nature = NATURE_PRESETS.find(n => n.id === selectedNatureId) ?? NATURE_PRESETS[0];
 
-  function handleShuffle() {
+  async function handleShuffle() {
+    if (isShuffling) return;
+    if (reducedMotion) {
+      setBotName(pickRandom(NAME_SUGGESTIONS));
+      setSelectedEmoji(pickRandom(EMOJI_OPTIONS));
+      setSelectedNatureId(pickRandom(NATURE_PRESETS).id);
+      return;
+    }
+    setIsShuffling(true);
+    for (let i = 0; i < SHUFFLE_STEPS; i++) {
+      setBotName(pickRandom(NAME_SUGGESTIONS));
+      setSelectedEmoji(pickRandom(EMOJI_OPTIONS));
+      setSelectedNatureId(pickRandom(NATURE_PRESETS).id);
+      await new Promise(resolve => setTimeout(resolve, SHUFFLE_INTERVAL_MS));
+    }
     setBotName(pickRandom(NAME_SUGGESTIONS));
     setSelectedEmoji(pickRandom(EMOJI_OPTIONS));
-    setCustomEmoji('');
+    setSelectedNatureId(pickRandom(NATURE_PRESETS).id);
+    setIsShuffling(false);
   }
 
   function handleContinue() {
     onContinue({
       botName: botName.trim() || 'KiloClaw',
-      botEmoji: activeEmoji,
+      botEmoji: selectedEmoji,
       botNature: nature.label,
       botVibe: nature.vibe,
     });
@@ -89,105 +111,162 @@ export function BotIdentityStep({
       showProvisioningBanner={!instanceRunning}
       contentClassName="gap-6"
     >
-      <div className="border-border bg-muted/30 flex items-center gap-3 rounded-lg border p-4">
-        <span className="text-2xl">{activeEmoji}</span>
-        <div className="min-w-0 flex-1">
-          <p className="text-foreground font-medium">{botName || 'Your bot'}</p>
-          <p className="text-muted-foreground text-sm">{nature.label}</p>
-        </div>
-        <button
-          type="button"
-          onClick={handleShuffle}
-          aria-label="Shuffle name and emoji"
-          className="border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground flex h-9 w-9 shrink-0 items-center justify-center rounded-md border transition-colors"
-        >
-          <Shuffle className="h-4 w-4" />
-        </button>
-      </div>
-
-      <div className="space-y-3">
-        <Input
-          value={botName}
-          onChange={e => setBotName(e.target.value)}
-          maxLength={80}
-          placeholder="Name your bot"
-        />
-        <div className="flex flex-wrap gap-2">
-          {NAME_SUGGESTIONS.map(name => (
-            <button
-              key={name}
-              type="button"
-              className={cn(
-                'rounded-full border px-3 py-1 text-sm transition-colors',
-                botName === name
-                  ? 'border-brand-primary bg-brand-primary/10 text-brand-primary'
-                  : 'border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground'
-              )}
-              onClick={() => setBotName(name)}
-            >
-              {name}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div className="space-y-3">
-        <div className="flex flex-wrap gap-3">
-          {EMOJI_OPTIONS.map(emoji => (
-            <button
-              key={emoji}
-              type="button"
-              className={cn(
-                'flex h-14 w-14 items-center justify-center rounded-lg border text-2xl transition-colors',
-                selectedEmoji === emoji && !customEmoji
-                  ? 'border-brand-primary bg-brand-primary/10'
-                  : 'border-border hover:border-foreground/30 hover:bg-muted/50'
-              )}
-              onClick={() => {
-                setSelectedEmoji(emoji);
-                setCustomEmoji('');
+      <div className="grid gap-6 md:grid-cols-[1fr_2fr] md:gap-8">
+        <div className="relative">
+          <div className="border-border bg-muted/30 relative flex h-full flex-col items-center justify-center gap-4 overflow-hidden rounded-lg border p-8 text-center">
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0"
+              style={{
+                backgroundImage: `linear-gradient(var(--muted-foreground) 1px, transparent 1px), linear-gradient(90deg, var(--muted-foreground) 1px, transparent 1px)`,
+                backgroundSize: '28px 28px',
+                maskImage: 'radial-gradient(circle at 50% 50%, black 25%, transparent 75%)',
+                WebkitMaskImage: 'radial-gradient(circle at 50% 50%, black 25%, transparent 75%)',
+                opacity: 0.22,
               }}
-            >
-              {emoji}
-            </button>
-          ))}
-        </div>
-        <Input
-          value={customEmoji}
-          onChange={e => {
-            setCustomEmoji(e.target.value);
-          }}
-          maxLength={16}
-          placeholder="or type your own..."
-        />
-      </div>
-
-      <div className="flex flex-wrap gap-2">
-        {NATURE_PRESETS.map(preset => (
-          <button
-            key={preset.id}
+            />
+            <div className="relative flex h-24 w-24 items-center justify-center">
+              <AnimatePresence mode="popLayout" initial={false}>
+                <motion.span
+                  key={selectedEmoji}
+                  initial={{ scale: 0.85, opacity: 0, rotate: -8 }}
+                  animate={{ scale: 1, opacity: 1, rotate: 0 }}
+                  exit={{ scale: 0.85, opacity: 0, rotate: 8 }}
+                  transition={{ type: 'spring', stiffness: 380, damping: 26 }}
+                  className="text-7xl leading-none"
+                >
+                  {selectedEmoji}
+                </motion.span>
+              </AnimatePresence>
+            </div>
+            <div className="relative flex min-h-[3.5rem] flex-col items-center gap-1">
+              <AnimatePresence mode="popLayout" initial={false}>
+                <motion.p
+                  key={botName || 'empty'}
+                  initial={{ y: 4, opacity: 0 }}
+                  animate={{ y: 0, opacity: 1 }}
+                  exit={{ y: -4, opacity: 0 }}
+                  transition={TEXT_SWAP_EASE}
+                  className={cn(
+                    'text-xl font-semibold',
+                    botName ? 'text-foreground' : 'text-muted-foreground italic'
+                  )}
+                >
+                  {botName || 'Your bot'}
+                </motion.p>
+              </AnimatePresence>
+              <AnimatePresence mode="popLayout" initial={false}>
+                <motion.p
+                  key={nature.label}
+                  initial={{ y: 4, opacity: 0 }}
+                  animate={{ y: 0, opacity: 1 }}
+                  exit={{ y: -4, opacity: 0 }}
+                  transition={TEXT_SWAP_EASE}
+                  className="text-muted-foreground text-sm"
+                >
+                  {nature.label}
+                </motion.p>
+              </AnimatePresence>
+            </div>
+          </div>
+          <motion.button
             type="button"
-            className={cn(
-              'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors',
-              selectedNatureId === preset.id
-                ? 'border-brand-primary bg-brand-primary/10 text-brand-primary'
-                : 'border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground'
-            )}
-            onClick={() => setSelectedNatureId(preset.id)}
+            onClick={handleShuffle}
+            disabled={isShuffling}
+            aria-label="Shuffle name and emoji"
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.97 }}
+            transition={TAP_EASE}
+            className="bg-card border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 absolute bottom-0 left-1/2 flex h-11 w-11 -translate-x-1/2 translate-y-1/2 cursor-pointer items-center justify-center rounded-full border shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-60"
           >
-            <span>{preset.emoji}</span>
-            {preset.label}
-          </button>
-        ))}
+            <Shuffle className="h-4 w-4" />
+          </motion.button>
+        </div>
+
+        <div className="flex flex-col gap-6">
+          <div className="space-y-3">
+            <Input
+              value={botName}
+              onChange={e => setBotName(e.target.value)}
+              maxLength={80}
+              placeholder="Name your bot"
+            />
+            <div className="flex flex-wrap gap-2">
+              {NAME_SUGGESTIONS.map(name => (
+                <motion.button
+                  key={name}
+                  type="button"
+                  whileHover={{ scale: 1.03 }}
+                  whileTap={{ scale: 0.97 }}
+                  transition={TAP_EASE}
+                  className={cn(
+                    'cursor-pointer rounded-full border px-3 py-1 text-sm transition-colors',
+                    botName === name
+                      ? 'border-brand-primary bg-brand-primary/10 text-brand-primary'
+                      : 'border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+                  )}
+                  onClick={() => setBotName(name)}
+                >
+                  {name}
+                </motion.button>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            {EMOJI_OPTIONS.map(emoji => (
+              <motion.button
+                key={emoji}
+                type="button"
+                whileHover={{ scale: 1.05, y: -1 }}
+                whileTap={{ scale: 0.97 }}
+                transition={TAP_EASE}
+                className={cn(
+                  'flex h-14 w-14 cursor-pointer items-center justify-center rounded-lg border text-2xl transition-colors',
+                  selectedEmoji === emoji
+                    ? 'border-brand-primary bg-brand-primary/10'
+                    : 'border-border hover:border-foreground/30 hover:bg-muted/50'
+                )}
+                onClick={() => setSelectedEmoji(emoji)}
+              >
+                {emoji}
+              </motion.button>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {NATURE_PRESETS.map(preset => (
+              <motion.button
+                key={preset.id}
+                type="button"
+                whileHover={{ scale: 1.03 }}
+                whileTap={{ scale: 0.97 }}
+                transition={TAP_EASE}
+                className={cn(
+                  'inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors',
+                  selectedNatureId === preset.id
+                    ? 'border-brand-primary bg-brand-primary/10 text-brand-primary'
+                    : 'border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+                )}
+                onClick={() => setSelectedNatureId(preset.id)}
+              >
+                <span>{preset.emoji}</span>
+                {preset.label}
+              </motion.button>
+            ))}
+          </div>
+        </div>
       </div>
 
-      <Button
-        className="bg-brand-primary hover:bg-brand-primary/90 w-full py-6 text-base text-black"
-        onClick={handleContinue}
-      >
-        Continue
-        <ChevronRight className="ml-1 h-5 w-5" />
-      </Button>
+      <div className="flex justify-end">
+        <Button
+          className="bg-brand-primary hover:bg-brand-primary/90 text-black"
+          onClick={handleContinue}
+        >
+          Continue
+          <ChevronRight className="ml-1 h-4 w-4" />
+        </Button>
+      </div>
     </OnboardingStepView>
   );
 }

--- a/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
@@ -136,7 +136,7 @@ export function BotIdentityStep({
               aria-hidden
               className="pointer-events-none absolute inset-0"
               style={{
-                backgroundImage: `linear-gradient(var(--muted-foreground) 1px, transparent 1px), linear-gradient(90deg, var(--muted-foreground) 1px, transparent 1px)`,
+                backgroundImage: `linear-gradient(lab(95 -34.46 117.24 / 0.55) 1px, transparent 1px), linear-gradient(90deg, lab(95 -34.46 117.24 / 0.55) 1px, transparent 1px)`,
                 backgroundSize: '28px 28px',
                 maskImage: 'radial-gradient(circle at 50% 50%, black 25%, transparent 75%)',
                 WebkitMaskImage: 'radial-gradient(circle at 50% 50%, black 25%, transparent 75%)',

--- a/apps/web/src/app/(app)/claw/components/OnboardingStepView.tsx
+++ b/apps/web/src/app/(app)/claw/components/OnboardingStepView.tsx
@@ -20,7 +20,10 @@ export function OnboardingStepIndicator({
         {Array.from({ length: totalSteps }, (_, i) => (
           <span
             key={i}
-            className={cn('h-1.5 w-6 rounded-full', i < currentStep ? 'bg-blue-500' : 'bg-muted')}
+            className={cn(
+              'h-1.5 w-6 rounded-full',
+              i < currentStep ? 'bg-brand-primary' : 'bg-muted'
+            )}
           />
         ))}
       </div>

--- a/apps/web/src/app/(app)/claw/components/OnboardingStepView.tsx
+++ b/apps/web/src/app/(app)/claw/components/OnboardingStepView.tsx
@@ -82,8 +82,12 @@ export function OnboardingStepView({
         {title || description ? (
           <div className="flex flex-col gap-3">
             {indicator}
-            {title && <h2 className="text-foreground text-2xl font-bold">{title}</h2>}
-            {description && <p className="text-muted-foreground text-sm">{description}</p>}
+            {(title || description) && (
+              <div className="flex flex-col gap-1">
+                {title && <h2 className="text-foreground text-2xl font-bold">{title}</h2>}
+                {description && <p className="text-muted-foreground text-sm">{description}</p>}
+              </div>
+            )}
           </div>
         ) : (
           <div className="self-start">{indicator}</div>


### PR DESCRIPTION
## Summary

Visual + UX pass on the bot identity step (step 2 of 5 in `/claw/new` onboarding). No logic, API, or data-model changes — props, state, and the `onContinue` payload shape are all unchanged.

- **Layout**: Split into a 2-column grid on desktop — persistent preview card on the left with a circular shuffle button anchored on the card's bottom edge; name / avatar / personality controls on the right. Stacks on mobile.
- **Preview card**: Animated emoji (spring), animated name + nature label + **vibe copy** (previously defined on each preset but never rendered), soft brand-primary radial glow layered with a subtle grid backdrop using the brand color in LAB notation.
- **Controls**: Added section labels (`Name` / `Avatar` / `Personality` with a short helper). Curated emoji set trimmed from 16 to 9 hero picks; the custom emoji input was removed. Nature cards collapsed into pills matching the name-suggestion pattern. Brand primary (yellow/lime) applied consistently across selection states and the Continue CTA.
- **Motion**: Emil Kowalski's ease-out-quart curve (`[0.22, 1, 0.36, 1]`), shared `TAP_EASE` / `TEXT_SWAP_EASE` constants for consistency, shuffle cycles through 4 random picks (~360ms) before settling, respects `prefers-reduced-motion`.
- **A11y**: `aria-label` on emoji tiles, `aria-pressed` on all toggles, decorative glyphs marked `aria-hidden`, `focus-visible` rings on every interactive button, `cursor-pointer` on all `motion.button` elements. Keystroke jitter on the preview name fixed with a dedicated animation counter so typing no longer re-triggers enter/exit animations.
- **Step indicator** (shared): Color in `OnboardingStepView` shifted from blue to `brand-primary`.

## Verification

- [x] `pnpm typecheck` passes
- [x] `pnpm format` applied
- [x] Visual iteration via `/claw/new?fakeOnboardingStep=identity` (dev-only fake walkthrough) — shuffle, manual pills, name input, emoji grid, and personality pills all exercised
- The component's `onContinue` payload shape is unchanged, so downstream `ProvisioningStep` / `mutations.patchBotIdentity` behavior is unaffected

## Visual Changes

| Before | After |
| ------ | ----- |
| _Single-column form: name input + 16-emoji grid + custom emoji input + 4 nature cards stacked + full-width Continue_ | _2-col: preview card with animated emoji/name/vibe + shuffle button anchored on card edge, labeled Name/Avatar/Personality sections on the right, compact right-aligned Continue_ |

<img width="800" height="465" alt="ezgif-69030c7315b3f2bf" src="https://github.com/user-attachments/assets/ce7268f8-1c08-4dca-a955-6e57c19b80e8" />

## Reviewer Notes

- The step indicator color change in `OnboardingStepView` affects **every** onboarding step (identity, permissions, channels, provisioning, pairing), not just this one. Worth a visual glance at the other steps.
- `vibe` strings on `NATURE_PRESETS` ("Helpful, capable, professional", etc.) are now user-visible — copy changes there have real impact.
- `ClawOnboardingFakeWalkthrough` renders `BotIdentityStep` directly with the same props, so preview via `?fakeOnboardingStep=identity` should match production behavior.