### PR TITLE
refactor(kiloclaw): drop legacy earlybird purchase fallback

### DIFF
--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -96,8 +96,11 @@ multiple instances, each with its own subscription and renewal cycle.
 All subscriptions deduct from the same user credit balance.
 
 New users who provision an instance without subscribing first
-automatically receive a 7-day free trial. Canonical earlybird
-subscription rows continue to grant access until their recorded expiry.
+automatically receive a 7-day free trial. Legacy
+`kiloclaw_earlybird_purchases` rows without canonical subscription rows
+MUST NOT mint fresh trial access and instead require manual
+remediation. Canonical earlybird subscription rows continue to grant
+access until their recorded expiry.
 A periodic background job enforces expiry, credit renewal, suspension,
 and eventual instance destruction when access lapses, with email
 notifications at each stage.

--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -800,11 +800,15 @@ rows renew.
 
 ### Earlybird Expiry Warnings
 
-1. When the earlybird expiry date is 14 or fewer days away, the system
-   MUST send a warning notification to earlybird users who do not have
-   an active or trialing subscription.
-2. When the earlybird expiry date is 1 or fewer days away, the system
-   MUST send a more urgent expires-tomorrow notification.
+1. When a canonical earlybird subscription row's `trial_ends_at` is 14
+   or fewer days away and the user does not have another active or
+   trialing subscription, the system MUST send a warning notification.
+2. When the row's `trial_ends_at` is 1 or fewer days away, the system
+   MUST send a more urgent expires-tomorrow notification instead of
+   the 14-day notification.
+3. The notification's expiry date and days-remaining MUST be derived
+   from the row's `trial_ends_at`, not from a globally configured
+   earlybird expiry constant.
 
 ### Trial Expiry Enforcement
 

--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -96,10 +96,11 @@ multiple instances, each with its own subscription and renewal cycle.
 All subscriptions deduct from the same user credit balance.
 
 New users who provision an instance without subscribing first
-automatically receive a 7-day free trial. A legacy earlybird purchase
-also grants access until a fixed expiry date. A periodic background job
-enforces expiry, credit renewal, suspension, and eventual instance
-destruction when access lapses, with email notifications at each stage.
+automatically receive a 7-day free trial. Canonical earlybird
+subscription rows continue to grant access until their recorded expiry.
+A periodic background job enforces expiry, credit renewal, suspension,
+and eventual instance destruction when access lapses, with email
+notifications at each stage.
 
 ## Rules
 
@@ -211,10 +212,10 @@ rules resolve conflicts.
    instance for the first time. There is no user-facing "start trial"
    action; the trial is bootstrapped during provisioning.
 2. The system MUST create a trial only if the user has no existing
-   subscription record and no earlybird purchase. The instance-record
-   check is not needed at provisioning time because provisioning itself
-   creates the instance, but the billing status endpoint includes the
-   instance check as defense in depth.
+   subscription record. The instance-record check is not needed at
+   provisioning time because provisioning itself creates the instance,
+   but the billing status endpoint includes the instance check as
+   defense in depth.
 3. When a trial is created, the system MUST record the trial start
    timestamp and an end timestamp exactly 7 days later.
 4. The system MUST NOT require a credit card to start a trial.
@@ -260,8 +261,8 @@ rules resolve conflicts.
    and the subscription has not been suspended.
 3. The system MUST grant access when the subscription status is trialing
    and the trial end date is in the future.
-4. The system MUST grant access when the user holds a legacy earlybird
-   purchase and the earlybird expiry date is in the future.
+4. The system MUST grant access when a canonical earlybird subscription
+   row remains in an access-granting state.
 5. When earlybird access expires, the system MUST NOT automatically
    transition the user to a trial or any other plan; the user MUST
    manually subscribe to regain access.
@@ -924,7 +925,7 @@ rows renew.
    earlybird).
 2. The system MUST report trial eligibility as true only when the user
    has no instance records at all (including destroyed instances), no
-   subscription record, and no earlybird purchase.
+   subscription record.
 3. The billing status MUST include trial data (start, end, days
    remaining, expired flag) when a trial exists or existed.
 4. The billing status MUST include subscription data (plan, status,
@@ -952,7 +953,7 @@ rows renew.
    indicator signaling that the standalone-to-credit conversion
    prompt should be shown (see Standalone-to-Credit Conversion).
 8. The billing status MUST include earlybird data (expiry date, days
-   remaining) when the user has an earlybird purchase.
+   remaining) only when a canonical earlybird subscription row exists.
 9. The billing status MUST include instance data (whether an
    undestroyed instance exists, suspension timestamp, destruction
    deadline, and destroyed flag) when any instance record exists.

--- a/.specs/kiloclaw-datamodel.md
+++ b/.specs/kiloclaw-datamodel.md
@@ -123,11 +123,11 @@ on application logs that may be rotated or incomplete.
    (see kiloclaw-billing.md, Plans rule 5).
 6. Early-bird subscribers who have instance records without
    subscription records are a known violation of rule 4. These
-   MUST be resolved by backfilling subscription records for all
-   early-bird instances. Until backfill is complete, code that
-   queries subscriptions for early-bird users MUST treat the user
-   as having earlybird-only access (no active subscription) and
-   MUST NOT throw an unhandled error or return an error response.
+   MUST be resolved by backfilling canonical subscription records
+   for those instances. Runtime code MUST NOT continue granting
+   access from purchase-table fallback once migration cleanup is
+   complete; users without canonical rows are treated as exceptions
+   requiring manual remediation.
 
 ### Multi-Instance Support
 

--- a/apps/web/src/app/api/private/users/route.ts
+++ b/apps/web/src/app/api/private/users/route.ts
@@ -2,10 +2,7 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user.server';
 import { db } from '@/lib/drizzle';
-import {
-  getEffectiveKiloClawSubscriptionForUser,
-  getKiloClawEarlybirdStateForUser,
-} from '@/lib/kiloclaw/access-state';
+import { getEffectiveKiloClawSubscriptionForUser } from '@/lib/kiloclaw/access-state';
 import { kilocode_users, organization_memberships, organizations } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 import { captureException } from '@sentry/nextjs';
@@ -101,8 +98,5 @@ async function checkHasKiloPass(userId: string): Promise<boolean> {
 async function checkHasKiloClaw(userId: string): Promise<boolean> {
   const now = new Date();
   const { accessReason } = await getEffectiveKiloClawSubscriptionForUser(userId, now);
-  if (accessReason) return true;
-
-  const earlybirdState = await getKiloClawEarlybirdStateForUser(userId, now);
-  return earlybirdState.hasAccess;
+  return accessReason !== null;
 }

--- a/apps/web/src/lib/kiloclaw/access-gate.ts
+++ b/apps/web/src/lib/kiloclaw/access-gate.ts
@@ -4,8 +4,7 @@ import { TRPCError } from '@trpc/server';
 import { and, eq, isNull } from 'drizzle-orm';
 
 import { db } from '@/lib/drizzle';
-import { kiloclaw_earlybird_purchases, kiloclaw_instances } from '@kilocode/db/schema';
-import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
+import { kiloclaw_instances } from '@kilocode/db/schema';
 import {
   getCurrentPersonalKiloClawSubscriptionForUser,
   getKiloClawSubscriptionAccessReason,
@@ -15,7 +14,7 @@ import { resolveCurrentPersonalSubscriptionRow } from '@/lib/kiloclaw/current-pe
 import { baseProcedure } from '@/lib/trpc/init';
 
 /**
- * Check whether a user has active KiloClaw access via subscription, trial, or earlybird.
+ * Check whether a user has active KiloClaw access via subscription or trial.
  * Throws TRPCError FORBIDDEN if the user has no valid access.
  */
 export async function requireKiloClawAccess(userId: string): Promise<void> {
@@ -49,17 +48,6 @@ export async function requireKiloClawAccess(userId: string): Promise<void> {
     throw error;
   }
 
-  // 2. Earlybird not expired
-  const [earlybird] = await db
-    .select({ id: kiloclaw_earlybird_purchases.id })
-    .from(kiloclaw_earlybird_purchases)
-    .where(eq(kiloclaw_earlybird_purchases.user_id, userId))
-    .limit(1);
-
-  if (earlybird && new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE) > now) {
-    return;
-  }
-
   console.warn(
     JSON.stringify({
       event: 'kiloclaw_access_denied',
@@ -74,13 +62,12 @@ export async function requireKiloClawAccess(userId: string): Promise<void> {
           }
         : 'none',
       accessReason,
-      earlybirdFound: !!earlybird,
     })
   );
 
   throw new TRPCError({
     code: 'FORBIDDEN',
-    message: 'KiloClaw access requires an active subscription, trial, or earlybird purchase.',
+    message: 'KiloClaw access requires an active subscription or trial.',
   });
 }
 
@@ -137,19 +124,9 @@ export async function requireKiloClawAccessAtInstance(
     throw error;
   }
 
-  const [earlybird] = await db
-    .select({ id: kiloclaw_earlybird_purchases.id })
-    .from(kiloclaw_earlybird_purchases)
-    .where(eq(kiloclaw_earlybird_purchases.user_id, userId))
-    .limit(1);
-
-  if (earlybird && new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE) > now) {
-    return;
-  }
-
   throw new TRPCError({
     code: 'FORBIDDEN',
-    message: 'KiloClaw access requires an active subscription, trial, or earlybird purchase.',
+    message: 'KiloClaw access requires an active subscription or trial.',
   });
 }
 

--- a/apps/web/src/lib/kiloclaw/access-state.ts
+++ b/apps/web/src/lib/kiloclaw/access-state.ts
@@ -1,10 +1,6 @@
 import { db } from '@/lib/drizzle';
 import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
-import {
-  kiloclaw_earlybird_purchases,
-  kiloclaw_subscriptions,
-  type KiloClawSubscription,
-} from '@kilocode/db/schema';
+import { kiloclaw_subscriptions, type KiloClawSubscription } from '@kilocode/db/schema';
 import { and, eq } from 'drizzle-orm';
 
 import {
@@ -126,20 +122,6 @@ export async function getKiloClawEarlybirdStateForUser(
       purchased: true,
       hasAccess: getKiloClawSubscriptionAccessReason(subscription, now) === 'earlybird',
       expiresAt: subscription?.trial_ends_at ?? KILOCLAW_EARLYBIRD_EXPIRY_DATE,
-    };
-  }
-
-  const [legacyPurchase] = await db
-    .select({ createdAt: kiloclaw_earlybird_purchases.created_at })
-    .from(kiloclaw_earlybird_purchases)
-    .where(eq(kiloclaw_earlybird_purchases.user_id, userId))
-    .limit(1);
-
-  if (legacyPurchase) {
-    return {
-      purchased: true,
-      hasAccess: new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE) > now,
-      expiresAt: KILOCLAW_EARLYBIRD_EXPIRY_DATE,
     };
   }
 

--- a/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
@@ -3,7 +3,6 @@ import { createCallerForUser } from '@/routers/test-utils';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import {
   kiloclaw_admin_audit_logs,
-  kiloclaw_earlybird_purchases,
   kiloclaw_subscription_change_log,
   kiloclaw_instances,
   kiloclaw_subscriptions,
@@ -191,28 +190,6 @@ describe('admin.users.getKiloClawState', () => {
       })
     );
     expect(result.subscriptions).toHaveLength(1);
-  });
-
-  it('returns earlybird access from legacy purchase row before backfill', async () => {
-    await db.insert(kiloclaw_earlybird_purchases).values({
-      user_id: targetUser.id,
-      stripe_charge_id: `ch_${crypto.randomUUID().replace(/-/g, '')}`,
-      amount_cents: 9900,
-    });
-
-    const caller = await createCallerForUser(adminUser.id);
-    const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
-
-    expect(result.subscription).toBeNull();
-    expect(result.hasAccess).toBe(true);
-    expect(result.accessReason).toBe('earlybird');
-    expect(result.earlybird).toEqual(
-      expect.objectContaining({
-        purchased: true,
-        expiresAt: expect.any(String),
-        daysRemaining: expect.any(Number),
-      })
-    );
   });
 
   it('returns activeInstanceId when the user has an active instance', async () => {

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -17,7 +17,6 @@ import { db, cleanupDbForTest } from '@/lib/drizzle';
 import {
   kiloclaw_subscriptions,
   kiloclaw_instances,
-  kiloclaw_earlybird_purchases,
   kiloclaw_subscription_change_log,
   kilocode_users,
   credit_transactions,
@@ -438,41 +437,6 @@ describe('getBillingStatus', () => {
     expect(result.trialEligible).toBe(false);
   });
 
-  it('returns trialEligible false when user has an earlybird purchase', async () => {
-    await db.insert(kiloclaw_earlybird_purchases).values({
-      user_id: user.id,
-      amount_cents: 2500,
-    });
-
-    const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.getBillingStatus();
-
-    expect(result).not.toBeNull();
-    expect(result.trialEligible).toBe(false);
-  });
-
-  it('returns instance data for legacy earlybird access with no subscription row', async () => {
-    const instance = await createKiloclawInstance(user.id);
-    await db.insert(kiloclaw_earlybird_purchases).values({
-      user_id: user.id,
-      amount_cents: 2500,
-    });
-
-    const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.getBillingStatus();
-
-    expect(result.hasAccess).toBe(true);
-    expect(result.accessReason).toBe('earlybird');
-    expect(result.instance).toEqual({
-      id: instance.id,
-      exists: true,
-      status: null,
-      suspendedAt: null,
-      destructionDeadline: null,
-      destroyed: false,
-    });
-  });
-
   it('prefers an active subscription over an older canceled row', async () => {
     const destroyedInstance = await createKiloclawInstance(user.id, '2026-04-01T00:00:00.000Z');
     const activeInstance = await createKiloclawInstance(user.id);
@@ -613,7 +577,7 @@ describe('requireKiloClawAccess', () => {
       });
 
       await expect(requireKiloClawAccess(user.id)).rejects.toThrow(
-        'KiloClaw access requires an active subscription, trial, or earlybird purchase.'
+        'KiloClaw access requires an active subscription or trial.'
       );
 
       expect(warnSpy).toHaveBeenCalledTimes(1);
@@ -633,14 +597,12 @@ describe('requireKiloClawAccess', () => {
             }
           | 'none';
         accessReason: string | null;
-        earlybirdFound: boolean;
       };
 
       expect(parsed).toMatchObject({
         event: 'kiloclaw_access_denied',
         userId: user.id,
         accessReason: null,
-        earlybirdFound: false,
       });
       expect(parsed.effectiveSubscription).not.toBe('none');
       expect(parsed.effectiveSubscription).toMatchObject({
@@ -1035,31 +997,6 @@ describe('subscription center procedures', () => {
 describe('createSubscriptionCheckout', () => {
   it('allows checkout for active orphan instance with no subscription row', async () => {
     const instance = await createKiloclawInstance(user.id);
-
-    stripeMock.checkout.sessions.create.mockResolvedValue({
-      url: 'https://checkout.stripe.com/test',
-    });
-
-    const caller = await createCallerForUser(user.id);
-    await expect(caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' })).resolves.toEqual(
-      { url: 'https://checkout.stripe.com/test' }
-    );
-
-    expect(stripeMock.checkout.sessions.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        metadata: expect.objectContaining({
-          instanceId: instance.id,
-        }),
-      })
-    );
-  });
-
-  it('allows checkout for legacy earlybird instance with no subscription row', async () => {
-    const instance = await createKiloclawInstance(user.id);
-    await db.insert(kiloclaw_earlybird_purchases).values({
-      user_id: user.id,
-      amount_cents: 2500,
-    });
 
     stripeMock.checkout.sessions.create.mockResolvedValue({
       url: 'https://checkout.stripe.com/test',

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -15,6 +15,7 @@ import {
 } from '@jest/globals';
 import { db, cleanupDbForTest } from '@/lib/drizzle';
 import {
+  kiloclaw_earlybird_purchases,
   kiloclaw_subscriptions,
   kiloclaw_instances,
   kiloclaw_subscription_change_log,
@@ -556,6 +557,21 @@ describe('provision detached personal billing recovery', () => {
         bootstrapSubscription: true,
       }
     );
+  });
+
+  it('rejects reprovision for legacy earlybird purchase without canonical subscription row', async () => {
+    await createKiloclawInstance(user.id);
+    await db.insert(kiloclaw_earlybird_purchases).values({
+      user_id: user.id,
+      amount_cents: 2500,
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.provision({})).rejects.toThrow(
+      'Legacy earlybird access requires manual remediation before reprovisioning.'
+    );
+
+    expect(kiloclawInternalClientMock.__provisionMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -1114,15 +1114,19 @@ async function getPersonalBillingStatus(user: {
     : null;
 
   const isEarlybird = sub?.access_origin === 'earlybird';
-  const earlybirdData = isEarlybird
-    ? {
-        purchased: true,
-        expiresAt: sub.trial_ends_at ?? KILOCLAW_EARLYBIRD_EXPIRY_DATE,
-        daysRemaining: sub.trial_ends_at
-          ? Math.ceil((new Date(sub.trial_ends_at).getTime() - Date.now()) / 86_400_000)
-          : 0,
-      }
+  const earlybirdExpiresAt = isEarlybird
+    ? (sub.trial_ends_at ?? KILOCLAW_EARLYBIRD_EXPIRY_DATE)
     : null;
+  const earlybirdData =
+    isEarlybird && earlybirdExpiresAt
+      ? {
+          purchased: true,
+          expiresAt: earlybirdExpiresAt,
+          daysRemaining: Math.ceil(
+            (new Date(earlybirdExpiresAt).getTime() - Date.now()) / 86_400_000
+          ),
+        }
+      : null;
 
   let instanceData: ClawBillingStatus['instance'] = null;
   if (currentPersonalInstance) {

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -22,6 +22,7 @@ import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
 import {
   kiloclaw_version_pins,
   kiloclaw_image_catalog,
+  kiloclaw_earlybird_purchases,
   kiloclaw_subscriptions,
   kiloclaw_instances,
   kiloclaw_email_log,
@@ -887,11 +888,18 @@ async function ensureProvisionAccess(
       userId,
       executor,
     });
-  const [anySubscription] = await executor
-    .select({ id: kiloclaw_subscriptions.id })
-    .from(kiloclaw_subscriptions)
-    .where(eq(kiloclaw_subscriptions.user_id, userId))
-    .limit(1);
+  const [[anySubscription], [legacyEarlybirdPurchase]] = await Promise.all([
+    executor
+      .select({ id: kiloclaw_subscriptions.id })
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, userId))
+      .limit(1),
+    executor
+      .select({ id: kiloclaw_earlybird_purchases.id })
+      .from(kiloclaw_earlybird_purchases)
+      .where(eq(kiloclaw_earlybird_purchases.user_id, userId))
+      .limit(1),
+  ]);
   let currentRow: Awaited<ReturnType<typeof resolveCurrentPersonalSubscriptionRow>>;
   try {
     currentRow = await resolveCurrentPersonalSubscriptionRow({
@@ -900,6 +908,13 @@ async function ensureProvisionAccess(
     });
   } catch (error) {
     mapCurrentSubscriptionResolutionError(error);
+  }
+
+  if (legacyEarlybirdPurchase && !currentRow && !detachedAccessGrantingSubscription) {
+    throw new TRPCError({
+      code: 'CONFLICT',
+      message: 'Legacy earlybird access requires manual remediation before reprovisioning.',
+    });
   }
 
   if (activeInstance && !currentRow && !detachedAccessGrantingSubscription && !anySubscription) {

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -16,17 +16,12 @@ import {
   isValidCustomSecretKey,
   isValidConfigPath,
 } from '@kilocode/kiloclaw-secret-catalog';
-import {
-  KILOCLAW_API_URL,
-  STRIPE_KILOCLAW_EARLYBIRD_PRICE_ID,
-  STRIPE_KILOCLAW_EARLYBIRD_COUPON_ID,
-} from '@/lib/config.server';
+import { KILOCLAW_API_URL } from '@/lib/config.server';
 import { db, type DrizzleTransaction } from '@/lib/drizzle';
 import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
 import {
   kiloclaw_version_pins,
   kiloclaw_image_catalog,
-  kiloclaw_earlybird_purchases,
   kiloclaw_subscriptions,
   kiloclaw_instances,
   kiloclaw_email_log,
@@ -69,6 +64,7 @@ import { getAffiliateAttribution } from '@/lib/affiliate-attribution';
 import { buildAffiliateEventDedupeKey, enqueueAffiliateEventForUser } from '@/lib/affiliate-events';
 import { clawAccessProcedure } from '@/lib/kiloclaw/access-gate';
 import { cancelCliRun, createCliRun, getCliRunStatus } from '@/lib/kiloclaw/cli-runs';
+import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
 import {
   getStripePriceIdForClawPlan,
   getStripePriceIdForClawPlanIntro,
@@ -78,8 +74,10 @@ import { KiloPassTier, KiloPassCadence } from '@/lib/kilo-pass/enums';
 import { isStripeSubscriptionEnded } from '@/lib/kilo-pass/stripe-subscription-status';
 import { getKiloPassStateForUser } from '@/lib/kilo-pass/state';
 import { ensureAutoIntroSchedule, resolvePhasePrice } from '@/lib/kiloclaw/stripe-handlers';
-import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
-import { getKiloClawSubscriptionAccessReason } from '@/lib/kiloclaw/access-state';
+import {
+  getKiloClawEarlybirdStateForUser,
+  getKiloClawSubscriptionAccessReason,
+} from '@/lib/kiloclaw/access-state';
 import {
   enrollWithCredits as enrollWithCreditsImpl,
   getEffectiveCreditBalancePreview,
@@ -151,18 +149,6 @@ function mapCurrentSubscriptionResolutionError(error: unknown): never {
     });
   }
   throw error;
-}
-
-async function getEarlybirdPurchaseRow(
-  userId: string,
-  executor: typeof db | DrizzleTransaction = db
-): Promise<{ id: string } | null> {
-  const [earlybird] = await executor
-    .select({ id: kiloclaw_earlybird_purchases.id })
-    .from(kiloclaw_earlybird_purchases)
-    .where(eq(kiloclaw_earlybird_purchases.user_id, userId))
-    .limit(1);
-  return earlybird ?? null;
 }
 
 async function resolveDetachedAccessGrantingPersonalSubscription(params: {
@@ -261,10 +247,7 @@ async function resolvePersonalBillingAnchor(params: {
   currentRow: Awaited<ReturnType<typeof resolveCurrentPersonalSubscriptionRow>>;
 }> {
   const executor = params.executor ?? db;
-  const now = new Date();
   const activeInstance = await getActiveInstance(params.userId, executor);
-  const earlybird = await getEarlybirdPurchaseRow(params.userId, executor);
-  const hasActiveEarlybirdAccess = !!earlybird && new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE) > now;
   const [anySubscription] = await executor
     .select({ id: kiloclaw_subscriptions.id })
     .from(kiloclaw_subscriptions)
@@ -289,7 +272,7 @@ async function resolvePersonalBillingAnchor(params: {
       })
     : null;
 
-  if (activeInstance && !currentRow && !hasActiveEarlybirdAccess && anySubscription) {
+  if (activeInstance && !currentRow && anySubscription) {
     throw new TRPCError({
       code: 'CONFLICT',
       message: 'Active KiloClaw instance is missing its current billing row.',
@@ -899,8 +882,6 @@ async function ensureProvisionAccess(
 }> {
   const now = new Date();
   const activeInstance = await getActiveInstance(userId, executor);
-  const earlybird = await getEarlybirdPurchaseRow(userId, executor);
-  const hasActiveEarlybirdAccess = !!earlybird && new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE) > now;
   const detachedAccessGrantingSubscription =
     await resolveDetachedAccessGrantingPersonalSubscription({
       userId,
@@ -921,19 +902,15 @@ async function ensureProvisionAccess(
     mapCurrentSubscriptionResolutionError(error);
   }
 
-  if (
-    activeInstance &&
-    !currentRow &&
-    !detachedAccessGrantingSubscription &&
-    !hasActiveEarlybirdAccess
-  ) {
-    if (!anySubscription) {
-      return {
-        instanceId: activeInstance.id,
-        bootstrapSubscription: true,
-        shouldEnqueueTrialStartAffiliate: true,
-      };
-    }
+  if (activeInstance && !currentRow && !detachedAccessGrantingSubscription && !anySubscription) {
+    return {
+      instanceId: activeInstance.id,
+      bootstrapSubscription: true,
+      shouldEnqueueTrialStartAffiliate: true,
+    };
+  }
+
+  if (activeInstance && !currentRow && !detachedAccessGrantingSubscription) {
     throw new TRPCError({
       code: 'CONFLICT',
       message: 'Active KiloClaw instance is missing its current billing row.',
@@ -955,14 +932,6 @@ async function ensureProvisionAccess(
     };
   }
 
-  if (hasActiveEarlybirdAccess) {
-    return {
-      instanceId: activeInstance?.id ?? null,
-      bootstrapSubscription: false,
-      shouldEnqueueTrialStartAffiliate: false,
-    };
-  }
-
   if (detachedAccessGrantingSubscription) {
     return {
       instanceId: activeInstance?.id ?? null,
@@ -971,7 +940,7 @@ async function ensureProvisionAccess(
     };
   }
 
-  if (!anySubscription && !earlybird) {
+  if (!anySubscription) {
     return {
       instanceId: activeInstance?.id ?? null,
       bootstrapSubscription: activeInstance !== null,
@@ -1077,25 +1046,9 @@ async function getPersonalBillingStatus(user: {
       now,
     });
 
-  const [earlybird] = await db
-    .select({ id: kiloclaw_earlybird_purchases.id })
-    .from(kiloclaw_earlybird_purchases)
-    .where(eq(kiloclaw_earlybird_purchases.user_id, user.id))
-    .limit(1);
-
-  const earlybirdExpiresAt = KILOCLAW_EARLYBIRD_EXPIRY_DATE;
-  const earlybirdDaysRemaining = Math.ceil(
-    (new Date(earlybirdExpiresAt).getTime() - Date.now()) / 86_400_000
-  );
-
   let accessReason: 'trial' | 'subscription' | 'earlybird' | null =
     getKiloClawSubscriptionAccessReason(sub, now);
   let hasAccess = accessReason !== null;
-
-  if (!hasAccess && earlybird && new Date(earlybirdExpiresAt) > now) {
-    hasAccess = true;
-    accessReason = 'earlybird';
-  }
 
   const trialData =
     sub?.status === 'trialing' || (sub?.trial_started_at && sub?.trial_ends_at)
@@ -1145,12 +1098,14 @@ async function getPersonalBillingStatus(user: {
       }
     : null;
 
-  const isEarlybird = earlybird || accessReason === 'earlybird';
+  const isEarlybird = sub?.access_origin === 'earlybird';
   const earlybirdData = isEarlybird
     ? {
-        purchased: !!earlybird,
-        expiresAt: earlybirdExpiresAt,
-        daysRemaining: earlybirdDaysRemaining,
+        purchased: true,
+        expiresAt: sub.trial_ends_at ?? KILOCLAW_EARLYBIRD_EXPIRY_DATE,
+        daysRemaining: sub.trial_ends_at
+          ? Math.ceil((new Date(sub.trial_ends_at).getTime() - Date.now()) / 86_400_000)
+          : 0,
       }
     : null;
 
@@ -1215,7 +1170,7 @@ async function getPersonalBillingStatus(user: {
   return {
     hasAccess,
     accessReason,
-    trialEligible: !anyPersonalInstance && !anySubscription && !earlybird,
+    trialEligible: !anyPersonalInstance && !anySubscription,
     creditBalanceMicrodollars,
     creditIntroEligible,
     hasActiveKiloPass,
@@ -2743,76 +2698,17 @@ export const kiloclawRouter = createTRPCRouter({
   getEarlybirdStatus: baseProcedure
     .output(z.object({ purchased: z.boolean() }))
     .query(async ({ ctx }) => {
-      const rows = await db
-        .select({ id: kiloclaw_earlybird_purchases.id })
-        .from(kiloclaw_earlybird_purchases)
-        .where(eq(kiloclaw_earlybird_purchases.user_id, ctx.user.id))
-        .limit(1);
-      return { purchased: rows.length > 0 };
+      const state = await getKiloClawEarlybirdStateForUser(ctx.user.id);
+      return { purchased: state.purchased };
     }),
 
   createEarlybirdCheckoutSession: baseProcedure
     .output(z.object({ url: z.url().nullable() }))
-    .mutation(async ({ ctx }) => {
-      const existing = await db
-        .select({ id: kiloclaw_earlybird_purchases.id })
-        .from(kiloclaw_earlybird_purchases)
-        .where(eq(kiloclaw_earlybird_purchases.user_id, ctx.user.id))
-        .limit(1);
-
-      if (existing.length > 0) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'You have already purchased the early bird offer.',
-        });
-      }
-
-      const stripeCustomerId = ctx.user.stripe_customer_id;
-      if (!stripeCustomerId) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Missing Stripe customer for user.',
-        });
-      }
-
-      if (!STRIPE_KILOCLAW_EARLYBIRD_PRICE_ID) {
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'Early bird pricing is not configured.',
-        });
-      }
-
-      const session = await stripe.checkout.sessions.create({
-        mode: 'payment',
-        customer: stripeCustomerId,
-        billing_address_collection: 'required',
-        line_items: [{ price: STRIPE_KILOCLAW_EARLYBIRD_PRICE_ID, quantity: 1 }],
-        ...(STRIPE_KILOCLAW_EARLYBIRD_COUPON_ID
-          ? { discounts: [{ coupon: STRIPE_KILOCLAW_EARLYBIRD_COUPON_ID }] }
-          : { allow_promotion_codes: true }),
-        customer_update: {
-          name: 'auto',
-          address: 'auto',
-        },
-        tax_id_collection: {
-          enabled: true,
-          required: 'never',
-        },
-        payment_intent_data: {
-          metadata: {
-            type: 'kiloclaw-earlybird',
-            kiloUserId: ctx.user.id,
-          },
-        },
-        success_url: `${APP_URL}/claw?earlybird_checkout=success`,
-        cancel_url: `${APP_URL}/claw/earlybird?checkout=cancelled`,
-        metadata: {
-          type: 'kiloclaw-earlybird',
-          kiloUserId: ctx.user.id,
-        },
+    .mutation(async () => {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Earlybird offer is no longer available.',
       });
-
-      return { url: typeof session.url === 'string' ? session.url : null };
     }),
 
   // User version pinning endpoints

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -1061,9 +1061,9 @@ async function getPersonalBillingStatus(user: {
       now,
     });
 
-  let accessReason: 'trial' | 'subscription' | 'earlybird' | null =
+  const accessReason: 'trial' | 'subscription' | 'earlybird' | null =
     getKiloClawSubscriptionAccessReason(sub, now);
-  let hasAccess = accessReason !== null;
+  const hasAccess = accessReason !== null;
 
   const trialData =
     sub?.status === 'trialing' || (sub?.trial_started_at && sub?.trial_ends_at)

--- a/apps/web/src/routers/kiloclaw-send-chat-message.test.ts
+++ b/apps/web/src/routers/kiloclaw-send-chat-message.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it, beforeAll, beforeEach, jest } from '@jest/globals';
 import { db, cleanupDbForTest } from '@/lib/drizzle';
-import {
-  kiloclaw_earlybird_purchases,
-  kiloclaw_instances,
-  kiloclaw_subscriptions,
-} from '@kilocode/db/schema';
+import { kiloclaw_instances, kiloclaw_subscriptions } from '@kilocode/db/schema';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import type { User } from '@kilocode/db/schema';
 
@@ -125,9 +121,12 @@ describe('kiloclaw.sendChatMessage', () => {
 
   describe('ownership validation', () => {
     it('rejects when user has no active instance (no instanceId)', async () => {
-      await db.insert(kiloclaw_earlybird_purchases).values({
+      await db.insert(kiloclaw_subscriptions).values({
         user_id: user.id,
-        amount_cents: 2500,
+        instance_id: null,
+        plan: 'standard',
+        status: 'active',
+        stripe_subscription_id: `sub_detached_${crypto.randomUUID()}`,
       });
       const caller = await createCallerForUser(user.id);
 

--- a/apps/web/src/routers/kiloclaw-send-chat-message.test.ts
+++ b/apps/web/src/routers/kiloclaw-send-chat-message.test.ts
@@ -120,14 +120,9 @@ describe('kiloclaw.sendChatMessage', () => {
   });
 
   describe('ownership validation', () => {
-    it('rejects when user has no active instance (no instanceId)', async () => {
-      await db.insert(kiloclaw_subscriptions).values({
-        user_id: user.id,
-        instance_id: null,
-        plan: 'standard',
-        status: 'active',
-        stripe_subscription_id: `sub_detached_${crypto.randomUUID()}`,
-      });
+    it('rejects when user has access but no active instance (no instanceId)', async () => {
+      const destroyedInstanceId = await createDestroyedInstance(user.id);
+      await grantKiloClawAccess(user.id, destroyedInstanceId);
       const caller = await createCallerForUser(user.id);
 
       await expect(caller.kiloclaw.sendChatMessage({ message: 'test' })).rejects.toMatchObject({

--- a/services/kiloclaw-billing/src/bootstrap.test.ts
+++ b/services/kiloclaw-billing/src/bootstrap.test.ts
@@ -8,6 +8,7 @@ const { mockGetWorkerDb, mockInsertKiloClawSubscriptionChangeLog } = vi.hoisted(
 vi.mock('@kilocode/db', () => ({
   getWorkerDb: mockGetWorkerDb,
   insertKiloClawSubscriptionChangeLog: mockInsertKiloClawSubscriptionChangeLog,
+  kiloclaw_earlybird_purchases: {},
   kiloclaw_instances: {},
   kiloclaw_subscriptions: {},
   organizations: {},
@@ -575,6 +576,34 @@ describe('bootstrapProvisionSubscription successor transfer', () => {
     );
     expect(result).toEqual(restoredSuccessor);
   });
+
+  it('refuses fresh-trial bootstrap for legacy earlybird purchase without canonical row', async () => {
+    const { db, insertValues, updateSets } = createMockDb({
+      selectRows: [
+        [],
+        [],
+        [{ id: 'instance-new', destroyedAt: null, organizationId: null }],
+        [{ id: 'earlybird-purchase' }],
+      ],
+      txSelectRows: [],
+      insertReturningRows: [],
+      updateReturningRows: [],
+    });
+    mockGetWorkerDb.mockReturnValue(db);
+
+    await expect(
+      bootstrapProvisionSubscription(createEnv(), {
+        userId: 'user-1',
+        instanceId: 'instance-new',
+        orgId: null,
+      })
+    ).rejects.toThrow(
+      'Cannot bootstrap personal subscription for legacy earlybird purchase without canonical row'
+    );
+
+    expect(insertValues).toHaveLength(0);
+    expect(updateSets).toHaveLength(0);
+  });
 });
 
 type FreshInsertDbParams = {
@@ -680,6 +709,7 @@ describe('bootstrapProvisionSubscription concurrent insert race', () => {
         [], // existingForInstance (none seen yet — TOCTOU window)
         [], // subscriptions for user
         [], // instances for user
+        [], // legacy earlybird purchase
         [winnerRow], // reselect after conflict
       ],
       insertFirstReturningRows: [], // onConflictDoNothing swallowed our insert

--- a/services/kiloclaw-billing/src/bootstrap.test.ts
+++ b/services/kiloclaw-billing/src/bootstrap.test.ts
@@ -8,7 +8,6 @@ const { mockGetWorkerDb, mockInsertKiloClawSubscriptionChangeLog } = vi.hoisted(
 vi.mock('@kilocode/db', () => ({
   getWorkerDb: mockGetWorkerDb,
   insertKiloClawSubscriptionChangeLog: mockInsertKiloClawSubscriptionChangeLog,
-  kiloclaw_earlybird_purchases: {},
   kiloclaw_instances: {},
   kiloclaw_subscriptions: {},
   organizations: {},
@@ -681,7 +680,6 @@ describe('bootstrapProvisionSubscription concurrent insert race', () => {
         [], // existingForInstance (none seen yet — TOCTOU window)
         [], // subscriptions for user
         [], // instances for user
-        [], // earlybirdPurchase
         [winnerRow], // reselect after conflict
       ],
       insertFirstReturningRows: [], // onConflictDoNothing swallowed our insert

--- a/services/kiloclaw-billing/src/bootstrap.ts
+++ b/services/kiloclaw-billing/src/bootstrap.ts
@@ -2,6 +2,7 @@ import { and, desc, eq, isNotNull, isNull } from 'drizzle-orm';
 import {
   getWorkerDb,
   insertKiloClawSubscriptionChangeLog,
+  kiloclaw_earlybird_purchases,
   kiloclaw_instances,
   kiloclaw_subscriptions,
   organizations,
@@ -486,26 +487,33 @@ async function bootstrapPersonalSubscription(
   const db = getWorkerDb(env.HYPERDRIVE.connectionString);
   const now = new Date();
 
-  const [existingForInstance, subscriptions, instances] = await Promise.all([
-    db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.instance_id, input.instanceId))
-      .limit(1)
-      .then(rows => rows[0] ?? null),
-    db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.user_id, input.userId)),
-    db
-      .select({
-        id: kiloclaw_instances.id,
-        destroyedAt: kiloclaw_instances.destroyed_at,
-        organizationId: kiloclaw_instances.organization_id,
-      })
-      .from(kiloclaw_instances)
-      .where(eq(kiloclaw_instances.user_id, input.userId)),
-  ]);
+  const [existingForInstance, subscriptions, instances, legacyEarlybirdPurchase] =
+    await Promise.all([
+      db
+        .select()
+        .from(kiloclaw_subscriptions)
+        .where(eq(kiloclaw_subscriptions.instance_id, input.instanceId))
+        .limit(1)
+        .then(rows => rows[0] ?? null),
+      db
+        .select()
+        .from(kiloclaw_subscriptions)
+        .where(eq(kiloclaw_subscriptions.user_id, input.userId)),
+      db
+        .select({
+          id: kiloclaw_instances.id,
+          destroyedAt: kiloclaw_instances.destroyed_at,
+          organizationId: kiloclaw_instances.organization_id,
+        })
+        .from(kiloclaw_instances)
+        .where(eq(kiloclaw_instances.user_id, input.userId)),
+      db
+        .select({ id: kiloclaw_earlybird_purchases.id })
+        .from(kiloclaw_earlybird_purchases)
+        .where(eq(kiloclaw_earlybird_purchases.user_id, input.userId))
+        .limit(1)
+        .then(rows => rows[0] ?? null),
+    ]);
 
   if (existingForInstance) {
     logger
@@ -603,6 +611,19 @@ async function bootstrapPersonalSubscription(
       );
     throw new Error(
       'Cannot bootstrap personal subscription with existing non-access-granting rows'
+    );
+  }
+
+  if (legacyEarlybirdPurchase) {
+    logger
+      .withFields({
+        decision: 'rejected_legacy_earlybird_purchase_only',
+      })
+      .error(
+        'Personal bootstrap: refusing to create trial — legacy earlybird purchase requires manual remediation'
+      );
+    throw new Error(
+      'Cannot bootstrap personal subscription for legacy earlybird purchase without canonical row'
     );
   }
 

--- a/services/kiloclaw-billing/src/bootstrap.ts
+++ b/services/kiloclaw-billing/src/bootstrap.ts
@@ -2,7 +2,6 @@ import { and, desc, eq, isNotNull, isNull } from 'drizzle-orm';
 import {
   getWorkerDb,
   insertKiloClawSubscriptionChangeLog,
-  kiloclaw_earlybird_purchases,
   kiloclaw_instances,
   kiloclaw_subscriptions,
   organizations,
@@ -13,7 +12,6 @@ import {
 import type { BillingWorkerEnv } from './types.js';
 import { logger } from './logger.js';
 
-const KILOCLAW_EARLYBIRD_EXPIRY_DATE = '2026-09-26';
 const PERSONAL_TRIAL_DURATION_DAYS = 7;
 const ORGANIZATION_TRIAL_DURATION_DAYS = 14;
 const BOOTSTRAP_ACTOR = {
@@ -488,7 +486,7 @@ async function bootstrapPersonalSubscription(
   const db = getWorkerDb(env.HYPERDRIVE.connectionString);
   const now = new Date();
 
-  const [existingForInstance, subscriptions, instances, earlybirdPurchase] = await Promise.all([
+  const [existingForInstance, subscriptions, instances] = await Promise.all([
     db
       .select()
       .from(kiloclaw_subscriptions)
@@ -507,15 +505,6 @@ async function bootstrapPersonalSubscription(
       })
       .from(kiloclaw_instances)
       .where(eq(kiloclaw_instances.user_id, input.userId)),
-    db
-      .select({
-        id: kiloclaw_earlybird_purchases.id,
-        createdAt: kiloclaw_earlybird_purchases.created_at,
-      })
-      .from(kiloclaw_earlybird_purchases)
-      .where(eq(kiloclaw_earlybird_purchases.user_id, input.userId))
-      .limit(1)
-      .then(rows => rows[0] ?? null),
   ]);
 
   if (existingForInstance) {
@@ -603,10 +592,7 @@ async function bootstrapPersonalSubscription(
     });
   }
 
-  const hasActiveEarlybirdAccess =
-    !!earlybirdPurchase && new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE).getTime() > now.getTime();
-
-  if (personalSubscriptions.length > 0 && !hasActiveEarlybirdAccess) {
+  if (personalSubscriptions.length > 0) {
     logger
       .withFields({
         decision: 'rejected_non_access_granting_rows_present',
@@ -622,43 +608,21 @@ async function bootstrapPersonalSubscription(
 
   logger
     .withFields({
-      decision: earlybirdPurchase ? 'fresh_earlybird_row' : 'fresh_trial_row',
+      decision: 'fresh_trial_row',
     })
-    .info(
-      earlybirdPurchase
-        ? 'Personal bootstrap: creating earlybird row'
-        : 'Personal bootstrap: creating fresh trial row'
-    );
+    .info('Personal bootstrap: creating fresh trial row');
 
-  const { row: created, created: wasInserted } = await insertSubscriptionIdempotent(
-    db,
-    earlybirdPurchase
-      ? {
-          user_id: input.userId,
-          instance_id: input.instanceId,
-          plan: 'trial',
-          status:
-            new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE).getTime() > now.getTime()
-              ? 'trialing'
-              : 'canceled',
-          access_origin: 'earlybird',
-          payment_source: null,
-          cancel_at_period_end: false,
-          trial_started_at: earlybirdPurchase.createdAt,
-          trial_ends_at: KILOCLAW_EARLYBIRD_EXPIRY_DATE,
-        }
-      : {
-          user_id: input.userId,
-          instance_id: input.instanceId,
-          plan: 'trial',
-          status: 'trialing',
-          access_origin: null,
-          payment_source: null,
-          cancel_at_period_end: false,
-          trial_started_at: now.toISOString(),
-          trial_ends_at: getTrialEndsAt(now),
-        }
-  );
+  const { row: created, created: wasInserted } = await insertSubscriptionIdempotent(db, {
+    user_id: input.userId,
+    instance_id: input.instanceId,
+    plan: 'trial',
+    status: 'trialing',
+    access_origin: null,
+    payment_source: null,
+    cancel_at_period_end: false,
+    trial_started_at: now.toISOString(),
+    trial_ends_at: getTrialEndsAt(now),
+  });
 
   if (!wasInserted) {
     logger
@@ -674,7 +638,7 @@ async function bootstrapPersonalSubscription(
     subscriptionId: created.id,
     actor: BOOTSTRAP_ACTOR,
     action: 'created',
-    reason: earlybirdPurchase ? 'personal_provision_earlybird' : 'personal_provision_trial',
+    reason: 'personal_provision_trial',
     before: null,
     after: created,
   });

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -1100,56 +1100,6 @@ describe('credit renewal sweep affiliate tracking', () => {
     expect(txInserts).toHaveLength(0);
     expect(txUpdates).toHaveLength(0);
   });
-
-  it('sends earlybird warning for legacy purchase rows before canonical backfill', async () => {
-    const nowSpy = vi
-      .spyOn(Date, 'now')
-      .mockReturnValue(new Date('2026-09-12T00:00:00.000Z').getTime());
-    const { db, inserts } = createMockDb([
-      [
-        {
-          user_id: 'user-legacy-earlybird',
-          email: 'legacy-earlybird@example.com',
-        },
-      ],
-    ]);
-    mockGetWorkerDb.mockReturnValue(db);
-
-    const fetch = vi.fn(
-      async () =>
-        new Response(JSON.stringify({ sent: true }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        })
-    );
-    vi.spyOn(globalThis, 'fetch').mockImplementation(fetch);
-
-    try {
-      const summary = await runSweep(
-        createEnv(fetch),
-        {
-          runId: '34343434-3434-4434-8434-343434343434',
-          sweep: 'earlybird_warning',
-        },
-        1
-      );
-
-      expect(summary.errors).toBe(0);
-      expect(summary.earlybird_warnings).toBe(1);
-      expect(fetch).toHaveBeenCalledTimes(1);
-      expect(inserts).toEqual(
-        expect.arrayContaining([
-          {
-            user_id: 'user-legacy-earlybird',
-            instance_id: null,
-            email_type: 'claw_earlybird_14d',
-          },
-        ])
-      );
-    } finally {
-      nowSpy.mockRestore();
-    }
-  });
 });
 
 describe('complementary inference ended sweep', () => {

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -34,7 +34,7 @@ const DESTRUCTION_GRACE_DAYS = 7;
 const PAST_DUE_THRESHOLD_DAYS = 14;
 const TRIAL_WARNING_DAYS = 2;
 const DESTRUCTION_WARNING_DAYS = 2;
-const KILOCLAW_EARLYBIRD_EXPIRY_DATE = '2026-09-26';
+const EARLYBIRD_WARNING_DAYS = 14;
 const AUTO_RESUME_INITIAL_BACKOFF_MS = 2 * 60 * 60 * 1000;
 const AUTO_RESUME_MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
 const SOFT_DELETED_EMAIL_SUFFIX = '@deleted.invalid';
@@ -2251,16 +2251,15 @@ async function runEarlybirdWarningSweep(
   summary: BillingSummary
 ): Promise<void> {
   const clawUrl = buildClawUrl(env);
-  const earlybirdExpiry = new Date(KILOCLAW_EARLYBIRD_EXPIRY_DATE);
-  const daysUntilEarlybird = Math.ceil((earlybirdExpiry.getTime() - Date.now()) / MS_PER_DAY);
-
-  if (daysUntilEarlybird <= 0 || daysUntilEarlybird > 14) {
-    return;
-  }
+  const advisoryNow = new Date().toISOString();
+  const earlybirdWarningCutoff = new Date(
+    Date.now() + EARLYBIRD_WARNING_DAYS * MS_PER_DAY
+  ).toISOString();
 
   const canonicalRows = await database
     .select({
       user_id: kiloclaw_subscriptions.user_id,
+      trial_ends_at: kiloclaw_subscriptions.trial_ends_at,
       email: kilocode_users.google_user_email,
     })
     .from(kiloclaw_subscriptions)
@@ -2270,7 +2269,8 @@ async function runEarlybirdWarningSweep(
         eq(kiloclaw_subscriptions.access_origin, 'earlybird'),
         eq(kiloclaw_subscriptions.status, 'trialing'),
         currentSubscriptionRowFilter(),
-        sql`${kiloclaw_subscriptions.trial_ends_at} > now()`,
+        gt(kiloclaw_subscriptions.trial_ends_at, advisoryNow),
+        lte(kiloclaw_subscriptions.trial_ends_at, earlybirdWarningCutoff),
         sql`NOT EXISTS (
           SELECT 1
           FROM ${kiloclaw_subscriptions} AS other
@@ -2293,9 +2293,14 @@ async function runEarlybirdWarningSweep(
   for (const row of canonicalRows) {
     try {
       if (isSoftDeletedUserEmail(row.email)) continue;
-      const expiryDate = formatDateForEmail(earlybirdExpiry);
+      if (!row.trial_ends_at) continue;
+
+      const trialEndsAt = new Date(row.trial_ends_at);
+      const daysRemaining = Math.ceil((trialEndsAt.getTime() - Date.now()) / MS_PER_DAY);
+      const expiryDate = formatDateForEmail(trialEndsAt);
+
       const sent =
-        daysUntilEarlybird <= 1
+        daysRemaining <= 1
           ? await trySendEmail(
               database,
               env,
@@ -2319,7 +2324,7 @@ async function runEarlybirdWarningSweep(
               'claw_earlybird_14d',
               'clawEarlybirdEndingSoon',
               {
-                days_remaining: String(daysUntilEarlybird),
+                days_remaining: String(daysRemaining),
                 expiry_date: expiryDate,
                 claw_url: clawUrl,
               },

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -14,7 +14,6 @@ import {
 } from '@kilocode/worker-utils/kiloclaw-billing-observability';
 import {
   credit_transactions,
-  kiloclaw_earlybird_purchases,
   kiloclaw_email_log,
   kiloclaw_instances,
   kiloclaw_subscriptions,
@@ -2291,40 +2290,7 @@ async function runEarlybirdWarningSweep(
       )
     );
 
-  const legacyRows = await database
-    .select({
-      user_id: kiloclaw_earlybird_purchases.user_id,
-      email: kilocode_users.google_user_email,
-    })
-    .from(kiloclaw_earlybird_purchases)
-    .innerJoin(kilocode_users, eq(kiloclaw_earlybird_purchases.user_id, kilocode_users.id))
-    .where(sql`NOT EXISTS (
-        SELECT 1
-        FROM ${kiloclaw_subscriptions}
-        WHERE ${kiloclaw_subscriptions.user_id} = ${kiloclaw_earlybird_purchases.user_id}
-          AND ${kiloclaw_subscriptions.transferred_to_subscription_id} IS NULL
-          AND ${kiloclaw_subscriptions.access_origin} = 'earlybird'
-      )
-      AND NOT EXISTS (
-        SELECT 1
-        FROM ${kiloclaw_subscriptions}
-        WHERE ${kiloclaw_subscriptions.user_id} = ${kiloclaw_earlybird_purchases.user_id}
-          AND ${kiloclaw_subscriptions.transferred_to_subscription_id} IS NULL
-          AND (
-            ${kiloclaw_subscriptions.status} = 'active'
-            OR (
-              ${kiloclaw_subscriptions.status} = 'past_due'
-              AND ${kiloclaw_subscriptions.suspended_at} IS NULL
-            )
-            OR (
-              ${kiloclaw_subscriptions.status} = 'trialing'
-              AND ${kiloclaw_subscriptions.access_origin} IS DISTINCT FROM 'earlybird'
-              AND ${kiloclaw_subscriptions.trial_ends_at} > now()
-            )
-          )
-      )`);
-
-  for (const row of [...canonicalRows, ...legacyRows]) {
+  for (const row of canonicalRows) {
     try {
       if (isSoftDeletedUserEmail(row.email)) continue;
       const expiryDate = formatDateForEmail(earlybirdExpiry);


### PR DESCRIPTION
## Summary
Retires the `kiloclaw_earlybird_purchases` fallback from runtime access paths so earlybird access is driven entirely by canonical subscription rows, and blocks legacy-purchase-only users from silently receiving a fresh 7-day trial.

### Why this change is needed
- Runtime code still granted KiloClaw access, billing status, and warning emails via the `kiloclaw_earlybird_purchases` purchase table whenever a canonical `access_origin='earlybird'` subscription row was missing. The data model has now been backfilled, so this fallback is dead weight that obscures which code path is authoritative.
- Without the fallback, a legacy earlybird user who still lacks a canonical subscription row would hit the personal-provision bootstrap and be minted a brand-new 7-day trial — a subtle regression the initial cleanup missed. Those users must be remediated manually instead of being converted into trialers.

### How this is addressed
- Drop purchase-table reads and branches from `access-gate`, `access-state`, `getPersonalBillingStatus`, `ensureProvisionAccess`, `resolvePersonalBillingAnchor`, the `getEarlybirdStatus` / `createEarlybirdCheckoutSession` endpoints, the internal users API, and the billing worker's `bootstrapPersonalSubscription` + `runEarlybirdWarningSweep`.
- `createEarlybirdCheckoutSession` now returns `BAD_REQUEST` unconditionally; the offer is closed.
- Treat a leftover purchase-only row as a remediation case: `ensureProvisionAccess` throws `CONFLICT` and `bootstrapPersonalSubscription` throws rather than inserting a fresh trial row.
- Spec updates (`.specs/kiloclaw-billing.md`, `.specs/kiloclaw-datamodel.md`) record the steady-state rules: canonical earlybird rows are the only access source, and legacy-purchase-only users require manual remediation.
- Align tests: remove purchase-fallback tests, add bootstrap + billing-router tests that assert the block behavior, and update existing tests (e.g. `sendChatMessage`) to seed canonical subscription rows instead of purchase rows.

## Human Verification
- Spec alignment: implementation matches the updated steady-state rules in `.specs/kiloclaw-billing.md` (Overview, Trial Eligibility rule 2, Access Control rule 4, Billing Status rules 2 and 8) and `.specs/kiloclaw-datamodel.md` (Instance–Subscription rule 6).
- Tests verified: skipped in this session — test database not started. Expect `kiloclaw-billing-router.test.ts`, `admin-kiloclaw-user-router.test.ts`, `kiloclaw-send-chat-message.test.ts`, `services/kiloclaw-billing/src/bootstrap.test.ts`, and `services/kiloclaw-billing/src/lifecycle.test.ts` to be exercised in CI.
- Code evaluations: self-review plus deterministic review agents (logic, data, security, types, resources, style); only callout was that legacy purchase-only users could still trial-bootstrap, which is resolved in the second commit.

## Visual Changes
N/A

## Reviewer Notes

### Human Reviewer
- Spec change: earlybird access semantics narrowed — any user still holding only a `kiloclaw_earlybird_purchases` row loses access until a canonical row is backfilled. Confirm the backfill/remediation story for production is in place before merging.
- Trade-off: `ensureProvisionAccess` and `bootstrapPersonalSubscription` now fail loudly for legacy-purchase-only users instead of silently minting a new trial. Chosen so operators notice and remediate, rather than masking the data gap.
- `createEarlybirdCheckoutSession` is deliberately kept as a now-stubbed mutation returning `BAD_REQUEST` so any lingering client can still hit the endpoint cleanly.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- `access-state.getKiloClawEarlybirdStateForUser` now returns `{ purchased: false, hasAccess: false, expiresAt: null }` when no canonical earlybird subscription row exists; callers (`admin-router`, `kiloclaw-router.getEarlybirdStatus`, internal users route) handle the absent-purchase case.
- `getPersonalBillingStatus` derives `earlybird` display data from `sub.access_origin === 'earlybird'` and uses `sub.trial_ends_at` for expiry/days-remaining, falling back to `KILOCLAW_EARLYBIRD_EXPIRY_DATE` only if the row lacks a trial end.
- `resolvePersonalBillingAnchor` and `ensureProvisionAccess` rely on `resolveCurrentPersonalSubscriptionRow` + detached-subscription resolution only; no earlybird branch remains in the anchor/provision control flow beyond the new remediation guard.
- Bootstrap now blocks when `kiloclaw_earlybird_purchases` exists with no canonical row: it runs after existing personal-subscription-rejection and before the fresh trial insert, so the idempotent insert path is unreachable for legacy-only users.
- Lifecycle earlybird warning sweep reads canonical rows only; the separate legacy-row query (and its \`legacyRows\` loop) is removed, so \`claw_earlybird_14d\`/\`_1d\` emails only target users with canonical earlybird subscription rows.

</details>