### PR TITLE
fix(security-advisor): use arrayOverlaps for coverage save

### DIFF
--- a/apps/web/src/routers/admin/security-advisor-content-router.ts
+++ b/apps/web/src/routers/admin/security-advisor-content-router.ts
@@ -6,7 +6,7 @@ import {
   security_advisor_content,
 } from '@kilocode/db/schema';
 import { invalidateSecurityAdvisorContentCache } from '@/lib/security-advisor/content-loader';
-import { and, asc, eq, ne, sql } from 'drizzle-orm';
+import { and, arrayOverlaps, asc, eq, ne } from 'drizzle-orm';
 import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
 
@@ -143,7 +143,14 @@ export const adminSecurityAdvisorContentRouter = createTRPCRouter({
             and(
               eq(security_advisor_kiloclaw_coverage.is_active, true),
               ne(security_advisor_kiloclaw_coverage.area, input.area),
-              sql`${security_advisor_kiloclaw_coverage.match_check_ids} && ${input.match_check_ids}::text[]`
+              // Native Drizzle helper — binds the JS array as a single PG
+              // `text[]` parameter. Hand-rolling this as raw SQL with
+              // `${arr}::text[]` serializes as a tuple `($1, $2, $3)` which
+              // `&&` rejects with a syntax error.
+              arrayOverlaps(
+                security_advisor_kiloclaw_coverage.match_check_ids,
+                input.match_check_ids
+              )
             )
           );
         if (conflicting.length > 0) {


### PR DESCRIPTION
## Summary
The admin UI's KiloClaw Coverage upsert overlap check hand rolled a raw SQL template with `${input.match_check_ids}::text[]`, which Drizzle serializes as a tuple `(\$1, \$2, \$3)::text[]`. The `&&` array overlap operator rejects the tuple form with a Postgres syntax error, so every coverage save crashed before the upsert ran.
Switch to Drizzle's native `arrayOverlaps` helper, which binds the JS array as a single `text[]` parameter.
<!-- What changed and why? Keep this brief and outcome-focused. -->
<!-- Include any architectural changes and enough context for a reviewer unfamiliar with this code area. -->

## Verification


- [x] linter and all unit tests
- [x] local testing

## Visual Changes
N/A

## Reviewer Notes
N/A
<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
