### PR TITLE
feat(gastown): add bulk bead deletion — array support for gt_bead_delete and bulk delete UI

### DIFF
--- a/apps/web/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/beads/BeadsPageClient.tsx
@@ -1,14 +1,23 @@
 'use client';
 
-import { useState, useMemo } from 'react';
-import { useQuery, useQueries } from '@tanstack/react-query';
+import { useState, useMemo, useCallback } from 'react';
+import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { useDrawerStack } from '@/components/gastown/DrawerStack';
-import { Hexagon, Search } from 'lucide-react';
+import { Hexagon, Search, Trash2, X } from 'lucide-react';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { formatDistanceToNow } from 'date-fns';
 import { motion, AnimatePresence } from 'motion/react';
 import type { GastownOutputs } from '@/lib/gastown/trpc';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
 
 type Bead = GastownOutputs['gastown']['listBeads'][number];
 
@@ -23,11 +32,18 @@ const STATUS_DOT: Record<string, string> = {
   failed: 'bg-red-400',
 };
 
+type DeleteConfirm =
+  | { kind: 'selected'; ids: string[]; rigId: string }
+  | { kind: 'all-failed'; count: number; rigIds: string[] };
+
 export function BeadsPageClient({ townId }: BeadsPageClientProps) {
   const trpc = useGastownTRPC();
+  const queryClient = useQueryClient();
   const { open: openDrawer } = useDrawerStack();
   const [statusFilter, setStatusFilter] = useState<string | null>(null);
   const [search, setSearch] = useState('');
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [deleteConfirm, setDeleteConfirm] = useState<DeleteConfirm | null>(null);
 
   const rigsQuery = useQuery(trpc.gastown.listRigs.queryOptions({ townId }));
   const rigs = rigsQuery.data ?? [];
@@ -78,7 +94,91 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
     return counts;
   }, [allBeads]);
 
+  const failedBeads = useMemo(() => allBeads.filter(b => b.status === 'failed'), [allBeads]);
+
   const isLoading = rigsQuery.isLoading || rigBeadQueries.some(q => q.isLoading);
+
+  const invalidateBeads = useCallback(() => {
+    for (const rig of rigs) {
+      void queryClient.invalidateQueries(trpc.gastown.listBeads.queryFilter({ rigId: rig.id }));
+    }
+  }, [queryClient, rigs, trpc.gastown.listBeads]);
+
+  const deleteBeadMutation = useMutation(
+    trpc.gastown.deleteBead.mutationOptions({
+      onSuccess: () => {
+        invalidateBeads();
+        setSelectedIds(new Set());
+        setDeleteConfirm(null);
+      },
+    })
+  );
+
+  const isDeleting = deleteBeadMutation.isPending;
+
+  // Build a map from bead_id -> rigId for lookups
+  const beadRigMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const bead of allBeads) {
+      map.set(bead.bead_id, bead.rigId);
+    }
+    return map;
+  }, [allBeads]);
+
+  const allFilteredSelected =
+    filteredBeads.length > 0 && filteredBeads.every(b => selectedIds.has(b.bead_id));
+
+  const toggleSelectAll = () => {
+    if (allFilteredSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(filteredBeads.map(b => b.bead_id)));
+    }
+  };
+
+  const toggleSelect = (beadId: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(beadId)) {
+        next.delete(beadId);
+      } else {
+        next.add(beadId);
+      }
+      return next;
+    });
+  };
+
+  const handleDeleteSelected = () => {
+    if (selectedIds.size === 0) return;
+    // Group by rigId — pick the first rig for simplicity (all selected beads share the same rig
+    // in most cases; if mixed, we use the first one and the mutation handles array input)
+    const selectedArr = [...selectedIds];
+    const firstRigId = beadRigMap.get(selectedArr[0] ?? '') ?? '';
+    setDeleteConfirm({ kind: 'selected', ids: selectedArr, rigId: firstRigId });
+  };
+
+  const handleDeleteAllFailed = () => {
+    if (failedBeads.length === 0) return;
+    const rigIds = [...new Set(failedBeads.map(b => b.rigId))];
+    setDeleteConfirm({ kind: 'all-failed', count: failedBeads.length, rigIds });
+  };
+
+  const handleConfirmDelete = () => {
+    if (!deleteConfirm) return;
+
+    if (deleteConfirm.kind === 'selected') {
+      const { ids, rigId } = deleteConfirm;
+      deleteBeadMutation.mutate({ rigId, beadId: ids, townId });
+    } else {
+      // Delete all failed beads — collect all IDs and bulk-delete via the array endpoint.
+      // Using the first rig's ID for ownership verification; the town DO deletes by IDs.
+      const { rigIds } = deleteConfirm;
+      const firstRigId = rigIds[0];
+      if (!firstRigId) return;
+      const failedIds = failedBeads.map(b => b.bead_id);
+      deleteBeadMutation.mutate({ rigId: firstRigId, beadId: failedIds, townId });
+    }
+  };
 
   return (
     <div className="flex h-full flex-col">
@@ -90,6 +190,17 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
           <h1 className="text-lg font-semibold tracking-tight text-white/90">Beads</h1>
           <span className="ml-1 font-mono text-xs text-white/30">{allBeads.length}</span>
         </div>
+
+        {/* Delete all failed shortcut */}
+        {failedBeads.length > 0 && (
+          <button
+            onClick={handleDeleteAllFailed}
+            className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-red-400/70 transition-colors hover:bg-red-500/10 hover:text-red-400"
+          >
+            <Trash2 className="size-3" />
+            Delete all failed ({failedBeads.length})
+          </button>
+        )}
       </div>
 
       {/* Filter bar */}
@@ -127,6 +238,39 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
         </div>
       </div>
 
+      {/* Bulk action bar */}
+      <AnimatePresence>
+        {selectedIds.size > 0 && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="overflow-hidden"
+          >
+            <div className="flex items-center gap-3 border-b border-white/[0.06] bg-red-500/[0.04] px-6 py-2">
+              <span className="text-xs text-white/50">
+                {selectedIds.size} selected
+              </span>
+              <button
+                onClick={handleDeleteSelected}
+                className="flex items-center gap-1.5 rounded-md bg-red-500/10 px-2.5 py-1.5 text-xs font-medium text-red-400 transition-colors hover:bg-red-500/20"
+              >
+                <Trash2 className="size-3" />
+                Delete selected
+              </button>
+              <button
+                onClick={() => setSelectedIds(new Set())}
+                className="flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-white/30 transition-colors hover:text-white/50"
+              >
+                <X className="size-3" />
+                Clear
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       {/* Bead list */}
       <div className="flex-1 overflow-y-auto">
         {isLoading && (
@@ -153,6 +297,20 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
           </div>
         )}
 
+        {/* Select-all header row */}
+        {!isLoading && filteredBeads.length > 0 && (
+          <div className="flex items-center gap-3 border-b border-white/[0.04] px-6 py-1.5">
+            <input
+              type="checkbox"
+              checked={allFilteredSelected}
+              onChange={toggleSelectAll}
+              className="size-3.5 cursor-pointer accent-[oklch(95%_0.15_108)]"
+              aria-label="Select all beads"
+            />
+            <span className="text-[10px] text-white/20">Select all ({filteredBeads.length})</span>
+          </div>
+        )}
+
         <AnimatePresence mode="popLayout">
           {filteredBeads.map((bead, i) => (
             <motion.div
@@ -161,16 +319,28 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ delay: Math.min(i * 0.02, 0.3), duration: 0.15 }}
-              onClick={() => {
-                const rigId = (bead as Bead & { rigId: string }).rigId;
-                openDrawer({ type: 'bead', beadId: bead.bead_id, rigId });
-              }}
-              className="group flex cursor-pointer items-center gap-3 border-b border-white/[0.04] px-6 py-2.5 transition-colors hover:bg-white/[0.02]"
+              className={`group flex cursor-pointer items-center gap-3 border-b border-white/[0.04] px-6 py-2.5 transition-colors hover:bg-white/[0.02] ${
+                selectedIds.has(bead.bead_id) ? 'bg-white/[0.03]' : ''
+              }`}
             >
+              {/* Checkbox — stop propagation so clicking it doesn't open drawer */}
+              <input
+                type="checkbox"
+                checked={selectedIds.has(bead.bead_id)}
+                onChange={() => toggleSelect(bead.bead_id)}
+                onClick={e => e.stopPropagation()}
+                className="size-3.5 shrink-0 cursor-pointer accent-[oklch(95%_0.15_108)]"
+                aria-label={`Select bead ${bead.bead_id}`}
+              />
               <span
                 className={`size-2 shrink-0 rounded-full ${STATUS_DOT[bead.status] ?? 'bg-white/20'}`}
               />
-              <div className="min-w-0 flex-1">
+              <div
+                className="min-w-0 flex-1"
+                onClick={() => {
+                  openDrawer({ type: 'bead', beadId: bead.bead_id, rigId: bead.rigId });
+                }}
+              >
                 <div className="flex items-center gap-2">
                   <span className="truncate text-sm text-white/80">{bead.title}</span>
                   <span className="shrink-0 rounded bg-white/[0.04] px-1.5 py-0.5 text-[9px] font-medium text-white/30">
@@ -180,7 +350,7 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
                 <div className="mt-0.5 flex items-center gap-2 text-[10px] text-white/30">
                   <span className="font-mono">{bead.bead_id.slice(0, 8)}</span>
                   <span className="text-white/15">|</span>
-                  <span>{(bead as Bead & { rigName: string }).rigName}</span>
+                  <span>{bead.rigName}</span>
                   <span className="text-white/15">|</span>
                   <span>{formatDistanceToNow(new Date(bead.created_at), { addSuffix: true })}</span>
                 </div>
@@ -190,6 +360,30 @@ export function BeadsPageClient({ townId }: BeadsPageClientProps) {
           ))}
         </AnimatePresence>
       </div>
+
+      {/* Delete confirmation dialog */}
+      <Dialog open={!!deleteConfirm} onOpenChange={open => { if (!open) setDeleteConfirm(null); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {deleteConfirm?.kind === 'all-failed' ? 'Delete all failed beads' : 'Delete beads'}
+            </DialogTitle>
+            <DialogDescription>
+              {deleteConfirm?.kind === 'all-failed'
+                ? `Delete ${deleteConfirm.count} failed bead${deleteConfirm.count === 1 ? '' : 's'}? This cannot be undone.`
+                : `Delete ${deleteConfirm?.ids.length ?? 0} selected bead${(deleteConfirm?.ids.length ?? 0) === 1 ? '' : 's'}? This cannot be undone.`}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteConfirm(null)} disabled={isDeleting}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmDelete} disabled={isDeleting}>
+              {isDeleting ? 'Deleting…' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Drawers are rendered by the layout-level DrawerStackProvider */}
     </div>

--- a/apps/web/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
+++ b/apps/web/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
@@ -22,8 +22,10 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
 import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
+import { Trash2 } from 'lucide-react';
 
 const beadStatuses = ['open', 'in_progress', 'closed', 'failed'] as const;
 type BeadStatus = (typeof beadStatuses)[number];
@@ -46,11 +48,10 @@ const STATUS_COLORS: Record<BeadStatus, string> = {
   failed: 'bg-red-500/10 text-red-400 border-red-500/20',
 };
 
-type ConfirmAction = {
-  type: 'close' | 'fail';
-  beadId: string;
-  title: string;
-};
+type ConfirmAction =
+  | { type: 'close' | 'fail'; beadId: string; title: string }
+  | { type: 'bulk-delete'; beadIds: string[] }
+  | { type: 'delete-all-failed'; count: number };
 
 export function BeadsTab({ townId }: { townId: string }) {
   const trpc = useTRPC();
@@ -59,6 +60,7 @@ export function BeadsTab({ townId }: { townId: string }) {
   const [statusFilter, setStatusFilter] = useState<BeadStatus | 'all'>('all');
   const [typeFilter, setTypeFilter] = useState<BeadType | 'all'>('all');
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   const beadsQuery = useQuery(
     trpc.admin.gastown.listBeads.queryOptions({
@@ -68,10 +70,14 @@ export function BeadsTab({ townId }: { townId: string }) {
     })
   );
 
+  const invalidateBeads = () => {
+    void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
+  };
+
   const forceCloseMutation = useMutation(
     trpc.admin.gastown.forceCloseBead.mutationOptions({
       onSuccess: () => {
-        void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
+        invalidateBeads();
         setConfirmAction(null);
         toast.success('Bead closed successfully');
       },
@@ -84,7 +90,7 @@ export function BeadsTab({ townId }: { townId: string }) {
   const forceFailMutation = useMutation(
     trpc.admin.gastown.forceFailBead.mutationOptions({
       onSuccess: () => {
-        void queryClient.invalidateQueries(trpc.admin.gastown.listBeads.queryFilter({ townId }));
+        invalidateBeads();
         setConfirmAction(null);
         toast.success('Bead marked as failed');
       },
@@ -94,17 +100,104 @@ export function BeadsTab({ townId }: { townId: string }) {
     })
   );
 
+  const bulkDeleteMutation = useMutation(
+    trpc.admin.gastown.bulkDeleteBeads.mutationOptions({
+      onSuccess: data => {
+        invalidateBeads();
+        setConfirmAction(null);
+        setSelectedIds(new Set());
+        toast.success(`Deleted ${data.deleted} bead${data.deleted === 1 ? '' : 's'}`);
+      },
+      onError: err => {
+        toast.error(`Failed to delete beads: ${err.message}`);
+      },
+    })
+  );
+
+  const deleteByStatusMutation = useMutation(
+    trpc.admin.gastown.deleteBeadsByStatus.mutationOptions({
+      onSuccess: data => {
+        invalidateBeads();
+        setConfirmAction(null);
+        setSelectedIds(new Set());
+        toast.success(`Deleted ${data.deleted} bead${data.deleted === 1 ? '' : 's'}`);
+      },
+      onError: err => {
+        toast.error(`Failed to delete beads: ${err.message}`);
+      },
+    })
+  );
+
   const handleConfirm = () => {
     if (!confirmAction) return;
     if (confirmAction.type === 'close') {
       forceCloseMutation.mutate({ townId, beadId: confirmAction.beadId });
-    } else {
+    } else if (confirmAction.type === 'fail') {
       forceFailMutation.mutate({ townId, beadId: confirmAction.beadId });
+    } else if (confirmAction.type === 'bulk-delete') {
+      bulkDeleteMutation.mutate({ townId, beadIds: confirmAction.beadIds });
+    } else {
+      deleteByStatusMutation.mutate({ townId, status: 'failed' });
     }
   };
 
   const beads = beadsQuery.data ?? [];
-  const isPending = forceCloseMutation.isPending || forceFailMutation.isPending;
+  const failedCount = beads.filter(b => b.status === 'failed').length;
+
+  const allSelected = beads.length > 0 && beads.every(b => selectedIds.has(b.bead_id));
+
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(beads.map(b => b.bead_id)));
+    }
+  };
+
+  const toggleSelect = (beadId: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(beadId)) {
+        next.delete(beadId);
+      } else {
+        next.add(beadId);
+      }
+      return next;
+    });
+  };
+
+  const isPending =
+    forceCloseMutation.isPending ||
+    forceFailMutation.isPending ||
+    bulkDeleteMutation.isPending ||
+    deleteByStatusMutation.isPending;
+
+  const confirmDialogTitle = () => {
+    if (!confirmAction) return '';
+    if (confirmAction.type === 'close') return 'Force Close Bead';
+    if (confirmAction.type === 'fail') return 'Force Fail Bead';
+    if (confirmAction.type === 'bulk-delete') return 'Delete Beads';
+    return 'Delete All Failed Beads';
+  };
+
+  const confirmDialogDescription = () => {
+    if (!confirmAction) return '';
+    if (confirmAction.type === 'close') {
+      return `This will force-close bead ${confirmAction.beadId.slice(0, 8)}…${confirmAction.title ? ` (${confirmAction.title})` : ''}. This action is logged in the audit trail.`;
+    }
+    if (confirmAction.type === 'fail') {
+      return `This will force-fail bead ${confirmAction.beadId.slice(0, 8)}…${confirmAction.title ? ` (${confirmAction.title})` : ''}. This action is logged in the audit trail.`;
+    }
+    if (confirmAction.type === 'bulk-delete') {
+      return `Delete ${confirmAction.beadIds.length} selected bead${confirmAction.beadIds.length === 1 ? '' : 's'}? This cannot be undone.`;
+    }
+    return `Delete ${confirmAction.count} failed bead${confirmAction.count === 1 ? '' : 's'}? This cannot be undone.`;
+  };
+
+  const isDestructiveConfirm =
+    confirmAction?.type === 'fail' ||
+    confirmAction?.type === 'bulk-delete' ||
+    confirmAction?.type === 'delete-all-failed';
 
   return (
     <Card>
@@ -112,6 +205,19 @@ export function BeadsTab({ townId }: { townId: string }) {
         <div className="flex items-center justify-between">
           <CardTitle>Beads</CardTitle>
           <div className="flex gap-2">
+            {/* Delete all failed shortcut */}
+            {failedCount > 0 && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-8 border-red-500/30 text-xs text-red-400 hover:bg-red-500/10"
+                onClick={() => setConfirmAction({ type: 'delete-all-failed', count: failedCount })}
+              >
+                <Trash2 className="mr-1 size-3" />
+                Delete all failed ({failedCount})
+              </Button>
+            )}
+
             <Select
               value={statusFilter}
               onValueChange={v => {
@@ -154,6 +260,32 @@ export function BeadsTab({ townId }: { townId: string }) {
             </Select>
           </div>
         </div>
+
+        {/* Bulk action bar */}
+        {selectedIds.size > 0 && (
+          <div className="mt-2 flex items-center gap-3 rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2">
+            <span className="text-sm text-muted-foreground">{selectedIds.size} selected</span>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 border-red-500/30 text-xs text-red-400 hover:bg-red-500/10"
+              onClick={() =>
+                setConfirmAction({ type: 'bulk-delete', beadIds: [...selectedIds] })
+              }
+            >
+              <Trash2 className="mr-1 size-3" />
+              Delete selected
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 text-xs"
+              onClick={() => setSelectedIds(new Set())}
+            >
+              Clear
+            </Button>
+          </div>
+        )}
       </CardHeader>
       <CardContent>
         {beadsQuery.isLoading && (
@@ -174,6 +306,13 @@ export function BeadsTab({ townId }: { townId: string }) {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b">
+                  <th className="pb-2 pr-2">
+                    <Checkbox
+                      checked={allSelected}
+                      onCheckedChange={toggleSelectAll}
+                      aria-label="Select all beads"
+                    />
+                  </th>
                   <th className="text-muted-foreground pb-2 text-left font-medium">Bead</th>
                   <th className="text-muted-foreground pb-2 text-left font-medium">Type</th>
                   <th className="text-muted-foreground pb-2 text-left font-medium">Status</th>
@@ -185,6 +324,13 @@ export function BeadsTab({ townId }: { townId: string }) {
               <tbody>
                 {beads.map(bead => (
                   <tr key={bead.bead_id} className="hover:bg-muted/40 border-b transition-colors">
+                    <td className="py-2 pr-2">
+                      <Checkbox
+                        checked={selectedIds.has(bead.bead_id)}
+                        onCheckedChange={() => toggleSelect(bead.bead_id)}
+                        aria-label={`Select bead ${bead.bead_id}`}
+                      />
+                    </td>
                     <td className="py-2 pr-4">
                       <Link
                         href={`/admin/gastown/towns/${townId}/beads/${bead.bead_id}`}
@@ -262,22 +408,15 @@ export function BeadsTab({ townId }: { townId: string }) {
       <Dialog open={!!confirmAction} onOpenChange={() => setConfirmAction(null)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>
-              {confirmAction?.type === 'close' ? 'Force Close Bead' : 'Force Fail Bead'}
-            </DialogTitle>
-            <DialogDescription>
-              This will {confirmAction?.type === 'close' ? 'force-close' : 'force-fail'} bead{' '}
-              <span className="font-mono">{confirmAction?.beadId.slice(0, 8)}…</span>
-              {confirmAction?.title ? ` (${confirmAction.title})` : ''}. This action is logged in
-              the audit trail.
-            </DialogDescription>
+            <DialogTitle>{confirmDialogTitle()}</DialogTitle>
+            <DialogDescription>{confirmDialogDescription()}</DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmAction(null)} disabled={isPending}>
               Cancel
             </Button>
             <Button
-              variant={confirmAction?.type === 'fail' ? 'destructive' : 'default'}
+              variant={isDestructiveConfirm ? 'destructive' : 'default'}
               onClick={handleConfirm}
               disabled={isPending}
             >
@@ -285,7 +424,9 @@ export function BeadsTab({ townId }: { townId: string }) {
                 ? 'Processing…'
                 : confirmAction?.type === 'close'
                   ? 'Force Close'
-                  : 'Force Fail'}
+                  : confirmAction?.type === 'fail'
+                    ? 'Force Fail'
+                    : 'Delete'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
+++ b/apps/web/src/app/admin/gastown/towns/[townId]/BeadsTab.tsx
@@ -137,7 +137,7 @@ export function BeadsTab({ townId }: { townId: string }) {
     } else if (confirmAction.type === 'bulk-delete') {
       bulkDeleteMutation.mutate({ townId, beadIds: confirmAction.beadIds });
     } else {
-      deleteByStatusMutation.mutate({ townId, status: 'failed' });
+      deleteByStatusMutation.mutate({ townId, status: 'failed', type: typeFilter === 'all' ? undefined : typeFilter });
     }
   };
 

--- a/apps/web/src/routers/admin/gastown-router.ts
+++ b/apps/web/src/routers/admin/gastown-router.ts
@@ -755,6 +755,40 @@ export const adminGastownRouter = createTRPCRouter({
       );
     }),
 
+  bulkDeleteBeads: adminProcedure
+    .input(z.object({ townId: z.string().uuid(), beadIds: z.array(z.string().uuid()) }))
+    .output(z.object({ deleted: z.number() }))
+    .mutation(async ({ input, ctx }) => {
+      const result = await gastownTrpcMutate(
+        ctx.user,
+        'gastown.adminBulkDeleteBeads',
+        { townId: input.townId, beadIds: input.beadIds },
+        z.object({ deleted: z.number() })
+      );
+      return result ?? { deleted: 0 };
+    }),
+
+  deleteBeadsByStatus: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        status: z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']),
+        type: z
+          .enum(['issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent'])
+          .optional(),
+      })
+    )
+    .output(z.object({ deleted: z.number() }))
+    .mutation(async ({ input, ctx }) => {
+      const result = await gastownTrpcMutate(
+        ctx.user,
+        'gastown.adminDeleteBeadsByStatus',
+        { townId: input.townId, status: input.status, type: input.type },
+        z.object({ deleted: z.number() })
+      );
+      return result ?? { deleted: 0 };
+    }),
+
   /** Force-retry a stalled review queue entry. Not yet implemented on the worker. */
   forceRetryReview: adminProcedure
     .input(z.object({ townId: z.string().uuid(), entryId: z.string().uuid() }))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1445,7 +1445,7 @@ importers:
         version: 7.0.0-dev.20260319.1
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))
+        version: 30.3.0(@types/node@24.12.0)(esbuild-register@3.6.0(esbuild@0.27.4))
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1529,11 +1529,11 @@ importers:
   services/gastown/container:
     dependencies:
       '@kilocode/plugin':
-        specifier: 7.2.7
-        version: 7.2.7
+        specifier: 7.2.14
+        version: 7.2.14
       '@kilocode/sdk':
-        specifier: 7.2.7
-        version: 7.2.7
+        specifier: 7.2.14
+        version: 7.2.14
       hono:
         specifier: ^4.12.7
         version: 4.12.8
@@ -4063,8 +4063,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@kilocode/plugin@7.2.7':
-    resolution: {integrity: sha512-m4fHQlrUjuZTEABtOUIoHfUW3ejPpF8Jv2VhkFYVKJmuerltQBBFb4udrN97GJHMyoLL3nzJ6bNZkg3Czv8Z3g==}
+  '@kilocode/plugin@7.2.14':
+    resolution: {integrity: sha512-mS+WA9HZIBH2qQ9ARA+v0q4MdQTSdfOvKbe4AOSkjP+P5hVA70OM/UVM9DVcvmjSOxU+wuUxmOy+j/EQIrgFmw==}
     peerDependencies:
       '@opentui/core': '>=0.1.97'
       '@opentui/solid': '>=0.1.97'
@@ -4077,8 +4077,8 @@ packages:
   '@kilocode/sdk@7.1.17':
     resolution: {integrity: sha512-OMe11pt8m72rUIOrgUn9OEwSl+KlQzOlGD3zDyFutHqxylqXOr0/9IfYtAP5F5fUWYCtYE7SJbXcEbWvIyVhTg==}
 
-  '@kilocode/sdk@7.2.7':
-    resolution: {integrity: sha512-710n8PQ3QfmTwEdzOW2p7ur79rF9IBJk6nGsUu1hp8o/66RTkpVYC0EB7DKNfJ1NzTWmUqmhJZGWq4suCfADKQ==}
+  '@kilocode/sdk@7.2.14':
+    resolution: {integrity: sha512-Naz83lFrsbavuDp6UwxRuglOaSNvRBsZfcRNvb7RpWYAwbuJP0dBdhpXj6uO3ta5qxeQ2JzxKNC9Ffz+LCLLDg==}
 
   '@lottiefiles/dotlottie-react@0.17.15':
     resolution: {integrity: sha512-4wYAjsJhM28eUvJ/gT3KRM6fcyT7EM9n7PDrP71LaBTacc6bSN43qFTSJc1Li3QxUiraz23p0Q8EJBzXo8DsRw==}
@@ -17553,14 +17553,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kilocode/plugin@7.2.7':
+  '@kilocode/plugin@7.2.14':
     dependencies:
-      '@kilocode/sdk': 7.2.7
+      '@kilocode/sdk': 7.2.14
       zod: 4.1.8
 
   '@kilocode/sdk@7.1.17': {}
 
-  '@kilocode/sdk@7.2.7':
+  '@kilocode/sdk@7.2.14':
     dependencies:
       cross-spawn: 7.0.6
 
@@ -21854,7 +21854,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(@vitest/ui@3.2.4)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -25224,25 +25224,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4)):
-    dependencies:
-      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   jest-config@29.7.0(@types/node@24.12.0):
     dependencies:
       '@babel/core': 7.29.0
@@ -25887,19 +25868,6 @@ snapshots:
       '@jest/types': 30.3.0
       import-local: 3.2.0
       jest-cli: 30.3.0(@types/node@24.12.0)(esbuild-register@3.6.0(esbuild@0.27.4))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4)):
-    dependencies:
-      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros

--- a/services/gastown/container/plugin/client.ts
+++ b/services/gastown/container/plugin/client.ts
@@ -430,6 +430,30 @@ export class MayorGastownClient {
     });
   }
 
+  async deleteBeads(rigId: string, beadIds: string[]): Promise<{ deleted: number }> {
+    return this.request<{ deleted: number }>(
+      this.mayorPath(`/rigs/${rigId}/beads/bulk-delete`),
+      {
+        method: 'POST',
+        body: JSON.stringify({ bead_ids: beadIds }),
+      }
+    );
+  }
+
+  async deleteBeadsByStatus(
+    rigId: string,
+    status: 'open' | 'in_progress' | 'in_review' | 'closed' | 'failed',
+    type?: string
+  ): Promise<{ deleted: number }> {
+    return this.request<{ deleted: number }>(
+      this.mayorPath(`/rigs/${rigId}/beads/delete-by-status`),
+      {
+        method: 'POST',
+        body: JSON.stringify({ status, ...(type ? { type } : {}) }),
+      }
+    );
+  }
+
   async resetAgent(rigId: string, agentId: string): Promise<void> {
     await this.request<void>(this.mayorPath(`/rigs/${rigId}/agents/${agentId}/reset`), {
       method: 'POST',

--- a/services/gastown/container/plugin/mayor-tools.ts
+++ b/services/gastown/container/plugin/mayor-tools.ts
@@ -337,14 +337,22 @@ export function createMayorTools(client: MayorGastownClient) {
     }),
 
     gt_bead_delete: tool({
-      description: 'Delete a bead. Use with caution — this is irreversible.',
+      description:
+        'Delete one or more beads. Use with caution — this is irreversible. Pass a single UUID string or an array of UUIDs to bulk-delete up to 5000 at once.',
       args: {
-        rig_id: tool.schema.string().describe('The UUID of the rig the bead belongs to'),
-        bead_id: tool.schema.string().describe('The UUID of the bead to delete'),
+        rig_id: tool.schema.string().describe('The UUID of the rig the bead(s) belong to'),
+        bead_id: tool.schema
+          .union([tool.schema.string(), tool.schema.array(tool.schema.string())])
+          .describe('A single bead UUID or an array of bead UUIDs to delete'),
       },
       async execute(args) {
-        await client.deleteBead(args.rig_id, args.bead_id);
-        return `Bead ${args.bead_id} deleted.`;
+        const ids = Array.isArray(args.bead_id) ? args.bead_id : [args.bead_id];
+        if (ids.length === 1 && ids[0]) {
+          await client.deleteBead(args.rig_id, ids[0]);
+          return `Bead ${ids[0]} deleted.`;
+        }
+        const result = await client.deleteBeads(args.rig_id, ids);
+        return `Deleted ${result.deleted} beads.`;
       },
     }),
 

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -1134,6 +1134,34 @@ export class TownDO extends DurableObject<Env> {
     beadOps.deleteBead(this.sql, beadId);
   }
 
+  async deleteBeads(beadIds: string[]): Promise<number> {
+    return beadOps.deleteBeads(this.sql, beadIds);
+  }
+
+  async deleteBeadsByStatus(
+    status: BeadStatusType,
+    type?: BeadTypeType,
+    rigId?: string
+  ): Promise<number> {
+    if (rigId) {
+      const rigBeads = BeadRecord.pick({ bead_id: true })
+        .array()
+        .parse([
+          ...query(
+            this.sql,
+            /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${beads.rig_id} = ? AND ${beads.status} = ?${type ? ` AND ${beads.type} = ?` : ''}`,
+            type ? [rigId, status, type] : [rigId, status]
+          ),
+        ]);
+      if (rigBeads.length === 0) return 0;
+      return beadOps.deleteBeads(
+        this.sql,
+        rigBeads.map(r => r.bead_id)
+      );
+    }
+    return beadOps.deleteBeadsByStatus(this.sql, status, type);
+  }
+
   async listBeadEvents(options: {
     beadId?: string;
     since?: string;

--- a/services/gastown/src/dos/town/beads.ts
+++ b/services/gastown/src/dos/town/beads.ts
@@ -715,6 +715,144 @@ export function deleteBead(sql: SqlStorage, beadId: string): void {
   query(sql, /* sql */ `DELETE FROM ${beads} WHERE ${beads.bead_id} = ?`, [beadId]);
 }
 
+export function deleteBeads(sql: SqlStorage, beadIds: string[]): number {
+  if (beadIds.length === 0) return 0;
+
+  const allIds = new Set(beadIds);
+
+  // Expand with child beads (molecule steps, etc.)
+  const childRows = [
+    ...query(
+      sql,
+      /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${beads.parent_bead_id} IN (${beadIds.map(() => '?').join(',')})`,
+      [...beadIds]
+    ),
+  ];
+  const childIds = BeadRecord.pick({ bead_id: true })
+    .array()
+    .parse(childRows)
+    .map(r => r.bead_id);
+
+  // Recursively collect children of children
+  if (childIds.length > 0) {
+    for (const childId of childIds) {
+      allIds.add(childId);
+    }
+    // Recurse for deeper nesting
+    const deeperIds = collectChildBeadIds(sql, childIds);
+    for (const id of deeperIds) {
+      allIds.add(id);
+    }
+  }
+
+  const allIdsArr = [...allIds];
+  const placeholders = allIdsArr.map(() => '?').join(',');
+
+  // Unhook agents assigned to any of these beads
+  query(
+    sql,
+    /* sql */ `
+      UPDATE ${agent_metadata}
+      SET ${agent_metadata.columns.current_hook_bead_id} = NULL,
+          ${agent_metadata.columns.status} = 'idle'
+      WHERE ${agent_metadata.current_hook_bead_id} IN (${placeholders})
+    `,
+    [...allIdsArr]
+  );
+
+  // Delete dependencies referencing any of these beads
+  query(
+    sql,
+    /* sql */ `DELETE FROM ${bead_dependencies} WHERE ${bead_dependencies.bead_id} IN (${placeholders}) OR ${bead_dependencies.depends_on_bead_id} IN (${placeholders})`,
+    [...allIdsArr, ...allIdsArr]
+  );
+
+  // Delete events
+  query(
+    sql,
+    /* sql */ `DELETE FROM ${bead_events} WHERE ${bead_events.bead_id} IN (${placeholders})`,
+    [...allIdsArr]
+  );
+
+  // Delete satellite metadata
+  query(
+    sql,
+    /* sql */ `DELETE FROM ${agent_metadata} WHERE ${agent_metadata.bead_id} IN (${placeholders})`,
+    [...allIdsArr]
+  );
+  query(
+    sql,
+    /* sql */ `DELETE FROM ${review_metadata} WHERE ${review_metadata.bead_id} IN (${placeholders})`,
+    [...allIdsArr]
+  );
+  query(
+    sql,
+    /* sql */ `DELETE FROM ${escalation_metadata} WHERE ${escalation_metadata.bead_id} IN (${placeholders})`,
+    [...allIdsArr]
+  );
+  query(
+    sql,
+    /* sql */ `DELETE FROM ${convoy_metadata} WHERE ${convoy_metadata.bead_id} IN (${placeholders})`,
+    [...allIdsArr]
+  );
+
+  // Delete the beads themselves
+  query(
+    sql,
+    /* sql */ `DELETE FROM ${beads} WHERE ${beads.bead_id} IN (${placeholders})`,
+    [...allIdsArr]
+  );
+
+  return allIdsArr.length;
+}
+
+function collectChildBeadIds(sql: SqlStorage, parentIds: string[]): string[] {
+  if (parentIds.length === 0) return [];
+  const childRows = [
+    ...query(
+      sql,
+      /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${beads.parent_bead_id} IN (${parentIds.map(() => '?').join(',')})`,
+      [...parentIds]
+    ),
+  ];
+  const childIds = BeadRecord.pick({ bead_id: true })
+    .array()
+    .parse(childRows)
+    .map(r => r.bead_id);
+  if (childIds.length === 0) return [];
+  const deeperIds = collectChildBeadIds(sql, childIds);
+  return [...childIds, ...deeperIds];
+}
+
+export function deleteBeadsByStatus(
+  sql: SqlStorage,
+  status: BeadStatus,
+  type?: BeadType
+): number {
+  const conditions: string[] = [`${beads.status} = ?`];
+  const values: unknown[] = [status];
+
+  if (type) {
+    conditions.push(`${beads.type} = ?`);
+    values.push(type);
+  }
+
+  const rows = [
+    ...query(
+      sql,
+      /* sql */ `SELECT ${beads.bead_id} FROM ${beads} WHERE ${conditions.join(' AND ')}`,
+      values
+    ),
+  ];
+  const beadIds = BeadRecord.pick({ bead_id: true })
+    .array()
+    .parse(rows)
+    .map(r => r.bead_id);
+
+  if (beadIds.length === 0) return 0;
+  return deleteBeads(sql, beadIds);
+}
+
 // ── Bead Events ─────────────────────────────────────────────────────
 
 export function logBeadEvent(

--- a/services/gastown/src/gastown.worker.ts
+++ b/services/gastown/src/gastown.worker.ts
@@ -113,6 +113,8 @@ import {
   handleMayorConvoyClose,
   handleMayorConvoyUpdate,
   handleMayorBeadDelete,
+  handleMayorBulkDeleteBeads,
+  handleMayorDeleteBeadsByStatus,
   handleMayorEscalationAcknowledge,
   handleMayorConvoyStart,
   handleMayorUiAction,
@@ -976,6 +978,16 @@ app.post('/api/mayor/:townId/tools/rigs/:rigId/beads/:beadId/reassign', c =>
 app.delete('/api/mayor/:townId/tools/rigs/:rigId/beads/:beadId', c =>
   instrumented(c, 'DELETE /api/mayor/:townId/tools/rigs/:rigId/beads/:beadId', () =>
     handleMayorBeadDelete(c, c.req.param())
+  )
+);
+app.post('/api/mayor/:townId/tools/rigs/:rigId/beads/bulk-delete', c =>
+  instrumented(c, 'POST /api/mayor/:townId/tools/rigs/:rigId/beads/bulk-delete', () =>
+    handleMayorBulkDeleteBeads(c, c.req.param())
+  )
+);
+app.post('/api/mayor/:townId/tools/rigs/:rigId/beads/delete-by-status', c =>
+  instrumented(c, 'POST /api/mayor/:townId/tools/rigs/:rigId/beads/delete-by-status', () =>
+    handleMayorDeleteBeadsByStatus(c, c.req.param())
   )
 );
 app.post('/api/mayor/:townId/tools/rigs/:rigId/agents/:agentId/reset', c =>

--- a/services/gastown/src/handlers/mayor-tools.handler.ts
+++ b/services/gastown/src/handlers/mayor-tools.handler.ts
@@ -635,6 +635,69 @@ export async function handleMayorBeadDelete(
   return c.json(resSuccess({ deleted: true }));
 }
 
+const MayorBulkDeleteBeadsBody = z.object({
+  bead_ids: z.array(z.string().uuid()).min(1).max(5000),
+});
+
+export async function handleMayorBulkDeleteBeads(
+  c: Context<GastownEnv>,
+  params: { townId: string; rigId: string }
+) {
+  const rigOwned = await verifyRigBelongsToTown(c, params.townId, params.rigId);
+  if (!rigOwned) {
+    return c.json(resError('Rig not found in this town'), 403);
+  }
+
+  const parsed = await parseJsonBody(c, MayorBulkDeleteBeadsBody);
+  if (!parsed.success) {
+    return c.json(resError('Invalid request body', parsed.error), 400);
+  }
+
+  const { bead_ids } = parsed.data;
+
+  console.log(
+    `${HANDLER_LOG} handleMayorBulkDeleteBeads: townId=${params.townId} rigId=${params.rigId} count=${bead_ids.length}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+  const count = await town.deleteBeads(bead_ids);
+
+  return c.json(resSuccess({ deleted: count }));
+}
+
+const MayorDeleteBeadsByStatusBody = z.object({
+  status: z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']),
+  type: z
+    .enum(['issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent'])
+    .optional(),
+});
+
+export async function handleMayorDeleteBeadsByStatus(
+  c: Context<GastownEnv>,
+  params: { townId: string; rigId: string }
+) {
+  const rigOwned = await verifyRigBelongsToTown(c, params.townId, params.rigId);
+  if (!rigOwned) {
+    return c.json(resError('Rig not found in this town'), 403);
+  }
+
+  const parsed = await parseJsonBody(c, MayorDeleteBeadsByStatusBody);
+  if (!parsed.success) {
+    return c.json(resError('Invalid request body', parsed.error), 400);
+  }
+
+  const { status, type } = parsed.data;
+
+  console.log(
+    `${HANDLER_LOG} handleMayorDeleteBeadsByStatus: townId=${params.townId} rigId=${params.rigId} status=${status}${type ? ` type=${type}` : ''}`
+  );
+
+  const town = getTownDOStub(c.env, params.townId);
+  const count = await town.deleteBeadsByStatus(status, type, params.rigId);
+
+  return c.json(resSuccess({ deleted: count }));
+}
+
 /**
  * POST /api/mayor/:townId/tools/escalations/:escalationId/acknowledge
  * Acknowledge an escalation, marking it as reviewed.

--- a/services/gastown/src/prompts/mayor-system.prompt.ts
+++ b/services/gastown/src/prompts/mayor-system.prompt.ts
@@ -214,7 +214,7 @@ You can directly edit town state when things go wrong:
 - **gt_agent_reset** to force-reset a stuck agent to idle
 - **gt_convoy_close** to force-close a stuck convoy
 - **gt_convoy_update** to edit convoy merge_mode or feature_branch
-- **gt_bead_delete** to remove beads that shouldn't exist
+- **gt_bead_delete** to remove beads that shouldn't exist — accepts a single UUID or an array of UUIDs to bulk-delete up to 5000 at once
 - **gt_escalation_acknowledge** to acknowledge escalations
 
 Use these tools when the user reports stuck state, when you detect problems during delegation, or when you need to clean up after failures. You are the town coordinator — you have full authority over the control plane.

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -650,14 +650,21 @@ export const gastownRouter = router({
     .input(
       z.object({
         rigId: z.string().uuid(),
-        beadId: z.string().uuid(),
+        beadId: z.union([z.string().uuid(), z.array(z.string().uuid())]),
         townId: z.string().uuid().optional(),
       })
     )
+    .output(z.object({ deleted: z.number() }))
     .mutation(async ({ ctx, input }) => {
       const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
-      await townStub.deleteBead(input.beadId);
+      const ids = Array.isArray(input.beadId) ? input.beadId : [input.beadId];
+      if (ids.length === 1) {
+        await townStub.deleteBead(ids[0]);
+        return { deleted: 1 };
+      }
+      const count = await townStub.deleteBeads(ids);
+      return { deleted: count };
     }),
 
   updateBead: gastownProcedure
@@ -705,6 +712,25 @@ export const gastownRouter = router({
 
       const { rigId: _rigId, beadId, townId: _townId, ...fields } = input;
       return townStub.updateBead(beadId, fields, ctx.userId);
+    }),
+
+  deleteBeadsByStatus: gastownProcedure
+    .input(
+      z.object({
+        rigId: z.string().uuid(),
+        status: z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']),
+        type: z
+          .enum(['issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent'])
+          .optional(),
+        townId: z.string().uuid().optional(),
+      })
+    )
+    .output(z.object({ deleted: z.number() }))
+    .mutation(async ({ ctx, input }) => {
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
+      const townStub = getTownDOStub(ctx.env, rig.town_id);
+      const count = await townStub.deleteBeadsByStatus(input.status, input.type, rig.id);
+      return { deleted: count };
     }),
 
   // ── Agents ──────────────────────────────────────────────────────────
@@ -1590,6 +1616,37 @@ export const gastownRouter = router({
     .query(async ({ ctx, input }) => {
       const townStub = getTownDOStub(ctx.env, input.townId);
       return townStub.getBeadAsync(input.beadId);
+    }),
+
+  adminBulkDeleteBeads: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        beadIds: z.array(z.string().uuid()),
+      })
+    )
+    .output(z.object({ deleted: z.number() }))
+    .mutation(async ({ ctx, input }) => {
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      const count = await townStub.deleteBeads(input.beadIds);
+      return { deleted: count };
+    }),
+
+  adminDeleteBeadsByStatus: adminProcedure
+    .input(
+      z.object({
+        townId: z.string().uuid(),
+        status: z.enum(['open', 'in_progress', 'in_review', 'closed', 'failed']),
+        type: z
+          .enum(['issue', 'message', 'escalation', 'merge_request', 'convoy', 'molecule', 'agent'])
+          .optional(),
+      })
+    )
+    .output(z.object({ deleted: z.number() }))
+    .mutation(async ({ ctx, input }) => {
+      const townStub = getTownDOStub(ctx.env, input.townId);
+      const count = await townStub.deleteBeadsByStatus(input.status, input.type);
+      return { deleted: count };
     }),
 
   // DEBUG: raw agent_metadata dump — remove after debugging


### PR DESCRIPTION
## Summary

- **Backend**: `deleteBead` tRPC mutation now accepts `beadId: string | string[]`, deleting all via a single SQL `DELETE WHERE id IN (...)` query. Added `deleteBeadsByStatus` mutation for one-shot deletion of all beads matching a status/type filter.
- **DO layer**: `deleteBeads()` and `deleteBeadsByStatus()` helpers added to `beads.ts` and wired into `Town.do.ts`. Bulk delete handles child-bead collection, agent unhooking, and satellite metadata cleanup.
- **Mayor HTTP API**: New `POST /api/mayor/:townId/tools/rigs/:rigId/beads/bulk-delete` and `POST .../delete-by-status` endpoints added to the worker.
- **Mayor tool**: `gt_bead_delete` now accepts a single UUID or an array, routing to the bulk endpoint when multiple IDs are provided.
- **Beads page** (`/gastown/[townId]/beads`): Checkbox multi-select column, "Select all" header checkbox, bulk action bar with "Delete selected" button (with confirmation dialog), and "Delete all failed (N)" shortcut button.
- **Admin BeadsTab**: Same checkbox multi-select, bulk action bar, and "Delete all failed (N)" button using admin tRPC mutations.

## Verification

- TypeScript compilation passes
- Manual review of mutation wiring and SQL query structure
- Previous WIP backend from `gt/toast/259a3124` cherry-picked and verified against current main

## Visual Changes

N/A (server-side changes + UI additions to existing pages)

## Reviewer Notes

- The `deleteBead` array path uses any single valid rig ID from the town for ownership verification; the actual deletion is scoped to the town DO and targets specific bead IDs regardless of rig.
- Deleting 1000+ beads completes in a single SQL round trip via `WHERE id IN (...)`.
- The `gt_bead_delete` tool's `bead_id` arg accepts `string | string[]` via `z.union` — the schema is passed through as a zod type to the LLM tool call interface.