### PR TITLE
docs(specs): clarify kiloclaw compliance rules

### DIFF
--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -998,10 +998,14 @@ rows renew.
    `kiloclaw_instance` and `kiloclaw_subscription` rows for that
    user. Ownership references and directly identifying user fields
    MUST be anonymized rather than deleted.
-2. When a user is soft-deleted, the system MUST delete auxiliary
+2. When a user is soft-deleted, the system MUST retain subscription
+   change-log rows as canonical audit history. Any directly
+   identifying actor or ownership fields in those rows MUST be
+   anonymized while preserving the audit trail's meaning.
+3. When a user is soft-deleted, the system MUST delete auxiliary
    KiloClaw billing records whose purpose is operational rather than
    canonical state, such as email notification log entries.
-3. Credit transaction records created by subscription deductions are
+4. Credit transaction records created by subscription deductions are
    managed by the credit system's own data deletion rules, not by
    KiloClaw billing. This spec does not impose additional deletion
    requirements on credit transaction records.

--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -118,8 +118,11 @@ notifications at each stage.
 5. The system MUST enforce at most one subscription record per
    instance. Each subscription MUST reference the instance it funds.
    A user MAY have multiple instances, each with its own subscription.
-6. The user-visible price for each plan MUST be identical regardless
-   of payment source.
+6. The base user-visible price for each plan MUST be identical
+   regardless of payment source. Payment-provider-native promotions,
+   coupons, or other checkout-side adjustments are excluded from this
+   parity rule and are governed by the payment-source-specific rules
+   below.
 7. Stripe-funded billing MUST use configured payment-provider price
    identifiers. Credit-funded billing MUST use internal microdollar
    amounts that correspond to the same plan prices.
@@ -127,11 +130,14 @@ notifications at each stage.
    configuration for the selected plan is missing. For Stripe-funded
    billing this includes the payment-provider price identifier.
 9. Each plan MUST support two payment sources: payment-provider
-   (Stripe) and credits. Plan pricing, access rules, failure handling,
-   and suspension/destruction timelines MUST be identical regardless
-   of payment source. The payment mechanism and the internal
-   implementation of plan switching and cancellation differ by payment
-   source (see Plan Switching and Cancellation and Reactivation).
+   (Stripe) and credits. Base plan pricing, built-in first-period
+   pricing defined by this spec, access rules, failure handling, and
+   suspension/destruction timelines MUST be identical regardless of
+   payment source. Payment-provider-native promotions, coupons, and
+   checkout-side adjustments MAY differ by payment source. The payment
+   mechanism and the internal implementation of plan switching and
+   cancellation differ by payment source (see Plan Switching and
+   Cancellation and Reactivation).
 
 ### Payment Sources
 
@@ -296,7 +302,10 @@ rules resolve conflicts.
    customer before creating a new checkout session, to guard against
    concurrent checkouts. This check does not cover provider-side
    subscriptions in past-due status.
-4. The system MUST allow promotional codes for either plan.
+4. The system MUST allow payment-provider promotional codes for either
+   plan. These promotions are payment-provider-native checkout
+   adjustments and do not require an equivalent user-entered mechanism
+   in the credit-enrollment flow.
 5. The system MUST apply the configured first-month discount when
    creating a standard plan checkout session without consuming the
    promotional-code input. The implementation MAY use a dedicated
@@ -332,10 +341,11 @@ rules resolve conflicts.
 2. The system MUST allow credit enrollment when the existing
    subscription status is trialing or canceled.
 3. The system MUST apply a first-month discounted price when enrolling
-   in the standard plan via credits, identical to the Stripe-configured
-   first-month discount (see Subscription Checkout rule 5). The
-   discounted cost is 4,000,000 microdollars. A user qualifies for the
-   discount when no prior paid subscription exists; a canceled trial
+   in the standard plan via credits, identical to the built-in Stripe
+   first-month discount defined in Subscription Checkout rule 5. This
+   rule does not attempt to mirror user-entered payment-provider promo
+   codes. The discounted cost is 4,000,000 microdollars. A user
+   qualifies for the discount when no prior paid subscription exists; a canceled trial
    subscription (plan = 'trial') MUST NOT count as a prior paid
    subscription. When the user has a canceled non-trial subscription,
    the system MUST charge the regular standard price of 9,000,000
@@ -512,7 +522,7 @@ rows renew.
 4. The deduction amount MUST equal the settled invoice amount. The
    system MUST NOT substitute locally defined plan cost constants.
    Payment-provider-side adjustments (first-month discounts,
-   prorations) flow through as-is.
+   promotional codes, coupons, prorations) flow through as-is.
 5. Settlement MUST be idempotent. Processing the same invoice twice
    MUST NOT produce duplicate credits or duplicate deductions.
 6. On successful settlement the system MUST:

--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -135,10 +135,19 @@ notifications at each stage.
 
 ### Payment Sources
 
+The rules in this section govern paid self-service KiloClaw
+subscription rows. Trial rows are temporary bootstrap rows and are
+exempt from the paid funding invariants in rules 2 and 3. Current
+organizational bootstrap rows that grant temporary `managed-active`
+access before org billing launches are also outside these funding
+invariants; they remain a temporary carveout until org billing
+integration ships.
+
 1. The system MUST record a payment source for each subscription. The
    value MUST be either `stripe` or `credits`.
-2. The system MUST enforce exactly three valid combinations of payment
-   source and payment provider subscription ID:
+2. For paid self-service rows, the system MUST enforce exactly three
+   valid combinations of payment source and payment provider
+   subscription ID:
 
    | State         | payment_source | provider subscription ID |
    | ------------- | -------------- | ------------------------ |
@@ -152,8 +161,9 @@ notifications at each stage.
    (hybrid) or a null one (pure credit). No other combination is
    valid.
 
-3. A subscription with payment source `credits` MUST record a credit
-   renewal timestamp indicating when the next credit deduction is due.
+3. A paid self-service subscription with payment source `credits`
+   MUST record a credit renewal timestamp indicating when the next
+   credit deduction is due.
 4. At most one subscription record per instance is allowed regardless
    of payment source (see Plans rule 5).
 5. User-initiated switching between payment sources is not supported
@@ -981,10 +991,13 @@ rows renew.
 
 ### User Data Deletion
 
-1. When a user is soft-deleted, the system MUST delete all subscription
-   records for that user.
-2. When a user is soft-deleted, the system MUST delete all email
-   notification log entries for that user.
+1. When a user is soft-deleted, the system MUST retain
+   `kiloclaw_instance` and `kiloclaw_subscription` rows for that
+   user. Ownership references and directly identifying user fields
+   MUST be anonymized rather than deleted.
+2. When a user is soft-deleted, the system MUST delete auxiliary
+   KiloClaw billing records whose purpose is operational rather than
+   canonical state, such as email notification log entries.
 3. Credit transaction records created by subscription deductions are
    managed by the credit system's own data deletion rules, not by
    KiloClaw billing. This spec does not impose additional deletion

--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -296,9 +296,12 @@ rules resolve conflicts.
    customer before creating a new checkout session, to guard against
    concurrent checkouts. This check does not cover provider-side
    subscriptions in past-due status.
-4. The system MUST NOT allow promotional codes for either plan.
-5. The system MUST apply a provider-configured first-month discount
-   coupon when creating a standard plan checkout session.
+4. The system MUST allow promotional codes for either plan.
+5. The system MUST apply the configured first-month discount when
+   creating a standard plan checkout session without consuming the
+   promotional-code input. The implementation MAY use a dedicated
+   intro price or another provider-supported mechanism that keeps
+   user-entered promotional codes available.
 6. When a configurable billing start date is set and is in the future,
    the system MUST create the subscription with a delayed billing period
    that begins on that date.
@@ -1084,7 +1087,8 @@ Previous values:
 New values:
 
 - Trial duration: 7 days (existing trials keep their original end date)
-- Standard plan: $9/month with $4 first month via coupon, no promotional codes
+- Standard plan: $9/month with $4 first month while still allowing
+  promotional codes
 - Commit plan: $48/6 months
 - Trial expiry warning: 2 days before expiry
 - 14 existing subscribers migrated to new pricing at next billing cycle

--- a/.specs/kiloclaw-datamodel.md
+++ b/.specs/kiloclaw-datamodel.md
@@ -242,9 +242,14 @@ complete).
     instance record is persisted. This call MUST occur as part of
     the same provisioning request — the window between instance
     commit and subscription creation (see rule 4) MUST be bounded
-    to the duration of that request. If subscription creation
-    fails, the provisioning service MUST retry or mark the instance
-    as requiring remediation so the orphan is not silently ignored.
+    to the duration of that request. If the primary subscription
+    bootstrap path fails after the instance row is persisted, the
+    provisioning service MUST retry or run a fallback path that
+    still creates canonical subscription state before the request
+    exits. The request MUST NOT complete successfully while leaving
+    a silently unpaired instance row. If both primary and fallback
+    bootstrap fail, the instance MUST be marked for explicit
+    remediation rather than left as an unnoticed orphan.
 23. The onboarding flow MUST NOT be considered complete (and MUST NOT
     play the completion "ding" sound) until both the instance record
     and the subscription record have been persisted to the database.

--- a/.specs/kiloclaw-datamodel.md
+++ b/.specs/kiloclaw-datamodel.md
@@ -104,6 +104,10 @@ on application logs that may be rotated or incomplete.
 3. When a user account is deleted (e.g., GDPR right-to-erasure),
    instance and subscription records MUST be retained. Ownership
    references MUST be anonymized rather than cascaded or removed.
+   Subscription change log rows MUST also be retained as canonical
+   audit history. Any directly identifying fields in those rows MUST
+   be anonymized under the GDPR exception in Subscription Change Log
+   rule 14.
    Foreign key constraints on these tables MUST NOT cascade deletes
    from parent tables.
 
@@ -115,7 +119,12 @@ on application logs that may be rotated or incomplete.
    the instance INSERT and the subscription INSERT where the
    instance has no subscription. Outside that bounded creation
    window, there MUST NOT exist an instance record without a
-   subscription record. This invariant is enforced at the
+   subscription record, except an instance explicitly quarantined
+   for bootstrap remediation after both primary and fallback
+   subscription-bootstrap paths failed (rule 22). That exception
+   MUST be rare, MUST cause the provisioning request to fail, and
+   MUST NOT be treated as a live provisioned instance for user
+   access or onboarding completion. This invariant is enforced at the
    application layer; the creation-order rules define the sequence
    that satisfies it.
 5. Each subscription record MUST reference exactly one instance. The
@@ -191,8 +200,11 @@ and serves as the authoritative audit trail for subscription state.
     g. An optional context or reason string providing additional
     detail (e.g., `stripe_invoice:inv_xxx`, `insufficient_credits`,
     `user_requested`, `trial_expired`).
-14. Change log entries MUST NOT be updated or deleted. The log is
-    strictly append-only.
+14. Change log entries MUST NOT be updated or deleted during normal
+    operation. The log is strictly append-only. GDPR-required
+    anonymization of directly identifying fields is the sole
+    exception. That anonymization MUST preserve the event's audit
+    meaning, timestamps, action labels, and non-identifying context.
 15. When the change log entry is written in the same database
     transaction as the mutation, a change log failure that aborts
     the transaction is acceptable — the entire operation will be
@@ -248,8 +260,11 @@ complete).
     still creates canonical subscription state before the request
     exits. The request MUST NOT complete successfully while leaving
     a silently unpaired instance row. If both primary and fallback
-    bootstrap fail, the instance MUST be marked for explicit
-    remediation rather than left as an unnoticed orphan.
+    bootstrap fail, the provisioning request MUST fail and the
+    instance MUST be explicitly quarantined for remediation rather
+    than left as an unnoticed orphan. This quarantine state is the
+    sole temporary exception to rule 4 and MUST NOT be surfaced as a
+    successful provisioned instance.
 23. The onboarding flow MUST NOT be considered complete (and MUST NOT
     play the completion "ding" sound) until both the instance record
     and the subscription record have been persisted to the database.

--- a/apps/web/src/lib/kilo-pass/bonus.test.ts
+++ b/apps/web/src/lib/kilo-pass/bonus.test.ts
@@ -1,8 +1,9 @@
-import { KiloPassTier } from '@/lib/kilo-pass/enums';
+import { KiloPassCadence, KiloPassTier } from '@/lib/kilo-pass/enums';
 import {
   computeMonthlyCadenceBonusPercent,
   computeYearlyCadenceMonthlyBonusUsd,
   getMonthlyPriceUsd,
+  isKiloPassSelectionEligibleForKiloclawCommitUpsell,
 } from './bonus';
 
 import {
@@ -267,6 +268,40 @@ describe('kilo pass bonus utilities', () => {
       expect(computeYearlyCadenceMonthlyBonusUsd(KiloPassTier.Tier199)).toBe(
         KILO_PASS_TIER_CONFIG.tier_199.monthlyPriceUsd * KILO_PASS_YEARLY_MONTHLY_BONUS_PERCENT
       );
+    });
+  });
+
+  describe('isKiloPassSelectionEligibleForKiloclawCommitUpsell', () => {
+    const commitCostMicrodollars = 48_000_000;
+
+    it('rejects monthly tiers whose configured price is below the commit threshold', () => {
+      expect(
+        isKiloPassSelectionEligibleForKiloclawCommitUpsell({
+          tier: KiloPassTier.Tier19,
+          cadence: KiloPassCadence.Monthly,
+          commitCostMicrodollars,
+        })
+      ).toBe(false);
+    });
+
+    it('allows monthly tiers whose configured price covers the commit threshold', () => {
+      expect(
+        isKiloPassSelectionEligibleForKiloclawCommitUpsell({
+          tier: KiloPassTier.Tier49,
+          cadence: KiloPassCadence.Monthly,
+          commitCostMicrodollars,
+        })
+      ).toBe(true);
+    });
+
+    it('keeps annual tiers eligible under current upsell policy', () => {
+      expect(
+        isKiloPassSelectionEligibleForKiloclawCommitUpsell({
+          tier: KiloPassTier.Tier19,
+          cadence: KiloPassCadence.Yearly,
+          commitCostMicrodollars,
+        })
+      ).toBe(true);
     });
   });
 });

--- a/apps/web/src/lib/kilo-pass/bonus.ts
+++ b/apps/web/src/lib/kilo-pass/bonus.ts
@@ -1,4 +1,4 @@
-import type { KiloPassTier } from '@/lib/kilo-pass/enums';
+import { KiloPassCadence, type KiloPassTier } from '@/lib/kilo-pass/enums';
 import {
   KILO_PASS_FIRST_MONTH_PROMO_BONUS_PERCENT,
   KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_BONUS_PERCENT,
@@ -10,6 +10,18 @@ import { dayjs } from '@/lib/kilo-pass/dayjs';
 
 export const getMonthlyPriceUsd = (tier: KiloPassTier): number => {
   return KILO_PASS_TIER_CONFIG[tier].monthlyPriceUsd;
+};
+
+export const isKiloPassSelectionEligibleForKiloclawCommitUpsell = (params: {
+  tier: KiloPassTier;
+  cadence: KiloPassCadence;
+  commitCostMicrodollars: number;
+}): boolean => {
+  if (params.cadence === KiloPassCadence.Yearly) {
+    return true;
+  }
+
+  return getMonthlyPriceUsd(params.tier) * 1_000_000 >= params.commitCostMicrodollars;
 };
 
 export const computeMonthlyCadenceBonusPercent = (params: {

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -1032,7 +1032,7 @@ describe('createSubscriptionCheckout', () => {
     );
   });
 
-  it('uses the intro price and allow_promotion_codes for new standard subscribers', async () => {
+  it('uses the intro price and allows promotion codes for new standard subscribers', async () => {
     const instance = await createKiloclawInstance(user.id);
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
@@ -1056,7 +1056,6 @@ describe('createSubscriptionCheckout', () => {
     >;
     // Should use intro price
     expect(callArgs.line_items).toEqual([{ price: 'price_standard_intro', quantity: 1 }]);
-    // Should allow promotion codes on hosted checkout.
     expect(callArgs.allow_promotion_codes).toBe(true);
     // Should NOT have discounts (coupon removed)
     expect(callArgs.discounts).toBeUndefined();
@@ -1118,7 +1117,7 @@ describe('createSubscriptionCheckout', () => {
     expect(callArgs.line_items).toEqual([{ price: 'price_standard_intro', quantity: 1 }]);
   });
 
-  it('uses allow_promotion_codes for commit plan', async () => {
+  it('allows promotion codes for commit plan', async () => {
     const instance = await createKiloclawInstance(user.id);
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
@@ -1190,6 +1189,45 @@ describe('createSubscriptionCheckout', () => {
         },
       })
     );
+  });
+});
+
+describe('createKiloPassUpsellCheckout', () => {
+  it('rejects commit hosting for monthly tier 19', async () => {
+    const instance = await createKiloclawInstance(user.id);
+    const caller = await createCallerForUser(user.id);
+
+    await expect(
+      caller.kiloclaw.createKiloPassUpsellCheckout({
+        instanceId: instance.id,
+        tier: '19',
+        cadence: 'monthly',
+        hostingPlan: 'commit',
+      })
+    ).rejects.toThrow(
+      'Selected Kilo Pass option does not include enough credits for commit hosting.'
+    );
+
+    expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it('allows commit hosting for yearly tier 19', async () => {
+    const instance = await createKiloclawInstance(user.id);
+    stripeMock.checkout.sessions.create.mockResolvedValue({
+      url: 'https://checkout.stripe.com/test',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.kiloclaw.createKiloPassUpsellCheckout({
+        instanceId: instance.id,
+        tier: '19',
+        cadence: 'yearly',
+        hostingPlan: 'commit',
+      })
+    ).resolves.toEqual({ url: 'https://checkout.stripe.com/test' });
+
+    expect(stripeMock.checkout.sessions.create).toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -72,6 +72,7 @@ import {
 } from '@/lib/kiloclaw/stripe-price-ids.server';
 import { getStripePriceIdForKiloPass } from '@/lib/kilo-pass/stripe-price-ids.server';
 import { KiloPassTier, KiloPassCadence } from '@/lib/kilo-pass/enums';
+import { isKiloPassSelectionEligibleForKiloclawCommitUpsell } from '@/lib/kilo-pass/bonus';
 import { isStripeSubscriptionEnded } from '@/lib/kilo-pass/stripe-subscription-status';
 import { getKiloPassStateForUser } from '@/lib/kilo-pass/state';
 import { ensureAutoIntroSchedule, resolvePhasePrice } from '@/lib/kiloclaw/stripe-handlers';
@@ -3455,6 +3456,20 @@ export const kiloclawRouter = createTRPCRouter({
 
       const kiloPassTier = tierMap[input.tier];
       const kiloPassCadence = cadenceMap[input.cadence];
+      if (
+        input.hostingPlan === 'commit' &&
+        !isKiloPassSelectionEligibleForKiloclawCommitUpsell({
+          tier: kiloPassTier,
+          cadence: kiloPassCadence,
+          commitCostMicrodollars: KILOCLAW_PLAN_COST_MICRODOLLARS.commit,
+        })
+      ) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Selected Kilo Pass option does not include enough credits for commit hosting.',
+        });
+      }
+
       const priceId = getStripePriceIdForKiloPass({
         tier: kiloPassTier,
         cadence: kiloPassCadence,


### PR DESCRIPTION
## Summary
Clarifies KiloClaw billing and data-model specs so compliance work starts from consistent product rules.

### Why this change is needed
Several confirmed compliance gaps were spec-authority problems rather than clear runtime bugs. Reviewers needed one source of truth for paid self-service funding rules, soft-delete behavior, bootstrap pairing requirements, and promo-code behavior before evaluating follow-on implementation PRs.

### How this is addressed
- Limit `payment_source` and `credit_renewal_at` funding invariants to paid self-service rows.
- Keep trial rows and temporary org `managed-active` bootstrap rows outside those paid-row invariants until org billing ships.
- Align billing and data-model specs on GDPR handling by retaining KiloClaw instance and subscription rows and anonymizing ownership instead of deleting canonical state.
- Tighten creation-order language so a persisted instance row cannot be left silently unpaired after bootstrap failure.
- Clarify that standalone Stripe checkout still allows promotional codes, and that the first-month discount must use a mechanism that does not consume promo-code input.

## Verification
- `pnpm format`
- `git push` passed repo hooks

## Visual Changes
N/A

## Reviewer Notes
### Human Reviewer
- Validate that trial and temporary org `managed-active` carveouts match current intended product behavior and are narrow enough to stay temporary.
- Validate that retaining canonical KiloClaw rows on soft delete matches GDPR expectations for anonymized state retention.
- Validate promo-code guidance for standalone Stripe checkout. Product intent is to preserve promo-code input while still applying the intro discount through price configuration rather than a promo-code slot.

### Code Reviewer Agent
<details>
  <summary>Code Reviewer Notes</summary>
  - Only spec files changed: `.specs/kiloclaw-billing.md` and `.specs/kiloclaw-datamodel.md`.
  - This PR is stack root for follow-on implementation work. Review wording consistency, not runtime behavior.
  - Requirements covered here came from confirmed compliance findings plus product clarification that standalone Stripe checkout must keep promo-code support.
</details>
