### PR TITLE
fix(kiloclaw): tighten checkout guardrails

### DIFF
--- a/apps/web/src/lib/kilo-pass/bonus.test.ts
+++ b/apps/web/src/lib/kilo-pass/bonus.test.ts
@@ -1,8 +1,9 @@
-import { KiloPassTier } from '@/lib/kilo-pass/enums';
+import { KiloPassCadence, KiloPassTier } from '@/lib/kilo-pass/enums';
 import {
   computeMonthlyCadenceBonusPercent,
   computeYearlyCadenceMonthlyBonusUsd,
   getMonthlyPriceUsd,
+  isKiloPassSelectionEligibleForKiloclawCommitUpsell,
 } from './bonus';
 
 import {
@@ -267,6 +268,40 @@ describe('kilo pass bonus utilities', () => {
       expect(computeYearlyCadenceMonthlyBonusUsd(KiloPassTier.Tier199)).toBe(
         KILO_PASS_TIER_CONFIG.tier_199.monthlyPriceUsd * KILO_PASS_YEARLY_MONTHLY_BONUS_PERCENT
       );
+    });
+  });
+
+  describe('isKiloPassSelectionEligibleForKiloclawCommitUpsell', () => {
+    const commitCostMicrodollars = 48_000_000;
+
+    it('rejects monthly tiers whose configured price is below the commit threshold', () => {
+      expect(
+        isKiloPassSelectionEligibleForKiloclawCommitUpsell({
+          tier: KiloPassTier.Tier19,
+          cadence: KiloPassCadence.Monthly,
+          commitCostMicrodollars,
+        })
+      ).toBe(false);
+    });
+
+    it('allows monthly tiers whose configured price covers the commit threshold', () => {
+      expect(
+        isKiloPassSelectionEligibleForKiloclawCommitUpsell({
+          tier: KiloPassTier.Tier49,
+          cadence: KiloPassCadence.Monthly,
+          commitCostMicrodollars,
+        })
+      ).toBe(true);
+    });
+
+    it('keeps annual tiers eligible under current upsell policy', () => {
+      expect(
+        isKiloPassSelectionEligibleForKiloclawCommitUpsell({
+          tier: KiloPassTier.Tier19,
+          cadence: KiloPassCadence.Yearly,
+          commitCostMicrodollars,
+        })
+      ).toBe(true);
     });
   });
 });

--- a/apps/web/src/lib/kilo-pass/bonus.ts
+++ b/apps/web/src/lib/kilo-pass/bonus.ts
@@ -1,4 +1,4 @@
-import type { KiloPassTier } from '@/lib/kilo-pass/enums';
+import { KiloPassCadence, type KiloPassTier } from '@/lib/kilo-pass/enums';
 import {
   KILO_PASS_FIRST_MONTH_PROMO_BONUS_PERCENT,
   KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_BONUS_PERCENT,
@@ -10,6 +10,18 @@ import { dayjs } from '@/lib/kilo-pass/dayjs';
 
 export const getMonthlyPriceUsd = (tier: KiloPassTier): number => {
   return KILO_PASS_TIER_CONFIG[tier].monthlyPriceUsd;
+};
+
+export const isKiloPassSelectionEligibleForKiloclawCommitUpsell = (params: {
+  tier: KiloPassTier;
+  cadence: KiloPassCadence;
+  commitCostMicrodollars: number;
+}): boolean => {
+  if (params.cadence === KiloPassCadence.Yearly) {
+    return true;
+  }
+
+  return getMonthlyPriceUsd(params.tier) * 1_000_000 >= params.commitCostMicrodollars;
 };
 
 export const computeMonthlyCadenceBonusPercent = (params: {

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -1032,7 +1032,7 @@ describe('createSubscriptionCheckout', () => {
     );
   });
 
-  it('uses the intro price and disables promotion codes for new standard subscribers', async () => {
+  it('uses the intro price and allows promotion codes for new standard subscribers', async () => {
     const instance = await createKiloclawInstance(user.id);
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
@@ -1056,7 +1056,7 @@ describe('createSubscriptionCheckout', () => {
     >;
     // Should use intro price
     expect(callArgs.line_items).toEqual([{ price: 'price_standard_intro', quantity: 1 }]);
-    expect(callArgs.allow_promotion_codes).toBe(false);
+    expect(callArgs.allow_promotion_codes).toBe(true);
     // Should NOT have discounts (coupon removed)
     expect(callArgs.discounts).toBeUndefined();
     expect(callArgs.metadata).toEqual(
@@ -1089,7 +1089,7 @@ describe('createSubscriptionCheckout', () => {
     >;
     // Should use regular price (via getStripePriceIdForClawPlan mock which returns 'price_test_kiloclaw')
     expect(callArgs.line_items).toEqual([{ price: 'price_test_kiloclaw', quantity: 1 }]);
-    expect(callArgs.allow_promotion_codes).toBe(false);
+    expect(callArgs.allow_promotion_codes).toBe(true);
     expect(callArgs.discounts).toBeUndefined();
   });
 
@@ -1117,7 +1117,7 @@ describe('createSubscriptionCheckout', () => {
     expect(callArgs.line_items).toEqual([{ price: 'price_standard_intro', quantity: 1 }]);
   });
 
-  it('disables promotion codes for commit plan', async () => {
+  it('allows promotion codes for commit plan', async () => {
     const instance = await createKiloclawInstance(user.id);
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
@@ -1139,7 +1139,7 @@ describe('createSubscriptionCheckout', () => {
       string,
       unknown
     >;
-    expect(callArgs.allow_promotion_codes).toBe(false);
+    expect(callArgs.allow_promotion_codes).toBe(true);
     expect(callArgs.discounts).toBeUndefined();
   });
 

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -1205,10 +1205,29 @@ describe('createKiloPassUpsellCheckout', () => {
         hostingPlan: 'commit',
       })
     ).rejects.toThrow(
-      'Kilo Pass tier 19 monthly does not include enough credits for commit hosting.'
+      'Selected Kilo Pass option does not include enough credits for commit hosting.'
     );
 
     expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it('allows commit hosting for yearly tier 19', async () => {
+    const instance = await createKiloclawInstance(user.id);
+    stripeMock.checkout.sessions.create.mockResolvedValue({
+      url: 'https://checkout.stripe.com/test',
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.kiloclaw.createKiloPassUpsellCheckout({
+        instanceId: instance.id,
+        tier: '19',
+        cadence: 'yearly',
+        hostingPlan: 'commit',
+      })
+    ).resolves.toEqual({ url: 'https://checkout.stripe.com/test' });
+
+    expect(stripeMock.checkout.sessions.create).toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -1032,7 +1032,7 @@ describe('createSubscriptionCheckout', () => {
     );
   });
 
-  it('uses the intro price and allow_promotion_codes for new standard subscribers', async () => {
+  it('uses the intro price and disables promotion codes for new standard subscribers', async () => {
     const instance = await createKiloclawInstance(user.id);
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
@@ -1056,8 +1056,7 @@ describe('createSubscriptionCheckout', () => {
     >;
     // Should use intro price
     expect(callArgs.line_items).toEqual([{ price: 'price_standard_intro', quantity: 1 }]);
-    // Should allow promotion codes on hosted checkout.
-    expect(callArgs.allow_promotion_codes).toBe(true);
+    expect(callArgs.allow_promotion_codes).toBe(false);
     // Should NOT have discounts (coupon removed)
     expect(callArgs.discounts).toBeUndefined();
     expect(callArgs.metadata).toEqual(
@@ -1090,7 +1089,7 @@ describe('createSubscriptionCheckout', () => {
     >;
     // Should use regular price (via getStripePriceIdForClawPlan mock which returns 'price_test_kiloclaw')
     expect(callArgs.line_items).toEqual([{ price: 'price_test_kiloclaw', quantity: 1 }]);
-    expect(callArgs.allow_promotion_codes).toBe(true);
+    expect(callArgs.allow_promotion_codes).toBe(false);
     expect(callArgs.discounts).toBeUndefined();
   });
 
@@ -1118,7 +1117,7 @@ describe('createSubscriptionCheckout', () => {
     expect(callArgs.line_items).toEqual([{ price: 'price_standard_intro', quantity: 1 }]);
   });
 
-  it('uses allow_promotion_codes for commit plan', async () => {
+  it('disables promotion codes for commit plan', async () => {
     const instance = await createKiloclawInstance(user.id);
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
@@ -1140,7 +1139,7 @@ describe('createSubscriptionCheckout', () => {
       string,
       unknown
     >;
-    expect(callArgs.allow_promotion_codes).toBe(true);
+    expect(callArgs.allow_promotion_codes).toBe(false);
     expect(callArgs.discounts).toBeUndefined();
   });
 
@@ -1190,6 +1189,26 @@ describe('createSubscriptionCheckout', () => {
         },
       })
     );
+  });
+});
+
+describe('createKiloPassUpsellCheckout', () => {
+  it('rejects commit hosting for monthly tier 19', async () => {
+    const instance = await createKiloclawInstance(user.id);
+    const caller = await createCallerForUser(user.id);
+
+    await expect(
+      caller.kiloclaw.createKiloPassUpsellCheckout({
+        instanceId: instance.id,
+        tier: '19',
+        cadence: 'monthly',
+        hostingPlan: 'commit',
+      })
+    ).rejects.toThrow(
+      'Kilo Pass tier 19 monthly does not include enough credits for commit hosting.'
+    );
+
+    expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -3334,7 +3334,7 @@ export const kiloclawRouter = createTRPCRouter({
         customer: stripeCustomerId,
         billing_address_collection: 'required',
         line_items: [{ price: priceId, quantity: 1 }],
-        allow_promotion_codes: false,
+        allow_promotion_codes: true,
         customer_update: { name: 'auto', address: 'auto' },
         tax_id_collection: { enabled: true, required: 'never' },
         success_url: successUrl,

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -72,6 +72,7 @@ import {
 } from '@/lib/kiloclaw/stripe-price-ids.server';
 import { getStripePriceIdForKiloPass } from '@/lib/kilo-pass/stripe-price-ids.server';
 import { KiloPassTier, KiloPassCadence } from '@/lib/kilo-pass/enums';
+import { isKiloPassSelectionEligibleForKiloclawCommitUpsell } from '@/lib/kilo-pass/bonus';
 import { isStripeSubscriptionEnded } from '@/lib/kilo-pass/stripe-subscription-status';
 import { getKiloPassStateForUser } from '@/lib/kilo-pass/state';
 import { ensureAutoIntroSchedule, resolvePhasePrice } from '@/lib/kiloclaw/stripe-handlers';
@@ -3411,12 +3412,6 @@ export const kiloclawRouter = createTRPCRouter({
       if (!stripeCustomerId) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Stripe customer for user.' });
       }
-      if (input.hostingPlan === 'commit' && input.cadence === 'monthly' && input.tier === '19') {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Kilo Pass tier 19 monthly does not include enough credits for commit hosting.',
-        });
-      }
 
       const { anchorInstance } = await resolvePersonalBillingAnchor({
         userId: ctx.user.id,
@@ -3461,6 +3456,20 @@ export const kiloclawRouter = createTRPCRouter({
 
       const kiloPassTier = tierMap[input.tier];
       const kiloPassCadence = cadenceMap[input.cadence];
+      if (
+        input.hostingPlan === 'commit' &&
+        !isKiloPassSelectionEligibleForKiloclawCommitUpsell({
+          tier: kiloPassTier,
+          cadence: kiloPassCadence,
+          commitCostMicrodollars: KILOCLAW_PLAN_COST_MICRODOLLARS.commit,
+        })
+      ) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Selected Kilo Pass option does not include enough credits for commit hosting.',
+        });
+      }
+
       const priceId = getStripePriceIdForKiloPass({
         tier: kiloPassTier,
         cadence: kiloPassCadence,

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -3334,7 +3334,7 @@ export const kiloclawRouter = createTRPCRouter({
         customer: stripeCustomerId,
         billing_address_collection: 'required',
         line_items: [{ price: priceId, quantity: 1 }],
-        allow_promotion_codes: true,
+        allow_promotion_codes: false,
         customer_update: { name: 'auto', address: 'auto' },
         tax_id_collection: { enabled: true, required: 'never' },
         success_url: successUrl,
@@ -3410,6 +3410,12 @@ export const kiloclawRouter = createTRPCRouter({
       const stripeCustomerId = ctx.user.stripe_customer_id;
       if (!stripeCustomerId) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Stripe customer for user.' });
+      }
+      if (input.hostingPlan === 'commit' && input.cadence === 'monthly' && input.tier === '19') {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Kilo Pass tier 19 monthly does not include enough credits for commit hosting.',
+        });
       }
 
       const { anchorInstance } = await resolvePersonalBillingAnchor({


### PR DESCRIPTION
## Summary
Rejects invalid Kilo Pass upsell selections server-side while preserving standalone checkout promo-code support.

### Why this change is needed
The upsell flow allowed a monthly tier 19 selection to proceed with commit hosting even though that tier cannot fund the first commit period. This rule must be enforced on the server so invalid combinations cannot slip past UI checks. Promo-code support on standalone Stripe checkout also needed to remain intact after product clarified that spec requirement.

### How this is addressed
- Reject monthly tier `19` when paired with `hostingPlan='commit'` before creating a Stripe checkout session.
- Add regression coverage for the invalid monthly-19/commit combination and assert that no checkout session is created.
- Keep standalone Stripe checkout promo-code expectations aligned with product behavior while using intro pricing for the first-month discount.

## Verification
- `pnpm test -- apps/web/src/routers/kiloclaw-billing-router.test.ts`
- `pnpm typecheck`
- `pnpm format`

## Visual Changes
N/A

## Reviewer Notes
### Human Reviewer
- This PR is stacked on top of #2578. Review with that base in mind.
- Validate that the commit-hosting guard should stay tied to the current tier-to-credit relationship from the billing spec. If Kilo Pass pricing or included credits change, this validation rule will need to move with that policy.
- Validate that preserving promo-code support on standalone Stripe checkout is intended product behavior and matches the updated spec root PR.

### Code Reviewer Agent
<details>
  <summary>Code Reviewer Notes</summary>
  - Validation lives in `createKiloPassUpsellCheckout` and intentionally rejects before Stripe session creation.
  - Regression coverage was added in `apps/web/src/routers/kiloclaw-billing-router.test.ts` for the invalid monthly-19/commit path.
  - Followed `Kilo Pass Upsell Checkout` rule 4 from the billing spec and kept standalone checkout promo-code behavior aligned with updated product guidance.
</details>
