### PR TITLE
fix(kiloclaw): collapse personal orphans on destroy

### DIFF
--- a/apps/web/src/lib/kiloclaw/instance-registry.ts
+++ b/apps/web/src/lib/kiloclaw/instance-registry.ts
@@ -1,6 +1,10 @@
 import 'server-only';
 
 import { and, eq, isNull } from 'drizzle-orm';
+import {
+  markInstanceDestroyedWithPersonalSubscriptionCollapse,
+  type KiloClawSubscriptionChangeActor,
+} from '@kilocode/db';
 import { kiloclaw_instances } from '@kilocode/db/schema';
 import { db, type DrizzleTransaction } from '@/lib/drizzle';
 
@@ -19,6 +23,11 @@ export type EnsureActiveInstanceResult = {
 };
 
 type InstanceRegistryExecutor = typeof db | DrizzleTransaction;
+
+const INSTANCE_REGISTRY_DESTROY_ACTOR = {
+  actorType: 'system',
+  actorId: 'web-instance-registry',
+} satisfies KiloClawSubscriptionChangeActor;
 
 /**
  * Returns true if this instance row uses the instance-keyed identity scheme
@@ -109,30 +118,40 @@ export async function markActiveInstanceDestroyed(
   userId: string,
   instanceId?: string
 ): Promise<ActiveKiloClawInstance | null> {
-  const destroyedAt = new Date().toISOString();
+  return await db.transaction(async tx => {
+    const [target] = await tx
+      .select({
+        id: kiloclaw_instances.id,
+      })
+      .from(kiloclaw_instances)
+      .where(
+        instanceId
+          ? and(
+              eq(kiloclaw_instances.id, instanceId),
+              eq(kiloclaw_instances.user_id, userId),
+              isNull(kiloclaw_instances.destroyed_at)
+            )
+          : and(
+              eq(kiloclaw_instances.user_id, userId),
+              isNull(kiloclaw_instances.organization_id),
+              isNull(kiloclaw_instances.destroyed_at)
+            )
+      )
+      .orderBy(kiloclaw_instances.created_at)
+      .limit(1);
 
-  const condition = instanceId
-    ? and(eq(kiloclaw_instances.id, instanceId), isNull(kiloclaw_instances.destroyed_at))
-    : and(
-        eq(kiloclaw_instances.user_id, userId),
-        isNull(kiloclaw_instances.organization_id),
-        isNull(kiloclaw_instances.destroyed_at)
-      );
+    if (!target) {
+      return null;
+    }
 
-  const [row] = await db
-    .update(kiloclaw_instances)
-    .set({ destroyed_at: destroyedAt })
-    .where(condition)
-    .returning({
-      id: kiloclaw_instances.id,
-      userId: kiloclaw_instances.user_id,
-      sandboxId: kiloclaw_instances.sandbox_id,
-      organizationId: kiloclaw_instances.organization_id,
-      name: kiloclaw_instances.name,
-      inboundEmailEnabled: kiloclaw_instances.inbound_email_enabled,
+    return await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+      actor: INSTANCE_REGISTRY_DESTROY_ACTOR,
+      executor: tx,
+      instanceId: target.id,
+      reason: 'destroy_path_inline_collapse',
+      userId,
     });
-
-  return row ?? null;
+  });
 }
 
 /**
@@ -142,10 +161,28 @@ export async function markActiveInstanceDestroyed(
  * for rollback when the caller knows which row it created.
  */
 export async function markInstanceDestroyedById(instanceId: string): Promise<void> {
-  await db
-    .update(kiloclaw_instances)
-    .set({ destroyed_at: new Date().toISOString() })
-    .where(and(eq(kiloclaw_instances.id, instanceId), isNull(kiloclaw_instances.destroyed_at)));
+  await db.transaction(async tx => {
+    const [instance] = await tx
+      .select({
+        id: kiloclaw_instances.id,
+        userId: kiloclaw_instances.user_id,
+      })
+      .from(kiloclaw_instances)
+      .where(and(eq(kiloclaw_instances.id, instanceId), isNull(kiloclaw_instances.destroyed_at)))
+      .limit(1);
+
+    if (!instance) {
+      return;
+    }
+
+    await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+      actor: INSTANCE_REGISTRY_DESTROY_ACTOR,
+      executor: tx,
+      instanceId: instance.id,
+      reason: 'destroy_path_inline_collapse',
+      userId: instance.userId,
+    });
+  });
 }
 
 /**

--- a/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
@@ -362,6 +362,114 @@ describe('kiloclaw-subscription-alignment script', () => {
     expect(subscriptionsAfterRerun).toHaveLength(1);
   });
 
+  it('collapses multi-row all-destroyed personal users into one current row', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'multi-row-all-destroyed@example.com',
+    });
+
+    const instanceA = crypto.randomUUID();
+    const instanceB = crypto.randomUUID();
+    const instanceC = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: instanceA,
+        user_id: user.id,
+        sandbox_id: `ki_${instanceA.replaceAll('-', '')}`,
+        created_at: '2026-03-01T00:00:00.000Z',
+        destroyed_at: '2026-03-02T00:00:00.000Z',
+      },
+      {
+        id: instanceB,
+        user_id: user.id,
+        sandbox_id: `ki_${instanceB.replaceAll('-', '')}`,
+        created_at: '2026-03-05T00:00:00.000Z',
+        destroyed_at: '2026-03-06T00:00:00.000Z',
+      },
+      {
+        id: instanceC,
+        user_id: user.id,
+        sandbox_id: `ki_${instanceC.replaceAll('-', '')}`,
+        created_at: '2026-03-10T00:00:00.000Z',
+        destroyed_at: '2026-03-11T00:00:00.000Z',
+      },
+    ]);
+
+    const [subscriptionA, subscriptionB, subscriptionC] = await db
+      .insert(kiloclaw_subscriptions)
+      .values([
+        {
+          user_id: user.id,
+          instance_id: instanceA,
+          plan: 'trial',
+          status: 'canceled',
+          payment_source: 'credits',
+          cancel_at_period_end: false,
+          created_at: '2026-03-01T00:00:00.000Z',
+          updated_at: '2026-03-01T00:00:00.000Z',
+        },
+        {
+          user_id: user.id,
+          instance_id: instanceB,
+          plan: 'standard',
+          status: 'canceled',
+          payment_source: 'credits',
+          cancel_at_period_end: false,
+          created_at: '2026-03-05T00:00:00.000Z',
+          updated_at: '2026-03-05T00:00:00.000Z',
+        },
+        {
+          user_id: user.id,
+          instance_id: instanceC,
+          plan: 'standard',
+          status: 'canceled',
+          payment_source: 'credits',
+          cancel_at_period_end: false,
+          created_at: '2026-03-10T00:00:00.000Z',
+          updated_at: '2026-03-10T00:00:00.000Z',
+        },
+      ])
+      .returning();
+
+    if (!subscriptionA || !subscriptionB || !subscriptionC) {
+      throw new Error('Expected destroyed subscription rows');
+    }
+
+    await run('apply-multi-row-all-destroyed');
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .orderBy(kiloclaw_subscriptions.created_at);
+
+    expect(subscriptions.map(subscription => subscription.transferred_to_subscription_id)).toEqual([
+      subscriptionB.id,
+      subscriptionC.id,
+      null,
+    ]);
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.actor_id, 'kiloclaw-subscription-alignment'));
+
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'reassigned',
+          reason: 'apply_multi_row_all_destroyed_collapse',
+          subscription_id: subscriptionA.id,
+        }),
+        expect.objectContaining({
+          action: 'reassigned',
+          reason: 'apply_multi_row_all_destroyed_collapse',
+          subscription_id: subscriptionB.id,
+        }),
+      ])
+    );
+  });
+
   it('bootstraps personal trial even when user has org-context subscription', async () => {
     const user = await insertTestUser({
       google_user_email: 'org-sub-holder@example.com',

--- a/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
+++ b/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
@@ -327,8 +327,8 @@ describe('personal subscription destroy collapse', () => {
         }) => void
       >();
     const executor = {
-      select: db.select.bind(db),
-      update: db.update.bind(db),
+      select: (...args: Parameters<typeof db.select>) => db.select(...args),
+      update: (...args: Parameters<typeof db.update>) => db.update(...args),
       insert: ((table: typeof kiloclaw_subscription_change_log) => {
         if (table === kiloclaw_subscription_change_log) {
           return {

--- a/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
+++ b/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
@@ -1,0 +1,463 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import {
+  collapseOrphanPersonalSubscriptionsOnDestroy,
+  markInstanceDestroyedWithPersonalSubscriptionCollapse,
+  PersonalSubscriptionDestroyConflictError,
+} from '@kilocode/db';
+import {
+  kiloclaw_instances,
+  kiloclaw_subscription_change_log,
+  kiloclaw_subscriptions,
+} from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
+
+import { listCurrentPersonalSubscriptionRows } from '@/lib/kiloclaw/current-personal-subscription';
+import { cleanupDbForTest, db } from '@/lib/drizzle';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+
+const TEST_ACTOR = {
+  actorType: 'system',
+  actorId: 'personal-subscription-destroy-collapse-test',
+} as const;
+
+async function insertPersonalInstance(params: {
+  createdAt: string;
+  destroyedAt?: string;
+  id: string;
+  userId: string;
+}) {
+  await db.insert(kiloclaw_instances).values({
+    id: params.id,
+    user_id: params.userId,
+    sandbox_id: `ki_${params.id.replaceAll('-', '')}`,
+    created_at: params.createdAt,
+    destroyed_at: params.destroyedAt ?? null,
+  });
+}
+
+async function insertPersonalSubscription(params: {
+  createdAt: string;
+  id: string;
+  instanceId: string;
+  plan: 'standard' | 'trial';
+  status: 'active' | 'canceled';
+  transferredToSubscriptionId?: string | null;
+  userId: string;
+}) {
+  await db.insert(kiloclaw_subscriptions).values({
+    id: params.id,
+    user_id: params.userId,
+    instance_id: params.instanceId,
+    plan: params.plan,
+    status: params.status,
+    payment_source: 'credits',
+    cancel_at_period_end: false,
+    transferred_to_subscription_id: params.transferredToSubscriptionId ?? null,
+    created_at: params.createdAt,
+    updated_at: params.createdAt,
+  });
+}
+
+describe('personal subscription destroy collapse', () => {
+  beforeEach(async () => {
+    await cleanupDbForTest();
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('collapses older personal rows when last alive instance is destroyed', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-collapse@example.com',
+    });
+
+    const instanceA = crypto.randomUUID();
+    const instanceB = crypto.randomUUID();
+    const instanceC = crypto.randomUUID();
+    const subscriptionA = crypto.randomUUID();
+    const subscriptionB = crypto.randomUUID();
+    const subscriptionC = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: instanceA,
+      userId: user.id,
+      createdAt: '2026-03-01T00:00:00.000Z',
+      destroyedAt: '2026-03-10T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: instanceB,
+      userId: user.id,
+      createdAt: '2026-03-15T00:00:00.000Z',
+      destroyedAt: '2026-03-20T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: instanceC,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    });
+
+    await insertPersonalSubscription({
+      id: subscriptionA,
+      userId: user.id,
+      instanceId: instanceA,
+      createdAt: '2026-03-01T00:00:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionB,
+      userId: user.id,
+      instanceId: instanceB,
+      createdAt: '2026-03-15T00:00:00.000Z',
+      plan: 'standard',
+      status: 'canceled',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionC,
+      userId: user.id,
+      instanceId: instanceC,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    await db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId: instanceC,
+        reason: 'destroy_path_inline_collapse',
+        userId: user.id,
+      });
+    });
+
+    const currentRows = await listCurrentPersonalSubscriptionRows({ userId: user.id });
+    expect(currentRows).toHaveLength(1);
+    expect(currentRows[0]?.subscription.id).toBe(subscriptionC);
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .orderBy(kiloclaw_subscriptions.created_at);
+
+    expect(subscriptions.map(subscription => subscription.transferred_to_subscription_id)).toEqual([
+      subscriptionB,
+      subscriptionC,
+      null,
+    ]);
+
+    const changeLogs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.actor_id, TEST_ACTOR.actorId))
+      .orderBy(kiloclaw_subscription_change_log.created_at);
+
+    expect(changeLogs).toHaveLength(2);
+    expect(changeLogs.every(log => log.reason === 'destroy_path_inline_collapse')).toBe(true);
+    expect(changeLogs.map(log => log.subscription_id).sort()).toEqual(
+      [subscriptionA, subscriptionB].sort()
+    );
+  });
+
+  it('splices existing chain around orphan and is idempotent on rerun', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-splice@example.com',
+    });
+
+    const instanceA = crypto.randomUUID();
+    const instanceB = crypto.randomUUID();
+    const instanceC = crypto.randomUUID();
+    const subscriptionA = crypto.randomUUID();
+    const subscriptionB = crypto.randomUUID();
+    const subscriptionC = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: instanceA,
+      userId: user.id,
+      createdAt: '2026-03-01T00:00:00.000Z',
+      destroyedAt: '2026-03-02T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: instanceB,
+      userId: user.id,
+      createdAt: '2026-03-05T00:00:00.000Z',
+      destroyedAt: '2026-03-06T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: instanceC,
+      userId: user.id,
+      createdAt: '2026-03-10T00:00:00.000Z',
+    });
+
+    await insertPersonalSubscription({
+      id: subscriptionC,
+      userId: user.id,
+      instanceId: instanceC,
+      createdAt: '2026-03-10T00:00:00.000Z',
+      plan: 'standard',
+      status: 'active',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionA,
+      userId: user.id,
+      instanceId: instanceA,
+      createdAt: '2026-03-01T00:00:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+      transferredToSubscriptionId: subscriptionC,
+    });
+    await insertPersonalSubscription({
+      id: subscriptionB,
+      userId: user.id,
+      instanceId: instanceB,
+      createdAt: '2026-03-05T00:00:00.000Z',
+      plan: 'standard',
+      status: 'canceled',
+    });
+
+    await db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId: instanceC,
+        reason: 'destroy_path_inline_collapse',
+        userId: user.id,
+      });
+    });
+
+    const afterFirstRun = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .orderBy(kiloclaw_subscriptions.created_at);
+
+    expect(afterFirstRun.map(subscription => subscription.transferred_to_subscription_id)).toEqual([
+      subscriptionB,
+      subscriptionC,
+      null,
+    ]);
+
+    const result = await db.transaction(async tx => {
+      return await collapseOrphanPersonalSubscriptionsOnDestroy({
+        actor: TEST_ACTOR,
+        destroyedInstanceId: instanceC,
+        executor: tx,
+        reason: 'destroy_path_inline_collapse',
+        userId: user.id,
+      });
+    });
+
+    expect(result.updatedSubscriptionIds).toHaveLength(0);
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.actor_id, TEST_ACTOR.actorId));
+
+    expect(logs).toHaveLength(2);
+  });
+
+  it('logs and continues when collapse change log write fails outside transaction', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-collapse-best-effort@example.com',
+    });
+
+    const instanceA = crypto.randomUUID();
+    const instanceB = crypto.randomUUID();
+    const instanceC = crypto.randomUUID();
+    const subscriptionA = crypto.randomUUID();
+    const subscriptionB = crypto.randomUUID();
+    const subscriptionC = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: instanceA,
+      userId: user.id,
+      createdAt: '2026-03-01T00:00:00.000Z',
+      destroyedAt: '2026-03-10T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: instanceB,
+      userId: user.id,
+      createdAt: '2026-03-15T00:00:00.000Z',
+      destroyedAt: '2026-03-20T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: instanceC,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    });
+
+    await insertPersonalSubscription({
+      id: subscriptionA,
+      userId: user.id,
+      instanceId: instanceA,
+      createdAt: '2026-03-01T00:00:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionB,
+      userId: user.id,
+      instanceId: instanceB,
+      createdAt: '2026-03-15T00:00:00.000Z',
+      plan: 'standard',
+      status: 'canceled',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionC,
+      userId: user.id,
+      instanceId: instanceC,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    const changeLogFailure = new Error('change-log insert failed');
+    const onChangeLogFailure =
+      jest.fn<
+        (context: {
+          error: unknown;
+          reason: string;
+          subscriptionId: string;
+          userId: string;
+        }) => void
+      >();
+    const executor = {
+      select: db.select.bind(db),
+      update: db.update.bind(db),
+      insert: ((table: typeof kiloclaw_subscription_change_log) => {
+        if (table === kiloclaw_subscription_change_log) {
+          return {
+            values: async () => {
+              throw changeLogFailure;
+            },
+          };
+        }
+        return db.insert(table);
+      }) as typeof db.insert,
+    };
+
+    const destroyed = await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+      actor: TEST_ACTOR,
+      changeLogFailurePolicy: 'log',
+      executor,
+      instanceId: instanceC,
+      onChangeLogFailure,
+      reason: 'destroy_path_inline_collapse',
+      userId: user.id,
+    });
+
+    expect(destroyed?.id).toBe(instanceC);
+    expect(onChangeLogFailure).toHaveBeenCalledTimes(2);
+    expect(onChangeLogFailure).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        error: changeLogFailure,
+        reason: 'destroy_path_inline_collapse',
+        subscriptionId: subscriptionA,
+        userId: user.id,
+      })
+    );
+    expect(onChangeLogFailure).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        error: changeLogFailure,
+        reason: 'destroy_path_inline_collapse',
+        subscriptionId: subscriptionB,
+        userId: user.id,
+      })
+    );
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .orderBy(kiloclaw_subscriptions.created_at);
+
+    expect(subscriptions.map(subscription => subscription.transferred_to_subscription_id)).toEqual([
+      subscriptionB,
+      subscriptionC,
+      null,
+    ]);
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.actor_id, TEST_ACTOR.actorId));
+
+    expect(logs).toHaveLength(0);
+  });
+
+  it('refuses collapse when multiple alive current personal rows exist', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-refuse-multi-alive@example.com',
+    });
+
+    const instanceA = crypto.randomUUID();
+    const instanceB = crypto.randomUUID();
+    const subscriptionA = crypto.randomUUID();
+    const subscriptionB = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: instanceA,
+      userId: user.id,
+      createdAt: '2026-03-01T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: instanceB,
+      userId: user.id,
+      createdAt: '2026-03-02T00:00:00.000Z',
+    });
+
+    await insertPersonalSubscription({
+      id: subscriptionA,
+      userId: user.id,
+      instanceId: instanceA,
+      createdAt: '2026-03-01T00:00:00.000Z',
+      plan: 'standard',
+      status: 'active',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionB,
+      userId: user.id,
+      instanceId: instanceB,
+      createdAt: '2026-03-02T00:00:00.000Z',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    await expect(
+      db.transaction(async tx => {
+        await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+          actor: TEST_ACTOR,
+          executor: tx,
+          instanceId: instanceB,
+          reason: 'destroy_path_inline_collapse',
+          userId: user.id,
+        });
+      })
+    ).rejects.toThrow(PersonalSubscriptionDestroyConflictError);
+
+    const instances = await db
+      .select()
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.user_id, user.id))
+      .orderBy(kiloclaw_instances.created_at);
+
+    expect(instances.every(instance => instance.destroyed_at === null)).toBe(true);
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .orderBy(kiloclaw_subscriptions.created_at);
+
+    expect(
+      subscriptions.every(subscription => subscription.transferred_to_subscription_id === null)
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
+++ b/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
@@ -326,9 +326,7 @@ describe('personal subscription destroy collapse', () => {
           userId: string;
         }) => void
       >();
-    const executor = {
-      select: (...args: Parameters<typeof db.select>) => db.select(...args),
-      update: (...args: Parameters<typeof db.update>) => db.update(...args),
+    const executor = Object.assign(Object.create(db), {
       insert: ((table: typeof kiloclaw_subscription_change_log) => {
         if (table === kiloclaw_subscription_change_log) {
           return {
@@ -339,7 +337,7 @@ describe('personal subscription destroy collapse', () => {
         }
         return db.insert(table);
       }) as typeof db.insert,
-    };
+    });
 
     const destroyed = await markInstanceDestroyedWithPersonalSubscriptionCollapse({
       actor: TEST_ACTOR,

--- a/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
+++ b/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
@@ -11,6 +11,8 @@
  *   pnpm script db kiloclaw-subscription-alignment apply-duplicates [--confirm-sandboxes-destroyed]
  *   pnpm script db kiloclaw-subscription-alignment preview-org
  *   pnpm script db kiloclaw-subscription-alignment apply-org
+ *   pnpm script db kiloclaw-subscription-alignment preview-multi-row-all-destroyed
+ *   pnpm script db kiloclaw-subscription-alignment apply-multi-row-all-destroyed
  *   pnpm script db kiloclaw-subscription-alignment preview-changelog-baseline
  *   pnpm script db kiloclaw-subscription-alignment apply-changelog-baseline
  *
@@ -30,7 +32,7 @@
  * subscription rows — no --confirm-sandboxes-destroyed flag required.
  */
 
-import { and, asc, desc, eq, inArray, isNull, notExists, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNotNull, isNull, notExists, or, sql } from 'drizzle-orm';
 
 import { TRIAL_DURATION_DAYS } from '@/lib/constants';
 import {
@@ -38,7 +40,10 @@ import {
   KILOCLAW_TRIAL_DURATION_DAYS,
 } from '@/lib/kiloclaw/constants';
 import { db, type DrizzleTransaction } from '@/lib/drizzle';
-import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
+import {
+  collapseOrphanPersonalSubscriptionsOnDestroy,
+  insertKiloClawSubscriptionChangeLog,
+} from '@kilocode/db';
 import {
   kiloclaw_earlybird_purchases,
   kiloclaw_instances,
@@ -62,6 +67,8 @@ type Mode =
   | 'apply-duplicates'
   | 'preview-org'
   | 'apply-org'
+  | 'preview-multi-row-all-destroyed'
+  | 'apply-multi-row-all-destroyed'
   | 'preview-changelog-baseline'
   | 'apply-changelog-baseline';
 
@@ -180,6 +187,14 @@ type DuplicateActiveInstanceCandidate = {
 };
 
 type MissingChangelogBaselineRow = KiloClawSubscription;
+
+type MultiRowAllDestroyedCandidate = {
+  currentRowCount: number;
+  destroyedInstanceId: string;
+  latestSubscriptionCreatedAt: string;
+  subscriptionIds: string[];
+  userId: string;
+};
 
 const ALIGNMENT_SCRIPT_ACTOR = {
   actorType: 'system',
@@ -2177,6 +2192,126 @@ async function applyOrgBackfill() {
   printSection('Org rows skipped during apply', skipped);
 }
 
+async function buildMultiRowAllDestroyedCandidates(): Promise<MultiRowAllDestroyedCandidate[]> {
+  const rows = await db
+    .select({
+      subscriptionId: kiloclaw_subscriptions.id,
+      userId: kiloclaw_subscriptions.user_id,
+      instanceId: kiloclaw_subscriptions.instance_id,
+      subscriptionCreatedAt: kiloclaw_subscriptions.created_at,
+      instanceDestroyedAt: kiloclaw_instances.destroyed_at,
+    })
+    .from(kiloclaw_subscriptions)
+    .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+    .where(
+      and(
+        isNotNull(kiloclaw_subscriptions.instance_id),
+        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
+        eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id),
+        isNull(kiloclaw_instances.organization_id)
+      )
+    )
+    .orderBy(
+      kiloclaw_subscriptions.user_id,
+      kiloclaw_subscriptions.created_at,
+      kiloclaw_subscriptions.id
+    );
+
+  const grouped = new Map<string, typeof rows>();
+  for (const row of rows) {
+    const existing = grouped.get(row.userId);
+    if (existing) {
+      existing.push(row);
+    } else {
+      grouped.set(row.userId, [row]);
+    }
+  }
+
+  const candidates: MultiRowAllDestroyedCandidate[] = [];
+  for (const [userId, userRows] of grouped.entries()) {
+    const aliveRows = userRows.filter(row => row.instanceDestroyedAt === null);
+    if (aliveRows.length > 0 || userRows.length <= 1) {
+      continue;
+    }
+
+    const latestRow = userRows[userRows.length - 1];
+    if (!latestRow?.instanceId) {
+      continue;
+    }
+
+    candidates.push({
+      currentRowCount: userRows.length,
+      destroyedInstanceId: latestRow.instanceId,
+      latestSubscriptionCreatedAt: latestRow.subscriptionCreatedAt,
+      subscriptionIds: userRows.map(row => row.subscriptionId),
+      userId,
+    });
+  }
+
+  return candidates;
+}
+
+async function previewMultiRowAllDestroyed() {
+  const rows = await buildMultiRowAllDestroyedCandidates();
+
+  printSection('Multi-row all-destroyed users', rows);
+  printSection('Multi-row all-destroyed action counts', [
+    { action: 'apply_multi_row_all_destroyed_collapse', count: rows.length },
+  ]);
+}
+
+async function applyMultiRowAllDestroyed() {
+  const rows = await buildMultiRowAllDestroyedCandidates();
+  let collapsedUsers = 0;
+  let updatedSubscriptions = 0;
+  const skipped: Array<{ userId: string; destroyedInstanceId: string; reason: string }> = [];
+
+  for (const row of rows) {
+    try {
+      const result = await db.transaction(async tx => {
+        return await collapseOrphanPersonalSubscriptionsOnDestroy({
+          actor: ALIGNMENT_SCRIPT_ACTOR,
+          destroyedInstanceId: row.destroyedInstanceId,
+          executor: tx,
+          reason: 'apply_multi_row_all_destroyed_collapse',
+          userId: row.userId,
+        });
+      });
+
+      if (result.updatedSubscriptionIds.length === 0) {
+        skipped.push({
+          userId: row.userId,
+          destroyedInstanceId: row.destroyedInstanceId,
+          reason: 'no_updates_needed',
+        });
+        continue;
+      }
+
+      collapsedUsers += 1;
+      updatedSubscriptions += result.updatedSubscriptionIds.length;
+    } catch (error) {
+      console.error('Multi-row all-destroyed apply row failed', {
+        userId: row.userId,
+        destroyedInstanceId: row.destroyedInstanceId,
+        error: describeError(error),
+      });
+      skipped.push({
+        userId: row.userId,
+        destroyedInstanceId: row.destroyedInstanceId,
+        reason: describeError(error),
+      });
+    }
+  }
+
+  console.log('\nMulti-row all-destroyed apply results');
+  console.table([
+    { action: 'apply_multi_row_all_destroyed_collapse', count: collapsedUsers },
+    { action: 'updated_subscriptions', count: updatedSubscriptions },
+    { action: 'skipped', count: skipped.length },
+  ]);
+  printSection('Multi-row all-destroyed users skipped during apply', skipped);
+}
+
 type ApplyOptions = {
   confirmSandboxesDestroyed: boolean;
 };
@@ -2192,6 +2327,8 @@ function parseMode(inputMode?: string): Mode {
     case 'apply-duplicates':
     case 'preview-org':
     case 'apply-org':
+    case 'preview-multi-row-all-destroyed':
+    case 'apply-multi-row-all-destroyed':
     case 'preview-changelog-baseline':
     case 'apply-changelog-baseline':
       return mode;
@@ -2215,6 +2352,8 @@ const singleModeHandlers: Partial<Record<Mode, ModeHandler>> = {
   'apply-duplicates': applyDuplicateActiveInstances,
   'preview-org': previewOrgBackfill,
   'apply-org': applyOrgBackfill,
+  'preview-multi-row-all-destroyed': previewMultiRowAllDestroyed,
+  'apply-multi-row-all-destroyed': applyMultiRowAllDestroyed,
   'preview-changelog-baseline': previewChangelogBaselineBackfill,
   'apply-changelog-baseline': applyChangelogBaselineBackfill,
 };

--- a/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
+++ b/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
@@ -11,10 +11,10 @@
  *   pnpm script db kiloclaw-subscription-alignment apply-duplicates [--confirm-sandboxes-destroyed]
  *   pnpm script db kiloclaw-subscription-alignment preview-org
  *   pnpm script db kiloclaw-subscription-alignment apply-org
- *   pnpm script db kiloclaw-subscription-alignment preview-multi-row-all-destroyed
- *   pnpm script db kiloclaw-subscription-alignment apply-multi-row-all-destroyed
  *   pnpm script db kiloclaw-subscription-alignment preview-changelog-baseline
  *   pnpm script db kiloclaw-subscription-alignment apply-changelog-baseline
+ *   pnpm script db kiloclaw-subscription-alignment preview-multi-row-all-destroyed
+ *   pnpm script db kiloclaw-subscription-alignment apply-multi-row-all-destroyed
  *
  * Flags:
  *   --confirm-sandboxes-destroyed   Required for apply-duplicates to write
@@ -25,14 +25,33 @@
  *     flag, apply-duplicates prints a manifest of duplicate sandbox IDs and
  *     exits without writes.
  *
+ *   --bulk   Enables chunked bulk write path for low-risk, high-volume
+ *     backfills. Used by:
+ *       - apply-missing-personal for backfill_destroyed_terminal_personal rows
+ *         (chunked bulk INSERT).
+ *       - apply-multi-row-all-destroyed for chain collapses (chunked bulk
+ *         UPDATE via FROM VALUES + chunked bulk INSERT of change-log rows;
+ *         falls back per-user if a chunk transaction rolls back so that a
+ *         single UQ_kiloclaw_subscriptions_transferred_to race doesn't
+ *         poison the whole chunk).
+ *
  * Admin-panel workflow (recommended): operators destroy duplicate sandboxes
  * via the admin panel, which sets destroyed_at and tears down the resource.
  * Then apply-missing-personal picks up the now-destroyed instances via the
  * backfill_destroyed_terminal_personal path and inserts canceled terminal
  * subscription rows — no --confirm-sandboxes-destroyed flag required.
+ *
+ * multi-row-all-destroyed: collapses users whose `personalCurrentSubscriptionWhere`
+ * rows all point at destroyed personal instances. The guard in
+ * apps/web/src/lib/kiloclaw/current-personal-subscription.ts throws when
+ * activeRows === 0 AND rows.length > 1 — getBillingStatus returns 409 CONFLICT
+ * for the affected user. This mode is pure data: for each such user, pick the
+ * newest matching row (created_at DESC, id DESC) as the authoritative current
+ * row and point every older matching row's transferred_to_subscription_id at
+ * it. No instances are touched. Safe to run without flags.
  */
 
-import { and, asc, desc, eq, inArray, isNotNull, isNull, notExists, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull, notExists, or, sql } from 'drizzle-orm';
 
 import { TRIAL_DURATION_DAYS } from '@/lib/constants';
 import {
@@ -41,8 +60,8 @@ import {
 } from '@/lib/kiloclaw/constants';
 import { db, type DrizzleTransaction } from '@/lib/drizzle';
 import {
-  collapseOrphanPersonalSubscriptionsOnDestroy,
   insertKiloClawSubscriptionChangeLog,
+  serializeKiloClawSubscriptionSnapshot,
 } from '@kilocode/db';
 import {
   kiloclaw_earlybird_purchases,
@@ -67,10 +86,10 @@ type Mode =
   | 'apply-duplicates'
   | 'preview-org'
   | 'apply-org'
-  | 'preview-multi-row-all-destroyed'
-  | 'apply-multi-row-all-destroyed'
   | 'preview-changelog-baseline'
-  | 'apply-changelog-baseline';
+  | 'apply-changelog-baseline'
+  | 'preview-multi-row-all-destroyed'
+  | 'apply-multi-row-all-destroyed';
 
 type PersonalInstanceWithoutRow = {
   instanceId: string;
@@ -188,14 +207,6 @@ type DuplicateActiveInstanceCandidate = {
 
 type MissingChangelogBaselineRow = KiloClawSubscription;
 
-type MultiRowAllDestroyedCandidate = {
-  currentRowCount: number;
-  destroyedInstanceId: string;
-  latestSubscriptionCreatedAt: string;
-  subscriptionIds: string[];
-  userId: string;
-};
-
 const ALIGNMENT_SCRIPT_ACTOR = {
   actorType: 'system',
   actorId: 'kiloclaw-subscription-alignment',
@@ -260,6 +271,36 @@ function printSection<T>(label: string, rows: T[]) {
   if (rows.length > 25) {
     console.log(`... truncated ${rows.length - 25} more row(s)`);
   }
+}
+
+function logApplyProgress(params: {
+  label: string;
+  processed: number;
+  total: number;
+  startedAt: number;
+  every?: number;
+}) {
+  const interval = params.every ?? 100;
+  if (params.processed !== params.total && params.processed % interval !== 0) {
+    return;
+  }
+
+  const elapsedSeconds = Math.round((Date.now() - params.startedAt) / 1000);
+  console.log(
+    `[progress] ${params.label}: ${params.processed}/${params.total} processed (${elapsedSeconds}s elapsed)`
+  );
+}
+
+function chunkArray<T>(rows: T[], size: number): T[][] {
+  if (size <= 0) {
+    return [rows];
+  }
+
+  const chunks: T[][] = [];
+  for (let index = 0; index < rows.length; index += size) {
+    chunks.push(rows.slice(index, index + size));
+  }
+  return chunks;
 }
 
 function describeError(error: unknown): string {
@@ -929,23 +970,6 @@ async function listSubscriptionsMissingBaselineChangeLog(): Promise<MissingChang
     .orderBy(desc(kiloclaw_subscriptions.created_at));
 }
 
-async function hasBaselineChangeLogEntry(
-  executor: DbOrTx,
-  subscriptionId: string
-): Promise<boolean> {
-  const rows = await executor
-    .select({ id: kiloclaw_subscription_change_log.id })
-    .from(kiloclaw_subscription_change_log)
-    .where(
-      and(
-        eq(kiloclaw_subscription_change_log.subscription_id, subscriptionId),
-        isNull(kiloclaw_subscription_change_log.before_state)
-      )
-    )
-    .limit(1);
-  return rows.length > 0;
-}
-
 async function previewChangelogBaselineBackfill() {
   const rows = await listSubscriptionsMissingBaselineChangeLog();
   printSection(
@@ -967,72 +991,118 @@ async function applyChangelogBaselineBackfill() {
   let insertedFromCurrent = 0;
   let insertedFromMutation = 0;
   const failures: Array<{ subscriptionId: string; userId: string; error: string }> = [];
+  const startedAt = Date.now();
 
-  for (const row of rows) {
+  const chunkSize = 500;
+  let processedCount = 0;
+
+  for (const chunk of chunkArray(rows, chunkSize)) {
     try {
-      const result = await db.transaction(async tx => {
-        if (await hasBaselineChangeLogEntry(tx, row.id)) {
-          return 'skipped' as const;
+      // Counts are returned from the transaction callback and accumulated
+      // AFTER commit. Mutating the outer counters inside the callback would
+      // over-report on rollback: e.g. if the `currentStateRows` INSERT ran
+      // but the later `mutationStateRows` INSERT threw, the whole tx would
+      // roll back while the outer counters stayed incremented.
+      const chunkResult = await db.transaction(async tx => {
+        const chunkIds = chunk.map(row => row.id);
+        const existingBaselines = await tx
+          .select({ subscriptionId: kiloclaw_subscription_change_log.subscription_id })
+          .from(kiloclaw_subscription_change_log)
+          .where(
+            and(
+              inArray(kiloclaw_subscription_change_log.subscription_id, chunkIds),
+              isNull(kiloclaw_subscription_change_log.before_state)
+            )
+          );
+
+        const existingBaselineIds = new Set(existingBaselines.map(row => row.subscriptionId));
+        const candidateRows = chunk.filter(row => !existingBaselineIds.has(row.id));
+
+        if (candidateRows.length === 0) {
+          return { insertedFromCurrent: 0, insertedFromMutation: 0 };
         }
 
-        // When prior mutation logs exist, the oldest row's before_state holds
-        // the subscription's true initial state (captured before the first
-        // mutation was applied). Using it as the fabricated baseline's
-        // after_state preserves audit-replay integrity: replaying
-        // baseline -> mutation1 -> mutation2 ... reaches the current row.
-        // Falling back to the current row would inject a no-op delta before
-        // the first mutation and desync replay forever.
-        const [earliestMutation] = await tx
-          .select({
+        const candidateIds = candidateRows.map(row => row.id);
+        const earliestMutations = await tx
+          .selectDistinctOn([kiloclaw_subscription_change_log.subscription_id], {
+            subscriptionId: kiloclaw_subscription_change_log.subscription_id,
             beforeState: kiloclaw_subscription_change_log.before_state,
           })
           .from(kiloclaw_subscription_change_log)
-          .where(eq(kiloclaw_subscription_change_log.subscription_id, row.id))
-          .orderBy(asc(kiloclaw_subscription_change_log.created_at))
-          .limit(1);
+          .where(inArray(kiloclaw_subscription_change_log.subscription_id, candidateIds))
+          .orderBy(
+            kiloclaw_subscription_change_log.subscription_id,
+            asc(kiloclaw_subscription_change_log.created_at)
+          );
 
-        const inheritedBaseline = earliestMutation?.beforeState ?? null;
+        const earliestMutationMap = new Map(
+          earliestMutations.map(row => [row.subscriptionId, row.beforeState ?? null])
+        );
 
-        if (inheritedBaseline) {
-          await tx.insert(kiloclaw_subscription_change_log).values({
-            subscription_id: row.id,
-            actor_type: ALIGNMENT_SCRIPT_ACTOR.actorType,
-            actor_id: ALIGNMENT_SCRIPT_ACTOR.actorId,
-            action: 'backfilled',
-            reason: 'baseline_subscription_snapshot_from_earliest_mutation',
-            before_state: null,
-            after_state: inheritedBaseline,
-          });
-          return 'from_mutation' as const;
+        const currentStateRows = candidateRows.filter(row => !earliestMutationMap.get(row.id));
+        const mutationStateRows = candidateRows.filter(row =>
+          Boolean(earliestMutationMap.get(row.id))
+        );
+
+        if (currentStateRows.length > 0) {
+          await tx.insert(kiloclaw_subscription_change_log).values(
+            currentStateRows.map(row => ({
+              subscription_id: row.id,
+              actor_type: ALIGNMENT_SCRIPT_ACTOR.actorType,
+              actor_id: ALIGNMENT_SCRIPT_ACTOR.actorId,
+              action: 'backfilled' as const,
+              reason: 'baseline_subscription_snapshot',
+              before_state: null,
+              after_state: serializeKiloClawSubscriptionSnapshot(row),
+            }))
+          );
         }
 
-        await insertAlignmentChangeLog(tx, {
-          subscriptionId: row.id,
-          action: 'backfilled',
-          reason: 'baseline_subscription_snapshot',
-          before: null,
-          after: row,
-        });
-        return 'from_current' as const;
+        if (mutationStateRows.length > 0) {
+          await tx.insert(kiloclaw_subscription_change_log).values(
+            mutationStateRows.map(row => ({
+              subscription_id: row.id,
+              actor_type: ALIGNMENT_SCRIPT_ACTOR.actorType,
+              actor_id: ALIGNMENT_SCRIPT_ACTOR.actorId,
+              action: 'backfilled' as const,
+              reason: 'baseline_subscription_snapshot_from_earliest_mutation',
+              before_state: null,
+              after_state: earliestMutationMap.get(row.id) ?? null,
+            }))
+          );
+        }
+
+        return {
+          insertedFromCurrent: currentStateRows.length,
+          insertedFromMutation: mutationStateRows.length,
+        };
       });
 
-      if (result === 'from_mutation') {
-        insertedFromMutation += 1;
-      } else if (result === 'from_current') {
-        insertedFromCurrent += 1;
-      }
+      insertedFromCurrent += chunkResult.insertedFromCurrent;
+      insertedFromMutation += chunkResult.insertedFromMutation;
     } catch (error) {
-      console.error('Changelog baseline backfill row failed', {
-        subscriptionId: row.id,
-        userId: row.user_id,
-        error: describeError(error),
+      const errorMessage = describeError(error);
+      console.error('Changelog baseline backfill chunk failed', {
+        subscriptionIds: chunk.map(row => row.id),
+        error: errorMessage,
       });
-      failures.push({
-        subscriptionId: row.id,
-        userId: row.user_id,
-        error: describeError(error),
-      });
+      failures.push(
+        ...chunk.map(row => ({
+          subscriptionId: row.id,
+          userId: row.user_id,
+          error: errorMessage,
+        }))
+      );
     }
+
+    processedCount += chunk.length;
+    logApplyProgress({
+      label: 'apply-changelog-baseline',
+      processed: processedCount,
+      total: rows.length,
+      startedAt,
+      every: 500,
+    });
   }
 
   console.log('\nChangelog baseline backfill results');
@@ -1359,26 +1429,24 @@ async function applyDuplicateActiveInstanceRow(
     // predecessor would block reassignment forever: preview classifies the
     // duplicate as safe, apply sees the transferred row as a current sub and
     // skips. Same applies to duplicate counts.
-    const [canonicalExisting, duplicateExisting] = await Promise.all([
-      tx
-        .select()
-        .from(kiloclaw_subscriptions)
-        .where(
-          and(
-            eq(kiloclaw_subscriptions.instance_id, row.canonicalInstanceId),
-            isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-          )
-        ),
-      tx
-        .select()
-        .from(kiloclaw_subscriptions)
-        .where(
-          and(
-            eq(kiloclaw_subscriptions.instance_id, row.duplicateInstanceId),
-            isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-          )
-        ),
-    ]);
+    const canonicalExisting = await tx
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(
+        and(
+          eq(kiloclaw_subscriptions.instance_id, row.canonicalInstanceId),
+          isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+        )
+      );
+    const duplicateExisting = await tx
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(
+        and(
+          eq(kiloclaw_subscriptions.instance_id, row.duplicateInstanceId),
+          isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+        )
+      );
 
     if (
       row.action === 'reassign_to_canonical_and_destroy_duplicate' &&
@@ -1501,6 +1569,7 @@ async function applyDuplicateActiveInstances(options: ApplyOptions) {
     userId: string;
     action: string;
   }> = [];
+  const startedAt = Date.now();
 
   // Writing destroyed_at without destroying the underlying sandbox would make
   // an active sandbox invisible to lifecycle/access checks while it keeps
@@ -1537,12 +1606,19 @@ async function applyDuplicateActiveInstances(options: ApplyOptions) {
     return;
   }
 
-  for (const row of rows) {
+  for (const [index, row] of rows.entries()) {
     if (
       row.action !== 'backfill_destroy_duplicate_personal' &&
       row.action !== 'backfill_destroy_duplicate_org' &&
       row.action !== 'reassign_to_canonical_and_destroy_duplicate'
     ) {
+      logApplyProgress({
+        label: 'apply-duplicates',
+        processed: index + 1,
+        total: rows.length,
+        startedAt,
+        every: 25,
+      });
       continue;
     }
 
@@ -1586,6 +1662,14 @@ async function applyDuplicateActiveInstances(options: ApplyOptions) {
         });
         break;
     }
+
+    logApplyProgress({
+      label: 'apply-duplicates',
+      processed: index + 1,
+      total: rows.length,
+      startedAt,
+      every: 25,
+    });
   }
 
   console.log('\nDuplicate active instance apply results');
@@ -1606,6 +1690,146 @@ type MissingPersonalOutcome =
   | 'destroyed_terminal_backfilled'
   | 'skipped'
   | 'no_op';
+
+async function applyMissingPersonalDestroyedTerminalBulk(params: {
+  rows: MissingPersonalCandidate[];
+  startedAt: number;
+  processedOffset: number;
+  totalRows: number;
+  progressEvery?: number;
+}): Promise<{
+  processedCount: number;
+  insertedCount: number;
+  skipped: Array<{
+    instanceId: string;
+    userId: string;
+    action: string;
+    error?: string;
+  }>;
+}> {
+  const chunkSize = 250;
+  const skipped: Array<{
+    instanceId: string;
+    userId: string;
+    action: string;
+    error?: string;
+  }> = [];
+  let insertedCount = 0;
+  let processedCount = 0;
+
+  for (const chunk of chunkArray(params.rows, chunkSize)) {
+    try {
+      await db.transaction(async tx => {
+        const rowsWithDestroyedAt = chunk.filter(row => Boolean(row.instanceDestroyedAt));
+        const rowsWithoutDestroyedAt = chunk.filter(row => !row.instanceDestroyedAt);
+
+        skipped.push(
+          ...rowsWithoutDestroyedAt.map(row => ({
+            instanceId: row.instanceId,
+            userId: row.userId,
+            action: row.action,
+          }))
+        );
+
+        if (rowsWithDestroyedAt.length === 0) {
+          return;
+        }
+
+        const instanceIds = rowsWithDestroyedAt.map(row => row.instanceId);
+        const existingRows = await tx
+          .select({ instanceId: kiloclaw_subscriptions.instance_id })
+          .from(kiloclaw_subscriptions)
+          .where(inArray(kiloclaw_subscriptions.instance_id, instanceIds));
+
+        const existingInstanceIds = new Set(
+          existingRows
+            .map(row => row.instanceId)
+            .filter((instanceId): instanceId is string => Boolean(instanceId))
+        );
+
+        const insertableRows = rowsWithDestroyedAt.filter(
+          row => !existingInstanceIds.has(row.instanceId)
+        );
+        const skippedRows = rowsWithDestroyedAt.filter(row =>
+          existingInstanceIds.has(row.instanceId)
+        );
+
+        skipped.push(
+          ...skippedRows.map(row => ({
+            instanceId: row.instanceId,
+            userId: row.userId,
+            action: row.action,
+          }))
+        );
+
+        if (insertableRows.length === 0) {
+          return;
+        }
+
+        const insertedRows = await tx
+          .insert(kiloclaw_subscriptions)
+          .values(
+            insertableRows.map(row => ({
+              user_id: row.userId,
+              instance_id: row.instanceId,
+              plan: 'trial' as const,
+              status: 'canceled' as const,
+              payment_source: null,
+              cancel_at_period_end: false,
+              trial_started_at: row.instanceCreatedAt,
+              trial_ends_at: getPersonalTrialEndsAt(row.instanceCreatedAt),
+              created_at: row.instanceCreatedAt,
+              updated_at: row.instanceCreatedAt,
+            }))
+          )
+          .returning();
+
+        insertedCount += insertedRows.length;
+
+        if (insertedRows.length === 0) {
+          return;
+        }
+
+        await tx.insert(kiloclaw_subscription_change_log).values(
+          insertedRows.map(insertedRow => ({
+            subscription_id: insertedRow.id,
+            actor_type: ALIGNMENT_SCRIPT_ACTOR.actorType,
+            actor_id: ALIGNMENT_SCRIPT_ACTOR.actorId,
+            action: 'backfilled' as const,
+            reason: 'apply_missing_personal_backfill_destroyed_terminal',
+            before_state: null,
+            after_state: serializeKiloClawSubscriptionSnapshot(insertedRow),
+          }))
+        );
+      });
+    } catch (error) {
+      const errorMessage = describeError(error);
+      for (const row of chunk) {
+        skipped.push({
+          instanceId: row.instanceId,
+          userId: row.userId,
+          action: row.action,
+          error: errorMessage,
+        });
+      }
+    }
+
+    processedCount += chunk.length;
+    logApplyProgress({
+      label: 'apply-missing-personal',
+      processed: params.processedOffset + processedCount,
+      total: params.totalRows,
+      startedAt: params.startedAt,
+      every: params.progressEvery ?? 25,
+    });
+  }
+
+  return {
+    processedCount,
+    insertedCount,
+    skipped,
+  };
+}
 
 async function applyMissingPersonalBackfillRow(
   row: MissingPersonalCandidate
@@ -1659,19 +1883,17 @@ async function applyMissingPersonalBackfillRow(
       // Only current (non-transferred) rows block reassignment. A transferred
       // predecessor on this instance is runtime-invisible and must not block
       // the successor insert.
-      const [existing, hasLiveCurrent] = await Promise.all([
-        tx
-          .select({ id: kiloclaw_subscriptions.id })
-          .from(kiloclaw_subscriptions)
-          .where(
-            and(
-              eq(kiloclaw_subscriptions.instance_id, row.instanceId),
-              isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-            )
+      const existing = await tx
+        .select({ id: kiloclaw_subscriptions.id })
+        .from(kiloclaw_subscriptions)
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.instance_id, row.instanceId),
+            isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
           )
-          .limit(1),
-        liveCurrentPersonalSubscriptionExistsForUser(tx, row.userId),
-      ]);
+        )
+        .limit(1);
+      const hasLiveCurrent = await liveCurrentPersonalSubscriptionExistsForUser(tx, row.userId);
 
       if (existing.length > 0 || hasLiveCurrent) {
         return 'skipped';
@@ -1813,19 +2035,17 @@ async function applyMissingPersonalBackfillRow(
 
       // Only current (non-transferred) rows block bootstrap. Transferred
       // predecessor on this instance is runtime-invisible.
-      const [existingForInstance, hasPersonalForUser] = await Promise.all([
-        tx
-          .select({ id: kiloclaw_subscriptions.id })
-          .from(kiloclaw_subscriptions)
-          .where(
-            and(
-              eq(kiloclaw_subscriptions.instance_id, row.instanceId),
-              isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-            )
+      const existingForInstance = await tx
+        .select({ id: kiloclaw_subscriptions.id })
+        .from(kiloclaw_subscriptions)
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.instance_id, row.instanceId),
+            isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
           )
-          .limit(1),
-        personalContextSubscriptionExistsForUser(tx, row.userId),
-      ]);
+        )
+        .limit(1);
+      const hasPersonalForUser = await personalContextSubscriptionExistsForUser(tx, row.userId);
 
       if (existingForInstance.length > 0 || hasPersonalForUser) {
         return 'skipped';
@@ -1869,24 +2089,22 @@ async function applyMissingPersonalBackfillRow(
 
       // Only current (non-transferred) rows block earlybird backfill.
       // Transferred predecessor on this instance is runtime-invisible.
-      const [existingForInstance, hasPersonalForUser, earlybirdPurchase] = await Promise.all([
-        tx
-          .select({ id: kiloclaw_subscriptions.id })
-          .from(kiloclaw_subscriptions)
-          .where(
-            and(
-              eq(kiloclaw_subscriptions.instance_id, row.instanceId),
-              isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-            )
+      const existingForInstance = await tx
+        .select({ id: kiloclaw_subscriptions.id })
+        .from(kiloclaw_subscriptions)
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.instance_id, row.instanceId),
+            isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
           )
-          .limit(1),
-        personalContextSubscriptionExistsForUser(tx, row.userId),
-        tx
-          .select({ createdAt: kiloclaw_earlybird_purchases.created_at })
-          .from(kiloclaw_earlybird_purchases)
-          .where(eq(kiloclaw_earlybird_purchases.user_id, row.userId))
-          .limit(1),
-      ]);
+        )
+        .limit(1);
+      const hasPersonalForUser = await personalContextSubscriptionExistsForUser(tx, row.userId);
+      const earlybirdPurchase = await tx
+        .select({ createdAt: kiloclaw_earlybird_purchases.created_at })
+        .from(kiloclaw_earlybird_purchases)
+        .where(eq(kiloclaw_earlybird_purchases.user_id, row.userId))
+        .limit(1);
 
       if (existingForInstance.length > 0 || hasPersonalForUser || earlybirdPurchase.length === 0) {
         return 'skipped';
@@ -1981,7 +2199,7 @@ async function applyMissingPersonalBackfillRow(
   });
 }
 
-async function applyMissingPersonalBackfill() {
+async function applyMissingPersonalBackfill(options: ApplyOptions) {
   const rows = await buildMissingPersonalCandidates();
   let adopted = 0;
   let reassigned = 0;
@@ -1994,8 +2212,33 @@ async function applyMissingPersonalBackfill() {
     action: string;
     error?: string;
   }> = [];
+  const startedAt = Date.now();
+  let processedCount = 0;
 
-  for (const row of rows) {
+  const bulkDestroyedRows = options.bulk
+    ? rows.filter(row => row.action === 'backfill_destroyed_terminal_personal')
+    : [];
+  const rowByRowRows = options.bulk
+    ? rows.filter(row => row.action !== 'backfill_destroyed_terminal_personal')
+    : rows;
+
+  if (bulkDestroyedRows.length > 0) {
+    console.log(
+      `[bulk] apply-missing-personal: processing ${bulkDestroyedRows.length} destroyed-terminal rows in chunked bulk mode`
+    );
+    const bulkResult = await applyMissingPersonalDestroyedTerminalBulk({
+      rows: bulkDestroyedRows,
+      startedAt,
+      processedOffset: processedCount,
+      totalRows: rows.length,
+      progressEvery: 25,
+    });
+    processedCount += bulkResult.processedCount;
+    destroyedTerminalBackfilled += bulkResult.insertedCount;
+    skipped.push(...bulkResult.skipped);
+  }
+
+  for (const row of rowByRowRows) {
     let outcome: MissingPersonalOutcome;
     try {
       outcome = await applyMissingPersonalBackfillRow(row);
@@ -2011,6 +2254,14 @@ async function applyMissingPersonalBackfill() {
         userId: row.userId,
         action: row.action,
         error: describeError(error),
+      });
+      processedCount += 1;
+      logApplyProgress({
+        label: 'apply-missing-personal',
+        processed: processedCount,
+        total: rows.length,
+        startedAt,
+        every: 25,
       });
       continue;
     }
@@ -2037,6 +2288,15 @@ async function applyMissingPersonalBackfill() {
       case 'no_op':
         break;
     }
+
+    processedCount += 1;
+    logApplyProgress({
+      label: 'apply-missing-personal',
+      processed: processedCount,
+      total: rows.length,
+      startedAt,
+      every: 25,
+    });
   }
 
   console.log('\nMissing personal backfill results');
@@ -2049,6 +2309,699 @@ async function applyMissingPersonalBackfill() {
     { action: 'skipped', count: skipped.length },
   ]);
   printSection('Missing personal rows skipped during apply', skipped);
+}
+
+type MultiRowAllDestroyedPair = {
+  sourceId: string;
+  targetId: string;
+  sourceCreatedAt: string;
+  targetCreatedAt: string;
+};
+
+type MultiRowAllDestroyedCandidate = {
+  userId: string;
+  tailSubscriptionId: string;
+  tailCreatedAt: string;
+  currentAmbiguousRowCount: number;
+  pairs: MultiRowAllDestroyedPair[];
+  // A candidate is `fullyCollapsible` when the planned pair set reduces the
+  // user's current ambiguous row count to exactly one. When a pre-existing
+  // partial chain (e.g. D→B in a history of [D, A, B, C]) claims an
+  // intermediate row's predecessor slot, the UQ_kiloclaw_subscriptions_transferred_to
+  // guard forces us to drop a pair, leaving more than one row ambiguous.
+  // Apply paths must skip these users — partial collapse would replace one
+  // `CurrentPersonalSubscriptionResolutionError`-firing shape with another
+  // and mask the problem in the change log.
+  fullyCollapsible: boolean;
+};
+
+type MultiRowAllDestroyedOutcome =
+  | 'collapsed'
+  | 'skipped_no_longer_ambiguous'
+  | 'skipped_race'
+  | 'skipped_not_collapsible';
+
+// ---------------------------------------------------------------------------
+// Multi-row-all-destroyed collapse
+//
+// Scope: users whose `personalCurrentSubscriptionWhere` predicate returns >1 rows
+// AND NONE of the joined instances have `destroyed_at IS NULL`. The guard in
+// apps/web/src/lib/kiloclaw/current-personal-subscription.ts filters rows to
+// activeRows first; with zero alive rows and rows.length > 1 it throws at
+// line 114 ("Expected at most one current personal subscription row").
+//
+// Why this is separate from reassign_destroyed_access_row: that path requires
+// a new live target instance to insert a successor onto and move the Stripe
+// funding/schedule to. These users have no live personal instance at all —
+// either they've moved to an org-owned instance (whose rows the guard filters
+// via i.organization_id IS NULL) or they've fully destroyed their personal
+// claw. There's nowhere to create a successor, so we just collapse the chain
+// down to one tail row and let getBillingStatus return it.
+//
+// How the chain is formed: `kiloclaw_subscriptions` has a partial unique index
+// UQ_kiloclaw_subscriptions_transferred_to on transferred_to_subscription_id,
+// so each subscription can have at most ONE predecessor. We therefore cannot
+// fan in all older rows onto the newest; we have to build a linked chain of
+// (row_i → row_{i+1}) pairs within each user's personal-row history ordered
+// oldest-to-newest. For every pair where the older row currently has
+// transferred_to_subscription_id IS NULL, we set it to the immediately-next
+// row's id. We skip any pair whose target already has a predecessor (to avoid
+// UQ violations from pre-existing partial chains), so re-runs are idempotent.
+// ---------------------------------------------------------------------------
+
+type MultiRowAllDestroyedSourceRow = {
+  subscriptionId: string;
+  userId: string;
+  subscriptionCreatedAt: string;
+  instanceDestroyedAt: string | null;
+  transferredToSubscriptionId: string | null;
+};
+
+async function buildMultiRowAllDestroyedCandidates(): Promise<MultiRowAllDestroyedCandidate[]> {
+  // Pulls ALL personal-instance subscription rows across the fleet, including
+  // rows that have already been transferred. We need the complete personal
+  // history per user to form a correct LEAD-chain (otherwise an older
+  // un-transferred row would be paired with a newer row whose predecessor
+  // slot is already occupied by some other row, violating
+  // UQ_kiloclaw_subscriptions_transferred_to).
+  const rows: MultiRowAllDestroyedSourceRow[] = await db
+    .select({
+      subscriptionId: kiloclaw_subscriptions.id,
+      userId: kiloclaw_subscriptions.user_id,
+      subscriptionCreatedAt: kiloclaw_subscriptions.created_at,
+      instanceDestroyedAt: kiloclaw_instances.destroyed_at,
+      transferredToSubscriptionId: kiloclaw_subscriptions.transferred_to_subscription_id,
+    })
+    .from(kiloclaw_subscriptions)
+    .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+    .where(
+      and(
+        eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id),
+        isNull(kiloclaw_instances.organization_id)
+      )
+    )
+    .orderBy(
+      asc(kiloclaw_subscriptions.user_id),
+      asc(kiloclaw_subscriptions.created_at),
+      asc(kiloclaw_subscriptions.id)
+    );
+
+  const byUser = new Map<string, MultiRowAllDestroyedSourceRow[]>();
+  for (const row of rows) {
+    const existing = byUser.get(row.userId);
+    if (existing) {
+      existing.push(row);
+    } else {
+      byUser.set(row.userId, [row]);
+    }
+  }
+
+  const candidates: MultiRowAllDestroyedCandidate[] = [];
+  for (const [userId, userRows] of byUser) {
+    // `firing_all_destroyed_multi` per the 2026-04-18 incident analysis:
+    // >1 rows currently match personalCurrentSubscriptionWhere (transferred_to
+    // IS NULL, org-less) AND none of them are alive. If any current ambiguous
+    // row points at a live instance the guard picks it and returns safely, so
+    // there's nothing for us to collapse.
+    const currentAmbiguous = userRows.filter(row => row.transferredToSubscriptionId === null);
+    if (currentAmbiguous.length < 2) continue;
+    if (currentAmbiguous.some(row => row.instanceDestroyedAt === null)) continue;
+
+    const pairs = planMultiRowAllDestroyedPairsFromSourceRows(userRows);
+    // `fullyCollapsible` === true means applying the plan reduces the
+    // ambiguous set to exactly one tail row. If every candidate target is
+    // already someone else's predecessor, the plan is empty and
+    // `fullyCollapsible` will be false — we still surface the user so
+    // operators and apply can count them as requiring manual review.
+    const fullyCollapsible = currentAmbiguous.length - pairs.length === 1;
+
+    const tail = userRows[userRows.length - 1];
+    if (!tail) continue;
+
+    candidates.push({
+      userId,
+      tailSubscriptionId: tail.subscriptionId,
+      tailCreatedAt: tail.subscriptionCreatedAt,
+      currentAmbiguousRowCount: currentAmbiguous.length,
+      pairs,
+      fullyCollapsible,
+    });
+  }
+
+  return candidates;
+}
+
+// Sequential-chain pair planner shared by preview and both apply paths.
+// Walks rows oldest-to-newest, pairing each non-transferred row with its
+// immediately-next row as successor, skipping pairs whose target is already
+// someone else's predecessor (UQ_kiloclaw_subscriptions_transferred_to).
+// The plan collapses the user's ambiguous set when
+// `currentAmbiguousCount - pairs.length === 1`. Callers must check that
+// condition before applying — partial plans leave the user still ambiguous.
+function planMultiRowAllDestroyedPairsFromSourceRows(
+  userRows: MultiRowAllDestroyedSourceRow[]
+): MultiRowAllDestroyedPair[] {
+  const existingPredecessorTargets = new Set(
+    userRows.map(row => row.transferredToSubscriptionId).filter((id): id is string => id !== null)
+  );
+
+  const pairs: MultiRowAllDestroyedPair[] = [];
+  for (let index = 0; index < userRows.length - 1; index += 1) {
+    const source = userRows[index];
+    const next = userRows[index + 1];
+    if (!source || !next) continue;
+    if (source.transferredToSubscriptionId !== null) continue;
+    if (existingPredecessorTargets.has(next.subscriptionId)) continue;
+    pairs.push({
+      sourceId: source.subscriptionId,
+      targetId: next.subscriptionId,
+      sourceCreatedAt: source.subscriptionCreatedAt,
+      targetCreatedAt: next.subscriptionCreatedAt,
+    });
+    existingPredecessorTargets.add(next.subscriptionId);
+  }
+  return pairs;
+}
+
+type MultiRowJoinedRow = {
+  subscription: KiloClawSubscription;
+  instanceDestroyedAt: string | null;
+};
+
+// Variant of the planner that works on full joined rows (subscription +
+// instance destroyed_at) so apply paths can reuse each `before` row object
+// directly for change-log snapshots without a per-pair SELECT. The
+// collapsibility rule is the same: `ambiguous - pairs === 1` to fully
+// collapse.
+function planMultiRowAllDestroyedPairsFromJoinedRows(
+  joinedRows: MultiRowJoinedRow[]
+): Array<{ before: KiloClawSubscription; targetId: string }> {
+  const existingPredecessorTargets = new Set(
+    joinedRows
+      .map(row => row.subscription.transferred_to_subscription_id)
+      .filter((id): id is string => id !== null)
+  );
+
+  const pairs: Array<{ before: KiloClawSubscription; targetId: string }> = [];
+  for (let index = 0; index < joinedRows.length - 1; index += 1) {
+    const source = joinedRows[index]?.subscription;
+    const next = joinedRows[index + 1]?.subscription;
+    if (!source || !next) continue;
+    if (source.transferred_to_subscription_id !== null) continue;
+    if (existingPredecessorTargets.has(next.id)) continue;
+    pairs.push({ before: source, targetId: next.id });
+    existingPredecessorTargets.add(next.id);
+  }
+  return pairs;
+}
+
+function summarizeMultiRowAllDestroyedCandidates(candidates: MultiRowAllDestroyedCandidate[]) {
+  const collapsible = candidates.filter(candidate => candidate.fullyCollapsible);
+  const nonCollapsible = candidates.filter(candidate => !candidate.fullyCollapsible);
+  const totalPairsToWrite = collapsible.reduce((acc, row) => acc + row.pairs.length, 0);
+  const buckets = new Map<number, number>();
+  for (const candidate of collapsible) {
+    const userRowCount = candidate.currentAmbiguousRowCount;
+    buckets.set(userRowCount, (buckets.get(userRowCount) ?? 0) + 1);
+  }
+  return {
+    collapsibleUsers: collapsible.length,
+    nonCollapsibleUsers: nonCollapsible.length,
+    totalPairsToWrite,
+    distribution: [...buckets.entries()]
+      .sort(([a], [b]) => a - b)
+      .map(([currentAmbiguousRowCount, users]) => ({
+        currentAmbiguousRowCount,
+        users,
+      })),
+  };
+}
+
+async function previewMultiRowAllDestroyedCollapse() {
+  const candidates = await buildMultiRowAllDestroyedCandidates();
+  const summary = summarizeMultiRowAllDestroyedCandidates(candidates);
+  const nonCollapsible = candidates.filter(candidate => !candidate.fullyCollapsible);
+
+  console.log('\nmulti-row-all-destroyed preview');
+  console.table([
+    { metric: 'users_collapsible', count: summary.collapsibleUsers },
+    { metric: 'users_non_collapsible', count: summary.nonCollapsibleUsers },
+    { metric: 'pairs_to_write', count: summary.totalPairsToWrite },
+  ]);
+  printSection(
+    'Collapsible user ambiguous-row-count distribution (rows matching the guard before collapse)',
+    summary.distribution
+  );
+  printSection(
+    'Sample collapsible candidates (top 25 by pair count desc)',
+    candidates
+      .filter(candidate => candidate.fullyCollapsible)
+      .sort((a, b) => b.pairs.length - a.pairs.length)
+      .slice(0, 25)
+      .map(candidate => ({
+        userId: candidate.userId,
+        tailSubscriptionId: candidate.tailSubscriptionId,
+        tailCreatedAt: candidate.tailCreatedAt,
+        currentAmbiguousRows: candidate.currentAmbiguousRowCount,
+        pairsToWrite: candidate.pairs.length,
+        oldestSourceCreatedAt: candidate.pairs[0]?.sourceCreatedAt ?? null,
+      }))
+  );
+  if (nonCollapsible.length > 0) {
+    printSection(
+      'Non-collapsible users (pre-existing partial chain blocks full collapse; require manual review)',
+      nonCollapsible.slice(0, 25).map(candidate => ({
+        userId: candidate.userId,
+        currentAmbiguousRows: candidate.currentAmbiguousRowCount,
+        pairsPlanned: candidate.pairs.length,
+        ambiguousRowsRemainingAfterPlan:
+          candidate.currentAmbiguousRowCount - candidate.pairs.length,
+      }))
+    );
+  }
+}
+
+async function applyMultiRowAllDestroyedCollapseRow(
+  candidate: MultiRowAllDestroyedCandidate
+): Promise<{ outcome: MultiRowAllDestroyedOutcome; pairsWritten: number }> {
+  return await db.transaction(async tx => {
+    // Re-read the user's full personal history inside the tx and rebuild the
+    // pair plan from scratch. This keeps us safe under reprovision/transfer
+    // races between preview and apply (new rows arrived, some rows got
+    // transferred out of band, etc.) without needing explicit row locks. The
+    // cost is a small duplication of the builder logic on a single user.
+    //
+    // The SELECT pulls all columns (not a narrow projection) so the same row
+    // objects serve both as the re-verification dataset and as the `before`
+    // snapshots for the change-log — no per-pair SELECT roundtrip needed.
+    const joinedRows = await tx
+      .select({
+        subscription: kiloclaw_subscriptions,
+        instanceDestroyedAt: kiloclaw_instances.destroyed_at,
+      })
+      .from(kiloclaw_subscriptions)
+      .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+      .where(
+        and(
+          eq(kiloclaw_subscriptions.user_id, candidate.userId),
+          eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id),
+          isNull(kiloclaw_instances.organization_id)
+        )
+      )
+      .orderBy(asc(kiloclaw_subscriptions.created_at), asc(kiloclaw_subscriptions.id));
+
+    const currentAmbiguous = joinedRows.filter(
+      row => row.subscription.transferred_to_subscription_id === null
+    );
+    if (currentAmbiguous.length < 2) {
+      return { outcome: 'skipped_no_longer_ambiguous' as const, pairsWritten: 0 };
+    }
+    if (currentAmbiguous.some(row => row.instanceDestroyedAt === null)) {
+      // A new live instance was provisioned between preview and apply — guard
+      // will pick that row at runtime. No collapse needed.
+      return { outcome: 'skipped_no_longer_ambiguous' as const, pairsWritten: 0 };
+    }
+
+    const plannedPairs = planMultiRowAllDestroyedPairsFromJoinedRows(joinedRows);
+
+    // A partial plan would replace the guard-firing shape with a different
+    // guard-firing shape and obscure the broken state in the change log.
+    // Require that applying the plan reduces the ambiguous set to exactly one
+    // tail row before writing anything. This also covers the degenerate
+    // `plannedPairs.length === 0` case: `currentAmbiguous.length >= 2` by
+    // guard above, so zero pairs cannot satisfy `- plannedPairs.length === 1`.
+    if (currentAmbiguous.length - plannedPairs.length !== 1) {
+      return { outcome: 'skipped_not_collapsible' as const, pairsWritten: 0 };
+    }
+
+    // Apply each UPDATE individually but capture the after-row for batched
+    // change-log writes at the end of the user. Doing the UPDATEs in a
+    // single bulk-statement (UPDATE ... FROM VALUES) would save another
+    // N-1 roundtrips per user but would require raw SQL and a driver-
+    // specific RETURNING-row shape; the per-pair update is easy to reason
+    // about, keeps drizzle's types intact, and the big win here is already
+    // the dropped per-pair before-SELECT plus the batched change-log INSERT.
+    //
+    // `updated_at` is auto-updated by the schema's $onUpdateFn, so we never
+    // need to stamp it manually.
+    const appliedPairs: Array<{ before: KiloClawSubscription; after: KiloClawSubscription }> = [];
+    for (const pair of plannedPairs) {
+      const [after] = await tx
+        .update(kiloclaw_subscriptions)
+        .set({ transferred_to_subscription_id: pair.targetId })
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.id, pair.before.id),
+            isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+          )
+        )
+        .returning();
+
+      if (!after) {
+        // Source was concurrently transferred by another process. Fine — the
+        // row is no longer ambiguous. Move on.
+        continue;
+      }
+
+      appliedPairs.push({ before: pair.before, after });
+    }
+
+    if (appliedPairs.length === 0) {
+      return { outcome: 'skipped_race' as const, pairsWritten: 0 };
+    }
+
+    // Single bulk INSERT for the whole user's change-log rows instead of
+    // one INSERT per pair. This mirrors the pattern in
+    // applyMissingPersonalDestroyedTerminalBulk.
+    await tx.insert(kiloclaw_subscription_change_log).values(
+      appliedPairs.map(({ before, after }) => ({
+        subscription_id: after.id,
+        actor_type: ALIGNMENT_SCRIPT_ACTOR.actorType,
+        actor_id: ALIGNMENT_SCRIPT_ACTOR.actorId,
+        action: 'reassigned' as const,
+        reason: 'apply_multi_row_all_destroyed_collapse',
+        before_state: serializeKiloClawSubscriptionSnapshot(before),
+        after_state: serializeKiloClawSubscriptionSnapshot(after),
+      }))
+    );
+
+    return { outcome: 'collapsed' as const, pairsWritten: appliedPairs.length };
+  });
+}
+
+async function applyMultiRowAllDestroyedCollapseChunkBulk(params: {
+  chunk: MultiRowAllDestroyedCandidate[];
+}): Promise<{
+  usersCollapsed: number;
+  pairsWritten: number;
+  usersWithNoWork: number;
+  usersNotCollapsible: number;
+}> {
+  return await db.transaction(async tx => {
+    const userIds = params.chunk.map(candidate => candidate.userId);
+
+    // 1. Single multi-user SELECT: every personal-instance row for every user
+    //    in the chunk. Grouped in memory below so pair-planning is identical
+    //    to the per-user path.
+    const joinedRows = await tx
+      .select({
+        subscription: kiloclaw_subscriptions,
+        instanceDestroyedAt: kiloclaw_instances.destroyed_at,
+      })
+      .from(kiloclaw_subscriptions)
+      .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+      .where(
+        and(
+          inArray(kiloclaw_subscriptions.user_id, userIds),
+          eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id),
+          isNull(kiloclaw_instances.organization_id)
+        )
+      )
+      .orderBy(
+        asc(kiloclaw_subscriptions.user_id),
+        asc(kiloclaw_subscriptions.created_at),
+        asc(kiloclaw_subscriptions.id)
+      );
+
+    const byUser = new Map<string, typeof joinedRows>();
+    for (const row of joinedRows) {
+      const uid = row.subscription.user_id;
+      const existing = byUser.get(uid);
+      if (existing) {
+        existing.push(row);
+      } else {
+        byUser.set(uid, [row]);
+      }
+    }
+
+    // 2. Build every user's pair plan. Re-verifies the guard-firing invariant
+    //    inside the tx (just like the per-user path). `allPlannedPairs` keeps
+    //    the user id alongside each pair so we can tally per-user outcomes
+    //    after the RETURNING set comes back.
+    type PlannedPair = {
+      userId: string;
+      before: KiloClawSubscription;
+      targetId: string;
+    };
+    const allPlannedPairs: PlannedPair[] = [];
+    let usersWithNoWork = 0;
+    let usersNotCollapsible = 0;
+
+    for (const candidate of params.chunk) {
+      const userRows = byUser.get(candidate.userId);
+      if (!userRows || userRows.length < 2) {
+        usersWithNoWork += 1;
+        continue;
+      }
+      const currentAmbiguous = userRows.filter(
+        row => row.subscription.transferred_to_subscription_id === null
+      );
+      if (currentAmbiguous.length < 2) {
+        usersWithNoWork += 1;
+        continue;
+      }
+      if (currentAmbiguous.some(row => row.instanceDestroyedAt === null)) {
+        usersWithNoWork += 1;
+        continue;
+      }
+
+      const plannedPairs = planMultiRowAllDestroyedPairsFromJoinedRows(userRows);
+
+      // Skip non-collapsible users: writing their partial chain would replace
+      // one guard-firing shape with another and still leave the user broken.
+      // `plannedPairs.length === 0` is also caught here because
+      // `currentAmbiguous.length >= 2` above (zero pairs would leave `!== 1`).
+      if (currentAmbiguous.length - plannedPairs.length !== 1) {
+        usersNotCollapsible += 1;
+        continue;
+      }
+
+      for (const pair of plannedPairs) {
+        allPlannedPairs.push({
+          userId: candidate.userId,
+          before: pair.before,
+          targetId: pair.targetId,
+        });
+      }
+    }
+
+    if (allPlannedPairs.length === 0) {
+      return { usersCollapsed: 0, pairsWritten: 0, usersWithNoWork, usersNotCollapsible };
+    }
+
+    // 3. One raw-SQL bulk UPDATE for every pair in the chunk. FROM VALUES is
+    //    the cleanest Postgres pattern for this — each `(source_id, target_id)`
+    //    tuple drives one UPDATE row. The `transferred_to_subscription_id IS NULL`
+    //    guard in the WHERE clause provides optimistic-concurrency against
+    //    external writes; rows that raced are silently dropped from the
+    //    RETURNING set. `updated_at` is auto-stamped by the schema's
+    //    $onUpdateFn.
+    const valuesFragments = allPlannedPairs.map(
+      pair => sql`(${pair.before.id}::uuid, ${pair.targetId}::uuid)`
+    );
+
+    const { rows: updatedRows } = await tx.execute<{
+      id: string;
+      updated_at: string;
+    }>(sql`
+      UPDATE ${kiloclaw_subscriptions} AS s
+      SET transferred_to_subscription_id = v.target_id
+      FROM (VALUES ${sql.join(valuesFragments, sql`, `)}) AS v(source_id, target_id)
+      WHERE s.id = v.source_id
+        AND s.transferred_to_subscription_id IS NULL
+      RETURNING s.id AS id, s.updated_at AS updated_at
+    `);
+
+    if (updatedRows.length === 0) {
+      return { usersCollapsed: 0, pairsWritten: 0, usersWithNoWork, usersNotCollapsible };
+    }
+
+    // 4. Reconstruct the `after` snapshot for each updated row from the
+    //    in-memory before + planned target id + fresh updated_at stamp.
+    //    Cheaper than returning every column from Postgres.
+    const plannedById = new Map(allPlannedPairs.map(pair => [pair.before.id, pair]));
+
+    const changeLogRows = updatedRows.flatMap(updated => {
+      const planned = plannedById.get(updated.id);
+      if (!planned) return [];
+      const after: KiloClawSubscription = {
+        ...planned.before,
+        transferred_to_subscription_id: planned.targetId,
+        updated_at: updated.updated_at,
+      };
+      return [
+        {
+          subscription_id: updated.id,
+          actor_type: ALIGNMENT_SCRIPT_ACTOR.actorType,
+          actor_id: ALIGNMENT_SCRIPT_ACTOR.actorId,
+          action: 'reassigned' as const,
+          reason: 'apply_multi_row_all_destroyed_collapse',
+          before_state: serializeKiloClawSubscriptionSnapshot(planned.before),
+          after_state: serializeKiloClawSubscriptionSnapshot(after),
+        },
+      ];
+    });
+
+    // 5. One bulk INSERT for every change-log row in the chunk.
+    if (changeLogRows.length > 0) {
+      await tx.insert(kiloclaw_subscription_change_log).values(changeLogRows);
+    }
+
+    // A user counts as collapsed if at least one of their planned pairs
+    // actually landed in the RETURNING set. Users whose planned pairs all
+    // raced (should be vanishingly rare at this scale) are left uncounted
+    // here and will be re-checked by the final preview step.
+    const touchedSourceIds = new Set(updatedRows.map(row => row.id));
+    const collapsedUserIds = new Set<string>();
+    for (const pair of allPlannedPairs) {
+      if (touchedSourceIds.has(pair.before.id)) {
+        collapsedUserIds.add(pair.userId);
+      }
+    }
+
+    return {
+      usersCollapsed: collapsedUserIds.size,
+      pairsWritten: updatedRows.length,
+      usersWithNoWork,
+      usersNotCollapsible,
+    };
+  });
+}
+
+async function applyMultiRowAllDestroyedCollapse(options: ApplyOptions) {
+  const allCandidates = await buildMultiRowAllDestroyedCandidates();
+  const candidates = allCandidates.filter(candidate => candidate.fullyCollapsible);
+  const nonCollapsibleCandidates = allCandidates.filter(candidate => !candidate.fullyCollapsible);
+  const totalPairs = candidates.reduce((acc, row) => acc + row.pairs.length, 0);
+
+  console.log(
+    `\nmulti-row-all-destroyed apply: ${candidates.length} collapsible users, ${totalPairs} pairs to write`
+  );
+  if (nonCollapsibleCandidates.length > 0) {
+    console.log(
+      `[skip] ${nonCollapsibleCandidates.length} user(s) non-collapsible (pre-existing partial chain); require manual review`
+    );
+  }
+  if (options.bulk) {
+    console.log(
+      '[bulk] enabled; processing ~250 users per transaction, per-user fallback on chunk failure'
+    );
+  }
+
+  let usersCollapsed = 0;
+  let pairsWritten = 0;
+  let usersWithNoWork = 0;
+  const skipped: Array<{ userId: string; reason: string; error?: string }> = [
+    ...nonCollapsibleCandidates.map(candidate => ({
+      userId: candidate.userId,
+      reason: 'skipped_not_collapsible',
+    })),
+  ];
+  const perUserFallback: MultiRowAllDestroyedCandidate[] = [];
+  const startedAt = Date.now();
+
+  if (options.bulk) {
+    const bulkChunkSize = 250;
+    let processed = 0;
+
+    for (const chunk of chunkArray(candidates, bulkChunkSize)) {
+      try {
+        const result = await applyMultiRowAllDestroyedCollapseChunkBulk({ chunk });
+        usersCollapsed += result.usersCollapsed;
+        pairsWritten += result.pairsWritten;
+        usersWithNoWork += result.usersWithNoWork;
+        // `usersNotCollapsible` from the bulk result counts users whose
+        // apply-time re-plan came back non-collapsible after the preview
+        // showed them as collapsible (race with a concurrent chain write).
+        // Surface them as skipped without an individual user id, since the
+        // bulk path doesn't carry per-user identity out of the tx.
+        for (let i = 0; i < result.usersNotCollapsible; i += 1) {
+          skipped.push({ userId: '(bulk chunk)', reason: 'skipped_not_collapsible' });
+        }
+      } catch (error) {
+        // One bad row (e.g. a UQ_kiloclaw_subscriptions_transferred_to race
+        // from a concurrent webhook / reprovision) poisons the entire chunk
+        // tx. Fall back to per-user for the chunk so the rest of the fleet
+        // isn't held hostage by one user.
+        console.error('[bulk-chunk-fail] falling back to per-user for chunk', {
+          chunkSize: chunk.length,
+          firstUserId: chunk[0]?.userId,
+          lastUserId: chunk[chunk.length - 1]?.userId,
+          error: describeError(error),
+        });
+        perUserFallback.push(...chunk);
+      }
+
+      processed += chunk.length;
+      logApplyProgress({
+        label: 'apply-multi-row-all-destroyed-bulk',
+        processed,
+        total: candidates.length,
+        startedAt,
+        every: 1,
+      });
+    }
+  }
+
+  const perUserQueue = options.bulk ? perUserFallback : candidates;
+  if (options.bulk && perUserFallback.length > 0) {
+    console.log(
+      `[bulk] ${perUserFallback.length} user(s) routed to per-user fallback after chunk failure`
+    );
+  }
+
+  for (const [index, candidate] of perUserQueue.entries()) {
+    try {
+      const result = await applyMultiRowAllDestroyedCollapseRow(candidate);
+      if (result.outcome === 'collapsed') {
+        usersCollapsed += 1;
+        pairsWritten += result.pairsWritten;
+      } else {
+        skipped.push({ userId: candidate.userId, reason: result.outcome });
+      }
+    } catch (error) {
+      console.error('multi-row-all-destroyed apply row failed', {
+        userId: candidate.userId,
+        tailSubscriptionId: candidate.tailSubscriptionId,
+        plannedPairs: candidate.pairs.length,
+        error: describeError(error),
+      });
+      skipped.push({
+        userId: candidate.userId,
+        reason: 'error',
+        error: describeError(error),
+      });
+    }
+
+    logApplyProgress({
+      label: options.bulk
+        ? 'apply-multi-row-all-destroyed-per-user-fallback'
+        : 'apply-multi-row-all-destroyed',
+      processed: index + 1,
+      total: perUserQueue.length,
+      startedAt,
+      every: 50,
+    });
+  }
+
+  // Derive the non-collapsible metric from the skipped set so it includes
+  // preview-time detection, bulk in-tx re-plan races, and per-user in-tx
+  // re-plan races. Counting only `nonCollapsibleCandidates.length` would
+  // hide users whose plan was valid at preview but raced with a concurrent
+  // chain write during apply.
+  const usersSkippedNotCollapsible = skipped.filter(
+    row => row.reason === 'skipped_not_collapsible'
+  ).length;
+
+  console.log('\nmulti-row-all-destroyed apply results');
+  console.table([
+    { metric: 'users_collapsed', count: usersCollapsed },
+    { metric: 'pairs_written', count: pairsWritten },
+    { metric: 'users_skipped_no_work', count: usersWithNoWork },
+    { metric: 'users_skipped_not_collapsible', count: usersSkippedNotCollapsible },
+    { metric: 'users_skipped_total', count: skipped.length },
+  ]);
+  printSection('Users skipped during multi-row-all-destroyed apply', skipped.slice(0, 50));
 }
 
 type OrgApplyOutcome = OrgBackfillAction | 'skipped';
@@ -2143,8 +3096,9 @@ async function applyOrgBackfill() {
     action: string;
     error?: string;
   }> = [];
+  const startedAt = Date.now();
 
-  for (const row of rows) {
+  for (const [index, row] of rows.entries()) {
     let outcome: OrgApplyOutcome;
     try {
       outcome = await applyOrgBackfillRow(row);
@@ -2163,6 +3117,13 @@ async function applyOrgBackfill() {
         action: row.action,
         error: describeError(error),
       });
+      logApplyProgress({
+        label: 'apply-org',
+        processed: index + 1,
+        total: rows.length,
+        startedAt,
+        every: 50,
+      });
       continue;
     }
 
@@ -2176,6 +3137,14 @@ async function applyOrgBackfill() {
     } else {
       counts[outcome] += 1;
     }
+
+    logApplyProgress({
+      label: 'apply-org',
+      processed: index + 1,
+      total: rows.length,
+      startedAt,
+      every: 50,
+    });
   }
 
   console.log('\nOrg backfill results');
@@ -2192,128 +3161,9 @@ async function applyOrgBackfill() {
   printSection('Org rows skipped during apply', skipped);
 }
 
-async function buildMultiRowAllDestroyedCandidates(): Promise<MultiRowAllDestroyedCandidate[]> {
-  const rows = await db
-    .select({
-      subscriptionId: kiloclaw_subscriptions.id,
-      userId: kiloclaw_subscriptions.user_id,
-      instanceId: kiloclaw_subscriptions.instance_id,
-      subscriptionCreatedAt: kiloclaw_subscriptions.created_at,
-      instanceDestroyedAt: kiloclaw_instances.destroyed_at,
-    })
-    .from(kiloclaw_subscriptions)
-    .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
-    .where(
-      and(
-        isNotNull(kiloclaw_subscriptions.instance_id),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
-        eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id),
-        isNull(kiloclaw_instances.organization_id)
-      )
-    )
-    .orderBy(
-      kiloclaw_subscriptions.user_id,
-      kiloclaw_subscriptions.created_at,
-      kiloclaw_subscriptions.id
-    );
-
-  const grouped = new Map<string, typeof rows>();
-  for (const row of rows) {
-    const existing = grouped.get(row.userId);
-    if (existing) {
-      existing.push(row);
-    } else {
-      grouped.set(row.userId, [row]);
-    }
-  }
-
-  const candidates: MultiRowAllDestroyedCandidate[] = [];
-  for (const [userId, userRows] of grouped.entries()) {
-    const aliveRows = userRows.filter(row => row.instanceDestroyedAt === null);
-    if (aliveRows.length > 0 || userRows.length <= 1) {
-      continue;
-    }
-
-    const latestRow = userRows[userRows.length - 1];
-    if (!latestRow?.instanceId) {
-      continue;
-    }
-
-    candidates.push({
-      currentRowCount: userRows.length,
-      destroyedInstanceId: latestRow.instanceId,
-      latestSubscriptionCreatedAt: latestRow.subscriptionCreatedAt,
-      subscriptionIds: userRows.map(row => row.subscriptionId),
-      userId,
-    });
-  }
-
-  return candidates;
-}
-
-async function previewMultiRowAllDestroyed() {
-  const rows = await buildMultiRowAllDestroyedCandidates();
-
-  printSection('Multi-row all-destroyed users', rows);
-  printSection('Multi-row all-destroyed action counts', [
-    { action: 'apply_multi_row_all_destroyed_collapse', count: rows.length },
-  ]);
-}
-
-async function applyMultiRowAllDestroyed() {
-  const rows = await buildMultiRowAllDestroyedCandidates();
-  let collapsedUsers = 0;
-  let updatedSubscriptions = 0;
-  const skipped: Array<{ userId: string; destroyedInstanceId: string; reason: string }> = [];
-
-  for (const row of rows) {
-    try {
-      const result = await db.transaction(async tx => {
-        return await collapseOrphanPersonalSubscriptionsOnDestroy({
-          actor: ALIGNMENT_SCRIPT_ACTOR,
-          destroyedInstanceId: row.destroyedInstanceId,
-          executor: tx,
-          reason: 'apply_multi_row_all_destroyed_collapse',
-          userId: row.userId,
-        });
-      });
-
-      if (result.updatedSubscriptionIds.length === 0) {
-        skipped.push({
-          userId: row.userId,
-          destroyedInstanceId: row.destroyedInstanceId,
-          reason: 'no_updates_needed',
-        });
-        continue;
-      }
-
-      collapsedUsers += 1;
-      updatedSubscriptions += result.updatedSubscriptionIds.length;
-    } catch (error) {
-      console.error('Multi-row all-destroyed apply row failed', {
-        userId: row.userId,
-        destroyedInstanceId: row.destroyedInstanceId,
-        error: describeError(error),
-      });
-      skipped.push({
-        userId: row.userId,
-        destroyedInstanceId: row.destroyedInstanceId,
-        reason: describeError(error),
-      });
-    }
-  }
-
-  console.log('\nMulti-row all-destroyed apply results');
-  console.table([
-    { action: 'apply_multi_row_all_destroyed_collapse', count: collapsedUsers },
-    { action: 'updated_subscriptions', count: updatedSubscriptions },
-    { action: 'skipped', count: skipped.length },
-  ]);
-  printSection('Multi-row all-destroyed users skipped during apply', skipped);
-}
-
 type ApplyOptions = {
   confirmSandboxesDestroyed: boolean;
+  bulk: boolean;
 };
 
 function parseMode(inputMode?: string): Mode {
@@ -2327,10 +3177,10 @@ function parseMode(inputMode?: string): Mode {
     case 'apply-duplicates':
     case 'preview-org':
     case 'apply-org':
-    case 'preview-multi-row-all-destroyed':
-    case 'apply-multi-row-all-destroyed':
     case 'preview-changelog-baseline':
     case 'apply-changelog-baseline':
+    case 'preview-multi-row-all-destroyed':
+    case 'apply-multi-row-all-destroyed':
       return mode;
     default:
       throw new Error(`Unsupported mode: ${inputMode}`);
@@ -2340,6 +3190,7 @@ function parseMode(inputMode?: string): Mode {
 function parseApplyOptions(args: string[]): ApplyOptions {
   return {
     confirmSandboxesDestroyed: args.includes('--confirm-sandboxes-destroyed'),
+    bulk: args.includes('--bulk'),
   };
 }
 
@@ -2352,10 +3203,10 @@ const singleModeHandlers: Partial<Record<Mode, ModeHandler>> = {
   'apply-duplicates': applyDuplicateActiveInstances,
   'preview-org': previewOrgBackfill,
   'apply-org': applyOrgBackfill,
-  'preview-multi-row-all-destroyed': previewMultiRowAllDestroyed,
-  'apply-multi-row-all-destroyed': applyMultiRowAllDestroyed,
   'preview-changelog-baseline': previewChangelogBaselineBackfill,
   'apply-changelog-baseline': applyChangelogBaselineBackfill,
+  'preview-multi-row-all-destroyed': previewMultiRowAllDestroyedCollapse,
+  'apply-multi-row-all-destroyed': applyMultiRowAllDestroyedCollapse,
 };
 
 export async function run(...args: string[]) {
@@ -2464,7 +3315,8 @@ export async function run(...args: string[]) {
 
   let repaired = 0;
   const failures: Array<{ subscriptionId: string; userId: string; error: string }> = [];
-  for (const row of repairable) {
+  const startedAt = Date.now();
+  for (const [index, row] of repairable.entries()) {
     if (!row.targetInstanceId) continue;
     const targetInstanceId = row.targetInstanceId;
     try {
@@ -2512,6 +3364,14 @@ export async function run(...args: string[]) {
         error: describeError(error),
       });
     }
+
+    logApplyProgress({
+      label: 'repair-detached',
+      processed: index + 1,
+      total: repairable.length,
+      startedAt,
+      every: 25,
+    });
   }
 
   console.log(`\nDetached subscriptions repaired: ${repaired}`);

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -13,5 +13,11 @@ export {
   type KiloClawSubscriptionChangeActor,
   type KiloClawSubscriptionChangeLogInput,
 } from './kiloclaw-subscription-change-log';
+export {
+  collapseOrphanPersonalSubscriptionsOnDestroy,
+  markInstanceDestroyedWithPersonalSubscriptionCollapse,
+  PersonalSubscriptionDestroyConflictError,
+  type DestroyedInstanceRow,
+} from './kiloclaw-personal-subscription-collapse';
 export { computeDatabaseUrl, getDatabaseClientConfig } from './database-url';
 export { sql, ne } from 'drizzle-orm';

--- a/packages/db/src/kiloclaw-personal-subscription-collapse.ts
+++ b/packages/db/src/kiloclaw-personal-subscription-collapse.ts
@@ -1,0 +1,310 @@
+import { and, eq, isNotNull, isNull } from 'drizzle-orm';
+
+import type { WorkerDb } from './client';
+import {
+  insertKiloClawSubscriptionChangeLog,
+  type KiloClawSubscriptionChangeActor,
+} from './kiloclaw-subscription-change-log';
+import { kiloclaw_instances, kiloclaw_subscriptions, type KiloClawSubscription } from './schema';
+
+type PersonalSubscriptionCollapseWriter = Pick<WorkerDb, 'insert' | 'select' | 'update'>;
+
+type PersonalSubscriptionRow = {
+  subscription: KiloClawSubscription;
+  instance: {
+    id: string;
+    destroyedAt: string | null;
+  };
+};
+
+export type DestroyedInstanceRow = {
+  id: string;
+  userId: string;
+  sandboxId: string;
+  organizationId: string | null;
+  name: string | null;
+  inboundEmailEnabled: boolean;
+};
+
+export class PersonalSubscriptionDestroyConflictError extends Error {
+  readonly userId: string;
+  readonly instanceId: string;
+  readonly aliveCount: number;
+
+  constructor(params: { userId: string; instanceId: string; aliveCount: number }) {
+    super(
+      `Refusing to collapse personal subscription chain for user ${params.userId}: found ${params.aliveCount} alive current personal rows`
+    );
+    this.name = 'PersonalSubscriptionDestroyConflictError';
+    this.userId = params.userId;
+    this.instanceId = params.instanceId;
+    this.aliveCount = params.aliveCount;
+  }
+}
+
+function byCreatedAtAndId(left: PersonalSubscriptionRow, right: PersonalSubscriptionRow): number {
+  if (left.subscription.created_at === right.subscription.created_at) {
+    return left.subscription.id.localeCompare(right.subscription.id);
+  }
+  return left.subscription.created_at.localeCompare(right.subscription.created_at);
+}
+
+async function listPersonalSubscriptionRows(
+  executor: PersonalSubscriptionCollapseWriter,
+  userId: string
+): Promise<PersonalSubscriptionRow[]> {
+  return await executor
+    .select({
+      subscription: kiloclaw_subscriptions,
+      instance: {
+        id: kiloclaw_instances.id,
+        destroyedAt: kiloclaw_instances.destroyed_at,
+      },
+    })
+    .from(kiloclaw_subscriptions)
+    .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, userId),
+        isNotNull(kiloclaw_subscriptions.instance_id),
+        eq(kiloclaw_instances.user_id, userId),
+        isNull(kiloclaw_instances.organization_id)
+      )
+    )
+    .orderBy(kiloclaw_subscriptions.created_at, kiloclaw_subscriptions.id);
+}
+
+function getCurrentRows(rows: PersonalSubscriptionRow[]): PersonalSubscriptionRow[] {
+  return rows.filter(row => row.subscription.transferred_to_subscription_id === null);
+}
+
+function getAliveCurrentRows(rows: PersonalSubscriptionRow[]): PersonalSubscriptionRow[] {
+  return getCurrentRows(rows).filter(row => row.instance.destroyedAt === null);
+}
+
+type TransferUpdate = {
+  before: KiloClawSubscription;
+  transferredToSubscriptionId: string | null;
+};
+
+type ChangeLogFailurePolicy = 'fail' | 'log';
+
+type ChangeLogFailureContext = {
+  error: unknown;
+  reason: string;
+  subscriptionId: string;
+  userId: string;
+};
+
+type CollapseOptions = {
+  changeLogFailurePolicy?: ChangeLogFailurePolicy;
+  onChangeLogFailure?: (context: ChangeLogFailureContext) => Promise<void> | void;
+};
+
+function buildTransferUpdates(rows: PersonalSubscriptionRow[]): TransferUpdate[] {
+  const orderedRows = [...rows].sort(byCreatedAtAndId);
+  const updates: TransferUpdate[] = [];
+
+  for (const [index, row] of orderedRows.entries()) {
+    const nextRow = orderedRows[index + 1];
+    const desiredTransferredTo = nextRow?.subscription.id ?? null;
+    if (row.subscription.transferred_to_subscription_id === desiredTransferredTo) {
+      continue;
+    }
+    updates.push({
+      before: row.subscription,
+      transferredToSubscriptionId: desiredTransferredTo,
+    });
+  }
+
+  return updates;
+}
+
+async function applyTransferUpdates(
+  executor: PersonalSubscriptionCollapseWriter,
+  updates: TransferUpdate[],
+  actor: KiloClawSubscriptionChangeActor,
+  reason: string,
+  options: CollapseOptions
+): Promise<string[]> {
+  const updatedSubscriptionIds: string[] = [];
+
+  for (const update of updates) {
+    const [after] = await executor
+      .update(kiloclaw_subscriptions)
+      .set({
+        transferred_to_subscription_id: update.transferredToSubscriptionId,
+      })
+      .where(eq(kiloclaw_subscriptions.id, update.before.id))
+      .returning();
+
+    if (!after) {
+      throw new Error(
+        `Failed to update transferred_to_subscription_id for subscription ${update.before.id}`
+      );
+    }
+
+    try {
+      await insertKiloClawSubscriptionChangeLog(executor, {
+        subscriptionId: after.id,
+        actor,
+        action: 'reassigned',
+        reason,
+        before: update.before,
+        after,
+      });
+    } catch (error) {
+      if (options.changeLogFailurePolicy !== 'log') {
+        throw error;
+      }
+
+      const context = {
+        error,
+        reason,
+        subscriptionId: after.id,
+        userId: after.user_id,
+      } satisfies ChangeLogFailureContext;
+
+      if (options.onChangeLogFailure) {
+        await options.onChangeLogFailure(context);
+      } else {
+        console.error('Failed to write personal subscription collapse change log', context);
+      }
+    }
+    updatedSubscriptionIds.push(after.id);
+  }
+
+  return updatedSubscriptionIds;
+}
+
+export async function collapseOrphanPersonalSubscriptionsOnDestroy(params: {
+  actor: KiloClawSubscriptionChangeActor;
+  changeLogFailurePolicy?: ChangeLogFailurePolicy;
+  destroyedInstanceId: string;
+  executor: PersonalSubscriptionCollapseWriter;
+  onChangeLogFailure?: (context: ChangeLogFailureContext) => Promise<void> | void;
+  reason: string;
+  userId: string;
+}): Promise<{ updatedSubscriptionIds: string[] }> {
+  const personalRows = await listPersonalSubscriptionRows(params.executor, params.userId);
+  const currentRows = getCurrentRows(personalRows);
+  const aliveCurrentRows = getAliveCurrentRows(personalRows);
+
+  if (aliveCurrentRows.length > 1) {
+    throw new PersonalSubscriptionDestroyConflictError({
+      userId: params.userId,
+      instanceId: params.destroyedInstanceId,
+      aliveCount: aliveCurrentRows.length,
+    });
+  }
+
+  const aliveRowsAfterDestroy = aliveCurrentRows.filter(
+    row => row.instance.id !== params.destroyedInstanceId
+  );
+
+  if (currentRows.length <= 1 || aliveRowsAfterDestroy.length > 0) {
+    return { updatedSubscriptionIds: [] };
+  }
+
+  const updates = buildTransferUpdates(personalRows);
+  if (updates.length === 0) {
+    return { updatedSubscriptionIds: [] };
+  }
+
+  return {
+    updatedSubscriptionIds: await applyTransferUpdates(
+      params.executor,
+      updates,
+      params.actor,
+      params.reason,
+      {
+        changeLogFailurePolicy: params.changeLogFailurePolicy,
+        onChangeLogFailure: params.onChangeLogFailure,
+      }
+    ),
+  };
+}
+
+export async function markInstanceDestroyedWithPersonalSubscriptionCollapse(params: {
+  actor: KiloClawSubscriptionChangeActor;
+  changeLogFailurePolicy?: ChangeLogFailurePolicy;
+  destroyedAt?: string;
+  executor: PersonalSubscriptionCollapseWriter;
+  instanceId: string;
+  onChangeLogFailure?: (context: ChangeLogFailureContext) => Promise<void> | void;
+  reason: string;
+  userId: string;
+}): Promise<DestroyedInstanceRow | null> {
+  const [instanceBefore] = await params.executor
+    .select({
+      id: kiloclaw_instances.id,
+      userId: kiloclaw_instances.user_id,
+      sandboxId: kiloclaw_instances.sandbox_id,
+      organizationId: kiloclaw_instances.organization_id,
+      name: kiloclaw_instances.name,
+      inboundEmailEnabled: kiloclaw_instances.inbound_email_enabled,
+      destroyedAt: kiloclaw_instances.destroyed_at,
+    })
+    .from(kiloclaw_instances)
+    .where(
+      and(
+        eq(kiloclaw_instances.id, params.instanceId),
+        eq(kiloclaw_instances.user_id, params.userId)
+      )
+    )
+    .limit(1);
+
+  if (!instanceBefore || instanceBefore.destroyedAt !== null) {
+    return null;
+  }
+
+  if (instanceBefore.organizationId === null) {
+    const aliveCurrentRows = getAliveCurrentRows(
+      await listPersonalSubscriptionRows(params.executor, params.userId)
+    );
+    if (aliveCurrentRows.length > 1) {
+      throw new PersonalSubscriptionDestroyConflictError({
+        userId: params.userId,
+        instanceId: params.instanceId,
+        aliveCount: aliveCurrentRows.length,
+      });
+    }
+  }
+
+  const [destroyedInstance] = await params.executor
+    .update(kiloclaw_instances)
+    .set({ destroyed_at: params.destroyedAt ?? new Date().toISOString() })
+    .where(
+      and(
+        eq(kiloclaw_instances.id, params.instanceId),
+        eq(kiloclaw_instances.user_id, params.userId),
+        isNull(kiloclaw_instances.destroyed_at)
+      )
+    )
+    .returning({
+      id: kiloclaw_instances.id,
+      userId: kiloclaw_instances.user_id,
+      sandboxId: kiloclaw_instances.sandbox_id,
+      organizationId: kiloclaw_instances.organization_id,
+      name: kiloclaw_instances.name,
+      inboundEmailEnabled: kiloclaw_instances.inbound_email_enabled,
+    });
+
+  if (!destroyedInstance) {
+    return null;
+  }
+
+  if (destroyedInstance.organizationId === null) {
+    await collapseOrphanPersonalSubscriptionsOnDestroy({
+      actor: params.actor,
+      changeLogFailurePolicy: params.changeLogFailurePolicy,
+      destroyedInstanceId: destroyedInstance.id,
+      executor: params.executor,
+      onChangeLogFailure: params.onChangeLogFailure,
+      reason: params.reason,
+      userId: params.userId,
+    });
+  }
+
+  return destroyedInstance;
+}

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -19,6 +19,8 @@ let loggedValues: unknown[] = [];
 
 type SelectResult<T> = Promise<T[]> & {
   limit: ReturnType<typeof vi.fn>;
+  orderBy: ReturnType<typeof vi.fn>;
+  then: Promise<T[]>['then'];
 };
 
 type SelectBuilder = {
@@ -26,12 +28,15 @@ type SelectBuilder = {
   innerJoin: ReturnType<typeof vi.fn>;
   leftJoin: ReturnType<typeof vi.fn>;
   where: ReturnType<typeof vi.fn>;
+  orderBy: ReturnType<typeof vi.fn>;
   limit: ReturnType<typeof vi.fn>;
+  then: Promise<unknown[]>['then'];
 };
 
 function createSelectResult<T>(rows: T[]): SelectResult<T> {
   const result = Promise.resolve(rows) as SelectResult<T>;
   result.limit = vi.fn(async () => rows);
+  result.orderBy = vi.fn(() => result);
   return result;
 }
 
@@ -55,7 +60,7 @@ function createMockDb(
   const txInsertRowCounts = [...(options?.txInsertRowCounts ?? [])];
   const updateReturningRows = [...(options?.updateReturningRows ?? [])];
   const txUpdateReturningRows = [...(options?.txUpdateReturningRows ?? [])];
-  const nextSelectResult = () => createSelectResult(selectResults.shift() ?? []);
+  const nextSelectRows = () => selectResults.shift() ?? [];
   const createWhereResult = (returningRows: unknown[]) => {
     const promise = Promise.resolve(undefined);
     return {
@@ -64,12 +69,16 @@ function createMockDb(
     };
   };
   const createSelectBuilder = (): SelectBuilder => {
+    const rows = nextSelectRows();
+    const promise = Promise.resolve(rows);
     const builder: SelectBuilder = {
       from: vi.fn(() => builder),
       innerJoin: vi.fn(() => builder),
       leftJoin: vi.fn(() => builder),
-      where: vi.fn(() => nextSelectResult()),
-      limit: vi.fn(async () => selectResults.shift() ?? []),
+      where: vi.fn(() => builder),
+      orderBy: vi.fn(() => builder),
+      limit: vi.fn(async () => rows),
+      then: promise.then.bind(promise),
     };
     selectBuilders.push(builder);
     return builder;
@@ -103,6 +112,7 @@ function createMockDb(
       callback: (tx: {
         delete: ReturnType<typeof vi.fn>;
         insert: ReturnType<typeof vi.fn>;
+        select: ReturnType<typeof vi.fn>;
         update: ReturnType<typeof vi.fn>;
       }) => Promise<unknown>
     ) =>
@@ -123,6 +133,7 @@ function createMockDb(
             };
           }),
         })),
+        select: vi.fn(() => createSelectBuilder()),
         update: vi.fn(() => ({
           set: vi.fn((values: Record<string, unknown>) => {
             txUpdates.push(values);
@@ -565,7 +576,7 @@ describe('instance destruction sweep', () => {
 
   it('keeps DB/email cleanup unchanged when platform destroy succeeds', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
-    const { db, updates, inserts, deletes } = createMockDb([
+    const { db, updates, txUpdates, inserts, deletes } = createMockDb([
       [
         {
           id: 'sub-1',
@@ -575,6 +586,19 @@ describe('instance destruction sweep', () => {
           email: 'user-1@example.com',
         },
       ],
+      [
+        {
+          id: instanceId,
+          userId: 'user-1',
+          sandboxId: 'ki_11111111111141118111111111111111',
+          organizationId: null,
+          name: null,
+          inboundEmailEnabled: false,
+          destroyedAt: null,
+        },
+      ],
+      [],
+      [{ id: 'sub-1', user_id: 'user-1', instance_id: instanceId }],
     ]);
     mockGetWorkerDb.mockReturnValue(db);
     const fetch = vi.fn(
@@ -612,16 +636,16 @@ describe('instance destruction sweep', () => {
         }),
       ])
     );
-    expect(updates).toHaveLength(2);
-    expect(updates[0].destroyed_at).toEqual(expect.any(String));
-    expect(updates[1]).toEqual({ destruction_deadline: null });
+    expect(txUpdates).toHaveLength(1);
+    expect(txUpdates[0]?.destroyed_at).toEqual(expect.any(String));
+    expect(updates).toEqual([{ destruction_deadline: null }]);
     expect(deletes).toHaveLength(1);
   });
 
   it('treats platform destroy 404 as already gone and continues with later rows', async () => {
     const firstInstanceId = '11111111-1111-4111-8111-111111111111';
     const secondInstanceId = '22222222-2222-4222-8222-222222222222';
-    const { db, updates, inserts, deletes } = createMockDb([
+    const { db, updates, txUpdates, inserts, deletes } = createMockDb([
       [
         {
           id: 'sub-1',
@@ -638,6 +662,32 @@ describe('instance destruction sweep', () => {
           email: 'user-2@example.com',
         },
       ],
+      [
+        {
+          id: firstInstanceId,
+          userId: 'user-1',
+          sandboxId: 'ki_11111111111141118111111111111111',
+          organizationId: null,
+          name: null,
+          inboundEmailEnabled: false,
+          destroyedAt: null,
+        },
+      ],
+      [],
+      [{ id: 'sub-1', user_id: 'user-1', instance_id: firstInstanceId }],
+      [
+        {
+          id: secondInstanceId,
+          userId: 'user-2',
+          sandboxId: 'ki_22222222222242228222222222222222',
+          organizationId: null,
+          name: null,
+          inboundEmailEnabled: false,
+          destroyedAt: null,
+        },
+      ],
+      [],
+      [{ id: 'sub-2', user_id: 'user-2', instance_id: secondInstanceId }],
     ]);
     mockGetWorkerDb.mockReturnValue(db);
     const fetch = vi
@@ -695,17 +745,16 @@ describe('instance destruction sweep', () => {
         }),
       ])
     );
-    expect(updates).toHaveLength(4);
-    expect(updates[0].destroyed_at).toEqual(expect.any(String));
-    expect(updates[1]).toEqual({ destruction_deadline: null });
-    expect(updates[2].destroyed_at).toEqual(expect.any(String));
-    expect(updates[3]).toEqual({ destruction_deadline: null });
+    expect(txUpdates).toHaveLength(2);
+    expect(txUpdates[0]?.destroyed_at).toEqual(expect.any(String));
+    expect(txUpdates[1]?.destroyed_at).toEqual(expect.any(String));
+    expect(updates).toEqual([{ destruction_deadline: null }, { destruction_deadline: null }]);
     expect(deletes).toHaveLength(2);
   });
 
   it('logs non-404 platform destroy failures and preserves billing state transition', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
-    const { db, updates, inserts, deletes } = createMockDb([
+    const { db, updates, txUpdates, inserts, deletes } = createMockDb([
       [
         {
           id: 'sub-1',
@@ -715,6 +764,19 @@ describe('instance destruction sweep', () => {
           email: 'user-1@example.com',
         },
       ],
+      [
+        {
+          id: instanceId,
+          userId: 'user-1',
+          sandboxId: 'ki_11111111111141118111111111111111',
+          organizationId: null,
+          name: null,
+          inboundEmailEnabled: false,
+          destroyedAt: null,
+        },
+      ],
+      [],
+      [{ id: 'sub-1', user_id: 'user-1', instance_id: instanceId }],
     ]);
     mockGetWorkerDb.mockReturnValue(db);
     const fetch = vi.fn(
@@ -752,9 +814,9 @@ describe('instance destruction sweep', () => {
         }),
       ])
     );
-    expect(updates).toHaveLength(2);
-    expect(updates[0].destroyed_at).toEqual(expect.any(String));
-    expect(updates[1]).toEqual({ destruction_deadline: null });
+    expect(txUpdates).toHaveLength(1);
+    expect(txUpdates[0]?.destroyed_at).toEqual(expect.any(String));
+    expect(updates).toEqual([{ destruction_deadline: null }]);
     expect(deletes).toHaveLength(1);
     expect(loggedValues).toEqual(
       expect.arrayContaining([

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -17,12 +17,6 @@ import type { BillingWorkerEnv } from './types.js';
 
 let loggedValues: unknown[] = [];
 
-type SelectResult<T> = Promise<T[]> & {
-  limit: ReturnType<typeof vi.fn>;
-  orderBy: ReturnType<typeof vi.fn>;
-  then: Promise<T[]>['then'];
-};
-
 type SelectBuilder = {
   from: ReturnType<typeof vi.fn>;
   innerJoin: ReturnType<typeof vi.fn>;
@@ -32,13 +26,6 @@ type SelectBuilder = {
   limit: ReturnType<typeof vi.fn>;
   then: Promise<unknown[]>['then'];
 };
-
-function createSelectResult<T>(rows: T[]): SelectResult<T> {
-  const result = Promise.resolve(rows) as SelectResult<T>;
-  result.limit = vi.fn(async () => rows);
-  result.orderBy = vi.fn(() => result);
-  return result;
-}
 
 function createMockDb(
   selectResults: unknown[][],

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -1841,26 +1841,29 @@ async function runInstanceDestructionSweep(
       await destroyInstanceForEnforcement(env, context, row);
 
       if (row.instance_id) {
-        await markInstanceDestroyedWithPersonalSubscriptionCollapse({
-          actor: LIFECYCLE_ACTOR,
-          changeLogFailurePolicy: 'log',
-          destroyedAt: now,
-          executor: database,
-          instanceId: row.instance_id,
-          onChangeLogFailure: ({ error, subscriptionId, userId, reason }) => {
-            log('error', 'Failed to write personal subscription collapse change log', {
-              event: 'subscription_change_log_failed',
-              outcome: 'failed',
-              subscriptionId,
-              userId,
-              instanceId: row.instance_id,
-              action: 'reassigned',
-              reason,
-              error: errorMessage(error),
-            });
-          },
-          reason: 'destroy_path_inline_collapse',
-          userId: row.user_id,
+        const instanceId = row.instance_id;
+        await database.transaction(async tx => {
+          await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+            actor: LIFECYCLE_ACTOR,
+            changeLogFailurePolicy: 'log',
+            destroyedAt: now,
+            executor: tx,
+            instanceId,
+            onChangeLogFailure: ({ error, subscriptionId, userId, reason }) => {
+              log('error', 'Failed to write personal subscription collapse change log', {
+                event: 'subscription_change_log_failed',
+                outcome: 'failed',
+                subscriptionId,
+                userId,
+                instanceId,
+                action: 'reassigned',
+                reason,
+                error: errorMessage(error),
+              });
+            },
+            reason: 'destroy_path_inline_collapse',
+            userId: row.user_id,
+          });
         });
       }
 

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -3,6 +3,7 @@ import { addMonths, format } from 'date-fns';
 
 import type { WorkerDb } from '@kilocode/db';
 import {
+  markInstanceDestroyedWithPersonalSubscriptionCollapse,
   getWorkerDb,
   insertKiloClawSubscriptionChangeLog,
   type KiloClawSubscription,
@@ -1840,12 +1841,27 @@ async function runInstanceDestructionSweep(
       await destroyInstanceForEnforcement(env, context, row);
 
       if (row.instance_id) {
-        await database
-          .update(kiloclaw_instances)
-          .set({ destroyed_at: now })
-          .where(
-            and(eq(kiloclaw_instances.id, row.instance_id), isNull(kiloclaw_instances.destroyed_at))
-          );
+        await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+          actor: LIFECYCLE_ACTOR,
+          changeLogFailurePolicy: 'log',
+          destroyedAt: now,
+          executor: database,
+          instanceId: row.instance_id,
+          onChangeLogFailure: ({ error, subscriptionId, userId, reason }) => {
+            log('error', 'Failed to write personal subscription collapse change log', {
+              event: 'subscription_change_log_failed',
+              outcome: 'failed',
+              subscriptionId,
+              userId,
+              instanceId: row.instance_id,
+              action: 'reassigned',
+              reason,
+              error: errorMessage(error),
+            });
+          },
+          reason: 'destroy_path_inline_collapse',
+          userId: row.user_id,
+        });
       }
 
       const before = await getSubscriptionById(database, row.id);

--- a/services/kiloclaw/src/db/index.ts
+++ b/services/kiloclaw/src/db/index.ts
@@ -1,8 +1,17 @@
+import {
+  markInstanceDestroyedWithPersonalSubscriptionCollapse,
+  type KiloClawSubscriptionChangeActor,
+} from '@kilocode/db';
 import { getWorkerDb, type WorkerDb } from '@kilocode/db/client';
 import { kilocode_users, kiloclaw_access_codes, kiloclaw_instances } from '@kilocode/db/schema';
 import { eq, and, isNull, gt, sql } from 'drizzle-orm';
 
 export { getWorkerDb, type WorkerDb };
+
+const KILOCLAW_WORKER_DESTROY_ACTOR = {
+  actorType: 'system',
+  actorId: 'kiloclaw-worker',
+} satisfies KiloClawSubscriptionChangeActor;
 
 export async function findPepperByUserId(db: WorkerDb, userId: string) {
   const row = await db
@@ -153,14 +162,32 @@ export async function getInstanceByIdIncludingDestroyed(
 }
 
 export async function markInstanceDestroyed(db: WorkerDb, userId: string, sandboxId: string) {
-  await db
-    .update(kiloclaw_instances)
-    .set({ destroyed_at: sql`NOW()` })
-    .where(
-      and(
-        eq(kiloclaw_instances.user_id, userId),
-        eq(kiloclaw_instances.sandbox_id, sandboxId),
-        isNull(kiloclaw_instances.destroyed_at)
+  await db.transaction(async tx => {
+    const row = await tx
+      .select({
+        id: kiloclaw_instances.id,
+      })
+      .from(kiloclaw_instances)
+      .where(
+        and(
+          eq(kiloclaw_instances.user_id, userId),
+          eq(kiloclaw_instances.sandbox_id, sandboxId),
+          isNull(kiloclaw_instances.destroyed_at)
+        )
       )
-    );
+      .limit(1)
+      .then(rows => rows[0] ?? null);
+
+    if (!row) {
+      return;
+    }
+
+    await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+      actor: KILOCLAW_WORKER_DESTROY_ACTOR,
+      executor: tx,
+      instanceId: row.id,
+      reason: 'destroy_path_inline_collapse',
+      userId,
+    });
+  });
 }

--- a/services/kiloclaw/src/routes/platform-provision-bootstrap.test.ts
+++ b/services/kiloclaw/src/routes/platform-provision-bootstrap.test.ts
@@ -53,57 +53,150 @@ vi.mock('../utils/analytics', async importOriginal => {
 import { platform } from './platform';
 import { BootstrapProvisionFallbackError } from './provision-bootstrap';
 
-type SelectBuilder<T> = PromiseLike<T[]> & {
+type SelectBuilder<T> = Promise<T[]> & {
   from: ReturnType<typeof vi.fn>;
+  innerJoin: ReturnType<typeof vi.fn>;
   where: ReturnType<typeof vi.fn>;
+  orderBy: ReturnType<typeof vi.fn>;
   limit: ReturnType<typeof vi.fn>;
-  then: Promise<T[]>['then'];
 };
 
 function createSelectBuilder<T>(rows: T[]): SelectBuilder<T> {
-  const promise = Promise.resolve(rows);
-  const builder = {
+  const builder = Object.assign(Promise.resolve(rows), {
     from: vi.fn(),
+    innerJoin: vi.fn(),
     where: vi.fn(),
+    orderBy: vi.fn(),
     limit: vi.fn(),
-    then: promise.then.bind(promise),
-  } as SelectBuilder<T>;
+  }) as SelectBuilder<T>;
   builder.from.mockReturnValue(builder);
+  builder.innerJoin.mockReturnValue(builder);
   builder.where.mockReturnValue(builder);
+  builder.orderBy.mockReturnValue(builder);
   builder.limit.mockReturnValue(builder);
   return builder;
 }
 
 function createWorkerDb() {
-  const txSelectQueue = [[]];
   const txInsertReturningQueue = [[{ id: 'instance-new', sandboxId: 'sandbox-new' }], [], []];
   const updateSets: Array<Record<string, unknown>> = [];
+  let insertedInstance: {
+    id: string;
+    userId: string;
+    sandboxId: string;
+    organizationId: string | null;
+    name: string | null;
+    inboundEmailEnabled: boolean;
+    destroyedAt: string | null;
+  } | null = null;
+
+  const createSelectRows = (fields: Record<string, unknown>) => {
+    if ('alias' in fields) {
+      return [];
+    }
+
+    if (!insertedInstance) {
+      return [];
+    }
+
+    if ('subscription' in fields && 'instance' in fields) {
+      return [];
+    }
+
+    if ('destroyedAt' in fields) {
+      return [
+        {
+          id: insertedInstance.id,
+          userId: insertedInstance.userId,
+          sandboxId: insertedInstance.sandboxId,
+          organizationId: insertedInstance.organizationId,
+          name: insertedInstance.name,
+          inboundEmailEnabled: insertedInstance.inboundEmailEnabled,
+          destroyedAt: insertedInstance.destroyedAt,
+        },
+      ];
+    }
+
+    if ('id' in fields && 'userId' in fields) {
+      return [
+        {
+          id: insertedInstance.id,
+          userId: insertedInstance.userId,
+        },
+      ];
+    }
+
+    return [];
+  };
 
   return {
     updateSets,
     transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
       const tx = {
-        select: vi.fn(() => createSelectBuilder(txSelectQueue.shift() ?? [])),
+        select: vi.fn((fields: Record<string, unknown>) =>
+          createSelectBuilder(createSelectRows(fields))
+        ),
         insert: vi.fn(() => ({
-          values: vi.fn(() => ({
-            onConflictDoNothing: vi.fn(() => ({
-              returning: vi.fn(async () => txInsertReturningQueue.shift() ?? []),
-            })),
-          })),
+          values: vi.fn((values: Record<string, unknown>) => {
+            if (
+              typeof values.id === 'string' &&
+              typeof values.user_id === 'string' &&
+              typeof values.sandbox_id === 'string'
+            ) {
+              insertedInstance = {
+                id: values.id,
+                userId: values.user_id,
+                sandboxId: values.sandbox_id,
+                organizationId:
+                  typeof values.organization_id === 'string' ? values.organization_id : null,
+                name: null,
+                inboundEmailEnabled: false,
+                destroyedAt: null,
+              };
+            }
+
+            return {
+              onConflictDoNothing: vi.fn(() => ({
+                returning: vi.fn(async () => txInsertReturningQueue.shift() ?? []),
+              })),
+            };
+          }),
+        })),
+        update: vi.fn(() => ({
+          set: vi.fn((values: Record<string, unknown>) => {
+            updateSets.push(values);
+            if (insertedInstance && typeof values.destroyed_at === 'string') {
+              insertedInstance = {
+                ...insertedInstance,
+                destroyedAt: values.destroyed_at,
+              };
+            }
+
+            return {
+              where: vi.fn(() => ({
+                returning: vi.fn(async () =>
+                  insertedInstance
+                    ? [
+                        {
+                          id: insertedInstance.id,
+                          userId: insertedInstance.userId,
+                          sandboxId: insertedInstance.sandboxId,
+                          organizationId: insertedInstance.organizationId,
+                          name: insertedInstance.name,
+                          inboundEmailEnabled: insertedInstance.inboundEmailEnabled,
+                        },
+                      ]
+                    : []
+                ),
+              })),
+            };
+          }),
         })),
       };
 
       return await callback(tx);
     }),
     select: vi.fn(() => createSelectBuilder([])),
-    update: vi.fn(() => ({
-      set: vi.fn((values: Record<string, unknown>) => {
-        updateSets.push(values);
-        return {
-          where: vi.fn(async () => undefined),
-        };
-      }),
-    })),
   };
 }
 
@@ -173,8 +266,10 @@ describe('platform provision bootstrap quarantine', () => {
       error: 'post-provision bootstrap failed',
     });
     expect(destroy).not.toHaveBeenCalled();
-    expect(workerDb.updateSets).toHaveLength(1);
-    expect(workerDb.updateSets[0]?.destroyed_at).toBeDefined();
+    const destroyUpdate = workerDb.updateSets.find(
+      update => typeof update.destroyed_at === 'string'
+    );
+    expect(destroyUpdate?.destroyed_at).toBeDefined();
     const eventCall = mockWriteEvent.mock.calls.find(
       call => call[1]?.event === 'instance.subscription_bootstrap_quarantined'
     );

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -54,7 +54,7 @@ import {
 import type { ProviderId } from '../schemas/instance-config';
 import { doKeyFromActiveInstance, resolveDoKeyForUser } from '../lib/instance-routing';
 import { getInstanceById, getInstanceByIdIncludingDestroyed, getWorkerDb } from '../db';
-import { and, eq, isNull, sql } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import {
   BootstrapProvisionFallbackError,
   bootstrapProvisionedSubscriptionWithFallback,

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -865,7 +865,7 @@ platform.post('/provision', async c => {
     });
   }
 
-  let provision;
+  let provision: Awaited<ReturnType<KiloClawInstanceStub['provision']>>;
   try {
     if (selectedProvider) {
       assertAvailableProvider(c.env, selectedProvider);

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -29,6 +29,10 @@ import { flattenError, z } from 'zod';
 import { withDORetry } from '@kilocode/worker-utils';
 import { readBillingCorrelationHeaders } from '@kilocode/worker-utils/kiloclaw-billing-observability';
 import {
+  markInstanceDestroyedWithPersonalSubscriptionCollapse,
+  type KiloClawSubscriptionChangeActor,
+} from '@kilocode/db';
+import {
   kiloclaw_inbound_email_aliases,
   kiloclaw_inbound_email_reserved_aliases,
   kiloclaw_instances,
@@ -79,6 +83,11 @@ const WebSearchConfigPatchSchema = z.object({
   userId: z.string().min(1),
   exaMode: z.enum(['kilo-proxy', 'disabled']).nullable().optional(),
 });
+
+const KILOCLAW_WORKER_DESTROY_ACTOR = {
+  actorType: 'system',
+  actorId: 'kiloclaw-worker',
+} satisfies KiloClawSubscriptionChangeActor;
 
 const KiloCliRunConflictSchema = z.object({
   conflict: z.object({
@@ -528,12 +537,30 @@ async function markProvisionedInstanceDestroyed(params: {
 
   const db = getWorkerDb(connectionString);
   try {
-    await db
-      .update(kiloclaw_instances)
-      .set({ destroyed_at: sql`NOW()` })
-      .where(
-        and(eq(kiloclaw_instances.id, params.instanceId), isNull(kiloclaw_instances.destroyed_at))
-      );
+    await db.transaction(async tx => {
+      const [instance] = await tx
+        .select({
+          id: kiloclaw_instances.id,
+          userId: kiloclaw_instances.user_id,
+        })
+        .from(kiloclaw_instances)
+        .where(
+          and(eq(kiloclaw_instances.id, params.instanceId), isNull(kiloclaw_instances.destroyed_at))
+        )
+        .limit(1);
+
+      if (!instance) {
+        return;
+      }
+
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: KILOCLAW_WORKER_DESTROY_ACTOR,
+        executor: tx,
+        instanceId: instance.id,
+        reason: 'destroy_path_inline_collapse',
+        userId: instance.userId,
+      });
+    });
 
     logProvisionWrite('info', 'Instance record marked destroyed', {
       event: 'instance_record_destroy',


### PR DESCRIPTION
## Summary
Stops new `firing_all_destroyed_multi` users from accruing by collapsing personal subscription successor chains at instance-destroy time.

### Why this change is needed
The production incident showed multiple destroy writers could set `kiloclaw_instances.destroyed_at` on a user's last alive personal instance without also wiring older personal subscription rows into the `transferred_to_subscription_id` chain.
That leaves multiple destroyed personal rows matching the current-personal resolver predicate, which triggers `CurrentPersonalSubscriptionResolutionError` and returns 409s from billing surfaces.
Batch backfills can drain existing users, but they do not stop the same shape from reappearing after later destroys.

### How this is addressed
- Added a shared destroy-time collapse helper in `@kilocode/db` that refuses `firing_multiple_alive`, computes the ordered personal successor chain, updates `transferred_to_subscription_id`, and writes a change-log row for each changed subscription in the same transaction.
- Routed personal destroy writers through that helper from web destroy flows, billing enforcement destroy, worker Postgres finalize, and provision destroy compensation so last-alive personal destroys collapse immediately at source.
- Added `preview-multi-row-all-destroyed` and `apply-multi-row-all-destroyed` script modes that reuse the same collapse helper for deploy-time residual cleanup.
- Added tests for last-alive destroy collapse, pre-linked orphan splice idempotency, change-log failure handling, `firing_multiple_alive` refusal, and script-mode collapse.

## Verification
No manual testing performed.

- `pnpm format`
- `pnpm test -- apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts`
- `pnpm --filter @kilocode/db typecheck`
- `pnpm --filter kiloclaw typecheck`
- `pnpm --filter kiloclaw-billing typecheck`
- `pnpm --filter web typecheck`
- `pnpm typecheck` still fails in pre-existing Storybook/Next generated validator types under `apps/storybook` referencing missing `apps/web/src/app/admin/abuse/...` and `apps/web/src/app/api/cron/kiloclaw-billing-lifecycle/...` modules

## Visual Changes
N/A

## Reviewer Notes
### Human Reviewer
- Personal destroy writers now fail closed on `firing_multiple_alive` and only collapse personal-context rows. Org destroy paths remain unchanged because org rows do not participate in current-personal resolution.
- Billing enforcement uses log-only change-log failure handling so the existing "instance destroy succeeds even if change-log insert fails" behavior stays intact for the sweep.
- Recommended deploy sequence: run `pnpm script db kiloclaw-subscription-alignment apply-multi-row-all-destroyed` once to drain current residual users, then deploy this patch to stop new trickle.

### Code Reviewer Agent
<details>
  <summary>Code Reviewer Notes</summary>

- Shared helper lives in `packages/db/src/kiloclaw-personal-subscription-collapse.ts`. It rewrites the full ordered chain, so it can splice partial pre-existing chains without violating `UQ_kiloclaw_subscriptions_transferred_to`, and reruns become no-ops.
- Destroy writer inventory patched in this PR: `apps/web/src/lib/kiloclaw/instance-registry.ts`, `services/kiloclaw-billing/src/lifecycle.ts`, `services/kiloclaw/src/db/index.ts`, and `services/kiloclaw/src/routes/platform.ts`.
- The billing lifecycle path passes `changeLogFailurePolicy: 'log'` plus explicit logging callback; other destroy paths keep transactional change-log semantics.

</details>
