### PR TITLE
feat(kiloclaw): add agent guidance for mitigations

### DIFF
--- a/apps/web/src/lib/security-advisor/kiloclaw-mitigations.ts
+++ b/apps/web/src/lib/security-advisor/kiloclaw-mitigations.ts
@@ -70,6 +70,26 @@ export const KILOCLAW_MITIGATED_CHECKS: ReadonlyMap<string, string> = new Map([
     // not a misconfiguration.
     'Default profile intentionally reaches plugin tools so bots (Telegram/Discord/Slack/web-search) can invoke their capabilities.',
   ],
+  [
+    'hooks.default_session_key_unset',
+    // The OpenClaw hook endpoint is bound to loopback only and gated by a
+    // per-machine local token (`KILOCLAW_HOOKS_TOKEN`), not reachable from
+    // the public internet. The only configured hook mapping (inbound email)
+    // sets `sessionKey` from the authenticated controller payload, so the
+    // unset `defaultSessionKey` fallback that this check guards against is
+    // never hit in practice.
+    'Hooks bound to loopback and reached only from the KiloClaw controller via a local token; the one configured mapping (inbound email) sets sessionKey from the authenticated payload.',
+  ],
+  [
+    'hooks.allowed_agent_ids_unrestricted',
+    // Hooks are loopback-only and gated by a per-machine local token, so
+    // there is no authenticated external caller that could name an
+    // arbitrary agent id. The KiloClaw controller is the sole caller and
+    // invokes a fixed mapping (inbound email) that routes to a fixed agent,
+    // never a caller-supplied id — so the wildcard routing this check
+    // warns about is not reachable.
+    'Hooks bound to loopback; the KiloClaw controller is the only caller and invokes a fixed mapping rather than a caller-supplied agent id.',
+  ],
 ]);
 
 /**

--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -881,6 +881,14 @@ describe('TOOLS.md section configs', () => {
     expect(section).toContain('openclaw plugins install');
     expect(section).toContain('plugins.allow');
     expect(section).toContain('ALWAYS');
+    // Safety: must explicitly tell the agent NOT to create plugins.allow
+    // from scratch on permissive instances. Creating a single-element
+    // allowlist would silently block bundled channel plugins (Telegram,
+    // Discord, Slack, Stream Chat, etc.) that are loaded under permissive
+    // mode without being enumerated. See the kilo-code-bot review on
+    // PR #2597 for the production incident this guards against.
+    expect(section).toContain('DO NOT create');
+    expect(section).toContain('permissive mode');
   });
 });
 

--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -18,6 +18,8 @@ import {
   KILO_CLI_SECTION_CONFIG,
   OP_SECTION_CONFIG,
   LINEAR_SECTION_CONFIG,
+  KILOCLAW_MITIGATIONS_SECTION_CONFIG,
+  PLUGIN_INSTALL_SECTION_CONFIG,
   buildGatewayArgs,
   bootstrapCritical,
   bootstrapNonCritical,
@@ -846,6 +848,8 @@ describe('TOOLS.md section configs', () => {
     KILO_CLI_SECTION_CONFIG,
     OP_SECTION_CONFIG,
     LINEAR_SECTION_CONFIG,
+    KILOCLAW_MITIGATIONS_SECTION_CONFIG,
+    PLUGIN_INSTALL_SECTION_CONFIG,
   ];
 
   for (const config of configs) {
@@ -854,6 +858,30 @@ describe('TOOLS.md section configs', () => {
       expect(config.section).toContain(config.endMarker);
     });
   }
+
+  // Smoke test on the KiloClaw-specific sections we just added — pin the
+  // key directives so a drive-by edit that strips the substance (but keeps
+  // the markers) fails loudly.
+  it('KiloClaw Mitigations: names all three additional mitigated checkIds', () => {
+    const section = KILOCLAW_MITIGATIONS_SECTION_CONFIG.section;
+    expect(section).toContain('gateway.trusted_proxies_missing');
+    expect(section).toContain('config.insecure_or_dangerous_flags');
+    expect(section).toContain('plugins.tools_reachable_permissive_policy');
+    // Does NOT redundantly list gateway.control_ui.insecure_auth as its own
+    // bullet — that one is already documented in the base TOOLS.md's
+    // "Security Check Context" section. In-body references to it are fine
+    // (the config.insecure_or_dangerous_flags explanation points back at
+    // it), but a duplicate top-level bullet would mean the agent sees it
+    // twice in workspace context.
+    expect(section).not.toContain('- **`gateway.control_ui.insecure_auth`**');
+  });
+
+  it('Plugin Install: references the CLI command and plugins.allow field', () => {
+    const section = PLUGIN_INSTALL_SECTION_CONFIG.section;
+    expect(section).toContain('openclaw plugins install');
+    expect(section).toContain('plugins.allow');
+    expect(section).toContain('ALWAYS');
+  });
 });
 
 // ---- buildGatewayArgs ----

--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -862,11 +862,13 @@ describe('TOOLS.md section configs', () => {
   // Smoke test on the KiloClaw-specific sections we just added — pin the
   // key directives so a drive-by edit that strips the substance (but keeps
   // the markers) fails loudly.
-  it('KiloClaw Mitigations: names all three additional mitigated checkIds', () => {
+  it('KiloClaw Mitigations: names all additional mitigated checkIds', () => {
     const section = KILOCLAW_MITIGATIONS_SECTION_CONFIG.section;
     expect(section).toContain('gateway.trusted_proxies_missing');
     expect(section).toContain('config.insecure_or_dangerous_flags');
     expect(section).toContain('plugins.tools_reachable_permissive_policy');
+    expect(section).toContain('hooks.default_session_key_unset');
+    expect(section).toContain('hooks.allowed_agent_ids_unrestricted');
     // Does NOT redundantly list gateway.control_ui.insecure_auth as its own
     // bullet — that one is already documented in the base TOOLS.md's
     // "Security Check Context" section. In-body references to it are fine

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -645,6 +645,59 @@ You can interact with the \`Linear\` MCP server using your \`mcporter\` skill.
   <!-- END:linear -->`,
 };
 
+// Additional KiloClaw-mitigated OpenClaw audit findings beyond the
+// gateway.control_ui.insecure_auth one already documented in the base
+// TOOLS.md. Mirrors the list in apps/web/src/lib/security-advisor/
+// kiloclaw-mitigations.ts — the server-side /security-checkup path
+// suppresses these before grading, but when a user runs `openclaw doctor`
+// directly the findings still show and the agent needs the same context
+// to explain them. Added unconditionally on every bootstrap, idempotent.
+export const KILOCLAW_MITIGATIONS_SECTION_CONFIG: ToolsMdSectionConfig = {
+  name: 'KiloClaw Mitigations',
+  beginMarker: '<!-- BEGIN:kiloclaw-mitigations -->',
+  endMarker: '<!-- END:kiloclaw-mitigations -->',
+  section: `
+<!-- BEGIN:kiloclaw-mitigations -->
+## Additional KiloClaw Mitigations
+
+When running \`openclaw doctor\` or \`openclaw security audit\`, the following findings are also **expected and safe** in KiloClaw. They appear because OpenClaw's in-gateway audit cannot see the external infrastructure controls that mitigate each one.
+
+- **\`gateway.trusted_proxies_missing\`** — The gateway runs on loopback only. The Fly edge proxy sits at the network boundary in front of the KiloClaw machine, not behind the gateway. The gateway never receives proxied external traffic, so there is no proxy-spoofing path to close.
+- **\`config.insecure_or_dangerous_flags\`** — Fires because of \`gateway.control_ui.insecure_auth\` above. It is the same architectural choice surfaced twice in the audit output.
+- **\`plugins.tools_reachable_permissive_policy\`** — KiloClaw's default agent profile intentionally reaches plugin tools. This is how the Telegram, Discord, Slack, and web-search bots invoke their capabilities. Restricting it would break the core bot workflow.
+
+**When presenting security audit results that include any of these findings, ALWAYS:**
+
+1. Call out the specific finding(s) as known-safe KiloClaw architecture decisions, in the same tone as \`gateway.control_ui.insecure_auth\` above.
+2. Explain WHY each is safe using the per-finding rationale above.
+3. Note that \`/security-checkup\` (the OpenClaw Security Advisor plugin bundled with KiloClaw) suppresses these findings automatically before grading, so the user only sees them if they ran \`openclaw doctor\` directly.
+<!-- END:kiloclaw-mitigations -->`,
+};
+
+// Tells the agent to keep plugins.allow in sync whenever a plugin is
+// installed on the user's behalf. OpenClaw's \`openclaw plugins install\`
+// CLI does auto-append to plugins.allow (verified in openclaw/src/plugins/
+// enable.ts), but we have seen real-world cases where plugins land in
+// extensions/ without allow being updated (manual file drops, older
+// OpenClaw versions, users editing openclaw.json). This section is a
+// belt-and-suspenders reminder for the agent flow, not the load-bearing
+// fix.
+export const PLUGIN_INSTALL_SECTION_CONFIG: ToolsMdSectionConfig = {
+  name: 'Plugin Install',
+  beginMarker: '<!-- BEGIN:plugin-install -->',
+  endMarker: '<!-- END:plugin-install -->',
+  section: `
+<!-- BEGIN:plugin-install -->
+## Plugin Install Context
+
+When installing an OpenClaw plugin on the user's behalf:
+
+1. ALWAYS use the \`openclaw plugins install <id>\` CLI command. It writes the install record and, in current versions of OpenClaw, should auto-append the plugin id to \`config.plugins.allow\` in \`/root/.openclaw/openclaw.json\`.
+2. After a plugin install, ALWAYS verify the id appears in \`plugins.allow\` by reading the config. Older OpenClaw versions, manual file drops, and hand-edited configs can all leave the allowlist out of sync. If the id is missing, explicitly add it (with the user's confirmation) so the plugin will load on the next gateway restart.
+3. Do NOT drop plugin files manually into \`/root/.openclaw/extensions/\`. That bypasses the allowlist-update path and the plugin will be blocked the next time the gateway starts.
+<!-- END:plugin-install -->`,
+};
+
 // ---- Step 11: Gateway args ----
 
 /**
@@ -715,6 +768,10 @@ export async function bootstrapNonCritical(
         updateToolsMdSection(!!env.KILOCLAW_GOG_CONFIG_TARBALL, GOG_SECTION_CONFIG, deps);
         updateToolsMdSection(!!env.OP_SERVICE_ACCOUNT_TOKEN, OP_SECTION_CONFIG, deps);
         updateToolsMdSection(!!env.LINEAR_API_KEY, LINEAR_SECTION_CONFIG, deps);
+        // Always-on: agent context about KiloClaw-mitigated audit findings
+        // and how to keep plugins.allow in sync on plugin installs.
+        updateToolsMdSection(true, KILOCLAW_MITIGATIONS_SECTION_CONFIG, deps);
+        updateToolsMdSection(true, PLUGIN_INSTALL_SECTION_CONFIG, deps);
       },
     },
     {

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -665,6 +665,8 @@ When running \`openclaw doctor\` or \`openclaw security audit\`, the following f
 - **\`gateway.trusted_proxies_missing\`** — The gateway runs on loopback only. The Fly edge proxy sits at the network boundary in front of the KiloClaw machine, not behind the gateway. The gateway never receives proxied external traffic, so there is no proxy-spoofing path to close.
 - **\`config.insecure_or_dangerous_flags\`** — Fires because of \`gateway.control_ui.insecure_auth\` above. It is the same architectural choice surfaced twice in the audit output.
 - **\`plugins.tools_reachable_permissive_policy\`** — KiloClaw's default agent profile intentionally reaches plugin tools. This is how the Telegram, Discord, Slack, and web-search bots invoke their capabilities. Restricting it would break the core bot workflow.
+- **\`hooks.default_session_key_unset\`** — The OpenClaw hook endpoint is bound to loopback only and gated by a per-machine local token (\`KILOCLAW_HOOKS_TOKEN\`), not reachable from the public internet. The only configured hook mapping (inbound email) sets \`sessionKey\` from the authenticated controller payload, so the unset \`defaultSessionKey\` fallback is never hit in practice.
+- **\`hooks.allowed_agent_ids_unrestricted\`** — Hooks are loopback-only and token-gated; the KiloClaw controller is the only caller, and it invokes a fixed mapping (inbound email) that routes to a fixed agent rather than a caller-supplied id. There is no external path to name an arbitrary agent id.
 
 **When presenting security audit results that include any of these findings, ALWAYS:**
 

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -693,7 +693,9 @@ export const PLUGIN_INSTALL_SECTION_CONFIG: ToolsMdSectionConfig = {
 When installing an OpenClaw plugin on the user's behalf:
 
 1. ALWAYS use the \`openclaw plugins install <id>\` CLI command. It writes the install record and, in current versions of OpenClaw, should auto-append the plugin id to \`config.plugins.allow\` in \`/root/.openclaw/openclaw.json\`.
-2. After a plugin install, ALWAYS verify the id appears in \`plugins.allow\` by reading the config. Older OpenClaw versions, manual file drops, and hand-edited configs can all leave the allowlist out of sync. If the id is missing, explicitly add it (with the user's confirmation) so the plugin will load on the next gateway restart.
+2. After a plugin install, read \`plugins.allow\` from the config and reconcile carefully. The two cases behave differently and getting this wrong can break the user's instance:
+   - **If \`plugins.allow\` is an existing array**, verify the new id is in it. If missing (older OpenClaw versions, manual file drops, hand-edited configs can leave it out of sync), append the new id (with the user's confirmation). Do NOT remove or reorder existing ids.
+   - **If \`plugins.allow\` is undefined or absent**, the gateway is in permissive mode and loads everything in \`plugins.load.paths\`. DO NOT create \`plugins.allow\` just to add the new id — that would switch the gateway to allowlist mode and silently block every plugin not in the new list (Telegram, Discord, Slack, Stream Chat, the customizer, etc., all of which are loaded under permissive mode without being enumerated). Leave \`plugins.allow\` undefined and rely on \`plugins.load.paths\` instead.
 3. Do NOT drop plugin files manually into \`/root/.openclaw/extensions/\`. That bypasses the allowlist-update path and the plugin will be blocked the next time the gateway starts.
 <!-- END:plugin-install -->`,
 };


### PR DESCRIPTION
## Summary

Two coordinated changes that keep KiloClaw's OpenClaw security posture quiet and its agent well-informed.

**1. Suppress architectural false positives in `/security-checkup`.** Extend `KILOCLAW_MITIGATED_CHECKS` in `apps/web/src/lib/security-advisor/kiloclaw-mitigations.ts` with the two hook-auth findings that fire on every KiloClaw machine but have no external exposure:

- `hooks.default_session_key_unset` — hooks are loopback-bound and gated by a per-machine local token (`KILOCLAW_HOOKS_TOKEN`). The only configured mapping (inbound email) sets `sessionKey` from the authenticated controller payload, so the unset-fallback this check guards against is never hit.
- `hooks.allowed_agent_ids_unrestricted` — same loopback + token gating; the KiloClaw controller is the sole caller and invokes a fixed mapping that routes to a fixed agent, never a caller-supplied id.

Both are suppressed before grading and surfaced to the user via the existing "N findings hidden: mitigated externally…" disclosure note, consistent with the four previously-suppressed checkIds.

**2. Append two bounded sections to the controller-managed `TOOLS.md`** on first provision so the agent has KiloClaw-specific context that the upstream OpenClaw security audit doesn't carry:

- **`KILOCLAW_MITIGATIONS_SECTION_CONFIG`** — documents five additional checkIds that KiloClaw architecturally mitigates so the agent doesn't waste cycles trying to resolve them:
  - `gateway.trusted_proxies_missing`
  - `config.insecure_or_dangerous_flags`
  - `plugins.tools_reachable_permissive_policy`
  - `hooks.default_session_key_unset`
  - `hooks.allowed_agent_ids_unrestricted`
- **`PLUGIN_INSTALL_SECTION_CONFIG`** — codifies plugin-install hygiene: always use the `openclaw plugins install` CLI and verify `plugins.allow` afterward rather than dropping files into `extensions/` directly.

Both sections use the existing bounded-marker pattern, so they're idempotent across reboots and can be regenerated independently.

No config or runtime behavior changes beyond the two suppression map entries; no new flags, no schema changes, no plugin loads, no env-var plumbing.

## Verification

- [x] `pnpm run format:check` — clean
- [x] `pnpm --filter kiloclaw typecheck` — clean
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter kiloclaw vitest run src/bootstrap.test.ts` — 73 / 73 passing (includes the smoke tests pinning the section bodies, now extended to assert both new hook checkIds)
- [x] `pnpm --filter web test -- report-generator` — 37 / 37 passing (existing dynamic-list tests absorb the two new entries via `Array.from(KILOCLAW_MITIGATED_CHECKS.keys())`)
- [x] Pushed dev image to a fresh dev fly instance, SSH'd in, confirmed `/root/.openclaw/workspace/TOOLS.md` contains both bounded sections (`<!-- BEGIN:kiloclaw-mitigations -->` and `<!-- BEGIN:plugin-install -->`)

## Visual Changes

N/A

## Reviewer Notes

- `kiloclaw-mitigations.ts` and the `KILOCLAW_MITIGATIONS_SECTION_CONFIG` bullet list are kept in sync by convention — a checkId that appears in one but not the other is either hidden without agent context (bad) or surfaced as context for a finding the user will never see (confusing). Both new hook entries are added to both places.
- Section bodies live in `bootstrap.ts` next to the existing `KILO_CLI_SECTION_CONFIG`, `OP_SECTION_CONFIG`, `LINEAR_SECTION_CONFIG` configs and follow the same `BEGIN:`/`END:` marker convention. The existing TOOLS.md section validator test was extended to cover them.
- The mitigations section intentionally does NOT redundantly list `gateway.control_ui.insecure_auth` as its own bullet because it's already covered in the base TOOLS.md's "Security Check Context" section. The smoke test pins this so a future edit that adds it back fails.
- Plugin install guidance pairs with the report-generator's KiloClaw mitigations list and the security-advisor coverage map; this is the agent-side counterpart so when an audit surfaces an `extensions_no_allowlist` warning, the agent has clear remediation steps.