### PR TITLE
fix(security-advisor): suppress summary.attack_surface on KiloClaw

### DIFF
--- a/apps/web/src/lib/security-advisor/kiloclaw-mitigations.ts
+++ b/apps/web/src/lib/security-advisor/kiloclaw-mitigations.ts
@@ -70,6 +70,21 @@ export const KILOCLAW_MITIGATED_CHECKS: ReadonlyMap<string, string> = new Map([
     // not a misconfiguration.
     'Default profile intentionally reaches plugin tools so bots (Telegram/Discord/Slack/web-search) can invoke their capabilities.',
   ],
+  [
+    'summary.attack_surface',
+    // Informational aggregate of the gateway's attack surface (groups,
+    // tool reachability, hook types, browser/trust model). The finding's
+    // implicit framing is "you composed this attack surface and may want
+    // to reduce it" — accurate for self-hosted OpenClaw operators who
+    // pick their own channels and tool policies, misleading on KiloClaw
+    // where the bundled channel set, tool reachability, and trust model
+    // are product-fixed rather than user-chosen. Showing it on KiloClaw
+    // without that framing being actionable just adds noise to the
+    // report. Genuinely concerning items in the same domain (e.g.
+    // open-internet exposure, missing TLS) have their own checkIds and
+    // continue to surface on KiloClaw.
+    'Aggregate attack-surface summary aimed at self-hosted operators who composed their own gateway; KiloClaw bundles the channel set and trust model as product-fixed defaults so the framing is not actionable here.',
+  ],
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Add `summary.attack_surface` to `KILOCLAW_MITIGATED_CHECKS` so the informational aggregate disappears from KiloClaw reports the same way the four other architecturally mitigated checkIds do.

The finding's implicit framing, "you composed this attack surface and may want to reduce it", is accurate for self hosted OpenClaw operators who pick their own channels and tool policies, but misleading on KiloClaw where the bundled channel set (Telegram/Discord/Slack/Stream Chat), tool reachability, and trust model are product-fixed defaults the user did not pick.

Genuinely concerning items in the same domain (open internet exposure, missing TLS, etc.) have their own checkIds and continue to surface on KiloClaw unchanged. This change only suppresses the aggregate summary, not the underlying signals.

## Verification

- [x] `pnpm run format:check` — clean
- [x] `apps/web` typecheck — clean
- [x] `apps/web` security-advisor tests — 57 / 57 passing. Notable: the suppression-count tests in `report-generator.test.ts` derive their inputs from `Array.from(KILOCLAW_MITIGATED_CHECKS.keys())`, so adding an entry doesn't silently break them. The existing "falls back to audit detail for unknown checkIds" test in the `for openclaw source (isKiloClaw=false)` describe block continues to assert that `summary.attack_surface` still appears on OpenClaw.
- [x] Manual end-to-end: re-run `/security-checkup` against a KiloClaw instance after merge, confirm `summary.attack_surface` no longer appears in the Informational section and the disclosure note count is incremented by one.

## Visual Changes

N/A (markdown report content)

**Before** (KiloClaw report, Informational section): `summary.attack_surface` appears with raw plugin output (`groups: open=0, allowlist=1\ntools.elevated: enabled\n...`) and "you may want to reduce this" framing that is not actionable on KiloClaw.

**After**: finding is dropped before grading and rendering. Disclosure note at the top of the report goes from "4 findings hidden" to "5 findings hidden" with the same per-finding rationale already documented for the others.

## Reviewer Notes

- Suppression rationale is documented inline in the new `KILOCLAW_MITIGATED_CHECKS` map entry. The repo is public so the rationale lives next to the suppression itself rather than in a separate doc.
- Self-hosted OpenClaw behavior is unchanged: `isKiloClawMitigated()` is gated by `source.platform === 'kiloclaw'` at the call site in `report-generator.ts`. The same finding still surfaces on OpenClaw and still affects the OpenClaw grade.
- Earlier in the project's history this finding was attempted to be hidden by removing it from the `gateway_exposure` coverage row (which fixed the misleading "diverged" framing) and by deactivating the catalog row (which produced ugly fallback text). Adding it to the mitigations list is the correct lever for full suppression on KiloClaw — same path, same disclosure semantics, same test coverage as the other four entries.
