### PR TITLE
feat(auth): reject signups with duplicate normalized_email

### DIFF
--- a/apps/web/src/components/auth/AuthErrorNotification.tsx
+++ b/apps/web/src/components/auth/AuthErrorNotification.tsx
@@ -54,6 +54,20 @@ export function AuthErrorNotification({ error }: { error: string }) {
       </div>
     );
 
+  if (error === 'EMAIL-ALREADY-USED')
+    return (
+      <div data-error-notification>
+        <ErrorNotificationBox title="Account Already Exists">
+          An account already exists for this email address. Try signing in with the original login
+          method, or{' '}
+          <a href="https://kilo.ai/support" className="underline hover:text-red-100">
+            contact support
+          </a>{' '}
+          if you need help accessing it.
+        </ErrorNotificationBox>
+      </div>
+    );
+
   if (error === 'EMAIL-MUST-BE-LOWERCASE')
     return (
       <div data-error-notification>

--- a/apps/web/src/lib/auth/constants.ts
+++ b/apps/web/src/lib/auth/constants.ts
@@ -11,6 +11,7 @@ export type AuthErrorType =
   | 'INVALID_VERIFICATION'
   | 'IP_MISMATCH'
   | 'SIGNUP-RATE-LIMITED'
+  | 'EMAIL-ALREADY-USED'
   | 'SSO_ERROR';
 
 export const hosted_domain_specials = {

--- a/apps/web/src/lib/sso-user.ts
+++ b/apps/web/src/lib/sso-user.ts
@@ -53,8 +53,8 @@ async function processSSOInternal(
 
   const res = await createOrUpdateUser(args, undefined, true, requestHeaders);
   if (!res.success) {
-    if (res.error === 'SIGNUP-RATE-LIMITED') {
-      return `${SSO_SIGNIN_PATH}?error=SIGNUP-RATE-LIMITED`;
+    if (res.error === 'SIGNUP-RATE-LIMITED' || res.error === 'EMAIL-ALREADY-USED') {
+      return `${SSO_SIGNIN_PATH}?error=${res.error}`;
     }
     throw new Error(res.error);
   }

--- a/apps/web/src/lib/user.server.ts
+++ b/apps/web/src/lib/user.server.ts
@@ -678,6 +678,7 @@ const authOptions: NextAuthOptions = {
             'PROVIDER-ALREADY-LINKED',
             'DIFFERENT-OAUTH',
             'SIGNUP-RATE-LIMITED',
+            'EMAIL-ALREADY-USED',
           ];
 
           // Only log unexpected errors to Sentry

--- a/apps/web/src/lib/user.test.ts
+++ b/apps/web/src/lib/user.test.ts
@@ -160,6 +160,33 @@ describe('User', () => {
       if (result.success) return;
       expect(result.error).toBe('SIGNUP-RATE-LIMITED');
     });
+
+    it('rejects new signups whose normalized_email is already in use', async () => {
+      await insertTestUser({
+        id: 'existing-normalized',
+        google_user_email: 'dedup.user@gmail.com',
+        normalized_email: 'dedupuser@gmail.com',
+      });
+
+      // New signup with a different raw email but same normalized form
+      // (Gmail dots + plus-alias both collapse to dedupuser@gmail.com).
+      const result = await createOrUpdateUser(
+        {
+          google_user_email: 'dedup.user+alias@gmail.com',
+          google_user_name: 'Dedup User',
+          google_user_image_url: 'https://example.com/avatar.png',
+          hosted_domain: null,
+          provider: 'github',
+          provider_account_id: 'github-dedup',
+        },
+        undefined,
+        false
+      );
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error).toBe('EMAIL-ALREADY-USED');
+    });
   });
 
   describe('softDeleteUser', () => {

--- a/apps/web/src/lib/user.ts
+++ b/apps/web/src/lib/user.ts
@@ -151,6 +151,26 @@ async function checkSignupIpRateLimit(
   return failureResult('SIGNUP-RATE-LIMITED');
 }
 
+async function checkNormalizedEmailUnique(
+  normalizedEmail: string,
+  tx: DrizzleTransaction
+): Promise<Result<null, AuthErrorType>> {
+  const [existing] = await tx
+    .select({ id: kilocode_users.id })
+    .from(kilocode_users)
+    .where(eq(kilocode_users.normalized_email, normalizedEmail))
+    .limit(1);
+
+  if (!existing) return successResult(null);
+
+  console.warn('[auth] Signup rejected: normalized_email already in use', {
+    normalized_email: normalizedEmail,
+    existing_user_id: existing.id,
+  });
+
+  return failureResult('EMAIL-ALREADY-USED');
+}
+
 /**
  * Determines if a user should have admin privileges based on their email and hosted domain.
  * Centralized logic ensures all auth providers (Google, magic link, GitHub, etc.) get
@@ -379,6 +399,9 @@ export async function createOrUpdateUser(
     txResult = await db.transaction(async tx => {
       const signupRateLimitResult = await checkSignupIpRateLimit(signupIp, tx);
       if (!signupRateLimitResult.success) return signupRateLimitResult;
+
+      const dedupResult = await checkNormalizedEmailUnique(newUser.normalized_email, tx);
+      if (!dedupResult.success) return dedupResult;
 
       const [inserted] = await tx.insert(kilocode_users).values(newUser).returning();
       assert(inserted, 'Failed to save new user');


### PR DESCRIPTION
## Summary

- Reject signups at the application layer when another user already has the same `normalized_email`. This blocks abuse via Gmail dot/plus-alias variants of an existing account (e.g. `dedup.user+foo@gmail.com` when `dedupuser@gmail.com` already exists).
- Add a new `EMAIL-ALREADY-USED` auth error surfaced to the user with a friendly message that links to support.
- Check runs inside the signup DB transaction so it also catches concurrent signups.

A unique index on `normalized_email` is not viable — existing production data contains duplicates (see `/admin/account-deduplication`).

## Verification

- [x] `pnpm format`
- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web test -- src/lib/user.test.ts -t createOrUpdateUser` — new test covers the rejection path

## Visual Changes

N/A — user-facing copy for the new error renders in `AuthErrorNotification` ("Account Already Exists" with a support link).

## Reviewer Notes

- The existing exact-email check (`findUserByEmail`) runs first and can still auto-link providers or return `DIFFERENT-OAUTH`; the new `normalized_email` check only fires when the raw email doesn't match any existing user, but the normalized form does.
- `EMAIL-ALREADY-USED` is added to `expectedErrors` in `user.server.ts` so it isn't noisy in Sentry, and to the SSO redirect handling in `sso-user.ts` so WorkOS signups get the user-facing message too.

<img width="583" height="328" alt="CleanShot 2026-04-20 at 11 51 02" src="https://github.com/user-attachments/assets/bca4062b-a267-470b-979d-ff5b8d4a98b7" />

