### PR TITLE
fix(auth): normalize googlemail.com to gmail.com in email dedup

### DIFF
--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -179,6 +179,7 @@ export function getLowerDomainFromEmail(email: string): string | null {
  * - Lowercases the entire address
  * - Strips `+` aliases (e.g. `user+tag@example.com` → `user@example.com`)
  * - For Gmail/Googlemail: removes dots from the local part
+ * - Normalizes `googlemail.com` → `gmail.com` (same mailbox)
  */
 export function normalizeEmail(email: string): string {
   const trimmed = email.trim().toLowerCase();
@@ -194,12 +195,13 @@ export function normalizeEmail(email: string): string {
     local = local.slice(0, plusIndex);
   }
 
-  // Gmail ignores dots in the local part
-  if (domain === 'gmail.com' || domain === 'googlemail.com') {
+  // Gmail and Googlemail are the same mailbox; normalize dots and domain
+  const isGmail = domain === 'gmail.com' || domain === 'googlemail.com';
+  if (isGmail) {
     local = local.replace(/\./g, '');
   }
 
-  return `${local}@${domain}`;
+  return `${local}@${isGmail ? 'gmail.com' : domain}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

`normalizeEmail()` was already stripping `+` aliases and removing dots for Gmail/Googlemail, but it wasn't normalizing the domain itself. `user@googlemail.com` and `user@gmail.com` route to the exact same Google mailbox, so they must produce the same normalized output for duplicate detection to work.

This adds `googlemail.com` → `gmail.com` domain normalization.

**Note:** After deploying, the normalized-email backfill should be re-run to update any existing `@googlemail.com` rows.

## Verification

- Typecheck passes (pre-existing `apps/mobile` errors only)
- No manual testing — change is a straightforward string normalization

## Visual Changes

N/A

## Reviewer Notes

- The backfill route at `/admin/api/backfills/normalized-email` already calls `normalizeEmail()`, so re-running it will pick up this fix automatically.
