### PR TITLE
fix(claw): add org web search config mutation

### DIFF
--- a/apps/web/src/hooks/useOrgKiloClaw.ts
+++ b/apps/web/src/hooks/useOrgKiloClaw.ts
@@ -177,7 +177,9 @@ export function useOrgReadFile(organizationId: string, path: string | null, enab
  * interface as personal mutations. All other properties (isPending, data, etc.)
  * pass through from the raw mutation.
  */
-export function useOrgKiloClawMutations(organizationId: string) {
+export function useOrgKiloClawMutations(
+  organizationId: string
+): ReturnType<typeof useKiloClawMutations> {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
@@ -205,7 +207,7 @@ export function useOrgKiloClawMutations(organizationId: string) {
 
   // Helper: wrap a raw org mutation so mutate/mutateAsync inject organizationId.
   // The `any` types are unavoidable here — we're wrapping tRPC mutations generically
-  // to pre-bind organizationId. The final return is cast to the personal mutations type.
+  // to pre-bind organizationId. The final return uses `satisfies` to catch missing keys.
   /* eslint-disable @typescript-eslint/no-explicit-any */
   function bind<T extends { mutate: any; mutateAsync: any }>(raw: T): any {
     return {
@@ -369,6 +371,16 @@ export function useOrgKiloClawMutations(organizationId: string) {
   const rawPatchExecPreset = useMutation(
     trpc.organizations.kiloclaw.patchExecPreset.mutationOptions({ onSuccess: invalidateStatus })
   );
+  const rawPatchWebSearchConfig = useMutation(
+    trpc.organizations.kiloclaw.patchWebSearchConfig.mutationOptions({
+      onSuccess: async () => {
+        await invalidateStatus();
+        await queryClient.invalidateQueries({
+          queryKey: trpc.organizations.kiloclaw.getConfig.queryKey({ organizationId }),
+        });
+      },
+    })
+  );
   const rawPatchBotIdentity = useMutation(
     trpc.organizations.kiloclaw.patchBotIdentity.mutationOptions({ onSuccess: invalidateStatus })
   );
@@ -400,7 +412,7 @@ export function useOrgKiloClawMutations(organizationId: string) {
     trpc.organizations.kiloclaw.cancelKiloCliRun.mutationOptions({ onSuccess: invalidateStatus })
   );
 
-  return {
+  const mutations = {
     start: bindVoid(rawStart),
     stop: bindVoid(rawStop),
     destroy: bindVoid(rawDestroy),
@@ -421,6 +433,7 @@ export function useOrgKiloClawMutations(organizationId: string) {
     removeMyPin: bindVoid(rawRemoveMyPin),
     writeFile: bind(rawWriteFile),
     patchExecPreset: bind(rawPatchExecPreset),
+    patchWebSearchConfig: bind(rawPatchWebSearchConfig),
     patchBotIdentity: bind(rawPatchBotIdentity),
     patchOpenclawConfig: bind(rawPatchOpenclawConfig),
     disconnectGoogle: bindVoid(rawDisconnectGoogle),
@@ -428,5 +441,7 @@ export function useOrgKiloClawMutations(organizationId: string) {
     startKiloCliRun: bind(rawStartKiloCliRun),
     cancelKiloCliRun: bind(rawCancelKiloCliRun),
     rename: bind(rawRename),
-  } as unknown as ReturnType<typeof useKiloClawMutations>;
+  } satisfies ReturnType<typeof useKiloClawMutations>;
+
+  return mutations;
 }

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, beforeAll, beforeEach, jest } from '@jest/globals';
+import { db, cleanupDbForTest } from '@/lib/drizzle';
+import { kiloclaw_instances } from '@kilocode/db/schema';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { createOrganization } from '@/lib/organizations/organizations';
+import type { User, Organization } from '@kilocode/db/schema';
+import type { createCallerForUser as createCallerForUserType } from '@/routers/test-utils';
+
+type PatchWebSearchConfig = (
+  userId: string,
+  patch: { exaMode?: 'kilo-proxy' | 'disabled' | null },
+  instanceId?: string
+) => Promise<{ exaMode: 'kilo-proxy' | 'disabled' | null }>;
+
+const mockPatchWebSearchConfig = jest.fn<PatchWebSearchConfig>();
+
+jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    '@/lib/kiloclaw/kiloclaw-internal-client'
+  );
+
+  return {
+    KiloClawInternalClient: jest.fn().mockImplementation(() => ({
+      patchWebSearchConfig: mockPatchWebSearchConfig,
+    })),
+    KiloClawApiError: actual.KiloClawApiError,
+  };
+});
+
+jest.mock('next/headers', () => {
+  const get = jest.fn<() => unknown>();
+
+  return {
+    cookies: jest.fn<() => Promise<{ get: typeof get }>>().mockResolvedValue({ get }),
+    headers: jest.fn<() => Map<string, string>>().mockReturnValue(new Map()),
+  };
+});
+
+let createCallerForUser: typeof createCallerForUserType;
+let user: User;
+let org: Organization;
+
+beforeAll(async () => {
+  const mod = await import('@/routers/test-utils');
+  createCallerForUser = mod.createCallerForUser;
+});
+
+beforeEach(async () => {
+  await cleanupDbForTest();
+  mockPatchWebSearchConfig.mockReset();
+
+  user = await insertTestUser({
+    google_user_email: `org-kiloclaw-web-search-${crypto.randomUUID()}@example.com`,
+  });
+  org = await createOrganization('Org KiloClaw Web Search Test', user.id);
+});
+
+async function createActiveOrgInstance(userId: string, organizationId: string): Promise<string> {
+  const instanceId = crypto.randomUUID();
+  const [row] = await db
+    .insert(kiloclaw_instances)
+    .values({
+      id: instanceId,
+      user_id: userId,
+      organization_id: organizationId,
+      sandbox_id: `ki_${instanceId.replace(/-/g, '')}`,
+    })
+    .returning({ id: kiloclaw_instances.id });
+
+  if (!row) throw new Error('Failed to create organization KiloClaw instance');
+  return row.id;
+}
+
+describe('organizations.kiloclaw.patchWebSearchConfig', () => {
+  it('patches web search config for the active org instance', async () => {
+    const instanceId = await createActiveOrgInstance(user.id, org.id);
+    mockPatchWebSearchConfig.mockResolvedValue({ exaMode: 'disabled' });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.patchWebSearchConfig({
+        organizationId: org.id,
+        exaMode: 'disabled',
+      })
+    ).resolves.toEqual({ exaMode: 'disabled' });
+
+    expect(mockPatchWebSearchConfig).toHaveBeenCalledTimes(1);
+    expect(mockPatchWebSearchConfig).toHaveBeenCalledWith(
+      user.id,
+      { exaMode: 'disabled' },
+      instanceId
+    );
+
+    const firstCall = mockPatchWebSearchConfig.mock.calls[0];
+    if (!firstCall) throw new Error('Expected patchWebSearchConfig to be called');
+    expect(firstCall[1]).not.toHaveProperty('organizationId');
+  });
+
+  it('rejects when the organization has no active instance', async () => {
+    const caller = await createCallerForUser(user.id);
+
+    await expect(
+      caller.organizations.kiloclaw.patchWebSearchConfig({
+        organizationId: org.id,
+        exaMode: 'disabled',
+      })
+    ).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'No active KiloClaw instance found for this organization',
+    });
+
+    expect(mockPatchWebSearchConfig).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -175,6 +175,11 @@ const updateKiloCodeConfigSchema = z.object({
   kilocodeDefaultModel: kilocodeDefaultModelSchema.nullable().optional(),
 });
 
+const patchWebSearchConfigSchema = z.object({
+  organizationId: z.uuid(),
+  exaMode: z.enum(['kilo-proxy', 'disabled']).nullable().optional(),
+});
+
 const patchChannelsSchema = z.object({
   organizationId: z.uuid(),
   telegramBotToken: z.string().nullable().optional(),
@@ -592,6 +597,18 @@ export const organizationKiloclawRouter = createTRPCRouter({
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
       const client = new KiloClawInternalClient();
       return client.patchExecPreset(ctx.user.id, input, workerInstanceId(instance));
+    }),
+
+  patchWebSearchConfig: organizationMemberMutationProcedure
+    .input(patchWebSearchConfigSchema)
+    .mutation(async ({ ctx, input }) => {
+      const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
+      const client = new KiloClawInternalClient();
+      return client.patchWebSearchConfig(
+        ctx.user.id,
+        { exaMode: input.exaMode },
+        workerInstanceId(instance)
+      );
     }),
 
   patchBotIdentity: organizationMemberMutationProcedure


### PR DESCRIPTION
## Summary
- Add the missing organization-scoped KiloClaw web search config mutation and route it to the active org instance.
- Wire the org mutation hook to expose `patchWebSearchConfig` with matching cache invalidation and a stricter mutation surface check.
- Add focused router tests for instance-scoped forwarding and missing-instance rejection.
