### PR TITLE
feat(auth): add Create Account button to mobile login

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -4,8 +4,8 @@
   "version": "1.0.0",
   "scripts": {
     "start": "expo start --dev-client",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "build": "pnpx eas-cli@latest build --profile development",
     "build:ios": "pnpx eas-cli@latest build -p ios --profile development",
     "build:android": "pnpx eas-cli@latest build -p android --profile development",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -4,8 +4,8 @@
   "version": "1.0.0",
   "scripts": {
     "start": "expo start --dev-client",
-    "android": "expo run:android",
-    "ios": "expo run:ios",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
     "build": "pnpx eas-cli@latest build --profile development",
     "build:ios": "pnpx eas-cli@latest build -p ios --profile development",
     "build:android": "pnpx eas-cli@latest build -p android --profile development",

--- a/apps/mobile/src/components/login-screen.tsx
+++ b/apps/mobile/src/components/login-screen.tsx
@@ -27,6 +27,32 @@ function errorMessage(status: string, fallback: string | undefined) {
   }
 }
 
+function AuthButtons({ start }: { start: (mode: 'signin' | 'signup') => Promise<void> }) {
+  return (
+    <>
+      <Button
+        size="lg"
+        onPress={() => {
+          void start('signin');
+        }}
+        accessibilityLabel="Sign in with browser"
+      >
+        <Text>Sign In</Text>
+      </Button>
+      <Button
+        variant="outline"
+        size="lg"
+        onPress={() => {
+          void start('signup');
+        }}
+        accessibilityLabel="Create a new account"
+      >
+        <Text>Create Account</Text>
+      </Button>
+    </>
+  );
+}
+
 export function LoginScreen() {
   const { signIn } = useAuth();
   const { status, token, code, error, verificationUrl, start, cancel, openBrowser } =
@@ -47,7 +73,7 @@ export function LoginScreen() {
     <View className="flex-1 items-center justify-center gap-6 bg-background px-6">
       <View className="items-center gap-2">
         <Image source={logo} className="mb-1 h-16 w-16" accessibilityLabel="Kilo logo" />
-        <Text className="text-lg">Sign in to continue</Text>
+        <Text className="text-lg">Welcome to Kilo Code</Text>
       </View>
 
       <Animated.View className="w-full max-w-sm gap-3" layout={LinearTransition}>
@@ -57,15 +83,7 @@ export function LoginScreen() {
             entering={FadeIn.duration(200)}
             exiting={FadeOut.duration(150)}
           >
-            <Button
-              size="lg"
-              onPress={() => {
-                void start();
-              }}
-              accessibilityLabel="Sign in with browser"
-            >
-              <Text>Sign In</Text>
-            </Button>
+            <AuthButtons start={start} />
             <Text variant="muted" className="text-center text-xs">
               You will be redirected to your browser
             </Text>
@@ -134,22 +152,14 @@ export function LoginScreen() {
 
         {(status === 'denied' || status === 'expired' || status === 'error') && (
           <Animated.View
-            className="items-center gap-4"
+            className="gap-3"
             entering={FadeIn.duration(200)}
             exiting={FadeOut.duration(150)}
           >
             <Text className="text-center text-sm text-destructive">
               {errorMessage(status, error)}
             </Text>
-            <Button
-              size="lg"
-              onPress={() => {
-                void start();
-              }}
-              accessibilityLabel="Try signing in again"
-            >
-              <Text>Try Again</Text>
-            </Button>
+            <AuthButtons start={start} />
           </Animated.View>
         )}
       </Animated.View>

--- a/apps/mobile/src/lib/auth/use-device-auth.ts
+++ b/apps/mobile/src/lib/auth/use-device-auth.ts
@@ -1,7 +1,7 @@
 import * as WebBrowser from 'expo-web-browser';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { API_BASE_URL } from '@/lib/config';
+import { API_BASE_URL, WEB_BASE_URL } from '@/lib/config';
 
 type DeviceAuthStatus = 'idle' | 'pending' | 'approved' | 'denied' | 'expired' | 'error';
 
@@ -14,7 +14,7 @@ type DeviceAuthState = {
 };
 
 type DeviceAuthResult = DeviceAuthState & {
-  start: () => Promise<void>;
+  start: (mode?: 'signin' | 'signup') => Promise<void>;
   cancel: () => void;
   openBrowser: () => Promise<void>;
 };
@@ -115,23 +115,66 @@ export function useDeviceAuth(): DeviceAuthResult {
     [cleanup]
   );
 
-  const start = useCallback(async () => {
-    cleanup();
-    setState({
-      status: 'pending',
-      code: undefined,
-      token: undefined,
-      error: undefined,
-      verificationUrl: undefined,
-    });
-
-    try {
-      const response = await fetch(`${API_BASE_URL}/api/device-auth/codes`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+  const start = useCallback(
+    async (mode?: 'signin' | 'signup') => {
+      cleanup();
+      setState({
+        status: 'pending',
+        code: undefined,
+        token: undefined,
+        error: undefined,
+        verificationUrl: undefined,
       });
 
-      if (!response.ok) {
+      try {
+        const response = await fetch(`${API_BASE_URL}/api/device-auth/codes`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        });
+
+        if (!response.ok) {
+          setState({
+            status: 'error',
+            code: undefined,
+            token: undefined,
+            error: 'Failed to start sign in. Please try again.',
+            verificationUrl: undefined,
+          });
+          return;
+        }
+
+        const data = (await response.json()) as {
+          code: string;
+          verificationUrl: string;
+        };
+
+        // Sign-in uses the server-provided verificationUrl which points directly
+        // at /device-auth?code=... Sign-up instead routes through the sign-in
+        // page with signup=true so the web UI renders the create-account flow;
+        // callbackPath then forwards the user to /device-auth?code=... after
+        // account creation to complete the device-auth approval.
+        const browserUrl =
+          mode === 'signup'
+            ? `${WEB_BASE_URL}/users/sign_in?${new URLSearchParams({
+                callbackPath: `/device-auth?code=${data.code}`,
+                signup: 'true',
+              }).toString()}`
+            : data.verificationUrl;
+
+        setState({
+          status: 'pending',
+          code: data.code,
+          token: undefined,
+          error: undefined,
+          verificationUrl: browserUrl,
+        });
+
+        const abort = new AbortController();
+        abortReference.current = abort;
+        poll(data.code, abort);
+
+        await WebBrowser.openAuthSessionAsync(browserUrl);
+      } catch {
         setState({
           status: 'error',
           code: undefined,
@@ -139,37 +182,10 @@ export function useDeviceAuth(): DeviceAuthResult {
           error: 'Failed to start sign in. Please try again.',
           verificationUrl: undefined,
         });
-        return;
       }
-
-      const data = (await response.json()) as {
-        code: string;
-        verificationUrl: string;
-      };
-
-      setState({
-        status: 'pending',
-        code: data.code,
-        token: undefined,
-        error: undefined,
-        verificationUrl: data.verificationUrl,
-      });
-
-      const abort = new AbortController();
-      abortReference.current = abort;
-      poll(data.code, abort);
-
-      await WebBrowser.openAuthSessionAsync(data.verificationUrl);
-    } catch {
-      setState({
-        status: 'error',
-        code: undefined,
-        token: undefined,
-        error: 'Failed to start sign in. Please try again.',
-        verificationUrl: undefined,
-      });
-    }
-  }, [cleanup, poll]);
+    },
+    [cleanup, poll]
+  );
 
   const cancel = useCallback(() => {
     cleanup();

--- a/apps/web/src/app/users/sign_in/page.tsx
+++ b/apps/web/src/app/users/sign_in/page.tsx
@@ -10,6 +10,7 @@ export default async function SignInPage({
 }) {
   const { params, error } = await getAuthPageProps(searchParams);
   const ssoMode = params['sso'] === 'true' || !!params['domain'];
+  const isSignUp = params['signup'] === 'true';
 
   return (
     <AuthPageLayout>
@@ -17,13 +18,21 @@ export default async function SignInPage({
         <SignInForm
           searchParams={params}
           error={error}
-          isSignUp={false}
+          isSignUp={isSignUp}
           allowFakeLogin={allow_fake_login}
-          title={ssoMode ? 'Enterprise SSO' : 'Welcome to Kilo Code'}
+          title={
+            ssoMode
+              ? 'Enterprise SSO'
+              : isSignUp
+                ? 'Create your Kilo Code account'
+                : 'Welcome to Kilo Code'
+          }
           subtitle={
             ssoMode
               ? "Enter your work email address to sign in with your organization's Single Sign-On"
-              : 'Sign in or create an account to get started'
+              : isSignUp
+                ? 'Sign up to get started'
+                : 'Sign in or create an account to get started'
           }
           ssoMode={ssoMode}
           emailOnly={ssoMode}

--- a/apps/web/src/components/auth/SignInForm.tsx
+++ b/apps/web/src/components/auth/SignInForm.tsx
@@ -26,6 +26,13 @@ type SignInFormProps = {
   storybookInitialState?: SignInFormInitialState;
 };
 
+function signInHrefFromSearchParams(searchParams: Record<string, string>): string {
+  const params = new URLSearchParams(searchParams);
+  params.delete('signup');
+  const query = params.toString();
+  return query ? `/users/sign_in?${query}` : '/users/sign_in';
+}
+
 export function SignInForm({
   searchParams,
   error: initialError,
@@ -333,7 +340,10 @@ export function SignInForm({
                 {isSignUp ? (
                   <p className="text-muted-foreground text-sm">
                     Already have an account?{' '}
-                    <Link href="/users/sign_in" className="text-primary hover:underline">
+                    <Link
+                      href={signInHrefFromSearchParams(searchParams)}
+                      className="text-primary hover:underline"
+                    >
                       Sign in
                     </Link>
                   </p>

--- a/apps/web/src/lib/getSignInCallbackUrl.test.ts
+++ b/apps/web/src/lib/getSignInCallbackUrl.test.ts
@@ -189,6 +189,19 @@ describe('getSignInCallbackUrl', () => {
 
       expect(result).toBe('/users/after-sign-in?im_ref=impact-click-id-123');
     });
+
+    test('includes signup=true when present so error bounces can preserve signup mode', () => {
+      const searchParams = { signup: 'true' };
+      const result = getSignInCallbackUrl(searchParams);
+
+      expect(result).toBe('/users/after-sign-in?signup=true');
+    });
+
+    test('ignores non-"true" signup values', () => {
+      expect(getSignInCallbackUrl({ signup: 'false' })).toBe('/users/after-sign-in');
+      expect(getSignInCallbackUrl({ signup: '' })).toBe('/users/after-sign-in');
+      expect(getSignInCallbackUrl({ signup: ['true'] })).toBe('/users/after-sign-in');
+    });
   });
 
   describe('parameter combinations', () => {

--- a/apps/web/src/lib/getSignInCallbackUrl.ts
+++ b/apps/web/src/lib/getSignInCallbackUrl.ts
@@ -43,5 +43,12 @@ export default function getSignInCallbackUrl(searchParams?: NextAppSearchParams)
     callbackParams.set('callbackPath', searchParams.callbackPath);
   }
 
+  // Preserve signup=true so an OAuth error bounce (see parseSignInRedirectContext
+  // in user.server.ts) can send the user back to the create-account UI instead
+  // of the plain sign-in UI.
+  if (searchParams?.signup === 'true') {
+    callbackParams.set('signup', 'true');
+  }
+
   return `/users/after-sign-in${callbackParams.size > 0 ? `?${callbackParams.toString()}` : ''}`;
 }

--- a/apps/web/src/lib/user.server.test.ts
+++ b/apps/web/src/lib/user.server.test.ts
@@ -5,6 +5,7 @@ import {
   parseLinkedInProfileName,
   getUserUUID,
   uuidSchema,
+  parseSignInRedirectContext,
 } from './user.server';
 import type { User } from '@kilocode/db/schema';
 import { v5 as uuidv5 } from 'uuid';
@@ -402,5 +403,58 @@ describe('uuidSchema (organization ID validation)', () => {
   test('should reject numbers', () => {
     expect(uuidSchema.safeParse(12345).success).toBe(false);
     expect(uuidSchema.safeParse(0).success).toBe(false);
+  });
+});
+
+describe('parseSignInRedirectContext', () => {
+  test('returns empty context when cookie value is undefined', () => {
+    expect(parseSignInRedirectContext(undefined)).toEqual({});
+  });
+
+  test('returns empty context when cookie value is empty string', () => {
+    expect(parseSignInRedirectContext('')).toEqual({});
+  });
+
+  test('returns empty context for malformed URL', () => {
+    expect(parseSignInRedirectContext('::::not a url::::')).toEqual({});
+  });
+
+  test('extracts callbackPath from /users/after-sign-in destination', () => {
+    const cookie = '/users/after-sign-in?callbackPath=%2Fdevice-auth%3Fcode%3Dabc123';
+    expect(parseSignInRedirectContext(cookie)).toEqual({
+      callbackPath: '/device-auth?code=abc123',
+    });
+  });
+
+  test('extracts signup=true flag', () => {
+    const cookie = '/users/after-sign-in?signup=true';
+    expect(parseSignInRedirectContext(cookie)).toEqual({
+      signup: true,
+    });
+  });
+
+  test('extracts both callbackPath and signup together', () => {
+    const cookie = '/users/after-sign-in?callbackPath=%2Fdevice-auth%3Fcode%3Dabc123&signup=true';
+    expect(parseSignInRedirectContext(cookie)).toEqual({
+      callbackPath: '/device-auth?code=abc123',
+      signup: true,
+    });
+  });
+
+  test('rejects callbackPath that fails isValidCallbackPath', () => {
+    const cookie = '/users/after-sign-in?callbackPath=https%3A%2F%2Fevil.example.com%2Fphish';
+    expect(parseSignInRedirectContext(cookie)).toEqual({});
+  });
+
+  test('treats signup values other than "true" as absent', () => {
+    const cookie = '/users/after-sign-in?signup=false';
+    expect(parseSignInRedirectContext(cookie)).toEqual({});
+  });
+
+  test('handles absolute URL cookie value', () => {
+    const cookie = 'https://kilo.ai/users/after-sign-in?callbackPath=%2Fdevice-auth%3Fcode%3Dxyz';
+    expect(parseSignInRedirectContext(cookie)).toEqual({
+      callbackPath: '/device-auth?code=xyz',
+    });
   });
 });

--- a/apps/web/src/lib/user.server.ts
+++ b/apps/web/src/lib/user.server.ts
@@ -51,6 +51,7 @@ import type { FailureResult } from '@/lib/maybe-result';
 import { failureResult, whenOk } from '@/lib/maybe-result';
 import type { AuthErrorType } from '@/lib/auth/constants';
 import { hosted_domain_specials, SSO_SIGNIN_PATH } from '@/lib/auth/constants';
+import { isValidCallbackPath } from '@/lib/getSignInCallbackUrl';
 import {
   GITHUB_CLIENT_ID,
   GITHUB_CLIENT_SECRET,
@@ -352,6 +353,54 @@ function createAccountInfo(
   return accountInfo;
 }
 
+export type SignInRedirectContext = {
+  callbackPath?: string;
+  signup?: boolean;
+};
+
+/**
+ * Extracts the sign-in redirect context from the NextAuth callback-url cookie
+ * value. Exported so the parsing logic can be tested without mocking the
+ * next/headers cookie store.
+ *
+ * The NextAuth callback-url cookie holds the post-auth destination, e.g.
+ * `/users/after-sign-in?callbackPath=/device-auth?code=<CODE>`. We lift
+ * `callbackPath` and `signup` out so that bouncing back to `/users/sign_in`
+ * on an auth error preserves the mobile device-auth context and the signup
+ * UI mode the user originally requested.
+ */
+export function parseSignInRedirectContext(
+  callbackUrlCookieValue: string | undefined
+): SignInRedirectContext {
+  if (!callbackUrlCookieValue) return {};
+
+  let callbackUrl: URL;
+  try {
+    callbackUrl = new URL(callbackUrlCookieValue, 'http://localhost');
+  } catch {
+    return {};
+  }
+
+  const nestedCallbackPath = callbackUrl.searchParams.get('callbackPath')?.trim();
+  const nestedSignup = callbackUrl.searchParams.get('signup') === 'true';
+
+  return {
+    callbackPath:
+      nestedCallbackPath && isValidCallbackPath(nestedCallbackPath)
+        ? nestedCallbackPath
+        : undefined,
+    signup: nestedSignup || undefined,
+  };
+}
+
+async function getSignInRedirectContext(): Promise<SignInRedirectContext> {
+  const cookieStore = await cookies();
+  const raw =
+    cookieStore.get('__Secure-next-auth.callback-url')?.value ??
+    cookieStore.get('next-auth.callback-url')?.value;
+  return parseSignInRedirectContext(raw);
+}
+
 async function getAffiliateTrackingIdFromAuthFlow(): Promise<string | null> {
   const cookieStore = await cookies();
 
@@ -529,13 +578,25 @@ const authOptions: NextAuthOptions = {
       let accountInfo: CreateOrUpdateUserArgs | undefined;
       let isAccountLinking: boolean | null = null;
       let linkingSession: AccountLinkingSession | null = null;
+      const redirectContext = await getSignInRedirectContext();
       const redirectUrlForCode = (error: AuthErrorType, email?: string): string => {
-        const baseUrl = isAccountLinking ? '/connected-accounts' : '/users/sign_in';
         const params = new URLSearchParams({ error });
         if (email) {
           params.set('email', email);
         }
-        return `${baseUrl}?${params.toString()}`;
+        if (isAccountLinking) {
+          return `/connected-accounts?${params.toString()}`;
+        }
+        // Preserve the original sign-in context so an error bounce (e.g. BLOCKED,
+        // USER-NOT-FOUND, DIFFERENT-OAUTH) doesn't strand a mobile device-auth
+        // flow on a plain sign-in page without the code or signup mode.
+        if (redirectContext.callbackPath) {
+          params.set('callbackPath', redirectContext.callbackPath);
+        }
+        if (redirectContext.signup) {
+          params.set('signup', 'true');
+        }
+        return `/users/sign_in?${params.toString()}`;
       };
       try {
         if (!account) return `TRAP: No account found`;


### PR DESCRIPTION
## Summary

Adds a "Create Account" button to the mobile login screen next to the existing
"Sign In" button, and wires signup mode through the web device-auth flow.

## Verification

- [x] Manual check

## Visual Changes

<img width="1080" height="2424" alt="Screenshot_1776684265" src="https://github.com/user-attachments/assets/930a5cfb-8043-4bca-8475-4c1dde51ab75" />

