### PR TITLE
style(emails): convert transactional emails to light mode

### DIFF
--- a/apps/web/src/emails/AGENTS.md
+++ b/apps/web/src/emails/AGENTS.md
@@ -4,22 +4,25 @@ These HTML files are server-rendered transactional email templates, sent via Mai
 
 ## Styling
 
-All templates use the Kilo brand design system:
+All templates use a light-mode design system aligned with the Customer.io marketing template:
 
-| Property                | Value                                                 |
-| ----------------------- | ----------------------------------------------------- |
-| Font                    | `'JetBrains Mono', 'Courier New', Courier, monospace` |
-| Page background         | `#1a1a1a`                                             |
-| Card background         | `#2a2a2a`                                             |
-| Card border             | `1px solid #3a3a3a`                                   |
-| H1 color                | `#f4e452` (yellow)                                    |
-| Body text               | `#9ca3af` (gray)                                      |
-| Strong / emphasis text  | `#d1d5db` (light gray)                                |
-| Links                   | `#f4e452` (yellow)                                    |
-| CTA button background   | `#f4e452` (yellow)                                    |
-| CTA button text         | `#6b7280` (dark gray)                                 |
-| Footer / secondary text | `#6b7280`                                             |
-| Section divider         | `1px solid #3a3a3a`                                   |
+| Property                      | Value                                                                                 |
+| ----------------------------- | ------------------------------------------------------------------------------------- |
+| Font                          | `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif` |
+| Page background               | `#ffffff`                                                                             |
+| Content width                 | 520px max                                                                             |
+| H1 / strong / emphasis        | `#1a1a1a`, 24px/700                                                                   |
+| Body text                     | `#333`, 14–15px, line-height 1.5–1.7                                                  |
+| Secondary text (inside boxes) | `#555`, 13–14px                                                                       |
+| Inline links                  | `#1a1a1a` underlined                                                                  |
+| Info-box background           | `#f6f6f4`                                                                             |
+| Info-box border               | `1px solid #ebebea`                                                                   |
+| Info-box border-radius        | `10px`                                                                                |
+| Primary CTA button background | `#1a1a1a`                                                                             |
+| Primary CTA button text       | `#ffffff`, 13px/600, `border-radius: 7px`, `padding: 10px 20px`                       |
+| Section divider               | `1px solid #ebebea`                                                                   |
+| Footer divider                | `1px solid #eee`                                                                      |
+| Footer legal / address        | `#ccc`, 11px                                                                          |
 
 ## Content Guidelines
 
@@ -32,19 +35,20 @@ All templates in this directory are **transactional** emails sent via `app.kiloc
 
 ## Footer
 
-Every template must include this branding footer below the card:
+Every template must include this branding footer below the content table:
 
 ```html
 <!-- Branding Footer -->
-<table width="600" cellpadding="0" cellspacing="0">
+<table width="520" cellpadding="0" cellspacing="0">
   <tr>
-    <td align="center" style="padding: 30px 20px">
+    <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
       <p
         style="
           margin: 0;
-          font-size: 12px;
-          color: #6b7280;
-          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+          font-size: 11px;
+          color: #ccc;
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+            Arial, sans-serif;
         "
       >
         © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San Francisco, CA

--- a/apps/web/src/emails/accountDeletionRequest.html
+++ b/apps/web/src/emails/accountDeletionRequest.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Account Deletion Request Received
@@ -47,20 +45,24 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   We've received your request to delete your Kilo Code account associated with
-                  <strong style="color: #d1d5db">{{ email }}</strong>.
+                  <strong style="color: #1a1a1a">{{ email }}</strong>.
                 </p>
                 <p
                   style="
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Our team will process your request and you'll receive a follow-up email once your
@@ -71,8 +73,10 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you did not make this request, please reply to this email immediately.
@@ -81,14 +85,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -97,15 +103,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/autoTopUpFailed.html
+++ b/apps/web/src/emails/autoTopUpFailed.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Auto Top-Up Failed
@@ -47,26 +45,30 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   We couldn't process your automatic top-up.
-                  <strong style="color: #d1d5db">{{ reason }}</strong>
+                  <strong style="color: #1a1a1a">{{ reason }}</strong>
                 </p>
                 <p
                   style="
                     margin: 0 0 20px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   We've disabled auto-top-up to prevent repeated failures. To continue using Kilo
                   without interruption, please update your payment method or manually add credits on
                   your
-                  <a href="{{ credits_url }}" style="color: #f4e452; text-decoration: underline"
+                  <a href="{{ credits_url }}" style="color: #1a1a1a; text-decoration: underline"
                     >credits page</a
                   >.
                 </p>
@@ -78,14 +80,16 @@
                         href="{{ credits_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Go to Credits Page
@@ -98,8 +102,10 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -109,14 +115,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -125,15 +133,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/balanceAlert.html
+++ b/apps/web/src/emails/balanceAlert.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Balance Alert
@@ -47,16 +45,18 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your Kilo available balance has dropped below your configured alert threshold of
-                  <strong style="color: #d1d5db">${{ minimum_balance }}</strong>. You can add more
+                  <strong style="color: #1a1a1a">${{ minimum_balance }}</strong>. You can add more
                   credits
                   <a
                     href="{{ organization_url }}"
-                    style="color: #f4e452; text-decoration: underline"
+                    style="color: #1a1a1a; text-decoration: underline"
                     >on your organization page</a
                   >.
                 </p>
@@ -68,14 +68,16 @@
                         href="{{ organization_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Add Credits
@@ -88,8 +90,10 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -99,14 +103,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -115,15 +121,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/clawComplementaryInferenceEnded.html
+++ b/apps/web/src/emails/clawComplementaryInferenceEnded.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your Free Inference Period Has Ended
@@ -47,8 +45,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 22px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   The 6 hours of complimentary AI usage included with your KiloClaw trial have now
@@ -63,14 +63,16 @@
                         href="{{ claw_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Open KiloClaw
@@ -82,14 +84,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, reply to this email — we're here to help.
@@ -99,8 +103,10 @@
                     margin: 16px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -109,15 +115,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/clawCreditRenewalFailed.html
+++ b/apps/web/src/emails/clawCreditRenewalFailed.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Hosting Renewal Failed
@@ -47,8 +45,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your KiloClaw hosting renewal failed because your account does not have enough
@@ -62,14 +62,16 @@
                         href="{{ claw_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Add Credits
@@ -82,8 +84,10 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -93,14 +97,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -109,15 +115,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/clawDestructionWarning.html
+++ b/apps/web/src/emails/clawDestructionWarning.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Deletion in 2 Days
@@ -47,14 +45,16 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your KiloClaw instance
-                  <strong style="color: #d1d5db">{{ instance_label }}</strong>
+                  <strong style="color: #1a1a1a">{{ instance_label }}</strong>
                   is scheduled for deletion on
-                  <strong style="color: #d1d5db">{{ destruction_date }}</strong>. Take action now to
+                  <strong style="color: #1a1a1a">{{ destruction_date }}</strong>. Take action now to
                   prevent deletion.
                 </p>
                 <!-- CTA Button -->
@@ -65,14 +65,16 @@
                         href="{{ claw_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Go to KiloClaw
@@ -85,8 +87,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   This cannot be undone. All data associated with this instance will be permanently
@@ -97,8 +101,10 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -108,14 +114,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -124,15 +132,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/clawEarlybirdEndingSoon.html
+++ b/apps/web/src/emails/clawEarlybirdEndingSoon.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Earlybird Access Ending Soon
@@ -47,13 +45,15 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your KiloClaw earlybird access ends in
-                  <strong style="color: #d1d5db">{{ days_remaining }} days</strong> on
-                  <strong style="color: #d1d5db">{{ expiry_date }}</strong>. Subscribe now to keep
+                  <strong style="color: #1a1a1a">{{ days_remaining }} days</strong> on
+                  <strong style="color: #1a1a1a">{{ expiry_date }}</strong>. Subscribe now to keep
                   your instance running.
                 </p>
                 <!-- CTA Button -->
@@ -64,14 +64,16 @@
                         href="{{ claw_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Update Your Subscription
@@ -84,8 +86,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Without an active subscription, your instance will be stopped after your earlybird
@@ -96,8 +100,10 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -107,14 +113,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -123,15 +131,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/clawEarlybirdExpiresTomorrow.html
+++ b/apps/web/src/emails/clawEarlybirdExpiresTomorrow.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Earlybird Access Expires Tomorrow
@@ -47,12 +45,14 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your KiloClaw earlybird access expires tomorrow on
-                  <strong style="color: #d1d5db">{{ expiry_date }}</strong>. Subscribe now to keep
+                  <strong style="color: #1a1a1a">{{ expiry_date }}</strong>. Subscribe now to keep
                   your instance running.
                 </p>
                 <!-- CTA Button -->
@@ -63,14 +63,16 @@
                         href="{{ claw_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Update Your Subscription
@@ -83,8 +85,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Without an active subscription, your instance will be stopped after your earlybird
@@ -95,8 +99,10 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -106,14 +112,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -122,15 +130,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/clawInstanceDestroyed.html
+++ b/apps/web/src/emails/clawInstanceDestroyed.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Instance Deleted
@@ -47,8 +45,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your KiloClaw instance has been permanently deleted. All associated data has been
@@ -62,14 +62,16 @@
                         href="{{ claw_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Go to KiloClaw
@@ -82,8 +84,10 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -93,14 +97,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -109,15 +115,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/clawInstanceReady.html
+++ b/apps/web/src/emails/clawInstanceReady.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your KiloClaw instance is live
@@ -47,8 +45,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 22px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your KiloClaw instance is now ready to use. Hosting is free for 7 days and AI
@@ -63,14 +63,16 @@
                         href="{{ claw_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Open KiloClaw
@@ -82,14 +84,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, reply to this email — we're here to help.
@@ -99,8 +103,10 @@
                     margin: 16px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -109,15 +115,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/clawSuspendedPayment.html
+++ b/apps/web/src/emails/clawSuspendedPayment.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Payment Overdue
@@ -47,8 +45,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your KiloClaw payment has failed and your instance has been stopped. Update your
@@ -62,14 +62,16 @@
                         href="{{ claw_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Update Payment
@@ -82,20 +84,24 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If no action is taken, your instance will be permanently deleted on
-                  <strong style="color: #d1d5db">{{ destruction_date }}</strong>.
+                  <strong style="color: #1a1a1a">{{ destruction_date }}</strong>.
                 </p>
                 <p
                   style="
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -105,14 +111,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -121,15 +129,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/clawSuspendedSubscription.html
+++ b/apps/web/src/emails/clawSuspendedSubscription.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your Subscription Has Ended
@@ -47,8 +45,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your KiloClaw subscription has ended and your instance has been stopped.
@@ -62,14 +62,16 @@
                         href="{{ claw_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Resubscribe
@@ -82,20 +84,24 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If no action is taken, your instance will be permanently deleted on
-                  <strong style="color: #d1d5db">{{ destruction_date }}</strong>.
+                  <strong style="color: #1a1a1a">{{ destruction_date }}</strong>.
                 </p>
                 <p
                   style="
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -105,14 +111,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -121,15 +129,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/clawSuspendedTrial.html
+++ b/apps/web/src/emails/clawSuspendedTrial.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your Trial Has Ended
@@ -47,8 +45,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your free KiloClaw trial has ended and your instance has been stopped. Subscribe
@@ -62,14 +62,16 @@
                         href="{{ claw_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Subscribe Now
@@ -82,20 +84,24 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If no action is taken, your instance will be permanently deleted on
-                  <strong style="color: #d1d5db">{{ destruction_date }}</strong>.
+                  <strong style="color: #1a1a1a">{{ destruction_date }}</strong>.
                 </p>
                 <p
                   style="
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -105,14 +111,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -121,15 +129,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/clawTrialEndingSoon.html
+++ b/apps/web/src/emails/clawTrialEndingSoon.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your Trial Ends Soon
@@ -47,12 +45,14 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your free KiloClaw trial ends in
-                  <strong style="color: #d1d5db">{{ days_remaining }} days</strong>. Subscribe now
+                  <strong style="color: #1a1a1a">{{ days_remaining }} days</strong>. Subscribe now
                   to keep your instance running.
                 </p>
                 <!-- CTA Button -->
@@ -63,14 +63,16 @@
                         href="{{ claw_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Update Your Subscription
@@ -83,8 +85,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you don't subscribe, your instance will be stopped and scheduled for deletion 7
@@ -95,8 +99,10 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -106,14 +112,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -122,15 +130,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/clawTrialExpiresTomorrow.html
+++ b/apps/web/src/emails/clawTrialExpiresTomorrow.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your Trial Expires Tomorrow
@@ -47,8 +45,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your free KiloClaw trial expires tomorrow. Subscribe now to keep your instance
@@ -62,14 +62,16 @@
                         href="{{ claw_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Update Your Subscription
@@ -82,8 +84,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you don't subscribe, your instance will be stopped and scheduled for deletion
@@ -94,8 +98,10 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -105,14 +111,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -121,15 +129,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/deployFailed.html
+++ b/apps/web/src/emails/deployFailed.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Deployment Failed
@@ -47,13 +45,15 @@
                     margin: 0 0 20px;
                     font-size: 16px;
                     line-height: 24px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your deployment
-                  <strong style="color: #d1d5db">{{ deployment_name }}</strong> from repository
-                  <strong style="color: #d1d5db">{{ repository }}</strong> has failed.
+                  <strong style="color: #1a1a1a">{{ deployment_name }}</strong> from repository
+                  <strong style="color: #1a1a1a">{{ repository }}</strong> has failed.
                 </p>
                 <!-- CTA Button -->
                 <table width="100%" cellpadding="0" cellspacing="0">
@@ -63,14 +63,16 @@
                         href="{{ deployment_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         View Deployment
@@ -82,15 +84,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/magicLink.html
+++ b/apps/web/src/emails/magicLink.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Sign in to Kilo Code
@@ -48,8 +46,10 @@
                     margin: 0 0 20px;
                     font-size: 16px;
                     line-height: 24px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Click the button below to sign in to your Kilo Code account:
@@ -63,14 +63,16 @@
                         href="{{ magic_link_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Sign in to Kilo Code
@@ -84,8 +86,10 @@
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Or copy and paste this link into your browser:
@@ -95,9 +99,11 @@
                     margin: 8px 0 0;
                     font-size: 13px;
                     line-height: 20px;
-                    color: #6b7280;
+                    color: #555;
                     word-break: break-all;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   {{ magic_link_url }}
@@ -110,22 +116,24 @@
               <td style="padding: 0 40px 30px">
                 <div
                   style="
-                    background-color: #1a1a1a;
-                    border-left: 3px solid #f4e452;
-                    padding: 16px;
-                    border-radius: 4px;
+                    background-color: #f6f6f4;
+                    border: 1px solid #ebebea;
+                    padding: 14px 16px;
+                    border-radius: 10px;
                   "
                 >
                   <p
                     style="
                       margin: 0;
                       font-size: 14px;
-                      line-height: 20px;
-                      color: #9ca3af;
-                      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                      line-height: 1.5;
+                      color: #555;
+                      font-family:
+                        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                        sans-serif;
                     "
                   >
-                    <strong style="color: #d1d5db">Security Notice:</strong> This link will expire
+                    <strong style="color: #1a1a1a">Security Notice:</strong> This link will expire
                     in {{ expires_in }} and can only be used once.
                   </p>
                 </div>
@@ -134,14 +142,16 @@
 
             <!-- Footer -->
             <tr>
-              <td style="padding: 20px 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 20px 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 0;
                     font-size: 13px;
                     line-height: 18px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #555;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you didn't request this email, you can safely ignore it.
@@ -151,8 +161,10 @@
                     margin: 12px 0 0;
                     font-size: 13px;
                     line-height: 18px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #555;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   This email was sent to {{ email }}
@@ -162,15 +174,17 @@
           </table>
 
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/orgCancelled.html
+++ b/apps/web/src/emails/orgCancelled.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your Kilo for Teams Subscription is Cancelled
@@ -47,8 +45,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your subscription for Kilo for Teams has been cancelled. We're sad to see you go!
@@ -58,12 +58,14 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   You can view your organization's invoices
-                  <a href="{{ invoices_url }}" style="color: #f4e452; text-decoration: underline"
+                  <a href="{{ invoices_url }}" style="color: #1a1a1a; text-decoration: underline"
                     >here</a
                   >
                   including your final invoice.
@@ -73,8 +75,10 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -84,14 +88,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -100,15 +106,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/orgInvitation.html
+++ b/apps/web/src/emails/orgInvitation.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Kilo Code Teams Invitation
@@ -47,13 +45,15 @@
                     margin: 0 0 20px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   You've been invited to join a team on Kilo Code by
-                  <strong style="color: #d1d5db">{{ inviter_name }}</strong>. Please click the
-                  accept invite button to be added to the team "<strong style="color: #d1d5db"
+                  <strong style="color: #1a1a1a">{{ inviter_name }}</strong>. Please click the
+                  accept invite button to be added to the team "<strong style="color: #1a1a1a"
                     >{{ organization_name }}</strong
                   >".
                 </p>
@@ -65,14 +65,16 @@
                         href="{{ accept_invite_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Accept Invite
@@ -84,14 +86,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Happy coding!<br /><br />~ The Kilo Code Team
@@ -100,15 +104,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/orgRenewed.html
+++ b/apps/web/src/emails/orgRenewed.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Kilo for Teams Subscription Renewal
@@ -47,12 +45,14 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your subscription for
-                  <strong style="color: #d1d5db">{{ seats }}</strong> has been renewed for another
+                  <strong style="color: #1a1a1a">{{ seats }}</strong> has been renewed for another
                   month.
                 </p>
                 <p
@@ -60,12 +60,14 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   You can view your organization's invoices
-                  <a href="{{ invoices_url }}" style="color: #f4e452; text-decoration: underline"
+                  <a href="{{ invoices_url }}" style="color: #1a1a1a; text-decoration: underline"
                     >here</a
                   >.
                 </p>
@@ -74,8 +76,10 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -85,14 +89,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -101,15 +107,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/orgSSOUserJoined.html
+++ b/apps/web/src/emails/orgSSOUserJoined.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   New SSO User Joined
@@ -47,15 +45,17 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
-                  Howdy! <strong style="color: #d1d5db">{{ new_user_email }}</strong> has joined
+                  Howdy! <strong style="color: #1a1a1a">{{ new_user_email }}</strong> has joined
                   your organization by logging in with Enterprise SSO. You can view your member list
                   <a
                     href="{{ organization_url }}"
-                    style="color: #f4e452; text-decoration: underline"
+                    style="color: #1a1a1a; text-decoration: underline"
                     >on your organization page</a
                   >.
                 </p>
@@ -64,8 +64,10 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -75,14 +77,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -91,15 +95,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/orgSubscription.html
+++ b/apps/web/src/emails/orgSubscription.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Welcome to Kilo for Teams!
@@ -47,15 +45,17 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
-                  Your subscription for <strong style="color: #d1d5db">{{ seats }}</strong> is now
+                  Your subscription for <strong style="color: #1a1a1a">{{ seats }}</strong> is now
                   active! Visit your
                   <a
                     href="{{ organization_url }}"
-                    style="color: #f4e452; text-decoration: underline"
+                    style="color: #1a1a1a; text-decoration: underline"
                     >organization dashboard</a
                   >
                   to invite members & purchase AI credits to get your team going.
@@ -65,12 +65,14 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   You can also view your organization's invoices
-                  <a href="{{ invoices_url }}" style="color: #f4e452; text-decoration: underline"
+                  <a href="{{ invoices_url }}" style="color: #1a1a1a; text-decoration: underline"
                     >here</a
                   >.
                 </p>
@@ -79,8 +81,10 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   If you have any questions, please don't hesitate to reply to this email. We are
@@ -90,14 +94,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   — The Kilo Team
@@ -106,15 +112,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/ossExistingOrgProvisioned.html
+++ b/apps/web/src/emails/ossExistingOrgProvisioned.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Kilo OSS Sponsorship Offer
@@ -47,21 +45,25 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Congratulations! You've been selected for the
-                  <strong style="color: #d1d5db">Kilo OSS Sponsorship Program</strong> at the
-                  <strong style="color: #d1d5db">{{ tier_name }} tier</strong>.
+                  <strong style="color: #1a1a1a">Kilo OSS Sponsorship Program</strong> at the
+                  <strong style="color: #1a1a1a">{{ tier_name }} tier</strong>.
                 </p>
                 <p
                   style="
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Your sponsorship includes:
@@ -71,11 +73,13 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
-                  • <strong style="color: #d1d5db">{{ seats }} Enterprise Seats</strong> (a ${{
+                  • <strong style="color: #1a1a1a">{{ seats }} Enterprise Seats</strong> (a ${{
                   seat_value }} value){{ credits_section }}
                 </p>
                 <p
@@ -83,8 +87,10 @@
                     margin: 0 0 20px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   View your upgraded Organization here:
@@ -97,14 +103,16 @@
                         href="{{ organization_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         View Organization
@@ -117,8 +125,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   To accept the offer and complete onboarding, please enable these features for your
@@ -129,20 +139,22 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   •
-                  <strong style="color: #d1d5db">GitHub Integration</strong>:
+                  <strong style="color: #1a1a1a">GitHub Integration</strong>:
                   <a
                     href="{{ integrations_url }}"
-                    style="color: #f4e452; text-decoration: underline"
+                    style="color: #1a1a1a; text-decoration: underline"
                     >Enable GitHub</a
-                  ><br />• <strong style="color: #d1d5db">Code Reviews</strong>:
+                  ><br />• <strong style="color: #1a1a1a">Code Reviews</strong>:
                   <a
                     href="{{ code_reviews_url }}"
-                    style="color: #f4e452; text-decoration: underline"
+                    style="color: #1a1a1a; text-decoration: underline"
                     >Enable Code Reviews</a
                   >
                 </p>
@@ -150,14 +162,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Excited to build together!<br /><br />~ Brian<br />DevRel @ Kilo
@@ -166,15 +180,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/ossInviteExistingUser.html
+++ b/apps/web/src/emails/ossInviteExistingUser.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Kilo OSS Sponsorship Offer
@@ -47,24 +45,28 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Congratulations! You've been selected for the
-                  <strong style="color: #d1d5db">Kilo OSS Sponsorship Program</strong> at the
-                  <strong style="color: #d1d5db">{{ tier_name }} tier</strong>.
+                  <strong style="color: #1a1a1a">Kilo OSS Sponsorship Program</strong> at the
+                  <strong style="color: #1a1a1a">{{ tier_name }} tier</strong>.
                 </p>
                 <p
                   style="
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
-                  You've been added as the <strong style="color: #d1d5db">Owner</strong> of a new
+                  You've been added as the <strong style="color: #1a1a1a">Owner</strong> of a new
                   Kilo Enterprise Organization. Your sponsorship includes:
                 </p>
                 <p
@@ -72,11 +74,13 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
-                  • <strong style="color: #d1d5db">{{ seats }} Enterprise Seats</strong> (a ${{
+                  • <strong style="color: #1a1a1a">{{ seats }} Enterprise Seats</strong> (a ${{
                   seat_value }} value){{ credits_section }}
                 </p>
                 <p
@@ -84,8 +88,10 @@
                     margin: 0 0 20px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Sign in to access your organization:
@@ -98,14 +104,16 @@
                         href="{{ organization_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         View Organization
@@ -118,8 +126,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   To accept the offer and complete onboarding, please enable these features for your
@@ -130,20 +140,22 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   •
-                  <strong style="color: #d1d5db">GitHub Integration</strong>:
+                  <strong style="color: #1a1a1a">GitHub Integration</strong>:
                   <a
                     href="{{ integrations_url }}"
-                    style="color: #f4e452; text-decoration: underline"
+                    style="color: #1a1a1a; text-decoration: underline"
                     >Enable GitHub</a
-                  ><br />• <strong style="color: #d1d5db">Code Reviews</strong>:
+                  ><br />• <strong style="color: #1a1a1a">Code Reviews</strong>:
                   <a
                     href="{{ code_reviews_url }}"
-                    style="color: #f4e452; text-decoration: underline"
+                    style="color: #1a1a1a; text-decoration: underline"
                     >Enable Code Reviews</a
                   >
                 </p>
@@ -151,14 +163,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Excited to build together!<br /><br />~ Brian<br />DevRel @ Kilo
@@ -167,15 +181,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/emails/ossInviteNewUser.html
+++ b/apps/web/src/emails/ossInviteNewUser.html
@@ -9,20 +9,16 @@
     style="
       margin: 0;
       padding: 0;
-      font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
-      background-color: #1a1a1a;
-      color: #d1d5db;
+      font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background-color: #ffffff;
+      color: #1a1a1a;
     "
   >
-    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #1a1a1a">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #ffffff">
       <tr>
         <td align="center" style="padding: 40px 20px">
-          <table
-            width="600"
-            cellpadding="0"
-            cellspacing="0"
-            style="background-color: #2a2a2a; border-radius: 8px; border: 1px solid #3a3a3a"
-          >
+          <table width="520" cellpadding="0" cellspacing="0">
             <!-- Header -->
             <tr>
               <td style="padding: 40px 40px 20px">
@@ -31,8 +27,10 @@
                     margin: 0;
                     font-size: 24px;
                     font-weight: 700;
-                    color: #f4e452;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #1a1a1a;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Kilo OSS Sponsorship Offer
@@ -47,24 +45,28 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Congratulations! You've been selected for the
-                  <strong style="color: #d1d5db">Kilo OSS Sponsorship Program</strong> at the
-                  <strong style="color: #d1d5db">{{ tier_name }} tier</strong>.
+                  <strong style="color: #1a1a1a">Kilo OSS Sponsorship Program</strong> at the
+                  <strong style="color: #1a1a1a">{{ tier_name }} tier</strong>.
                 </p>
                 <p
                   style="
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
-                  You've been added as the <strong style="color: #d1d5db">Owner</strong> of a new
+                  You've been added as the <strong style="color: #1a1a1a">Owner</strong> of a new
                   Kilo Enterprise Organization. Your sponsorship includes:
                 </p>
                 <p
@@ -72,11 +74,13 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
-                  • <strong style="color: #d1d5db">{{ seats }} Enterprise Seats</strong> (a ${{
+                  • <strong style="color: #1a1a1a">{{ seats }} Enterprise Seats</strong> (a ${{
                   seat_value }} value){{ credits_section }}
                 </p>
                 <p
@@ -84,8 +88,10 @@
                     margin: 0 0 20px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Sign in to access your organization:
@@ -98,14 +104,16 @@
                         href="{{ accept_invite_url }}"
                         style="
                           display: inline-block;
-                          padding: 14px 32px;
-                          background-color: #f4e452;
-                          color: #6b7280;
+                          padding: 10px 20px;
+                          background-color: #1a1a1a;
+                          color: #ffffff;
                           text-decoration: none;
-                          border-radius: 6px;
-                          font-size: 16px;
-                          font-weight: 700;
-                          font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                          border-radius: 7px;
+                          font-size: 13px;
+                          font-weight: 600;
+                          font-family:
+                            -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                            sans-serif;
                         "
                       >
                         Accept Invite
@@ -118,8 +126,10 @@
                     margin: 0 0 16px;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   To accept the offer and complete onboarding, please enable these features for your
@@ -130,20 +140,22 @@
                     margin: 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   •
-                  <strong style="color: #d1d5db">GitHub Integration</strong>:
+                  <strong style="color: #1a1a1a">GitHub Integration</strong>:
                   <a
                     href="{{ integrations_url }}"
-                    style="color: #f4e452; text-decoration: underline"
+                    style="color: #1a1a1a; text-decoration: underline"
                     >Enable GitHub</a
-                  ><br />• <strong style="color: #d1d5db">Code Reviews</strong>:
+                  ><br />• <strong style="color: #1a1a1a">Code Reviews</strong>:
                   <a
                     href="{{ code_reviews_url }}"
-                    style="color: #f4e452; text-decoration: underline"
+                    style="color: #1a1a1a; text-decoration: underline"
                     >Enable Code Reviews</a
                   >
                 </p>
@@ -151,14 +163,16 @@
             </tr>
             <!-- Sign-off -->
             <tr>
-              <td style="padding: 0 40px 40px; border-top: 1px solid #3a3a3a">
+              <td style="padding: 0 40px 40px; border-top: 1px solid #ebebea">
                 <p
                   style="
                     margin: 20px 0 0;
                     font-size: 14px;
                     line-height: 20px;
-                    color: #9ca3af;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    color: #333;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   Excited to build together!<br /><br />~ Brian<br />DevRel @ Kilo
@@ -167,15 +181,17 @@
             </tr>
           </table>
           <!-- Branding Footer -->
-          <table width="600" cellpadding="0" cellspacing="0">
+          <table width="520" cellpadding="0" cellspacing="0">
             <tr>
-              <td align="center" style="padding: 30px 20px">
+              <td align="center" style="padding: 30px 20px; border-top: 1px solid #eee">
                 <p
                   style="
                     margin: 0;
-                    font-size: 12px;
-                    color: #6b7280;
-                    font-family: 'JetBrains Mono', 'Courier New', Courier, monospace;
+                    font-size: 11px;
+                    color: #ccc;
+                    font-family:
+                      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                      sans-serif;
                   "
                 >
                   © {{ year }} Kilo Code, Inc<br />455 Market St, Ste 1940 PMB 993504<br />San

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -69,7 +69,7 @@ export function renderTemplate(name: string, vars: TemplateVars): string {
 export function buildCreditsSection(monthlyCreditsUsd: number): RawHtml {
   if (monthlyCreditsUsd <= 0) return new RawHtml('');
   return new RawHtml(
-    `<br />• <strong style="color: #d1d5db">$${monthlyCreditsUsd} USD in Kilo credits</strong>, which reset every 30 days`
+    `<br />• <strong style="color: #1a1a1a">$${monthlyCreditsUsd} USD in Kilo credits</strong>, which reset every 30 days`
   );
 }
 


### PR DESCRIPTION
## Summary

Restyle all 25 transactional email templates in `apps/web/src/emails/` from the legacy dark design (JetBrains Mono, `#1a1a1a`/`#2a2a2a` card, yellow CTAs) to a light-mode system aligned with the marketing template.

- **Font**: system sans (`-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif`) replaces JetBrains Mono
- **Layout**: pure white page, no outer card; 520px content container replaces the 600px rounded dark card
- **Typography**: H1 / strong / links `#1a1a1a`; body `#333`; secondary `#555`
- **CTAs**: dark `#1a1a1a` pill with white text, `7px` radius, `10px 20px` padding, `13px/600` (was yellow `#f4e452` on gray)
- **Callouts**: `magicLink.html` "Security Notice" yellow-left-border block → neutral `#f6f6f4`/`#ebebea` info-box
- **Dividers**: `#ebebea` sections; `#eee` above the branding footer
- **Footer**: 520px-wide, `#ccc` 11px legal line on white
- **AGENTS.md**: palette table and footer snippet updated to the new system so new templates stay consistent

No logic, router, fixture, variable, or send-pipeline code is modified.

## Verification

- `pnpm format` — clean (no changes)
- `pnpm typecheck` — pass
- `pnpm lint` — 0 warnings, 0 errors
- `pnpm test` — 240 suites, 4067 passed, 2 skipped

## Visual Changes

<img width="528" height="539" alt="image" src="https://github.com/user-attachments/assets/dc06c043-be73-4857-b5b6-dae1f8f1fdf4" />
<img width="537" height="516" alt="image" src="https://github.com/user-attachments/assets/38cc2255-db83-4807-9c59-8e8f10752384" />
<img width="576" height="511" alt="image" src="https://github.com/user-attachments/assets/a0cfdd17-ed08-4490-a47c-4e29aec44a8c" />

## Reviewer Notes

- Pure CSS/markup restyle — `{{ variable }}` placeholders are unchanged, so `fixtureTemplateVars` in `apps/web/src/routers/admin/email-testing-router.ts` still covers all 25 templates.
- Dropping JetBrains Mono is a brand shift for email only; in-app and site typography are unaffected.
- No dark-mode (`prefers-color-scheme`) adaptive styling — can be a follow-up.