### PR TITLE
fix(kiloclaw): support docker-local dev provider

### DIFF
--- a/services/kiloclaw/controller/src/routes/gateway.test.ts
+++ b/services/kiloclaw/controller/src/routes/gateway.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from 'vitest';
+import os from 'node:os';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { Hono } from 'hono';
-import { registerGatewayRoutes } from './gateway';
+import { loadFields, registerGatewayRoutes } from './gateway';
 import type { Supervisor } from '../supervisor';
 
 function createMockSupervisor(): Supervisor {
@@ -25,6 +26,42 @@ function createMockSupervisor(): Supervisor {
 function authHeaders(token = 'test-token'): HeadersInit {
   return { Authorization: `Bearer ${token}` };
 }
+
+type RuntimeEnvSnapshot = {
+  FLY_MACHINE_ID: string | undefined;
+  KILOCLAW_RUNTIME_PROVIDER: string | undefined;
+  KILOCLAW_MACHINE_CPU_KIND: string | undefined;
+};
+
+function snapshotRuntimeEnv(): RuntimeEnvSnapshot {
+  return {
+    FLY_MACHINE_ID: process.env.FLY_MACHINE_ID,
+    KILOCLAW_RUNTIME_PROVIDER: process.env.KILOCLAW_RUNTIME_PROVIDER,
+    KILOCLAW_MACHINE_CPU_KIND: process.env.KILOCLAW_MACHINE_CPU_KIND,
+  };
+}
+
+function restoreRuntimeEnv(snapshot: RuntimeEnvSnapshot): void {
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+let runtimeEnvSnapshot: RuntimeEnvSnapshot;
+
+beforeEach(() => {
+  runtimeEnvSnapshot = snapshotRuntimeEnv();
+});
+
+afterEach(() => {
+  restoreRuntimeEnv(runtimeEnvSnapshot);
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 describe('/_kilo/gateway routes', () => {
   it('enforces bearer auth on GET /_kilo/gateway/status', async () => {
@@ -82,5 +119,47 @@ describe('/_kilo/gateway routes', () => {
     const resp = await app.request('/_kilo/gateway/status');
     expect(resp.status).toBe(401);
     expect(await resp.json()).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('marks high load as unsettled on Fly shared CPU instances', () => {
+    vi.spyOn(os, 'loadavg').mockReturnValue([0.5, 0.2, 0.1]);
+
+    expect(
+      loadFields({
+        KILOCLAW_RUNTIME_PROVIDER: 'fly',
+        KILOCLAW_MACHINE_CPU_KIND: 'shared',
+      })
+    ).toEqual({
+      loadAverage: [0.5, 0.2, 0.1],
+      settled: false,
+    });
+  });
+
+  it('does not wait for load settling on Fly performance CPU instances', () => {
+    vi.spyOn(os, 'loadavg').mockReturnValue([0.5, 0.2, 0.1]);
+
+    expect(
+      loadFields({
+        KILOCLAW_RUNTIME_PROVIDER: 'fly',
+        KILOCLAW_MACHINE_CPU_KIND: 'performance',
+      })
+    ).toEqual({
+      loadAverage: [0.5, 0.2, 0.1],
+      settled: true,
+    });
+  });
+
+  it('does not wait for load settling on docker-local instances', () => {
+    vi.spyOn(os, 'loadavg').mockReturnValue([0.5, 0.2, 0.1]);
+
+    expect(
+      loadFields({
+        KILOCLAW_RUNTIME_PROVIDER: 'docker-local',
+        KILOCLAW_MACHINE_CPU_KIND: 'shared',
+      })
+    ).toEqual({
+      loadAverage: [0.5, 0.2, 0.1],
+      settled: true,
+    });
   });
 });

--- a/services/kiloclaw/controller/src/routes/gateway.ts
+++ b/services/kiloclaw/controller/src/routes/gateway.ts
@@ -3,14 +3,28 @@ import type { Hono } from 'hono';
 import { timingSafeTokenEqual } from '../auth';
 import type { Supervisor } from '../supervisor';
 
-// shared-cpu-2x gives ~6% of 2 physical cores, so even modest load
-// averages represent heavy pressure. After boot completes, an idle
-// system sits near 0. A threshold of 0.1 ensures boot CPU work has
-// fully subsided before we tell the frontend it's safe to proceed.
+// shared-cpu Fly machines can see high load averages from modest boot work.
+// Performance Fly machines and non-Fly local Docker runs should not block
+// provisioning on host load average settling.
 const LOAD_SETTLED_THRESHOLD = 0.1;
 
-function loadFields(): { loadAverage: number[]; settled: boolean } {
+type LoadEnv = Record<string, string | undefined>;
+
+export function shouldCheckLoadSettled(env: LoadEnv = process.env): boolean {
+  const isFly = env.KILOCLAW_RUNTIME_PROVIDER
+    ? env.KILOCLAW_RUNTIME_PROVIDER === 'fly'
+    : Boolean(env.FLY_MACHINE_ID);
+  return isFly && env.KILOCLAW_MACHINE_CPU_KIND === 'shared';
+}
+
+export function loadFields(env: LoadEnv = process.env): {
+  loadAverage: number[];
+  settled: boolean;
+} {
   const loadAverage = os.loadavg();
+  if (!shouldCheckLoadSettled(env)) {
+    return { loadAverage, settled: true };
+  }
   return { loadAverage, settled: loadAverage[0] < LOAD_SETTLED_THRESHOLD };
 }
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { resolveDockerLocalKiloCodeApiBaseUrl } from './config';
+
+describe('resolveDockerLocalKiloCodeApiBaseUrl', () => {
+  it('rewrites localhost backend URLs to the Docker host gateway endpoint', () => {
+    expect(resolveDockerLocalKiloCodeApiBaseUrl('http://localhost:3000')).toBe(
+      'http://host.docker.internal:3000/api/gateway/'
+    );
+  });
+
+  it('rewrites loopback backend URLs to the Docker host gateway endpoint', () => {
+    expect(resolveDockerLocalKiloCodeApiBaseUrl('http://127.0.0.1:3000')).toBe(
+      'http://host.docker.internal:3000/api/gateway/'
+    );
+  });
+
+  it('preserves non-loopback hosts while replacing the path', () => {
+    expect(resolveDockerLocalKiloCodeApiBaseUrl('https://dev.example.com/base')).toBe(
+      'https://dev.example.com/api/gateway/'
+    );
+  });
+
+  it('returns null when BACKEND_API_URL is missing or invalid', () => {
+    expect(resolveDockerLocalKiloCodeApiBaseUrl(undefined)).toBeNull();
+    expect(resolveDockerLocalKiloCodeApiBaseUrl('not a url')).toBeNull();
+  });
+});

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
@@ -10,6 +10,7 @@ import { storageUpdate } from './state';
 import { doWarn, toLoggable } from './log';
 
 const MINT_TIMEOUT_MS = 5_000;
+const DOCKER_HOST_INTERNAL = 'host.docker.internal';
 
 /**
  * Resolve the Docker image tag for this instance.
@@ -38,6 +39,27 @@ export function resolveRuntimeImageRef(state: InstanceMutableState, env: KiloCla
     return env.DOCKER_LOCAL_IMAGE ?? 'kiloclaw:local';
   }
   return resolveImageRef(state, env);
+}
+
+export function resolveDockerLocalKiloCodeApiBaseUrl(
+  backendApiUrl: string | undefined
+): string | null {
+  if (!backendApiUrl) return null;
+
+  let url: URL;
+  try {
+    url = new URL(backendApiUrl);
+  } catch {
+    return null;
+  }
+
+  if (url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]') {
+    url.hostname = DOCKER_HOST_INTERNAL;
+  }
+  url.pathname = '/api/gateway/';
+  url.search = '';
+  url.hash = '';
+  return url.toString();
 }
 
 /**
@@ -169,6 +191,13 @@ export async function buildUserEnvVars(
       customSecretMeta: state.customSecretMeta ?? undefined,
     }
   );
+
+  if (state.provider === 'docker-local') {
+    const dockerLocalBaseUrl = resolveDockerLocalKiloCodeApiBaseUrl(env.BACKEND_API_URL);
+    if (dockerLocalBaseUrl) {
+      plainEnv.KILOCODE_API_BASE_URL = dockerLocalBaseUrl;
+    }
+  }
 
   // Inject latest Gmail historyId for controller to patch gog state on startup.
   if (state.gmailLastHistoryId) {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -1475,7 +1475,8 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       envVars,
       bootstrapEnv,
       this.s.machineSize,
-      identity
+      identity,
+      this.s.provider
     );
 
     const startResult = await this.provider().startRuntime({
@@ -2735,7 +2736,8 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         envVars,
         bootstrapEnv,
         this.s.machineSize,
-        identity
+        identity,
+        this.s.provider
       );
 
       const restart = await this.provider().restartRuntime({

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
@@ -407,7 +407,8 @@ export async function runUnexpectedStopRecoveryInBackground(
       envVars,
       bootstrapEnv,
       state.machineSize,
-      identity
+      identity,
+      state.provider
     );
 
     const previousRegion = state.flyRegion;

--- a/services/kiloclaw/src/durable-objects/machine-config.ts
+++ b/services/kiloclaw/src/durable-objects/machine-config.ts
@@ -1,4 +1,4 @@
-import type { MachineSize } from '../schemas/instance-config';
+import type { MachineSize, ProviderId } from '../schemas/instance-config';
 import { OPENCLAW_PORT, DEFAULT_MACHINE_GUEST } from '../config';
 import type { RuntimeSpec } from '../providers/types';
 import type { FlyMachineConfig } from '../fly/types';
@@ -33,11 +33,16 @@ export function buildRuntimeSpec(
   envVars: Record<string, string>,
   bootstrapEnv: Record<string, string>,
   machineSize: MachineSize | null,
-  identity: MachineIdentity
+  identity: MachineIdentity,
+  provider: ProviderId
 ): RuntimeSpec {
   return {
     imageRef,
-    env: envVars,
+    env: {
+      ...envVars,
+      KILOCLAW_RUNTIME_PROVIDER: provider,
+      KILOCLAW_MACHINE_CPU_KIND: machineSize?.cpu_kind ?? DEFAULT_MACHINE_GUEST.cpu_kind,
+    },
     bootstrapEnv,
     machineSize,
     rootMountPath: '/root',

--- a/services/kiloclaw/src/providers/docker-local/index.test.ts
+++ b/services/kiloclaw/src/providers/docker-local/index.test.ts
@@ -152,10 +152,16 @@ describe('dockerLocalProviderAdapter', () => {
         });
       }
       if (url.includes('/containers/json?all=1')) {
-        return new Response(JSON.stringify([{ Ports: [{ PublicPort: 45000 }] }]), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        });
+        return new Response(
+          JSON.stringify([
+            { Ports: null },
+            { Ports: [{ PublicPort: null }, { PublicPort: 45000 }] },
+          ]),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        );
       }
       if (url.endsWith('/containers/kiloclaw-sandbox-1/json')) {
         events.push('inspect-container');

--- a/services/kiloclaw/src/providers/docker-local/index.ts
+++ b/services/kiloclaw/src/providers/docker-local/index.ts
@@ -12,7 +12,7 @@ type DockerApiError = Error & { status: number };
 type DockerContainerSummary = {
   Id?: string;
   Names?: string[];
-  Ports?: Array<{ PublicPort?: number }>;
+  Ports?: Array<{ PublicPort?: number | null }> | null;
 };
 
 type DockerContainerInspect = {
@@ -65,12 +65,14 @@ function isDockerContainerSummaryArray(value: unknown): value is DockerContainer
     const ports = item.Ports;
     if (
       ports !== undefined &&
+      ports !== null &&
       (!Array.isArray(ports) ||
         ports.some(
           port =>
             !isRecord(port) ||
             ('PublicPort' in port &&
               port.PublicPort !== undefined &&
+              port.PublicPort !== null &&
               typeof port.PublicPort !== 'number')
         ))
     ) {

--- a/services/kiloclaw/src/providers/rollout.test.ts
+++ b/services/kiloclaw/src/providers/rollout.test.ts
@@ -69,6 +69,39 @@ describe('provider rollout config', () => {
     ).resolves.toBe('fly');
   });
 
+  it('selects the configured default provider in development', async () => {
+    await expect(
+      selectProviderForProvision({
+        kv: createKv(),
+        userId: 'user-1',
+        workerEnv: 'development',
+        defaultProvider: 'docker-local',
+      })
+    ).resolves.toBe('docker-local');
+  });
+
+  it('uses rollout rather than local defaults outside development', async () => {
+    await expect(
+      selectProviderForProvision({
+        kv: createKv(),
+        userId: 'user-1',
+        workerEnv: 'production',
+        defaultProvider: 'docker-local',
+      })
+    ).resolves.toBe('fly');
+  });
+
+  it('ignores invalid default provider values in development', async () => {
+    await expect(
+      selectProviderForProvision({
+        kv: createKv(),
+        userId: 'user-1',
+        workerEnv: 'development',
+        defaultProvider: 'bogus',
+      })
+    ).resolves.toBe('fly');
+  });
+
   it('does not select Northflank for orgs that are not opted in', async () => {
     const kv = createKv(
       JSON.stringify({

--- a/services/kiloclaw/src/providers/rollout.ts
+++ b/services/kiloclaw/src/providers/rollout.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { ProviderId } from '../schemas/instance-config';
+import { ProviderIdSchema, type ProviderId } from '../schemas/instance-config';
 
 export const PROVIDER_ROLLOUT_KV_KEY = 'provider-rollout';
 export const NORTHFLANK_ROLLOUT_AVAILABLE = false;
@@ -88,11 +88,26 @@ async function selectProviderFromRollout(params: {
   return (await rolloutBucket(params.key)) < params.percent ? 'northflank' : 'fly';
 }
 
+function resolveDevelopmentDefaultProvider(params: {
+  workerEnv?: string;
+  defaultProvider?: string;
+}): ProviderId | null {
+  if (params.workerEnv !== 'development') return null;
+
+  const parsed = ProviderIdSchema.safeParse(params.defaultProvider);
+  return parsed.success ? parsed.data : null;
+}
+
 export async function selectProviderForProvision(params: {
   kv: TextKVReader;
   userId: string;
   orgId?: string | null;
+  workerEnv?: string;
+  defaultProvider?: string;
 }): Promise<ProviderId> {
+  const developmentDefault = resolveDevelopmentDefaultProvider(params);
+  if (developmentDefault) return developmentDefault;
+
   const { config } = await readProviderRolloutConfig(params.kv);
   const orgId = params.orgId ?? null;
   if (orgId && !config.northflank.enabledOrganizationIds.includes(orgId)) return 'fly';

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -873,6 +873,8 @@ platform.post('/provision', async c => {
       kv: c.env.KV_CLAW_CACHE,
       userId,
       orgId,
+      workerEnv: c.env.WORKER_ENV,
+      defaultProvider: c.env.KILOCLAW_DEFAULT_PROVIDER,
     });
   }
 


### PR DESCRIPTION
## Summary
- Honor `KILOCLAW_DEFAULT_PROVIDER` in development so local KiloClaw provisioning can select `docker-local` instead of rollout-forcing Fly.
- Make docker-local tolerate real Docker container-list payloads with `Ports: null` or `PublicPort: null` during host port allocation.
- Pass runtime provider and CPU kind into the controller so gateway readiness only waits for load settling on Fly shared-CPU machines.
- Route docker-local KiloCode provider calls directly to the host Next.js dev server via `host.docker.internal` instead of stale quick-tunnel URLs.

## Reviewer Notes
- Existing local instances need to be restarted/recreated before the new runtime env vars and host-routed KiloCode URL are present in the controller process.
- Local uncommitted changes in unrelated files were left out of this PR.