### PR TITLE
feat(security): autoban users with Stytch SMART_RATE_LIMIT_BANNED verdict

### DIFF
--- a/apps/web/src/lib/stytch.test.ts
+++ b/apps/web/src/lib/stytch.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach } from '@jest/globals';
 import { insertTestUser } from '../tests/helpers/user.helper';
 import { db } from './drizzle';
-import { stytch_fingerprints, credit_transactions } from '@kilocode/db/schema';
+import { kilocode_users, stytch_fingerprints, credit_transactions } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 import type { FraudFingerprintLookupResponse } from 'stytch';
 
@@ -211,6 +211,77 @@ describe('Stytch Fingerprint Functions', () => {
       const result = await saveFingerprints(user, fingerprintData, headers);
 
       expect(result.kilo_free_tier_allowed).toBe(false);
+    });
+
+    test('should autoban user when verdict is BLOCK with SMART_RATE_LIMIT_BANNED reason', async () => {
+      const user = await insertTestUser();
+      const fingerprintData = {
+        ...createMockFingerprintData(),
+        verdict: {
+          action: 'BLOCK',
+          detected_device_type: 'desktop',
+          is_authentic_device: false,
+          reasons: ['SMART_RATE_LIMIT_BANNED'],
+          verdict_reason_overrides: [],
+        },
+      };
+
+      await saveFingerprints(user, fingerprintData, createMockHeaders());
+
+      const updatedUser = await db.query.kilocode_users.findFirst({
+        where: eq(kilocode_users.id, user.id),
+        columns: { blocked_reason: true },
+      });
+      expect(updatedUser?.blocked_reason).toBe('autoban: stytch SMART_RATE_LIMIT_BANNED');
+    });
+
+    test('should not overwrite existing blocked_reason when autobanning', async () => {
+      const user = await insertTestUser();
+      await db
+        .update(kilocode_users)
+        .set({ blocked_reason: 'already blocked' })
+        .where(eq(kilocode_users.id, user.id));
+
+      const fingerprintData = {
+        ...createMockFingerprintData(),
+        verdict: {
+          action: 'BLOCK',
+          detected_device_type: 'desktop',
+          is_authentic_device: false,
+          reasons: ['SMART_RATE_LIMIT_BANNED'],
+          verdict_reason_overrides: [],
+        },
+      };
+
+      await saveFingerprints(user, fingerprintData, createMockHeaders());
+
+      const updatedUser = await db.query.kilocode_users.findFirst({
+        where: eq(kilocode_users.id, user.id),
+        columns: { blocked_reason: true },
+      });
+      expect(updatedUser?.blocked_reason).toBe('already blocked');
+    });
+
+    test('should not autoban when verdict is BLOCK without SMART_RATE_LIMIT_BANNED reason', async () => {
+      const user = await insertTestUser();
+      const fingerprintData = {
+        ...createMockFingerprintData(),
+        verdict: {
+          action: 'BLOCK',
+          detected_device_type: 'desktop',
+          is_authentic_device: false,
+          reasons: ['suspicious_activity'],
+          verdict_reason_overrides: [],
+        },
+      };
+
+      await saveFingerprints(user, fingerprintData, createMockHeaders());
+
+      const updatedUser = await db.query.kilocode_users.findFirst({
+        where: eq(kilocode_users.id, user.id),
+        columns: { blocked_reason: true },
+      });
+      expect(updatedUser?.blocked_reason).toBeNull();
     });
   });
 

--- a/apps/web/src/lib/stytch.ts
+++ b/apps/web/src/lib/stytch.ts
@@ -3,8 +3,8 @@ import type { FraudFingerprintLookupResponse } from 'stytch';
 import { Client, envs } from 'stytch';
 import { db } from '@/lib/drizzle';
 import type { User } from '@kilocode/db/schema';
-import { stytch_fingerprints } from '@kilocode/db/schema';
-import { eq } from 'drizzle-orm';
+import { kilocode_users, stytch_fingerprints } from '@kilocode/db/schema';
+import { and, eq, isNull } from 'drizzle-orm';
 import { getFraudDetectionHeaders } from './utils';
 import { captureException } from '@sentry/nextjs';
 import { updateStytchValidation } from './customerInfo';
@@ -146,6 +146,22 @@ export async function saveFingerprints(
     ...user,
     has_validation_stytch: kilo_free_tier_allowed,
   });
+
+  // Autoban users blocked by Stytch for smart rate limit abuse
+  if (
+    verdict.action === 'BLOCK' &&
+    verdict.reasons.includes('SMART_RATE_LIMIT_BANNED')
+  ) {
+    await db
+      .update(kilocode_users)
+      .set({ blocked_reason: 'autoban: stytch SMART_RATE_LIMIT_BANNED' })
+      .where(and(eq(kilocode_users.id, user.id), isNull(kilocode_users.blocked_reason)));
+    if (process.env.NODE_ENV !== 'test')
+      console.log('SECURITY: autobanned user for SMART_RATE_LIMIT_BANNED:', {
+        userId: user.id,
+        email: user.google_user_email,
+      });
+  }
 
   // User created event in PostHog
   try {

--- a/apps/web/src/lib/stytch.ts
+++ b/apps/web/src/lib/stytch.ts
@@ -148,10 +148,7 @@ export async function saveFingerprints(
   });
 
   // Autoban users blocked by Stytch for smart rate limit abuse
-  if (
-    verdict.action === 'BLOCK' &&
-    verdict.reasons.includes('SMART_RATE_LIMIT_BANNED')
-  ) {
+  if (verdict.action === 'BLOCK' && verdict.reasons.includes('SMART_RATE_LIMIT_BANNED')) {
     await db
       .update(kilocode_users)
       .set({ blocked_reason: 'autoban: stytch SMART_RATE_LIMIT_BANNED' })


### PR DESCRIPTION
## Summary

Automatically ban users who receive a Stytch BLOCK verdict with the `SMART_RATE_LIMIT_BANNED` reason. Previously, these users were only denied free-tier credits (`kilo_free_tier_allowed = false`) but could still access the platform. Now they are immediately blocked via `blocked_reason`, which the existing auth layer (`validateUserAuthorization`) enforces.

The autoban uses `isNull(blocked_reason)` in the WHERE clause to avoid overwriting any pre-existing block reason.

## Verification

- [x] No manual testing needed — this is backend logic covered by automated tests
- [x] `pnpm test -- apps/web/src/lib/stytch.test.ts` — all 19 tests pass (3 new)
- [x] `pnpm --filter web typecheck` — clean

## Visual Changes

N/A

## Reviewer Notes

- The `blocked_reason` value is `'autoban: stytch SMART_RATE_LIMIT_BANNED'` — prefixed with `autoban:` so admins can distinguish automated blocks from manual ones.
- A `SECURITY:` log line is emitted when an autoban fires (suppressed in tests).
- This only triggers for `SMART_RATE_LIMIT_BANNED` specifically, not other Stytch BLOCK reasons.
