### PR TITLE
fix(admin): raise suspicious domains threshold from 1% to 30%

### DIFF
--- a/apps/web/src/app/admin/components/BlacklistedDomains.tsx
+++ b/apps/web/src/app/admin/components/BlacklistedDomains.tsx
@@ -208,7 +208,7 @@ function SuspiciousTab() {
             <CardTitle>Suspicious Domains</CardTitle>
             <CardDescription>
               Top 100 registrable domains by blocked account count, then total account count. Only
-              shows domains where at least 1% of accounts have been blocked, to filter out
+              shows domains where at least 30% of accounts have been blocked, to filter out
               legitimate high-volume providers. Use this to spot domains that are accumulating abuse
               but aren&apos;t yet blacklisted.
             </CardDescription>

--- a/apps/web/src/routers/admin/blacklist-domains-router.test.ts
+++ b/apps/web/src/routers/admin/blacklist-domains-router.test.ts
@@ -218,27 +218,42 @@ describe('admin.blacklistDomains.suspicious', () => {
     expect(ordered.indexOf('more-blocked.com')).toBeLessThan(ordered.indexOf('fewer-blocked.com'));
   });
 
-  it('hides domains with fewer than 1% of accounts blocked', async () => {
-    // noisy.com: 99 clean users + 0 blocked → 0% → filtered out
-    for (let i = 0; i < 99; i++) {
+  it('hides domains with fewer than 30% of accounts blocked', async () => {
+    // noisy.com: 10 clean users + 0 blocked → 0% → filtered out
+    for (let i = 0; i < 10; i++) {
       await insertTestUser({
         google_user_email: `u${i}@noisy.com`,
         email_domain: 'noisy.com',
       });
     }
-    // just-under.com: 99 clean + 0 blocked → filtered out (0%)
-    // over-threshold.com: 99 clean + 1 blocked → 1% → surfaced
-    for (let i = 0; i < 99; i++) {
+    // under-threshold.com: 8 clean + 2 blocked → 20% → filtered out (below 30%)
+    for (let i = 0; i < 8; i++) {
+      await insertTestUser({
+        google_user_email: `u${i}@under-threshold.com`,
+        email_domain: 'under-threshold.com',
+      });
+    }
+    for (let i = 0; i < 2; i++) {
+      await insertTestUser({
+        google_user_email: `b${i}@under-threshold.com`,
+        email_domain: 'under-threshold.com',
+        blocked_reason: 'abuse',
+      });
+    }
+    // over-threshold.com: 7 clean + 3 blocked → 30% → surfaced
+    for (let i = 0; i < 7; i++) {
       await insertTestUser({
         google_user_email: `u${i}@over-threshold.com`,
         email_domain: 'over-threshold.com',
       });
     }
-    await insertTestUser({
-      google_user_email: 'b@over-threshold.com',
-      email_domain: 'over-threshold.com',
-      blocked_reason: 'abuse',
-    });
+    for (let i = 0; i < 3; i++) {
+      await insertTestUser({
+        google_user_email: `b${i}@over-threshold.com`,
+        email_domain: 'over-threshold.com',
+        blocked_reason: 'abuse',
+      });
+    }
 
     const caller = await createCallerForUser(admin.id);
     const { domains } = await caller.admin.blacklistDomains.suspicious();
@@ -246,6 +261,7 @@ describe('admin.blacklistDomains.suspicious', () => {
     const names = domains.map(d => d.domain);
     expect(names).toContain('over-threshold.com');
     expect(names).not.toContain('noisy.com');
+    expect(names).not.toContain('under-threshold.com');
   });
 
   it('excludes users whose email_domain is NULL', async () => {

--- a/apps/web/src/routers/admin/blacklist-domains-router.ts
+++ b/apps/web/src/routers/admin/blacklist-domains-router.ts
@@ -72,10 +72,10 @@ export const adminBlacklistDomainsRouter = createTRPCRouter({
     const normalizedBlacklist = blacklistedDomains.map(d => d.toLowerCase());
 
     const blockedCountExpr = sql<number>`count(*) FILTER (WHERE ${kilocode_users.blocked_reason} IS NOT NULL)`;
-    // Hide noise: require at least 1% of users on the domain to have been
-    // blocked before surfacing it. Computed against count(*) so a one-off
-    // block on a huge domain doesn't appear here.
-    const minBlockedPercent = sql`${blockedCountExpr} * 100 >= count(*)`;
+    // Hide noise: require at least 30% of users on the domain to have been
+    // blocked before surfacing it. Keeps large legitimate providers (gmail,
+    // hotmail, etc.) from showing up.
+    const minBlockedPercent = sql`${blockedCountExpr} * 100 >= count(*) * 30`;
 
     const rows = await db
       .select({


### PR DESCRIPTION
## Summary

Raises the suspicious domains threshold from 1% to 30% blocked accounts. The old 1% threshold was too low, causing legitimate high-volume providers like gmail and hotmail to show up in the suspicious domains list on `/admin/blacklisted-domains`. With 30%, only domains where nearly a third of accounts are blocked get surfaced.

## Verification

- [x] `pnpm test -- apps/web/src/routers/admin/blacklist-domains-router.test.ts` — all 18 tests pass
- [x] `pnpm typecheck` — no new errors (existing `apps/mobile` failures are unrelated)

## Visual Changes

N/A

## Reviewer Notes

N/A
