### PR TITLE
Feat(openclaw security advisor) new user signup bonus

### DIFF
--- a/apps/web/src/app/account-verification/page.tsx
+++ b/apps/web/src/app/account-verification/page.tsx
@@ -10,8 +10,19 @@ import { PageContainer } from '@/components/layouts/PageContainer';
 import { isValidCallbackPath } from '@/lib/getSignInCallbackUrl';
 import { maybeInterceptWithSurvey } from '@/lib/survey-redirect';
 
+// Matches exactly the `/openclaw-advisor` pathname, optionally followed by a
+// trailing slash, query string, or fragment. Guards against sibling paths like
+// `/openclaw-advisor-fake` that would otherwise pass a naive `startsWith` check.
+const OPENCLAW_ADVISOR_PATH_RE = /^\/openclaw-advisor(?:[/?#]|$)/;
+
 export default async function AccountVerificationPage({ searchParams }: AppPageProps) {
   const user = await getUserFromAuthOrRedirect('/users/sign_in');
+  // Capture whether the user was still unvalidated when they arrived. This
+  // prevents an already-verified user from directly visiting
+  // `/account-verification?callbackPath=/openclaw-advisor?code=...` to self-award
+  // the signup bonus. The bonus must only fire on the transition from
+  // null -> true, which is the real "new-user signup" event.
+  const isFirstValidation = user.has_validation_stytch === null;
   const params = await searchParams;
   const telemetry_id = typeof params.telemetry_id === 'string' ? params.telemetry_id : null;
   const stytchStatus = await getStytchStatus(user, telemetry_id, await headers());
@@ -19,7 +30,10 @@ export default async function AccountVerificationPage({ searchParams }: AppPageP
   const rawCallback = params.callbackPath;
   const callbackStr = typeof rawCallback === 'string' ? rawCallback : null;
   const signupSource: SignupSource =
-    callbackStr && isValidCallbackPath(callbackStr) && callbackStr.startsWith('/openclaw-advisor')
+    isFirstValidation &&
+    callbackStr &&
+    isValidCallbackPath(callbackStr) &&
+    OPENCLAW_ADVISOR_PATH_RE.test(callbackStr)
       ? 'openclaw-security-advisor'
       : null;
 

--- a/apps/web/src/app/account-verification/page.tsx
+++ b/apps/web/src/app/account-verification/page.tsx
@@ -5,7 +5,7 @@ import { StytchClient } from '@/components/auth/StytchClient';
 import { AnimatedLogo } from '@/components/AnimatedLogo';
 import BigLoader from '@/components/BigLoader';
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
-import { getStytchStatus, handleSignupPromotion } from '@/lib/stytch';
+import { getStytchStatus, handleSignupPromotion, type SignupSource } from '@/lib/stytch';
 import { PageContainer } from '@/components/layouts/PageContainer';
 import { isValidCallbackPath } from '@/lib/getSignInCallbackUrl';
 import { maybeInterceptWithSurvey } from '@/lib/survey-redirect';
@@ -16,7 +16,14 @@ export default async function AccountVerificationPage({ searchParams }: AppPageP
   const telemetry_id = typeof params.telemetry_id === 'string' ? params.telemetry_id : null;
   const stytchStatus = await getStytchStatus(user, telemetry_id, await headers());
 
-  await handleSignupPromotion(user, stytchStatus || false);
+  const rawCallback = params.callbackPath;
+  const callbackStr = typeof rawCallback === 'string' ? rawCallback : null;
+  const signupSource: SignupSource =
+    callbackStr && isValidCallbackPath(callbackStr) && callbackStr.startsWith('/openclaw-advisor')
+      ? 'openclaw-security-advisor'
+      : null;
+
+  await handleSignupPromotion(user, stytchStatus || false, signupSource);
 
   if (stytchStatus !== null) {
     const callbackPath = params.callbackPath;

--- a/apps/web/src/app/openclaw-advisor/page.tsx
+++ b/apps/web/src/app/openclaw-advisor/page.tsx
@@ -16,7 +16,12 @@ export default async function OpenclawAdvisorPage({ searchParams }: PageProps) {
   const rawCode = params.code;
   const code = rawCode && DEVICE_AUTH_CODE_FORMAT.test(rawCode) ? rawCode : undefined;
 
-  const callbackPath = `/openclaw-advisor${code ? `?code=${encodeURIComponent(code)}` : ''}`;
+  // code has already been validated against [A-Za-z0-9-]{1,16}, so no
+  // per-char encoding is needed when building the inner callback path.
+  // The outer encodeURIComponent around the whole callbackPath is still
+  // required so the `?` and `=` it contains travel as a single query-param
+  // value into /users/sign_in.
+  const callbackPath = `/openclaw-advisor${code ? `?code=${code}` : ''}`;
   await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=${encodeURIComponent(callbackPath)}`
   );
@@ -25,5 +30,6 @@ export default async function OpenclawAdvisorPage({ searchParams }: PageProps) {
     redirect('/');
   }
 
-  redirect(`/device-auth?code=${encodeURIComponent(code)}`);
+  // Same rationale as above: `code` is validated, so percent-encoding is redundant.
+  redirect(`/device-auth?code=${code}`);
 }

--- a/apps/web/src/app/openclaw-advisor/page.tsx
+++ b/apps/web/src/app/openclaw-advisor/page.tsx
@@ -1,0 +1,29 @@
+import { redirect } from 'next/navigation';
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+
+type PageProps = {
+  searchParams: Promise<{ code?: string }>;
+};
+
+// Device-auth codes are generated as `XXXX-XXXX` from an unambiguous
+// alphanumeric charset (see generateDeviceCode in lib/device-auth/device-auth.ts).
+// This guard drops obviously malformed input before it reaches the device-auth
+// flow and eliminates any risk of injecting non-code content via the query param.
+const DEVICE_AUTH_CODE_FORMAT = /^[A-Za-z0-9-]{1,16}$/;
+
+export default async function OpenclawAdvisorPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const rawCode = params.code;
+  const code = rawCode && DEVICE_AUTH_CODE_FORMAT.test(rawCode) ? rawCode : undefined;
+
+  const callbackPath = `/openclaw-advisor${code ? `?code=${encodeURIComponent(code)}` : ''}`;
+  await getUserFromAuthOrRedirect(
+    `/users/sign_in?callbackPath=${encodeURIComponent(callbackPath)}`
+  );
+
+  if (!code) {
+    redirect('/');
+  }
+
+  redirect(`/device-auth?code=${encodeURIComponent(code)}`);
+}

--- a/apps/web/src/app/users/after-sign-in/route.tsx
+++ b/apps/web/src/app/users/after-sign-in/route.tsx
@@ -26,6 +26,7 @@ function resolveSignupProduct(callbackPath: string | null, hasSource: boolean): 
   if (callbackPath.startsWith('/code-reviews')) return 'code-reviews';
   if (callbackPath.startsWith('/app-builder')) return 'app-builder';
   if (callbackPath.startsWith('/install')) return 'kilo-code';
+  if (callbackPath.startsWith('/openclaw-advisor')) return 'openclaw-security-advisor';
   return null;
 }
 

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -4,6 +4,7 @@ export const REFERRAL_BONUS_AMOUNT = 10;
 
 export const PROMO_CREDIT_EXPIRY_HRS = 60 * 24; // 60 days in hours
 export const WELCOME_CREDIT_EXPIRY_HRS = 30 * 24; // 30 days in hours
+export const OPENCLAW_SECURITY_ADVISOR_BONUS_EXPIRY_HRS = 48; // 2 days in hours
 
 export const allow_fake_login =
   !!process.env.DEBUG_SHOW_DEV_UI &&

--- a/apps/web/src/lib/promoCreditCategories.ts
+++ b/apps/web/src/lib/promoCreditCategories.ts
@@ -9,6 +9,7 @@ import {
   REFERRAL_BONUS_AMOUNT,
   PROMO_CREDIT_EXPIRY_HRS,
   WELCOME_CREDIT_EXPIRY_HRS,
+  OPENCLAW_SECURITY_ADVISOR_BONUS_EXPIRY_HRS,
 } from '@/lib/constants';
 import { promoCategoriesOld } from '@/lib/promoCreditCategoriesOld';
 import {
@@ -177,6 +178,13 @@ const nonSelfServicePromos: readonly NonSelfServicePromoCreditCategoryConfig[] =
     amount_usd: 2.5,
     is_idempotent: true,
     expiry_hours: WELCOME_CREDIT_EXPIRY_HRS,
+  },
+  {
+    credit_category: 'openclaw-security-advisor-signup-bonus',
+    description: 'Bonus for new users signing up via the OpenClaw Security Advisor plugin',
+    amount_usd: 7.13,
+    is_idempotent: true,
+    expiry_hours: OPENCLAW_SECURITY_ADVISOR_BONUS_EXPIRY_HRS,
   },
   {
     credit_category: 'autocomplete-rollout-2025-11',

--- a/apps/web/src/lib/stytch.test.ts
+++ b/apps/web/src/lib/stytch.test.ts
@@ -4,6 +4,7 @@ import { db } from './drizzle';
 import { kilocode_users, stytch_fingerprints, credit_transactions } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 import type { FraudFingerprintLookupResponse } from 'stytch';
+import { OPENCLAW_SECURITY_ADVISOR_BONUS_EXPIRY_HRS } from './constants';
 
 import {
   saveFingerprints,
@@ -324,7 +325,7 @@ describe('Stytch Fingerprint Functions', () => {
 
       if (!bonus?.expiry_date) throw new Error('bonus.expiry_date should be set');
       const expiryMs = new Date(bonus.expiry_date).getTime();
-      const expectedMs = Date.now() + 48 * 60 * 60 * 1000;
+      const expectedMs = Date.now() + OPENCLAW_SECURITY_ADVISOR_BONUS_EXPIRY_HRS * 60 * 60 * 1000;
       // Loose ±2 minute window — test DB inserts + clock drift
       expect(Math.abs(expiryMs - expectedMs)).toBeLessThan(2 * 60 * 1000);
     });

--- a/apps/web/src/lib/stytch.test.ts
+++ b/apps/web/src/lib/stytch.test.ts
@@ -304,6 +304,78 @@ describe('Stytch Fingerprint Functions', () => {
     });
   });
 
+  describe('handleSignupPromotion with signupSource', () => {
+    test('grants both welcome and openclaw-security-advisor bonus when passed + source matches', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'osa-bonus-pass@example.com',
+      });
+
+      await handleSignupPromotion(user, true, 'openclaw-security-advisor');
+
+      const grants = await db.query.credit_transactions.findMany({
+        where: eq(credit_transactions.kilo_user_id, user.id),
+      });
+
+      const byCategory = new Map(grants.map(g => [g.credit_category, g]));
+      expect(byCategory.get('automatic-welcome-credits')?.amount_microdollars).toBe(2_500_000);
+
+      const bonus = byCategory.get('openclaw-security-advisor-signup-bonus');
+      expect(bonus?.amount_microdollars).toBe(7_130_000);
+
+      if (!bonus?.expiry_date) throw new Error('bonus.expiry_date should be set');
+      const expiryMs = new Date(bonus.expiry_date).getTime();
+      const expectedMs = Date.now() + 48 * 60 * 60 * 1000;
+      // Loose ±2 minute window — test DB inserts + clock drift
+      expect(Math.abs(expiryMs - expectedMs)).toBeLessThan(2 * 60 * 1000);
+    });
+
+    test('grants only welcome credit when signupSource is null', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'osa-bonus-nosource@example.com',
+      });
+
+      await handleSignupPromotion(user, true, null);
+
+      const grants = await db.query.credit_transactions.findMany({
+        where: eq(credit_transactions.kilo_user_id, user.id),
+      });
+
+      expect(grants.map(g => g.credit_category).sort()).toEqual(['automatic-welcome-credits']);
+    });
+
+    test('grants nothing when Stytch validation fails even with source set', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'osa-bonus-stytchfail@example.com',
+      });
+
+      await handleSignupPromotion(user, false, 'openclaw-security-advisor');
+
+      const grants = await db.query.credit_transactions.findMany({
+        where: eq(credit_transactions.kilo_user_id, user.id),
+      });
+
+      expect(grants).toHaveLength(0);
+    });
+
+    test('bonus grant is idempotent: repeat call inserts no additional row', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'osa-bonus-idempotent@example.com',
+      });
+
+      await handleSignupPromotion(user, true, 'openclaw-security-advisor');
+      await handleSignupPromotion(user, true, 'openclaw-security-advisor');
+
+      const bonusRows = await db.query.credit_transactions.findMany({
+        where: eq(credit_transactions.kilo_user_id, user.id),
+      });
+
+      const bonusOnly = bonusRows.filter(
+        g => g.credit_category === 'openclaw-security-advisor-signup-bonus'
+      );
+      expect(bonusOnly).toHaveLength(1);
+    });
+  });
+
   describe('Integration: saveFingerprints -> getStoredFingerprint -> isKnownFingerprintOfOtherUser', () => {
     test('should demonstrate complete workflow with multiple users', async () => {
       const user1 = await insertTestUser({ google_user_email: 'fp-workflow-alice@example.com' });

--- a/apps/web/src/lib/stytch.ts
+++ b/apps/web/src/lib/stytch.ts
@@ -216,8 +216,11 @@ export async function handleSignupPromotion(
   } catch (error) {
     // Don't fail the entire process if credit granting fails
     captureException(error, {
-      tags: { source: 'signup_promotion_credit_grant' },
-      extra: { userId: user.id, email: user.google_user_email },
+      tags: {
+        source: 'signup_promotion_credit_grant',
+        credit_category: 'automatic-welcome-credits',
+      },
+      extra: { userId: user.id, email: user.google_user_email, signupSource },
     });
   }
 
@@ -229,7 +232,10 @@ export async function handleSignupPromotion(
       });
     } catch (error) {
       captureException(error, {
-        tags: { source: 'signup_promotion_credit_grant' },
+        tags: {
+          source: 'signup_promotion_credit_grant',
+          credit_category: 'openclaw-security-advisor-signup-bonus',
+        },
         extra: { userId: user.id, email: user.google_user_email, signupSource },
       });
     }

--- a/apps/web/src/lib/stytch.ts
+++ b/apps/web/src/lib/stytch.ts
@@ -193,23 +193,44 @@ export async function saveFingerprints(
   return { kilo_free_tier_allowed };
 }
 
+export type SignupSource = 'openclaw-security-advisor' | null;
+
 /**
  * Handles signup promotion logic: grants credits for users who pass
- * both Turnstile and Stytch validation
+ * both Turnstile and Stytch validation. When signupSource is set, layers
+ * an additional product-specific bonus on top of the base welcome credit.
  */
-export async function handleSignupPromotion(user: User, passedValidations: boolean): Promise<void> {
-  if (passedValidations) {
+export async function handleSignupPromotion(
+  user: User,
+  passedValidations: boolean,
+  signupSource: SignupSource = null
+): Promise<void> {
+  if (!passedValidations) return;
+
+  try {
+    // Grant automatic-welcome-credits for passing both Turnstile and Stytch validation
+    await grantCreditForCategory(user, {
+      credit_category: 'automatic-welcome-credits',
+      counts_as_selfservice: false,
+    });
+  } catch (error) {
+    // Don't fail the entire process if credit granting fails
+    captureException(error, {
+      tags: { source: 'signup_promotion_credit_grant' },
+      extra: { userId: user.id, email: user.google_user_email },
+    });
+  }
+
+  if (signupSource === 'openclaw-security-advisor') {
     try {
-      // Grant automatic-welcome-credits for passing both Turnstile and Stytch validation
       await grantCreditForCategory(user, {
-        credit_category: 'automatic-welcome-credits',
+        credit_category: 'openclaw-security-advisor-signup-bonus',
         counts_as_selfservice: false,
       });
     } catch (error) {
-      // Don't fail the entire process if credit granting fails
       captureException(error, {
         tags: { source: 'signup_promotion_credit_grant' },
-        extra: { userId: user.id, email: user.google_user_email },
+        extra: { userId: user.id, email: user.google_user_email, signupSource },
       });
     }
   }

--- a/apps/web/src/tests/account-verification-redirect.test.ts
+++ b/apps/web/src/tests/account-verification-redirect.test.ts
@@ -36,11 +36,13 @@ jest.mock('@/lib/user.server', () => ({
   getUserFromAuthOrRedirect: (...args: [string?]) => mockGetUserFromAuthOrRedirect(...args),
 }));
 
+type SignupSourceArg = 'openclaw-security-advisor' | null;
 const mockGetStytchStatus = jest.fn<Promise<boolean | null>, [User, string | null, Headers]>();
-const mockHandleSignupPromotion = jest.fn<Promise<void>, [User, boolean]>();
+const mockHandleSignupPromotion = jest.fn<Promise<void>, [User, boolean, SignupSourceArg?]>();
 jest.mock('@/lib/stytch', () => ({
   getStytchStatus: (...args: [User, string | null, Headers]) => mockGetStytchStatus(...args),
-  handleSignupPromotion: (...args: [User, boolean]) => mockHandleSignupPromotion(...args),
+  handleSignupPromotion: (...args: [User, boolean, SignupSourceArg?]) =>
+    mockHandleSignupPromotion(...args),
 }));
 
 // Mock React components that aren't relevant to redirect testing
@@ -273,6 +275,61 @@ describe('account-verification redirect logic', () => {
 
       expect(mockRedirect).toHaveBeenCalledTimes(1);
       expect(mockRedirect).toHaveBeenCalledWith('/get-started');
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Bonus attribution: signupSource passed to handleSignupPromotion
+  // Regression coverage for kilobot findings on PR #2622:
+  //   1. `startsWith('/openclaw-advisor')` matched sibling paths like
+  //      `/openclaw-advisor-fake` — must now exact-match the pathname.
+  //   2. Already-validated users hitting /account-verification directly
+  //      could self-award the bonus once — must gate on the transition
+  //      from has_validation_stytch=null to non-null.
+  // ---------------------------------------------------------------
+  describe('openclaw-security-advisor signupSource attribution', () => {
+    it('attributes a new user with callbackPath=/openclaw-advisor', async () => {
+      const user = makeUser({ has_validation_stytch: null });
+      mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
+      mockGetStytchStatus.mockResolvedValue(true);
+
+      await renderPage({ callbackPath: '/openclaw-advisor?code=ABCD-1234' });
+
+      expect(mockHandleSignupPromotion).toHaveBeenCalledWith(
+        user,
+        true,
+        'openclaw-security-advisor'
+      );
+    });
+
+    it('does NOT attribute sibling path /openclaw-advisor-fake (exact-pathname match)', async () => {
+      const user = makeUser({ has_validation_stytch: null });
+      mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
+      mockGetStytchStatus.mockResolvedValue(true);
+
+      await renderPage({ callbackPath: '/openclaw-advisor-fake?code=ABCD-1234' });
+
+      expect(mockHandleSignupPromotion).toHaveBeenCalledWith(user, true, null);
+    });
+
+    it('does NOT attribute already-validated user who visits with openclaw-advisor callback', async () => {
+      const user = makeUser({ has_validation_stytch: true });
+      mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
+      mockGetStytchStatus.mockResolvedValue(true);
+
+      await renderPage({ callbackPath: '/openclaw-advisor?code=ABCD-1234' });
+
+      expect(mockHandleSignupPromotion).toHaveBeenCalledWith(user, true, null);
+    });
+
+    it('does NOT attribute when callbackPath is a different product path', async () => {
+      const user = makeUser({ has_validation_stytch: null });
+      mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
+      mockGetStytchStatus.mockResolvedValue(true);
+
+      await renderPage({ callbackPath: '/device-auth?code=ABCD-1234' });
+
+      expect(mockHandleSignupPromotion).toHaveBeenCalledWith(user, true, null);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a per-product signup bonus for users who arrive through the OpenClaw Security Advisor plugin. New users who complete signup via the plugin's device-auth flow AND pass Stytch validation receive an additional \$7.13 credit with a 48 hour expiry, on top of the existing \$2.50 / 30 day welcome credit.

The plugin's device-auth URL previously pointed at the generic \`/device-auth?code=...\` path, which is shared with the Kilo CLI and the mobile app. That made it impossible to attribute signups specifically to the Security Advisor and grant product-specific bonuses.

**Approach:** reuse the existing path-based attribution pattern that \`resolveSignupProduct\` in \`users/after-sign-in/route.tsx\` already applies to \`/claw\`, \`/cloud\`, \`/install\`, and similar product entry points. A thin new page at \`/openclaw-advisor\` accepts the device-auth code, requires the user to be signed in (redirecting unauthenticated visitors through \`/users/sign_in\` with the callback path preserved), then forwards to the shared \`/device-auth\` flow. On the account-verification step, the callback path prefix is inspected and passed to \`handleSignupPromotion\` as a typed \`SignupSource\`.

### Changes

- New page \`apps/web/src/app/openclaw-advisor/page.tsx\`. Validates \`code\` against a tight regex, requires auth, redirects to \`/device-auth\`.
- New promo category \`openclaw-security-advisor-signup-bonus\` in \`promoCreditCategories.ts\`. Idempotent, 48 hour expiry, \$7.13.
- New constant \`OPENCLAW_SECURITY_ADVISOR_BONUS_EXPIRY_HRS\` in \`constants.ts\`.
- \`handleSignupPromotion\` now accepts an optional \`SignupSource\` argument. When \`passedValidations\` and source is \`openclaw-security-advisor\`, it grants the bonus in addition to the standard welcome credit. Each grant has its own try/catch so one failure does not block the other, and each Sentry capture tags the specific \`credit_category\` so the two failure modes can be grouped separately.
- \`account-verification/page.tsx\` reads \`callbackPath\` and derives \`signupSource\` through the same \`isValidCallbackPath\` validator already used for the final redirect.
- \`resolveSignupProduct\` in \`users/after-sign-in/route.tsx\` tags \`/openclaw-advisor\` signups as \`openclaw-security-advisor\` for the \`signup_product_attributed\` PostHog event.

### Trade-offs

- The bonus is additive, not a replacement. A qualifying signup now gets \$2.50 + \$7.13 = \$9.63 total across two grants. Flip to if/else in \`handleSignupPromotion\` if product wants replacement semantics.
- 48 hour expiry is intentionally short per product spec. A Friday signup that does not engage until Monday will see the bonus already expired.
- No schema change. The \`credit_transactions.expiry_date\` column already supports per-grant expiry, and existing lazy-expiration logic in \`creditExpiration.ts\` reclaims the balance at read time.
- Stytch stays the abuse gate. The same fingerprint-collision, email-digit heuristic, and autoban rules that guard the welcome credit also guard the bonus, because both grants live behind the same \`passedValidations\` flag.

### Plugin side

Plugin-side change lives on branch \`feat/openclaw-advisor-url\` in \`Kilo-Org/openclaw-security-advisor\`. The cloud side is backward compatible: existing plugin installs continue to hit \`/device-auth?code=...\` directly and simply do not qualify for the bonus until users upgrade to a plugin build that points at the new URL. No release ordering requirement.

## Verification

- [x] Unit: \`pnpm --filter web exec jest src/lib/stytch.test.ts\`. 23/23 pass, including four new cases covering pass+source, null source, Stytch-fail, and idempotency.
- [x] Format, lint, typecheck all green on \`apps/web\`.
- [x] Manual E2E: signed up \`stytchpass+advisor1@example.com\` through the plugin against a local Next.js dev server and the docker-based openclaw gateway. Confirmed in postgres: two rows in \`credit_transactions\` for the user, one \`automatic-welcome-credits\` at \$2.50 with 30 day expiry, one \`openclaw-security-advisor-signup-bonus\` at \$7.13 with 48 hour expiry.
- [x] Stytch gate sanity check: a separate signup where Stytch ALLOW passed but \`isKnownFingerprintOfOtherUser\` triggered (shared device with an admin account) correctly produced \`kilo_free_tier_allowed=false\` and zero credit rows. Same gate behavior as the existing welcome credit.

## Visual Changes

N/A. The new page is a transparent auth gate plus redirect and does not render UI.

## Reviewer Notes

- Path-based attribution keeps this change small and consistent with how \`/claw\`, \`/cloud\`, \`/install\`, and \`/app-builder\` already work. No new DB columns, no API body changes.
- The \`code\` query param is validated against \`/^[A-Za-z0-9-]{1,16}\$/\` in the new page before any redirect, so the downstream flow can trust its shape.
- For a returning user, \`after-sign-in\` skips account-verification entirely because \`has_validation_stytch\` is already set, so \`handleSignupPromotion\` only runs on genuine new signups in practice. Idempotency on the promo category is the defense-in-depth if that invariant ever breaks.