### PR TITLE
feat(models): promote Kimi K2.6 above Sonnet 4.6 in recommended list

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -39,11 +39,11 @@ export const preferredModels = [
   stepfun_35_flash_free_model.status === 'public' ? stepfun_35_flash_free_model.public_id : null,
   'openrouter/elephant-alpha',
   CLAUDE_OPUS_CURRENT_MODEL_ID,
+  KIMI_CURRENT_MODEL_ID,
   CLAUDE_SONNET_CURRENT_MODEL_ID,
   'openai/gpt-5.4',
   'google/gemini-3.1-pro-preview',
   MINIMAX_CURRENT_MODEL_ID,
-  KIMI_CURRENT_MODEL_ID,
   'z-ai/glm-5.1',
 ].filter(m => m !== null);
 

--- a/apps/web/src/lib/ai-gateway/providers/moonshotai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/moonshotai.ts
@@ -7,10 +7,10 @@ export function isMoonshotModel(model: string) {
 export function applyMoonshotModelSettings(requestToMutate: GatewayRequest) {
   // Moonshot models don't support the temperature parameter
   delete requestToMutate.body.temperature;
-  // kimi-k2.5 only accepts top_p=0.95; any other value causes a 400 error
+  // Kimi models only accept top_p=0.95; any other value causes a 400 error
   delete requestToMutate.body.top_p;
 }
 
-export const KIMI_CURRENT_MODEL_ID = 'moonshotai/kimi-k2.5';
+export const KIMI_CURRENT_MODEL_ID = 'moonshotai/kimi-k2.6';
 
-export const KIMI_CURRENT_MODEL_NAME = 'Kimi K2.5';
+export const KIMI_CURRENT_MODEL_NAME = 'Kimi K2.6';


### PR DESCRIPTION
## Summary

- Bump `KIMI_CURRENT_MODEL_ID`/`KIMI_CURRENT_MODEL_NAME` from `moonshotai/kimi-k2.5`/`Kimi K2.5` to `moonshotai/kimi-k2.6`/`Kimi K2.6`, so Kimi K2.6 replaces K2.5 as the current recommended Kimi model.
- Reorder `preferredModels` so Kimi sits immediately after `CLAUDE_OPUS_CURRENT_MODEL_ID` and above `CLAUDE_SONNET_CURRENT_MODEL_ID`.
- Generalize the Moonshot `top_p` comment since the same constraint still applies to K2.6.

## Verification

- [x] `pnpm format`
- [x] `pnpm --filter web lint` (0 warnings/errors)
- [x] `pnpm --filter web test openrouter-models-config` (1/1 passing)

Did not run full `pnpm typecheck`/`pnpm lint` — both surface pre-existing errors on `main` in unrelated files (`request-helpers.ts`, `email-domain.ts`, `redis.ts`, `kilo-auto/resolution.ts`, and several worker test files). Pre-push hook was bypassed with `--no-verify` with user approval for the same reason.

## Visual Changes

N/A

## Reviewer Notes

- Left `KILOCODE_CATALOG_IDS` in `apps/web/src/app/(app)/claw/components/modelSupport.ts` alone — that set is the baked-in catalog for pre-`2026.03.08` OpenClaw builds and removing `moonshotai/kimi-k2.5` would break older clients that selected it.
- Left the BytePlus BYOK model entry (`kimi-k2.5` in `byteplus-coding.ts`) alone — that ID is defined by BytePlus's catalog, not ours.
- Left the hardcoded stats in `apps/web/src/app/api/modelstats/route.ts` alone — it's historical data for a legacy extension endpoint.