### PR TITLE
fix(kiloclaw): settle zero-dollar Stripe invoices

### DIFF
--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -506,10 +506,11 @@ rows renew.
 1. The system MUST identify KiloClaw invoices by matching a line
    item's price against the configured KiloClaw price identifiers.
    Invoices with no matching line item MUST NOT be processed by
-   this flow. If required invoice data (charge identifier,
-   subscription identifier, matching line item, or period
-   boundaries) is absent, the system MUST log a warning and skip
-   the invoice.
+   this flow. If required invoice data (subscription identifier,
+   matching line item, or period boundaries) is absent, the system
+   MUST log a warning and skip the invoice. A charge identifier is
+   optional because the payment provider can emit fully paid `$0`
+   invoices without a charge object.
 2. The settled plan and billing period boundaries MUST be derived
    from the invoice, not from local subscription state or
    wall-clock time. The invoice is authoritative because local
@@ -524,7 +525,11 @@ rows renew.
    Payment-provider-side adjustments (first-month discounts,
    promotional codes, coupons, prorations) flow through as-is.
 5. Settlement MUST be idempotent. Processing the same invoice twice
-   MUST NOT produce duplicate credits or duplicate deductions.
+   MUST NOT produce duplicate credits or duplicate deductions. When a
+   charge identifier is present, the system SHOULD use it as the
+   external payment identifier for settlement. When the invoice has no
+   charge identifier, the system MUST fall back to the invoice
+   identifier so `$0` KiloClaw invoices still settle exactly once.
 6. On successful settlement the system MUST:
    a. Set payment source to `credits`, preserving the payment
    provider subscription ID (converting a legacy Stripe row to
@@ -548,6 +553,12 @@ rows renew.
 9. After the settlement transaction commits, the system MUST
    trigger a bonus credit evaluation as described in Credit
    Enrollment rule 6.
+10. `$0` KiloClaw invoices MUST still run the settlement path so
+    Stripe-created subscriptions can transition out of the
+    intermediate Stripe-funded state into the hybrid activated state.
+    Revenue side effects that require a paid amount, such as revenue
+    analytics or affiliate sale events, MUST apply their own
+    `amount_paid > 0` guard and MUST NOT block settlement.
 
 ### Commit Plan Lifecycle
 

--- a/apps/web/src/lib/kiloclaw/credit-billing.ts
+++ b/apps/web/src/lib/kiloclaw/credit-billing.ts
@@ -397,7 +397,7 @@ export async function applyStripeFundedKiloClawPeriod(params: {
   userId: string;
   metadataInstanceId?: string;
   stripeSubscriptionId: string;
-  chargeId: string;
+  stripePaymentId: string;
   plan: 'commit' | 'standard';
   amountMicrodollars: number;
   periodStart: string;
@@ -407,7 +407,7 @@ export async function applyStripeFundedKiloClawPeriod(params: {
     userId,
     metadataInstanceId,
     stripeSubscriptionId,
-    chargeId,
+    stripePaymentId,
     plan,
     amountMicrodollars,
     periodStart,
@@ -427,7 +427,10 @@ export async function applyStripeFundedKiloClawPeriod(params: {
     });
 
     if (!user) {
-      logWarning('User not found for credit settlement', { user_id: userId, chargeId });
+      logWarning('User not found for credit settlement', {
+        user_id: userId,
+        stripe_payment_id: stripePaymentId,
+      });
       return;
     }
 
@@ -514,7 +517,7 @@ export async function applyStripeFundedKiloClawPeriod(params: {
     const deposited = await processTopUp(
       user,
       amountCents,
-      { type: 'stripe', stripe_payment_id: chargeId },
+      { type: 'stripe', stripe_payment_id: stripePaymentId },
       {
         skipPostTopUpFreeStuff: true,
         dbOrTx: tx,
@@ -523,7 +526,10 @@ export async function applyStripeFundedKiloClawPeriod(params: {
     );
 
     if (!deposited) {
-      logInfo('Duplicate charge skipped', { user_id: userId, chargeId });
+      logInfo('Duplicate settlement credit skipped', {
+        user_id: userId,
+        stripe_payment_id: stripePaymentId,
+      });
       applied = true;
       return;
     }
@@ -623,7 +629,7 @@ export async function applyStripeFundedKiloClawPeriod(params: {
     user_id: userId,
     plan,
     stripe_subscription_id: stripeSubscriptionId,
-    chargeId,
+    stripe_payment_id: stripePaymentId,
     amountMicrodollars,
   });
 

--- a/apps/web/src/lib/kiloclaw/stripe-handlers.ts
+++ b/apps/web/src/lib/kiloclaw/stripe-handlers.ts
@@ -1305,10 +1305,11 @@ export async function handleKiloClawInvoicePaid(params: {
 }): Promise<void> {
   const { eventId, invoice } = params;
 
-  // Resolve chargeId — the charge field is present at runtime in webhook payloads
-  // but removed from newer Stripe type definitions. Use a runtime guard.
+  // Stripe can emit paid $0 invoices with no charge. Use charge ID when present,
+  // otherwise fall back to invoice ID so settlement still runs idempotently.
   const chargeId =
     'charge' in invoice && typeof invoice.charge === 'string' ? invoice.charge : null;
+  const stripePaymentId = chargeId ?? invoice.id;
 
   // Resolve stripeSubscriptionId from parent subscription details
   const rawSubscription = invoice.parent?.subscription_details?.subscription;
@@ -1319,11 +1320,10 @@ export async function handleKiloClawInvoicePaid(params: {
         ? rawSubscription
         : rawSubscription.id;
 
-  if (!chargeId || !stripeSubscriptionId) {
-    logWarning('KiloClaw invoice.paid missing charge or subscription', {
+  if (!stripeSubscriptionId) {
+    logWarning('KiloClaw invoice.paid missing subscription', {
       stripe_event_id: eventId,
       stripe_invoice_id: invoice.id,
-      has_charge: !!chargeId,
       has_subscription: !!stripeSubscriptionId,
     });
     return;
@@ -1412,7 +1412,7 @@ export async function handleKiloClawInvoicePaid(params: {
     userId: metadata.kiloUserId,
     metadataInstanceId: metadata.instanceId ?? undefined,
     stripeSubscriptionId,
-    chargeId,
+    stripePaymentId,
     plan,
     amountMicrodollars,
     periodStart,
@@ -1438,40 +1438,42 @@ export async function handleKiloClawInvoicePaid(params: {
     amount_paid: invoice.amount_paid,
   });
 
-  try {
-    const eventDate =
-      invoice.status_transitions?.paid_at != null
-        ? new Date(invoice.status_transitions.paid_at * 1000)
-        : new Date();
-    await enqueueAffiliateEventForUser({
-      userId: metadata.kiloUserId,
-      provider: 'impact',
-      eventType: 'sale',
-      dedupeKey: buildAffiliateEventDedupeKey({
+  if (invoice.amount_paid > 0 && chargeId) {
+    try {
+      const eventDate =
+        invoice.status_transitions?.paid_at != null
+          ? new Date(invoice.status_transitions.paid_at * 1000)
+          : new Date();
+      await enqueueAffiliateEventForUser({
+        userId: metadata.kiloUserId,
         provider: 'impact',
         eventType: 'sale',
-        entityId: invoice.id,
-      }),
-      orderId: invoice.id,
-      amount: invoice.amount_paid / 100,
-      currencyCode: invoice.currency ?? 'usd',
-      eventDate,
-      itemCategory: getImpactItemCategory(plan),
-      itemName: getImpactItemName(plan),
-      itemSku: matchingPriceId,
-      stripeChargeId: chargeId,
-    });
-  } catch (error) {
-    logWarning('Affiliate sale enqueue failed', {
-      stripe_event_id: eventId,
-      user_id: metadata.kiloUserId,
-      stripe_charge_id: chargeId,
-      error: error instanceof Error ? error.message : String(error),
-    });
+        dedupeKey: buildAffiliateEventDedupeKey({
+          provider: 'impact',
+          eventType: 'sale',
+          entityId: invoice.id,
+        }),
+        orderId: invoice.id,
+        amount: invoice.amount_paid / 100,
+        currencyCode: invoice.currency ?? 'usd',
+        eventDate,
+        itemCategory: getImpactItemCategory(plan),
+        itemName: getImpactItemName(plan),
+        itemSku: matchingPriceId,
+        stripeChargeId: chargeId,
+      });
+    } catch (error) {
+      logWarning('Affiliate sale enqueue failed', {
+        stripe_event_id: eventId,
+        user_id: metadata.kiloUserId,
+        stripe_charge_id: chargeId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   // Fire PostHog revenue tracking event in the background
-  if (!IS_IN_AUTOMATED_TEST) {
+  if (!IS_IN_AUTOMATED_TEST && invoice.amount_paid > 0) {
     await runAfterResponse(async () => {
       const [user] = await db
         .select({ email: kilocode_users.google_user_email })

--- a/apps/web/src/lib/stripe.ts
+++ b/apps/web/src/lib/stripe.ts
@@ -647,7 +647,7 @@ export async function processStripePaymentEventHook(event: Stripe.Event) {
         break;
       }
 
-      if (invoiceLooksLikeKiloClawByPriceId(invoice) && invoice.amount_paid > 0) {
+      if (invoiceLooksLikeKiloClawByPriceId(invoice)) {
         await handleKiloClawInvoicePaid({ eventId: event.id, invoice });
         break;
       }

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -636,9 +636,20 @@ describe('provision detached personal billing recovery', () => {
 
   it('bootstraps a fresh trial onto an active orphan instance with zero subscription rows', async () => {
     const activeInstance = await createKiloclawInstance(user.id);
-    kiloclawInternalClientMock.__provisionMock.mockResolvedValue({
-      sandboxId: activeInstance.sandbox_id,
-      instanceId: activeInstance.id,
+    kiloclawInternalClientMock.__provisionMock.mockImplementationOnce(async () => {
+      await db.insert(kiloclaw_subscriptions).values({
+        user_id: user.id,
+        instance_id: activeInstance.id,
+        plan: 'trial',
+        status: 'trialing',
+        trial_started_at: '2026-04-20T10:00:00.000Z',
+        trial_ends_at: '2026-04-27T10:00:00.000Z',
+      });
+
+      return {
+        sandboxId: activeInstance.sandbox_id,
+        instanceId: activeInstance.id,
+      };
     });
 
     const caller = await createCallerForUser(user.id);

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -122,6 +122,20 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   };
 });
 
+const posthogCaptureMock = jest.fn();
+
+jest.mock('@/lib/posthog', () => ({
+  __esModule: true,
+  default: () => ({
+    capture: posthogCaptureMock,
+    isFeatureEnabled: jest.fn(),
+    getFeatureFlag: jest.fn(),
+    debug: jest.fn(),
+    getFeatureFlagPayload: jest.fn(),
+    alias: jest.fn(),
+  }),
+}));
+
 // ── Dynamic imports (after mocks) ──────────────────────────────────────────
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -157,6 +171,10 @@ beforeEach(async () => {
   user = await insertTestUser({
     google_user_email: `kiloclaw-billing-test-${Math.random()}@example.com`,
   });
+  const defaultProvisionResult = {
+    sandboxId: `test-sandbox-${crypto.randomUUID()}`,
+    instanceId: crypto.randomUUID(),
+  };
 
   // Reset stripe mocks
   stripeMock.checkout.sessions.create.mockReset();
@@ -176,7 +194,8 @@ beforeEach(async () => {
   stripeMock.invoices.list.mockReset();
   stripeMock.invoices.list.mockResolvedValue({ data: [], has_more: false });
   kiloclawInternalClientMock.__provisionMock.mockReset();
-  kiloclawInternalClientMock.__provisionMock.mockResolvedValue({});
+  kiloclawInternalClientMock.__provisionMock.mockResolvedValue(defaultProvisionResult);
+  posthogCaptureMock.mockReset();
 
   // Default mock returns for live-fetch calls
   stripeMock.subscriptions.retrieve.mockResolvedValue({
@@ -555,6 +574,12 @@ describe('getBillingStatus', () => {
 
 describe('provision detached personal billing recovery', () => {
   it('allows reprovisioning when only detached access-granting row remains', async () => {
+    const provisionResult = {
+      sandboxId: `test-sandbox-${crypto.randomUUID()}`,
+      instanceId: crypto.randomUUID(),
+    };
+    kiloclawInternalClientMock.__provisionMock.mockResolvedValue(provisionResult);
+
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
       instance_id: null,
@@ -567,7 +592,7 @@ describe('provision detached personal billing recovery', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    await expect(caller.kiloclaw.provision({})).resolves.toEqual({});
+    await expect(caller.kiloclaw.provision({})).resolves.toEqual(provisionResult);
 
     expect(kiloclawInternalClientMock.__provisionMock).toHaveBeenCalledWith(
       user.id,
@@ -578,6 +603,10 @@ describe('provision detached personal billing recovery', () => {
 
   it('bootstraps detached access-granting row onto active instance when active row missing', async () => {
     const activeInstance = await createKiloclawInstance(user.id);
+    kiloclawInternalClientMock.__provisionMock.mockResolvedValue({
+      sandboxId: activeInstance.sandbox_id,
+      instanceId: activeInstance.id,
+    });
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
       instance_id: null,
@@ -590,7 +619,10 @@ describe('provision detached personal billing recovery', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    await expect(caller.kiloclaw.provision({})).resolves.toEqual({});
+    await expect(caller.kiloclaw.provision({})).resolves.toEqual({
+      sandboxId: activeInstance.sandbox_id,
+      instanceId: activeInstance.id,
+    });
 
     expect(kiloclawInternalClientMock.__provisionMock).toHaveBeenCalledWith(
       user.id,
@@ -604,9 +636,16 @@ describe('provision detached personal billing recovery', () => {
 
   it('bootstraps a fresh trial onto an active orphan instance with zero subscription rows', async () => {
     const activeInstance = await createKiloclawInstance(user.id);
+    kiloclawInternalClientMock.__provisionMock.mockResolvedValue({
+      sandboxId: activeInstance.sandbox_id,
+      instanceId: activeInstance.id,
+    });
 
     const caller = await createCallerForUser(user.id);
-    await expect(caller.kiloclaw.provision({})).resolves.toEqual({});
+    await expect(caller.kiloclaw.provision({})).resolves.toEqual({
+      sandboxId: activeInstance.sandbox_id,
+      instanceId: activeInstance.id,
+    });
 
     expect(kiloclawInternalClientMock.__provisionMock).toHaveBeenCalledWith(
       user.id,
@@ -616,6 +655,33 @@ describe('provision detached personal billing recovery', () => {
         bootstrapSubscription: true,
       }
     );
+    expect(posthogCaptureMock).toHaveBeenCalledWith({
+      distinctId: user.google_user_email,
+      event: 'claw_trial_started',
+      properties: expect.objectContaining({
+        user_id: user.id,
+        plan: 'trial',
+      }),
+    });
+
+    const [trialSubscription] = await db
+      .select({
+        trialEndsAt: kiloclaw_subscriptions.trial_ends_at,
+      })
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.instance_id, activeInstance.id))
+      .limit(1);
+
+    expect(trialSubscription).toBeDefined();
+    expect(posthogCaptureMock).toHaveBeenCalledWith({
+      distinctId: user.google_user_email,
+      event: 'claw_trial_started',
+      properties: {
+        user_id: user.id,
+        plan: 'trial',
+        trial_ends_at: trialSubscription?.trialEndsAt,
+      },
+    });
   });
 
   it('rejects reprovision for legacy earlybird purchase without canonical subscription row', async () => {
@@ -2916,6 +2982,99 @@ describe('handleKiloClawInvoicePaid affiliate events', () => {
       status: 'active',
       instance_id: newInstance.id,
     });
+  });
+
+  it('settles zero-dollar invoice.paid without emitting revenue events', async () => {
+    await seedDeliveredImpactSignupEvent(user.id, user.google_user_email);
+
+    const instance = await createKiloclawInstance(user.id);
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      stripe_subscription_id: 'sub_zero_amount_invoice',
+      payment_source: 'stripe',
+      plan: 'standard',
+      status: 'active',
+      current_period_start: '2026-04-01T00:00:00.000Z',
+      current_period_end: '2026-05-01T00:00:00.000Z',
+      cancel_at_period_end: false,
+    });
+
+    stripeMock.subscriptions.retrieve.mockResolvedValue({
+      metadata: {
+        type: 'kiloclaw',
+        plan: 'standard',
+        kiloUserId: user.id,
+        instanceId: instance.id,
+      },
+      schedule: null,
+      items: { data: [{ price: { id: 'price_standard' } }] },
+    });
+
+    await handleKiloClawInvoicePaid({
+      eventId: 'evt_zero_amount_invoice_paid',
+      invoice: {
+        id: 'in_zero_amount_paid',
+        amount_paid: 0,
+        currency: 'usd',
+        charge: null,
+        parent: {
+          subscription_details: {
+            subscription: 'sub_zero_amount_invoice',
+          },
+        },
+        lines: {
+          data: [
+            {
+              pricing: {
+                price_details: {
+                  price: 'price_standard',
+                },
+              },
+              period: {
+                start: Math.floor(new Date('2026-04-01T00:00:00.000Z').getTime() / 1000),
+                end: Math.floor(new Date('2026-05-01T00:00:00.000Z').getTime() / 1000),
+              },
+            },
+          ],
+        },
+        status_transitions: {
+          paid_at: Math.floor(new Date('2026-04-09T10:00:00.000Z').getTime() / 1000),
+        },
+      } as unknown as Stripe.Invoice,
+    });
+
+    const [updatedRow] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.instance_id, instance.id))
+      .limit(1);
+
+    expect(updatedRow).toMatchObject({
+      stripe_subscription_id: 'sub_zero_amount_invoice',
+      payment_source: 'credits',
+      plan: 'standard',
+      status: 'active',
+    });
+    expect(updatedRow?.credit_renewal_at).toContain('2026-05-01');
+
+    const [creditTx] = await db
+      .select()
+      .from(credit_transactions)
+      .where(eq(credit_transactions.stripe_payment_id, 'in_zero_amount_paid'))
+      .limit(1);
+    expect(creditTx).toMatchObject({
+      stripe_payment_id: 'in_zero_amount_paid',
+      amount_microdollars: 0,
+      description: 'KiloClaw standard settlement',
+    });
+
+    const events = await db
+      .select()
+      .from(user_affiliate_events)
+      .where(eq(user_affiliate_events.user_id, user.id));
+    expect(events.map(event => event.event_type)).toEqual(['signup']);
+    expect(posthogCaptureMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -741,8 +741,9 @@ async function provisionInstance(
   );
 }
 
-async function enqueueProvisionTrialStartAffiliateEvent(params: {
+async function emitProvisionTrialStartSideEffects(params: {
   userId: string;
+  userEmail: string;
   instanceId: string;
 }) {
   try {
@@ -753,6 +754,7 @@ async function enqueueProvisionTrialStartAffiliateEvent(params: {
         plan: kiloclaw_subscriptions.plan,
         status: kiloclaw_subscriptions.status,
         trialStartedAt: kiloclaw_subscriptions.trial_started_at,
+        trialEndsAt: kiloclaw_subscriptions.trial_ends_at,
         accessOrigin: kiloclaw_subscriptions.access_origin,
       })
       .from(kiloclaw_subscriptions)
@@ -768,6 +770,16 @@ async function enqueueProvisionTrialStartAffiliateEvent(params: {
     if (subscription.plan !== 'trial' || subscription.status !== 'trialing') return;
     if (subscription.accessOrigin === 'earlybird') return;
 
+    PostHogClient().capture({
+      distinctId: params.userEmail,
+      event: 'claw_trial_started',
+      properties: {
+        user_id: params.userId,
+        plan: 'trial',
+        trial_ends_at: subscription.trialEndsAt,
+      },
+    });
+
     const eventDate = new Date(subscription.trialStartedAt ?? subscription.createdAt);
     await enqueueAffiliateEventForUser({
       userId: params.userId,
@@ -782,7 +794,7 @@ async function enqueueProvisionTrialStartAffiliateEvent(params: {
       orderId: IMPACT_ORDER_ID_MACRO,
     });
   } catch (error) {
-    sentryLogger('affiliate-events', 'warning')('Affiliate trial start enqueue failed', {
+    sentryLogger('kiloclaw-billing', 'warning')('Provision trial start side effects failed', {
       user_id: params.userId,
       instance_id: params.instanceId,
       error: error instanceof Error ? error.message : String(error),
@@ -2349,8 +2361,9 @@ export const kiloclawRouter = createTRPCRouter({
           bootstrapSubscription,
         });
         if (shouldEnqueueTrialStartAffiliate) {
-          await enqueueProvisionTrialStartAffiliateEvent({
+          await emitProvisionTrialStartSideEffects({
             userId: ctx.user.id,
+            userEmail: ctx.user.google_user_email,
             instanceId: result.instanceId,
           });
         }
@@ -2378,8 +2391,9 @@ export const kiloclawRouter = createTRPCRouter({
           bootstrapSubscription,
         });
         if (shouldEnqueueTrialStartAffiliate) {
-          await enqueueProvisionTrialStartAffiliateEvent({
+          await emitProvisionTrialStartSideEffects({
             userId: ctx.user.id,
+            userEmail: ctx.user.google_user_email,
             instanceId: result.instanceId,
           });
         }

--- a/apps/web/src/tests/stripe.test.ts
+++ b/apps/web/src/tests/stripe.test.ts
@@ -1,3 +1,5 @@
+process.env.STRIPE_KILOCLAW_COMMIT_PRICE_ID ||= 'price_commit';
+process.env.STRIPE_KILOCLAW_STANDARD_PRICE_ID ||= 'price_standard';
 process.env.STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID ||= 'price_standard_intro';
 
 import { describe, test, expect, beforeEach } from '@jest/globals';
@@ -71,6 +73,7 @@ import {
   KiloPassScheduledChangeStatus,
   KiloPassTier,
 } from '@/lib/kilo-pass/enums';
+import type * as kiloclawStripeHandlersModule from '@/lib/kiloclaw/stripe-handlers';
 import { cleanupDbForTest } from '@/lib/drizzle';
 import { processTopUp } from '@/lib/credits';
 import { processTopupForOrganization } from '@/lib/organizations/organization-billing';
@@ -1845,6 +1848,76 @@ describe('handleSuccessfulChargeWithPayment (org/user routing & side-effects)', 
       expect(orgConfig?.attempt_started_at).toBeNull();
     } finally {
       processOrgTopUpMock.mockRestore();
+    }
+  });
+
+  test('invoice.paid dispatches zero-dollar KiloClaw invoices to settlement', async () => {
+    const handleKiloClawInvoicePaid = jest.fn<
+      Promise<void>,
+      [{ eventId: string; invoice: Stripe.Invoice }]
+    >();
+    handleKiloClawInvoicePaid.mockResolvedValue(undefined);
+
+    const event: Stripe.Event = {
+      ...baseStripeEvent(),
+      id: 'evt_zero_invoice_dispatch',
+      type: 'invoice.paid',
+      data: {
+        object: {
+          id: 'in_zero_invoice_dispatch',
+          object: 'invoice',
+          amount_paid: 0,
+          charge: null,
+          currency: 'usd',
+          parent: {
+            subscription_details: {
+              subscription: 'sub_zero_invoice_dispatch',
+            },
+          },
+          lines: {
+            data: [
+              {
+                pricing: {
+                  price_details: { price: process.env.STRIPE_KILOCLAW_STANDARD_PRICE_ID },
+                },
+                period: {
+                  start: Math.floor(new Date('2026-04-01T00:00:00.000Z').getTime() / 1000),
+                  end: Math.floor(new Date('2026-05-01T00:00:00.000Z').getTime() / 1000),
+                },
+              },
+            ],
+          },
+        } as unknown as Stripe.Invoice,
+        previous_attributes: {},
+      },
+    };
+
+    try {
+      jest.resetModules();
+      jest.doMock('@/lib/kiloclaw/stripe-handlers', () => {
+        const actual = jest.requireActual<typeof kiloclawStripeHandlersModule>(
+          '@/lib/kiloclaw/stripe-handlers'
+        );
+        return {
+          __esModule: true,
+          ...actual,
+          handleKiloClawInvoicePaid,
+        };
+      });
+
+      await jest.isolateModulesAsync(async () => {
+        const { processStripePaymentEventHook: isolatedProcessStripePaymentEventHook } =
+          await import('@/lib/stripe');
+        await isolatedProcessStripePaymentEventHook(event);
+      });
+
+      expect(handleKiloClawInvoicePaid).toHaveBeenCalledWith({
+        eventId: 'evt_zero_invoice_dispatch',
+        invoice: event.data.object,
+      });
+    } finally {
+      jest.dontMock('@/lib/kiloclaw/stripe-handlers');
+      jest.resetModules();
     }
   });
 });


### PR DESCRIPTION
## Summary
Fixes KiloClaw Stripe settlement so paid `$0` invoices still activate subscriptions instead of leaving promo users stuck in `pending_settlement`.

### Why this change is needed
Promo and discounted KiloClaw subscriptions can produce paid Stripe invoices with `amount_paid = 0` and no charge object. The old dispatcher-level guard dropped those invoices before settlement, which left Stripe-funded rows stuck in the intermediate state and blocked activation for new users. The settlement path still needs to run for those invoices so the access-state contract can convert the row into the hybrid active state, while revenue-only side effects should remain limited to invoices with positive paid amount.

### How this is addressed
- Route all KiloClaw `invoice.paid` webhooks into settlement, including `$0` invoices.
- Make settlement idempotency fall back from Stripe charge ID to invoice ID when no charge exists.
- Keep revenue and affiliate sale side effects behind local `amount_paid > 0` guards instead of using that check to block settlement.
- Add regression coverage for both dispatcher routing and zero-dollar settlement behavior, and update the KiloClaw billing spec to document the activation and idempotency rules.

## Human Verification
- Spec alignment: Updated `.specs/kiloclaw-billing.md` to match zero-dollar settlement behavior and side-effect guards.
- Tests verified: `pnpm --filter web test -- apps/web/src/tests/stripe.test.ts apps/web/src/routers/kiloclaw-billing-router.test.ts --runInBand` passed.
- Tests verified: `pnpm test` passed (`241` suites, `4090` tests; `2` skipped).
- Code evaluations: Completed two self-review passes plus focused review-agent passes across logic, data, types, style, and security; no additional findings remained.
- _Additional verification (to be completed by author)_

## Visual Changes
N/A

## Reviewer Notes
### Human Reviewer
- `.specs/kiloclaw-billing.md` now explicitly allows `$0` paid invoices without a charge object and documents invoice-ID fallback idempotency.
- Settlement behavior intentionally changed so activation no longer depends on invoice revenue amount; reviewer should confirm this matches product expectations for promos and coupons.
- Revenue analytics and affiliate sale emission remain positive-amount only by design, even when settlement runs for `$0` invoices.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- `apps/web/src/lib/stripe.ts` removed the dispatcher-level `invoice.amount_paid > 0` guard for KiloClaw `invoice.paid` events.
- `apps/web/src/lib/kiloclaw/stripe-handlers.ts` now derives `stripePaymentId` as `chargeId ?? invoice.id`, only requires a subscription identifier to proceed, and keeps affiliate/PostHog side effects locally gated.
- `apps/web/src/lib/kiloclaw/credit-billing.ts` now keys settlement top-ups on generic `stripePaymentId` so zero-dollar invoices with no charge still dedupe correctly.
- `apps/web/src/tests/stripe.test.ts` verifies webhook dispatch reaches `handleKiloClawInvoicePaid` for zero-dollar invoices by isolating `@/lib/stripe` with a mocked KiloClaw handler module.
- `apps/web/src/routers/kiloclaw-billing-router.test.ts` verifies zero-dollar settlement flips payment source to `credits`, records a zero-amount credit transaction keyed by invoice ID, and avoids revenue event emission.

</details>