### PR TITLE
fix(openclaw-security-advisor) bonus guard

### DIFF
--- a/apps/web/src/app/account-verification/page.tsx
+++ b/apps/web/src/app/account-verification/page.tsx
@@ -9,11 +9,7 @@ import { getStytchStatus, handleSignupPromotion, type SignupSource } from '@/lib
 import { PageContainer } from '@/components/layouts/PageContainer';
 import { isValidCallbackPath } from '@/lib/getSignInCallbackUrl';
 import { maybeInterceptWithSurvey } from '@/lib/survey-redirect';
-
-// Matches exactly the `/openclaw-advisor` pathname, optionally followed by a
-// trailing slash, query string, or fragment. Guards against sibling paths like
-// `/openclaw-advisor-fake` that would otherwise pass a naive `startsWith` check.
-const OPENCLAW_ADVISOR_PATH_RE = /^\/openclaw-advisor(?:[/?#]|$)/;
+import { isOpenclawAdvisorCallback } from '@/lib/signup-source';
 
 export default async function AccountVerificationPage({ searchParams }: AppPageProps) {
   const user = await getUserFromAuthOrRedirect('/users/sign_in');
@@ -33,7 +29,7 @@ export default async function AccountVerificationPage({ searchParams }: AppPageP
     isFirstValidation &&
     callbackStr &&
     isValidCallbackPath(callbackStr) &&
-    OPENCLAW_ADVISOR_PATH_RE.test(callbackStr)
+    isOpenclawAdvisorCallback(callbackStr)
       ? 'openclaw-security-advisor'
       : null;
 

--- a/apps/web/src/app/openclaw-advisor/page.tsx
+++ b/apps/web/src/app/openclaw-advisor/page.tsx
@@ -1,34 +1,43 @@
 import { redirect } from 'next/navigation';
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+// Single source of truth for the device-auth code shape. The shared
+// `isOpenclawAdvisorCallback` helper applies the same regex on the
+// callback-path side so the page-level guard here and the attribution
+// guard at /account-verification can't drift.
+import { DEVICE_AUTH_CODE_FORMAT } from '@/lib/signup-source';
 
 type PageProps = {
   searchParams: Promise<{ code?: string }>;
 };
-
-// Device-auth codes are generated as `XXXX-XXXX` from an unambiguous
-// alphanumeric charset (see generateDeviceCode in lib/device-auth/device-auth.ts).
-// This guard drops obviously malformed input before it reaches the device-auth
-// flow and eliminates any risk of injecting non-code content via the query param.
-const DEVICE_AUTH_CODE_FORMAT = /^[A-Za-z0-9-]{1,16}$/;
 
 export default async function OpenclawAdvisorPage({ searchParams }: PageProps) {
   const params = await searchParams;
   const rawCode = params.code;
   const code = rawCode && DEVICE_AUTH_CODE_FORMAT.test(rawCode) ? rawCode : undefined;
 
+  // Short-circuit BEFORE the auth redirect when the code is missing or
+  // malformed. Otherwise an unauthenticated visit to
+  // `/openclaw-advisor` (no code, or `?code=garbage`) would set
+  // `callbackPath=/openclaw-advisor` on the sign-in redirect, and
+  // account-verification would then read that callback as a signal that
+  // the user arrived through the Security Advisor plugin and grant the
+  // product-specific signup bonus — without the user ever having a
+  // device-auth session to complete. Bouncing to `/` here means
+  // callbackPath never carries the bonus-eligible path for code-less
+  // visits, so bonus attribution stays tied to real plugin traffic.
+  if (!code) {
+    redirect('/');
+  }
+
   // code has already been validated against [A-Za-z0-9-]{1,16}, so no
   // per-char encoding is needed when building the inner callback path.
   // The outer encodeURIComponent around the whole callbackPath is still
   // required so the `?` and `=` it contains travel as a single query-param
   // value into /users/sign_in.
-  const callbackPath = `/openclaw-advisor${code ? `?code=${code}` : ''}`;
+  const callbackPath = `/openclaw-advisor?code=${code}`;
   await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=${encodeURIComponent(callbackPath)}`
   );
-
-  if (!code) {
-    redirect('/');
-  }
 
   // Same rationale as above: `code` is validated, so percent-encoding is redundant.
   redirect(`/device-auth?code=${code}`);

--- a/apps/web/src/app/users/after-sign-in/route.tsx
+++ b/apps/web/src/app/users/after-sign-in/route.tsx
@@ -12,6 +12,7 @@ import {
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { APP_URL } from '@/lib/constants';
+import { isOpenclawAdvisorCallback } from '@/lib/signup-source';
 
 /**
  * Resolves a product identifier from the signup entry point. Returns null when
@@ -26,7 +27,12 @@ function resolveSignupProduct(callbackPath: string | null, hasSource: boolean): 
   if (callbackPath.startsWith('/code-reviews')) return 'code-reviews';
   if (callbackPath.startsWith('/app-builder')) return 'app-builder';
   if (callbackPath.startsWith('/install')) return 'kilo-code';
-  if (callbackPath.startsWith('/openclaw-advisor')) return 'openclaw-security-advisor';
+  // Exact-pathname match via shared helper — a naive startsWith check would
+  // also attribute `/openclaw-advisor-fake` and any sibling path sharing the
+  // prefix. The account-verification bonus path already uses this helper for
+  // the same reason; keeping both sides on the shared check prevents the two
+  // attribution paths from drifting.
+  if (isOpenclawAdvisorCallback(callbackPath)) return 'openclaw-security-advisor';
   return null;
 }
 

--- a/apps/web/src/lib/signup-source.test.ts
+++ b/apps/web/src/lib/signup-source.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for the signup-source parsing helper. Pins the monetary
+ * attribution decision: which callback paths qualify a signup for the
+ * OpenClaw Security Advisor product-specific bonus, and which don't.
+ *
+ * Added after the post-merge review on PR #2622 flagged that bonus
+ * attribution was reachable without a valid device-auth code.
+ */
+
+import { isOpenclawAdvisorCallback } from './signup-source';
+
+describe('isOpenclawAdvisorCallback', () => {
+  describe('positive cases — attributes to the advisor', () => {
+    it('matches /openclaw-advisor with a well-formed code query', () => {
+      expect(isOpenclawAdvisorCallback('/openclaw-advisor?code=ABCD-1234')).toBe(true);
+    });
+
+    it('matches a shorter but valid device-auth code', () => {
+      expect(isOpenclawAdvisorCallback('/openclaw-advisor?code=A1')).toBe(true);
+    });
+
+    it('matches when additional query params follow the code', () => {
+      // The helper only checks for a valid `code` param; extra params like
+      // utm tags or state are allowed to pass through.
+      expect(isOpenclawAdvisorCallback('/openclaw-advisor?code=ABCD-1234&utm_source=plugin')).toBe(
+        true
+      );
+    });
+
+    it('matches when the code param is not first in the query string', () => {
+      expect(isOpenclawAdvisorCallback('/openclaw-advisor?utm_source=plugin&code=ABCD-1234')).toBe(
+        true
+      );
+    });
+  });
+
+  describe('negative cases — must not attribute', () => {
+    it('rejects null callbackPath', () => {
+      expect(isOpenclawAdvisorCallback(null)).toBe(false);
+    });
+
+    it('rejects undefined callbackPath', () => {
+      expect(isOpenclawAdvisorCallback(undefined)).toBe(false);
+    });
+
+    it('rejects empty string', () => {
+      expect(isOpenclawAdvisorCallback('')).toBe(false);
+    });
+
+    it('rejects bare /openclaw-advisor with no query', () => {
+      // This was the post-merge-review blocker: a no-code callback
+      // previously granted the signup bonus via the old pathname-only
+      // check. Now the `code` query param is required.
+      expect(isOpenclawAdvisorCallback('/openclaw-advisor')).toBe(false);
+    });
+
+    it('rejects /openclaw-advisor with empty code value', () => {
+      expect(isOpenclawAdvisorCallback('/openclaw-advisor?code=')).toBe(false);
+    });
+
+    it('rejects /openclaw-advisor with malformed code (invalid chars)', () => {
+      // `.` and `_` survive URL parsing but are outside the device-auth
+      // charset `[A-Za-z0-9-]`. `#` would be stripped into the fragment
+      // before searchParams.get sees the code, so it's not a useful probe.
+      expect(isOpenclawAdvisorCallback('/openclaw-advisor?code=ab.cd')).toBe(false);
+      expect(isOpenclawAdvisorCallback('/openclaw-advisor?code=ab_cd')).toBe(false);
+    });
+
+    it('rejects /openclaw-advisor with code longer than 16 chars', () => {
+      expect(isOpenclawAdvisorCallback('/openclaw-advisor?code=ABCDEFGHIJKLMNOPQ')).toBe(false);
+    });
+
+    it('rejects the sibling path /openclaw-advisor-fake even with a valid code', () => {
+      // Defense against the naive-prefix-match bug the post-merge review
+      // also called out for the analytics resolver. Exact-pathname match
+      // only — a sibling path that shares the prefix must not qualify.
+      expect(isOpenclawAdvisorCallback('/openclaw-advisor-fake?code=ABCD-1234')).toBe(false);
+    });
+
+    it('rejects /openclaw-advisory (typo-sibling) even with a valid code', () => {
+      expect(isOpenclawAdvisorCallback('/openclaw-advisory?code=ABCD-1234')).toBe(false);
+    });
+
+    it('rejects a generic device-auth callback', () => {
+      expect(isOpenclawAdvisorCallback('/device-auth?code=ABCD-1234')).toBe(false);
+    });
+
+    it('rejects other product entry points', () => {
+      expect(isOpenclawAdvisorCallback('/claw?code=ABCD-1234')).toBe(false);
+      expect(isOpenclawAdvisorCallback('/cloud?code=ABCD-1234')).toBe(false);
+      expect(isOpenclawAdvisorCallback('/install?code=ABCD-1234')).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('accepts a trailing slash on /openclaw-advisor/', () => {
+      // The pathname regex permits a trailing `/` before the query.
+      // With a valid code the attribution should still fire.
+      expect(isOpenclawAdvisorCallback('/openclaw-advisor/?code=ABCD-1234')).toBe(true);
+    });
+
+    it('rejects the openclaw-advisor path when a fragment carries the code', () => {
+      // The device-auth flow never uses URL fragments for the code.
+      // Fragments also aren't sent to the server, so they can't survive
+      // a round-trip through sign-in anyway. Explicit about this for
+      // anyone who wonders later.
+      expect(isOpenclawAdvisorCallback('/openclaw-advisor#code=ABCD-1234')).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/lib/signup-source.ts
+++ b/apps/web/src/lib/signup-source.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared parsing for the callback paths that attribute a signup to a
+ * specific product. Used by both the account-verification page (which
+ * grants product-specific signup bonuses based on the source) and the
+ * after-sign-in analytics route (which tags the signup_product_attributed
+ * PostHog event).
+ *
+ * Centralized so bonus-attribution logic and analytics-attribution logic
+ * can't drift. A new product attribution should be added in one place.
+ *
+ * Matching uses an exact pathname check rather than a prefix check.
+ * A naive `callbackPath.startsWith('/openclaw-advisor')` would also
+ * match `/openclaw-advisor-fake`, `/openclaw-advisory`, or any sibling
+ * path that happens to share the prefix. Exact matching requires the
+ * pathname to terminate after `/openclaw-advisor` with one of: end-of-
+ * string, `/`, `?`, or `#`.
+ *
+ * For the OpenClaw Security Advisor attribution we also require a valid
+ * `code` query parameter in the callback path. That's the authoritative
+ * signal that the user arrived through the real plugin device-auth flow
+ * rather than having had `callbackPath=/openclaw-advisor` injected by
+ * visiting the sign-in URL directly. Without this check, a bare
+ * `/openclaw-advisor` callback would qualify for the signup bonus even
+ * when no plugin ever issued a device-auth code.
+ */
+
+/**
+ * Matches exactly the `/openclaw-advisor` pathname, optionally followed
+ * by a trailing slash, query string, or fragment. Intentionally not
+ * exported: callers should use `isOpenclawAdvisorCallback`, which also
+ * gates on a valid device-auth code. Exposing the pathname regex on its
+ * own would invite callers to skip the code check.
+ */
+const OPENCLAW_ADVISOR_PATH_RE = /^\/openclaw-advisor(?:[/?#]|$)/;
+
+/**
+ * Device-auth code shape: unambiguous alphanumeric with optional dashes,
+ * 1 to 16 chars. Exported so `apps/web/src/app/openclaw-advisor/page.tsx`
+ * (which also validates the raw `?code=` query param before kicking off
+ * the auth redirect) can consume the single source of truth instead of
+ * carrying its own copy.
+ */
+export const DEVICE_AUTH_CODE_FORMAT = /^[A-Za-z0-9-]{1,16}$/;
+
+/**
+ * True when the callback path attributes the signup to the OpenClaw
+ * Security Advisor plugin: pathname exact-matches `/openclaw-advisor`
+ * AND the path carries a `code` query parameter matching the device-auth
+ * code format. The `code` requirement is the real-plugin-flow gate;
+ * without it, a manually-constructed callbackPath could award the
+ * product-specific signup bonus without the user ever completing a
+ * device-auth session.
+ *
+ * Parses the callback path as if it were relative to an arbitrary
+ * origin so query-string extraction uses the standard URL API. Returns
+ * false on any parse failure.
+ */
+export function isOpenclawAdvisorCallback(callbackPath: string | null | undefined): boolean {
+  if (typeof callbackPath !== 'string' || callbackPath.length === 0) return false;
+  if (!OPENCLAW_ADVISOR_PATH_RE.test(callbackPath)) return false;
+
+  let url: URL;
+  try {
+    url = new URL(callbackPath, 'https://placeholder.invalid');
+  } catch {
+    return false;
+  }
+
+  const code = url.searchParams.get('code');
+  if (code === null) return false;
+  return DEVICE_AUTH_CODE_FORMAT.test(code);
+}

--- a/apps/web/src/tests/account-verification-redirect.test.ts
+++ b/apps/web/src/tests/account-verification-redirect.test.ts
@@ -331,6 +331,48 @@ describe('account-verification redirect logic', () => {
 
       expect(mockHandleSignupPromotion).toHaveBeenCalledWith(user, true, null);
     });
+
+    // Defense-in-depth for the blocker called out in the post-merge review
+    // on PR #2622: even if a user manually reaches /account-verification
+    // with callbackPath=/openclaw-advisor (bypassing the page-level
+    // short-circuit in openclaw-advisor/page.tsx), bonus attribution must
+    // still refuse when no valid device-auth code accompanies the path.
+    // The code is the "real plugin flow" signal; without it any visitor
+    // could self-award the bonus by visiting the sign-in URL directly.
+    it('does NOT attribute when callbackPath=/openclaw-advisor has no code param', async () => {
+      const user = makeUser({ has_validation_stytch: null });
+      mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
+      mockGetStytchStatus.mockResolvedValue(true);
+
+      await renderPage({ callbackPath: '/openclaw-advisor' });
+
+      expect(mockHandleSignupPromotion).toHaveBeenCalledWith(user, true, null);
+    });
+
+    it('does NOT attribute when callbackPath=/openclaw-advisor code is malformed', async () => {
+      const user = makeUser({ has_validation_stytch: null });
+      mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
+      mockGetStytchStatus.mockResolvedValue(true);
+
+      // `.` and `_` survive URL parsing but fall outside the device-auth
+      // charset `[A-Za-z0-9-]`. Must not qualify for the bonus even
+      // though the pathname exact-matches.
+      await renderPage({ callbackPath: '/openclaw-advisor?code=ab.cd' });
+
+      expect(mockHandleSignupPromotion).toHaveBeenCalledWith(user, true, null);
+    });
+
+    it('does NOT attribute when callbackPath=/openclaw-advisor code exceeds 16 chars', async () => {
+      const user = makeUser({ has_validation_stytch: null });
+      mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
+      mockGetStytchStatus.mockResolvedValue(true);
+
+      // 17 ASCII alphanumerics — within the charset but longer than the
+      // device-auth generator ever produces. Rejected by the format guard.
+      await renderPage({ callbackPath: '/openclaw-advisor?code=ABCDEFGHIJKLMNOPQ' });
+
+      expect(mockHandleSignupPromotion).toHaveBeenCalledWith(user, true, null);
+    });
   });
 
   // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes an abuse vector surfaced by the post merge review on PR #2622. 


## Verification

- [x] `pnpm run format:check` clean
- [x] `apps/web` typecheck clean
- [x] `apps/web/src/lib/signup-source.test.ts` passes 17 of 17: positive attribution cases, null / undefined / empty input, bare path with no query, empty code value, malformed code chars (`.` and `_`), over length code, sibling path `/openclaw-advisor-fake`, typo sibling `/openclaw-advisory`, generic `/device-auth` callback, other product entry points, trailing slash, fragment carried code
- [x] `apps/web/src/tests/account-verification-redirect.test.ts` passes 20 of 20, including three new regression cases that assert `signupSource === null` for no code, malformed code, and over length code callbacks
- [x] Existing `apps/web/src/lib/stytch.test.ts` bonus tests (23 of 23) continue to pass, confirming no regression on the legitimate plugin flow

## Visual Changes

N/A. No UI changes. All fixes are in the auth callback and attribution path.

## Reviewer Notes

- The page level short circuit at `apps/web/src/app/openclaw-advisor/page.tsx` and the attribution guard in the shared helper are layered on purpose. Either one alone closes the reported abuse path, but both together protect against paths we have not thought of yet. The page guard handles the normal user flow; the attribution guard handles anyone who reaches account-verification by any other route.
- `OPENCLAW_ADVISOR_PATH_RE` is intentionally unexported from `signup-source.ts`. Callers should always go through `isOpenclawAdvisorCallback` so they cannot accidentally skip the code gate.
- The three other prefix based checks in `resolveSignupProduct` (`/claw`, `/cloud`, `/install`, `/app-builder`, `/code-reviews`) have the same naive startsWith shape but carry no monetary behavior, so they are out of scope for this fix. Worth a follow up if we want consistent semantics across all product attributions.
- No schema changes, no new env vars, no migration, no plugin side changes. Drops straight onto the existing `handleSignupPromotion` flow.
