### PR TITLE
feat(mobile): Render Markdown In Agent Chat Messages

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -65,6 +65,7 @@
     "react-native-appsflyer": "^6.17.9",
     "react-native-css": "3.0.6",
     "react-native-gesture-handler": "~2.30.0",
+    "react-native-marked": "^8.0.1",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",

--- a/apps/mobile/src/components/agents/markdown-text.tsx
+++ b/apps/mobile/src/components/agents/markdown-text.tsx
@@ -147,7 +147,12 @@ class MarkdownRenderer extends Renderer {
     _rowStyle: ViewStyle | undefined,
     _cellStyle: ViewStyle | undefined
   ): ReactNode {
-    const columnCount = header.length;
+    let columnCount = header.length;
+    for (const row of rows) {
+      if (row.length > columnCount) {
+        columnCount = row.length;
+      }
+    }
 
     return (
       <ScrollView key={this.getKey()} horizontal showsHorizontalScrollIndicator={false}>
@@ -200,16 +205,15 @@ function TableRow({ palette, cells, columnCount, isLastRow, isHeader = false }: 
       // eslint-disable-next-line react-native/no-inline-styles -- dynamic per-variant header background
       style={isHeader ? { backgroundColor: palette.codeBackground } : undefined}
     >
-      {cells.map((cell, colIdx) => (
+      {Array.from({ length: columnCount }, (_, colIdx) => (
         <TableCell
           key={colIdx}
           palette={palette}
           width={columnWidth}
           hasRightBorder={colIdx < columnCount - 1}
           hasBottomBorder={isHeader || !isLastRow}
-          isHeader={isHeader}
         >
-          {cell}
+          {cells[colIdx] ?? []}
         </TableCell>
       ))}
     </View>
@@ -221,18 +225,10 @@ type TableCellProps = {
   width: number;
   hasRightBorder: boolean;
   hasBottomBorder: boolean;
-  isHeader: boolean;
   children: ReactNode;
 };
 
-function TableCell({
-  palette,
-  width,
-  hasRightBorder,
-  hasBottomBorder,
-  isHeader,
-  children,
-}: TableCellProps) {
+function TableCell({ palette, width, hasRightBorder, hasBottomBorder, children }: TableCellProps) {
   return (
     <View
       className="p-2"
@@ -244,14 +240,7 @@ function TableCell({
         borderBottomWidth: hasBottomBorder ? 1 : 0,
       }}
     >
-      <Text
-        selectable
-        className={isHeader ? 'font-bold' : undefined}
-        // eslint-disable-next-line react-native/no-inline-styles -- dynamic per-variant text color
-        style={{ color: palette.textColor }}
-      >
-        {children}
-      </Text>
+      {children}
     </View>
   );
 }

--- a/apps/mobile/src/components/agents/markdown-text.tsx
+++ b/apps/mobile/src/components/agents/markdown-text.tsx
@@ -1,0 +1,301 @@
+import { Fragment, type ReactNode, useMemo } from 'react';
+import {
+  ScrollView,
+  Text,
+  type TextStyle,
+  useColorScheme,
+  View,
+  type ViewStyle,
+} from 'react-native';
+import { type MarkedStyles, Renderer, useMarkdown } from 'react-native-marked';
+
+import { type ThemeColors, useThemeColors } from '@/lib/hooks/use-theme-colors';
+
+type MarkdownVariant = 'assistant' | 'user';
+
+type MarkdownTextProps = {
+  value: string;
+  variant?: MarkdownVariant;
+};
+
+// Convert an `hsl(h, s%, l%)` theme token into `hsla(..., alpha)`.
+// Theme tokens in `use-theme-colors.ts` are authored as `hsl(...)` strings
+// so React Navigation accepts them directly; this helper lets us derive
+// translucent variants for in-bubble dividers without duplicating tokens.
+function withAlpha(hslColor: string, alpha: number): string {
+  const match = /^hsl\(\s*([^)]+)\)$/i.exec(hslColor);
+  if (!match) {
+    return hslColor;
+  }
+  return `hsla(${match[1]}, ${alpha})`;
+}
+
+type MarkdownPalette = {
+  textColor: string;
+  mutedTextColor: string;
+  codeBackground: string;
+  borderColor: string;
+};
+
+function getPalette(variant: MarkdownVariant, colors: ThemeColors): MarkdownPalette {
+  const isUser = variant === 'user';
+  return {
+    textColor: isUser ? colors.primaryForeground : colors.foreground,
+    mutedTextColor: isUser ? withAlpha(colors.primaryForeground, 0.7) : colors.mutedForeground,
+    codeBackground: isUser ? withAlpha(colors.primaryForeground, 0.15) : colors.muted,
+    borderColor: isUser ? withAlpha(colors.primaryForeground, 0.3) : colors.border,
+  };
+}
+
+// `react-native-marked`'s `useMarkdown` takes an inline styles map rather than
+// `className`, so we cannot use NativeWind here. Centralizing style creation
+// keeps both variants in sync and makes the color choices reviewable.
+function getMarkdownStyles(palette: MarkdownPalette): MarkedStyles {
+  const { textColor, mutedTextColor, codeBackground, borderColor } = palette;
+
+  return {
+    text: { color: textColor, fontSize: 16, lineHeight: 24 },
+    paragraph: { marginVertical: 2, paddingVertical: 0 },
+    strong: { color: textColor, fontWeight: '700' },
+    em: { color: textColor, fontStyle: 'italic' },
+    link: { color: textColor, fontStyle: 'normal', textDecorationLine: 'underline' },
+    h1: { color: textColor, fontSize: 22, fontWeight: '700', marginTop: 8, marginBottom: 4 },
+    h2: { color: textColor, fontSize: 20, fontWeight: '700', marginTop: 8, marginBottom: 4 },
+    h3: { color: textColor, fontSize: 18, fontWeight: '700', marginTop: 6, marginBottom: 4 },
+    h4: { color: textColor, fontSize: 16, fontWeight: '700', marginTop: 6, marginBottom: 4 },
+    h5: { color: textColor, fontSize: 15, fontWeight: '700', marginTop: 4, marginBottom: 2 },
+    h6: { color: textColor, fontSize: 14, fontWeight: '700', marginTop: 4, marginBottom: 2 },
+    // Override the library defaults that set italic + light weight on codespan.
+    codespan: {
+      color: textColor,
+      backgroundColor: codeBackground,
+      fontFamily: 'Menlo',
+      fontSize: 14,
+      fontStyle: 'normal',
+      fontWeight: '400',
+    },
+    code: {
+      backgroundColor: codeBackground,
+      borderRadius: 8,
+      padding: 12,
+      marginVertical: 4,
+    },
+    blockquote: {
+      borderLeftWidth: 3,
+      borderLeftColor: borderColor,
+      paddingLeft: 12,
+      marginVertical: 4,
+    },
+    list: { marginVertical: 2 },
+    li: { color: textColor, fontSize: 16, lineHeight: 24 },
+    hr: {
+      borderBottomWidth: 1,
+      borderBottomColor: borderColor,
+      marginVertical: 8,
+    },
+    table: { borderColor, borderWidth: 1, borderRadius: 6, marginVertical: 4 },
+    tableRow: { borderColor },
+    tableCell: { borderColor },
+    strikethrough: { color: mutedTextColor, textDecorationLine: 'line-through' },
+  };
+}
+
+// The library's default `Renderer` renders code blocks with the `em` text
+// style (italic) and renders tables with fixed column widths that frequently
+// overflow the screen with no way to scroll within a chat bubble. We subclass
+// it to render code blocks in a monospace font and to render tables with our
+// own layout that scales to the container.
+class MarkdownRenderer extends Renderer {
+  private readonly palette: MarkdownPalette;
+
+  constructor(palette: MarkdownPalette) {
+    super();
+    this.palette = palette;
+  }
+
+  // eslint-disable-next-line eslint/max-params -- signature fixed by react-native-marked's RendererInterface
+  override code(
+    text: string,
+    _language: string | undefined,
+    containerStyle: ViewStyle | undefined,
+    _textStyle: TextStyle | undefined
+  ): ReactNode {
+    return (
+      <ScrollView
+        key={this.getKey()}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={containerStyle}
+      >
+        <Text
+          selectable
+          className="font-mono text-sm leading-5"
+          // eslint-disable-next-line react-native/no-inline-styles -- dynamic per-variant text color
+          style={{ color: this.palette.textColor }}
+        >
+          {text}
+        </Text>
+      </ScrollView>
+    );
+  }
+
+  // eslint-disable-next-line eslint/max-params -- signature fixed by react-native-marked's RendererInterface
+  override table(
+    header: ReactNode[][],
+    rows: ReactNode[][][],
+    tableStyle: ViewStyle | undefined,
+    _rowStyle: ViewStyle | undefined,
+    _cellStyle: ViewStyle | undefined
+  ): ReactNode {
+    const columnCount = header.length;
+
+    return (
+      <ScrollView key={this.getKey()} horizontal showsHorizontalScrollIndicator={false}>
+        <View style={tableStyle}>
+          <TableRow
+            palette={this.palette}
+            cells={header}
+            columnCount={columnCount}
+            isHeader
+            isLastRow={rows.length === 0}
+          />
+          {rows.map((row, rowIdx) => (
+            <TableRow
+              key={rowIdx}
+              palette={this.palette}
+              cells={row}
+              columnCount={columnCount}
+              isLastRow={rowIdx === rows.length - 1}
+            />
+          ))}
+        </View>
+      </ScrollView>
+    );
+  }
+}
+
+const TABLE_COLUMN_MIN_WIDTH = 120;
+const TABLE_COLUMN_TARGET_TOTAL_WIDTH = 320;
+
+function getColumnWidth(columnCount: number): number {
+  return Math.max(
+    TABLE_COLUMN_MIN_WIDTH,
+    Math.floor(TABLE_COLUMN_TARGET_TOTAL_WIDTH / Math.max(columnCount, 1))
+  );
+}
+
+type TableRowProps = {
+  palette: MarkdownPalette;
+  cells: ReactNode[][];
+  columnCount: number;
+  isLastRow: boolean;
+  isHeader?: boolean;
+};
+
+function TableRow({ palette, cells, columnCount, isLastRow, isHeader = false }: TableRowProps) {
+  const columnWidth = getColumnWidth(columnCount);
+  return (
+    <View
+      className="flex-row"
+      // eslint-disable-next-line react-native/no-inline-styles -- dynamic per-variant header background
+      style={isHeader ? { backgroundColor: palette.codeBackground } : undefined}
+    >
+      {cells.map((cell, colIdx) => (
+        <TableCell
+          key={colIdx}
+          palette={palette}
+          width={columnWidth}
+          hasRightBorder={colIdx < columnCount - 1}
+          hasBottomBorder={isHeader || !isLastRow}
+          isHeader={isHeader}
+        >
+          {cell}
+        </TableCell>
+      ))}
+    </View>
+  );
+}
+
+type TableCellProps = {
+  palette: MarkdownPalette;
+  width: number;
+  hasRightBorder: boolean;
+  hasBottomBorder: boolean;
+  isHeader: boolean;
+  children: ReactNode;
+};
+
+function TableCell({
+  palette,
+  width,
+  hasRightBorder,
+  hasBottomBorder,
+  isHeader,
+  children,
+}: TableCellProps) {
+  return (
+    <View
+      className="p-2"
+      // eslint-disable-next-line react-native/no-inline-styles -- dynamic column width and per-variant border color
+      style={{
+        width,
+        borderColor: palette.borderColor,
+        borderRightWidth: hasRightBorder ? 1 : 0,
+        borderBottomWidth: hasBottomBorder ? 1 : 0,
+      }}
+    >
+      <Text
+        selectable
+        className={isHeader ? 'font-bold' : undefined}
+        // eslint-disable-next-line react-native/no-inline-styles -- dynamic per-variant text color
+        style={{ color: palette.textColor }}
+      >
+        {children}
+      </Text>
+    </View>
+  );
+}
+
+export function MarkdownText({ value, variant = 'assistant' }: Readonly<MarkdownTextProps>) {
+  const colorScheme = useColorScheme();
+  const colors = useThemeColors();
+
+  const { styles, renderer, themeColors } = useMemo(() => {
+    const palette = getPalette(variant, colors);
+    return {
+      styles: getMarkdownStyles(palette),
+      renderer: new MarkdownRenderer(palette),
+      themeColors: {
+        text: palette.textColor,
+        code: palette.textColor,
+        link: palette.textColor,
+        border: palette.borderColor,
+      },
+    };
+  }, [variant, colors]);
+
+  const elements = useMarkdown(value, {
+    colorScheme,
+    theme: { colors: themeColors },
+    styles,
+    renderer,
+  });
+
+  return (
+    <View>
+      {elements.map((node, index) => (
+        <Fragment key={getNodeKey(node, index)}>{node}</Fragment>
+      ))}
+    </View>
+  );
+}
+
+// Prefer the element's own key when `react-native-marked` provides one so that
+// streamed updates (token-by-token appends) keep stable identities for nodes
+// that haven't changed.
+function getNodeKey(node: ReactNode, index: number): string | number {
+  if (node && typeof node === 'object' && 'key' in node && node.key != null) {
+    return node.key;
+  }
+  return index;
+}

--- a/apps/mobile/src/components/agents/message-bubble.tsx
+++ b/apps/mobile/src/components/agents/message-bubble.tsx
@@ -4,10 +4,9 @@ import * as Clipboard from 'expo-clipboard';
 import { type StoredMessage } from 'cloud-agent-sdk';
 import { toast } from 'sonner-native';
 
-import { Text } from '@/components/ui/text';
-
 import { CompactionSeparator } from './compaction-separator';
 import { FilePartRenderer } from './file-part-renderer';
+import { MarkdownText } from './markdown-text';
 import { PartRenderer } from './part-renderer';
 import { isFilePart, isTextPart } from './part-types';
 
@@ -75,9 +74,7 @@ export function MessageBubble({
           // eslint-disable-next-line react-native/no-inline-styles -- NativeWind has no className for borderCurve
           style={{ borderCurve: 'continuous' }}
         >
-          {textContent ? (
-            <Text className="text-base leading-6 text-primary-foreground">{textContent}</Text>
-          ) : null}
+          {textContent ? <MarkdownText value={textContent} variant="user" /> : null}
           {fileParts.map(part => (
             <FilePartRenderer key={part.id} part={part} />
           ))}

--- a/apps/mobile/src/components/agents/text-part-renderer.tsx
+++ b/apps/mobile/src/components/agents/text-part-renderer.tsx
@@ -1,59 +1,4 @@
-import { ScrollView, View } from 'react-native';
-
-import { Text } from '@/components/ui/text';
-
-type Segment =
-  | { type: 'text'; content: string }
-  | { type: 'code-block'; content: string; language?: string };
-
-function parseMarkdownSegments(text: string): Segment[] {
-  const segments: Segment[] = [];
-  const codeBlockRegex = /```(\w*)\n([\s\S]*?)```/g;
-  let lastIndex = 0;
-
-  let match = codeBlockRegex.exec(text);
-  while (match !== null) {
-    // Text before the code block
-    if (match.index > lastIndex) {
-      const before = text.slice(lastIndex, match.index).trim();
-      if (before) {
-        segments.push({ type: 'text', content: before });
-      }
-    }
-    segments.push({
-      type: 'code-block',
-      content: match[2] ?? '',
-      language: match[1] ?? undefined,
-    });
-    lastIndex = match.index + match[0].length;
-    match = codeBlockRegex.exec(text);
-  }
-
-  // Remaining text after last code block
-  if (lastIndex < text.length) {
-    const remaining = text.slice(lastIndex).trim();
-    if (remaining) {
-      segments.push({ type: 'text', content: remaining });
-    }
-  }
-
-  return segments;
-}
-
-function CodeBlock({ code, language }: Readonly<{ code: string; language?: string }>) {
-  return (
-    <View className="my-1 overflow-hidden rounded-lg bg-neutral-100 dark:bg-neutral-900">
-      {language ? (
-        <Text className="px-3 pt-2 text-xs text-muted-foreground">{language}</Text>
-      ) : null}
-      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-        <Text selectable className="p-3 font-mono text-sm leading-5 text-foreground">
-          {code}
-        </Text>
-      </ScrollView>
-    </View>
-  );
-}
+import { MarkdownText } from './markdown-text';
 
 type TextPartRendererProps = {
   text: string;
@@ -64,20 +9,5 @@ export function TextPartRenderer({ text }: Readonly<TextPartRendererProps>) {
     return null;
   }
 
-  const segments = parseMarkdownSegments(text);
-
-  return (
-    <View className="gap-1">
-      {segments.map((segment, index) => {
-        if (segment.type === 'code-block') {
-          return <CodeBlock key={index} code={segment.content} language={segment.language} />;
-        }
-        return (
-          <Text key={index} selectable className="text-base leading-6 text-foreground">
-            {segment.content}
-          </Text>
-        );
-      })}
-    </View>
-  );
+  return <MarkdownText value={text} variant="assistant" />;
 }

--- a/apps/mobile/src/lib/hooks/use-theme-colors.ts
+++ b/apps/mobile/src/lib/hooks/use-theme-colors.ts
@@ -31,7 +31,9 @@ const darkColors = {
   card: 'hsl(0, 0%, 3.9%)',
 } as const;
 
-export function useThemeColors() {
+export type ThemeColors = { readonly [K in keyof typeof lightColors]: string };
+
+export function useThemeColors(): ThemeColors {
   const colorScheme = useColorScheme();
   return colorScheme === 'dark' ? darkColors : lightColors;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,9 @@ importers:
       react-native-gesture-handler:
         specifier: ~2.30.0
         version: 2.30.0(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      react-native-marked:
+        specifier: ^8.0.1
+        version: 8.0.1(react-native-svg@15.15.3(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-reanimated:
         specifier: 4.2.1
         version: 4.2.1(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -1461,7 +1464,7 @@ importers:
         version: 7.0.0-dev.20260319.1
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@24.12.0)(esbuild-register@3.6.0(esbuild@0.27.4))
+        version: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -4128,6 +4131,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@jsamr/counter-style@2.0.2':
+    resolution: {integrity: sha512-2mXudGVtSzVxWEA7B9jZLKjoXUeUFYDDtFrQoC0IFX9/Dszz4t1vZOmafi3JSw/FxD+udMQ+4TAFR8Qs0J3URQ==}
+
+  '@jsamr/react-native-li@2.3.1':
+    resolution: {integrity: sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w==}
+    peerDependencies:
+      '@jsamr/counter-style': ^1.0.0 || ^2.0.0
+      react: '*'
+      react-native: '*'
 
   '@kilocode/plugin@7.1.23':
     resolution: {integrity: sha512-sFI0rlgQg3mzYP05/gg09IE1mN4QyAXyOlJjM36CFoVKi1bPYz/dqEqr6ddmMNmB577A4gDu0D07hr0pGIFrBA==}
@@ -10298,6 +10311,9 @@ packages:
     resolution: {integrity: sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==}
     engines: {node: '>=6'}
 
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -11545,6 +11561,11 @@ packages:
   marked@14.0.0:
     resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
     engines: {node: '>= 18'}
+    hasBin: true
+
+  marked@17.0.4:
+    resolution: {integrity: sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   marky@1.3.0:
@@ -12811,6 +12832,20 @@ packages:
   react-native-markdown-package@1.8.2:
     resolution: {integrity: sha512-F3z/p0XfY6Nu9NlXQx1pYcPdz7Y37NRcAKTN+yb9nwRi8BW75mdc3uaBrM13PDVUlL0hbfTL7FuoAdSbsyB5vg==}
 
+  react-native-marked@8.0.1:
+    resolution: {integrity: sha512-lUAM/w9AxY54PP2BKHnDiarJ1+8s9R8HzkjnIrCkZO1fOSAdFn0XsAVMM4fGOP8QM4wIZcJhhvaW/5K7oGy5aQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.6'
+      react-native: '>=0.76.0'
+      react-native-svg: '>=12.3.0'
+
+  react-native-reanimated-table@0.0.2:
+    resolution: {integrity: sha512-OeuqfU1AFEmHNTJlEOLWrV78JgAXnM0/ZrCm0Ab+9e5nwYJ+xab/UFXkNKz3Gyf08ZfLSNzwMQRjt3eZWPWoGA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-native: '>=0.6.0'
+
   react-native-reanimated@4.2.1:
     resolution: {integrity: sha512-/NcHnZMyOvsD/wYXug/YqSKw90P9edN0kEPL5lP4PFf1aQ4F1V7MKe/E0tvfkXKIajy3Qocp5EiEnlcrK/+BZg==}
     peerDependencies:
@@ -13809,6 +13844,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svg-parser@2.0.4:
+    resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
@@ -17655,6 +17693,14 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jsamr/counter-style@2.0.2': {}
+
+  '@jsamr/react-native-li@2.3.1(@jsamr/counter-style@2.0.2)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@jsamr/counter-style': 2.0.2
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
 
   '@kilocode/plugin@7.1.23':
     dependencies:
@@ -24620,6 +24666,8 @@ snapshots:
 
   getenv@2.0.0: {}
 
+  github-slugger@2.0.0: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -25332,6 +25380,25 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-cli@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4)):
+    dependencies:
+      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
+      '@jest/test-result': 30.3.0
+      '@jest/types': 30.3.0
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
   jest-config@29.7.0(@types/node@24.12.0):
     dependencies:
       '@babel/core': 7.29.0
@@ -25983,6 +26050,19 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4)):
+    dependencies:
+      '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.4))
+      '@jest/types': 30.3.0
+      import-local: 3.2.0
+      jest-cli: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
   jimp-compact@0.16.1: {}
 
   jiti@2.6.1: {}
@@ -26377,6 +26457,8 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@14.0.0: {}
+
+  marked@17.0.4: {}
 
   marky@1.3.0: {}
 
@@ -28205,6 +28287,24 @@ snapshots:
       react-native-lightbox: 0.7.0
       simple-markdown: 0.7.3
 
+  react-native-marked@8.0.1(react-native-svg@15.15.3(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@jsamr/counter-style': 2.0.2
+      '@jsamr/react-native-li': 2.3.1(@jsamr/counter-style@2.0.2)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      github-slugger: 2.0.0
+      html-entities: 2.6.0
+      marked: 17.0.4
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native-reanimated-table: 0.0.2(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      react-native-svg: 15.15.3(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      svg-parser: 2.0.4
+
+  react-native-reanimated-table@0.0.2(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+
   react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
@@ -29521,6 +29621,8 @@ snapshots:
       supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svg-parser@2.0.4: {}
 
   synckit@0.11.12:
     dependencies:


### PR DESCRIPTION
## Summary

- Replace the custom code-block parser in `text-part-renderer.tsx` with `react-native-marked`, so assistant messages render full Markdown (headings, lists, inline code, links, tables, etc.) instead of just plain text with fenced code blocks.
- Extract a shared `MarkdownText` component with `assistant` and `user` variants, and use it for user message bubbles too so copy-pasted snippets render consistently on both sides.
- Subclass the library's `Renderer` to keep code blocks monospace/horizontally scrollable and to render tables with a layout that fits inside a chat bubble (horizontal scroll, per-variant borders, sensible column widths).
- Add a `ThemeColors` type exported from `useThemeColors` so the renderer can derive a palette (text/muted/code-bg/border) per variant without duplicating tokens.
- Add `react-native-marked` as a dependency.

## Verification

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-04-21 at 09 44 18" src="https://github.com/user-attachments/assets/3e2cf3c5-d3b8-4a7c-bc39-fea2ffae7e31" />


## Reviewer Notes

- `MarkdownText` uses inline styles for `react-native-marked` (it does not support `className`). Palette colors are derived from `useThemeColors` via a small `withAlpha` helper that converts `hsl(...)` tokens to `hsla(...)`.
- The custom `Renderer` uses `eslint-disable` for `max-params` because the signatures are fixed by the library's `RendererInterface`.
- No backend or schema changes.