### PR TITLE
feat(auth): log email-domain signup patterns

### DIFF
--- a/apps/web/src/lib/user.test.ts
+++ b/apps/web/src/lib/user.test.ts
@@ -189,6 +189,229 @@ describe('User', () => {
       if (result.success) return;
       expect(result.error).toBe('EMAIL-ALREADY-USED');
     });
+
+    it('emits a SECURITY log when a fresh email_domain is first seen', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await createOrUpdateUser(
+        {
+          google_user_email: 'ceo@brand-new-corp.test',
+          google_user_name: 'New Corp CEO',
+          google_user_image_url: 'https://example.com/avatar.png',
+          hosted_domain: null,
+          provider: 'google',
+          provider_account_id: 'google-new-domain',
+        },
+        undefined,
+        false,
+        new Headers({ 'x-forwarded-for': '198.51.102.10' })
+      );
+
+      expect(result.success).toBe(true);
+      const newDomainLog = warnSpy.mock.calls.find(
+        ([msg]) =>
+          typeof msg === 'string' && msg === '[auth] SECURITY: first signup on new email domain'
+      );
+      expect(newDomainLog).toBeDefined();
+      expect(newDomainLog?.[1]).toEqual(
+        expect.objectContaining({
+          email_domain: 'brand-new-corp.test',
+          ip_address: '198.51.102.10',
+        })
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('does NOT emit a new-domain SECURITY log once the domain has an existing account', async () => {
+      await insertTestUser({
+        id: 'seed-existing-domain',
+        google_user_email: 'first@existing-corp.test',
+        normalized_email: 'first@existing-corp.test',
+        email_domain: 'existing-corp.test',
+      });
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await createOrUpdateUser(
+        {
+          google_user_email: 'second@existing-corp.test',
+          google_user_name: 'Second User',
+          google_user_image_url: 'https://example.com/avatar.png',
+          hosted_domain: null,
+          provider: 'google',
+          provider_account_id: 'google-existing-domain',
+        },
+        undefined,
+        false,
+        new Headers({ 'x-forwarded-for': '198.51.103.10' })
+      );
+
+      expect(result.success).toBe(true);
+      const newDomainLog = warnSpy.mock.calls.find(
+        ([msg]) =>
+          typeof msg === 'string' && msg === '[auth] SECURITY: first signup on new email domain'
+      );
+      expect(newDomainLog).toBeUndefined();
+
+      warnSpy.mockRestore();
+    });
+
+    it('does NOT emit a new-domain SECURITY log for exempt consumer-provider domains', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await createOrUpdateUser(
+        {
+          google_user_email: 'someone@gmail.com',
+          google_user_name: 'Gmail User',
+          google_user_image_url: 'https://example.com/avatar.png',
+          hosted_domain: null,
+          provider: 'google',
+          provider_account_id: 'google-gmail-fresh',
+        },
+        undefined,
+        false,
+        new Headers({ 'x-forwarded-for': '198.51.104.10' })
+      );
+
+      expect(result.success).toBe(true);
+      const newDomainLog = warnSpy.mock.calls.find(
+        ([msg]) =>
+          typeof msg === 'string' && msg === '[auth] SECURITY: first signup on new email domain'
+      );
+      expect(newDomainLog).toBeUndefined();
+
+      warnSpy.mockRestore();
+    });
+
+    it('emits a SECURITY log when an email_domain crosses the distinct-hostname threshold', async () => {
+      // Seed 4 existing accounts on 4 distinct hostnames under the same
+      // registrable email_domain.
+      for (let i = 1; i <= 4; i++) {
+        await insertTestUser({
+          id: `hostname-spread-${i}`,
+          google_user_email: `user-${i}@host${i}.spread-corp.test`,
+          normalized_email: `user-${i}@host${i}.spread-corp.test`,
+          email_domain: 'spread-corp.test',
+          signup_ip: `198.51.105.${i}`,
+        });
+      }
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // This 5th signup on a 5th distinct hostname pushes the count to the
+      // threshold.
+      const result = await createOrUpdateUser(
+        {
+          google_user_email: 'user-5@host5.spread-corp.test',
+          google_user_name: 'Spread User 5',
+          google_user_image_url: 'https://example.com/avatar.png',
+          hosted_domain: null,
+          provider: 'google',
+          provider_account_id: 'google-hostname-spread',
+        },
+        undefined,
+        false,
+        new Headers({ 'x-forwarded-for': '198.51.105.222' })
+      );
+
+      expect(result.success).toBe(true);
+      const spreadLog = warnSpy.mock.calls.find(
+        ([msg]) =>
+          typeof msg === 'string' &&
+          msg === '[auth] SECURITY: high distinct-hostname count on email domain'
+      );
+      expect(spreadLog).toBeDefined();
+      expect(spreadLog?.[1]).toEqual(
+        expect.objectContaining({
+          email_domain: 'spread-corp.test',
+        })
+      );
+      expect(spreadLog?.[1]?.distinct_hostnames_24h).toBeGreaterThanOrEqual(5);
+
+      warnSpy.mockRestore();
+    });
+
+    it('does NOT emit a hostname-spread SECURITY log when all signups share one hostname', async () => {
+      // Concentrated legit pattern: many users, one hostname. Must not
+      // trigger the spread signal regardless of volume.
+      for (let i = 1; i <= 30; i++) {
+        await insertTestUser({
+          id: `concentrated-${i}`,
+          google_user_email: `user-${i}@concentrated-corp.test`,
+          normalized_email: `user-${i}@concentrated-corp.test`,
+          email_domain: 'concentrated-corp.test',
+          signup_ip: `198.51.106.${i}`,
+        });
+      }
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await createOrUpdateUser(
+        {
+          google_user_email: 'user-31@concentrated-corp.test',
+          google_user_name: 'Concentrated User 31',
+          google_user_image_url: 'https://example.com/avatar.png',
+          hosted_domain: null,
+          provider: 'google',
+          provider_account_id: 'google-concentrated',
+        },
+        undefined,
+        false,
+        new Headers({ 'x-forwarded-for': '198.51.106.222' })
+      );
+
+      expect(result.success).toBe(true);
+      const spreadLog = warnSpy.mock.calls.find(
+        ([msg]) =>
+          typeof msg === 'string' &&
+          msg === '[auth] SECURITY: high distinct-hostname count on email domain'
+      );
+      expect(spreadLog).toBeUndefined();
+
+      warnSpy.mockRestore();
+    });
+
+    it('does NOT emit a hostname-spread SECURITY log for exempt consumer-provider domains', async () => {
+      // Even if 5+ distinct hostnames happen to sit under an exempt
+      // email_domain bucket, the helper must short-circuit on exempt and
+      // not emit a log (the shared-provider case is uninformative).
+      for (let i = 1; i <= 4; i++) {
+        await insertTestUser({
+          id: `gmail-spread-${i}`,
+          google_user_email: `user-${i}@host${i}.example.com`,
+          normalized_email: `user-${i}@host${i}.example.com`,
+          email_domain: 'gmail.com',
+          signup_ip: `198.51.107.${i}`,
+        });
+      }
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await createOrUpdateUser(
+        {
+          google_user_email: 'user-5@gmail.com',
+          google_user_name: 'Gmail User 5',
+          google_user_image_url: 'https://example.com/avatar.png',
+          hosted_domain: null,
+          provider: 'google',
+          provider_account_id: 'google-gmail-spread',
+        },
+        undefined,
+        false,
+        new Headers({ 'x-forwarded-for': '198.51.107.222' })
+      );
+
+      expect(result.success).toBe(true);
+      const spreadLog = warnSpy.mock.calls.find(
+        ([msg]) =>
+          typeof msg === 'string' &&
+          msg === '[auth] SECURITY: high distinct-hostname count on email domain'
+      );
+      expect(spreadLog).toBeUndefined();
+
+      warnSpy.mockRestore();
+    });
   });
 
   describe('softDeleteUser', () => {

--- a/apps/web/src/lib/user.ts
+++ b/apps/web/src/lib/user.ts
@@ -122,6 +122,68 @@ if (process.env.NEXT_PUBLIC_POSTHOG_DEBUG) {
 const SIGNUP_RATE_LIMIT_MAX = 5;
 const SIGNUP_RATE_LIMIT_WINDOW_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Threshold for the farm-shape signup-pattern SECURITY log. When the
+ * same registrable `email_domain` has signups across this many distinct
+ * email hostnames within the rolling window, emit a log for ops.
+ */
+const EMAIL_DOMAIN_DISTINCT_HOSTNAME_LOG_THRESHOLD = 5;
+
+/**
+ * Registrable domains skipped by the email-domain SECURITY log helpers.
+ * Consumer mailbox providers where a shared domain serves millions of
+ * unrelated mailboxes — any signal keyed on the domain is too noisy to
+ * be useful. The logs are purely for detection on non-exempt domains;
+ * they never block a signup.
+ */
+const EMAIL_DOMAIN_LOG_EXEMPT: ReadonlySet<string> = new Set([
+  // Google consumer
+  'gmail.com',
+  'googlemail.com',
+  // Microsoft consumer
+  'outlook.com',
+  'hotmail.com',
+  'live.com',
+  'msn.com',
+  // Apple
+  'icloud.com',
+  'me.com',
+  'mac.com',
+  // Yahoo family
+  'yahoo.com',
+  'yahoo.co.uk',
+  'yahoo.co.jp',
+  'yahoo.fr',
+  'yahoo.de',
+  'ymail.com',
+  'rocketmail.com',
+  // Proton
+  'proton.me',
+  'protonmail.com',
+  'pm.me',
+  // Other major free providers
+  'aol.com',
+  'gmx.com',
+  'gmx.de',
+  'gmx.net',
+  'web.de',
+  'mail.com',
+  't-online.de',
+  'qq.com',
+  '163.com',
+  '126.com',
+  'sina.com',
+  'yandex.ru',
+  'yandex.com',
+  'mail.ru',
+  'zoho.com',
+  'fastmail.com',
+  'fastmail.fm',
+  'tutanota.com',
+  'tuta.io',
+  'tuta.com',
+]);
+
 function getSignupIp(requestHeaders?: Headers): string | null {
   return requestHeaders?.get('x-forwarded-for')?.split(',')[0]?.trim() || null;
 }
@@ -151,6 +213,81 @@ async function checkSignupIpRateLimit(
   });
 
   return failureResult('SIGNUP-RATE-LIMITED');
+}
+
+/**
+ * Emit a `SECURITY:` log the first time any non-exempt `email_domain`
+ * is seen. Detection-only; never blocks a signup. Best-effort — swallows
+ * errors so a logging failure cannot break signup.
+ */
+async function maybeLogNewEmailDomainSignup(
+  emailDomain: string | null,
+  signupIp: string | null,
+  tx: DrizzleTransaction
+): Promise<void> {
+  if (IS_DEVELOPMENT) return;
+  if (!emailDomain) return;
+  if (EMAIL_DOMAIN_LOG_EXEMPT.has(emailDomain)) return;
+
+  try {
+    const [result] = await tx
+      .select({ count: count() })
+      .from(kilocode_users)
+      .where(eq(kilocode_users.email_domain, emailDomain));
+
+    const lifetimeAccounts = result?.count ?? 0;
+    if (lifetimeAccounts !== 0) return;
+
+    console.warn('[auth] SECURITY: first signup on new email domain', {
+      email_domain: emailDomain,
+      ip_address: signupIp,
+    });
+  } catch (err) {
+    captureException(err, { tags: { source: 'new-email-domain-signup-log' } });
+  }
+}
+
+/**
+ * Emit a `SECURITY:` log when a non-exempt `email_domain` has signups
+ * spanning many distinct email hostnames within the rolling window.
+ * A legitimate custom domain typically concentrates its users under one
+ * (or a small handful of) hostnames; a wide hostname spread is a useful
+ * detection signal for ops. Detection-only; never blocks a signup.
+ * Best-effort — swallows errors so a logging failure cannot break signup.
+ */
+async function maybeLogEmailDomainHostnameSpread(
+  emailDomain: string | null,
+  tx: DrizzleTransaction
+): Promise<void> {
+  if (IS_DEVELOPMENT) return;
+  if (!emailDomain) return;
+  if (EMAIL_DOMAIN_LOG_EXEMPT.has(emailDomain)) return;
+
+  try {
+    const windowStart = new Date(Date.now() - SIGNUP_RATE_LIMIT_WINDOW_MS).toISOString();
+    const [result] = await tx
+      .select({
+        distinctHostnames: sql<number>`COUNT(DISTINCT LOWER(SUBSTRING(${kilocode_users.google_user_email} FROM '@(.+)$')))::int`,
+      })
+      .from(kilocode_users)
+      .where(
+        and(
+          eq(kilocode_users.email_domain, emailDomain),
+          gte(kilocode_users.created_at, windowStart)
+        )
+      );
+
+    const distinctHostnames = result?.distinctHostnames ?? 0;
+    if (distinctHostnames < EMAIL_DOMAIN_DISTINCT_HOSTNAME_LOG_THRESHOLD) return;
+
+    console.warn('[auth] SECURITY: high distinct-hostname count on email domain', {
+      email_domain: emailDomain,
+      distinct_hostnames_24h: distinctHostnames,
+      threshold: EMAIL_DOMAIN_DISTINCT_HOSTNAME_LOG_THRESHOLD,
+    });
+  } catch (err) {
+    captureException(err, { tags: { source: 'email-domain-hostname-spread-log' } });
+  }
 }
 
 async function checkNormalizedEmailUnique(
@@ -399,14 +536,22 @@ export async function createOrUpdateUser(
   let caughtError: unknown;
   try {
     txResult = await db.transaction(async tx => {
-      const signupRateLimitResult = await checkSignupIpRateLimit(signupIp, tx);
-      if (!signupRateLimitResult.success) return signupRateLimitResult;
+      const ipRateLimitResult = await checkSignupIpRateLimit(signupIp, tx);
+      if (!ipRateLimitResult.success) return ipRateLimitResult;
 
       const dedupResult = await checkNormalizedEmailUnique(newUser.normalized_email, tx);
       if (!dedupResult.success) return dedupResult;
 
+      // Flag first-ever sighting of this email_domain. Detection-only.
+      await maybeLogNewEmailDomainSignup(newUser.email_domain, signupIp, tx);
+
       const [inserted] = await tx.insert(kilocode_users).values(newUser).returning();
       assert(inserted, 'Failed to save new user');
+
+      // Flag unusual hostname spread on the email_domain (see the helper
+      // comment for rationale). Runs after the insert so the current
+      // signup counts toward the spread. Detection-only.
+      await maybeLogEmailDomainHostnameSpread(newUser.email_domain, tx);
 
       await tx.insert(user_auth_provider).values({
         kilo_user_id: inserted.id,


### PR DESCRIPTION
## Summary

Adds two SECURITY log lines on the signup path as lead indicators for ops. Both are logs, not blocks — no user-visible behaviour change for any signup.

- `[auth] SECURITY: first signup on new email domain` — fires the first time a non-exempt registrable email domain is seen.
- `[auth] SECURITY: high distinct-hostname count on email domain` — fires when a non-exempt email domain has signups across many distinct email hostnames within the rolling window.

Common consumer mailbox providers are exempt from both (too noisy to be useful).

## Test plan

- \`pnpm run typecheck\`, \`lint\`, \`format:changed\` clean
- \`pnpm test src/lib/user.test.ts\` → 62/62 (6 new/updated tests covering both logs + exempt paths)