### PR TITLE
fix(kiloclaw): handle stuck replacing state and retry start during restart

### DIFF
--- a/services/kiloclaw/src/config.ts
+++ b/services/kiloclaw/src/config.ts
@@ -62,6 +62,10 @@ export const ALARM_INTERVAL_RECOVERING_MS = 60 * 1000; // 1 min
 export const STARTING_TIMEOUT_MS = 5 * 60 * 1000; // 5 min
 /** Maximum time to stay in 'restarting' before surfacing a timeout */
 export const RESTARTING_TIMEOUT_MS = 5 * 60 * 1000; // 5 min
+/** Hard ceiling for 'restarting' — transient Fly states like 'replacing' (image
+ *  pull) can legitimately take 10+ min. After this, give up and transition to
+ *  'stopped' regardless of Fly state. */
+export const RESTARTING_MAX_TIMEOUT_MS = 15 * 60 * 1000; // 15 min
 /** Maximum time to stay in 'recovering' before surfacing a timeout */
 export const RECOVERING_TIMEOUT_MS = 10 * 60 * 1000; // 10 min
 /** Destroying: retry pending deletes quickly */

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -120,6 +120,7 @@ import {
   SELF_HEAL_THRESHOLD,
   STARTING_TIMEOUT_MS,
   RESTARTING_TIMEOUT_MS,
+  RESTARTING_MAX_TIMEOUT_MS,
   RECOVERING_TIMEOUT_MS,
   STALE_PROVISION_THRESHOLD_MS,
 } from '../config';
@@ -7240,6 +7241,78 @@ describe('restartMachine restartingAt guard', () => {
     expect(storage._store.get('lastRestartErrorMessage')).toBe(
       'Restart is taking longer than expected; still reconciling while the machine remains updating'
     );
+  });
+
+  it('transitions to stopped when replacing exceeds max timeout', async () => {
+    const { instance, storage } = createInstance();
+    await seedRestarting(storage, {
+      restartingAt: Date.now() - RESTARTING_MAX_TIMEOUT_MS - 1_000,
+    });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      id: 'machine-1',
+      state: 'replacing',
+      config: { guest: { cpus: 1, memory_mb: 256, cpu_kind: 'shared' } },
+    });
+
+    await instance.alarm();
+
+    expect(storage._store.get('status')).toBe('stopped');
+    expect(storage._store.get('restartingAt')).toBeNull();
+  });
+
+  it('retries startMachine when stopped and restartUpdateSent during restarting', async () => {
+    const { instance, storage } = createInstance();
+    await seedRestarting(storage, {
+      restartUpdateSent: true,
+    });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      id: 'machine-1',
+      state: 'stopped',
+      config: { guest: { cpus: 1, memory_mb: 256, cpu_kind: 'shared' } },
+    });
+    (flyClient.startMachine as Mock).mockResolvedValue(undefined);
+
+    await instance.alarm();
+
+    expect(flyClient.startMachine).toHaveBeenCalledWith(expect.anything(), 'machine-1');
+    expect(storage._store.get('status')).toBe('restarting');
+  });
+
+  it('does not retry startMachine when stopped but restartUpdateSent is false', async () => {
+    const { instance, storage } = createInstance();
+    await seedRestarting(storage);
+
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      id: 'machine-1',
+      state: 'stopped',
+      config: { guest: { cpus: 1, memory_mb: 256, cpu_kind: 'shared' } },
+    });
+
+    await instance.alarm();
+
+    expect(flyClient.startMachine).not.toHaveBeenCalled();
+    expect(storage._store.get('status')).toBe('restarting');
+  });
+
+  it('does not retry startMachine after soft timeout — transitions to stopped', async () => {
+    const { instance, storage } = createInstance();
+    await seedRestarting(storage, {
+      restartUpdateSent: true,
+      restartingAt: Date.now() - RESTARTING_TIMEOUT_MS - 1_000,
+    });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      id: 'machine-1',
+      state: 'stopped',
+      config: { guest: { cpus: 1, memory_mb: 256, cpu_kind: 'shared' } },
+    });
+
+    await instance.alarm();
+
+    expect(flyClient.startMachine).not.toHaveBeenCalled();
+    expect(storage._store.get('status')).toBe('stopped');
   });
 
   it('transitions to stopped on terminal stopped state during restart reconcile', async () => {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
@@ -8,6 +8,7 @@ import {
   STARTUP_TIMEOUT_SECONDS,
   STARTING_TIMEOUT_MS,
   RESTARTING_TIMEOUT_MS,
+  RESTARTING_MAX_TIMEOUT_MS,
   RECOVERING_TIMEOUT_MS,
   getProactiveRefreshThresholdMs,
 } from '../../config';
@@ -526,6 +527,22 @@ async function reconcileRestarting(
       return;
     }
 
+    // The update was applied but the machine is stopped — kick it.
+    // Fly sometimes finishes a 'replacing' cycle in 'stopped' instead of
+    // auto-starting. Retry on each alarm cycle until the soft timeout.
+    if (machine.state === 'stopped' && state.restartUpdateSent && !isTimedOut) {
+      rctx.log('restarting_retry_start', { machine_id: state.flyMachineId });
+      try {
+        await fly.startMachine(flyConfig, state.flyMachineId);
+      } catch (startErr) {
+        rctx.log('restarting_retry_start_failed', {
+          machine_id: state.flyMachineId,
+          error: startErr instanceof Error ? startErr.message : String(startErr),
+        });
+      }
+      return;
+    }
+
     if (!isTimedOut) {
       return;
     }
@@ -540,6 +557,32 @@ async function reconcileRestarting(
     await setRestartError(ctx, state, timeoutMessage);
 
     if (TERMINAL_STOPPED_STATES.has(machine.state)) {
+      state.status = 'stopped';
+      state.restartingAt = null;
+      state.lastStoppedAt = Date.now();
+      state.healthCheckFailCount = 0;
+      await ctx.storage.put(
+        storageUpdate({
+          status: 'stopped',
+          restartingAt: null,
+          lastStoppedAt: state.lastStoppedAt,
+          healthCheckFailCount: 0,
+        })
+      );
+      return;
+    }
+
+    // Hard ceiling for transient states (replacing, updating, etc.) that
+    // can hang indefinitely on Fly. The soft timeout above handles terminal
+    // states; this catches everything else.
+    const isMaxTimedOut =
+      restartingAt !== null && Date.now() - restartingAt > RESTARTING_MAX_TIMEOUT_MS;
+    if (isMaxTimedOut) {
+      rctx.log('restarting_max_timeout', {
+        machine_id: state.flyMachineId,
+        fly_state: machine.state,
+        elapsed_ms: Date.now() - restartingAt,
+      });
       state.status = 'stopped';
       state.restartingAt = null;
       state.lastStoppedAt = Date.now();


### PR DESCRIPTION
## Summary

- **Add 15-minute hard ceiling for transient Fly states during restart** (`RESTARTING_MAX_TIMEOUT_MS`). Previously, if a Fly machine entered `replacing` state (pulling a new Docker image), `reconcileRestarting()` would log timeout warnings every minute but never transition out. One machine was observed stuck in `replacing` for 17+ hours. After 15 minutes, we now transition to `stopped` so the user can retry.

- **Retry `startMachine()` when machine is `stopped` during restart**. After `updateMachine()`, Fly sometimes finishes a `replacing` cycle in `stopped` state instead of auto-starting. Previously reconciliation just polled `getMachine()` without retrying start, waited 5 minutes, then gave up. Now retries `startMachine()` on each alarm cycle (every 60s) while within the 5-minute soft timeout window.

## Root cause investigation

Axiom logs showed two failure patterns across the fleet:
- `restarting_timeout_transient` with `fly_state: "replacing"` and `elapsed_ms` up to 62M ms (17+ hours)
- `restarting_timeout_transient` with `fly_state: "stopped"` and `elapsed_ms` ~300-400s before giving up

The kiloclaw Docker image is large (~2GB: Debian + Node.js 24 + Chromium + Go + OpenClaw + many tools), so cold-cache image pulls on Fly can legitimately take 5-10+ minutes.

## Test plan

- [x] Existing tests pass (1441 kiloclaw tests, 4138 monorepo total)
- [x] New test: `replacing` exceeding max timeout transitions to `stopped`
- [x] New test: `startMachine` retried when stopped + restartUpdateSent
- [x] New test: no retry when restartUpdateSent is false
- [x] New test: no retry after soft timeout — transitions to stopped
- [x] Typecheck, lint, format all pass