### PR TITLE
fix(web): redirect docs domains

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -23,6 +23,43 @@ function validateGitLfs() {
 validateGitLfs();
 
 const monorepoRoot = resolve(import.meta.dirname, '../..');
+const docsRedirectHosts = ['docs.kilo.ai', 'docs.kilocode.ai'];
+
+const docsDomainRedirects = docsRedirectHosts.flatMap(host => [
+  {
+    source: '/',
+    has: [
+      {
+        type: 'host',
+        value: host,
+      },
+    ],
+    destination: 'https://kilo.ai/docs',
+    permanent: true,
+  },
+  {
+    source: '/docs/:path*',
+    has: [
+      {
+        type: 'host',
+        value: host,
+      },
+    ],
+    destination: 'https://kilo.ai/docs/:path*',
+    permanent: true,
+  },
+  {
+    source: '/:path*',
+    has: [
+      {
+        type: 'host',
+        value: host,
+      },
+    ],
+    destination: 'https://kilo.ai/docs/:path*',
+    permanent: true,
+  },
+]);
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -92,28 +129,7 @@ const nextConfig = {
 
   redirects: async () => {
     return [
-      {
-        source: '/:path*',
-        has: [
-          {
-            type: 'host',
-            value: 'docs.kilo.ai',
-          },
-        ],
-        destination: 'https://kilo.ai/docs/:path*',
-        permanent: true,
-      },
-      {
-        source: '/:path*',
-        has: [
-          {
-            type: 'host',
-            value: 'docs.kilocode.ai',
-          },
-        ],
-        destination: 'https://kilo.ai/docs/:path*',
-        permanent: true,
-      },
+      ...docsDomainRedirects,
       {
         source: '/cli/install',
         destination: 'https://raw.githubusercontent.com/Kilo-Org/kilo/refs/heads/dev/install',

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -93,6 +93,28 @@ const nextConfig = {
   redirects: async () => {
     return [
       {
+        source: '/:path*',
+        has: [
+          {
+            type: 'host',
+            value: 'docs.kilo.ai',
+          },
+        ],
+        destination: 'https://kilo.ai/docs/:path*',
+        permanent: true,
+      },
+      {
+        source: '/:path*',
+        has: [
+          {
+            type: 'host',
+            value: 'docs.kilocode.ai',
+          },
+        ],
+        destination: 'https://kilo.ai/docs/:path*',
+        permanent: true,
+      },
+      {
         source: '/cli/install',
         destination: 'https://raw.githubusercontent.com/Kilo-Org/kilo/refs/heads/dev/install',
         permanent: false,


### PR DESCRIPTION
## Summary
- Redirect requests from `docs.kilo.ai` and `docs.kilocode.ai` to the canonical `kilo.ai/docs` path.
- Preserve the original request path under `/docs` so existing docs links continue resolving after the domain migration.

## Verification
- `pnpm typecheck`
- `pnpm format`

## Visual Changes
N/A

## Reviewer Notes
- Host-based redirects are ordered before existing path redirects in `apps/web/next.config.mjs` so docs subdomain traffic is handled first.