### PR TITLE
CloudAgentNext - Add suggest tool support

### DIFF
--- a/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -19,7 +19,7 @@ import { WorkingIndicator } from './WorkingIndicator';
 import { QuestionToolCard } from './QuestionToolCard';
 import { QuestionContextProvider } from './QuestionContext';
 import { PermissionCard, PermissionContextProvider } from './PermissionCard';
-import { SuggestionCard, SuggestionContextProvider } from './SuggestionCard';
+import { SuggestionContextProvider } from './SuggestionCard';
 import { SessionContinuationPanel } from './SessionContinuationPanel';
 import { isMessageStreaming } from './types';
 import { useOrganizationModels } from './hooks/useOrganizationModels';
@@ -435,26 +435,12 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
                         />
                       </div>
                     )}
-                    {activeSuggestion && (
-                      <div className="flex items-center border-t p-4">
-                        <SuggestionCard
-                          key={activeSuggestion.requestId}
-                          requestId={activeSuggestion.requestId}
-                          text={activeSuggestion.text}
-                          actions={activeSuggestion.actions}
-                        />
-                      </div>
-                    )}
-                    <div
-                      className={
-                        activeQuestion || activePermission || activeSuggestion ? 'hidden' : ''
-                      }
-                    >
+                    <div className={activeQuestion || activePermission ? 'hidden' : ''}>
                       <ChatInput
                         onSend={handleSendMessage}
                         onStop={handleStopExecution}
-                        disabled={isStreaming || !canSend}
-                        isStreaming={isStreaming}
+                        disabled={(isStreaming && !activeSuggestion) || !canSend}
+                        isStreaming={isStreaming && !activeSuggestion}
                         placeholder={placeholder}
                         slashCommands={availableCommands}
                         mode={sessionConfig?.mode as AgentMode | undefined}

--- a/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -19,6 +19,7 @@ import { WorkingIndicator } from './WorkingIndicator';
 import { QuestionToolCard } from './QuestionToolCard';
 import { QuestionContextProvider } from './QuestionContext';
 import { PermissionCard, PermissionContextProvider } from './PermissionCard';
+import { SuggestionCard, SuggestionContextProvider } from './SuggestionCard';
 import { SessionContinuationPanel } from './SessionContinuationPanel';
 import { isMessageStreaming } from './types';
 import { useOrganizationModels } from './hooks/useOrganizationModels';
@@ -126,6 +127,7 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
   const cloudStatus = useAtomValue(manager.atoms.cloudStatus);
   const activeQuestion = useAtomValue(manager.atoms.activeQuestion);
   const activePermission = useAtomValue(manager.atoms.activePermission);
+  const activeSuggestion = useAtomValue(manager.atoms.activeSuggestion);
   const failedPrompt = useAtomValue(manager.atoms.failedPrompt);
   const staticMessages = useAtomValue(manager.atoms.staticMessages);
   const dynamicMessages = useAtomValue(manager.atoms.dynamicMessages);
@@ -258,6 +260,16 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
     [manager]
   );
 
+  const handleAcceptSuggestion = useCallback(
+    (requestId: string, index: number) => manager.acceptSuggestion(requestId, index),
+    [manager]
+  );
+
+  const handleDismissSuggestion = useCallback(
+    (requestId: string) => manager.dismissSuggestion(requestId),
+    [manager]
+  );
+
   const handleModeChange = useCallback(
     (mode: AgentMode) => {
       if (sessionConfig) setSessionConfig({ ...sessionConfig, mode });
@@ -341,136 +353,160 @@ export default function CloudChatPage({ organizationId }: CloudChatPageProps) {
         organizationId={organizationId ?? null}
         respondToPermission={handleRespondToPermission}
       >
-        <div className="flex h-full w-full flex-col overflow-hidden">
-          <SetPageTitle
-            title={fetchedSessionData?.title || sessionConfig?.repository || 'Cloud Agent'}
-          >
-            {totalCost > 0 && (
-              <span className="text-muted-foreground text-sm">${totalCost.toFixed(4)}</span>
-            )}
-          </SetPageTitle>
-          {showChatInterface ? (
-            <>
-              {showLoadingIndicator && <div className="bg-primary h-0.5 w-full animate-pulse" />}
+        <SuggestionContextProvider
+          acceptSuggestion={handleAcceptSuggestion}
+          dismissSuggestion={handleDismissSuggestion}
+        >
+          <div className="flex h-full w-full flex-col overflow-hidden">
+            <SetPageTitle
+              title={fetchedSessionData?.title || sessionConfig?.repository || 'Cloud Agent'}
+            >
+              {totalCost > 0 && (
+                <span className="text-muted-foreground text-sm">${totalCost.toFixed(4)}</span>
+              )}
+            </SetPageTitle>
+            {showChatInterface ? (
+              <>
+                {showLoadingIndicator && <div className="bg-primary h-0.5 w-full animate-pulse" />}
 
-              <div className="flex shrink-0 items-center justify-between border-b px-3 py-2 lg:hidden">
-                <MobileSidebarToggle variant="inline" label="Sessions" />
-                {sessionActions}
-              </div>
-
-              <div className="relative min-h-0 flex-1">
-                <div className="absolute right-3 top-2 z-10 hidden lg:block">{sessionActions}</div>
-
-                <div
-                  ref={scrollContainerRef}
-                  className={`absolute inset-0 overflow-y-auto px-[max(1rem,calc(50%_-_27rem))] pb-2 pt-4 transition-opacity duration-150 lg:pt-12 ${showLoadingIndicator ? 'pointer-events-none opacity-40' : 'opacity-100'}`}
-                  onScroll={handleScroll}
-                >
-                  <StaticMessages messages={staticMessages} getChildMessages={getChildMessages} />
-                  <DynamicMessages messages={dynamicMessages} getChildMessages={getChildMessages} />
-
-                  <WorkingIndicator messages={dynamicMessages} isStreaming={isStreaming} />
-                  {statusIndicator && <SessionStatusIndicator indicator={statusIndicator} />}
-
-                  <div ref={messagesEndRef} />
+                <div className="flex shrink-0 items-center justify-between border-b px-3 py-2 lg:hidden">
+                  <MobileSidebarToggle variant="inline" label="Sessions" />
+                  {sessionActions}
                 </div>
 
-                {showScrollButton && (
-                  <button
-                    type="button"
-                    onClick={scrollToBottom}
-                    className="border-border bg-background absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full border p-2 shadow-md"
-                  >
-                    <ArrowDown className="h-4 w-4" />
-                  </button>
-                )}
-              </div>
+                <div className="relative min-h-0 flex-1">
+                  <div className="absolute right-3 top-2 z-10 hidden lg:block">
+                    {sessionActions}
+                  </div>
 
-              {isReadOnly ? (
-                !isLoading && sessionIdFromParams && fetchedSessionData ? (
-                  <SessionContinuationPanel sessionId={sessionIdFromParams} />
-                ) : null
-              ) : (
-                <>
-                  {activeQuestion && (
-                    <div className="border-t px-[max(1rem,calc(50%_-_27rem))] py-4">
-                      <QuestionToolCard
-                        key={activeQuestion.requestId}
-                        questions={activeQuestion.questions}
-                        requestId={activeQuestion.requestId}
-                        status="running"
-                      />
-                    </div>
-                  )}
-                  {activePermission && (
-                    <div className="flex items-center border-t p-4">
-                      <PermissionCard
-                        key={activePermission.requestId}
-                        requestId={activePermission.requestId}
-                        permission={activePermission.permission}
-                        patterns={activePermission.patterns}
-                        metadata={activePermission.metadata}
-                        always={activePermission.always}
-                      />
-                    </div>
-                  )}
-                  <div className={activeQuestion || activePermission ? 'hidden' : ''}>
-                    <ChatInput
-                      onSend={handleSendMessage}
-                      onStop={handleStopExecution}
-                      disabled={isStreaming || !canSend}
-                      isStreaming={isStreaming}
-                      placeholder={placeholder}
-                      slashCommands={availableCommands}
-                      mode={sessionConfig?.mode as AgentMode | undefined}
-                      model={sessionConfig?.model}
-                      modelOptions={modelOptions}
-                      isLoadingModels={isLoadingModels}
-                      onModeChange={handleModeChange}
-                      onModelChange={handleModelChange}
-                      variant={sessionConfig?.variant ?? undefined}
-                      onVariantChange={handleVariantChange}
-                      availableVariants={availableVariants}
-                      showToolbar={Boolean(sessionIdFromParams)}
-                      initialValue={failedPrompt ?? undefined}
-                      imageUploadOptions={{
-                        messageUuid: imageMessageUuid,
-                        organizationId,
-                        maxImages: CLOUD_AGENT_IMAGE_MAX_COUNT,
-                        maxOriginalFileSizeBytes: CLOUD_AGENT_IMAGE_MAX_ORIGINAL_SIZE_BYTES,
-                        maxFileSizeBytes: CLOUD_AGENT_IMAGE_MAX_SIZE_BYTES,
-                        allowedTypes: CLOUD_AGENT_IMAGE_ALLOWED_TYPES,
-                        resizeImages: { maxDimensionPx: CLOUD_AGENT_IMAGE_MAX_DIMENSION_PX },
-                        getUploadUrl: {
-                          personal: personalUploadUrl,
-                          organization: orgUploadUrl,
-                        },
-                      }}
+                  <div
+                    ref={scrollContainerRef}
+                    className={`absolute inset-0 overflow-y-auto px-[max(1rem,calc(50%_-_27rem))] pb-2 pt-4 transition-opacity duration-150 lg:pt-12 ${showLoadingIndicator ? 'pointer-events-none opacity-40' : 'opacity-100'}`}
+                    onScroll={handleScroll}
+                  >
+                    <StaticMessages messages={staticMessages} getChildMessages={getChildMessages} />
+                    <DynamicMessages
+                      messages={dynamicMessages}
+                      getChildMessages={getChildMessages}
                     />
-                    {sessionConfig?.repository && (
-                      <div className="text-muted-foreground flex items-center gap-1.5 px-[max(1rem,calc(50%_-_27rem))] pb-3 text-xs md:pb-4">
-                        <GitBranch className="h-3 w-3 shrink-0" />
-                        <span className="truncate">{sessionConfig.repository}</span>
-                        {fetchedSessionData?.gitBranch && (
-                          <>
-                            <span>·</span>
-                            <span className="truncate">{fetchedSessionData.gitBranch}</span>
-                          </>
-                        )}
+
+                    <WorkingIndicator messages={dynamicMessages} isStreaming={isStreaming} />
+                    {statusIndicator && <SessionStatusIndicator indicator={statusIndicator} />}
+
+                    <div ref={messagesEndRef} />
+                  </div>
+
+                  {showScrollButton && (
+                    <button
+                      type="button"
+                      onClick={scrollToBottom}
+                      className="border-border bg-background absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full border p-2 shadow-md"
+                    >
+                      <ArrowDown className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
+
+                {isReadOnly ? (
+                  !isLoading && sessionIdFromParams && fetchedSessionData ? (
+                    <SessionContinuationPanel sessionId={sessionIdFromParams} />
+                  ) : null
+                ) : (
+                  <>
+                    {activeQuestion && (
+                      <div className="border-t px-[max(1rem,calc(50%_-_27rem))] py-4">
+                        <QuestionToolCard
+                          key={activeQuestion.requestId}
+                          questions={activeQuestion.questions}
+                          requestId={activeQuestion.requestId}
+                          status="running"
+                        />
                       </div>
                     )}
-                  </div>
-                </>
-              )}
-            </>
-          ) : (
-            <div className="text-muted-foreground relative flex h-full flex-col items-center justify-center gap-2">
-              <MobileSidebarToggle />
-              <p className="text-sm">No active session</p>
-              <p className="text-xs">Select a session from the sidebar or create a new one</p>
-            </div>
-          )}
-        </div>
+                    {activePermission && (
+                      <div className="flex items-center border-t p-4">
+                        <PermissionCard
+                          key={activePermission.requestId}
+                          requestId={activePermission.requestId}
+                          permission={activePermission.permission}
+                          patterns={activePermission.patterns}
+                          metadata={activePermission.metadata}
+                          always={activePermission.always}
+                        />
+                      </div>
+                    )}
+                    {activeSuggestion && (
+                      <div className="flex items-center border-t p-4">
+                        <SuggestionCard
+                          key={activeSuggestion.requestId}
+                          requestId={activeSuggestion.requestId}
+                          text={activeSuggestion.text}
+                          actions={activeSuggestion.actions}
+                        />
+                      </div>
+                    )}
+                    <div
+                      className={
+                        activeQuestion || activePermission || activeSuggestion ? 'hidden' : ''
+                      }
+                    >
+                      <ChatInput
+                        onSend={handleSendMessage}
+                        onStop={handleStopExecution}
+                        disabled={isStreaming || !canSend}
+                        isStreaming={isStreaming}
+                        placeholder={placeholder}
+                        slashCommands={availableCommands}
+                        mode={sessionConfig?.mode as AgentMode | undefined}
+                        model={sessionConfig?.model}
+                        modelOptions={modelOptions}
+                        isLoadingModels={isLoadingModels}
+                        onModeChange={handleModeChange}
+                        onModelChange={handleModelChange}
+                        variant={sessionConfig?.variant ?? undefined}
+                        onVariantChange={handleVariantChange}
+                        availableVariants={availableVariants}
+                        showToolbar={Boolean(sessionIdFromParams)}
+                        initialValue={failedPrompt ?? undefined}
+                        imageUploadOptions={{
+                          messageUuid: imageMessageUuid,
+                          organizationId,
+                          maxImages: CLOUD_AGENT_IMAGE_MAX_COUNT,
+                          maxOriginalFileSizeBytes: CLOUD_AGENT_IMAGE_MAX_ORIGINAL_SIZE_BYTES,
+                          maxFileSizeBytes: CLOUD_AGENT_IMAGE_MAX_SIZE_BYTES,
+                          allowedTypes: CLOUD_AGENT_IMAGE_ALLOWED_TYPES,
+                          resizeImages: { maxDimensionPx: CLOUD_AGENT_IMAGE_MAX_DIMENSION_PX },
+                          getUploadUrl: {
+                            personal: personalUploadUrl,
+                            organization: orgUploadUrl,
+                          },
+                        }}
+                      />
+                      {sessionConfig?.repository && (
+                        <div className="text-muted-foreground flex items-center gap-1.5 px-[max(1rem,calc(50%_-_27rem))] pb-3 text-xs md:pb-4">
+                          <GitBranch className="h-3 w-3 shrink-0" />
+                          <span className="truncate">{sessionConfig.repository}</span>
+                          {fetchedSessionData?.gitBranch && (
+                            <>
+                              <span>·</span>
+                              <span className="truncate">{fetchedSessionData.gitBranch}</span>
+                            </>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </>
+                )}
+              </>
+            ) : (
+              <div className="text-muted-foreground relative flex h-full flex-col items-center justify-center gap-2">
+                <MobileSidebarToggle />
+                <p className="text-sm">No active session</p>
+                <p className="text-xs">Select a session from the sidebar or create a new one</p>
+              </div>
+            )}
+          </div>
+        </SuggestionContextProvider>
       </PermissionContextProvider>
     </QuestionContextProvider>
   );

--- a/apps/web/src/components/cloud-agent-next/PartRenderer.tsx
+++ b/apps/web/src/components/cloud-agent-next/PartRenderer.tsx
@@ -16,6 +16,7 @@ import { GenericToolCard } from './GenericToolCard';
 import { TodoReadToolCard } from './TodoReadToolCard';
 import { TodoWriteToolCard } from './TodoWriteToolCard';
 import { QuestionToolStatus } from './QuestionToolStatus';
+import { SuggestToolCard } from './SuggestToolCard';
 import { ChildSessionSection, getTaskToolSessionId } from './ChildSessionSection';
 import type { RenderPartFn } from './ChildSessionSection';
 import { useState } from 'react';
@@ -115,6 +116,7 @@ function hasRequiredInput(part: Extract<Part, { type: 'tool' }>): boolean {
     case 'todoread':
     case 'todowrite':
     case 'question':
+    case 'suggest':
       // These tools can render without specific input or handle empty arrays gracefully
       return true;
     default:
@@ -239,6 +241,12 @@ function ToolPartRenderer({
   // Question tool — read-only status in message stream (interactive UI is in the dock)
   if (part.tool === 'question') {
     return <QuestionToolStatus toolPart={part} />;
+  }
+
+  // Suggest tool — interactive card rendered inline (no dock), so the text
+  // input stays available for the user to send messages in parallel.
+  if (part.tool === 'suggest') {
+    return <SuggestToolCard toolPart={part} />;
   }
 
   return <GenericToolCard toolPart={part} />;

--- a/apps/web/src/components/cloud-agent-next/SuggestToolCard.tsx
+++ b/apps/web/src/components/cloud-agent-next/SuggestToolCard.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useAtomValue } from 'jotai';
+import { Sparkles } from 'lucide-react';
+
+import { useManager } from './CloudAgentProvider';
+import { SuggestionCard } from './SuggestionCard';
+import { ToolCardShell } from './ToolCardShell';
+import type { ToolPart } from './types';
+
+/**
+ * Inline renderer for the `suggest` tool.
+ *
+ * While the tool is awaiting a user response, the interactive SuggestionCard
+ * is rendered in-place using data from the activeSuggestion atom. This keeps
+ * the card visually anchored to the tool call in the message stream and
+ * leaves the text input free for the user to send messages in parallel.
+ *
+ * Once the suggestion has been accepted or dismissed, a compact summary card
+ * replaces the interactive UI.
+ */
+export function SuggestToolCard({ toolPart }: { toolPart: ToolPart }) {
+  const { state } = toolPart;
+  const manager = useManager();
+  const activeSuggestion = useAtomValue(manager.atoms.activeSuggestion);
+
+  const isPending = state.status === 'pending' || state.status === 'running';
+
+  if (isPending && activeSuggestion) {
+    return (
+      <SuggestionCard
+        requestId={activeSuggestion.requestId}
+        text={activeSuggestion.text}
+        actions={activeSuggestion.actions}
+      />
+    );
+  }
+
+  // Resolved states (or pending without a loaded activeSuggestion) — compact summary.
+  const subtitle = state.status === 'error' ? 'Suggestion dismissed' : 'Suggestion';
+  return (
+    <ToolCardShell icon={Sparkles} title="Suggestion" subtitle={subtitle} status={state.status} />
+  );
+}

--- a/apps/web/src/components/cloud-agent-next/SuggestToolCard.tsx
+++ b/apps/web/src/components/cloud-agent-next/SuggestToolCard.tsx
@@ -16,6 +16,10 @@ import type { ToolPart } from './types';
  * the card visually anchored to the tool call in the message stream and
  * leaves the text input free for the user to send messages in parallel.
  *
+ * The card is only rendered when activeSuggestion.callId matches this tool
+ * part's callID, so older pending suggest calls in the history don't repaint
+ * with the newest suggestion's text/actions.
+ *
  * Once the suggestion has been accepted or dismissed, a compact summary card
  * replaces the interactive UI.
  */
@@ -25,8 +29,10 @@ export function SuggestToolCard({ toolPart }: { toolPart: ToolPart }) {
   const activeSuggestion = useAtomValue(manager.atoms.activeSuggestion);
 
   const isPending = state.status === 'pending' || state.status === 'running';
+  const isActiveForThisCall =
+    activeSuggestion?.callId !== undefined && activeSuggestion.callId === toolPart.callID;
 
-  if (isPending && activeSuggestion) {
+  if (isPending && activeSuggestion && isActiveForThisCall) {
     return (
       <SuggestionCard
         requestId={activeSuggestion.requestId}
@@ -36,7 +42,7 @@ export function SuggestToolCard({ toolPart }: { toolPart: ToolPart }) {
     );
   }
 
-  // Resolved states (or pending without a loaded activeSuggestion) — compact summary.
+  // Resolved states (or pending without a matching activeSuggestion) — compact summary.
   const subtitle = state.status === 'error' ? 'Suggestion dismissed' : 'Suggestion';
   return (
     <ToolCardShell icon={Sparkles} title="Suggestion" subtitle={subtitle} status={state.status} />

--- a/apps/web/src/components/cloud-agent-next/SuggestionCard.tsx
+++ b/apps/web/src/components/cloud-agent-next/SuggestionCard.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState, useCallback, createContext, useContext, useMemo, type ReactNode } from 'react';
+
+import { Sparkles, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import type { SuggestionAction } from '@/lib/cloud-agent-sdk';
+
+// ---------------------------------------------------------------------------
+// SuggestionContext — mirrors PermissionContext pattern
+// ---------------------------------------------------------------------------
+
+type SuggestionContextValue = {
+  /** When set, SuggestionCard routes through the session manager. */
+  acceptSuggestion?: (requestId: string, index: number) => Promise<void>;
+  dismissSuggestion?: (requestId: string) => Promise<void>;
+};
+
+const SuggestionContext = createContext<SuggestionContextValue>({});
+
+function useSuggestionContext(): SuggestionContextValue {
+  return useContext(SuggestionContext);
+}
+
+type SuggestionContextProviderProps = SuggestionContextValue & {
+  children: ReactNode;
+};
+
+export function SuggestionContextProvider({
+  acceptSuggestion,
+  dismissSuggestion,
+  children,
+}: SuggestionContextProviderProps) {
+  const value = useMemo(
+    () => ({ acceptSuggestion, dismissSuggestion }),
+    [acceptSuggestion, dismissSuggestion]
+  );
+  return <SuggestionContext.Provider value={value}>{children}</SuggestionContext.Provider>;
+}
+
+// ---------------------------------------------------------------------------
+// SuggestionCard
+// ---------------------------------------------------------------------------
+
+type SuggestionCardProps = {
+  requestId: string;
+  text: string;
+  actions: SuggestionAction[];
+};
+
+type PendingState = { kind: 'accept'; index: number } | { kind: 'dismiss' };
+
+export function SuggestionCard({ requestId, text, actions }: SuggestionCardProps) {
+  const [pending, setPending] = useState<PendingState | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { acceptSuggestion, dismissSuggestion } = useSuggestionContext();
+
+  const onAccept = useCallback(
+    async (index: number) => {
+      if (pending) return;
+      if (!acceptSuggestion) {
+        console.warn(
+          'SuggestionCard: no acceptSuggestion handler in context — wrap the card in <SuggestionContextProvider>.'
+        );
+        setError('Suggestion handler not configured');
+        return;
+      }
+      setPending({ kind: 'accept', index });
+      setError(null);
+      try {
+        await acceptSuggestion(requestId, index);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to accept suggestion');
+        setPending(null);
+      }
+    },
+    [pending, acceptSuggestion, requestId]
+  );
+
+  const onDismiss = useCallback(async () => {
+    if (pending) return;
+    if (!dismissSuggestion) {
+      console.warn(
+        'SuggestionCard: no dismissSuggestion handler in context — wrap the card in <SuggestionContextProvider>.'
+      );
+      setError('Suggestion handler not configured');
+      return;
+    }
+    setPending({ kind: 'dismiss' });
+    setError(null);
+    try {
+      await dismissSuggestion(requestId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to dismiss suggestion');
+      setPending(null);
+    }
+  }, [pending, dismissSuggestion, requestId]);
+
+  return (
+    <div className="bg-muted/30 w-full max-w-lg rounded-md border border-l-4 border-blue-500/40">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-2">
+        <Sparkles className="h-4 w-4 shrink-0 text-blue-500" />
+        <span className="text-sm font-medium">Suggestion</span>
+      </div>
+
+      <div className="border-muted space-y-3 border-t px-3 py-2">
+        <div className="text-sm">{text}</div>
+
+        {error && <div className="text-xs text-red-500">{error}</div>}
+
+        {/* Action buttons — one per suggested action, plus a Dismiss */}
+        <div className="flex flex-wrap items-center gap-2">
+          {actions.map((action, index) => {
+            const isPending = pending?.kind === 'accept' && pending.index === index;
+            return (
+              <Button
+                key={`${action.label}-${index}`}
+                size="sm"
+                onClick={() => {
+                  void onAccept(index);
+                }}
+                disabled={pending !== null}
+                title={action.description}
+                className={cn(
+                  'gap-1.5',
+                  !isPending && 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500'
+                )}
+              >
+                {isPending && <Loader2 className="h-3 w-3 animate-spin" />}
+                {action.label}
+              </Button>
+            );
+          })}
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => {
+              void onDismiss();
+            }}
+            disabled={pending !== null}
+            className="gap-1.5"
+          >
+            {pending?.kind === 'dismiss' && <Loader2 className="h-3 w-3 animate-spin" />}
+            Dismiss
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/cloud-agent-next/SuggestionCard.tsx
+++ b/apps/web/src/components/cloud-agent-next/SuggestionCard.tsx
@@ -99,7 +99,7 @@ export function SuggestionCard({ requestId, text, actions }: SuggestionCardProps
   }, [pending, dismissSuggestion, requestId]);
 
   return (
-    <div className="bg-muted/30 w-full max-w-lg rounded-md border border-l-4 border-blue-500/40">
+    <div className="bg-muted/30 w-full rounded-md border border-l-4 border-blue-500/40">
       {/* Header */}
       <div className="flex items-center gap-2 px-3 py-2">
         <Sparkles className="h-4 w-4 shrink-0 text-blue-500" />

--- a/apps/web/src/lib/cloud-agent-sdk/cli-live-transport.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cli-live-transport.test.ts
@@ -708,6 +708,46 @@ describe('CliLiveTransport typed command methods', () => {
     return promise;
   });
 
+  it('acceptSuggestion() sends suggestion_accept command with requestID and index', () => {
+    const { transport } = createTransportWithSinks();
+
+    transport.connect();
+    openConnection();
+    mockWs.send.mockClear();
+
+    const promise = transport.acceptSuggestion!({ requestId: 'sug-1', index: 1 });
+
+    const sent = JSON.parse(mockWs.send.mock.calls[0][0]) as {
+      command: string;
+      data: Record<string, unknown>;
+    };
+    expect(sent.command).toBe('suggestion_accept');
+    expect(sent.data).toEqual({ requestID: 'sug-1', index: 1 });
+
+    sendInbound({ type: 'response', id: 'mock-uuid-1234', result: {} });
+    return promise;
+  });
+
+  it('dismissSuggestion() sends suggestion_dismiss command with requestID', () => {
+    const { transport } = createTransportWithSinks();
+
+    transport.connect();
+    openConnection();
+    mockWs.send.mockClear();
+
+    const promise = transport.dismissSuggestion!({ requestId: 'sug-2' });
+
+    const sent = JSON.parse(mockWs.send.mock.calls[0][0]) as {
+      command: string;
+      data: Record<string, unknown>;
+    };
+    expect(sent.command).toBe('suggestion_dismiss');
+    expect(sent.data).toEqual({ requestID: 'sug-2' });
+
+    sendInbound({ type: 'response', id: 'mock-uuid-1234', result: {} });
+    return promise;
+  });
+
   it('resolves when response arrives', async () => {
     const { transport } = createTransportWithSinks();
 

--- a/apps/web/src/lib/cloud-agent-sdk/cli-live-transport.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cli-live-transport.ts
@@ -290,6 +290,15 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
           requestID: payload.requestId,
           reply: payload.response,
         }),
+      acceptSuggestion: (payload: { requestId: string; index: number }) =>
+        rawSendCommand('suggestion_accept', {
+          requestID: payload.requestId,
+          index: payload.index,
+        }),
+      dismissSuggestion: (payload: { requestId: string }) =>
+        rawSendCommand('suggestion_dismiss', {
+          requestID: payload.requestId,
+        }),
 
       disconnect() {
         generation += 1;

--- a/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.test.ts
@@ -193,6 +193,30 @@ describe('CloudAgentTransport event routing', () => {
 
     transport.destroy();
   });
+
+  it('drops suggestion events since cloud-agent has no accept/dismiss command path', async () => {
+    const { transport, chatEvents, serviceEvents } = createTransportWithSinks();
+
+    transport.connect();
+    await flushPromises();
+
+    const serviceCountBefore = serviceEvents.length;
+
+    sendRaw(
+      kilocode('suggestion.shown', {
+        id: 'sug-1',
+        text: 'review your changes',
+        actions: [{ label: 'review', prompt: '/review' }],
+      })
+    );
+    sendRaw(kilocode('suggestion.accepted', { requestID: 'sug-1', index: 0 }));
+    sendRaw(kilocode('suggestion.dismissed', { requestID: 'sug-1' }));
+
+    expect(serviceEvents).toHaveLength(serviceCountBefore);
+    expect(chatEvents).toHaveLength(0);
+
+    transport.destroy();
+  });
 });
 
 describe('CloudAgentTransport unexpected disconnect', () => {

--- a/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/cloud-agent-transport.ts
@@ -88,6 +88,17 @@ function createCloudAgentTransport(config: CloudAgentTransportConfig): Transport
           const event = normalize(raw);
           if (!event) return;
 
+          // Cloud Agent sessions have no command path for accepting or
+          // dismissing suggestions, so drop these events before they reach the
+          // sink — otherwise the UI would render a card whose buttons throw.
+          if (
+            event.type === 'suggestion.shown' ||
+            event.type === 'suggestion.accepted' ||
+            event.type === 'suggestion.dismissed'
+          ) {
+            return;
+          }
+
           if (event.type === 'stopped') {
             stoppedReceived = true;
           }

--- a/apps/web/src/lib/cloud-agent-sdk/index.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/index.ts
@@ -7,6 +7,7 @@ export type {
   SessionConfig,
   StandalonePermission,
   StandaloneQuestion,
+  StandaloneSuggestion,
   StoredMessage,
   FetchedSessionData,
   PrepareInput,
@@ -15,8 +16,10 @@ export type {
 export { createCloudAgentSession } from './session';
 export type {
   CloudAgentSession,
+  CloudAgentSessionAcceptSuggestionInput,
   CloudAgentSessionAnswerInput,
   CloudAgentSessionConfig,
+  CloudAgentSessionDismissSuggestionInput,
   CloudAgentSessionRejectInput,
   CloudAgentSessionRespondToPermissionInput,
   CloudAgentSessionSendInput,
@@ -83,6 +86,8 @@ export type {
   CloudStatus,
   QuestionState,
   PermissionState,
+  SuggestionAction,
+  SuggestionState,
   ServiceStateSnapshot,
   SessionInfo,
   KiloSessionId,

--- a/apps/web/src/lib/cloud-agent-sdk/normalizer.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/normalizer.test.ts
@@ -727,6 +727,110 @@ describe('normalize', () => {
     });
   });
 
+  describe('suggestion.shown', () => {
+    it('normalizes suggestion.shown with all fields', () => {
+      const data = {
+        id: 'sug-1',
+        sessionID: 'ses-1',
+        text: 'Would you like to run a code review?',
+        actions: [
+          {
+            label: 'Review uncommitted',
+            description: 'Run /local-review-uncommitted',
+            prompt: '/local-review-uncommitted',
+          },
+          { label: 'Review branch', prompt: '/local-review' },
+        ],
+        tool: { messageID: 'msg-1', callID: 'call-1' },
+      };
+      const result = normalize(createKilocode('suggestion.shown', data));
+      expect(result).toEqual({
+        type: 'suggestion.shown',
+        requestId: 'sug-1',
+        text: 'Would you like to run a code review?',
+        actions: [
+          {
+            label: 'Review uncommitted',
+            description: 'Run /local-review-uncommitted',
+            prompt: '/local-review-uncommitted',
+          },
+          { label: 'Review branch', prompt: '/local-review' },
+        ],
+      });
+    });
+
+    it('defaults actions to empty array when missing', () => {
+      const data = { id: 'sug-2', text: 'Any follow-up?' };
+      const result = normalize(createRaw('suggestion.shown', data));
+      expect(result).toEqual({
+        type: 'suggestion.shown',
+        requestId: 'sug-2',
+        text: 'Any follow-up?',
+        actions: [],
+      });
+    });
+
+    it('returns null when id is missing', () => {
+      expect(normalize(createRaw('suggestion.shown', { text: 'hi', actions: [] }))).toBeNull();
+    });
+
+    it('returns null when text is missing', () => {
+      expect(normalize(createRaw('suggestion.shown', { id: 'sug-3', actions: [] }))).toBeNull();
+    });
+  });
+
+  describe('suggestion.accepted', () => {
+    it('normalizes suggestion.accepted with action', () => {
+      const data = {
+        requestID: 'sug-1',
+        index: 0,
+        action: { label: 'Review', prompt: '/local-review' },
+      };
+      const result = normalize(createRaw('suggestion.accepted', data));
+      expect(result).toEqual({
+        type: 'suggestion.accepted',
+        requestId: 'sug-1',
+        index: 0,
+        action: { label: 'Review', prompt: '/local-review' },
+      });
+    });
+
+    it('normalizes suggestion.accepted without action', () => {
+      const data = { requestID: 'sug-2', index: 1 };
+      const result = normalize(createRaw('suggestion.accepted', data));
+      expect(result).toEqual({
+        type: 'suggestion.accepted',
+        requestId: 'sug-2',
+        index: 1,
+        action: undefined,
+      });
+    });
+
+    it('returns null when requestID is missing', () => {
+      expect(normalize(createRaw('suggestion.accepted', { index: 0 }))).toBeNull();
+    });
+
+    it('returns null when index is not a number', () => {
+      expect(
+        normalize(createRaw('suggestion.accepted', { requestID: 'sug-1', index: 'zero' }))
+      ).toBeNull();
+    });
+  });
+
+  describe('suggestion.dismissed', () => {
+    it('normalizes suggestion.dismissed', () => {
+      const result = normalize(createRaw('suggestion.dismissed', { requestID: 'sug-1' }));
+      expect(result).toEqual({
+        type: 'suggestion.dismissed',
+        requestId: 'sug-1',
+      });
+    });
+
+    it('returns null when requestID is missing', () => {
+      expect(normalize(createRaw('suggestion.dismissed', {}))).toBeNull();
+    });
+  });
+
   describe('complete → stopped(complete)', () => {
     it('maps to stopped with reason complete and branch', () => {
       const result = normalize(createRaw('complete', { currentBranch: 'main' }));

--- a/apps/web/src/lib/cloud-agent-sdk/normalizer.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/normalizer.test.ts
@@ -756,6 +756,7 @@ describe('normalize', () => {
           },
           { label: 'Review branch', prompt: '/local-review' },
         ],
+        callId: 'call-1',
       });
     });
 
@@ -767,6 +768,7 @@ describe('normalize', () => {
         requestId: 'sug-2',
         text: 'Any follow-up?',
         actions: [],
+        callId: undefined,
       });
     });
 

--- a/apps/web/src/lib/cloud-agent-sdk/normalizer.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/normalizer.ts
@@ -84,6 +84,8 @@ export type ServiceEvent =
       requestId: string;
       text: string;
       actions: SuggestionAction[];
+      /** Tool call ID that emitted this suggestion, when available. */
+      callId?: string;
     }
   | { type: 'suggestion.accepted'; requestId: string; index: number; action?: SuggestionAction }
   | { type: 'suggestion.dismissed'; requestId: string }
@@ -287,6 +289,7 @@ function normalizeInnerEvent(eventType: string, data: unknown): NormalizedEvent 
         requestId: r.data.id,
         text: r.data.text,
         actions: r.data.actions,
+        callId: r.data.tool?.callID,
       };
     }
 

--- a/apps/web/src/lib/cloud-agent-sdk/normalizer.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/normalizer.ts
@@ -4,7 +4,7 @@
  * boundary `as` casts so downstream code receives properly typed NormalizedEvents.
  */
 import type { Part, SessionStatus, QuestionInfo, Message } from '@/types/opencode.gen';
-import type { SessionInfo, CloudStatus } from './types';
+import type { SessionInfo, CloudStatus, SuggestionAction } from './types';
 import {
   cloudAgentEventSchema,
   kilocodePayloadSchema,
@@ -23,6 +23,9 @@ import {
   questionRejectedDataSchema,
   permissionAskedDataSchema,
   permissionRepliedDataSchema,
+  suggestionShownDataSchema,
+  suggestionAcceptedDataSchema,
+  suggestionDismissedDataSchema,
   completeDataSchema,
   errorDataSchema,
   preparingDataSchema,
@@ -76,6 +79,14 @@ export type ServiceEvent =
       always: string[];
     }
   | { type: 'permission.replied'; requestId: string }
+  | {
+      type: 'suggestion.shown';
+      requestId: string;
+      text: string;
+      actions: SuggestionAction[];
+    }
+  | { type: 'suggestion.accepted'; requestId: string; index: number; action?: SuggestionAction }
+  | { type: 'suggestion.dismissed'; requestId: string }
   | {
       type: 'stopped';
       reason: 'complete' | 'interrupted' | 'disconnected' | 'error';
@@ -266,6 +277,34 @@ function normalizeInnerEvent(eventType: string, data: unknown): NormalizedEvent 
       const r = permissionRepliedDataSchema.safeParse(data);
       if (!r.success) return null;
       return { type: 'permission.replied', requestId: r.data.requestID };
+    }
+
+    case 'suggestion.shown': {
+      const r = suggestionShownDataSchema.safeParse(data);
+      if (!r.success) return null;
+      return {
+        type: 'suggestion.shown',
+        requestId: r.data.id,
+        text: r.data.text,
+        actions: r.data.actions,
+      };
+    }
+
+    case 'suggestion.accepted': {
+      const r = suggestionAcceptedDataSchema.safeParse(data);
+      if (!r.success) return null;
+      return {
+        type: 'suggestion.accepted',
+        requestId: r.data.requestID,
+        index: r.data.index,
+        action: r.data.action,
+      };
+    }
+
+    case 'suggestion.dismissed': {
+      const r = suggestionDismissedDataSchema.safeParse(data);
+      if (!r.success) return null;
+      return { type: 'suggestion.dismissed', requestId: r.data.requestID };
     }
 
     case 'complete': {

--- a/apps/web/src/lib/cloud-agent-sdk/schemas.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/schemas.ts
@@ -236,6 +236,37 @@ export const permissionRepliedDataSchema = z.object({
 });
 export type PermissionRepliedData = z.infer<typeof permissionRepliedDataSchema>;
 
+// `suggest` tool payloads — requires Kilo CLI >= v7.2.7 (recommended >= v7.2.14).
+// Older CLIs never emit these events, so no explicit version gate is needed here.
+
+export const suggestionActionSchema = z.object({
+  label: z.string(),
+  description: z.string().optional(),
+  prompt: z.string(),
+});
+export type SuggestionActionData = z.infer<typeof suggestionActionSchema>;
+
+export const suggestionShownDataSchema = z.object({
+  id: z.string(),
+  sessionID: z.string().optional(),
+  text: z.string(),
+  actions: z.array(suggestionActionSchema).catch([]),
+  tool: z.object({ messageID: z.string(), callID: z.string() }).optional(),
+});
+export type SuggestionShownData = z.infer<typeof suggestionShownDataSchema>;
+
+export const suggestionAcceptedDataSchema = z.object({
+  requestID: z.string(),
+  index: z.number(),
+  action: suggestionActionSchema.optional(),
+});
+export type SuggestionAcceptedData = z.infer<typeof suggestionAcceptedDataSchema>;
+
+export const suggestionDismissedDataSchema = z.object({
+  requestID: z.string(),
+});
+export type SuggestionDismissedData = z.infer<typeof suggestionDismissedDataSchema>;
+
 export const completeDataSchema = z
   .object({
     currentBranch: z.string().optional().catch(undefined),

--- a/apps/web/src/lib/cloud-agent-sdk/service-state.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/service-state.test.ts
@@ -1114,14 +1114,16 @@ describe('createServiceState', () => {
         requestId: 'sug-1',
         text: 'Review?',
         actions,
+        callId: 'call-1',
       });
 
       expect(state.getSuggestion()).toEqual({
         requestId: 'sug-1',
         text: 'Review?',
         actions,
+        callId: 'call-1',
       });
-      expect(onSuggestionAsked).toHaveBeenCalledWith('sug-1', 'Review?', actions);
+      expect(onSuggestionAsked).toHaveBeenCalledWith('sug-1', 'Review?', actions, 'call-1');
     });
   });
 

--- a/apps/web/src/lib/cloud-agent-sdk/service-state.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/service-state.test.ts
@@ -1100,6 +1100,95 @@ describe('createServiceState', () => {
     });
   });
 
+  describe('suggestion.shown', () => {
+    it('sets suggestion state and fires onSuggestionAsked', () => {
+      const onSuggestionAsked = jest.fn();
+      const state = createServiceState(makeConfig({ onSuggestionAsked }));
+      const actions = [
+        { label: 'Review', prompt: '/local-review' },
+        { label: 'Skip', prompt: 'no thanks' },
+      ];
+
+      state.process({
+        type: 'suggestion.shown',
+        requestId: 'sug-1',
+        text: 'Review?',
+        actions,
+      });
+
+      expect(state.getSuggestion()).toEqual({
+        requestId: 'sug-1',
+        text: 'Review?',
+        actions,
+      });
+      expect(onSuggestionAsked).toHaveBeenCalledWith('sug-1', 'Review?', actions);
+    });
+  });
+
+  describe('suggestion.accepted', () => {
+    it('clears suggestion and fires onSuggestionResolved', () => {
+      const onSuggestionResolved = jest.fn();
+      const state = createServiceState(makeConfig({ onSuggestionResolved }));
+
+      state.process({ type: 'suggestion.shown', requestId: 'sug-1', text: 't', actions: [] });
+      state.process({ type: 'suggestion.accepted', requestId: 'sug-1', index: 0 });
+
+      expect(state.getSuggestion()).toBeNull();
+      expect(onSuggestionResolved).toHaveBeenCalledWith('sug-1');
+    });
+
+    it('second matching resolve is fully a no-op (callback fires exactly once)', () => {
+      const onSuggestionResolved = jest.fn();
+      const state = createServiceState(makeConfig({ onSuggestionResolved }));
+
+      state.process({ type: 'suggestion.shown', requestId: 'sug-1', text: 't', actions: [] });
+      state.process({ type: 'suggestion.accepted', requestId: 'sug-1', index: 0 });
+      state.process({ type: 'suggestion.dismissed', requestId: 'sug-1' });
+
+      expect(state.getSuggestion()).toBeNull();
+      expect(onSuggestionResolved).toHaveBeenCalledTimes(1);
+      expect(onSuggestionResolved).toHaveBeenCalledWith('sug-1');
+    });
+
+    it('resolve with mismatched requestId does not clear state', () => {
+      const state = createServiceState(makeConfig());
+
+      state.process({ type: 'suggestion.shown', requestId: 'sug-1', text: 't', actions: [] });
+      state.process({ type: 'suggestion.accepted', requestId: 'other', index: 0 });
+
+      expect(state.getSuggestion()).toEqual({
+        requestId: 'sug-1',
+        text: 't',
+        actions: [],
+      });
+    });
+  });
+
+  describe('suggestion.dismissed', () => {
+    it('clears suggestion and fires onSuggestionResolved', () => {
+      const onSuggestionResolved = jest.fn();
+      const state = createServiceState(makeConfig({ onSuggestionResolved }));
+
+      state.process({ type: 'suggestion.shown', requestId: 'sug-1', text: 't', actions: [] });
+      state.process({ type: 'suggestion.dismissed', requestId: 'sug-1' });
+
+      expect(state.getSuggestion()).toBeNull();
+      expect(onSuggestionResolved).toHaveBeenCalledWith('sug-1');
+    });
+  });
+
+  describe('reset suggestion', () => {
+    it('clears suggestion on reset', () => {
+      const state = createServiceState(makeConfig());
+      state.process({ type: 'suggestion.shown', requestId: 'sug-1', text: 't', actions: [] });
+      expect(state.getSuggestion()).not.toBeNull();
+
+      state.reset();
+
+      expect(state.getSuggestion()).toBeNull();
+    });
+  });
+
   describe('child session detection', () => {
     it('root session busy changes activity', () => {
       const state = createServiceState(makeConfig());

--- a/apps/web/src/lib/cloud-agent-sdk/service-state.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/service-state.ts
@@ -14,6 +14,8 @@ import type {
   QuestionState,
   PermissionState,
   ServiceStateSnapshot,
+  SuggestionAction,
+  SuggestionState,
   CloudStatus,
 } from './types';
 
@@ -31,6 +33,10 @@ type ServiceStateConfig = {
     always?: string[]
   ) => void;
   onPermissionResolved?: (requestId: string) => void;
+  /** Fired when a `suggest` tool asks the user to pick an action. */
+  onSuggestionAsked?: (requestId: string, text: string, actions: SuggestionAction[]) => void;
+  /** Fired when a suggestion is resolved (accepted or dismissed). */
+  onSuggestionResolved?: (requestId: string) => void;
   onBranchChanged?: (branch: string) => void;
   onSessionCreated?: (info: SessionInfo) => void;
   onSessionUpdated?: (info: SessionInfo) => void;
@@ -47,6 +53,7 @@ type ServiceState = {
   getCloudStatus(): CloudStatus | null;
   getQuestion(): QuestionState | null;
   getPermission(): PermissionState | null;
+  getSuggestion(): SuggestionState | null;
   getSessionInfo(): SessionInfo | null;
   snapshot(): ServiceStateSnapshot;
   /** Set activity directly (for transport lifecycle events like connecting/disconnected). */
@@ -69,6 +76,7 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
   let sessionInfo: SessionInfo | null = null;
   let question: QuestionState | null = null;
   let permission: PermissionState | null = null;
+  let suggestion: SuggestionState | null = null;
 
   // Tracks whether we've received a terminal stopped event (error/interrupted/disconnected).
   // While terminated, session.error events are suppressed as aftershocks.
@@ -198,6 +206,29 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
     notify();
   }
 
+  function processSuggestionShown(
+    event: Extract<ServiceEvent, { type: 'suggestion.shown' }>
+  ): void {
+    suggestion = {
+      requestId: event.requestId,
+      text: event.text,
+      actions: event.actions,
+    };
+    config.onSuggestionAsked?.(event.requestId, event.text, event.actions);
+    notify();
+  }
+
+  function processSuggestionResolved(requestId: string): void {
+    // Clear only when the resolution matches the currently-pending suggestion.
+    // The CLI emits both a command `response` and a `suggestion.accepted` /
+    // `suggestion.dismissed` bus event; whichever arrives first clears state,
+    // and the second is fully a no-op (no callback, no notify).
+    if (!suggestion || suggestion.requestId !== requestId) return;
+    suggestion = null;
+    config.onSuggestionResolved?.(requestId);
+    notify();
+  }
+
   function processPreparing(event: Extract<ServiceEvent, { type: 'preparing' }>): void {
     if (event.step === 'ready') {
       cloudStatus = { type: 'ready' };
@@ -285,6 +316,13 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
     } else {
       permission = null;
     }
+    if (suggestion) {
+      const { requestId } = suggestion;
+      suggestion = null;
+      config.onSuggestionResolved?.(requestId);
+    } else {
+      suggestion = null;
+    }
 
     // Clear terminated on connected
     terminated = false;
@@ -330,6 +368,13 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
       case 'permission.replied':
         processPermissionResolved(event.requestId);
         break;
+      case 'suggestion.shown':
+        processSuggestionShown(event);
+        break;
+      case 'suggestion.accepted':
+      case 'suggestion.dismissed':
+        processSuggestionResolved(event.requestId);
+        break;
       case 'preparing':
         processPreparing(event);
         break;
@@ -361,6 +406,7 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
     getCloudStatus: () => cloudStatus,
     getQuestion: () => question,
     getPermission: () => permission,
+    getSuggestion: () => suggestion,
     getSessionInfo: () => sessionInfo,
 
     snapshot: () => ({
@@ -370,6 +416,7 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
       sessionInfo,
       question,
       permission,
+      suggestion,
     }),
 
     setActivity(next: SessionActivity): void {
@@ -401,6 +448,7 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
       sessionInfo = null;
       question = null;
       permission = null;
+      suggestion = null;
       terminated = false;
       notify();
     },

--- a/apps/web/src/lib/cloud-agent-sdk/service-state.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/service-state.ts
@@ -34,7 +34,12 @@ type ServiceStateConfig = {
   ) => void;
   onPermissionResolved?: (requestId: string) => void;
   /** Fired when a `suggest` tool asks the user to pick an action. */
-  onSuggestionAsked?: (requestId: string, text: string, actions: SuggestionAction[]) => void;
+  onSuggestionAsked?: (
+    requestId: string,
+    text: string,
+    actions: SuggestionAction[],
+    callId?: string
+  ) => void;
   /** Fired when a suggestion is resolved (accepted or dismissed). */
   onSuggestionResolved?: (requestId: string) => void;
   onBranchChanged?: (branch: string) => void;
@@ -213,8 +218,9 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
       requestId: event.requestId,
       text: event.text,
       actions: event.actions,
+      callId: event.callId,
     };
-    config.onSuggestionAsked?.(event.requestId, event.text, event.actions);
+    config.onSuggestionAsked?.(event.requestId, event.text, event.actions, event.callId);
     notify();
   }
 

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -1267,17 +1267,18 @@ describe('createSessionManager', () => {
       expect(atomValue(config.store, mgr.atoms.activePermission)).toBeNull();
     });
 
-    it('onSuggestionAsked sets activeSuggestion', async () => {
+    it('onSuggestionAsked sets activeSuggestion with callId', async () => {
       const config = createMockConfig();
       const mgr = createSessionManager(config);
       await mgr.switchSession(kiloId('ses-1'));
 
       const actions = [{ label: 'Review', prompt: '/local-review' }];
-      mockSessionCallbacks.onSuggestionAsked?.('sug-1', 'Review?', actions);
+      mockSessionCallbacks.onSuggestionAsked?.('sug-1', 'Review?', actions, 'call-1');
       expect(atomValue(config.store, mgr.atoms.activeSuggestion)).toEqual({
         requestId: 'sug-1',
         text: 'Review?',
         actions,
+        callId: 'call-1',
       });
     });
 
@@ -1286,7 +1287,7 @@ describe('createSessionManager', () => {
       const mgr = createSessionManager(config);
       await mgr.switchSession(kiloId('ses-1'));
 
-      mockSessionCallbacks.onSuggestionAsked?.('sug-1', 'Review?', []);
+      mockSessionCallbacks.onSuggestionAsked?.('sug-1', 'Review?', [], 'call-1');
       expect(atomValue(config.store, mgr.atoms.activeSuggestion)).not.toBeNull();
 
       mockSessionCallbacks.onSuggestionResolved?.('sug-1');

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -25,6 +25,8 @@ const mockSession = {
   answer: jest.fn(),
   reject: jest.fn(),
   respondToPermission: jest.fn(),
+  acceptSuggestion: jest.fn(),
+  dismissSuggestion: jest.fn(),
   canSend: true,
   canInterrupt: true,
   state: {
@@ -38,6 +40,7 @@ const mockSession = {
     getQuestion: jest.fn(() => null),
     getSessionInfo: jest.fn(() => null),
     getPermission: jest.fn(() => null),
+    getSuggestion: jest.fn(() => null),
   },
   storage: null as JotaiSessionStorage | null,
 };
@@ -48,6 +51,8 @@ const mockSessionCallbacks: {
   onQuestionResolved?: (...args: unknown[]) => void;
   onPermissionAsked?: (...args: unknown[]) => void;
   onPermissionResolved?: (...args: unknown[]) => void;
+  onSuggestionAsked?: (...args: unknown[]) => void;
+  onSuggestionResolved?: (...args: unknown[]) => void;
   onResolved?: (resolved: ResolvedSession) => void;
 } = {};
 
@@ -63,6 +68,8 @@ jest.mock('./session', () => ({
       onQuestionResolved?: (...args: unknown[]) => void;
       onPermissionAsked?: (...args: unknown[]) => void;
       onPermissionResolved?: (...args: unknown[]) => void;
+      onSuggestionAsked?: (...args: unknown[]) => void;
+      onSuggestionResolved?: (...args: unknown[]) => void;
       onResolved?: (resolved: ResolvedSession) => void;
     }) => {
       latestStorage = sessionConfig.storage;
@@ -82,6 +89,8 @@ jest.mock('./session', () => ({
       mockSessionCallbacks.onQuestionResolved = sessionConfig.onQuestionResolved;
       mockSessionCallbacks.onPermissionAsked = sessionConfig.onPermissionAsked;
       mockSessionCallbacks.onPermissionResolved = sessionConfig.onPermissionResolved;
+      mockSessionCallbacks.onSuggestionAsked = sessionConfig.onSuggestionAsked;
+      mockSessionCallbacks.onSuggestionResolved = sessionConfig.onSuggestionResolved;
       mockSessionCallbacks.onResolved = sessionConfig.onResolved;
       return mockSession;
     }
@@ -1256,6 +1265,52 @@ describe('createSessionManager', () => {
 
       mockSessionCallbacks.onPermissionResolved?.('req-1');
       expect(atomValue(config.store, mgr.atoms.activePermission)).toBeNull();
+    });
+
+    it('onSuggestionAsked sets activeSuggestion', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+      await mgr.switchSession(kiloId('ses-1'));
+
+      const actions = [{ label: 'Review', prompt: '/local-review' }];
+      mockSessionCallbacks.onSuggestionAsked?.('sug-1', 'Review?', actions);
+      expect(atomValue(config.store, mgr.atoms.activeSuggestion)).toEqual({
+        requestId: 'sug-1',
+        text: 'Review?',
+        actions,
+      });
+    });
+
+    it('onSuggestionResolved clears activeSuggestion', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+      await mgr.switchSession(kiloId('ses-1'));
+
+      mockSessionCallbacks.onSuggestionAsked?.('sug-1', 'Review?', []);
+      expect(atomValue(config.store, mgr.atoms.activeSuggestion)).not.toBeNull();
+
+      mockSessionCallbacks.onSuggestionResolved?.('sug-1');
+      expect(atomValue(config.store, mgr.atoms.activeSuggestion)).toBeNull();
+    });
+
+    it('acceptSuggestion forwards to session', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+      await mgr.switchSession(kiloId('ses-1'));
+
+      await mgr.acceptSuggestion('sug-1', 0);
+
+      expect(mockSession.acceptSuggestion).toHaveBeenCalledWith({ requestId: 'sug-1', index: 0 });
+    });
+
+    it('dismissSuggestion forwards to session', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+      await mgr.switchSession(kiloId('ses-1'));
+
+      await mgr.dismissSuggestion('sug-2');
+
+      expect(mockSession.dismissSuggestion).toHaveBeenCalledWith({ requestId: 'sug-2' });
     });
 
     it('destroy clears activeQuestion and activePermission', async () => {

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
@@ -59,6 +59,8 @@ type StandaloneSuggestion = {
   requestId: string;
   text: string;
   actions: SuggestionAction[];
+  /** Tool call ID that emitted this suggestion, when available. */
+  callId?: string;
 };
 
 type FetchedSessionData = {
@@ -578,8 +580,8 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
         const ap = store.get(activePermissionAtom);
         if (ap?.requestId === requestId) store.set(activePermissionAtom, null);
       },
-      onSuggestionAsked: (requestId, text, actions) => {
-        store.set(activeSuggestionAtom, { requestId, text, actions });
+      onSuggestionAsked: (requestId, text, actions, callId) => {
+        store.set(activeSuggestionAtom, { requestId, text, actions, callId });
       },
       onSuggestionResolved: requestId => {
         const as = store.get(activeSuggestionAtom);

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
@@ -19,6 +19,8 @@ import type {
   CloudStatus,
   QuestionState,
   PermissionState,
+  SuggestionAction,
+  SuggestionState,
   MessageInfo,
   Part,
   TextPart,
@@ -52,6 +54,11 @@ type StandalonePermission = {
   patterns: string[];
   metadata: Record<string, unknown>;
   always: string[];
+};
+type StandaloneSuggestion = {
+  requestId: string;
+  text: string;
+  actions: SuggestionAction[];
 };
 
 type FetchedSessionData = {
@@ -127,6 +134,7 @@ type SessionManagerAtoms = {
   question: W<QuestionState | null>;
   activeQuestion: W<StandaloneQuestion | null>;
   activePermission: W<StandalonePermission | null>;
+  activeSuggestion: W<StandaloneSuggestion | null>;
   sessionInfo: W<SessionInfo | null>;
   sessionId: W<CloudAgentSessionId | null>;
   activity: W<SessionActivity>;
@@ -135,6 +143,7 @@ type SessionManagerAtoms = {
   sessionConfig: W<SessionConfig | null>;
   chatUI: W<{ shouldAutoScroll: boolean }>;
   permission: W<PermissionState | null>;
+  suggestion: W<SuggestionState | null>;
   failedPrompt: W<string | null>;
   fetchedSessionData: W<FetchedSessionData | null>;
   messagesList: Atom<StoredMessage[]>;
@@ -157,6 +166,8 @@ type SessionManager = {
   answerQuestion(requestId: string, answers: string[][]): Promise<void>;
   rejectQuestion(requestId: string): Promise<void>;
   respondToPermission(requestId: string, response: 'once' | 'always' | 'reject'): Promise<void>;
+  acceptSuggestion(requestId: string, index: number): Promise<void>;
+  dismissSuggestion(requestId: string): Promise<void>;
   createAndStart(input: PrepareInput): Promise<void>;
   clearError(): void;
   destroy(): void;
@@ -265,6 +276,8 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
   const activeQuestionAtom = atom<StandaloneQuestion | null>(null);
   const permissionAtom = atom<PermissionState | null>(null);
   const activePermissionAtom = atom<StandalonePermission | null>(null);
+  const suggestionAtom = atom<SuggestionState | null>(null);
+  const activeSuggestionAtom = atom<StandaloneSuggestion | null>(null);
   const failedPromptAtom = atom<string | null>(null);
   const fetchedSessionDataAtom = atom<FetchedSessionData | null>(null);
 
@@ -354,6 +367,8 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     store.set(activeQuestionAtom, null);
     store.set(permissionAtom, null);
     store.set(activePermissionAtom, null);
+    store.set(suggestionAtom, null);
+    store.set(activeSuggestionAtom, null);
     store.set(failedPromptAtom, null);
     store.set(fetchedSessionDataAtom, null);
     store.set(chatUIAtom, { shouldAutoScroll: true });
@@ -415,6 +430,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       store.set(isStreamingAtom, act.type === 'busy');
       store.set(questionAtom, session.state.getQuestion());
       store.set(permissionAtom, session.state.getPermission());
+      store.set(suggestionAtom, session.state.getSuggestion());
       store.set(sessionInfoAtom, session.state.getSessionInfo());
 
       // canSend factors in cloud status: preparing/finalizing blocks input
@@ -561,6 +577,13 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       onPermissionResolved: requestId => {
         const ap = store.get(activePermissionAtom);
         if (ap?.requestId === requestId) store.set(activePermissionAtom, null);
+      },
+      onSuggestionAsked: (requestId, text, actions) => {
+        store.set(activeSuggestionAtom, { requestId, text, actions });
+      },
+      onSuggestionResolved: requestId => {
+        const as = store.get(activeSuggestionAtom);
+        if (as?.requestId === requestId) store.set(activeSuggestionAtom, null);
       },
       onResolved: resolved => {
         if (resolved.type === 'cloud-agent') activeSessionType = 'cloud-agent';
@@ -722,6 +745,14 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     if (currentSession) await currentSession.respondToPermission({ requestId, response });
   }
 
+  async function acceptSuggestion(requestId: string, index: number): Promise<void> {
+    if (currentSession) await currentSession.acceptSuggestion({ requestId, index });
+  }
+
+  async function dismissSuggestion(requestId: string): Promise<void> {
+    if (currentSession) await currentSession.dismissSuggestion({ requestId });
+  }
+
   async function createAndStart(input: PrepareInput): Promise<void> {
     try {
       const { cloudAgentSessionId, kiloSessionId } = await config.prepare(input);
@@ -754,6 +785,8 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     answerQuestion,
     rejectQuestion,
     respondToPermission,
+    acceptSuggestion,
+    dismissSuggestion,
     createAndStart,
     clearError: () => {
       store.set(errorAtom, null);
@@ -779,6 +812,8 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       activeQuestion: activeQuestionAtom,
       permission: permissionAtom,
       activePermission: activePermissionAtom,
+      suggestion: suggestionAtom,
+      activeSuggestion: activeSuggestionAtom,
       failedPrompt: failedPromptAtom,
       fetchedSessionData: fetchedSessionDataAtom,
       messagesList: messagesListAtom,
@@ -799,6 +834,7 @@ export type {
   SessionConfig,
   StandalonePermission,
   StandaloneQuestion,
+  StandaloneSuggestion,
   StoredMessage,
   FetchedSessionData,
   PrepareInput,

--- a/apps/web/src/lib/cloud-agent-sdk/session.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session.ts
@@ -50,7 +50,12 @@ type CloudAgentSessionConfig = {
     always?: string[]
   ) => void;
   onPermissionResolved?: (requestId: string) => void;
-  onSuggestionAsked?: (requestId: string, text: string, actions: SuggestionAction[]) => void;
+  onSuggestionAsked?: (
+    requestId: string,
+    text: string,
+    actions: SuggestionAction[],
+    callId?: string
+  ) => void;
   onSuggestionResolved?: (requestId: string) => void;
   onBranchChanged?: (branch: string) => void;
   onResolved?: (resolved: ResolvedSession) => void;

--- a/apps/web/src/lib/cloud-agent-sdk/session.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session.ts
@@ -8,6 +8,7 @@
 import type { QuestionInfo } from '@/types/opencode.gen';
 import type { Images } from '@/lib/images-schema';
 import type { NormalizedEvent } from './normalizer';
+import type { SuggestionAction } from './types';
 import { createChatProcessor } from './chat-processor';
 import { createServiceState } from './service-state';
 import type { ServiceState } from './service-state';
@@ -49,6 +50,8 @@ type CloudAgentSessionConfig = {
     always?: string[]
   ) => void;
   onPermissionResolved?: (requestId: string) => void;
+  onSuggestionAsked?: (requestId: string, text: string, actions: SuggestionAction[]) => void;
+  onSuggestionResolved?: (requestId: string) => void;
   onBranchChanged?: (branch: string) => void;
   onResolved?: (resolved: ResolvedSession) => void;
   onSessionCreated?: (info: SessionInfo) => void;
@@ -81,6 +84,15 @@ type CloudAgentSessionRespondToPermissionInput = {
   response: PermissionResponse;
 };
 
+type CloudAgentSessionAcceptSuggestionInput = {
+  requestId: string;
+  index: number;
+};
+
+type CloudAgentSessionDismissSuggestionInput = {
+  requestId: string;
+};
+
 type CloudAgentSessionTransport = {
   // Cloud Agent transport construction
   getTicket?: (
@@ -110,6 +122,10 @@ type CloudAgentSession = {
   respondToPermission: (
     payload: CloudAgentSessionRespondToPermissionInput
   ) => unknown | Promise<unknown>;
+  acceptSuggestion: (payload: CloudAgentSessionAcceptSuggestionInput) => unknown | Promise<unknown>;
+  dismissSuggestion: (
+    payload: CloudAgentSessionDismissSuggestionInput
+  ) => unknown | Promise<unknown>;
 
   // Capability checks
   canSend: boolean;
@@ -133,6 +149,8 @@ function createCloudAgentSession(config: CloudAgentSessionConfig): CloudAgentSes
     onQuestionResolved: config.onQuestionResolved,
     onPermissionAsked: config.onPermissionAsked,
     onPermissionResolved: config.onPermissionResolved,
+    onSuggestionAsked: config.onSuggestionAsked,
+    onSuggestionResolved: config.onSuggestionResolved,
     onBranchChanged: config.onBranchChanged,
     onSessionCreated: config.onSessionCreated,
     onSessionUpdated: config.onSessionUpdated,
@@ -286,6 +304,40 @@ function createCloudAgentSession(config: CloudAgentSessionConfig): CloudAgentSes
       }
       return transport.respondToPermission(payload);
     },
+    acceptSuggestion: async payload => {
+      if (!transport?.acceptSuggestion) {
+        throw new Error('CloudAgentSession transport.acceptSuggestion is not configured');
+      }
+      // Wait for the command to be acknowledged before clearing local state,
+      // so that transport failures (network drop, 404, timeout) can propagate
+      // back to the caller and the SuggestionCard stays mounted to surface
+      // the error. The bus event that follows is a no-op thanks to the
+      // requestId guard in processSuggestionResolved.
+      const result = await transport.acceptSuggestion(payload);
+      const current = serviceState.getSuggestion();
+      if (current && current.requestId === payload.requestId) {
+        serviceState.process({
+          type: 'suggestion.accepted',
+          requestId: payload.requestId,
+          index: payload.index,
+        });
+      }
+      return result;
+    },
+    dismissSuggestion: async payload => {
+      if (!transport?.dismissSuggestion) {
+        throw new Error('CloudAgentSession transport.dismissSuggestion is not configured');
+      }
+      const result = await transport.dismissSuggestion(payload);
+      const current = serviceState.getSuggestion();
+      if (current && current.requestId === payload.requestId) {
+        serviceState.process({
+          type: 'suggestion.dismissed',
+          requestId: payload.requestId,
+        });
+      }
+      return result;
+    },
     get canSend() {
       return transport?.send !== undefined;
     },
@@ -323,8 +375,10 @@ function createCloudAgentSession(config: CloudAgentSessionConfig): CloudAgentSes
 export { createCloudAgentSession };
 export type {
   CloudAgentSession,
+  CloudAgentSessionAcceptSuggestionInput,
   CloudAgentSessionAnswerInput,
   CloudAgentSessionConfig,
+  CloudAgentSessionDismissSuggestionInput,
   CloudAgentSessionRejectInput,
   CloudAgentSessionRespondToPermissionInput,
   CloudAgentSessionSendInput,

--- a/apps/web/src/lib/cloud-agent-sdk/transport.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/transport.ts
@@ -44,6 +44,10 @@ type Transport = {
     requestId: string;
     response: 'once' | 'always' | 'reject';
   }) => Promise<unknown>;
+  /** Accept a `suggest` tool action. Requires Kilo CLI >= v7.2.7 on the remote side. */
+  acceptSuggestion?: (payload: { requestId: string; index: number }) => Promise<unknown>;
+  /** Dismiss a `suggest` tool request. Requires Kilo CLI >= v7.2.7 on the remote side. */
+  dismissSuggestion?: (payload: { requestId: string }) => Promise<unknown>;
 };
 
 /** Factory signature — creates a transport wired to the given sink. */

--- a/apps/web/src/lib/cloud-agent-sdk/types.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/types.ts
@@ -104,6 +104,8 @@ export type SuggestionState = {
   requestId: string;
   text: string;
   actions: SuggestionAction[];
+  /** Tool call ID that emitted this suggestion, when available. */
+  callId?: string;
 };
 
 /** Full service state — all non-chat state in one place. */

--- a/apps/web/src/lib/cloud-agent-sdk/types.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/types.ts
@@ -94,6 +94,18 @@ export type PermissionState = {
   always: string[];
 };
 
+export type SuggestionAction = {
+  label: string;
+  description?: string;
+  prompt: string;
+};
+
+export type SuggestionState = {
+  requestId: string;
+  text: string;
+  actions: SuggestionAction[];
+};
+
 /** Full service state — all non-chat state in one place. */
 export type ServiceStateSnapshot = {
   activity: SessionActivity;
@@ -102,6 +114,7 @@ export type ServiceStateSnapshot = {
   sessionInfo: SessionInfo | null;
   question: QuestionState | null;
   permission: PermissionState | null;
+  suggestion: SuggestionState | null;
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Plumbs the Kilo CLI `suggest` tool end-to-end into Cloud Agent Next, so when the agent offers a follow-up action the user sees an inline suggestion card and can either accept an action (sending its prompt back to the agent) or dismiss the request.

- **SDK events/state**: added `suggestion.shown` / `suggestion.accepted` / `suggestion.dismissed` events, zod schemas, normalizer mappings, and a `suggestion` slot in `ServiceStateSnapshot` / `SessionManager` atoms.
- **SDK session API**: `CloudAgentSession.acceptSuggestion` / `dismissSuggestion` (with matching `SessionManager` wrappers) that await transport ack before clearing local state so failures bubble back to the caller and keep the card mounted.
- **CLI live transport**: `suggestion_accept` / `suggestion_dismiss` commands targeting Kilo CLI ≥ v7.2.7.
- **UI**: new `SuggestionCard` + `SuggestionContextProvider`, rendered in `CloudChatPage` alongside existing question/permission cards and mutually exclusive with the chat input.

## Verification

<img width="916" height="430" alt="Screenshot 2026-04-21 at 17 05 22" src="https://github.com/user-attachments/assets/eaf8a8fb-ed90-480d-a708-4fed906eca6c" />


## Reviewer Notes

- `processSuggestionResolved` guards on `requestId` so the bus event that follows a command response is a no-op — this is intentional and covered by a test.
- Requires Kilo CLI ≥ v7.2.7 on the remote side; older CLIs simply never emit suggestion events, so no explicit version gate is needed.
- Accept/dismiss flows await the transport command before locally clearing the suggestion so network/timeout errors surface in the card.