### PR TITLE
fix(kiloclaw): preserve paid resumed subscriptions

### DIFF
--- a/apps/web/src/lib/kiloclaw/credit-billing.ts
+++ b/apps/web/src/lib/kiloclaw/credit-billing.ts
@@ -56,6 +56,11 @@ const PAID_ACTIVATION_LIFECYCLE_CLEAR_SET = {
   auto_resume_retry_after: null,
   auto_resume_attempt_count: 0,
 } as const;
+const PAID_AUTO_RESUME_INITIAL_STATE = {
+  auto_resume_requested_at: null,
+  auto_resume_retry_after: null,
+  auto_resume_attempt_count: 0,
+} as const;
 
 type CreditSettlementPersonalRow = {
   subscription: typeof kiloclaw_subscriptions.$inferSelect;
@@ -583,6 +588,7 @@ export async function applyStripeFundedKiloClawPeriod(params: {
       past_due_since: null,
       auto_top_up_triggered_for_period: null,
       ...PAID_ACTIVATION_LIFECYCLE_CLEAR_SET,
+      ...(wasSuspended ? PAID_AUTO_RESUME_INITIAL_STATE : {}),
       ...(shouldClearSchedule
         ? { scheduled_plan: null, scheduled_by: null, stripe_schedule_id: null }
         : {}),
@@ -617,7 +623,7 @@ export async function applyStripeFundedKiloClawPeriod(params: {
   }
 
   if (wasSuspended) {
-    await autoResumeIfSuspended(userId, resolvedInstanceId, { recordRetryState: false });
+    await autoResumeIfSuspended(userId, resolvedInstanceId);
   }
 
   // Best-effort Kilo Pass bonus evaluation.
@@ -824,6 +830,7 @@ export async function enrollWithCredits(params: {
         trial_started_at: null,
         trial_ends_at: null,
         ...PAID_ACTIVATION_LIFECYCLE_CLEAR_SET,
+        ...(wasSuspended ? PAID_AUTO_RESUME_INITIAL_STATE : {}),
       })
       .onConflictDoUpdate({
         target: kiloclaw_subscriptions.instance_id,
@@ -840,6 +847,7 @@ export async function enrollWithCredits(params: {
           past_due_since: null,
           cancel_at_period_end: false,
           ...PAID_ACTIVATION_LIFECYCLE_CLEAR_SET,
+          ...(wasSuspended ? PAID_AUTO_RESUME_INITIAL_STATE : {}),
         },
       })
       .returning();
@@ -909,7 +917,7 @@ export async function enrollWithCredits(params: {
 
   // Step 5: Auto-resume if suspended (spec rule 7)
   if (wasSuspended && instanceId) {
-    await autoResumeIfSuspended(userId, instanceId, { recordRetryState: false });
+    await autoResumeIfSuspended(userId, instanceId);
   }
 
   logInfo('Credit enrollment completed', {

--- a/apps/web/src/lib/kiloclaw/credit-billing.ts
+++ b/apps/web/src/lib/kiloclaw/credit-billing.ts
@@ -49,6 +49,13 @@ const CREDIT_BILLING_ACTOR = {
   actorType: 'system',
   actorId: 'kiloclaw-credit-billing',
 } as const;
+const PAID_ACTIVATION_LIFECYCLE_CLEAR_SET = {
+  suspended_at: null,
+  destruction_deadline: null,
+  auto_resume_requested_at: null,
+  auto_resume_retry_after: null,
+  auto_resume_attempt_count: 0,
+} as const;
 
 type CreditSettlementPersonalRow = {
   subscription: typeof kiloclaw_subscriptions.$inferSelect;
@@ -575,6 +582,7 @@ export async function applyStripeFundedKiloClawPeriod(params: {
       commit_ends_at: commitEndsAt,
       past_due_since: null,
       auto_top_up_triggered_for_period: null,
+      ...PAID_ACTIVATION_LIFECYCLE_CLEAR_SET,
       ...(shouldClearSchedule
         ? { scheduled_plan: null, scheduled_by: null, stripe_schedule_id: null }
         : {}),
@@ -609,7 +617,7 @@ export async function applyStripeFundedKiloClawPeriod(params: {
   }
 
   if (wasSuspended) {
-    await autoResumeIfSuspended(userId, resolvedInstanceId);
+    await autoResumeIfSuspended(userId, resolvedInstanceId, { recordRetryState: false });
   }
 
   // Best-effort Kilo Pass bonus evaluation.
@@ -815,7 +823,7 @@ export async function enrollWithCredits(params: {
         cancel_at_period_end: false,
         trial_started_at: null,
         trial_ends_at: null,
-        // DO NOT clear suspended_at or destruction_deadline (spec rule 5d)
+        ...PAID_ACTIVATION_LIFECYCLE_CLEAR_SET,
       })
       .onConflictDoUpdate({
         target: kiloclaw_subscriptions.instance_id,
@@ -831,6 +839,7 @@ export async function enrollWithCredits(params: {
           commit_ends_at: commitEndsAt,
           past_due_since: null,
           cancel_at_period_end: false,
+          ...PAID_ACTIVATION_LIFECYCLE_CLEAR_SET,
         },
       })
       .returning();
@@ -900,7 +909,7 @@ export async function enrollWithCredits(params: {
 
   // Step 5: Auto-resume if suspended (spec rule 7)
   if (wasSuspended && instanceId) {
-    await autoResumeIfSuspended(userId, instanceId);
+    await autoResumeIfSuspended(userId, instanceId, { recordRetryState: false });
   }
 
   logInfo('Credit enrollment completed', {

--- a/apps/web/src/lib/kiloclaw/instance-lifecycle.ts
+++ b/apps/web/src/lib/kiloclaw/instance-lifecycle.ts
@@ -230,8 +230,10 @@ async function resolveActiveInstance(
  */
 export async function autoResumeIfSuspended(
   kiloUserId: string,
-  instanceId?: string
+  instanceId?: string,
+  options: { recordRetryState?: boolean } = {}
 ): Promise<void> {
+  const recordRetryState = options.recordRetryState ?? true;
   const targetInstance = await resolveActiveInstance(kiloUserId, { instanceId });
   if (!targetInstance) {
     await clearAutoResumeState(kiloUserId, {
@@ -265,6 +267,33 @@ export async function autoResumeIfSuspended(
     const client = new KiloClawInternalClient();
     await client.startAsync(kiloUserId, workerInstanceId(targetInstance));
   } catch (startError) {
+    if (recordRetryState) {
+      await db
+        .update(kiloclaw_subscriptions)
+        .set({
+          auto_resume_requested_at: requestedAtIso,
+          auto_resume_retry_after: retryAfterIso,
+          auto_resume_attempt_count: nextAttemptCount,
+        })
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.user_id, kiloUserId),
+            eq(kiloclaw_subscriptions.instance_id, targetInstance.id),
+            isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+          )
+        );
+    }
+    logError('Failed to request async auto-resume', {
+      user_id: kiloUserId,
+      instance_id: targetInstance.id,
+      retry_after: retryAfterIso,
+      auto_resume_attempt_count: nextAttemptCount,
+      error: startError instanceof Error ? startError.message : String(startError),
+    });
+    return;
+  }
+
+  if (recordRetryState) {
     await db
       .update(kiloclaw_subscriptions)
       .set({
@@ -279,30 +308,7 @@ export async function autoResumeIfSuspended(
           isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
         )
       );
-    logError('Failed to request async auto-resume', {
-      user_id: kiloUserId,
-      instance_id: targetInstance.id,
-      retry_after: retryAfterIso,
-      auto_resume_attempt_count: nextAttemptCount,
-      error: startError instanceof Error ? startError.message : String(startError),
-    });
-    return;
   }
-
-  await db
-    .update(kiloclaw_subscriptions)
-    .set({
-      auto_resume_requested_at: requestedAtIso,
-      auto_resume_retry_after: retryAfterIso,
-      auto_resume_attempt_count: nextAttemptCount,
-    })
-    .where(
-      and(
-        eq(kiloclaw_subscriptions.user_id, kiloUserId),
-        eq(kiloclaw_subscriptions.instance_id, targetInstance.id),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-      )
-    );
 
   logInfo('Async auto-resume requested', {
     user_id: kiloUserId,

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -38,6 +38,7 @@ type AnyMock = jest.Mock<(...args: any[]) => any>;
 
 type KiloclawInternalClientMockShape = {
   __provisionMock: AnyMock;
+  __startAsyncMock: AnyMock;
 };
 
 jest.setTimeout(15_000);
@@ -102,9 +103,11 @@ jest.mock('next/server', () => {
 jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   const fn = jest.fn as (...args: unknown[]) => AnyMock;
   const provisionMock = fn().mockResolvedValue({});
+  const startAsyncMock = fn().mockResolvedValue(undefined);
   return {
     KiloClawInternalClient: fn().mockImplementation(() => ({
       start: fn().mockResolvedValue(undefined),
+      startAsync: startAsyncMock,
       stop: fn().mockResolvedValue(undefined),
       provision: provisionMock,
       getStatus: fn().mockResolvedValue({}),
@@ -119,6 +122,7 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
       }
     },
     __provisionMock: provisionMock,
+    __startAsyncMock: startAsyncMock,
   };
 });
 
@@ -195,6 +199,8 @@ beforeEach(async () => {
   stripeMock.invoices.list.mockResolvedValue({ data: [], has_more: false });
   kiloclawInternalClientMock.__provisionMock.mockReset();
   kiloclawInternalClientMock.__provisionMock.mockResolvedValue(defaultProvisionResult);
+  kiloclawInternalClientMock.__startAsyncMock.mockReset();
+  kiloclawInternalClientMock.__startAsyncMock.mockResolvedValue(undefined);
   posthogCaptureMock.mockReset();
 
   // Default mock returns for live-fetch calls
@@ -4659,6 +4665,91 @@ describe('cancelPlanSwitch', () => {
   });
 });
 
+// ── Stripe-Funded Credit Settlement ─────────────────────────────────────────
+
+describe('applyStripeFundedKiloClawPeriod', () => {
+  async function giveUserCredits(userId: string, microdollars: number) {
+    await db
+      .update(kilocode_users)
+      .set({ total_microdollars_acquired: microdollars })
+      .where(eq(kilocode_users.id, userId));
+  }
+
+  it('clears stale suspension and auto-resume fields when settlement activates a suspended trial', async () => {
+    await giveUserCredits(user.id, 1_000_000);
+    const instance = await createKiloclawInstance(user.id);
+    const now = new Date();
+    const suspendedAt = new Date(now.getTime() - 10 * 86_400_000).toISOString();
+    const deadline = new Date(now.getTime() - 3 * 86_400_000).toISOString();
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      stripe_subscription_id: 'sub_settlement_resume',
+      payment_source: 'stripe',
+      plan: 'trial',
+      status: 'canceled',
+      trial_started_at: new Date(now.getTime() - 17 * 86_400_000).toISOString(),
+      trial_ends_at: new Date(now.getTime() - 10 * 86_400_000).toISOString(),
+      suspended_at: suspendedAt,
+      destruction_deadline: deadline,
+      auto_resume_requested_at: new Date(now.getTime() - 2 * 86_400_000).toISOString(),
+      auto_resume_retry_after: new Date(now.getTime() - 1 * 86_400_000).toISOString(),
+      auto_resume_attempt_count: 3,
+    });
+
+    const { applyStripeFundedKiloClawPeriod } = await import('@/lib/kiloclaw/credit-billing');
+    const applied = await applyStripeFundedKiloClawPeriod({
+      userId: user.id,
+      metadataInstanceId: instance.id,
+      stripeSubscriptionId: 'sub_settlement_resume',
+      stripePaymentId: 'ch_settlement_resume',
+      plan: 'standard',
+      amountMicrodollars: 9_000_000,
+      periodStart: '2026-04-16T09:40:37.000Z',
+      periodEnd: '2026-05-16T09:40:37.000Z',
+    });
+
+    expect(applied).toBe(true);
+
+    const [subscription] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+
+    expect(subscription).toEqual(
+      expect.objectContaining({
+        status: 'active',
+        payment_source: 'credits',
+        stripe_subscription_id: 'sub_settlement_resume',
+        plan: 'standard',
+        suspended_at: null,
+        destruction_deadline: null,
+        auto_resume_requested_at: null,
+        auto_resume_retry_after: null,
+        auto_resume_attempt_count: 0,
+      })
+    );
+    expect(kiloclawInternalClientMock.__startAsyncMock).toHaveBeenCalledTimes(1);
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscription.id));
+    expect(logs[0]?.after_state).toEqual(
+      expect.objectContaining({
+        status: 'active',
+        suspended_at: null,
+        destruction_deadline: null,
+        auto_resume_requested_at: null,
+        auto_resume_retry_after: null,
+        auto_resume_attempt_count: 0,
+      })
+    );
+  });
+});
+
 // ── Credit Enrollment ──────────────────────────────────────────────────────
 
 describe('enrollWithCredits', () => {
@@ -4692,6 +4783,65 @@ describe('enrollWithCredits', () => {
     });
     return instance;
   }
+
+  it('clears stale suspension and auto-resume fields when credit enrollment activates a suspended trial', async () => {
+    const instance = await createInstance(user.id);
+    await giveUserCredits(user.id, 50_000_000);
+    const now = new Date();
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      plan: 'trial',
+      status: 'canceled',
+      trial_started_at: new Date(now.getTime() - 17 * 86_400_000).toISOString(),
+      trial_ends_at: new Date(now.getTime() - 10 * 86_400_000).toISOString(),
+      suspended_at: new Date(now.getTime() - 10 * 86_400_000).toISOString(),
+      destruction_deadline: new Date(now.getTime() - 3 * 86_400_000).toISOString(),
+      auto_resume_requested_at: new Date(now.getTime() - 2 * 86_400_000).toISOString(),
+      auto_resume_retry_after: new Date(now.getTime() - 1 * 86_400_000).toISOString(),
+      auto_resume_attempt_count: 4,
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.enrollWithCredits({ plan: 'standard' });
+
+    expect(result).toEqual({ success: true });
+
+    const [subscription] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+
+    expect(subscription).toEqual(
+      expect.objectContaining({
+        status: 'active',
+        payment_source: 'credits',
+        suspended_at: null,
+        destruction_deadline: null,
+        auto_resume_requested_at: null,
+        auto_resume_retry_after: null,
+        auto_resume_attempt_count: 0,
+      })
+    );
+    expect(kiloclawInternalClientMock.__startAsyncMock).toHaveBeenCalledTimes(1);
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscription.id));
+    expect(logs[0]?.after_state).toEqual(
+      expect.objectContaining({
+        status: 'active',
+        suspended_at: null,
+        destruction_deadline: null,
+        auto_resume_requested_at: null,
+        auto_resume_retry_after: null,
+        auto_resume_attempt_count: 0,
+      })
+    );
+  });
 
   it('enrolls with credits for standard plan at intro price for first-time subscriber', async () => {
     const instance = await createInstance(user.id);

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -4675,7 +4675,7 @@ describe('applyStripeFundedKiloClawPeriod', () => {
       .where(eq(kilocode_users.id, userId));
   }
 
-  it('clears stale suspension and auto-resume fields when settlement activates a suspended trial', async () => {
+  it('clears destruction fields and records resume retry state when settlement activates a suspended trial', async () => {
     await giveUserCredits(user.id, 1_000_000);
     const instance = await createKiloclawInstance(user.id);
     const now = new Date();
@@ -4726,11 +4726,11 @@ describe('applyStripeFundedKiloClawPeriod', () => {
         plan: 'standard',
         suspended_at: null,
         destruction_deadline: null,
-        auto_resume_requested_at: null,
-        auto_resume_retry_after: null,
-        auto_resume_attempt_count: 0,
+        auto_resume_attempt_count: 1,
       })
     );
+    expect(subscription.auto_resume_requested_at).toEqual(expect.any(String));
+    expect(subscription.auto_resume_retry_after).toEqual(expect.any(String));
     expect(kiloclawInternalClientMock.__startAsyncMock).toHaveBeenCalledTimes(1);
 
     const logs = await db
@@ -4747,6 +4747,61 @@ describe('applyStripeFundedKiloClawPeriod', () => {
         auto_resume_attempt_count: 0,
       })
     );
+  });
+
+  it('keeps settlement subscription retryable when auto-resume request fails', async () => {
+    kiloclawInternalClientMock.__startAsyncMock.mockRejectedValueOnce(new Error('start failed'));
+    await giveUserCredits(user.id, 1_000_000);
+    const instance = await createKiloclawInstance(user.id);
+    const now = new Date();
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      stripe_subscription_id: 'sub_settlement_resume_failed',
+      payment_source: 'stripe',
+      plan: 'trial',
+      status: 'canceled',
+      trial_started_at: new Date(now.getTime() - 17 * 86_400_000).toISOString(),
+      trial_ends_at: new Date(now.getTime() - 10 * 86_400_000).toISOString(),
+      suspended_at: new Date(now.getTime() - 10 * 86_400_000).toISOString(),
+      destruction_deadline: new Date(now.getTime() - 3 * 86_400_000).toISOString(),
+      auto_resume_requested_at: new Date(now.getTime() - 2 * 86_400_000).toISOString(),
+      auto_resume_retry_after: new Date(now.getTime() - 1 * 86_400_000).toISOString(),
+      auto_resume_attempt_count: 3,
+    });
+
+    const { applyStripeFundedKiloClawPeriod } = await import('@/lib/kiloclaw/credit-billing');
+    const applied = await applyStripeFundedKiloClawPeriod({
+      userId: user.id,
+      metadataInstanceId: instance.id,
+      stripeSubscriptionId: 'sub_settlement_resume_failed',
+      stripePaymentId: 'ch_settlement_resume_failed',
+      plan: 'standard',
+      amountMicrodollars: 9_000_000,
+      periodStart: '2026-04-16T09:40:37.000Z',
+      periodEnd: '2026-05-16T09:40:37.000Z',
+    });
+
+    expect(applied).toBe(true);
+
+    const [subscription] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+
+    expect(subscription).toEqual(
+      expect.objectContaining({
+        status: 'active',
+        payment_source: 'credits',
+        suspended_at: null,
+        destruction_deadline: null,
+        auto_resume_attempt_count: 1,
+      })
+    );
+    expect(subscription.auto_resume_requested_at).toEqual(expect.any(String));
+    expect(subscription.auto_resume_retry_after).toEqual(expect.any(String));
   });
 });
 
@@ -4784,7 +4839,7 @@ describe('enrollWithCredits', () => {
     return instance;
   }
 
-  it('clears stale suspension and auto-resume fields when credit enrollment activates a suspended trial', async () => {
+  it('clears destruction fields and records resume retry state when credit enrollment activates a suspended trial', async () => {
     const instance = await createInstance(user.id);
     await giveUserCredits(user.id, 50_000_000);
     const now = new Date();
@@ -4820,11 +4875,11 @@ describe('enrollWithCredits', () => {
         payment_source: 'credits',
         suspended_at: null,
         destruction_deadline: null,
-        auto_resume_requested_at: null,
-        auto_resume_retry_after: null,
-        auto_resume_attempt_count: 0,
+        auto_resume_attempt_count: 1,
       })
     );
+    expect(subscription.auto_resume_requested_at).toEqual(expect.any(String));
+    expect(subscription.auto_resume_retry_after).toEqual(expect.any(String));
     expect(kiloclawInternalClientMock.__startAsyncMock).toHaveBeenCalledTimes(1);
 
     const logs = await db
@@ -4841,6 +4896,50 @@ describe('enrollWithCredits', () => {
         auto_resume_attempt_count: 0,
       })
     );
+  });
+
+  it('keeps credit-enrolled subscription retryable when auto-resume request fails', async () => {
+    kiloclawInternalClientMock.__startAsyncMock.mockRejectedValueOnce(new Error('start failed'));
+    const instance = await createInstance(user.id);
+    await giveUserCredits(user.id, 50_000_000);
+    const now = new Date();
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      plan: 'trial',
+      status: 'canceled',
+      trial_started_at: new Date(now.getTime() - 17 * 86_400_000).toISOString(),
+      trial_ends_at: new Date(now.getTime() - 10 * 86_400_000).toISOString(),
+      suspended_at: new Date(now.getTime() - 10 * 86_400_000).toISOString(),
+      destruction_deadline: new Date(now.getTime() - 3 * 86_400_000).toISOString(),
+      auto_resume_requested_at: new Date(now.getTime() - 2 * 86_400_000).toISOString(),
+      auto_resume_retry_after: new Date(now.getTime() - 1 * 86_400_000).toISOString(),
+      auto_resume_attempt_count: 4,
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.enrollWithCredits({ plan: 'standard' });
+
+    expect(result).toEqual({ success: true });
+
+    const [subscription] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1);
+
+    expect(subscription).toEqual(
+      expect.objectContaining({
+        status: 'active',
+        payment_source: 'credits',
+        suspended_at: null,
+        destruction_deadline: null,
+        auto_resume_attempt_count: 1,
+      })
+    );
+    expect(subscription.auto_resume_requested_at).toEqual(expect.any(String));
+    expect(subscription.auto_resume_retry_after).toEqual(expect.any(String));
   });
 
   it('enrolls with credits for standard plan at intro price for first-time subscriber', async () => {

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -177,11 +177,20 @@ describe('interrupted auto-resume sweep', () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
   });
 
-  it('requests async start and only records retry metadata on acceptance', async () => {
+  it('requests async start and records retry metadata on acceptance', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
     const sandboxId = 'ki_11111111111141118111111111111111';
     const { db, updates } = createMockDb([
-      [{ user_id: 'user-1', instance_id: instanceId, auto_resume_attempt_count: 0 }],
+      [
+        {
+          user_id: 'user-1',
+          instance_id: instanceId,
+          suspended_at: null,
+          auto_resume_requested_at: '2026-04-21T10:00:00.000Z',
+          auto_resume_retry_after: '2026-04-21T12:00:00.000Z',
+          auto_resume_attempt_count: 0,
+        },
+      ],
       [{ id: instanceId, sandbox_id: sandboxId }],
     ]);
     mockGetWorkerDb.mockReturnValue(db);
@@ -218,11 +227,20 @@ describe('interrupted auto-resume sweep', () => {
     expect(updates[0]).not.toHaveProperty('destruction_deadline');
   });
 
-  it('keeps rows suspended when async resume request fails', async () => {
+  it('keeps retry metadata when async resume request fails', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
     const sandboxId = 'ki_11111111111141118111111111111111';
     const { db, updates } = createMockDb([
-      [{ user_id: 'user-1', instance_id: instanceId, auto_resume_attempt_count: 1 }],
+      [
+        {
+          user_id: 'user-1',
+          instance_id: instanceId,
+          suspended_at: null,
+          auto_resume_requested_at: '2026-04-21T10:00:00.000Z',
+          auto_resume_retry_after: '2026-04-21T12:00:00.000Z',
+          auto_resume_attempt_count: 1,
+        },
+      ],
       [{ id: instanceId, sandbox_id: sandboxId }],
     ]);
     mockGetWorkerDb.mockReturnValue(db);
@@ -257,11 +275,20 @@ describe('interrupted auto-resume sweep', () => {
     expect(updates[0]).not.toHaveProperty('destruction_deadline');
   });
 
-  it('keeps 404 from async resume request on the normal failure path', async () => {
+  it('keeps retry metadata after 404 from async resume request', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
     const sandboxId = 'ki_11111111111141118111111111111111';
     const { db, updates } = createMockDb([
-      [{ user_id: 'user-1', instance_id: instanceId, auto_resume_attempt_count: 0 }],
+      [
+        {
+          user_id: 'user-1',
+          instance_id: instanceId,
+          suspended_at: null,
+          auto_resume_requested_at: '2026-04-21T10:00:00.000Z',
+          auto_resume_retry_after: '2026-04-21T12:00:00.000Z',
+          auto_resume_attempt_count: 0,
+        },
+      ],
       [{ id: instanceId, sandbox_id: sandboxId }],
     ]);
     mockGetWorkerDb.mockReturnValue(db);
@@ -293,10 +320,19 @@ describe('interrupted auto-resume sweep', () => {
     );
   });
 
-  it('clears stale suspension state when no active instance remains', async () => {
+  it('clears stale resume state when no active instance remains', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
     const { db, updates, txUpdates, txDeletes } = createMockDb([
-      [{ user_id: 'user-1', instance_id: instanceId, auto_resume_attempt_count: 1 }],
+      [
+        {
+          user_id: 'user-1',
+          instance_id: instanceId,
+          suspended_at: null,
+          auto_resume_requested_at: '2026-04-21T10:00:00.000Z',
+          auto_resume_retry_after: '2026-04-21T12:00:00.000Z',
+          auto_resume_attempt_count: 1,
+        },
+      ],
       [],
     ]);
     mockGetWorkerDb.mockReturnValue(db);
@@ -335,6 +371,9 @@ describe('interrupted auto-resume sweep', () => {
           user_id: 'user-1',
           instance_id: null,
           organization_id: null,
+          suspended_at: null,
+          auto_resume_requested_at: '2026-04-21T10:00:00.000Z',
+          auto_resume_retry_after: '2026-04-21T12:00:00.000Z',
           auto_resume_attempt_count: 0,
         },
       ],

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -561,6 +561,51 @@ describe('instance destruction sweep', () => {
     );
   });
 
+  it('does not destroy active subscriptions even with stale expired destruction fields', async () => {
+    const instanceId = '11111111-1111-4111-8111-111111111111';
+    const { db, updates, txUpdates, inserts, deletes } = createMockDb([
+      [
+        {
+          id: 'sub-active',
+          user_id: 'user-1',
+          instance_id: instanceId,
+          sandbox_id: 'ki_11111111111141118111111111111111',
+          organization_id: null,
+          status: 'active',
+          email: 'user-1@example.com',
+        },
+      ],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi.fn();
+
+    const summary = await runSweep(
+      createEnv(fetch),
+      {
+        runId: 'abababab-abab-4bab-8bab-abababababab',
+        sweep: 'instance_destruction',
+      },
+      1
+    );
+
+    expect(summary.errors).toBe(0);
+    expect(summary.sweep3_instance_destruction).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(updates).toHaveLength(0);
+    expect(txUpdates).toHaveLength(0);
+    expect(inserts).toHaveLength(0);
+    expect(deletes).toHaveLength(0);
+    expect(loggedValues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: 'Skipping instance destruction for active subscription row',
+          reason: 'active_subscription',
+        }),
+      ])
+    );
+  });
+
   it('keeps DB/email cleanup unchanged when platform destroy succeeds', async () => {
     const instanceId = '11111111-1111-4111-8111-111111111111';
     const { db, updates, txUpdates, inserts, deletes } = createMockDb([
@@ -570,6 +615,7 @@ describe('instance destruction sweep', () => {
           user_id: 'user-1',
           instance_id: instanceId,
           sandbox_id: 'ki_11111111111141118111111111111111',
+          status: 'canceled',
           email: 'user-1@example.com',
         },
       ],
@@ -639,6 +685,7 @@ describe('instance destruction sweep', () => {
           user_id: 'user-1',
           instance_id: firstInstanceId,
           sandbox_id: 'ki_11111111111141118111111111111111',
+          status: 'canceled',
           email: 'user-1@example.com',
         },
         {
@@ -646,6 +693,7 @@ describe('instance destruction sweep', () => {
           user_id: 'user-2',
           instance_id: secondInstanceId,
           sandbox_id: 'ki_22222222222242228222222222222222',
+          status: 'canceled',
           email: 'user-2@example.com',
         },
       ],
@@ -748,6 +796,7 @@ describe('instance destruction sweep', () => {
           user_id: 'user-1',
           instance_id: instanceId,
           sandbox_id: 'ki_11111111111141118111111111111111',
+          status: 'canceled',
           email: 'user-1@example.com',
         },
       ],
@@ -827,6 +876,7 @@ describe('instance destruction sweep', () => {
           user_id: 'user-1',
           instance_id: '11111111-1111-4111-8111-111111111111',
           sandbox_id: null,
+          status: 'canceled',
           email: 'user-1@example.com',
         },
       ],

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -1788,6 +1788,7 @@ async function runInstanceDestructionSweep(
       instance_id: kiloclaw_subscriptions.instance_id,
       sandbox_id: kiloclaw_instances.sandbox_id,
       organization_id: kiloclaw_instances.organization_id,
+      status: kiloclaw_subscriptions.status,
       email: kilocode_users.google_user_email,
     })
     .from(kiloclaw_subscriptions)
@@ -1797,13 +1798,24 @@ async function runInstanceDestructionSweep(
       and(
         lt(kiloclaw_subscriptions.destruction_deadline, now),
         currentSubscriptionRowFilter(),
-        isNotNull(kiloclaw_subscriptions.suspended_at)
+        isNotNull(kiloclaw_subscriptions.suspended_at),
+        inArray(kiloclaw_subscriptions.status, ['canceled', 'past_due', 'unpaid'])
       )
     );
 
   for (const row of destructionCandidates) {
     try {
       if (isSoftDeletedUserEmail(row.email)) continue;
+      if (row.status === 'active') {
+        logSkippedSubscriptionRow(
+          'Skipping instance destruction for active subscription row',
+          row,
+          {
+            reason: 'active_subscription',
+          }
+        );
+        continue;
+      }
       if (!row.instance_id) {
         logSkippedSubscriptionRow(
           'Skipping instance destruction for detached subscription row',

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -1436,7 +1436,12 @@ async function runInterruptedAutoResumeSweep(
         eq(kiloclaw_subscriptions.payment_source, 'credits'),
         eq(kiloclaw_subscriptions.status, 'active'),
         currentSubscriptionRowFilter(),
-        isNotNull(kiloclaw_subscriptions.suspended_at),
+        or(
+          isNotNull(kiloclaw_subscriptions.suspended_at),
+          isNotNull(kiloclaw_subscriptions.auto_resume_requested_at),
+          isNotNull(kiloclaw_subscriptions.auto_resume_retry_after),
+          gt(kiloclaw_subscriptions.auto_resume_attempt_count, 0)
+        ),
         sql`(${kiloclaw_subscriptions.auto_resume_retry_after} IS NULL OR ${kiloclaw_subscriptions.auto_resume_retry_after} <= ${now})`
       )
     );


### PR DESCRIPTION
## Summary
Prevents paid KiloClaw subscriptions from remaining eligible for instance destruction after recovery from a suspended trial.

### Why this change is needed
Expired KiloClaw trials can leave `suspended_at` and `destruction_deadline` on the subscription row. If a user pays before the deadline, some activation paths recover the subscription to `active` but leave those lifecycle fields behind. A failed or incomplete auto-resume can then let the destruction sweep destroy a paid active personal instance because the old predicate only looked at stale destruction fields.

### How this is addressed
- Clear suspension, destruction, and auto-resume retry fields immediately when Stripe settlement or credit enrollment activates a paid subscription.
- Keep auto-resume as a best-effort instance start request without reintroducing destruction eligibility after paid activation.
- Narrow the destruction sweep to terminal suspended states and keep an active-row skip as defense in depth.
- Add regressions for Stripe settlement, credit enrollment, active stale-row sweep protection, and existing canceled-row destruction behavior.

## Human Verification
- Spec alignment: implementation follows KiloClaw billing/data-model requirements for paid activation preserving entitlement independently of auto-resume completion.
- Tests verified: `pnpm --filter web test -- apps/web/src/routers/kiloclaw-billing-router.test.ts --runTestsByPath --runInBand` passed.
- Tests verified: `pnpm --filter kiloclaw-billing test -- src/lifecycle.test.ts` passed.
- Code evaluations: self-review plus focused logic/data/types review found no issues.
- _Additional verification (to be completed by author)_

## Visual Changes
N/A

## Reviewer Notes
### Human Reviewer
- Business-rule shift: paid activation now clears destruction eligibility immediately, even though historical spec text said credit enrollment should keep suspension fields until auto-resume completed.
- Trade-off: auto-resume retry metadata is no longer recorded by these paid activation paths after lifecycle fields are cleared. This preserves paid entitlement and avoids stale destruction risk; failed starts still log through the KiloClaw internal client path.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- `PAID_ACTIVATION_LIFECYCLE_CLEAR_SET` centralizes fields cleared when subscription status is set to paid `active` in settlement and credit enrollment.
- `autoResumeIfSuspended` keeps default retry-state behavior for existing callers, with `recordRetryState: false` only for paid activation callers that already cleared lifecycle state.
- `runInstanceDestructionSweep` now selects only `canceled`, `past_due`, or `unpaid` rows with stale destruction fields; the active-row skip remains as in-loop defense if query criteria drift.
- Regression coverage lives in existing KiloClaw billing router and lifecycle worker tests.

</details>