### PR TITLE
feat(bot): seed Chat SDK state from Slack OAuth callback

### DIFF
--- a/apps/web/src/app/api/integrations/slack/callback/route.ts
+++ b/apps/web/src/app/api/integrations/slack/callback/route.ts
@@ -5,6 +5,7 @@ import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import type { Owner } from '@/lib/integrations/core/types';
 import { captureException, captureMessage } from '@sentry/nextjs';
 import { exchangeSlackCode, upsertSlackInstallation } from '@/lib/integrations/slack-service';
+import { syncOldSlackInstallationToSdk } from '@/lib/bot/slack-installation-sync';
 import { APP_URL } from '@/lib/constants';
 
 const buildSlackRedirectPath = (state: string | null, queryParam: string): string => {
@@ -97,7 +98,21 @@ export async function GET(request: NextRequest) {
     // 6. Store installation in database
     await upsertSlackInstallation(owner, oauthData);
 
-    // 7. Redirect to success page
+    // 7. Best-effort seed Chat SDK state for future migration
+    try {
+      await syncOldSlackInstallationToSdk(oauthData);
+    } catch (syncError) {
+      captureException(syncError, {
+        tags: { endpoint: 'slack/callback', source: 'slack_sdk_sync' },
+        extra: {
+          teamId: oauthData.team?.id,
+          ownerType: owner.type,
+          ownerId: owner.id,
+        },
+      });
+    }
+
+    // 8. Redirect to success page
     const successPath =
       owner.type === 'org'
         ? `/organizations/${owner.id}/integrations/slack?success=installed`

--- a/apps/web/src/lib/bot.ts
+++ b/apps/web/src/lib/bot.ts
@@ -1,7 +1,5 @@
 import { Chat, emoji, type ActionEvent, type Message, type Thread } from 'chat';
 import { createSlackAdapter } from '@chat-adapter/slack';
-import { createRedisState } from '@chat-adapter/state-redis';
-import { createMemoryState } from '@chat-adapter/state-memory';
 import { captureException } from '@sentry/nextjs';
 import { resolveKiloUserId, unlinkKiloUser } from '@/lib/bot-identity';
 import { getPlatformIdentity, getPlatformIntegration } from '@/lib/bot/platform-helpers';
@@ -9,6 +7,7 @@ import { LINK_ACCOUNT_ACTION_PREFIX, promptLinkAccount } from '@/lib/bot/link-ac
 import { createBotRequest, updateBotRequest } from '@/lib/bot/request-logging';
 import { findUserById } from '@/lib/user';
 import { processMessage } from '@/lib/bot/run';
+import { createChatState } from '@/lib/bot/state';
 
 const slackAdapter = createSlackAdapter({
   clientId: process.env.SLACK_NEXT_CLIENT_ID,
@@ -22,7 +21,7 @@ export const bot = new Chat({
   adapters: {
     slack: slackAdapter,
   },
-  state: process.env.REDIS_URL ? createRedisState() : createMemoryState(),
+  state: createChatState(),
 });
 
 bot.onNewMention(async function handleIncomingMessage(

--- a/apps/web/src/lib/bot/slack-installation-sync-mapping.ts
+++ b/apps/web/src/lib/bot/slack-installation-sync-mapping.ts
@@ -1,0 +1,27 @@
+import type { OAuthV2Response } from '@slack/oauth';
+
+export type SdkInstallationData = {
+  teamId: string;
+  botToken: string;
+  botUserId?: string;
+  teamName?: string;
+};
+
+export function extractSdkInstallationData(oauthResponse: OAuthV2Response): SdkInstallationData {
+  const teamId = oauthResponse.team?.id;
+  const accessToken = oauthResponse.access_token;
+
+  if (!teamId) {
+    throw new Error('Missing team.id in Slack OAuth response');
+  }
+  if (!accessToken) {
+    throw new Error('Missing access_token in Slack OAuth response');
+  }
+
+  return {
+    teamId,
+    botToken: accessToken,
+    botUserId: oauthResponse.bot_user_id ?? undefined,
+    teamName: oauthResponse.team?.name || undefined,
+  };
+}

--- a/apps/web/src/lib/bot/slack-installation-sync.test.ts
+++ b/apps/web/src/lib/bot/slack-installation-sync.test.ts
@@ -1,0 +1,69 @@
+import { extractSdkInstallationData } from './slack-installation-sync-mapping';
+import type { OAuthV2Response } from '@slack/oauth';
+
+function makeOAuthResponse(overrides: Partial<OAuthV2Response> = {}): OAuthV2Response {
+  return {
+    ok: true,
+    app_id: 'A123',
+    authed_user: { id: 'U123' },
+    team: { id: 'T123', name: 'Test Team' },
+    enterprise: null,
+    is_enterprise_install: false,
+    access_token: 'xoxb-test-token',
+    bot_user_id: 'B123',
+    ...overrides,
+  };
+}
+
+describe('extractSdkInstallationData', () => {
+  it('stores team.id as teamId', () => {
+    const result = extractSdkInstallationData(
+      makeOAuthResponse({ team: { id: 'T456', name: 'Team Name' } })
+    );
+    expect(result.teamId).toBe('T456');
+  });
+
+  it('stores access_token as botToken', () => {
+    const result = extractSdkInstallationData(makeOAuthResponse({ access_token: 'xoxb-abc' }));
+    expect(result.botToken).toBe('xoxb-abc');
+  });
+
+  it('stores bot_user_id when present', () => {
+    const result = extractSdkInstallationData(makeOAuthResponse({ bot_user_id: 'B456' }));
+    expect(result.botUserId).toBe('B456');
+  });
+
+  it('stores team.name when present', () => {
+    const result = extractSdkInstallationData(
+      makeOAuthResponse({ team: { id: 'T789', name: 'Acme' } })
+    );
+    expect(result.teamName).toBe('Acme');
+  });
+
+  it('omits botUserId when bot_user_id is missing', () => {
+    const { bot_user_id: _ignore, ...withoutBotUserId } = makeOAuthResponse({
+      bot_user_id: undefined,
+    });
+    const result = extractSdkInstallationData(withoutBotUserId);
+    expect(result.botUserId).toBeUndefined();
+  });
+
+  it('omits teamName when team.name is missing', () => {
+    const result = extractSdkInstallationData(
+      makeOAuthResponse({ team: { id: 'T000', name: '' } })
+    );
+    expect(result.teamName).toBeUndefined();
+  });
+
+  it('throws when team.id is missing', () => {
+    expect(() => extractSdkInstallationData(makeOAuthResponse({ team: null }))).toThrow(
+      'Missing team.id in Slack OAuth response'
+    );
+  });
+
+  it('throws when access_token is missing', () => {
+    expect(() =>
+      extractSdkInstallationData(makeOAuthResponse({ access_token: undefined }))
+    ).toThrow('Missing access_token in Slack OAuth response');
+  });
+});

--- a/apps/web/src/lib/bot/slack-installation-sync.ts
+++ b/apps/web/src/lib/bot/slack-installation-sync.ts
@@ -1,0 +1,33 @@
+import 'server-only';
+import { Chat } from 'chat';
+import { createSlackAdapter } from '@chat-adapter/slack';
+import type { OAuthV2Response } from '@slack/oauth';
+import { SLACK_SIGNING_SECRET } from '@/lib/config.server';
+import { createChatState } from './state';
+import { extractSdkInstallationData } from './slack-installation-sync-mapping';
+
+export {
+  extractSdkInstallationData,
+  type SdkInstallationData,
+} from './slack-installation-sync-mapping';
+
+const syncSlackAdapter = createSlackAdapter({
+  signingSecret: SLACK_SIGNING_SECRET,
+});
+
+const syncBot = new Chat({
+  userName: 'Kilo Sync Bot',
+  adapters: { slack: syncSlackAdapter },
+  state: createChatState(),
+});
+
+export async function syncOldSlackInstallationToSdk(oauthResponse: OAuthV2Response): Promise<void> {
+  const data = extractSdkInstallationData(oauthResponse);
+  await syncBot.initialize();
+  const adapter = syncBot.getAdapter('slack');
+  await adapter.setInstallation(data.teamId, {
+    botToken: data.botToken,
+    botUserId: data.botUserId,
+    teamName: data.teamName,
+  });
+}

--- a/apps/web/src/lib/bot/state.ts
+++ b/apps/web/src/lib/bot/state.ts
@@ -1,0 +1,7 @@
+import { createRedisState } from '@chat-adapter/state-redis';
+import { createMemoryState } from '@chat-adapter/state-memory';
+import type { StateAdapter } from 'chat';
+
+export function createChatState(): StateAdapter {
+  return process.env.REDIS_URL ? createRedisState() : createMemoryState();
+}


### PR DESCRIPTION
## Summary

Adds best-effort seeding of Chat SDK state whenever a user completes the Slack OAuth flow. This ensures existing Slack installations are synchronized into the Chat SDK's adapter state, paving the way for future migration away from the legacy bot storage.

- Extracts `createChatState()` helper into `apps/web/src/lib/bot/state.ts` so both the main bot and the sync utility share the same state adapter configuration.
- Introduces `syncOldSlackInstallationToSdk()` in `apps/web/src/lib/bot/slack-installation-sync.ts` which initializes a temporary Chat SDK bot and writes the Slack installation data via the Slack adapter.
- Adds `extractSdkInstallationData()` mapping utility with full test coverage for converting Slack OAuth V2 responses into the SDK's expected installation shape.
- Wires the sync call into the Slack OAuth callback route with wrapped error handling (failures are captured to Sentry but do not block the redirect).

## Reviewer Notes

- The sync step is intentionally best-effort: any exception is caught, reported to Sentry, and the user is still redirected to the success page. This prevents a Chat SDK initialization failure from breaking the existing Slack installation flow.