### PR TITLE
fix(kiloclaw): protect historical admin subscriptions

### DIFF
--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
@@ -264,6 +264,23 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
           </div>
         </CardHeader>
         <CardContent className="space-y-6">
+          {data?.needsSupportReview && (
+            <div className="rounded-lg border border-yellow-500/40 bg-yellow-950/20 p-4">
+              <h4 className="text-sm font-medium text-yellow-300">
+                Billing state needs support review
+              </h4>
+              <p className="mt-1 text-sm text-yellow-100/80">
+                Current personal subscription rows could not be resolved automatically. Inspect the
+                rows below before making changes.
+              </p>
+              {data.billingStateError ? (
+                <p className="text-muted-foreground mt-2 break-words font-mono text-xs">
+                  {data.billingStateError}
+                </p>
+              ) : null}
+            </div>
+          )}
+
           {/* Access & earlybird summary */}
           <div className="flex items-center gap-4">
             <div>

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import Link from 'next/link';
-import { ExternalLink } from 'lucide-react';
+import { ExternalLink, History } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -41,8 +41,26 @@ function localDateInputToEndOfDayIso(date: string): string {
   return new Date(year, month - 1, day, 23, 59, 59, 0).toISOString();
 }
 
+function formatJsonSummary(value: Record<string, unknown> | null | undefined): string {
+  if (!value) return '—';
+  return JSON.stringify(value, null, 2);
+}
+
 function getAccessBadgeClass(hasAccess: boolean) {
   return hasAccess ? 'bg-green-900/20 text-green-400' : 'bg-red-900/20 text-red-400';
+}
+
+function isTransferredHistoricalSubscription(subscription: {
+  transferred_to_subscription_id: string | null;
+}) {
+  return Boolean(subscription.transferred_to_subscription_id);
+}
+
+function isInactiveSubscription(subscription: {
+  status: string;
+  transferred_to_subscription_id: string | null;
+}) {
+  return subscription.status === 'canceled' || isTransferredHistoricalSubscription(subscription);
 }
 
 function getSubscriptionStatusBadgeClass(status: string) {
@@ -84,11 +102,21 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
   // Hide inactive toggle
   const [hideInactive, setHideInactive] = useState(true);
 
+  // Change log dialog
+  const [changeLogSubscriptionId, setChangeLogSubscriptionId] = useState<string | null>(null);
+
   const { data, isLoading, error } = useQuery(
     trpc.admin.users.getKiloClawState.queryOptions({ userId })
   );
 
   const trialSubscription = data?.subscriptions?.find(s => s.id === trialSubscriptionId);
+  const changeLogSubscription = data?.subscriptions?.find(s => s.id === changeLogSubscriptionId);
+  const changeLogsQuery = useQuery(
+    trpc.admin.users.getKiloClawSubscriptionChangeLogs.queryOptions(
+      { userId, subscriptionId: changeLogSubscriptionId ?? '', limit: 50 },
+      { enabled: Boolean(changeLogSubscriptionId) }
+    )
+  );
 
   useEffect(() => {
     if (!trialDialogOpen) return;
@@ -170,6 +198,14 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
     setCancelDialogOpen(true);
   };
 
+  const openChangeLogDialog = (subscriptionId: string) => {
+    setChangeLogSubscriptionId(subscriptionId);
+  };
+
+  const closeChangeLogDialog = () => {
+    setChangeLogSubscriptionId(null);
+  };
+
   if (isLoading) {
     return (
       <Card className="lg:col-span-4">
@@ -198,7 +234,7 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
 
   const subscriptions = data?.subscriptions ?? [];
   const visibleSubscriptions = hideInactive
-    ? subscriptions.filter(s => s.status !== 'canceled')
+    ? subscriptions.filter(s => !isInactiveSubscription(s))
     : subscriptions;
   const hiddenCount = subscriptions.length - visibleSubscriptions.length;
 
@@ -258,7 +294,7 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
           </div>
 
           {/* Hide inactive toggle */}
-          {subscriptions.some(s => s.status === 'canceled') && (
+          {subscriptions.some(isInactiveSubscription) && (
             <div className="flex items-center gap-2">
               <label className="flex cursor-pointer items-center gap-2 text-sm">
                 <input
@@ -288,16 +324,21 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
           ) : (
             <div className="space-y-4">
               {visibleSubscriptions.map(sub => {
-                const isEffective = sub.id === data?.effectiveSubscriptionId;
-                const canEditTrialEnd = sub.status === 'trialing' || sub.status === 'canceled';
+                const isTransferred = isTransferredHistoricalSubscription(sub);
+                const isEffective = !isTransferred && sub.id === data?.effectiveSubscriptionId;
+                const canEditTrialEnd =
+                  !isTransferred && (sub.status === 'trialing' || sub.status === 'canceled');
                 const isTrialReset = sub.status === 'canceled';
                 const canCancel =
+                  !isTransferred &&
                   (sub.status === 'active' || sub.status === 'past_due') &&
                   sub.plan !== 'trial' &&
                   !sub.cancel_at_period_end;
                 const canImmediateCancel =
-                  (sub.status === 'active' || sub.status === 'past_due') && sub.plan !== 'trial';
-                const canCancelTrial = sub.status === 'trialing';
+                  !isTransferred &&
+                  (sub.status === 'active' || sub.status === 'past_due') &&
+                  sub.plan !== 'trial';
+                const canCancelTrial = !isTransferred && sub.status === 'trialing';
 
                 return (
                   <div
@@ -314,6 +355,11 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
                         {isEffective && (
                           <Badge variant="outline" className="text-xs">
                             effective
+                          </Badge>
+                        )}
+                        {isTransferred && (
+                          <Badge variant="outline" className="text-muted-foreground text-xs">
+                            historical / ignored
                           </Badge>
                         )}
                         {sub.cancel_at_period_end && (
@@ -336,6 +382,14 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
                             </Link>
                           </Button>
                         )}
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => openChangeLogDialog(sub.id)}
+                        >
+                          <History className="mr-1 h-3 w-3" />
+                          Change Log
+                        </Button>
                         {canEditTrialEnd && (
                           <Button
                             variant="outline"
@@ -543,6 +597,77 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
                   : cancelMode === 'immediate'
                     ? 'Cancel Immediately'
                     : 'Cancel at Period End'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(changeLogSubscriptionId)}
+        onOpenChange={open => !open && closeChangeLogDialog()}
+      >
+        <DialogContent className="max-w-5xl">
+          <DialogHeader>
+            <DialogTitle>KiloClaw Subscription Change Log</DialogTitle>
+            <DialogDescription>
+              Latest 50 change log entries for subscription{' '}
+              <span className="font-mono">
+                {changeLogSubscription?.id ?? changeLogSubscriptionId}
+              </span>
+            </DialogDescription>
+          </DialogHeader>
+          <div className="max-h-[70vh] overflow-auto py-2">
+            {changeLogsQuery.isLoading ? (
+              <p className="text-muted-foreground text-sm">Loading change log...</p>
+            ) : changeLogsQuery.error ? (
+              <p className="text-sm text-red-400">Failed to load change log</p>
+            ) : !changeLogsQuery.data || changeLogsQuery.data.changeLogs.length === 0 ? (
+              <p className="text-muted-foreground text-sm">
+                No change log entries for this subscription.
+              </p>
+            ) : (
+              <div className="space-y-3">
+                {changeLogsQuery.data.changeLogs.map(changeLog => (
+                  <div key={changeLog.id} className="rounded-md border bg-muted/20 p-3">
+                    <div className="mb-2 flex flex-wrap items-center gap-2">
+                      <Badge variant="outline" className="text-xs">
+                        {changeLog.action}
+                      </Badge>
+                      <span className="text-muted-foreground text-xs">
+                        {formatDate(changeLog.created_at)}
+                      </span>
+                      <span className="text-muted-foreground text-xs">
+                        {changeLog.actor_type}:{' '}
+                        <span className="font-mono">{changeLog.actor_id}</span>
+                      </span>
+                      {changeLog.reason ? (
+                        <span className="text-muted-foreground text-xs">
+                          reason: <span className="font-mono">{changeLog.reason}</span>
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className="grid gap-2 text-xs md:grid-cols-2">
+                      <details className="rounded border bg-background/60 p-2">
+                        <summary className="cursor-pointer font-medium">Before</summary>
+                        <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] text-muted-foreground">
+                          {formatJsonSummary(changeLog.before_state)}
+                        </pre>
+                      </details>
+                      <details className="rounded border bg-background/60 p-2">
+                        <summary className="cursor-pointer font-medium">After</summary>
+                        <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] text-muted-foreground">
+                          {formatJsonSummary(changeLog.after_state)}
+                        </pre>
+                      </details>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={closeChangeLogDialog}>
+              Close
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/lib/kiloclaw/access-state.ts
+++ b/apps/web/src/lib/kiloclaw/access-state.ts
@@ -1,7 +1,7 @@
 import { db } from '@/lib/drizzle';
 import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
 import { kiloclaw_subscriptions, type KiloClawSubscription } from '@kilocode/db/schema';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 
 import {
   CurrentPersonalSubscriptionResolutionError,
@@ -12,7 +12,12 @@ export type KiloClawAccessReason = 'trial' | 'subscription' | 'earlybird';
 export type KiloClawActivationState = 'pending_settlement' | 'activated';
 export type KiloClawSubscriptionAccessRecord = Pick<
   KiloClawSubscription,
-  'status' | 'trial_ends_at' | 'suspended_at' | 'access_origin' | 'payment_source'
+  | 'status'
+  | 'trial_ends_at'
+  | 'suspended_at'
+  | 'access_origin'
+  | 'payment_source'
+  | 'transferred_to_subscription_id'
 >;
 export type KiloClawEarlybirdState = {
   purchased: boolean;
@@ -60,6 +65,7 @@ export function getKiloClawSubscriptionAccessReason(
   now = new Date()
 ): KiloClawAccessReason | null {
   if (!subscription) return null;
+  if (subscription.transferred_to_subscription_id) return null;
   if (getKiloClawSubscriptionActivationState(subscription) === 'pending_settlement') return null;
   if (subscription.status === 'active') return 'subscription';
   if (subscription.status === 'past_due' && !subscription.suspended_at) return 'subscription';
@@ -80,9 +86,12 @@ export function getEffectiveKiloClawSubscription(
   subscriptions: KiloClawSubscription[],
   now = new Date()
 ): KiloClawSubscription | null {
-  if (subscriptions.length === 0) return null;
+  const currentSubscriptions = subscriptions.filter(
+    subscription => !subscription.transferred_to_subscription_id
+  );
+  if (currentSubscriptions.length === 0) return null;
 
-  return [...subscriptions].sort((left, right) => {
+  return [...currentSubscriptions].sort((left, right) => {
     const priorityDiff = subscriptionPriority(left, now) - subscriptionPriority(right, now);
     if (priorityDiff !== 0) return priorityDiff;
 
@@ -124,7 +133,8 @@ export async function getKiloClawEarlybirdStateForUser(
     .where(
       and(
         eq(kiloclaw_subscriptions.user_id, userId),
-        eq(kiloclaw_subscriptions.access_origin, 'earlybird')
+        eq(kiloclaw_subscriptions.access_origin, 'earlybird'),
+        isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
       )
     );
 

--- a/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
@@ -7,7 +7,8 @@ import {
   kiloclaw_instances,
   kiloclaw_subscriptions,
 } from '@kilocode/db/schema';
-import { eq } from 'drizzle-orm';
+import { count, eq } from 'drizzle-orm';
+import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
 import type { User } from '@kilocode/db/schema';
 
 let adminUser: User;
@@ -59,8 +60,17 @@ describe('admin.users.getKiloClawState', () => {
   });
 
   it('returns subscription access for active subscriptions', async () => {
+    const [instance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        user_id: targetUser.id,
+        sandbox_id: 'sandbox-admin-kiloclaw-active',
+      })
+      .returning();
+
     await db.insert(kiloclaw_subscriptions).values({
       user_id: targetUser.id,
+      instance_id: instance.id,
       plan: 'standard',
       status: 'active',
       stripe_subscription_id: 'sub_admin_kiloclaw_active',
@@ -81,23 +91,43 @@ describe('admin.users.getKiloClawState', () => {
     expect(result.effectiveSubscriptionId).toBe(result.subscriptions[0].id);
   });
 
-  it('prefers an active subscription over an older canceled row', async () => {
-    await db.insert(kiloclaw_subscriptions).values([
-      {
+  it('prefers an active personal current row over an older canceled row', async () => {
+    const [oldInstance, activeInstance] = await db
+      .insert(kiloclaw_instances)
+      .values([
+        {
+          user_id: targetUser.id,
+          sandbox_id: 'sandbox-admin-kiloclaw-canceled',
+          destroyed_at: '2026-03-01T00:00:00.000Z',
+        },
+        {
+          user_id: targetUser.id,
+          sandbox_id: 'sandbox-admin-kiloclaw-active-latest',
+        },
+      ])
+      .returning();
+
+    const [activeSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
         user_id: targetUser.id,
-        plan: 'standard',
-        status: 'canceled',
-        stripe_subscription_id: 'sub_admin_kiloclaw_canceled',
-        current_period_end: '2026-03-01T00:00:00.000Z',
-      },
-      {
-        user_id: targetUser.id,
+        instance_id: activeInstance.id,
         plan: 'standard',
         status: 'active',
         stripe_subscription_id: 'sub_admin_kiloclaw_active_latest',
         current_period_end: '2026-05-01T00:00:00.000Z',
-      },
-    ]);
+      })
+      .returning();
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: targetUser.id,
+      instance_id: oldInstance.id,
+      plan: 'standard',
+      status: 'canceled',
+      stripe_subscription_id: 'sub_admin_kiloclaw_canceled',
+      current_period_end: '2026-03-01T00:00:00.000Z',
+      transferred_to_subscription_id: activeSub.id,
+    });
 
     const caller = await createCallerForUser(adminUser.id);
     const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
@@ -115,8 +145,17 @@ describe('admin.users.getKiloClawState', () => {
   it('returns trial access for future trial end dates', async () => {
     const futureTrialEnd = new Date(Date.now() + 5 * 86_400_000).toISOString();
 
+    const [instance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        user_id: targetUser.id,
+        sandbox_id: 'sandbox-admin-kiloclaw-trial',
+      })
+      .returning();
+
     await db.insert(kiloclaw_subscriptions).values({
       user_id: targetUser.id,
+      instance_id: instance.id,
       plan: 'trial',
       status: 'trialing',
       trial_started_at: new Date().toISOString(),
@@ -136,8 +175,17 @@ describe('admin.users.getKiloClawState', () => {
   it('shows expired trial rows without trial access', async () => {
     const expiredTrialEnd = new Date(Date.now() - 2 * 86_400_000).toISOString();
 
+    const [instance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        user_id: targetUser.id,
+        sandbox_id: 'sandbox-admin-kiloclaw-expired-trial',
+      })
+      .returning();
+
     await db.insert(kiloclaw_subscriptions).values({
       user_id: targetUser.id,
+      instance_id: instance.id,
       plan: 'trial',
       status: 'trialing',
       trial_started_at: new Date(Date.now() - 10 * 86_400_000).toISOString(),
@@ -251,6 +299,207 @@ describe('admin.users.getKiloClawState', () => {
         destroyed_at: null,
       })
     );
+  });
+
+  it('ignores transferred historical rows when selecting effective access', async () => {
+    const futureTrialEnd = new Date(Date.now() + 30 * 86_400_000).toISOString();
+    const [historicalInstance, currentInstance] = await db
+      .insert(kiloclaw_instances)
+      .values([
+        {
+          user_id: targetUser.id,
+          sandbox_id: 'sandbox-transferred-history',
+          destroyed_at: '2026-04-01T00:00:00.000Z',
+        },
+        {
+          user_id: targetUser.id,
+          sandbox_id: 'sandbox-transferred-current',
+        },
+      ])
+      .returning();
+
+    const [currentSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        instance_id: currentInstance.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+        current_period_end: '2026-05-01T00:00:00.000Z',
+      })
+      .returning();
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: targetUser.id,
+      instance_id: historicalInstance.id,
+      plan: 'trial',
+      status: 'trialing',
+      trial_started_at: '2026-04-01T00:00:00.000Z',
+      trial_ends_at: futureTrialEnd,
+      transferred_to_subscription_id: currentSub.id,
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
+
+    expect(result.subscription?.id).toBe(currentSub.id);
+    expect(result.effectiveSubscriptionId).toBe(currentSub.id);
+    expect(result.hasAccess).toBe(true);
+    expect(result.accessReason).toBe('subscription');
+    expect(result.subscriptions).toHaveLength(2);
+  });
+
+  it('returns subscription rows without eager-loading change log history', async () => {
+    const [instance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        user_id: targetUser.id,
+        sandbox_id: 'sandbox-admin-kiloclaw-change-log',
+      })
+      .returning();
+    const [subscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        instance_id: instance.id,
+        plan: 'trial',
+        status: 'trialing',
+        trial_started_at: '2026-04-01T00:00:00.000Z',
+        trial_ends_at: '2026-04-08T00:00:00.000Z',
+      })
+      .returning();
+
+    await insertKiloClawSubscriptionChangeLog(db, {
+      subscriptionId: subscription.id,
+      action: 'created',
+      actor: { actorType: 'system', actorId: 'test-bootstrap' },
+      reason: 'initial_test_row',
+      before: null,
+      after: subscription,
+    });
+    const [updatedSubscription] = await db
+      .update(kiloclaw_subscriptions)
+      .set({ trial_ends_at: '2026-04-10T00:00:00.000Z' })
+      .where(eq(kiloclaw_subscriptions.id, subscription.id))
+      .returning();
+    await insertKiloClawSubscriptionChangeLog(db, {
+      subscriptionId: subscription.id,
+      action: 'admin_override',
+      actor: { actorType: 'user', actorId: adminUser.id },
+      reason: 'admin_update_trial_end',
+      before: subscription,
+      after: updatedSubscription,
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
+
+    expect(result.subscriptions).toHaveLength(1);
+    expect('changeLogs' in result.subscriptions[0]).toBe(false);
+  });
+
+  it('lazy-loads subscription change log history', async () => {
+    const [instance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        user_id: targetUser.id,
+        sandbox_id: 'sandbox-admin-kiloclaw-change-log-lazy',
+      })
+      .returning();
+    const [subscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        instance_id: instance.id,
+        plan: 'trial',
+        status: 'trialing',
+        trial_started_at: '2026-04-01T00:00:00.000Z',
+        trial_ends_at: '2026-04-08T00:00:00.000Z',
+      })
+      .returning();
+
+    await insertKiloClawSubscriptionChangeLog(db, {
+      subscriptionId: subscription.id,
+      action: 'created',
+      actor: { actorType: 'system', actorId: 'test-bootstrap' },
+      reason: 'initial_test_row',
+      before: null,
+      after: subscription,
+    });
+    const [updatedSubscription] = await db
+      .update(kiloclaw_subscriptions)
+      .set({ trial_ends_at: '2026-04-10T00:00:00.000Z' })
+      .where(eq(kiloclaw_subscriptions.id, subscription.id))
+      .returning();
+    await insertKiloClawSubscriptionChangeLog(db, {
+      subscriptionId: subscription.id,
+      action: 'admin_override',
+      actor: { actorType: 'user', actorId: adminUser.id },
+      reason: 'admin_update_trial_end',
+      before: subscription,
+      after: updatedSubscription,
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.getKiloClawSubscriptionChangeLogs({
+      userId: targetUser.id,
+      subscriptionId: subscription.id,
+    });
+
+    expect(result.changeLogs).toHaveLength(2);
+    expect(result.changeLogs[0]).toEqual(
+      expect.objectContaining({
+        subscription_id: subscription.id,
+        action: 'admin_override',
+        actor_type: 'user',
+        actor_id: adminUser.id,
+        reason: 'admin_update_trial_end',
+      })
+    );
+    expectSameInstant(
+      result.changeLogs[0].before_state?.trial_ends_at as string | null,
+      '2026-04-08T00:00:00.000Z'
+    );
+    expectSameInstant(
+      result.changeLogs[0].after_state?.trial_ends_at as string | null,
+      '2026-04-10T00:00:00.000Z'
+    );
+    expect(result.changeLogs[1]).toEqual(
+      expect.objectContaining({
+        subscription_id: subscription.id,
+        action: 'created',
+        actor_type: 'system',
+        actor_id: 'test-bootstrap',
+        reason: 'initial_test_row',
+      })
+    );
+  });
+
+  it('rejects lazy-loading another user subscription change log history', async () => {
+    const otherUser = await insertTestUser({
+      google_user_email: 'other-kiloclaw-change-log@example.com',
+      google_user_name: 'Other User',
+    });
+    const [subscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: otherUser.id,
+        plan: 'trial',
+        status: 'trialing',
+        trial_started_at: '2026-04-01T00:00:00.000Z',
+        trial_ends_at: '2026-04-08T00:00:00.000Z',
+      })
+      .returning();
+
+    const caller = await createCallerForUser(adminUser.id);
+
+    await expect(
+      caller.admin.users.getKiloClawSubscriptionChangeLogs({
+        userId: targetUser.id,
+        subscriptionId: subscription.id,
+      })
+    ).rejects.toThrow('Subscription not found or does not belong to this user');
   });
 
   it('returns multiple subscription rows with correct effective selection', async () => {
@@ -401,6 +650,108 @@ describe('admin.users.updateKiloClawTrialEndAt', () => {
     ).rejects.toThrow(
       'Only trialing or canceled KiloClaw subscriptions can have their trial end date edited'
     );
+  });
+
+  it('rejects trial edits for transferred historical rows and leaves row unchanged', async () => {
+    const originalTrialEndsAt = '2026-03-20T23:59:59.000Z';
+    const requestedTrialEndsAt = '2026-04-01T23:59:59.000Z';
+    const [currentSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+      })
+      .returning();
+    const [transferredSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'trial',
+        status: 'trialing',
+        trial_started_at: '2026-03-13T12:00:00.000Z',
+        trial_ends_at: originalTrialEndsAt,
+        transferred_to_subscription_id: currentSub.id,
+      })
+      .returning();
+
+    const caller = await createCallerForUser(adminUser.id);
+
+    await expect(
+      caller.admin.users.updateKiloClawTrialEndAt({
+        userId: targetUser.id,
+        subscriptionId: transferredSub.id,
+        trial_ends_at: requestedTrialEndsAt,
+      })
+    ).rejects.toThrow(
+      'Transferred KiloClaw subscriptions are historical and cannot be modified. Edit the current subscription instead.'
+    );
+
+    const unchanged = await db.query.kiloclaw_subscriptions.findFirst({
+      where: eq(kiloclaw_subscriptions.id, transferredSub.id),
+    });
+    expect(unchanged?.status).toBe('trialing');
+    expectSameInstant(unchanged?.trial_ends_at, originalTrialEndsAt);
+
+    const [changeLogCount] = await db
+      .select({ value: count() })
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, transferredSub.id));
+    expect(changeLogCount?.value).toBe(0);
+  });
+
+  it('rejects trial resets for transferred historical rows and leaves row unchanged', async () => {
+    const originalTrialEndsAt = '2026-03-15T23:59:59.000Z';
+    const requestedTrialEndsAt = '2026-04-01T23:59:59.000Z';
+    const originalSuspendedAt = '2026-03-16T00:00:00.000Z';
+    const [currentSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+      })
+      .returning();
+    const [transferredSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'trial',
+        status: 'canceled',
+        trial_started_at: '2026-03-08T12:00:00.000Z',
+        trial_ends_at: originalTrialEndsAt,
+        suspended_at: originalSuspendedAt,
+        destruction_deadline: '2026-03-23T00:00:00.000Z',
+        transferred_to_subscription_id: currentSub.id,
+      })
+      .returning();
+
+    const caller = await createCallerForUser(adminUser.id);
+
+    await expect(
+      caller.admin.users.updateKiloClawTrialEndAt({
+        userId: targetUser.id,
+        subscriptionId: transferredSub.id,
+        trial_ends_at: requestedTrialEndsAt,
+      })
+    ).rejects.toThrow(
+      'Transferred KiloClaw subscriptions are historical and cannot be modified. Edit the current subscription instead.'
+    );
+
+    const unchanged = await db.query.kiloclaw_subscriptions.findFirst({
+      where: eq(kiloclaw_subscriptions.id, transferredSub.id),
+    });
+    expect(unchanged?.status).toBe('canceled');
+    expectSameInstant(unchanged?.trial_ends_at, originalTrialEndsAt);
+    expectSameInstant(unchanged?.suspended_at, originalSuspendedAt);
+
+    const [changeLogCount] = await db
+      .select({ value: count() })
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, transferredSub.id));
+    expect(changeLogCount?.value).toBe(0);
   });
 
   it('resets a canceled subscription to a new trial', async () => {
@@ -576,6 +927,54 @@ describe('admin.users.cancelKiloClawSubscription', () => {
     });
     expect(updated?.status).toBe('canceled');
     expect(updated?.cancel_at_period_end).toBe(false);
+  });
+
+  it('rejects canceling transferred historical rows and leaves row unchanged', async () => {
+    const originalTrialEndsAt = new Date(Date.now() + 5 * 86_400_000).toISOString();
+    const [currentSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+      })
+      .returning();
+    const [transferredSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'trial',
+        status: 'trialing',
+        trial_started_at: new Date().toISOString(),
+        trial_ends_at: originalTrialEndsAt,
+        transferred_to_subscription_id: currentSub.id,
+      })
+      .returning();
+
+    const caller = await createCallerForUser(adminUser.id);
+
+    await expect(
+      caller.admin.users.cancelKiloClawSubscription({
+        userId: targetUser.id,
+        subscriptionId: transferredSub.id,
+        mode: 'immediate',
+      })
+    ).rejects.toThrow(
+      'Transferred KiloClaw subscriptions are historical and cannot be modified. Edit the current subscription instead.'
+    );
+
+    const unchanged = await db.query.kiloclaw_subscriptions.findFirst({
+      where: eq(kiloclaw_subscriptions.id, transferredSub.id),
+    });
+    expect(unchanged?.status).toBe('trialing');
+    expectSameInstant(unchanged?.trial_ends_at, originalTrialEndsAt);
+
+    const [changeLogCount] = await db
+      .select({ value: count() })
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, transferredSub.id));
+    expect(changeLogCount?.value).toBe(0);
   });
 
   it("rejects another user's subscription id", async () => {

--- a/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
@@ -56,6 +56,8 @@ describe('admin.users.getKiloClawState', () => {
       accessReason: null,
       earlybird: null,
       activeInstanceId: null,
+      billingStateError: null,
+      needsSupportReview: false,
     });
   });
 
@@ -348,6 +350,75 @@ describe('admin.users.getKiloClawState', () => {
     expect(result.hasAccess).toBe(true);
     expect(result.accessReason).toBe('subscription');
     expect(result.subscriptions).toHaveLength(2);
+  });
+
+  it('keeps admin state inspectable when current personal rows conflict', async () => {
+    const [firstInstance, secondInstance] = await db
+      .insert(kiloclaw_instances)
+      .values([
+        {
+          user_id: targetUser.id,
+          sandbox_id: 'sandbox-conflict-first',
+        },
+        {
+          user_id: targetUser.id,
+          sandbox_id: 'sandbox-conflict-second',
+        },
+      ])
+      .returning();
+
+    await db.insert(kiloclaw_subscriptions).values([
+      {
+        user_id: targetUser.id,
+        instance_id: firstInstance.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+      },
+      {
+        user_id: targetUser.id,
+        instance_id: secondInstance.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+      },
+    ]);
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
+
+    expect(result.subscriptions).toHaveLength(2);
+    expect(result.subscription).toBeNull();
+    expect(result.effectiveSubscriptionId).toBeNull();
+    expect(result.hasAccess).toBe(false);
+    expect(result.accessReason).toBeNull();
+    expect(result.needsSupportReview).toBe(true);
+    expect(result.billingStateError).toContain(
+      'Expected at most one current personal subscription row'
+    );
+  });
+
+  it('uses detached non-transferred access rows when no current personal row grants access', async () => {
+    const [subscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        instance_id: null,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+      })
+      .returning();
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
+
+    expect(result.subscription?.id).toBe(subscription.id);
+    expect(result.effectiveSubscriptionId).toBe(subscription.id);
+    expect(result.hasAccess).toBe(true);
+    expect(result.accessReason).toBe('subscription');
+    expect(result.billingStateError).toBeNull();
+    expect(result.needsSupportReview).toBe(false);
   });
 
   it('returns subscription rows without eager-loading change log history', async () => {

--- a/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
@@ -1341,6 +1341,109 @@ describe('admin.users.cancelKiloClawSubscription', () => {
     expect(auditLog.metadata?.stripeMutationAttempted).toBe(true);
   });
 
+  it('normalizes stale canceled local state after immediate Stripe cancel succeeds', async () => {
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+        stripe_subscription_id: 'sub_admin_immediate_normalize',
+        stripe_schedule_id: 'sched_admin_immediate_normalize',
+        scheduled_plan: 'commit',
+        scheduled_by: 'user',
+      })
+      .returning();
+
+    jest.spyOn(stripeMock.subscriptions, 'cancel').mockImplementation(async () => {
+      await db
+        .update(kiloclaw_subscriptions)
+        .set({
+          status: 'canceled',
+          cancel_at_period_end: true,
+          stripe_schedule_id: 'sched_admin_immediate_normalize',
+          scheduled_plan: 'commit',
+          scheduled_by: 'user',
+        })
+        .where(eq(kiloclaw_subscriptions.id, sub.id));
+      return {} as never;
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    await caller.admin.users.cancelKiloClawSubscription({
+      userId: targetUser.id,
+      subscriptionId: sub.id,
+      mode: 'immediate',
+    });
+
+    const updated = await db.query.kiloclaw_subscriptions.findFirst({
+      where: eq(kiloclaw_subscriptions.id, sub.id),
+    });
+    expect(updated?.status).toBe('canceled');
+    expect(updated?.cancel_at_period_end).toBe(false);
+    expect(updated?.stripe_schedule_id).toBeNull();
+    expect(updated?.scheduled_plan).toBeNull();
+    expect(updated?.scheduled_by).toBeNull();
+
+    const [changeLogCount] = await db
+      .select({ value: count() })
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, sub.id));
+    expect(changeLogCount?.value).toBe(1);
+  });
+
+  it('throws and audits when period-end local row becomes canceled after Stripe success', async () => {
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+        stripe_subscription_id: 'sub_admin_period_end_canceled_race',
+      })
+      .returning();
+
+    jest.spyOn(stripeMock.subscriptions, 'update').mockImplementation(async () => {
+      await db
+        .update(kiloclaw_subscriptions)
+        .set({ status: 'canceled', cancel_at_period_end: false })
+        .where(eq(kiloclaw_subscriptions.id, sub.id));
+      return {} as never;
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.users.cancelKiloClawSubscription({
+        userId: targetUser.id,
+        subscriptionId: sub.id,
+        mode: 'period_end',
+      })
+    ).rejects.toThrow('Stripe cancellation was applied');
+
+    const updated = await db.query.kiloclaw_subscriptions.findFirst({
+      where: eq(kiloclaw_subscriptions.id, sub.id),
+    });
+    expect(updated?.status).toBe('canceled');
+    expect(updated?.cancel_at_period_end).toBe(false);
+
+    const [changeLogCount] = await db
+      .select({ value: count() })
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, sub.id));
+    expect(changeLogCount?.value).toBe(0);
+
+    const [auditLog] = await db
+      .select()
+      .from(kiloclaw_admin_audit_logs)
+      .where(eq(kiloclaw_admin_audit_logs.target_user_id, targetUser.id));
+    expect(auditLog.metadata?.reconciliationStatus).toBe('local_row_changed_after_stripe');
+    expect(auditLog.metadata?.localStateAtReconcile).toEqual(
+      expect.objectContaining({ status: 'canceled', cancel_at_period_end: false })
+    );
+  });
+
   it('period-end cancel clears scheduled plan on pure-credit row', async () => {
     const [sub] = await db
       .insert(kiloclaw_subscriptions)

--- a/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
@@ -10,6 +10,7 @@ import {
 import { count, eq } from 'drizzle-orm';
 import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
 import type { User } from '@kilocode/db/schema';
+import { client as stripeMock } from '@/lib/stripe-client';
 
 let adminUser: User;
 let targetUser: User;
@@ -22,6 +23,10 @@ function expectSameInstant(actual: string | null | undefined, expected: string) 
 
 beforeEach(async () => {
   await cleanupDbForTest();
+  jest.spyOn(stripeMock.subscriptions, 'retrieve').mockResolvedValue({ schedule: null } as never);
+  jest.spyOn(stripeMock.subscriptions, 'update').mockResolvedValue({} as never);
+  jest.spyOn(stripeMock.subscriptions, 'cancel').mockResolvedValue({} as never);
+  jest.spyOn(stripeMock.subscriptionSchedules, 'release').mockResolvedValue({} as never);
 
   adminUser = await insertTestUser({
     google_user_email: 'admin-kiloclaw-user-router@example.com',
@@ -1110,6 +1115,198 @@ describe('admin.users.cancelKiloClawSubscription', () => {
     expect(auditLog.metadata?.subscriptionId).toBe(sub.id);
     expect(auditLog.metadata?.mode).toBe('immediate');
     expect(auditLog.metadata?.previousStatus).toBe('active');
+    expect(auditLog.metadata?.reconciliationStatus).toBe('updated');
+    expect(auditLog.metadata?.stripeMutationAttempted).toBe(false);
+  });
+
+  it('period-end cancel after Stripe success updates local row and writes logs', async () => {
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+        stripe_subscription_id: 'sub_admin_period_end',
+        stripe_schedule_id: 'sched_admin_period_end',
+        scheduled_plan: 'commit',
+        scheduled_by: 'user',
+      })
+      .returning();
+
+    jest.spyOn(stripeMock.subscriptions, 'retrieve').mockResolvedValue({ schedule: null } as never);
+
+    const caller = await createCallerForUser(adminUser.id);
+    await caller.admin.users.cancelKiloClawSubscription({
+      userId: targetUser.id,
+      subscriptionId: sub.id,
+      mode: 'period_end',
+    });
+
+    expect(stripeMock.subscriptionSchedules.release).toHaveBeenCalledWith('sched_admin_period_end');
+    expect(stripeMock.subscriptions.update).toHaveBeenCalledWith('sub_admin_period_end', {
+      cancel_at_period_end: true,
+    });
+
+    const updated = await db.query.kiloclaw_subscriptions.findFirst({
+      where: eq(kiloclaw_subscriptions.id, sub.id),
+    });
+    expect(updated?.cancel_at_period_end).toBe(true);
+    expect(updated?.stripe_schedule_id).toBeNull();
+    expect(updated?.scheduled_plan).toBeNull();
+    expect(updated?.scheduled_by).toBeNull();
+
+    const [changeLogCount] = await db
+      .select({ value: count() })
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, sub.id));
+    expect(changeLogCount?.value).toBe(1);
+
+    const [auditLog] = await db
+      .select()
+      .from(kiloclaw_admin_audit_logs)
+      .where(eq(kiloclaw_admin_audit_logs.target_user_id, targetUser.id));
+    expect(auditLog.metadata?.reconciliationStatus).toBe('updated');
+    expect(auditLog.metadata?.stripeMutationAttempted).toBe(true);
+    expect(auditLog.metadata?.stripeSubscriptionId).toBe('sub_admin_period_end');
+    expect(auditLog.metadata?.scheduleReleased).toBe(true);
+    expect(auditLog.metadata?.scheduleIdToRelease).toBe('sched_admin_period_end');
+  });
+
+  it('throws and audits when local row is transferred after Stripe cancel succeeds', async () => {
+    const [successorSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+      })
+      .returning();
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+        stripe_subscription_id: 'sub_admin_race',
+      })
+      .returning();
+
+    jest.spyOn(stripeMock.subscriptions, 'update').mockImplementation(async () => {
+      await db
+        .update(kiloclaw_subscriptions)
+        .set({ transferred_to_subscription_id: successorSub.id })
+        .where(eq(kiloclaw_subscriptions.id, sub.id));
+      return {} as never;
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.users.cancelKiloClawSubscription({
+        userId: targetUser.id,
+        subscriptionId: sub.id,
+        mode: 'period_end',
+      })
+    ).rejects.toThrow('Stripe cancellation was applied');
+
+    const changed = await db.query.kiloclaw_subscriptions.findFirst({
+      where: eq(kiloclaw_subscriptions.id, sub.id),
+    });
+    expect(changed?.transferred_to_subscription_id).toBe(successorSub.id);
+
+    const [changeLogCount] = await db
+      .select({ value: count() })
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, sub.id));
+    expect(changeLogCount?.value).toBe(0);
+
+    const [auditLog] = await db
+      .select()
+      .from(kiloclaw_admin_audit_logs)
+      .where(eq(kiloclaw_admin_audit_logs.target_user_id, targetUser.id));
+    expect(auditLog.metadata?.reconciliationStatus).toBe('local_row_changed_after_stripe');
+    expect(auditLog.metadata?.stripeMutationAttempted).toBe(true);
+    expect(auditLog.metadata?.localStateAtReconcile).toEqual(
+      expect.objectContaining({ transferred_to_subscription_id: successorSub.id })
+    );
+  });
+
+  it('throws and audits when local row is missing after Stripe cancel succeeds', async () => {
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+        stripe_subscription_id: 'sub_admin_missing_row',
+      })
+      .returning();
+
+    jest.spyOn(stripeMock.subscriptions, 'update').mockImplementation(async () => {
+      await db.delete(kiloclaw_subscriptions).where(eq(kiloclaw_subscriptions.id, sub.id));
+      return {} as never;
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.users.cancelKiloClawSubscription({
+        userId: targetUser.id,
+        subscriptionId: sub.id,
+        mode: 'period_end',
+      })
+    ).rejects.toThrow('Stripe cancellation was applied');
+
+    const [auditLog] = await db
+      .select()
+      .from(kiloclaw_admin_audit_logs)
+      .where(eq(kiloclaw_admin_audit_logs.target_user_id, targetUser.id));
+    expect(auditLog.metadata?.reconciliationStatus).toBe('local_row_changed_after_stripe');
+    expect(auditLog.metadata?.stripeMutationAttempted).toBe(true);
+    expect(auditLog.metadata?.localStateAtReconcile).toBeNull();
+  });
+
+  it('treats already reconciled local cancel state as idempotent after Stripe success', async () => {
+    const [sub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: targetUser.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+        stripe_subscription_id: 'sub_admin_idempotent',
+      })
+      .returning();
+
+    jest.spyOn(stripeMock.subscriptions, 'update').mockImplementation(async () => {
+      await db
+        .update(kiloclaw_subscriptions)
+        .set({ cancel_at_period_end: true })
+        .where(eq(kiloclaw_subscriptions.id, sub.id));
+      return {} as never;
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    await caller.admin.users.cancelKiloClawSubscription({
+      userId: targetUser.id,
+      subscriptionId: sub.id,
+      mode: 'period_end',
+    });
+
+    const [changeLogCount] = await db
+      .select({ value: count() })
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, sub.id));
+    expect(changeLogCount?.value).toBe(0);
+
+    const [auditLog] = await db
+      .select()
+      .from(kiloclaw_admin_audit_logs)
+      .where(eq(kiloclaw_admin_audit_logs.target_user_id, targetUser.id));
+    expect(auditLog.metadata?.reconciliationStatus).toBe('already_desired');
+    expect(auditLog.metadata?.stripeMutationAttempted).toBe(true);
   });
 
   it('period-end cancel clears scheduled plan on pure-credit row', async () => {

--- a/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
@@ -426,6 +426,38 @@ describe('admin.users.getKiloClawState', () => {
     expect(result.needsSupportReview).toBe(false);
   });
 
+  it('surfaces support review when multiple detached rows grant access', async () => {
+    await db.insert(kiloclaw_subscriptions).values([
+      {
+        user_id: targetUser.id,
+        instance_id: null,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+      },
+      {
+        user_id: targetUser.id,
+        instance_id: null,
+        plan: 'standard',
+        status: 'past_due',
+        payment_source: 'credits',
+      },
+    ]);
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
+
+    expect(result.subscriptions).toHaveLength(2);
+    expect(result.subscription).toBeNull();
+    expect(result.effectiveSubscriptionId).toBeNull();
+    expect(result.hasAccess).toBe(false);
+    expect(result.accessReason).toBeNull();
+    expect(result.billingStateError).toBe(
+      'Multiple detached access-granting KiloClaw subscription rows exist.'
+    );
+    expect(result.needsSupportReview).toBe(true);
+  });
+
   it('returns subscription rows without eager-loading change log history', async () => {
     const [instance] = await db
       .insert(kiloclaw_instances)

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -214,7 +214,14 @@ function isKiloClawCancelDesiredState(params: {
     );
   }
 
-  return params.subscription.status === 'canceled';
+  return (
+    params.subscription.status === 'canceled' &&
+    !params.subscription.cancel_at_period_end &&
+    !params.subscription.pending_conversion &&
+    !params.subscription.stripe_schedule_id &&
+    !params.subscription.scheduled_plan &&
+    !params.subscription.scheduled_by
+  );
 }
 
 function parseJsonSafe(text: string): unknown {
@@ -1106,6 +1113,24 @@ export const adminRouter = createTRPCRouter({
               actor_name: ctx.user.google_user_name,
               target_user_id: input.userId,
               message: `Stripe cancel succeeded for KiloClaw subscription ${subscription.id}, but local row changed before reconciliation`,
+              metadata,
+              tx,
+            });
+            return { status: 'local_row_changed_after_stripe' as const };
+          }
+
+          if (input.mode === 'period_end' && localSubscription.status !== 'active') {
+            const metadata = {
+              ...baseMetadata,
+              reconciliationStatus: 'local_row_changed_after_stripe',
+            } satisfies KiloClawCancelAuditMetadata;
+            await createKiloClawAdminAuditLog({
+              action: 'kiloclaw.subscription.admin_cancel',
+              actor_id: ctx.user.id,
+              actor_email: ctx.user.google_user_email,
+              actor_name: ctx.user.google_user_name,
+              target_user_id: input.userId,
+              message: `Stripe period-end cancel succeeded for KiloClaw subscription ${subscription.id}, but local row was no longer active during reconciliation`,
               metadata,
               tx,
             });

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -1,6 +1,6 @@
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
-import { db } from '@/lib/drizzle';
-import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
+import { db, type DrizzleTransaction } from '@/lib/drizzle';
+import { insertKiloClawSubscriptionChangeLog, type KiloClawSubscription } from '@kilocode/db';
 import {
   user_admin_notes,
   kilocode_users,
@@ -13,6 +13,7 @@ import {
   cli_sessions_v2,
   credit_transactions,
   kiloclaw_subscriptions,
+  kiloclaw_subscription_change_log,
   kiloclaw_email_log,
   kiloclaw_instances,
 } from '@kilocode/db/schema';
@@ -70,9 +71,8 @@ import { releaseScheduledChangeForSubscription } from '@/lib/kilo-pass/scheduled
 import { kilo_pass_scheduled_changes } from '@kilocode/db/schema';
 import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
 import {
-  getEffectiveKiloClawSubscription,
+  getCurrentPersonalKiloClawSubscriptionForUser,
   getKiloClawEarlybirdStateForUser,
-  getKiloClawSubscriptionAccessReason,
 } from '@/lib/kiloclaw/access-state';
 import { createKiloClawAdminAuditLog } from '@/lib/kiloclaw/admin-audit-log';
 import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
@@ -100,6 +100,51 @@ function adminSubscriptionActor(ctxUser: {
     actorType: 'user',
     actorId: ctxUser.id,
   } as const;
+}
+
+const TRANSFERRED_KILOCLAW_SUBSCRIPTION_ERROR =
+  'Transferred KiloClaw subscriptions are historical and cannot be modified. Edit the current subscription instead.';
+
+function assertKiloClawSubscriptionIsMutable(
+  subscription: Pick<KiloClawSubscription, 'transferred_to_subscription_id'>
+) {
+  if (subscription.transferred_to_subscription_id) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: TRANSFERRED_KILOCLAW_SUBSCRIPTION_ERROR,
+    });
+  }
+}
+
+async function lockMutableKiloClawSubscription(params: {
+  tx: DrizzleTransaction;
+  userId: string;
+  subscriptionId: string;
+  notFoundCode: 'BAD_REQUEST' | 'NOT_FOUND';
+  notFoundMessage: string;
+}) {
+  const [subscription] = await params.tx
+    .select()
+    .from(kiloclaw_subscriptions)
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.id, params.subscriptionId),
+        eq(kiloclaw_subscriptions.user_id, params.userId)
+      )
+    )
+    .for('update')
+    .limit(1);
+
+  if (!subscription) {
+    throw new TRPCError({
+      code: params.notFoundCode,
+      message: params.notFoundMessage,
+    });
+  }
+
+  assertKiloClawSubscriptionIsMutable(subscription);
+
+  return subscription;
 }
 
 function parseJsonSafe(text: string): unknown {
@@ -195,6 +240,12 @@ const CancelAndRefundKiloPassSchema = z.object({
 
 const GetKiloClawStateSchema = z.object({
   userId: z.string(),
+});
+
+const GetKiloClawSubscriptionChangeLogsSchema = z.object({
+  userId: z.string(),
+  subscriptionId: z.string(),
+  limit: z.number().int().min(1).max(100).default(50),
 });
 
 const UpdateKiloClawTrialEndAtSchema = z.object({
@@ -530,12 +581,21 @@ export const adminRouter = createTRPCRouter({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
       }
 
-      const [allSubscriptions, earlybirdState, activeInstance, allInstances] = await Promise.all([
+      const now = new Date();
+      const [
+        allSubscriptions,
+        earlybirdState,
+        currentPersonalSubscriptionState,
+        activeInstance,
+        allInstances,
+      ] = await Promise.all([
         db
           .select()
           .from(kiloclaw_subscriptions)
-          .where(eq(kiloclaw_subscriptions.user_id, input.userId)),
-        getKiloClawEarlybirdStateForUser(input.userId, new Date()),
+          .where(eq(kiloclaw_subscriptions.user_id, input.userId))
+          .orderBy(desc(kiloclaw_subscriptions.created_at)),
+        getKiloClawEarlybirdStateForUser(input.userId, now),
+        getCurrentPersonalKiloClawSubscriptionForUser(input.userId, now),
         db.query.kiloclaw_instances.findFirst({
           columns: { id: true },
           where: and(
@@ -554,8 +614,8 @@ export const adminRouter = createTRPCRouter({
           .where(eq(kiloclaw_instances.user_id, input.userId)),
       ]);
 
-      const effectiveSub = getEffectiveKiloClawSubscription(allSubscriptions);
-      const accessReason = getKiloClawSubscriptionAccessReason(effectiveSub);
+      const effectiveSub = currentPersonalSubscriptionState.subscription;
+      const accessReason = currentPersonalSubscriptionState.accessReason;
       const earlybirdDaysRemaining = earlybirdState.expiresAt
         ? Math.ceil((new Date(earlybirdState.expiresAt).getTime() - Date.now()) / 86_400_000)
         : 0;
@@ -587,6 +647,37 @@ export const adminRouter = createTRPCRouter({
       };
     }),
 
+    getKiloClawSubscriptionChangeLogs: adminProcedure
+      .input(GetKiloClawSubscriptionChangeLogsSchema)
+      .query(async ({ input }) => {
+        const subscription = await db.query.kiloclaw_subscriptions.findFirst({
+          columns: { id: true },
+          where: and(
+            eq(kiloclaw_subscriptions.id, input.subscriptionId),
+            eq(kiloclaw_subscriptions.user_id, input.userId)
+          ),
+        });
+
+        if (!subscription) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Subscription not found or does not belong to this user',
+          });
+        }
+
+        const changeLogs = await db
+          .select()
+          .from(kiloclaw_subscription_change_log)
+          .where(eq(kiloclaw_subscription_change_log.subscription_id, input.subscriptionId))
+          .orderBy(
+            desc(kiloclaw_subscription_change_log.created_at),
+            desc(kiloclaw_subscription_change_log.id)
+          )
+          .limit(input.limit);
+
+        return { changeLogs };
+      }),
+
     updateKiloClawTrialEndAt: adminProcedure
       .input(UpdateKiloClawTrialEndAtSchema)
       .mutation(async ({ input, ctx }) => {
@@ -599,32 +690,27 @@ export const adminRouter = createTRPCRouter({
           throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
         }
 
-        const subscription = await db.query.kiloclaw_subscriptions.findFirst({
-          where: and(
-            eq(kiloclaw_subscriptions.id, input.subscriptionId),
-            eq(kiloclaw_subscriptions.user_id, input.userId)
-          ),
-        });
-
-        if (!subscription) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: 'No KiloClaw subscription found for this user',
-          });
-        }
-
-        if (subscription.status !== 'trialing' && subscription.status !== 'canceled') {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message:
-              'Only trialing or canceled KiloClaw subscriptions can have their trial end date edited',
-          });
-        }
-
-        const isReset = subscription.status === 'canceled';
-        const previousTrialEndsAt = subscription.trial_ends_at;
+        let isReset = false;
 
         await db.transaction(async tx => {
+          const subscription = await lockMutableKiloClawSubscription({
+            tx,
+            userId: input.userId,
+            subscriptionId: input.subscriptionId,
+            notFoundCode: 'BAD_REQUEST',
+            notFoundMessage: 'No KiloClaw subscription found for this user',
+          });
+
+          if (subscription.status !== 'trialing' && subscription.status !== 'canceled') {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message:
+                'Only trialing or canceled KiloClaw subscriptions can have their trial end date edited',
+            });
+          }
+
+          isReset = subscription.status === 'canceled';
+          const previousTrialEndsAt = subscription.trial_ends_at;
           if (isReset) {
             // Reset canceled subscription to a new trial
             const [updatedSubscription] = await tx
@@ -646,7 +732,12 @@ export const adminRouter = createTRPCRouter({
                 suspended_at: null,
                 destruction_deadline: null,
               })
-              .where(eq(kiloclaw_subscriptions.id, subscription.id))
+              .where(
+                and(
+                  eq(kiloclaw_subscriptions.id, subscription.id),
+                  isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+                )
+              )
               .returning();
 
             if (!updatedSubscription) {
@@ -693,7 +784,12 @@ export const adminRouter = createTRPCRouter({
             const [updatedSubscription] = await tx
               .update(kiloclaw_subscriptions)
               .set({ trial_ends_at: input.trial_ends_at })
-              .where(eq(kiloclaw_subscriptions.id, subscription.id))
+              .where(
+                and(
+                  eq(kiloclaw_subscriptions.id, subscription.id),
+                  isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+                )
+              )
               .returning();
 
             if (!updatedSubscription) {
@@ -766,51 +862,153 @@ export const adminRouter = createTRPCRouter({
     cancelKiloClawSubscription: adminProcedure
       .input(CancelKiloClawSubscriptionSchema)
       .mutation(async ({ input, ctx }) => {
-        const subscription = await db.query.kiloclaw_subscriptions.findFirst({
-          where: and(
-            eq(kiloclaw_subscriptions.id, input.subscriptionId),
-            eq(kiloclaw_subscriptions.user_id, input.userId)
-          ),
-        });
-
-        if (!subscription) {
-          throw new TRPCError({
-            code: 'NOT_FOUND',
-            message: 'Subscription not found or does not belong to this user',
+        await db.transaction(async tx => {
+          const subscription = await lockMutableKiloClawSubscription({
+            tx,
+            userId: input.userId,
+            subscriptionId: input.subscriptionId,
+            notFoundCode: 'NOT_FOUND',
+            notFoundMessage: 'Subscription not found or does not belong to this user',
           });
-        }
 
-        const previousStatus = subscription.status;
-        let scheduleReleased = false;
+          const previousStatus = subscription.status;
+          let scheduleReleased = false;
 
-        if (input.mode === 'period_end') {
-          if (subscription.status !== 'active') {
-            throw new TRPCError({
-              code: 'BAD_REQUEST',
-              message: 'Only active subscriptions can be canceled at period end',
-            });
-          }
-          if (subscription.cancel_at_period_end) {
-            throw new TRPCError({
-              code: 'BAD_REQUEST',
-              message: 'Subscription is already set to cancel at period end',
-            });
-          }
+          if (input.mode === 'period_end') {
+            if (subscription.status !== 'active') {
+              throw new TRPCError({
+                code: 'BAD_REQUEST',
+                message: 'Only active subscriptions can be canceled at period end',
+              });
+            }
+            if (subscription.cancel_at_period_end) {
+              throw new TRPCError({
+                code: 'BAD_REQUEST',
+                message: 'Subscription is already set to cancel at period end',
+              });
+            }
 
-          if (subscription.stripe_subscription_id) {
-            // Stripe-funded: release pending schedule, then set cancel_at_period_end
-            const liveSub = await stripeClient.subscriptions.retrieve(
-              subscription.stripe_subscription_id
-            );
-            const scheduleRef = liveSub.schedule;
-            const scheduleIdToRelease =
-              subscription.stripe_schedule_id ??
-              (scheduleRef
-                ? typeof scheduleRef === 'string'
-                  ? scheduleRef
-                  : scheduleRef.id
-                : null);
+            if (subscription.stripe_subscription_id) {
+              // Stripe-funded: release pending schedule, then set cancel_at_period_end
+              const liveSub = await stripeClient.subscriptions.retrieve(
+                subscription.stripe_subscription_id
+              );
+              const scheduleRef = liveSub.schedule;
+              const scheduleIdToRelease =
+                subscription.stripe_schedule_id ??
+                (scheduleRef
+                  ? typeof scheduleRef === 'string'
+                    ? scheduleRef
+                    : scheduleRef.id
+                  : null);
 
+              if (scheduleIdToRelease) {
+                try {
+                  await stripeClient.subscriptionSchedules.release(scheduleIdToRelease);
+                  scheduleReleased = true;
+                } catch (error) {
+                  const msg = error instanceof Error ? error.message : String(error);
+                  const alreadyInactive =
+                    msg.includes('not active') ||
+                    msg.includes('released') ||
+                    msg.includes('canceled') ||
+                    msg.includes('completed');
+                  if (!alreadyInactive) {
+                    throw new TRPCError({
+                      code: 'INTERNAL_SERVER_ERROR',
+                      message:
+                        'Unable to cancel: failed to release pending plan schedule. Please try again.',
+                    });
+                  }
+                  scheduleReleased = true;
+                }
+              }
+
+              await stripeClient.subscriptions.update(subscription.stripe_subscription_id, {
+                cancel_at_period_end: true,
+              });
+
+              const [updatedSubscription] = await tx
+                .update(kiloclaw_subscriptions)
+                .set({
+                  cancel_at_period_end: true,
+                  ...(scheduleIdToRelease
+                    ? { stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null }
+                    : {}),
+                })
+                .where(
+                  and(
+                    eq(kiloclaw_subscriptions.id, subscription.id),
+                    isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+                  )
+                )
+                .returning();
+
+              if (!updatedSubscription) {
+                throw new TRPCError({
+                  code: 'INTERNAL_SERVER_ERROR',
+                  message: 'Failed to update KiloClaw subscription',
+                });
+              }
+
+              await insertKiloClawSubscriptionChangeLog(tx, {
+                subscriptionId: subscription.id,
+                actor: adminSubscriptionActor(ctx.user),
+                action: 'canceled',
+                reason: 'admin_cancel_at_period_end',
+                before: subscription,
+                after: updatedSubscription,
+              });
+            } else {
+              // Pure-credit: set local cancel_at_period_end and clear schedule state
+              const [updatedSubscription] = await tx
+                .update(kiloclaw_subscriptions)
+                .set({
+                  cancel_at_period_end: true,
+                  stripe_schedule_id: null,
+                  scheduled_plan: null,
+                  scheduled_by: null,
+                })
+                .where(
+                  and(
+                    eq(kiloclaw_subscriptions.id, subscription.id),
+                    isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+                  )
+                )
+                .returning();
+
+              if (!updatedSubscription) {
+                throw new TRPCError({
+                  code: 'INTERNAL_SERVER_ERROR',
+                  message: 'Failed to update KiloClaw subscription',
+                });
+              }
+
+              await insertKiloClawSubscriptionChangeLog(tx, {
+                subscriptionId: subscription.id,
+                actor: adminSubscriptionActor(ctx.user),
+                action: 'canceled',
+                reason: 'admin_cancel_at_period_end',
+                before: subscription,
+                after: updatedSubscription,
+              });
+            }
+          } else {
+            // mode === 'immediate'
+            if (
+              subscription.status !== 'active' &&
+              subscription.status !== 'past_due' &&
+              subscription.status !== 'trialing'
+            ) {
+              throw new TRPCError({
+                code: 'BAD_REQUEST',
+                message:
+                  'Only active, past-due, or trialing subscriptions can be immediately canceled',
+              });
+            }
+
+            // Release any schedule first
+            const scheduleIdToRelease = subscription.stripe_schedule_id;
             if (scheduleIdToRelease) {
               try {
                 await stripeClient.subscriptionSchedules.release(scheduleIdToRelease);
@@ -833,161 +1031,71 @@ export const adminRouter = createTRPCRouter({
               }
             }
 
-            await stripeClient.subscriptions.update(subscription.stripe_subscription_id, {
-              cancel_at_period_end: true,
-            });
-
-            const [updatedSubscription] = await db
-              .update(kiloclaw_subscriptions)
-              .set({
-                cancel_at_period_end: true,
-                ...(scheduleIdToRelease
-                  ? { stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null }
-                  : {}),
-              })
-              .where(eq(kiloclaw_subscriptions.id, subscription.id))
-              .returning();
-
-            if (!updatedSubscription) {
-              throw new TRPCError({
-                code: 'INTERNAL_SERVER_ERROR',
-                message: 'Failed to update KiloClaw subscription',
+            // Cancel Stripe subscription immediately if present
+            if (subscription.stripe_subscription_id) {
+              await stripeClient.subscriptions.cancel(subscription.stripe_subscription_id, {
+                prorate: false,
+                invoice_now: false,
               });
             }
 
-            await insertKiloClawSubscriptionChangeLog(db, {
-              subscriptionId: subscription.id,
-              actor: adminSubscriptionActor(ctx.user),
-              action: 'canceled',
-              reason: 'admin_cancel_at_period_end',
-              before: subscription,
-              after: updatedSubscription,
-            });
-          } else {
-            // Pure-credit: set local cancel_at_period_end and clear schedule state
-            const [updatedSubscription] = await db
+            // Update local subscription to canceled
+            const now = new Date().toISOString();
+            const [updatedSubscription] = await tx
               .update(kiloclaw_subscriptions)
               .set({
-                cancel_at_period_end: true,
+                status: 'canceled',
+                cancel_at_period_end: false,
+                pending_conversion: false,
                 stripe_schedule_id: null,
                 scheduled_plan: null,
                 scheduled_by: null,
+                current_period_end: now,
+                credit_renewal_at: now,
+                // For trialing subscriptions, also end the trial immediately
+                ...(subscription.status === 'trialing' ? { trial_ends_at: now } : {}),
               })
-              .where(eq(kiloclaw_subscriptions.id, subscription.id))
+              .where(
+                and(
+                  eq(kiloclaw_subscriptions.id, subscription.id),
+                  isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+                )
+              )
               .returning();
 
             if (!updatedSubscription) {
               throw new TRPCError({
                 code: 'INTERNAL_SERVER_ERROR',
-                message: 'Failed to update KiloClaw subscription',
+                message: 'Failed to cancel KiloClaw subscription',
               });
             }
 
-            await insertKiloClawSubscriptionChangeLog(db, {
+            await insertKiloClawSubscriptionChangeLog(tx, {
               subscriptionId: subscription.id,
               actor: adminSubscriptionActor(ctx.user),
               action: 'canceled',
-              reason: 'admin_cancel_at_period_end',
+              reason: 'admin_cancel_immediate',
               before: subscription,
               after: updatedSubscription,
             });
           }
-        } else {
-          // mode === 'immediate'
-          if (
-            subscription.status !== 'active' &&
-            subscription.status !== 'past_due' &&
-            subscription.status !== 'trialing'
-          ) {
-            throw new TRPCError({
-              code: 'BAD_REQUEST',
-              message:
-                'Only active, past-due, or trialing subscriptions can be immediately canceled',
-            });
-          }
 
-          // Release any schedule first
-          const scheduleIdToRelease = subscription.stripe_schedule_id;
-          if (scheduleIdToRelease) {
-            try {
-              await stripeClient.subscriptionSchedules.release(scheduleIdToRelease);
-              scheduleReleased = true;
-            } catch (error) {
-              const msg = error instanceof Error ? error.message : String(error);
-              const alreadyInactive =
-                msg.includes('not active') ||
-                msg.includes('released') ||
-                msg.includes('canceled') ||
-                msg.includes('completed');
-              if (!alreadyInactive) {
-                throw new TRPCError({
-                  code: 'INTERNAL_SERVER_ERROR',
-                  message:
-                    'Unable to cancel: failed to release pending plan schedule. Please try again.',
-                });
-              }
-              scheduleReleased = true;
-            }
-          }
-
-          // Cancel Stripe subscription immediately if present
-          if (subscription.stripe_subscription_id) {
-            await stripeClient.subscriptions.cancel(subscription.stripe_subscription_id, {
-              prorate: false,
-              invoice_now: false,
-            });
-          }
-
-          // Update local subscription to canceled
-          const now = new Date().toISOString();
-          const [updatedSubscription] = await db
-            .update(kiloclaw_subscriptions)
-            .set({
-              status: 'canceled',
-              cancel_at_period_end: false,
-              pending_conversion: false,
-              stripe_schedule_id: null,
-              scheduled_plan: null,
-              scheduled_by: null,
-              current_period_end: now,
-              credit_renewal_at: now,
-              // For trialing subscriptions, also end the trial immediately
-              ...(subscription.status === 'trialing' ? { trial_ends_at: now } : {}),
-            })
-            .where(eq(kiloclaw_subscriptions.id, subscription.id))
-            .returning();
-
-          if (!updatedSubscription) {
-            throw new TRPCError({
-              code: 'INTERNAL_SERVER_ERROR',
-              message: 'Failed to cancel KiloClaw subscription',
-            });
-          }
-
-          await insertKiloClawSubscriptionChangeLog(db, {
-            subscriptionId: subscription.id,
-            actor: adminSubscriptionActor(ctx.user),
-            action: 'canceled',
-            reason: 'admin_cancel_immediate',
-            before: subscription,
-            after: updatedSubscription,
+          await createKiloClawAdminAuditLog({
+            action: 'kiloclaw.subscription.admin_cancel',
+            actor_id: ctx.user.id,
+            actor_email: ctx.user.google_user_email,
+            actor_name: ctx.user.google_user_name,
+            target_user_id: input.userId,
+            message: `Admin ${input.mode === 'immediate' ? 'immediately canceled' : 'set cancel-at-period-end on'} KiloClaw subscription ${subscription.id} (status was ${previousStatus}, stripe_sub=${subscription.stripe_subscription_id ?? 'none'})`,
+            metadata: {
+              subscriptionId: subscription.id,
+              mode: input.mode,
+              previousStatus,
+              stripeSubscriptionId: subscription.stripe_subscription_id,
+              scheduleReleased,
+            },
+            tx,
           });
-        }
-
-        await createKiloClawAdminAuditLog({
-          action: 'kiloclaw.subscription.admin_cancel',
-          actor_id: ctx.user.id,
-          actor_email: ctx.user.google_user_email,
-          actor_name: ctx.user.google_user_name,
-          target_user_id: input.userId,
-          message: `Admin ${input.mode === 'immediate' ? 'immediately canceled' : 'set cancel-at-period-end on'} KiloClaw subscription ${subscription.id} (status was ${previousStatus}, stripe_sub=${subscription.stripe_subscription_id ?? 'none'})`,
-          metadata: {
-            subscriptionId: subscription.id,
-            mode: input.mode,
-            previousStatus,
-            stripeSubscriptionId: subscription.stripe_subscription_id,
-            scheduleReleased,
-          },
         });
 
         return successResult();

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -119,12 +119,27 @@ function assertKiloClawSubscriptionIsMutable(
   }
 }
 
-async function lockMutableKiloClawSubscription(params: {
+type KiloClawCancelReconciliationStatus =
+  | 'updated'
+  | 'already_desired'
+  | 'local_row_changed_after_stripe';
+
+type KiloClawCancelAuditMetadata = {
+  subscriptionId: string;
+  mode: 'period_end' | 'immediate';
+  previousStatus: string;
+  stripeMutationAttempted: boolean;
+  stripeSubscriptionId: string | null;
+  scheduleReleased: boolean;
+  scheduleIdToRelease: string | null;
+  reconciliationStatus: KiloClawCancelReconciliationStatus;
+  localStateAtReconcile?: Partial<KiloClawSubscription> | null;
+};
+
+async function findKiloClawSubscriptionForUpdate(params: {
   tx: DrizzleTransaction;
   userId: string;
   subscriptionId: string;
-  notFoundCode: 'BAD_REQUEST' | 'NOT_FOUND';
-  notFoundMessage: string;
 }) {
   const [subscription] = await params.tx
     .select()
@@ -138,6 +153,18 @@ async function lockMutableKiloClawSubscription(params: {
     .for('update')
     .limit(1);
 
+  return subscription ?? null;
+}
+
+async function lockKiloClawSubscription(params: {
+  tx: DrizzleTransaction;
+  userId: string;
+  subscriptionId: string;
+  notFoundCode: 'BAD_REQUEST' | 'NOT_FOUND';
+  notFoundMessage: string;
+}) {
+  const subscription = await findKiloClawSubscriptionForUpdate(params);
+
   if (!subscription) {
     throw new TRPCError({
       code: params.notFoundCode,
@@ -145,9 +172,49 @@ async function lockMutableKiloClawSubscription(params: {
     });
   }
 
-  assertKiloClawSubscriptionIsMutable(subscription);
-
   return subscription;
+}
+
+async function lockMutableKiloClawSubscription(
+  params: Parameters<typeof lockKiloClawSubscription>[0]
+) {
+  const subscription = await lockKiloClawSubscription(params);
+  assertKiloClawSubscriptionIsMutable(subscription);
+  return subscription;
+}
+
+function localKiloClawSubscriptionStateForAudit(subscription: KiloClawSubscription | null) {
+  if (!subscription) return null;
+  return {
+    id: subscription.id,
+    status: subscription.status,
+    plan: subscription.plan,
+    cancel_at_period_end: subscription.cancel_at_period_end,
+    transferred_to_subscription_id: subscription.transferred_to_subscription_id,
+    stripe_subscription_id: subscription.stripe_subscription_id,
+    stripe_schedule_id: subscription.stripe_schedule_id,
+    scheduled_plan: subscription.scheduled_plan,
+    scheduled_by: subscription.scheduled_by,
+    current_period_end: subscription.current_period_end,
+    credit_renewal_at: subscription.credit_renewal_at,
+    trial_ends_at: subscription.trial_ends_at,
+  };
+}
+
+function isKiloClawCancelDesiredState(params: {
+  subscription: KiloClawSubscription;
+  mode: 'period_end' | 'immediate';
+}) {
+  if (params.mode === 'period_end') {
+    return (
+      params.subscription.cancel_at_period_end &&
+      !params.subscription.stripe_schedule_id &&
+      !params.subscription.scheduled_plan &&
+      !params.subscription.scheduled_by
+    );
+  }
+
+  return params.subscription.status === 'canceled';
 }
 
 function parseJsonSafe(text: string): unknown {
@@ -998,72 +1065,144 @@ export const adminRouter = createTRPCRouter({
           }
         }
 
+        const stripeMutationAttempted = Boolean(subscription.stripe_subscription_id);
         const now = new Date().toISOString();
-        const [updatedSubscription] = await db
-          .update(kiloclaw_subscriptions)
-          .set(
-            input.mode === 'period_end'
-              ? {
-                  cancel_at_period_end: true,
-                  stripe_schedule_id: null,
-                  scheduled_plan: null,
-                  scheduled_by: null,
-                }
-              : {
-                  status: 'canceled',
-                  cancel_at_period_end: false,
-                  pending_conversion: false,
-                  stripe_schedule_id: null,
-                  scheduled_plan: null,
-                  scheduled_by: null,
-                  current_period_end: now,
-                  credit_renewal_at: now,
-                  ...(subscription.status === 'trialing' ? { trial_ends_at: now } : {}),
-                }
-          )
-          .where(
-            and(
-              eq(kiloclaw_subscriptions.id, subscription.id),
-              isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-            )
-          )
-          .returning();
-
-        if (!updatedSubscription) {
-          throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message:
-              input.mode === 'period_end'
-                ? 'Failed to update KiloClaw subscription'
-                : 'Failed to cancel KiloClaw subscription',
+        const reconciliationResult = await db.transaction(async tx => {
+          const localSubscription = await findKiloClawSubscriptionForUpdate({
+            tx,
+            userId: input.userId,
+            subscriptionId: input.subscriptionId,
           });
-        }
-
-        await insertKiloClawSubscriptionChangeLog(db, {
-          subscriptionId: subscription.id,
-          actor: adminSubscriptionActor(ctx.user),
-          action: 'canceled',
-          reason:
-            input.mode === 'period_end' ? 'admin_cancel_at_period_end' : 'admin_cancel_immediate',
-          before: subscription,
-          after: updatedSubscription,
-        });
-
-        await createKiloClawAdminAuditLog({
-          action: 'kiloclaw.subscription.admin_cancel',
-          actor_id: ctx.user.id,
-          actor_email: ctx.user.google_user_email,
-          actor_name: ctx.user.google_user_name,
-          target_user_id: input.userId,
-          message: `Admin ${input.mode === 'immediate' ? 'immediately canceled' : 'set cancel-at-period-end on'} KiloClaw subscription ${subscription.id} (status was ${previousStatus}, stripe_sub=${subscription.stripe_subscription_id ?? 'none'})`,
-          metadata: {
+          const localStateAtReconcile = localKiloClawSubscriptionStateForAudit(localSubscription);
+          const baseMetadata = {
             subscriptionId: subscription.id,
             mode: input.mode,
             previousStatus,
+            stripeMutationAttempted,
             stripeSubscriptionId: subscription.stripe_subscription_id,
             scheduleReleased,
-          },
+            scheduleIdToRelease,
+            localStateAtReconcile,
+          } satisfies Omit<KiloClawCancelAuditMetadata, 'reconciliationStatus'>;
+
+          if (!localSubscription || localSubscription.transferred_to_subscription_id) {
+            const metadata = {
+              ...baseMetadata,
+              reconciliationStatus: 'local_row_changed_after_stripe',
+            } satisfies KiloClawCancelAuditMetadata;
+            await createKiloClawAdminAuditLog({
+              action: 'kiloclaw.subscription.admin_cancel',
+              actor_id: ctx.user.id,
+              actor_email: ctx.user.google_user_email,
+              actor_name: ctx.user.google_user_name,
+              target_user_id: input.userId,
+              message: `Stripe cancel succeeded for KiloClaw subscription ${subscription.id}, but local row changed before reconciliation`,
+              metadata,
+              tx,
+            });
+            return { status: 'local_row_changed_after_stripe' as const };
+          }
+
+          if (isKiloClawCancelDesiredState({ subscription: localSubscription, mode: input.mode })) {
+            const metadata = {
+              ...baseMetadata,
+              reconciliationStatus: 'already_desired',
+            } satisfies KiloClawCancelAuditMetadata;
+            await createKiloClawAdminAuditLog({
+              action: 'kiloclaw.subscription.admin_cancel',
+              actor_id: ctx.user.id,
+              actor_email: ctx.user.google_user_email,
+              actor_name: ctx.user.google_user_name,
+              target_user_id: input.userId,
+              message: `Admin cancel reconciliation found KiloClaw subscription ${subscription.id} already in desired state`,
+              metadata,
+              tx,
+            });
+            return { status: 'already_desired' as const };
+          }
+
+          const [updatedSubscription] = await tx
+            .update(kiloclaw_subscriptions)
+            .set(
+              input.mode === 'period_end'
+                ? {
+                    cancel_at_period_end: true,
+                    stripe_schedule_id: null,
+                    scheduled_plan: null,
+                    scheduled_by: null,
+                  }
+                : {
+                    status: 'canceled',
+                    cancel_at_period_end: false,
+                    pending_conversion: false,
+                    stripe_schedule_id: null,
+                    scheduled_plan: null,
+                    scheduled_by: null,
+                    current_period_end: now,
+                    credit_renewal_at: now,
+                    ...(localSubscription.status === 'trialing' ? { trial_ends_at: now } : {}),
+                  }
+            )
+            .where(
+              and(
+                eq(kiloclaw_subscriptions.id, localSubscription.id),
+                isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+              )
+            )
+            .returning();
+
+          if (!updatedSubscription) {
+            const metadata = {
+              ...baseMetadata,
+              reconciliationStatus: 'local_row_changed_after_stripe',
+            } satisfies KiloClawCancelAuditMetadata;
+            await createKiloClawAdminAuditLog({
+              action: 'kiloclaw.subscription.admin_cancel',
+              actor_id: ctx.user.id,
+              actor_email: ctx.user.google_user_email,
+              actor_name: ctx.user.google_user_name,
+              target_user_id: input.userId,
+              message: `Stripe cancel succeeded for KiloClaw subscription ${subscription.id}, but local update failed during reconciliation`,
+              metadata,
+              tx,
+            });
+            return { status: 'local_row_changed_after_stripe' as const };
+          }
+
+          await insertKiloClawSubscriptionChangeLog(tx, {
+            subscriptionId: subscription.id,
+            actor: adminSubscriptionActor(ctx.user),
+            action: 'canceled',
+            reason:
+              input.mode === 'period_end' ? 'admin_cancel_at_period_end' : 'admin_cancel_immediate',
+            before: localSubscription,
+            after: updatedSubscription,
+          });
+
+          const metadata = {
+            ...baseMetadata,
+            reconciliationStatus: 'updated',
+          } satisfies KiloClawCancelAuditMetadata;
+          await createKiloClawAdminAuditLog({
+            action: 'kiloclaw.subscription.admin_cancel',
+            actor_id: ctx.user.id,
+            actor_email: ctx.user.google_user_email,
+            actor_name: ctx.user.google_user_name,
+            target_user_id: input.userId,
+            message: `Admin ${input.mode === 'immediate' ? 'immediately canceled' : 'set cancel-at-period-end on'} KiloClaw subscription ${subscription.id} (status was ${previousStatus}, stripe_sub=${subscription.stripe_subscription_id ?? 'none'})`,
+            metadata,
+            tx,
+          });
+          return { status: 'updated' as const };
         });
+
+        if (reconciliationResult.status === 'local_row_changed_after_stripe') {
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message:
+              'Stripe cancellation was applied, but the local KiloClaw subscription changed before reconciliation. Review the admin audit log and current subscription row before retrying.',
+          });
+        }
 
         return successResult();
       }),

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -71,8 +71,11 @@ import { releaseScheduledChangeForSubscription } from '@/lib/kilo-pass/scheduled
 import { kilo_pass_scheduled_changes } from '@kilocode/db/schema';
 import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
 import {
+  CurrentPersonalSubscriptionResolutionError,
   getCurrentPersonalKiloClawSubscriptionForUser,
+  getEffectiveKiloClawSubscription,
   getKiloClawEarlybirdStateForUser,
+  getKiloClawSubscriptionAccessReason,
 } from '@/lib/kiloclaw/access-state';
 import { createKiloClawAdminAuditLog } from '@/lib/kiloclaw/admin-audit-log';
 import { KiloClawInternalClient } from '@/lib/kiloclaw/kiloclaw-internal-client';
@@ -582,20 +585,13 @@ export const adminRouter = createTRPCRouter({
       }
 
       const now = new Date();
-      const [
-        allSubscriptions,
-        earlybirdState,
-        currentPersonalSubscriptionState,
-        activeInstance,
-        allInstances,
-      ] = await Promise.all([
+      const [allSubscriptions, earlybirdState, activeInstance, allInstances] = await Promise.all([
         db
           .select()
           .from(kiloclaw_subscriptions)
           .where(eq(kiloclaw_subscriptions.user_id, input.userId))
           .orderBy(desc(kiloclaw_subscriptions.created_at)),
         getKiloClawEarlybirdStateForUser(input.userId, now),
-        getCurrentPersonalKiloClawSubscriptionForUser(input.userId, now),
         db.query.kiloclaw_instances.findFirst({
           columns: { id: true },
           where: and(
@@ -614,8 +610,35 @@ export const adminRouter = createTRPCRouter({
           .where(eq(kiloclaw_instances.user_id, input.userId)),
       ]);
 
-      const effectiveSub = currentPersonalSubscriptionState.subscription;
-      const accessReason = currentPersonalSubscriptionState.accessReason;
+      let billingStateError: string | null = null;
+      let effectiveSub: KiloClawSubscription | null = null;
+      let accessReason = null as ReturnType<typeof getKiloClawSubscriptionAccessReason>;
+      try {
+        const currentPersonalSubscriptionState =
+          await getCurrentPersonalKiloClawSubscriptionForUser(input.userId, now);
+        effectiveSub = currentPersonalSubscriptionState.subscription;
+        accessReason = currentPersonalSubscriptionState.accessReason;
+      } catch (error) {
+        if (!(error instanceof CurrentPersonalSubscriptionResolutionError)) {
+          throw error;
+        }
+        billingStateError = error.message;
+      }
+
+      if (!effectiveSub || !accessReason) {
+        const detachedAccessSubscription = getEffectiveKiloClawSubscription(
+          allSubscriptions.filter(subscription => subscription.instance_id === null),
+          now
+        );
+        const detachedAccessReason = getKiloClawSubscriptionAccessReason(
+          detachedAccessSubscription,
+          now
+        );
+        if (detachedAccessReason) {
+          effectiveSub = detachedAccessSubscription;
+          accessReason = detachedAccessReason;
+        }
+      }
       const earlybirdDaysRemaining = earlybirdState.expiresAt
         ? Math.ceil((new Date(earlybirdState.expiresAt).getTime() - Date.now()) / 86_400_000)
         : 0;
@@ -644,6 +667,8 @@ export const adminRouter = createTRPCRouter({
             }
           : null,
         activeInstanceId: activeInstance?.id ?? null,
+        billingStateError,
+        needsSupportReview: billingStateError !== null,
       };
     }),
 
@@ -862,153 +887,47 @@ export const adminRouter = createTRPCRouter({
     cancelKiloClawSubscription: adminProcedure
       .input(CancelKiloClawSubscriptionSchema)
       .mutation(async ({ input, ctx }) => {
-        await db.transaction(async tx => {
-          const subscription = await lockMutableKiloClawSubscription({
+        const subscription = await db.transaction(tx =>
+          lockMutableKiloClawSubscription({
             tx,
             userId: input.userId,
             subscriptionId: input.subscriptionId,
             notFoundCode: 'NOT_FOUND',
             notFoundMessage: 'Subscription not found or does not belong to this user',
-          });
+          })
+        );
 
-          const previousStatus = subscription.status;
-          let scheduleReleased = false;
+        const previousStatus = subscription.status;
+        let scheduleReleased = false;
+        let scheduleIdToRelease: string | null = null;
 
-          if (input.mode === 'period_end') {
-            if (subscription.status !== 'active') {
-              throw new TRPCError({
-                code: 'BAD_REQUEST',
-                message: 'Only active subscriptions can be canceled at period end',
-              });
-            }
-            if (subscription.cancel_at_period_end) {
-              throw new TRPCError({
-                code: 'BAD_REQUEST',
-                message: 'Subscription is already set to cancel at period end',
-              });
-            }
+        if (input.mode === 'period_end') {
+          if (subscription.status !== 'active') {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: 'Only active subscriptions can be canceled at period end',
+            });
+          }
+          if (subscription.cancel_at_period_end) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: 'Subscription is already set to cancel at period end',
+            });
+          }
 
-            if (subscription.stripe_subscription_id) {
-              // Stripe-funded: release pending schedule, then set cancel_at_period_end
-              const liveSub = await stripeClient.subscriptions.retrieve(
-                subscription.stripe_subscription_id
-              );
-              const scheduleRef = liveSub.schedule;
-              const scheduleIdToRelease =
-                subscription.stripe_schedule_id ??
-                (scheduleRef
-                  ? typeof scheduleRef === 'string'
-                    ? scheduleRef
-                    : scheduleRef.id
-                  : null);
+          if (subscription.stripe_subscription_id) {
+            const liveSub = await stripeClient.subscriptions.retrieve(
+              subscription.stripe_subscription_id
+            );
+            const scheduleRef = liveSub.schedule;
+            scheduleIdToRelease =
+              subscription.stripe_schedule_id ??
+              (scheduleRef
+                ? typeof scheduleRef === 'string'
+                  ? scheduleRef
+                  : scheduleRef.id
+                : null);
 
-              if (scheduleIdToRelease) {
-                try {
-                  await stripeClient.subscriptionSchedules.release(scheduleIdToRelease);
-                  scheduleReleased = true;
-                } catch (error) {
-                  const msg = error instanceof Error ? error.message : String(error);
-                  const alreadyInactive =
-                    msg.includes('not active') ||
-                    msg.includes('released') ||
-                    msg.includes('canceled') ||
-                    msg.includes('completed');
-                  if (!alreadyInactive) {
-                    throw new TRPCError({
-                      code: 'INTERNAL_SERVER_ERROR',
-                      message:
-                        'Unable to cancel: failed to release pending plan schedule. Please try again.',
-                    });
-                  }
-                  scheduleReleased = true;
-                }
-              }
-
-              await stripeClient.subscriptions.update(subscription.stripe_subscription_id, {
-                cancel_at_period_end: true,
-              });
-
-              const [updatedSubscription] = await tx
-                .update(kiloclaw_subscriptions)
-                .set({
-                  cancel_at_period_end: true,
-                  ...(scheduleIdToRelease
-                    ? { stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null }
-                    : {}),
-                })
-                .where(
-                  and(
-                    eq(kiloclaw_subscriptions.id, subscription.id),
-                    isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-                  )
-                )
-                .returning();
-
-              if (!updatedSubscription) {
-                throw new TRPCError({
-                  code: 'INTERNAL_SERVER_ERROR',
-                  message: 'Failed to update KiloClaw subscription',
-                });
-              }
-
-              await insertKiloClawSubscriptionChangeLog(tx, {
-                subscriptionId: subscription.id,
-                actor: adminSubscriptionActor(ctx.user),
-                action: 'canceled',
-                reason: 'admin_cancel_at_period_end',
-                before: subscription,
-                after: updatedSubscription,
-              });
-            } else {
-              // Pure-credit: set local cancel_at_period_end and clear schedule state
-              const [updatedSubscription] = await tx
-                .update(kiloclaw_subscriptions)
-                .set({
-                  cancel_at_period_end: true,
-                  stripe_schedule_id: null,
-                  scheduled_plan: null,
-                  scheduled_by: null,
-                })
-                .where(
-                  and(
-                    eq(kiloclaw_subscriptions.id, subscription.id),
-                    isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-                  )
-                )
-                .returning();
-
-              if (!updatedSubscription) {
-                throw new TRPCError({
-                  code: 'INTERNAL_SERVER_ERROR',
-                  message: 'Failed to update KiloClaw subscription',
-                });
-              }
-
-              await insertKiloClawSubscriptionChangeLog(tx, {
-                subscriptionId: subscription.id,
-                actor: adminSubscriptionActor(ctx.user),
-                action: 'canceled',
-                reason: 'admin_cancel_at_period_end',
-                before: subscription,
-                after: updatedSubscription,
-              });
-            }
-          } else {
-            // mode === 'immediate'
-            if (
-              subscription.status !== 'active' &&
-              subscription.status !== 'past_due' &&
-              subscription.status !== 'trialing'
-            ) {
-              throw new TRPCError({
-                code: 'BAD_REQUEST',
-                message:
-                  'Only active, past-due, or trialing subscriptions can be immediately canceled',
-              });
-            }
-
-            // Release any schedule first
-            const scheduleIdToRelease = subscription.stripe_schedule_id;
             if (scheduleIdToRelease) {
               try {
                 await stripeClient.subscriptionSchedules.release(scheduleIdToRelease);
@@ -1031,71 +950,119 @@ export const adminRouter = createTRPCRouter({
               }
             }
 
-            // Cancel Stripe subscription immediately if present
-            if (subscription.stripe_subscription_id) {
-              await stripeClient.subscriptions.cancel(subscription.stripe_subscription_id, {
-                prorate: false,
-                invoice_now: false,
-              });
-            }
-
-            // Update local subscription to canceled
-            const now = new Date().toISOString();
-            const [updatedSubscription] = await tx
-              .update(kiloclaw_subscriptions)
-              .set({
-                status: 'canceled',
-                cancel_at_period_end: false,
-                pending_conversion: false,
-                stripe_schedule_id: null,
-                scheduled_plan: null,
-                scheduled_by: null,
-                current_period_end: now,
-                credit_renewal_at: now,
-                // For trialing subscriptions, also end the trial immediately
-                ...(subscription.status === 'trialing' ? { trial_ends_at: now } : {}),
-              })
-              .where(
-                and(
-                  eq(kiloclaw_subscriptions.id, subscription.id),
-                  isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-                )
-              )
-              .returning();
-
-            if (!updatedSubscription) {
-              throw new TRPCError({
-                code: 'INTERNAL_SERVER_ERROR',
-                message: 'Failed to cancel KiloClaw subscription',
-              });
-            }
-
-            await insertKiloClawSubscriptionChangeLog(tx, {
-              subscriptionId: subscription.id,
-              actor: adminSubscriptionActor(ctx.user),
-              action: 'canceled',
-              reason: 'admin_cancel_immediate',
-              before: subscription,
-              after: updatedSubscription,
+            await stripeClient.subscriptions.update(subscription.stripe_subscription_id, {
+              cancel_at_period_end: true,
+            });
+          }
+        } else {
+          if (
+            subscription.status !== 'active' &&
+            subscription.status !== 'past_due' &&
+            subscription.status !== 'trialing'
+          ) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message:
+                'Only active, past-due, or trialing subscriptions can be immediately canceled',
             });
           }
 
-          await createKiloClawAdminAuditLog({
-            action: 'kiloclaw.subscription.admin_cancel',
-            actor_id: ctx.user.id,
-            actor_email: ctx.user.google_user_email,
-            actor_name: ctx.user.google_user_name,
-            target_user_id: input.userId,
-            message: `Admin ${input.mode === 'immediate' ? 'immediately canceled' : 'set cancel-at-period-end on'} KiloClaw subscription ${subscription.id} (status was ${previousStatus}, stripe_sub=${subscription.stripe_subscription_id ?? 'none'})`,
-            metadata: {
-              subscriptionId: subscription.id,
-              mode: input.mode,
-              previousStatus,
-              stripeSubscriptionId: subscription.stripe_subscription_id,
-              scheduleReleased,
-            },
-            tx,
+          scheduleIdToRelease = subscription.stripe_schedule_id;
+          if (scheduleIdToRelease) {
+            try {
+              await stripeClient.subscriptionSchedules.release(scheduleIdToRelease);
+              scheduleReleased = true;
+            } catch (error) {
+              const msg = error instanceof Error ? error.message : String(error);
+              const alreadyInactive =
+                msg.includes('not active') ||
+                msg.includes('released') ||
+                msg.includes('canceled') ||
+                msg.includes('completed');
+              if (!alreadyInactive) {
+                throw new TRPCError({
+                  code: 'INTERNAL_SERVER_ERROR',
+                  message:
+                    'Unable to cancel: failed to release pending plan schedule. Please try again.',
+                });
+              }
+              scheduleReleased = true;
+            }
+          }
+
+          if (subscription.stripe_subscription_id) {
+            await stripeClient.subscriptions.cancel(subscription.stripe_subscription_id, {
+              prorate: false,
+              invoice_now: false,
+            });
+          }
+        }
+
+        const now = new Date().toISOString();
+        const [updatedSubscription] = await db
+          .update(kiloclaw_subscriptions)
+          .set(
+            input.mode === 'period_end'
+              ? {
+                  cancel_at_period_end: true,
+                  stripe_schedule_id: null,
+                  scheduled_plan: null,
+                  scheduled_by: null,
+                }
+              : {
+                  status: 'canceled',
+                  cancel_at_period_end: false,
+                  pending_conversion: false,
+                  stripe_schedule_id: null,
+                  scheduled_plan: null,
+                  scheduled_by: null,
+                  current_period_end: now,
+                  credit_renewal_at: now,
+                  ...(subscription.status === 'trialing' ? { trial_ends_at: now } : {}),
+                }
+          )
+          .where(
+            and(
+              eq(kiloclaw_subscriptions.id, subscription.id),
+              isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+            )
+          )
+          .returning();
+
+        if (!updatedSubscription) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message:
+              input.mode === 'period_end'
+                ? 'Failed to update KiloClaw subscription'
+                : 'Failed to cancel KiloClaw subscription',
           });
+        }
+
+        await insertKiloClawSubscriptionChangeLog(db, {
+          subscriptionId: subscription.id,
+          actor: adminSubscriptionActor(ctx.user),
+          action: 'canceled',
+          reason:
+            input.mode === 'period_end' ? 'admin_cancel_at_period_end' : 'admin_cancel_immediate',
+          before: subscription,
+          after: updatedSubscription,
+        });
+
+        await createKiloClawAdminAuditLog({
+          action: 'kiloclaw.subscription.admin_cancel',
+          actor_id: ctx.user.id,
+          actor_email: ctx.user.google_user_email,
+          actor_name: ctx.user.google_user_name,
+          target_user_id: input.userId,
+          message: `Admin ${input.mode === 'immediate' ? 'immediately canceled' : 'set cancel-at-period-end on'} KiloClaw subscription ${subscription.id} (status was ${previousStatus}, stripe_sub=${subscription.stripe_subscription_id ?? 'none'})`,
+          metadata: {
+            subscriptionId: subscription.id,
+            mode: input.mode,
+            previousStatus,
+            stripeSubscriptionId: subscription.stripe_subscription_id,
+            scheduleReleased,
+          },
         });
 
         return successResult();

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -693,17 +693,26 @@ export const adminRouter = createTRPCRouter({
       }
 
       if (!effectiveSub || !accessReason) {
-        const detachedAccessSubscription = getEffectiveKiloClawSubscription(
-          allSubscriptions.filter(subscription => subscription.instance_id === null),
-          now
-        );
-        const detachedAccessReason = getKiloClawSubscriptionAccessReason(
-          detachedAccessSubscription,
-          now
-        );
-        if (detachedAccessReason) {
-          effectiveSub = detachedAccessSubscription;
-          accessReason = detachedAccessReason;
+        const detachedAccessSubscriptions = allSubscriptions.filter(subscription => {
+          if (subscription.instance_id !== null) return false;
+          const detachedAccessReason = getKiloClawSubscriptionAccessReason(subscription, now);
+          return detachedAccessReason !== null;
+        });
+        if (detachedAccessSubscriptions.length > 1) {
+          billingStateError = 'Multiple detached access-granting KiloClaw subscription rows exist.';
+        } else {
+          const detachedAccessSubscription = getEffectiveKiloClawSubscription(
+            detachedAccessSubscriptions,
+            now
+          );
+          const detachedAccessReason = getKiloClawSubscriptionAccessReason(
+            detachedAccessSubscription,
+            now
+          );
+          if (detachedAccessReason) {
+            effectiveSub = detachedAccessSubscription;
+            accessReason = detachedAccessReason;
+          }
         }
       }
       const earlybirdDaysRemaining = earlybirdState.expiresAt


### PR DESCRIPTION
## Summary
Prevents KiloClaw admin subscription actions from treating transferred historical rows as current subscriptions while adding lazy-loaded change-log visibility for reviewers and support.

### Why this change is needed
Transferred KiloClaw rows are historical after a subscription chain moves forward, but admin actions and filtering could still treat those rows as active candidates. That allowed reset/cancel actions to mutate old rows or expire current access in incident-shaped data. Admins also needed a safe way to inspect subscription mutation history without loading every change-log row in the main subscription list.

### How this is addressed
- Rejects trial edit/reset and cancel mutations for transferred KiloClaw subscription rows with a clear server-side error.
- Aligns admin effective/current subscription selection with runtime semantics by ignoring transferred rows and preferring current personal subscriptions.
- Marks transferred rows as historical/ignored in the admin UI, hides them with inactive subscriptions, and removes edit/cancel actions from those rows.
- Adds a lazy-loaded subscription change-log dialog that fetches the latest entries only when an admin opens a row's history.
- Adds tests for transferred-row mutation rejection, unchanged rows, absent rejected change logs, effective selection, and lazy-loaded change-log access control.

## Human Verification
- Spec alignment: checked KiloClaw billing and data model specs before changing admin subscription behavior.
- Tests verified: `pnpm test -- apps/web/src/routers/admin-kiloclaw-user-router.test.ts` passed with 33 tests.
- Code evaluations: self-reviewed transferred-row guard behavior, admin current-row selection, and lazy-loaded change-log scope.

## Reviewer Notes
### Human Reviewer
- Validate that lazy-loading the latest 50 change-log entries is enough for support workflows; the API allows up to 100 if UI pagination is needed later.
- Review the choice to run cancel mutations inside a transaction with row locking before Stripe side effects; this prevents concurrent transfer races but keeps the DB row lock open during Stripe calls.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- `getKiloClawState` now delegates current/effective selection to `getCurrentPersonalKiloClawSubscriptionForUser` instead of duplicating access selection logic.
- `lockMutableKiloClawSubscription` uses `SELECT ... FOR UPDATE` and all mutation updates also require `transferred_to_subscription_id IS NULL`.
- Rejected transferred-row mutations throw before change-log writes, preserving audit semantics for only allowed current-row mutations.
- Change-log history is exposed through `getKiloClawSubscriptionChangeLogs`, which first verifies the subscription belongs to the requested user before reading logs.
- UI keeps transferred-row metadata visible through `Transferred To <id>` while making historical rows inactive and non-actionable.

</details>