### PR TITLE
fix(kiloclaw): repair org replacement state and admin clarity

### DIFF
--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
@@ -63,6 +63,43 @@ function isInactiveSubscription(subscription: {
   return subscription.status === 'canceled' || isTransferredHistoricalSubscription(subscription);
 }
 
+function getSubscriptionScope(subscription: {
+  instance: {
+    organization_id?: string | null;
+    organization_name?: string | null;
+  } | null;
+}) {
+  if (!subscription.instance?.organization_id) {
+    return {
+      type: 'personal' as const,
+      organizationId: null,
+      organizationName: null,
+    };
+  }
+
+  return {
+    type: 'organization' as const,
+    organizationId: subscription.instance.organization_id,
+    organizationName: subscription.instance.organization_name ?? null,
+  };
+}
+
+function formatSubscriptionScopeValue(subscription: {
+  instance: {
+    organization_id?: string | null;
+    organization_name?: string | null;
+  } | null;
+}) {
+  const scope = getSubscriptionScope(subscription);
+  if (scope.type === 'personal') {
+    return 'personal';
+  }
+
+  return scope.organizationName
+    ? `organization — ${scope.organizationName} (${scope.organizationId})`
+    : `organization — ${scope.organizationId}`;
+}
+
 function getSubscriptionStatusBadgeClass(status: string) {
   switch (status) {
     case 'active':
@@ -237,8 +274,187 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
     ? subscriptions.filter(s => !isInactiveSubscription(s))
     : subscriptions;
   const hiddenCount = subscriptions.length - visibleSubscriptions.length;
+  const personalSubscriptions = subscriptions.filter(
+    subscription => getSubscriptionScope(subscription).type === 'personal'
+  );
+  const organizationSubscriptions = subscriptions.filter(
+    subscription => getSubscriptionScope(subscription).type === 'organization'
+  );
+  const visiblePersonalSubscriptions = visibleSubscriptions.filter(
+    subscription => getSubscriptionScope(subscription).type === 'personal'
+  );
+  const visibleOrganizationSubscriptions = visibleSubscriptions.filter(
+    subscription => getSubscriptionScope(subscription).type === 'organization'
+  );
 
   const cancelingSubscription = subscriptions.find(s => s.id === cancelSubscriptionId);
+
+  const renderSubscriptionCards = (sectionSubscriptions: typeof visibleSubscriptions) => {
+    if (sectionSubscriptions.length === 0) {
+      return null;
+    }
+
+    return (
+      <div className="space-y-4">
+        {sectionSubscriptions.map(sub => {
+          const scope = getSubscriptionScope(sub);
+          const isTransferred = isTransferredHistoricalSubscription(sub);
+          const isEffective = !isTransferred && sub.id === data?.effectiveSubscriptionId;
+          const canEditTrialEnd =
+            !isTransferred && (sub.status === 'trialing' || sub.status === 'canceled');
+          const isTrialReset = sub.status === 'canceled';
+          const canCancel =
+            !isTransferred &&
+            (sub.status === 'active' || sub.status === 'past_due') &&
+            sub.plan !== 'trial' &&
+            !sub.cancel_at_period_end;
+          const canImmediateCancel =
+            !isTransferred &&
+            (sub.status === 'active' || sub.status === 'past_due') &&
+            sub.plan !== 'trial';
+          const canCancelTrial = !isTransferred && sub.status === 'trialing';
+
+          return (
+            <div
+              key={sub.id}
+              className={`rounded-lg border p-4 ${isEffective ? 'border-blue-500/40 bg-blue-950/10' : ''}`}
+            >
+              <div className="mb-3 flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <Badge className={getSubscriptionStatusBadgeClass(sub.status)}>
+                    {sub.status}
+                  </Badge>
+                  <span className="text-sm font-semibold">{sub.plan}</span>
+                  <Badge variant="outline" className="text-xs">
+                    {scope.type}
+                  </Badge>
+                  {scope.type === 'organization' && scope.organizationName ? (
+                    <Badge variant="outline" className="text-xs">
+                      {scope.organizationName}
+                    </Badge>
+                  ) : null}
+                  {isEffective && (
+                    <Badge variant="outline" className="text-xs">
+                      personal effective
+                    </Badge>
+                  )}
+                  {isTransferred && (
+                    <Badge variant="outline" className="text-muted-foreground text-xs">
+                      historical / ignored
+                    </Badge>
+                  )}
+                  {sub.cancel_at_period_end && (
+                    <Badge className="bg-orange-900/20 text-orange-400">
+                      cancels at period end
+                    </Badge>
+                  )}
+                  {sub.pending_conversion && (
+                    <Badge className="bg-purple-900/20 text-purple-400">pending conversion</Badge>
+                  )}
+                </div>
+                <div className="flex gap-2">
+                  {sub.instance && (
+                    <Button variant="outline" size="sm" asChild>
+                      <Link href={`/admin/kiloclaw/${sub.instance.id}`}>
+                        <ExternalLink className="mr-1 h-3 w-3" />
+                        View Instance
+                      </Link>
+                    </Button>
+                  )}
+                  <Button variant="outline" size="sm" onClick={() => openChangeLogDialog(sub.id)}>
+                    <History className="mr-1 h-3 w-3" />
+                    Change Log
+                  </Button>
+                  {canEditTrialEnd && (
+                    <Button variant="outline" size="sm" onClick={() => openTrialDialog(sub.id)}>
+                      {isTrialReset ? 'Reset Trial' : 'Edit Trial End'}
+                    </Button>
+                  )}
+                  {canCancel && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="border-red-500/30 text-red-400 hover:bg-red-950/30"
+                      onClick={() => openCancelDialog(sub.id, sub.status)}
+                    >
+                      Cancel
+                    </Button>
+                  )}
+                  {!canCancel && canImmediateCancel && sub.cancel_at_period_end && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="border-red-500/30 text-red-400 hover:bg-red-950/30"
+                      onClick={() => openCancelDialog(sub.id, sub.status)}
+                    >
+                      Cancel Immediately
+                    </Button>
+                  )}
+                  {canCancelTrial && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="border-red-500/30 text-red-400 hover:bg-red-950/30"
+                      onClick={() => openCancelDialog(sub.id, sub.status)}
+                    >
+                      Cancel Trial
+                    </Button>
+                  )}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+                <Field label="Scope" value={formatSubscriptionScopeValue(sub)} />
+                {scope.type === 'organization' ? (
+                  <Field
+                    label="Organization"
+                    value={
+                      scope.organizationName
+                        ? `${scope.organizationName} (${scope.organizationId})`
+                        : (scope.organizationId ?? '—')
+                    }
+                  />
+                ) : null}
+                <Field label="Payment Source" value={sub.payment_source ?? '—'} />
+                <Field label="Stripe Subscription" value={sub.stripe_subscription_id ?? '—'} mono />
+                <Field
+                  label="Transferred To"
+                  value={sub.transferred_to_subscription_id ?? '—'}
+                  mono
+                />
+                <Field label="Instance ID" value={sub.instance_id ?? '—'} mono />
+                <Field
+                  label="Instance"
+                  value={
+                    sub.instance
+                      ? `${sub.instance.name ?? sub.instance.sandbox_id}${sub.instance.destroyed_at ? ' (destroyed)' : ''}`
+                      : '—'
+                  }
+                />
+                <Field label="Trial Started" value={formatDateOrDash(sub.trial_started_at)} />
+                <Field label="Trial Ends" value={formatDateOrDash(sub.trial_ends_at)} />
+                <Field label="Period Start" value={formatDateOrDash(sub.current_period_start)} />
+                <Field label="Period End" value={formatDateOrDash(sub.current_period_end)} />
+                <Field label="Commit Ends" value={formatDateOrDash(sub.commit_ends_at)} />
+                <Field label="Credit Renewal" value={formatDateOrDash(sub.credit_renewal_at)} />
+                <Field label="Scheduled Plan" value={sub.scheduled_plan ?? '—'} />
+                <Field label="Scheduled By" value={sub.scheduled_by ?? '—'} />
+                <Field label="Stripe Schedule" value={sub.stripe_schedule_id ?? '—'} mono />
+                <Field label="Suspended At" value={formatDateOrDash(sub.suspended_at)} />
+                <Field
+                  label="Destruction Deadline"
+                  value={formatDateOrDash(sub.destruction_deadline)}
+                />
+                <Field label="Past Due Since" value={formatDateOrDash(sub.past_due_since)} />
+                <Field label="Created" value={formatDate(sub.created_at)} />
+                <Field label="Updated" value={formatDate(sub.updated_at)} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
 
   return (
     <>
@@ -284,7 +500,7 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
           {/* Access & earlybird summary */}
           <div className="flex items-center gap-4">
             <div>
-              <h4 className="text-muted-foreground text-xs font-medium">Access</h4>
+              <h4 className="text-muted-foreground text-xs font-medium">Personal access</h4>
               <Badge className={getAccessBadgeClass(data?.hasAccess ?? false)}>
                 {data?.hasAccess ? 'has access' : 'no access'}
               </Badge>
@@ -329,175 +545,54 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
           )}
 
           {/* Subscription list */}
-          {visibleSubscriptions.length === 0 && subscriptions.length === 0 ? (
+          {subscriptions.length === 0 ? (
             <p className="text-muted-foreground text-sm">
               This user does not have any KiloClaw subscription rows.
             </p>
-          ) : visibleSubscriptions.length === 0 ? (
-            <p className="text-muted-foreground text-sm">
-              All subscriptions are inactive. Uncheck &quot;Hide inactive subscriptions&quot; to
-              view them.
-            </p>
           ) : (
-            <div className="space-y-4">
-              {visibleSubscriptions.map(sub => {
-                const isTransferred = isTransferredHistoricalSubscription(sub);
-                const isEffective = !isTransferred && sub.id === data?.effectiveSubscriptionId;
-                const canEditTrialEnd =
-                  !isTransferred && (sub.status === 'trialing' || sub.status === 'canceled');
-                const isTrialReset = sub.status === 'canceled';
-                const canCancel =
-                  !isTransferred &&
-                  (sub.status === 'active' || sub.status === 'past_due') &&
-                  sub.plan !== 'trial' &&
-                  !sub.cancel_at_period_end;
-                const canImmediateCancel =
-                  !isTransferred &&
-                  (sub.status === 'active' || sub.status === 'past_due') &&
-                  sub.plan !== 'trial';
-                const canCancelTrial = !isTransferred && sub.status === 'trialing';
+            <div className="space-y-6">
+              <div className="space-y-3">
+                <div>
+                  <h4 className="text-sm font-medium">Personal subscriptions</h4>
+                  <p className="text-muted-foreground text-xs">
+                    Personal subscriptions affect the Personal access state above.
+                  </p>
+                </div>
+                {visiblePersonalSubscriptions.length > 0 ? (
+                  renderSubscriptionCards(visiblePersonalSubscriptions)
+                ) : personalSubscriptions.length > 0 ? (
+                  <p className="text-muted-foreground text-sm">
+                    All personal subscriptions are inactive. Uncheck &quot;Hide inactive
+                    subscriptions&quot; to view them.
+                  </p>
+                ) : (
+                  <p className="text-muted-foreground text-sm">
+                    This user does not have any personal KiloClaw subscription rows.
+                  </p>
+                )}
+              </div>
 
-                return (
-                  <div
-                    key={sub.id}
-                    className={`rounded-lg border p-4 ${isEffective ? 'border-blue-500/40 bg-blue-950/10' : ''}`}
-                  >
-                    {/* Header row */}
-                    <div className="mb-3 flex items-center justify-between gap-2">
-                      <div className="flex items-center gap-2">
-                        <Badge className={getSubscriptionStatusBadgeClass(sub.status)}>
-                          {sub.status}
-                        </Badge>
-                        <span className="text-sm font-semibold">{sub.plan}</span>
-                        {isEffective && (
-                          <Badge variant="outline" className="text-xs">
-                            effective
-                          </Badge>
-                        )}
-                        {isTransferred && (
-                          <Badge variant="outline" className="text-muted-foreground text-xs">
-                            historical / ignored
-                          </Badge>
-                        )}
-                        {sub.cancel_at_period_end && (
-                          <Badge className="bg-orange-900/20 text-orange-400">
-                            cancels at period end
-                          </Badge>
-                        )}
-                        {sub.pending_conversion && (
-                          <Badge className="bg-purple-900/20 text-purple-400">
-                            pending conversion
-                          </Badge>
-                        )}
-                      </div>
-                      <div className="flex gap-2">
-                        {sub.instance && (
-                          <Button variant="outline" size="sm" asChild>
-                            <Link href={`/admin/kiloclaw/${sub.instance.id}`}>
-                              <ExternalLink className="mr-1 h-3 w-3" />
-                              View Instance
-                            </Link>
-                          </Button>
-                        )}
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => openChangeLogDialog(sub.id)}
-                        >
-                          <History className="mr-1 h-3 w-3" />
-                          Change Log
-                        </Button>
-                        {canEditTrialEnd && (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => openTrialDialog(sub.id)}
-                          >
-                            {isTrialReset ? 'Reset Trial' : 'Edit Trial End'}
-                          </Button>
-                        )}
-                        {canCancel && (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="border-red-500/30 text-red-400 hover:bg-red-950/30"
-                            onClick={() => openCancelDialog(sub.id, sub.status)}
-                          >
-                            Cancel
-                          </Button>
-                        )}
-                        {!canCancel && canImmediateCancel && sub.cancel_at_period_end && (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="border-red-500/30 text-red-400 hover:bg-red-950/30"
-                            onClick={() => openCancelDialog(sub.id, sub.status)}
-                          >
-                            Cancel Immediately
-                          </Button>
-                        )}
-                        {canCancelTrial && (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="border-red-500/30 text-red-400 hover:bg-red-950/30"
-                            onClick={() => openCancelDialog(sub.id, sub.status)}
-                          >
-                            Cancel Trial
-                          </Button>
-                        )}
-                      </div>
-                    </div>
-
-                    {/* Detail grid */}
-                    <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
-                      <Field label="Payment Source" value={sub.payment_source ?? '—'} />
-                      <Field
-                        label="Stripe Subscription"
-                        value={sub.stripe_subscription_id ?? '—'}
-                        mono
-                      />
-                      <Field
-                        label="Transferred To"
-                        value={sub.transferred_to_subscription_id ?? '—'}
-                        mono
-                      />
-                      <Field label="Instance ID" value={sub.instance_id ?? '—'} mono />
-                      <Field
-                        label="Instance"
-                        value={
-                          sub.instance
-                            ? `${sub.instance.name ?? sub.instance.sandbox_id}${sub.instance.destroyed_at ? ' (destroyed)' : ''}`
-                            : '—'
-                        }
-                      />
-                      <Field label="Trial Started" value={formatDateOrDash(sub.trial_started_at)} />
-                      <Field label="Trial Ends" value={formatDateOrDash(sub.trial_ends_at)} />
-                      <Field
-                        label="Period Start"
-                        value={formatDateOrDash(sub.current_period_start)}
-                      />
-                      <Field label="Period End" value={formatDateOrDash(sub.current_period_end)} />
-                      <Field label="Commit Ends" value={formatDateOrDash(sub.commit_ends_at)} />
-                      <Field
-                        label="Credit Renewal"
-                        value={formatDateOrDash(sub.credit_renewal_at)}
-                      />
-                      <Field label="Scheduled Plan" value={sub.scheduled_plan ?? '—'} />
-                      <Field label="Scheduled By" value={sub.scheduled_by ?? '—'} />
-                      <Field label="Stripe Schedule" value={sub.stripe_schedule_id ?? '—'} mono />
-                      <Field label="Suspended At" value={formatDateOrDash(sub.suspended_at)} />
-                      <Field
-                        label="Destruction Deadline"
-                        value={formatDateOrDash(sub.destruction_deadline)}
-                      />
-                      <Field label="Past Due Since" value={formatDateOrDash(sub.past_due_since)} />
-                      <Field label="Created" value={formatDate(sub.created_at)} />
-                      <Field label="Updated" value={formatDate(sub.updated_at)} />
-                    </div>
-                  </div>
-                );
-              })}
+              <div className="space-y-3">
+                <div>
+                  <h4 className="text-sm font-medium">Organization subscriptions</h4>
+                  <p className="text-muted-foreground text-xs">
+                    Organization-scoped subscriptions are listed separately and do not grant
+                    personal access.
+                  </p>
+                </div>
+                {visibleOrganizationSubscriptions.length > 0 ? (
+                  renderSubscriptionCards(visibleOrganizationSubscriptions)
+                ) : organizationSubscriptions.length > 0 ? (
+                  <p className="text-muted-foreground text-sm">
+                    All organization subscriptions are inactive. Uncheck &quot;Hide inactive
+                    subscriptions&quot; to view them.
+                  </p>
+                ) : (
+                  <p className="text-muted-foreground text-sm">
+                    This user does not have any organization-scoped KiloClaw subscription rows.
+                  </p>
+                )}
+              </div>
             </div>
           )}
         </CardContent>

--- a/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
@@ -924,6 +924,279 @@ describe('kiloclaw-subscription-alignment script', () => {
     );
   });
 
+  it('repairs org replacement drift by transferring destroyed predecessor to live row', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'org-replacement-drift@example.com',
+    });
+    const organization = await createTestOrganization('org-replacement', user.id, 0);
+
+    const destroyedInstanceId = crypto.randomUUID();
+    const liveInstanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: destroyedInstanceId,
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `ki_${destroyedInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-03-01T00:00:00.000Z',
+        destroyed_at: '2026-03-10T00:00:00.000Z',
+      },
+      {
+        id: liveInstanceId,
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `ki_${liveInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+      },
+    ]);
+
+    const [destroyedSubscription, liveSubscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values([
+        {
+          user_id: user.id,
+          instance_id: destroyedInstanceId,
+          plan: 'standard',
+          status: 'active',
+          payment_source: 'credits',
+          cancel_at_period_end: false,
+          created_at: '2026-03-01T00:00:00.000Z',
+          updated_at: '2026-03-01T00:00:00.000Z',
+        },
+        {
+          user_id: user.id,
+          instance_id: liveInstanceId,
+          plan: 'standard',
+          status: 'active',
+          payment_source: 'credits',
+          cancel_at_period_end: false,
+          created_at: '2026-04-01T00:00:00.000Z',
+          updated_at: '2026-04-01T00:00:00.000Z',
+        },
+      ])
+      .returning();
+
+    if (!destroyedSubscription || !liveSubscription) {
+      throw new Error('Expected org subscription seed rows');
+    }
+
+    await run('apply-org-replacement');
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .orderBy(kiloclaw_subscriptions.created_at);
+
+    const destroyedAfter = subscriptions.find(
+      subscription => subscription.id === destroyedSubscription.id
+    );
+    const liveAfter = subscriptions.find(subscription => subscription.id === liveSubscription.id);
+
+    expect(destroyedAfter?.transferred_to_subscription_id).toBe(liveSubscription.id);
+    expect(liveAfter?.transferred_to_subscription_id).toBeNull();
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, destroyedSubscription.id));
+
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'reassigned',
+          reason: 'apply_org_replacement_transfer_destroyed_predecessor',
+        }),
+      ])
+    );
+
+    const metricsCall = (console.table as jest.Mock).mock.calls.find(
+      ([rows]) => Array.isArray(rows) && rows.some(row => row.metric === 'orgs_succeeded')
+    );
+    expect(metricsCall?.[0]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ metric: 'orgs_succeeded', count: 1 }),
+        expect.objectContaining({ metric: 'orgs_skipped_no_work', count: 0 }),
+        expect.objectContaining({ metric: 'orgs_skipped_race', count: 0 }),
+        expect.objectContaining({ metric: 'orgs_error', count: 0 }),
+      ])
+    );
+  });
+
+  it('chains multiple destroyed org predecessors without violating transferred_to uniqueness', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'org-replacement-chain@example.com',
+    });
+    const organization = await createTestOrganization('org-replacement-chain', user.id, 0);
+
+    const oldestDestroyedInstanceId = crypto.randomUUID();
+    const newestDestroyedInstanceId = crypto.randomUUID();
+    const liveInstanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: oldestDestroyedInstanceId,
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `ki_${oldestDestroyedInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-02-01T00:00:00.000Z',
+        destroyed_at: '2026-02-10T00:00:00.000Z',
+      },
+      {
+        id: newestDestroyedInstanceId,
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `ki_${newestDestroyedInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-03-01T00:00:00.000Z',
+        destroyed_at: '2026-03-10T00:00:00.000Z',
+      },
+      {
+        id: liveInstanceId,
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `ki_${liveInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+      },
+    ]);
+
+    const [oldestDestroyedSubscription, newestDestroyedSubscription, liveSubscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values([
+        {
+          user_id: user.id,
+          instance_id: oldestDestroyedInstanceId,
+          plan: 'standard',
+          status: 'active',
+          payment_source: 'credits',
+          cancel_at_period_end: false,
+          created_at: '2026-02-01T00:00:00.000Z',
+          updated_at: '2026-02-01T00:00:00.000Z',
+        },
+        {
+          user_id: user.id,
+          instance_id: newestDestroyedInstanceId,
+          plan: 'standard',
+          status: 'active',
+          payment_source: 'credits',
+          cancel_at_period_end: false,
+          created_at: '2026-03-01T00:00:00.000Z',
+          updated_at: '2026-03-01T00:00:00.000Z',
+        },
+        {
+          user_id: user.id,
+          instance_id: liveInstanceId,
+          plan: 'standard',
+          status: 'active',
+          payment_source: 'credits',
+          cancel_at_period_end: false,
+          created_at: '2026-04-01T00:00:00.000Z',
+          updated_at: '2026-04-01T00:00:00.000Z',
+        },
+      ])
+      .returning();
+
+    if (!oldestDestroyedSubscription || !newestDestroyedSubscription || !liveSubscription) {
+      throw new Error('Expected org chain seed rows');
+    }
+
+    await run('apply-org-replacement');
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .orderBy(kiloclaw_subscriptions.created_at);
+
+    expect(subscriptions.map(subscription => subscription.transferred_to_subscription_id)).toEqual([
+      newestDestroyedSubscription.id,
+      liveSubscription.id,
+      null,
+    ]);
+  });
+
+  it('skips cleanly when org replacement candidate is repaired concurrently', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'org-replacement-race@example.com',
+    });
+    const organization = await createTestOrganization('org-replacement-race', user.id, 0);
+
+    const destroyedInstanceId = crypto.randomUUID();
+    const liveInstanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: destroyedInstanceId,
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `ki_${destroyedInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-03-01T00:00:00.000Z',
+        destroyed_at: '2026-03-10T00:00:00.000Z',
+      },
+      {
+        id: liveInstanceId,
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `ki_${liveInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+      },
+    ]);
+
+    const [destroyedSubscription, liveSubscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values([
+        {
+          user_id: user.id,
+          instance_id: destroyedInstanceId,
+          plan: 'standard',
+          status: 'active',
+          payment_source: 'credits',
+          cancel_at_period_end: false,
+          created_at: '2026-03-01T00:00:00.000Z',
+          updated_at: '2026-03-01T00:00:00.000Z',
+        },
+        {
+          user_id: user.id,
+          instance_id: liveInstanceId,
+          plan: 'standard',
+          status: 'active',
+          payment_source: 'credits',
+          cancel_at_period_end: false,
+          created_at: '2026-04-01T00:00:00.000Z',
+          updated_at: '2026-04-01T00:00:00.000Z',
+        },
+      ])
+      .returning();
+
+    if (!destroyedSubscription || !liveSubscription) {
+      throw new Error('Expected org race seed rows');
+    }
+
+    const originalTransaction = db.transaction.bind(db);
+    jest.spyOn(db, 'transaction').mockImplementationOnce(async callback => {
+      await db
+        .update(kiloclaw_subscriptions)
+        .set({ transferred_to_subscription_id: liveSubscription.id })
+        .where(eq(kiloclaw_subscriptions.id, destroyedSubscription.id));
+
+      return await originalTransaction(callback);
+    });
+
+    await run('apply-org-replacement');
+
+    const metricsCall = (console.table as jest.Mock).mock.calls.find(
+      ([rows]) => Array.isArray(rows) && rows.some(row => row.metric === 'orgs_skipped_race')
+    );
+    expect(metricsCall?.[0]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ metric: 'orgs_succeeded', count: 0 }),
+        expect.objectContaining({ metric: 'orgs_skipped_no_work', count: 0 }),
+        expect.objectContaining({ metric: 'orgs_skipped_race', count: 1 }),
+        expect.objectContaining({ metric: 'orgs_error', count: 0 }),
+      ])
+    );
+  });
+
   it('destroys duplicate instance whose only sub is a transferred predecessor', async () => {
     // Builder filters transferred rows from subscriptionsByInstanceId; the
     // apply existence checks must match. An instance holding only a

--- a/apps/web/src/lib/kiloclaw/provision-bootstrap-shared-org.test.ts
+++ b/apps/web/src/lib/kiloclaw/provision-bootstrap-shared-org.test.ts
@@ -1,0 +1,371 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { and, eq, inArray } from 'drizzle-orm';
+
+import { cleanupDbForTest, db } from '@/lib/drizzle';
+import { createTestOrganization } from '@/tests/helpers/organization.helper';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import {
+  kiloclaw_instances,
+  kiloclaw_subscription_change_log,
+  kiloclaw_subscriptions,
+} from '@kilocode/db/schema';
+import { bootstrapProvisionSubscriptionWithDb } from '../../../../../services/kiloclaw-billing/src/provision-bootstrap-shared';
+
+const BOOTSTRAP_ACTOR = {
+  actorType: 'system',
+  actorId: 'kiloclaw-billing-bootstrap',
+} as const;
+
+describe('bootstrapProvisionSubscriptionWithDb organization replacement', () => {
+  beforeEach(async () => {
+    await cleanupDbForTest();
+  });
+
+  it('transfers destroyed org predecessors to the new live row without touching personal or other-org rows', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'org-bootstrap-replacement@example.com',
+    });
+    const primaryOrg = await createTestOrganization('Primary Org', user.id, 0);
+    const otherOrg = await createTestOrganization('Other Org', user.id, 0);
+
+    const personalInstanceId = crypto.randomUUID();
+    const primaryDestroyedInstanceId = crypto.randomUUID();
+    const primaryLiveInstanceId = crypto.randomUUID();
+    const otherOrgDestroyedInstanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: personalInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${personalInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-02-01T00:00:00.000Z',
+      },
+      {
+        id: primaryDestroyedInstanceId,
+        user_id: user.id,
+        organization_id: primaryOrg.id,
+        sandbox_id: `ki_${primaryDestroyedInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-03-01T00:00:00.000Z',
+        destroyed_at: '2026-03-10T00:00:00.000Z',
+      },
+      {
+        id: primaryLiveInstanceId,
+        user_id: user.id,
+        organization_id: primaryOrg.id,
+        sandbox_id: `ki_${primaryLiveInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+      },
+      {
+        id: otherOrgDestroyedInstanceId,
+        user_id: user.id,
+        organization_id: otherOrg.id,
+        sandbox_id: `ki_${otherOrgDestroyedInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-03-15T00:00:00.000Z',
+        destroyed_at: '2026-03-20T00:00:00.000Z',
+      },
+    ]);
+
+    const [personalSubscription, primaryDestroyedSubscription, otherOrgDestroyedSubscription] =
+      await db
+        .insert(kiloclaw_subscriptions)
+        .values([
+          {
+            user_id: user.id,
+            instance_id: personalInstanceId,
+            plan: 'trial',
+            status: 'canceled',
+            cancel_at_period_end: false,
+            trial_started_at: '2026-02-01T00:00:00.000Z',
+            trial_ends_at: '2026-02-08T00:00:00.000Z',
+            created_at: '2026-02-01T00:00:00.000Z',
+            updated_at: '2026-02-08T00:00:00.000Z',
+          },
+          {
+            user_id: user.id,
+            instance_id: primaryDestroyedInstanceId,
+            plan: 'standard',
+            status: 'active',
+            payment_source: 'credits',
+            cancel_at_period_end: false,
+            created_at: '2026-03-01T00:00:00.000Z',
+            updated_at: '2026-03-01T00:00:00.000Z',
+          },
+          {
+            user_id: user.id,
+            instance_id: otherOrgDestroyedInstanceId,
+            plan: 'standard',
+            status: 'active',
+            payment_source: 'credits',
+            cancel_at_period_end: false,
+            created_at: '2026-03-15T00:00:00.000Z',
+            updated_at: '2026-03-15T00:00:00.000Z',
+          },
+        ])
+        .returning();
+
+    if (!personalSubscription || !primaryDestroyedSubscription || !otherOrgDestroyedSubscription) {
+      throw new Error('Expected seed subscription rows');
+    }
+
+    const created = await bootstrapProvisionSubscriptionWithDb({
+      db,
+      input: {
+        userId: user.id,
+        instanceId: primaryLiveInstanceId,
+        orgId: primaryOrg.id,
+      },
+      actor: BOOTSTRAP_ACTOR,
+    });
+
+    expect(created).toEqual(
+      expect.objectContaining({
+        user_id: user.id,
+        instance_id: primaryLiveInstanceId,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+      })
+    );
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+
+    const personalAfter = subscriptions.find(
+      subscription => subscription.id === personalSubscription.id
+    );
+    const primaryDestroyedAfter = subscriptions.find(
+      subscription => subscription.id === primaryDestroyedSubscription.id
+    );
+    const primaryLiveAfter = subscriptions.find(subscription => subscription.id === created.id);
+    const otherOrgAfter = subscriptions.find(
+      subscription => subscription.id === otherOrgDestroyedSubscription.id
+    );
+
+    expect(personalAfter?.transferred_to_subscription_id).toBeNull();
+    expect(personalAfter?.status).toBe('canceled');
+    expect(primaryDestroyedAfter?.transferred_to_subscription_id).toBe(created.id);
+    expect(primaryLiveAfter?.transferred_to_subscription_id).toBeNull();
+    expect(otherOrgAfter?.transferred_to_subscription_id).toBeNull();
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(
+        inArray(kiloclaw_subscription_change_log.subscription_id, [
+          primaryDestroyedSubscription.id,
+          created.id,
+        ])
+      );
+
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subscription_id: primaryDestroyedSubscription.id,
+          actor_id: BOOTSTRAP_ACTOR.actorId,
+          action: 'reassigned',
+          reason: 'org_provision_transfer_destroyed_predecessor',
+        }),
+        expect.objectContaining({
+          subscription_id: created.id,
+          actor_id: BOOTSTRAP_ACTOR.actorId,
+          action: 'created',
+          reason: 'org_provision_managed',
+        }),
+      ])
+    );
+  });
+
+  it('chains multiple destroyed org predecessors onto the live successor row', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'org-bootstrap-chain@example.com',
+    });
+    const organization = await createTestOrganization('Chain Org', user.id, 0);
+
+    const oldestDestroyedInstanceId = crypto.randomUUID();
+    const newestDestroyedInstanceId = crypto.randomUUID();
+    const liveInstanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: oldestDestroyedInstanceId,
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `ki_${oldestDestroyedInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-02-01T00:00:00.000Z',
+        destroyed_at: '2026-02-10T00:00:00.000Z',
+      },
+      {
+        id: newestDestroyedInstanceId,
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `ki_${newestDestroyedInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-03-01T00:00:00.000Z',
+        destroyed_at: '2026-03-10T00:00:00.000Z',
+      },
+      {
+        id: liveInstanceId,
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `ki_${liveInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+      },
+    ]);
+
+    const [oldestDestroyedSubscription, newestDestroyedSubscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values([
+        {
+          user_id: user.id,
+          instance_id: oldestDestroyedInstanceId,
+          plan: 'standard',
+          status: 'active',
+          payment_source: 'credits',
+          cancel_at_period_end: false,
+          created_at: '2026-02-01T00:00:00.000Z',
+          updated_at: '2026-02-01T00:00:00.000Z',
+        },
+        {
+          user_id: user.id,
+          instance_id: newestDestroyedInstanceId,
+          plan: 'standard',
+          status: 'active',
+          payment_source: 'credits',
+          cancel_at_period_end: false,
+          created_at: '2026-03-01T00:00:00.000Z',
+          updated_at: '2026-03-01T00:00:00.000Z',
+        },
+      ])
+      .returning();
+
+    if (!oldestDestroyedSubscription || !newestDestroyedSubscription) {
+      throw new Error('Expected destroyed predecessor rows');
+    }
+
+    const created = await bootstrapProvisionSubscriptionWithDb({
+      db,
+      input: {
+        userId: user.id,
+        instanceId: liveInstanceId,
+        orgId: organization.id,
+      },
+      actor: BOOTSTRAP_ACTOR,
+    });
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .orderBy(kiloclaw_subscriptions.created_at, kiloclaw_subscriptions.id);
+
+    expect(subscriptions.map(subscription => subscription.transferred_to_subscription_id)).toEqual([
+      newestDestroyedSubscription.id,
+      created.id,
+      null,
+    ]);
+  });
+
+  it('is idempotent when bootstrap is repeated for the same live org instance', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'org-bootstrap-idempotent@example.com',
+    });
+    const organization = await createTestOrganization('Idempotent Org', user.id, 0);
+
+    const destroyedInstanceId = crypto.randomUUID();
+    const liveInstanceId = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: destroyedInstanceId,
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `ki_${destroyedInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-03-01T00:00:00.000Z',
+        destroyed_at: '2026-03-10T00:00:00.000Z',
+      },
+      {
+        id: liveInstanceId,
+        user_id: user.id,
+        organization_id: organization.id,
+        sandbox_id: `ki_${liveInstanceId.replaceAll('-', '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+      },
+    ]);
+
+    const [destroyedSubscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: destroyedInstanceId,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+        cancel_at_period_end: false,
+        created_at: '2026-03-01T00:00:00.000Z',
+        updated_at: '2026-03-01T00:00:00.000Z',
+      })
+      .returning();
+
+    if (!destroyedSubscription) {
+      throw new Error('Expected destroyed predecessor row');
+    }
+
+    const first = await bootstrapProvisionSubscriptionWithDb({
+      db,
+      input: {
+        userId: user.id,
+        instanceId: liveInstanceId,
+        orgId: organization.id,
+      },
+      actor: BOOTSTRAP_ACTOR,
+    });
+
+    const second = await bootstrapProvisionSubscriptionWithDb({
+      db,
+      input: {
+        userId: user.id,
+        instanceId: liveInstanceId,
+        orgId: organization.id,
+      },
+      actor: BOOTSTRAP_ACTOR,
+    });
+
+    expect(second.id).toBe(first.id);
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+    expect(subscriptions).toHaveLength(2);
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(
+        and(
+          eq(kiloclaw_subscription_change_log.actor_id, BOOTSTRAP_ACTOR.actorId),
+          inArray(kiloclaw_subscription_change_log.subscription_id, [
+            destroyedSubscription.id,
+            first.id,
+          ])
+        )
+      );
+
+    expect(logs).toHaveLength(2);
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subscription_id: destroyedSubscription.id,
+          action: 'reassigned',
+          reason: 'org_provision_transfer_destroyed_predecessor',
+        }),
+        expect.objectContaining({
+          subscription_id: first.id,
+          action: 'created',
+          reason: 'org_provision_managed',
+        }),
+      ])
+    );
+  });
+});

--- a/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
@@ -1,6 +1,7 @@
 import { db, cleanupDbForTest } from '@/lib/drizzle';
 import { createCallerForUser } from '@/routers/test-utils';
 import { insertTestUser } from '@/tests/helpers/user.helper';
+import { createTestOrganization } from '@/tests/helpers/organization.helper';
 import {
   kiloclaw_admin_audit_logs,
   kiloclaw_subscription_change_log,
@@ -205,6 +206,78 @@ describe('admin.users.getKiloClawState', () => {
     expectSameInstant(result.subscription?.trial_ends_at, expiredTrialEnd);
     expect(result.hasAccess).toBe(false);
     expect(result.accessReason).toBeNull();
+  });
+
+  it('keeps personal access separate from organization-managed subscriptions', async () => {
+    const organization = await createTestOrganization('Org Access Test', targetUser.id, 0);
+
+    const [personalInstance, orgInstance] = await db
+      .insert(kiloclaw_instances)
+      .values([
+        {
+          user_id: targetUser.id,
+          sandbox_id: 'sandbox-admin-kiloclaw-personal-canceled',
+        },
+        {
+          user_id: targetUser.id,
+          organization_id: organization.id,
+          sandbox_id: 'sandbox-admin-kiloclaw-org-active',
+        },
+      ])
+      .returning();
+
+    await db.insert(kiloclaw_subscriptions).values([
+      {
+        user_id: targetUser.id,
+        instance_id: personalInstance.id,
+        plan: 'trial',
+        status: 'canceled',
+        cancel_at_period_end: false,
+        trial_started_at: '2026-04-01T00:00:00.000Z',
+        trial_ends_at: '2026-04-08T00:00:00.000Z',
+      },
+      {
+        user_id: targetUser.id,
+        instance_id: orgInstance.id,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+        cancel_at_period_end: false,
+      },
+    ]);
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.users.getKiloClawState({ userId: targetUser.id });
+
+    expect(result.hasAccess).toBe(false);
+    expect(result.accessReason).toBeNull();
+    expect(result.subscription).toEqual(
+      expect.objectContaining({
+        instance_id: personalInstance.id,
+        plan: 'trial',
+        status: 'canceled',
+      })
+    );
+
+    const personalSubscription = result.subscriptions.find(
+      subscription => subscription.instance_id === personalInstance.id
+    );
+    const orgSubscription = result.subscriptions.find(
+      subscription => subscription.instance_id === orgInstance.id
+    );
+
+    expect(personalSubscription?.instance).toEqual(
+      expect.objectContaining({
+        organization_id: null,
+        organization_name: null,
+      })
+    );
+    expect(orgSubscription?.instance).toEqual(
+      expect.objectContaining({
+        organization_id: organization.id,
+        organization_name: organization.name,
+      })
+    );
   });
 
   it('returns earlybird access from canonical subscription row', async () => {

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -16,6 +16,7 @@ import {
   kiloclaw_subscription_change_log,
   kiloclaw_email_log,
   kiloclaw_instances,
+  organizations,
 } from '@kilocode/db/schema';
 import { isNewSession } from '@/lib/cloud-agent/session-type';
 import { fetchSessionSnapshot, type SessionMessage } from '@/lib/session-ingest-client';
@@ -679,8 +680,11 @@ export const adminRouter = createTRPCRouter({
             name: kiloclaw_instances.name,
             sandbox_id: kiloclaw_instances.sandbox_id,
             destroyed_at: kiloclaw_instances.destroyed_at,
+            organization_id: kiloclaw_instances.organization_id,
+            organization_name: organizations.name,
           })
           .from(kiloclaw_instances)
+          .leftJoin(organizations, eq(organizations.id, kiloclaw_instances.organization_id))
           .where(eq(kiloclaw_instances.user_id, input.userId)),
       ]);
 

--- a/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
+++ b/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
@@ -11,6 +11,8 @@
  *   pnpm script db kiloclaw-subscription-alignment apply-duplicates [--confirm-sandboxes-destroyed]
  *   pnpm script db kiloclaw-subscription-alignment preview-org
  *   pnpm script db kiloclaw-subscription-alignment apply-org
+ *   pnpm script db kiloclaw-subscription-alignment preview-org-replacement
+ *   pnpm script db kiloclaw-subscription-alignment apply-org-replacement
  *   pnpm script db kiloclaw-subscription-alignment preview-changelog-baseline
  *   pnpm script db kiloclaw-subscription-alignment apply-changelog-baseline
  *   pnpm script db kiloclaw-subscription-alignment preview-multi-row-all-destroyed
@@ -86,6 +88,8 @@ type Mode =
   | 'apply-duplicates'
   | 'preview-org'
   | 'apply-org'
+  | 'preview-org-replacement'
+  | 'apply-org-replacement'
   | 'preview-changelog-baseline'
   | 'apply-changelog-baseline'
   | 'preview-multi-row-all-destroyed'
@@ -169,6 +173,41 @@ type OrgBackfillCandidate = {
   requireSeats: boolean;
   latestPurchaseStatus: OrganizationSeatsPurchase['subscription_status'] | null;
   destroyedAt: string | null;
+};
+
+type OrgReplacementJoinedRow = {
+  subscription: KiloClawSubscription;
+  instance: {
+    id: string;
+    destroyedAt: string | null;
+    organizationId: string;
+    organizationName: string;
+  };
+};
+
+type OrgReplacementDestroyedPredecessor = {
+  subscriptionId: string;
+  instanceId: string;
+  plan: string;
+  status: string;
+  destroyedAt: string;
+};
+
+type OrgReplacementTransferPlan = {
+  sourceSubscriptionId: string;
+  sourceInstanceId: string | null;
+  targetSubscriptionId: string | null;
+  targetInstanceId: string | null;
+};
+
+type OrgReplacementCandidate = {
+  organizationId: string;
+  organizationName: string;
+  userId: string;
+  liveSubscriptionId: string;
+  liveInstanceId: string;
+  destroyedPredecessors: OrgReplacementDestroyedPredecessor[];
+  plannedTransfers: OrgReplacementTransferPlan[];
 };
 
 type ActiveInstanceContextRow = {
@@ -305,6 +344,51 @@ function chunkArray<T>(rows: T[], size: number): T[][] {
 
 function describeError(error: unknown): string {
   return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+}
+
+type SubscriptionTransferUpdate = {
+  before: KiloClawSubscription;
+  transferredToSubscriptionId: string | null;
+};
+
+function compareSubscriptionsByCreatedAtAndId(
+  left: KiloClawSubscription,
+  right: KiloClawSubscription
+): number {
+  if (left.created_at === right.created_at) {
+    return left.id.localeCompare(right.id);
+  }
+  return left.created_at.localeCompare(right.created_at);
+}
+
+function buildSubscriptionTransferUpdates(
+  subscriptions: KiloClawSubscription[]
+): SubscriptionTransferUpdate[] {
+  const orderedSubscriptions = [...subscriptions].sort(compareSubscriptionsByCreatedAtAndId);
+  const updates: SubscriptionTransferUpdate[] = [];
+
+  for (const [index, subscription] of orderedSubscriptions.entries()) {
+    const nextSubscription = orderedSubscriptions[index + 1];
+    const desiredTransferredTo = nextSubscription?.id ?? null;
+    if (subscription.transferred_to_subscription_id === desiredTransferredTo) {
+      continue;
+    }
+    updates.push({
+      before: subscription,
+      transferredToSubscriptionId: desiredTransferredTo,
+    });
+  }
+
+  return updates;
+}
+
+function transferredToUnchangedWhere(subscription: KiloClawSubscription) {
+  return subscription.transferred_to_subscription_id === null
+    ? isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+    : eq(
+        kiloclaw_subscriptions.transferred_to_subscription_id,
+        subscription.transferred_to_subscription_id
+      );
 }
 
 async function insertAlignmentChangeLog(
@@ -1265,6 +1349,284 @@ async function previewOrgBackfill() {
         trialEndsAt: row.freeTrialEndAt ?? getOrganizationTrialEndsAt(row.organizationCreatedAt),
       }))
   );
+}
+
+function buildOrgReplacementCandidateFromRows(
+  rows: OrgReplacementJoinedRow[]
+): OrgReplacementCandidate | null {
+  const currentRows = rows.filter(row => row.subscription.transferred_to_subscription_id === null);
+  const liveCurrentRows = currentRows.filter(row => row.instance.destroyedAt === null);
+  const destroyedCurrentRows = currentRows.filter(row => row.instance.destroyedAt !== null);
+
+  if (currentRows.length < 2 || liveCurrentRows.length !== 1 || destroyedCurrentRows.length === 0) {
+    return null;
+  }
+
+  if (!destroyedCurrentRows.some(row => row.subscription.status === 'active')) {
+    return null;
+  }
+
+  const liveRow = liveCurrentRows[0];
+  if (!liveRow) {
+    return null;
+  }
+
+  const orderedSubscriptions = [...rows.map(row => row.subscription)].sort(
+    compareSubscriptionsByCreatedAtAndId
+  );
+  if (orderedSubscriptions.at(-1)?.id !== liveRow.subscription.id) {
+    return null;
+  }
+
+  const rowsBySubscriptionId = new Map(rows.map(row => [row.subscription.id, row]));
+  const plannedTransfers = buildSubscriptionTransferUpdates(orderedSubscriptions).map(update => ({
+    sourceSubscriptionId: update.before.id,
+    sourceInstanceId: update.before.instance_id,
+    targetSubscriptionId: update.transferredToSubscriptionId,
+    targetInstanceId: update.transferredToSubscriptionId
+      ? (rowsBySubscriptionId.get(update.transferredToSubscriptionId)?.subscription.instance_id ??
+        null)
+      : null,
+  }));
+
+  if (plannedTransfers.length === 0) {
+    return null;
+  }
+
+  return {
+    organizationId: liveRow.instance.organizationId,
+    organizationName: liveRow.instance.organizationName,
+    userId: liveRow.subscription.user_id,
+    liveSubscriptionId: liveRow.subscription.id,
+    liveInstanceId: liveRow.instance.id,
+    destroyedPredecessors: destroyedCurrentRows.flatMap(row =>
+      row.instance.destroyedAt
+        ? [
+            {
+              subscriptionId: row.subscription.id,
+              instanceId: row.instance.id,
+              plan: row.subscription.plan,
+              status: row.subscription.status,
+              destroyedAt: row.instance.destroyedAt,
+            },
+          ]
+        : []
+    ),
+    plannedTransfers,
+  };
+}
+
+async function buildOrgReplacementCandidates(): Promise<OrgReplacementCandidate[]> {
+  const rows: OrgReplacementJoinedRow[] = await db
+    .select({
+      subscription: kiloclaw_subscriptions,
+      instance: {
+        id: kiloclaw_instances.id,
+        destroyedAt: kiloclaw_instances.destroyed_at,
+        organizationId: organizations.id,
+        organizationName: organizations.name,
+      },
+    })
+    .from(kiloclaw_subscriptions)
+    .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+    .innerJoin(organizations, eq(organizations.id, kiloclaw_instances.organization_id))
+    .orderBy(
+      asc(organizations.id),
+      asc(kiloclaw_subscriptions.user_id),
+      asc(kiloclaw_subscriptions.created_at),
+      asc(kiloclaw_subscriptions.id)
+    );
+
+  const byContext = new Map<string, OrgReplacementJoinedRow[]>();
+  for (const row of rows) {
+    const key = `${row.subscription.user_id}:${row.instance.organizationId}`;
+    const existing = byContext.get(key);
+    if (existing) {
+      existing.push(row);
+    } else {
+      byContext.set(key, [row]);
+    }
+  }
+
+  const candidates: OrgReplacementCandidate[] = [];
+  for (const groupRows of byContext.values()) {
+    const candidate = buildOrgReplacementCandidateFromRows(groupRows);
+    if (candidate) {
+      candidates.push(candidate);
+    }
+  }
+
+  return candidates;
+}
+
+async function previewOrgReplacementRepair() {
+  const rows = await buildOrgReplacementCandidates();
+  printSection(
+    'Org replacement drift candidates',
+    rows.map(row => ({
+      organizationId: row.organizationId,
+      organizationName: row.organizationName,
+      userId: row.userId,
+      liveSubscriptionId: row.liveSubscriptionId,
+      liveInstanceId: row.liveInstanceId,
+      destroyedPredecessorSubscriptions: row.destroyedPredecessors
+        .map(
+          predecessor =>
+            `${predecessor.subscriptionId} (${predecessor.status}, ${predecessor.instanceId})`
+        )
+        .join(' | '),
+      plannedTransferChain: row.plannedTransfers
+        .map(
+          transfer => `${transfer.sourceSubscriptionId}→${transfer.targetSubscriptionId ?? 'null'}`
+        )
+        .join(' | '),
+    }))
+  );
+}
+
+class OrgReplacementRaceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OrgReplacementRaceError';
+  }
+}
+
+type OrgReplacementApplyOutcome = 'succeeded' | 'skipped_no_work' | 'skipped_race';
+
+async function applyOrgReplacementCandidate(
+  candidate: OrgReplacementCandidate
+): Promise<OrgReplacementApplyOutcome> {
+  try {
+    return await db.transaction(async tx => {
+      const rows: OrgReplacementJoinedRow[] = await tx
+        .select({
+          subscription: kiloclaw_subscriptions,
+          instance: {
+            id: kiloclaw_instances.id,
+            destroyedAt: kiloclaw_instances.destroyed_at,
+            organizationId: organizations.id,
+            organizationName: organizations.name,
+          },
+        })
+        .from(kiloclaw_subscriptions)
+        .innerJoin(
+          kiloclaw_instances,
+          eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id)
+        )
+        .innerJoin(organizations, eq(organizations.id, kiloclaw_instances.organization_id))
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.user_id, candidate.userId),
+            eq(kiloclaw_instances.organization_id, candidate.organizationId)
+          )
+        )
+        .orderBy(asc(kiloclaw_subscriptions.created_at), asc(kiloclaw_subscriptions.id))
+        .for('update');
+
+      const currentCandidate = buildOrgReplacementCandidateFromRows(rows);
+      if (!currentCandidate) {
+        throw new OrgReplacementRaceError(
+          `Org replacement candidate changed before apply for ${candidate.userId}/${candidate.organizationId}`
+        );
+      }
+
+      const transferUpdates = buildSubscriptionTransferUpdates(rows.map(row => row.subscription));
+      if (transferUpdates.length === 0) {
+        return 'skipped_no_work';
+      }
+
+      for (const update of transferUpdates) {
+        const [after] = await tx
+          .update(kiloclaw_subscriptions)
+          .set({
+            transferred_to_subscription_id: update.transferredToSubscriptionId,
+          })
+          .where(
+            and(
+              eq(kiloclaw_subscriptions.id, update.before.id),
+              transferredToUnchangedWhere(update.before)
+            )
+          )
+          .returning();
+
+        if (!after) {
+          throw new OrgReplacementRaceError(
+            `Org replacement transfer raced for subscription ${update.before.id}`
+          );
+        }
+
+        await insertAlignmentChangeLog(tx, {
+          subscriptionId: after.id,
+          action: 'reassigned',
+          reason: 'apply_org_replacement_transfer_destroyed_predecessor',
+          before: update.before,
+          after,
+        });
+      }
+
+      return 'succeeded';
+    });
+  } catch (error) {
+    if (error instanceof OrgReplacementRaceError) {
+      return 'skipped_race';
+    }
+    throw error;
+  }
+}
+
+async function applyOrgReplacementRepair() {
+  const rows = await buildOrgReplacementCandidates();
+  let orgsSucceeded = 0;
+  let orgsSkippedNoWork = 0;
+  let orgsSkippedRace = 0;
+  const orgsError: Array<{
+    organizationId: string;
+    organizationName: string;
+    userId: string;
+    error: string;
+  }> = [];
+  const startedAt = Date.now();
+
+  for (const [index, row] of rows.entries()) {
+    try {
+      const outcome = await applyOrgReplacementCandidate(row);
+      switch (outcome) {
+        case 'succeeded':
+          orgsSucceeded += 1;
+          break;
+        case 'skipped_no_work':
+          orgsSkippedNoWork += 1;
+          break;
+        case 'skipped_race':
+          orgsSkippedRace += 1;
+          break;
+      }
+    } catch (error) {
+      orgsError.push({
+        organizationId: row.organizationId,
+        organizationName: row.organizationName,
+        userId: row.userId,
+        error: describeError(error),
+      });
+    }
+
+    logApplyProgress({
+      label: 'apply-org-replacement',
+      processed: index + 1,
+      total: rows.length,
+      startedAt,
+      every: 25,
+    });
+  }
+
+  console.log('\nOrg replacement repair results');
+  console.table([
+    { metric: 'orgs_succeeded', count: orgsSucceeded },
+    { metric: 'orgs_skipped_no_work', count: orgsSkippedNoWork },
+    { metric: 'orgs_skipped_race', count: orgsSkippedRace },
+    { metric: 'orgs_error', count: orgsError.length },
+  ]);
+  printSection('Org replacement rows that failed to repair', orgsError);
 }
 
 async function previewDuplicateActiveInstances() {
@@ -3177,6 +3539,8 @@ function parseMode(inputMode?: string): Mode {
     case 'apply-duplicates':
     case 'preview-org':
     case 'apply-org':
+    case 'preview-org-replacement':
+    case 'apply-org-replacement':
     case 'preview-changelog-baseline':
     case 'apply-changelog-baseline':
     case 'preview-multi-row-all-destroyed':
@@ -3203,6 +3567,8 @@ const singleModeHandlers: Partial<Record<Mode, ModeHandler>> = {
   'apply-duplicates': applyDuplicateActiveInstances,
   'preview-org': previewOrgBackfill,
   'apply-org': applyOrgBackfill,
+  'preview-org-replacement': previewOrgReplacementRepair,
+  'apply-org-replacement': applyOrgReplacementRepair,
   'preview-changelog-baseline': previewChangelogBaselineBackfill,
   'apply-changelog-baseline': applyChangelogBaselineBackfill,
   'preview-multi-row-all-destroyed': previewMultiRowAllDestroyedCollapse,

--- a/services/kiloclaw-billing/src/bootstrap.test.ts
+++ b/services/kiloclaw-billing/src/bootstrap.test.ts
@@ -20,7 +20,9 @@ import type { BillingWorkerEnv } from './types.js';
 
 type SelectBuilder<T> = PromiseLike<T[]> & {
   from: ReturnType<typeof vi.fn>;
+  innerJoin: ReturnType<typeof vi.fn>;
   where: ReturnType<typeof vi.fn>;
+  orderBy: ReturnType<typeof vi.fn>;
   limit: ReturnType<typeof vi.fn>;
   for: ReturnType<typeof vi.fn>;
   then: Promise<T[]>['then'];
@@ -30,13 +32,17 @@ function createSelectBuilder<T>(rows: T[]): SelectBuilder<T> {
   const promise = Promise.resolve(rows);
   const builder = {
     from: vi.fn(),
+    innerJoin: vi.fn(),
     where: vi.fn(),
+    orderBy: vi.fn(),
     limit: vi.fn(),
     for: vi.fn(async () => rows),
     then: promise.then.bind(promise),
   } as SelectBuilder<T>;
   builder.from.mockReturnValue(builder);
+  builder.innerJoin.mockReturnValue(builder);
   builder.where.mockReturnValue(builder);
+  builder.orderBy.mockReturnValue(builder);
   builder.limit.mockReturnValue(builder);
   return builder;
 }
@@ -64,6 +70,9 @@ function createMockDb(params: {
             insertValues.push(values);
             return {
               returning: vi.fn(async () => insertQueue.shift() ?? []),
+              onConflictDoNothing: vi.fn(() => ({
+                returning: vi.fn(async () => insertQueue.shift() ?? []),
+              })),
             };
           }),
         })),
@@ -608,6 +617,7 @@ describe('bootstrapProvisionSubscription successor transfer', () => {
 
 type FreshInsertDbParams = {
   selectRows: unknown[][];
+  txSelectRows?: unknown[][];
   insertFirstReturningRows: unknown[];
   reselectAfterConflictRows: unknown[];
 };
@@ -616,18 +626,23 @@ function createFreshInsertSelectBuilder<T>(rows: T[]) {
   const promise = Promise.resolve(rows);
   const builder: {
     from: ReturnType<typeof vi.fn>;
+    innerJoin: ReturnType<typeof vi.fn>;
     where: ReturnType<typeof vi.fn>;
     orderBy: ReturnType<typeof vi.fn>;
     limit: ReturnType<typeof vi.fn>;
+    for: ReturnType<typeof vi.fn>;
     then: Promise<T[]>['then'];
   } = {
     from: vi.fn(),
+    innerJoin: vi.fn(),
     where: vi.fn(),
     orderBy: vi.fn(),
     limit: vi.fn(),
+    for: vi.fn(async () => rows),
     then: promise.then.bind(promise),
   };
   builder.from.mockReturnValue(builder);
+  builder.innerJoin.mockReturnValue(builder);
   builder.where.mockReturnValue(builder);
   builder.orderBy.mockReturnValue(builder);
   builder.limit.mockReturnValue(builder);
@@ -636,31 +651,42 @@ function createFreshInsertSelectBuilder<T>(rows: T[]) {
 
 function createFreshInsertDb(params: FreshInsertDbParams) {
   const selectQueue = [...params.selectRows];
+  const txSelectQueue = [...(params.txSelectRows ?? [])];
   const insertValues: Array<Record<string, unknown>> = [];
   const onConflictCalls: Array<unknown> = [];
   let firstInsert = true;
 
+  const createInsertBuilder = () => ({
+    values: vi.fn((values: Record<string, unknown>) => {
+      insertValues.push(values);
+      return {
+        onConflictDoNothing: vi.fn((target: unknown) => {
+          onConflictCalls.push(target);
+          return {
+            returning: vi.fn(async () => {
+              if (firstInsert) {
+                firstInsert = false;
+                return params.insertFirstReturningRows;
+              }
+              return [];
+            }),
+          };
+        }),
+      };
+    }),
+  });
+
   const db = {
     select: vi.fn(() => createFreshInsertSelectBuilder(selectQueue.shift() ?? [])),
-    insert: vi.fn(() => ({
-      values: vi.fn((values: Record<string, unknown>) => {
-        insertValues.push(values);
-        return {
-          onConflictDoNothing: vi.fn((target: unknown) => {
-            onConflictCalls.push(target);
-            return {
-              returning: vi.fn(async () => {
-                if (firstInsert) {
-                  firstInsert = false;
-                  return params.insertFirstReturningRows;
-                }
-                return [];
-              }),
-            };
-          }),
-        };
-      }),
-    })),
+    insert: vi.fn(() => createInsertBuilder()),
+    transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        select: vi.fn(() => createFreshInsertSelectBuilder(txSelectQueue.shift() ?? [])),
+        insert: vi.fn(() => createInsertBuilder()),
+      };
+
+      return await callback(tx);
+    }),
   };
 
   return { db, insertValues, onConflictCalls };
@@ -767,15 +793,22 @@ describe('bootstrapProvisionSubscription concurrent insert race', () => {
       updated_at: '2026-04-16T00:00:00.000Z',
     };
     const { db, insertValues, onConflictCalls } = createFreshInsertDb({
-      selectRows: [
-        [], // existing subscription for instance (none yet — TOCTOU window)
+      selectRows: [],
+      txSelectRows: [
+        [{ id: 'instance-new', destroyedAt: null }],
         [
           {
             createdAt: '2026-04-01T00:00:00.000Z',
             freeTrialEndAt: null,
           },
-        ], // organization row
-        [winnerRow], // reselect after conflict
+        ],
+        [winnerRow],
+        [
+          {
+            subscription: winnerRow,
+            instance: { id: 'instance-new', destroyedAt: null },
+          },
+        ],
       ],
       insertFirstReturningRows: [], // onConflictDoNothing swallowed our insert
       reselectAfterConflictRows: [winnerRow],

--- a/services/kiloclaw-billing/src/provision-bootstrap-shared.ts
+++ b/services/kiloclaw-billing/src/provision-bootstrap-shared.ts
@@ -35,7 +35,7 @@ type BootstrapProvisionWithDbParams = {
 };
 
 async function insertSubscriptionIdempotent(
-  db: WorkerDb,
+  db: Pick<WorkerDb, 'insert' | 'select'>,
   values: NewKiloClawSubscription & { instance_id: string }
 ): Promise<{ row: KiloClawSubscription; created: boolean }> {
   const [inserted] = await db
@@ -113,6 +113,175 @@ function getTrialEndsAt(startedAt: Date): string {
   ).toISOString();
 }
 
+type OrgBootstrapWriter = Pick<WorkerDb, 'insert' | 'select' | 'update'>;
+
+type OrgSubscriptionRow = {
+  subscription: KiloClawSubscription;
+  instance: {
+    id: string;
+    destroyedAt: string | null;
+  };
+};
+
+type TransferUpdate = {
+  before: KiloClawSubscription;
+  transferredToSubscriptionId: string | null;
+};
+
+function compareSubscriptionsByCreatedAtAndId(
+  left: KiloClawSubscription,
+  right: KiloClawSubscription
+): number {
+  if (left.created_at === right.created_at) {
+    return left.id.localeCompare(right.id);
+  }
+  return left.created_at.localeCompare(right.created_at);
+}
+
+function buildTransferUpdates(subscriptions: KiloClawSubscription[]): TransferUpdate[] {
+  const orderedSubscriptions = [...subscriptions].sort(compareSubscriptionsByCreatedAtAndId);
+  const updates: TransferUpdate[] = [];
+
+  for (const [index, subscription] of orderedSubscriptions.entries()) {
+    const nextSubscription = orderedSubscriptions[index + 1];
+    const desiredTransferredTo = nextSubscription?.id ?? null;
+    if (subscription.transferred_to_subscription_id === desiredTransferredTo) {
+      continue;
+    }
+    updates.push({
+      before: subscription,
+      transferredToSubscriptionId: desiredTransferredTo,
+    });
+  }
+
+  return updates;
+}
+
+function currentOrganizationSubscriptionRows(rows: OrgSubscriptionRow[]): OrgSubscriptionRow[] {
+  return rows.filter(row => row.subscription.transferred_to_subscription_id === null);
+}
+
+function transferredToUnchangedWhere(subscription: KiloClawSubscription) {
+  return subscription.transferred_to_subscription_id === null
+    ? isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+    : eq(
+        kiloclaw_subscriptions.transferred_to_subscription_id,
+        subscription.transferred_to_subscription_id
+      );
+}
+
+async function listOrganizationSubscriptionRowsForTransfer(
+  executor: OrgBootstrapWriter,
+  userId: string,
+  orgId: string
+): Promise<OrgSubscriptionRow[]> {
+  return await executor
+    .select({
+      subscription: kiloclaw_subscriptions,
+      instance: {
+        id: kiloclaw_instances.id,
+        destroyedAt: kiloclaw_instances.destroyed_at,
+      },
+    })
+    .from(kiloclaw_subscriptions)
+    .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, userId),
+        eq(kiloclaw_instances.user_id, userId),
+        eq(kiloclaw_instances.organization_id, orgId)
+      )
+    )
+    .orderBy(kiloclaw_subscriptions.created_at, kiloclaw_subscriptions.id)
+    .for('update');
+}
+
+async function transferDestroyedOrganizationPredecessors(params: {
+  actor: KiloClawSubscriptionChangeActor;
+  executor: OrgBootstrapWriter;
+  orgId: string;
+  targetSubscription: KiloClawSubscription;
+  targetWasInserted: boolean;
+  userId: string;
+}) {
+  const rows = await listOrganizationSubscriptionRowsForTransfer(
+    params.executor,
+    params.userId,
+    params.orgId
+  );
+  const targetRow = rows.find(row => row.subscription.id === params.targetSubscription.id);
+
+  if (!targetRow || targetRow.instance.destroyedAt !== null) {
+    if (params.targetWasInserted) {
+      throw new Error('New organization bootstrap target row is missing or destroyed');
+    }
+    return;
+  }
+
+  const currentRows = currentOrganizationSubscriptionRows(rows);
+  const liveCurrentRows = currentRows.filter(row => row.instance.destroyedAt === null);
+  if (liveCurrentRows.length > 1) {
+    throw new Error('Multiple current organization subscription rows found during bootstrap');
+  }
+
+  if (!liveCurrentRows.some(row => row.subscription.id === params.targetSubscription.id)) {
+    if (params.targetWasInserted) {
+      throw new Error('New organization bootstrap target row is not the current live row');
+    }
+    return;
+  }
+
+  const destroyedCurrentRows = currentRows.filter(row => row.instance.destroyedAt !== null);
+  if (destroyedCurrentRows.length === 0) {
+    return;
+  }
+
+  const orderedSubscriptions = [...rows.map(row => row.subscription)].sort(
+    compareSubscriptionsByCreatedAtAndId
+  );
+  if (orderedSubscriptions.at(-1)?.id !== params.targetSubscription.id) {
+    if (params.targetWasInserted) {
+      throw new Error('New organization bootstrap target row is not the newest org row');
+    }
+    return;
+  }
+
+  const updates = buildTransferUpdates(orderedSubscriptions);
+  if (updates.length === 0) {
+    return;
+  }
+
+  for (const update of updates) {
+    const [after] = await params.executor
+      .update(kiloclaw_subscriptions)
+      .set({
+        transferred_to_subscription_id: update.transferredToSubscriptionId,
+      })
+      .where(
+        and(
+          eq(kiloclaw_subscriptions.id, update.before.id),
+          transferredToUnchangedWhere(update.before)
+        )
+      )
+      .returning();
+
+    if (!after) {
+      throw new Error(
+        `Failed to transfer organization bootstrap predecessor subscription ${update.before.id}`
+      );
+    }
+
+    await insertKiloClawSubscriptionChangeLog(params.executor, {
+      subscriptionId: after.id,
+      actor: params.actor,
+      action: 'reassigned',
+      reason: 'org_provision_transfer_destroyed_predecessor',
+      before: update.before,
+      after,
+    });
+  }
+}
+
 async function bootstrapOrganizationSubscription(params: BootstrapProvisionWithDbParams) {
   const { db, input } = params;
   if (!input.orgId) {
@@ -122,79 +291,97 @@ async function bootstrapOrganizationSubscription(params: BootstrapProvisionWithD
   const now = new Date();
   const orgId = input.orgId;
 
-  const [existing, organization] = await Promise.all([
-    db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.instance_id, input.instanceId))
+  return await db.transaction(async tx => {
+    const [targetInstance] = await tx
+      .select({
+        id: kiloclaw_instances.id,
+        destroyedAt: kiloclaw_instances.destroyed_at,
+      })
+      .from(kiloclaw_instances)
+      .where(
+        and(
+          eq(kiloclaw_instances.id, input.instanceId),
+          eq(kiloclaw_instances.user_id, input.userId),
+          eq(kiloclaw_instances.organization_id, orgId)
+        )
+      )
       .limit(1)
-      .then(rows => rows[0] ?? null),
-    db
+      .for('update');
+
+    if (!targetInstance) {
+      throw new Error('Organization instance not found during subscription bootstrap');
+    }
+    if (targetInstance.destroyedAt !== null) {
+      throw new Error('Cannot bootstrap organization subscription on destroyed instance');
+    }
+
+    const [organization] = await tx
       .select({
         createdAt: organizations.created_at,
         freeTrialEndAt: organizations.free_trial_end_at,
       })
       .from(organizations)
       .where(eq(organizations.id, orgId))
-      .limit(1)
-      .then(rows => rows[0] ?? null),
-  ]);
+      .limit(1);
 
-  if (existing) {
-    return existing;
-  }
-  if (!organization) {
-    throw new Error('Organization not found during subscription bootstrap');
-  }
+    if (!organization) {
+      throw new Error('Organization not found during subscription bootstrap');
+    }
 
-  const hasManagedActiveAccess = true;
+    const hasManagedActiveAccess = true;
+    const trialEndsAt =
+      organization.freeTrialEndAt ??
+      new Date(
+        new Date(organization.createdAt).getTime() +
+          ORGANIZATION_TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000
+      ).toISOString();
 
-  const trialEndsAt =
-    organization.freeTrialEndAt ??
-    new Date(
-      new Date(organization.createdAt).getTime() +
-        ORGANIZATION_TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000
-    ).toISOString();
+    const { row: created, created: wasInserted } = await insertSubscriptionIdempotent(
+      tx,
+      hasManagedActiveAccess
+        ? {
+            user_id: input.userId,
+            instance_id: input.instanceId,
+            plan: 'standard',
+            status: 'active',
+            payment_source: 'credits',
+            cancel_at_period_end: false,
+          }
+        : {
+            user_id: input.userId,
+            instance_id: input.instanceId,
+            plan: 'trial',
+            status: new Date(trialEndsAt).getTime() > now.getTime() ? 'trialing' : 'canceled',
+            access_origin: null,
+            payment_source: null,
+            cancel_at_period_end: false,
+            trial_started_at: organization.createdAt,
+            trial_ends_at: trialEndsAt,
+          }
+    );
 
-  const { row: created, created: wasInserted } = await insertSubscriptionIdempotent(
-    db,
-    hasManagedActiveAccess
-      ? {
-          user_id: input.userId,
-          instance_id: input.instanceId,
-          plan: 'standard',
-          status: 'active',
-          payment_source: 'credits',
-          cancel_at_period_end: false,
-        }
-      : {
-          user_id: input.userId,
-          instance_id: input.instanceId,
-          plan: 'trial',
-          status: new Date(trialEndsAt).getTime() > now.getTime() ? 'trialing' : 'canceled',
-          access_origin: null,
-          payment_source: null,
-          cancel_at_period_end: false,
-          trial_started_at: organization.createdAt,
-          trial_ends_at: trialEndsAt,
-        }
-  );
+    if (wasInserted) {
+      await insertKiloClawSubscriptionChangeLog(tx, {
+        subscriptionId: created.id,
+        actor: params.actor,
+        action: 'created',
+        reason: hasManagedActiveAccess ? 'org_provision_managed' : 'org_provision_trial',
+        before: null,
+        after: created,
+      });
+    }
 
-  if (!wasInserted) {
+    await transferDestroyedOrganizationPredecessors({
+      actor: params.actor,
+      executor: tx,
+      orgId,
+      targetSubscription: created,
+      targetWasInserted: wasInserted,
+      userId: input.userId,
+    });
+
     return created;
-  }
-
-  await writeBootstrapChangeLogBestEffort({
-    db,
-    actor: params.actor,
-    subscriptionId: created.id,
-    action: 'created',
-    reason: hasManagedActiveAccess ? 'org_provision_managed' : 'org_provision_trial',
-    after: created,
-    onError: params.onChangeLogError,
   });
-
-  return created;
 }
 
 function currentPersonalSubscriptions(


### PR DESCRIPTION
## Summary
Repairs stale KiloClaw organization subscription replacement state and clarifies the admin billing view so organization-managed subscriptions no longer look like personal access.

### Why this change is needed
Destroying and re-provisioning an organization instance could leave multiple current org subscription rows behind, including active rows still anchored to destroyed instances. That drift made bootstrap state ambiguous and showed up in the admin UI as personal `no access` alongside active organization-managed subscriptions, which looked like contradictory billing state and obscured the actual issue. Existing drift also needed a safe operator repair path.

### How this is addressed
- Makes organization bootstrap repair same-user, same-organization destroyed predecessor rows inside the bootstrap transaction and records each reassignment in the subscription change log.
- Adds `preview-org-replacement` and `apply-org-replacement` modes to the subscription alignment script so existing destroyed-predecessor drift can be detected, previewed, and repaired with race guards and transfer-chain planning.
- Joins organization metadata into admin KiloClaw state and updates the admin UI to split Personal and Organization subscription sections with explicit scope labeling.
- Adds regression coverage for bootstrap reassignment, repair script chaining and race handling, and admin state separation between personal and organization subscriptions.

## Verification
- Ran targeted tests:
  - `pnpm test -- apps/web/src/lib/kiloclaw/provision-bootstrap-shared-org.test.ts apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts apps/web/src/routers/admin-kiloclaw-user-router.test.ts`
  - `pnpm --filter kiloclaw-billing test -- src/bootstrap.test.ts`
- Reviewed the implementation against `.specs/kiloclaw-billing.md` and `.specs/kiloclaw-datamodel.md` to preserve personal subscription collapse behavior while adding org-scoped replacement handling.
- _Additional verification (to be completed by author)_

## Visual Changes
N/A

## Reviewer Notes

### Human Reviewer
- Automatic org reassignment is intentionally limited to same `user_id` + same `organization_id` and only when the live target row is the sole undestroyed current row in that context.
- The repair path lives in new `preview-org-replacement` / `apply-org-replacement` modes so operators can run it independently of the existing org backfill flow.
- The bootstrap and repair paths build oldest-to-newest transfer chains to satisfy `UQ_kiloclaw_subscriptions_transferred_to`; please validate that this lineage shape is what we want for historical org rows.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Follows `.specs/kiloclaw-billing.md` successor-row requirements and `.specs/kiloclaw-datamodel.md` change-log requirements before mutating subscription lineage.
- `bootstrapOrganizationSubscription()` now locks the target org instance, performs the idempotent insert/find inside a database transaction, then re-reads all same-user/same-org rows `FOR UPDATE` and applies oldest-to-newest transfer updates with `reassigned` logs.
- Existing target rows are only reused for repair when the row is still the live current row and the newest org row, which keeps repeated bootstrap calls idempotent and avoids rewriting lineage around unrelated newer rows.
- The alignment script uses the same chaining logic in `preview-org-replacement` / `apply-org-replacement`, with an in-transaction re-read to bucket changed state as `orgs_skipped_race`.
- Admin state now joins `organizations.name` onto each instance so the UI can group subscriptions by personal vs organization scope without changing access resolution itself.

</details>
