### PR TITLE
fix(claw): show Pylon support on org routes

### DIFF
--- a/apps/web/src/app/(app)/organizations/[id]/claw/layout.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/claw/layout.tsx
@@ -1,5 +1,14 @@
+import { PylonSupportButton } from '@/components/pylon-support-button';
+import { PylonWidget } from '@/components/pylon-widget';
 import '@/app/(app)/claw/claw-chat.css';
 
 export default function OrgClawLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return (
+    <>
+      {children}
+      <PylonWidget>
+        <PylonSupportButton />
+      </PylonWidget>
+    </>
+  );
 }


### PR DESCRIPTION
## Summary

Render the Pylon support widget in the organizational claw layout so `/organizations/<ID>/claw/*` gets the same custom support entry point as personal `/claw/*` routes.

## Verification

- Confirmed `PylonWidget` and `PylonSupportButton` are mounted in `apps/web/src/app/(app)/organizations/[id]/claw/layout.tsx`
- `pnpm format`
- `pnpm --filter web typecheck` *(fails due to pre-existing unrelated repo issue: `src/lib/integrations/google-service.ts(3,30): Cannot find module 'google-auth-library' or its corresponding type declarations.`)*

## Visual Changes

N/A

## Reviewer Notes

This change is scoped to the org claw layout only. Unrelated local working tree changes were left untouched and are not part of the branch diff.