### PR TITLE
fix(kiloclaw): repair destroyed subscription drift

### DIFF
--- a/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
@@ -10,7 +10,7 @@ import {
   kiloclaw_subscription_change_log,
   kiloclaw_subscriptions,
 } from '@kilocode/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createTestOrganization } from '@/tests/helpers/organization.helper';
 
@@ -32,6 +32,7 @@ describe('kiloclaw-subscription-alignment script', () => {
     status: 'active' | 'trialing' | 'canceled';
     paymentSource: 'credits' | 'stripe' | null;
     organizationId?: string;
+    stripeSubscriptionId?: string | null;
     trialEndsAt?: string;
   }) {
     const user = await insertTestUser({ google_user_email: params.email });
@@ -53,6 +54,7 @@ describe('kiloclaw-subscription-alignment script', () => {
         plan: params.plan,
         status: params.status,
         payment_source: params.paymentSource,
+        stripe_subscription_id: params.stripeSubscriptionId ?? null,
         cancel_at_period_end: true,
         pending_conversion: true,
         scheduled_plan: 'standard',
@@ -229,30 +231,50 @@ describe('kiloclaw-subscription-alignment script', () => {
     );
   });
 
-  it('reports destroyed active Stripe row for manual review without mutation', async () => {
-    const { subscription } = await insertDestroyedCurrentAccessRow({
+  it('reports destroyed active Stripe and hybrid rows for manual review without mutation', async () => {
+    const stripe = await insertDestroyedCurrentAccessRow({
       email: 'destroyed-current-stripe@example.com',
       plan: 'standard',
       status: 'active',
       paymentSource: 'stripe',
+      stripeSubscriptionId: 'sub_destroyed_current_stripe',
+    });
+    const hybrid = await insertDestroyedCurrentAccessRow({
+      email: 'destroyed-current-hybrid@example.com',
+      plan: 'standard',
+      status: 'active',
+      paymentSource: 'credits',
+      stripeSubscriptionId: 'sub_destroyed_current_hybrid',
     });
 
     const candidates = await listPersonalDestroyedCurrentAccessCandidates();
-    expect(candidates).toEqual([
-      expect.objectContaining({
-        action: 'manual_review_stripe',
-        subscriptionId: subscription.id,
-      }),
-    ]);
+    expect(candidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'manual_review_stripe',
+          subscriptionId: stripe.subscription.id,
+        }),
+        expect.objectContaining({
+          action: 'manual_review_stripe',
+          subscriptionId: hybrid.subscription.id,
+        }),
+      ])
+    );
+    expect(candidates).toHaveLength(2);
 
-    await run('apply-personal-destroyed-current-access');
+    await run('apply-personal-destroyed-current-access', '--confirm-cancel-credit-access');
 
-    const [updated] = await db
+    const updated = await db
       .select()
       .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.id, subscription.id));
+      .where(inArray(kiloclaw_subscriptions.id, [stripe.subscription.id, hybrid.subscription.id]));
 
-    expect(updated?.status).toBe('active');
+    expect(updated).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: stripe.subscription.id, status: 'active' }),
+        expect.objectContaining({ id: hybrid.subscription.id, status: 'active' }),
+      ])
+    );
   });
 
   it('does not touch org-scoped destroyed current row', async () => {

--- a/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { cleanupDbForTest, db } from '@/lib/drizzle';
-import { run } from '@/scripts/db/kiloclaw-subscription-alignment';
+import {
+  applyPersonalDestroyedCurrentAccessRow,
+  listPersonalDestroyedCurrentAccessCandidates,
+  run,
+} from '@/scripts/db/kiloclaw-subscription-alignment';
 import {
   kiloclaw_instances,
   kiloclaw_subscription_change_log,
@@ -20,6 +24,501 @@ describe('kiloclaw-subscription-alignment script', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  async function insertDestroyedCurrentAccessRow(params: {
+    email: string;
+    plan: 'trial' | 'standard' | 'commit';
+    status: 'active' | 'trialing' | 'canceled';
+    paymentSource: 'credits' | 'stripe' | null;
+    organizationId?: string;
+    trialEndsAt?: string;
+  }) {
+    const user = await insertTestUser({ google_user_email: params.email });
+    const instanceId = crypto.randomUUID();
+    await db.insert(kiloclaw_instances).values({
+      id: instanceId,
+      user_id: user.id,
+      organization_id: params.organizationId,
+      sandbox_id: `ki_${instanceId.replaceAll('-', '')}`,
+      created_at: '2026-04-01T00:00:00.000Z',
+      destroyed_at: '2026-04-02T00:00:00.000Z',
+    });
+
+    const [subscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: instanceId,
+        plan: params.plan,
+        status: params.status,
+        payment_source: params.paymentSource,
+        cancel_at_period_end: true,
+        pending_conversion: true,
+        scheduled_plan: 'standard',
+        scheduled_by: 'user',
+        trial_started_at: params.status === 'trialing' ? '2026-04-01T00:00:00.000Z' : null,
+        trial_ends_at: params.trialEndsAt ?? null,
+        suspended_at: '2026-04-02T00:00:00.000Z',
+        destruction_deadline: '2026-04-03T00:00:00.000Z',
+        auto_resume_requested_at: '2026-04-02T01:00:00.000Z',
+        auto_resume_retry_after: '2026-04-02T03:00:00.000Z',
+        auto_resume_attempt_count: 3,
+        auto_top_up_triggered_for_period: '2026-04-01T00:00:00.000Z',
+        created_at: '2026-04-01T00:00:00.000Z',
+        updated_at: '2026-04-01T00:00:00.000Z',
+      })
+      .returning();
+
+    if (!subscription) {
+      throw new Error('Expected destroyed current subscription row');
+    }
+
+    return { user, instanceId, subscription };
+  }
+
+  it('previews destroyed trialing personal current row as cancel_destroyed_trial', async () => {
+    const { subscription } = await insertDestroyedCurrentAccessRow({
+      email: 'destroyed-current-trial-preview@example.com',
+      plan: 'trial',
+      status: 'trialing',
+      paymentSource: null,
+      trialEndsAt: '2999-04-08T00:00:00.000Z',
+    });
+
+    const candidates = await listPersonalDestroyedCurrentAccessCandidates();
+
+    expect(candidates).toEqual([
+      expect.objectContaining({
+        action: 'cancel_destroyed_trial',
+        subscriptionId: subscription.id,
+      }),
+    ]);
+  });
+
+  it('cancels destroyed trialing personal current row and writes canceled change log', async () => {
+    const { subscription } = await insertDestroyedCurrentAccessRow({
+      email: 'destroyed-current-trial-apply@example.com',
+      plan: 'trial',
+      status: 'trialing',
+      paymentSource: null,
+      trialEndsAt: '2999-04-08T00:00:00.000Z',
+    });
+
+    await run('apply-personal-destroyed-current-access');
+
+    const [updated] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, subscription.id));
+
+    expect(updated).toEqual(
+      expect.objectContaining({
+        status: 'canceled',
+        suspended_at: null,
+        destruction_deadline: null,
+        auto_resume_requested_at: null,
+        auto_resume_retry_after: null,
+        auto_resume_attempt_count: 0,
+        auto_top_up_triggered_for_period: null,
+        cancel_at_period_end: false,
+        pending_conversion: false,
+        scheduled_plan: null,
+        scheduled_by: null,
+      })
+    );
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscription.id));
+
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'canceled',
+          actor_type: 'system',
+          actor_id: 'kiloclaw-subscription-alignment',
+          reason: 'apply_personal_destroyed_current_access_cancel_trial',
+        }),
+      ])
+    );
+  });
+
+  it('previews destroyed active credits rows as cancel_destroyed_credits_subscription', async () => {
+    const standard = await insertDestroyedCurrentAccessRow({
+      email: 'destroyed-current-standard-preview@example.com',
+      plan: 'standard',
+      status: 'active',
+      paymentSource: 'credits',
+    });
+    const commit = await insertDestroyedCurrentAccessRow({
+      email: 'destroyed-current-commit-preview@example.com',
+      plan: 'commit',
+      status: 'active',
+      paymentSource: 'credits',
+    });
+
+    const candidates = await listPersonalDestroyedCurrentAccessCandidates();
+
+    expect(candidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'cancel_destroyed_credits_subscription',
+          subscriptionId: standard.subscription.id,
+        }),
+        expect.objectContaining({
+          action: 'cancel_destroyed_credits_subscription',
+          subscriptionId: commit.subscription.id,
+        }),
+      ])
+    );
+    expect(candidates).toHaveLength(2);
+  });
+
+  it('skips destroyed active credits row without confirm flag', async () => {
+    const { subscription } = await insertDestroyedCurrentAccessRow({
+      email: 'destroyed-current-credits-no-confirm@example.com',
+      plan: 'standard',
+      status: 'active',
+      paymentSource: 'credits',
+    });
+
+    await run('apply-personal-destroyed-current-access');
+
+    const [updated] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, subscription.id));
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscription.id));
+
+    expect(updated?.status).toBe('active');
+    expect(logs).toHaveLength(0);
+  });
+
+  it('cancels destroyed active credits row with confirm flag and writes credits reason', async () => {
+    const { subscription } = await insertDestroyedCurrentAccessRow({
+      email: 'destroyed-current-credits-confirm@example.com',
+      plan: 'commit',
+      status: 'active',
+      paymentSource: 'credits',
+    });
+
+    await run('apply-personal-destroyed-current-access', '--confirm-cancel-credit-access');
+
+    const [updated] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, subscription.id));
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscription.id));
+
+    expect(updated?.status).toBe('canceled');
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'canceled',
+          reason: 'apply_personal_destroyed_current_access_cancel_credits',
+        }),
+      ])
+    );
+  });
+
+  it('reports destroyed active Stripe row for manual review without mutation', async () => {
+    const { subscription } = await insertDestroyedCurrentAccessRow({
+      email: 'destroyed-current-stripe@example.com',
+      plan: 'standard',
+      status: 'active',
+      paymentSource: 'stripe',
+    });
+
+    const candidates = await listPersonalDestroyedCurrentAccessCandidates();
+    expect(candidates).toEqual([
+      expect.objectContaining({
+        action: 'manual_review_stripe',
+        subscriptionId: subscription.id,
+      }),
+    ]);
+
+    await run('apply-personal-destroyed-current-access');
+
+    const [updated] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, subscription.id));
+
+    expect(updated?.status).toBe('active');
+  });
+
+  it('does not touch org-scoped destroyed current row', async () => {
+    const user = await insertTestUser({ google_user_email: 'destroyed-current-org@example.com' });
+    const org = await createTestOrganization('destroyed-current-org', user.id, 0);
+    const { subscription } = await insertDestroyedCurrentAccessRow({
+      email: 'destroyed-current-org-owner@example.com',
+      plan: 'standard',
+      status: 'active',
+      paymentSource: 'credits',
+      organizationId: org.id,
+    });
+
+    await run('apply-personal-destroyed-current-access', '--confirm-cancel-credit-access');
+
+    const candidates = await listPersonalDestroyedCurrentAccessCandidates();
+    const [updated] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, subscription.id));
+
+    expect(candidates).toHaveLength(0);
+    expect(updated?.status).toBe('active');
+  });
+
+  it('does not touch destroyed non-access row', async () => {
+    const { subscription } = await insertDestroyedCurrentAccessRow({
+      email: 'destroyed-current-non-access@example.com',
+      plan: 'trial',
+      status: 'canceled',
+      paymentSource: null,
+      trialEndsAt: '2026-04-08T00:00:00.000Z',
+    });
+
+    await run('apply-personal-destroyed-current-access');
+
+    const candidates = await listPersonalDestroyedCurrentAccessCandidates();
+    const [updated] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, subscription.id));
+
+    expect(candidates).toHaveLength(0);
+    expect(updated?.status).toBe('canceled');
+  });
+
+  it('does not touch user with live current personal row plus destroyed current row', async () => {
+    const user = await insertTestUser({ google_user_email: 'destroyed-plus-live@example.com' });
+    const destroyedInstanceId = crypto.randomUUID();
+    const liveInstanceId = crypto.randomUUID();
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: destroyedInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${destroyedInstanceId.replaceAll('-', '')}`,
+        destroyed_at: '2026-04-02T00:00:00.000Z',
+      },
+      {
+        id: liveInstanceId,
+        user_id: user.id,
+        sandbox_id: `ki_${liveInstanceId.replaceAll('-', '')}`,
+      },
+    ]);
+    const [destroyedSubscription] = await db
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: user.id,
+        instance_id: destroyedInstanceId,
+        plan: 'standard',
+        status: 'active',
+        payment_source: 'credits',
+        cancel_at_period_end: false,
+      })
+      .returning();
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: liveInstanceId,
+      plan: 'standard',
+      status: 'active',
+      payment_source: 'credits',
+      cancel_at_period_end: false,
+    });
+
+    await run('apply-personal-destroyed-current-access', '--confirm-cancel-credit-access');
+
+    const candidates = await listPersonalDestroyedCurrentAccessCandidates();
+    const [updated] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, destroyedSubscription?.id));
+
+    expect(candidates).toHaveLength(0);
+    expect(updated?.status).toBe('active');
+  });
+
+  it('race guard skips already transferred row and live current row before update', async () => {
+    const transferred = await insertDestroyedCurrentAccessRow({
+      email: 'destroyed-current-transferred-race@example.com',
+      plan: 'trial',
+      status: 'trialing',
+      paymentSource: null,
+      trialEndsAt: '2999-04-08T00:00:00.000Z',
+    });
+    const [transferredCandidate] = await listPersonalDestroyedCurrentAccessCandidates();
+    if (!transferredCandidate) {
+      throw new Error('Expected transferred race candidate');
+    }
+    const successorId = crypto.randomUUID();
+    await db.insert(kiloclaw_subscriptions).values({
+      id: successorId,
+      user_id: transferred.user.id,
+      instance_id: null,
+      plan: 'trial',
+      status: 'canceled',
+      cancel_at_period_end: false,
+    });
+    await db
+      .update(kiloclaw_subscriptions)
+      .set({ transferred_to_subscription_id: successorId })
+      .where(eq(kiloclaw_subscriptions.id, transferred.subscription.id));
+
+    await expect(
+      applyPersonalDestroyedCurrentAccessRow(transferredCandidate, {
+        confirmSandboxesDestroyed: false,
+        confirmCancelCreditAccess: false,
+        bulk: false,
+      })
+    ).resolves.toBe('skipped_already_transferred');
+
+    const liveRace = await insertDestroyedCurrentAccessRow({
+      email: 'destroyed-current-live-race@example.com',
+      plan: 'trial',
+      status: 'trialing',
+      paymentSource: null,
+      trialEndsAt: '2999-04-08T00:00:00.000Z',
+    });
+    const [liveRaceCandidate] = await listPersonalDestroyedCurrentAccessCandidates();
+    if (!liveRaceCandidate) {
+      throw new Error('Expected live row race candidate');
+    }
+    const liveInstanceId = crypto.randomUUID();
+    await db.insert(kiloclaw_instances).values({
+      id: liveInstanceId,
+      user_id: liveRace.user.id,
+      sandbox_id: `ki_${liveInstanceId.replaceAll('-', '')}`,
+    });
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: liveRace.user.id,
+      instance_id: liveInstanceId,
+      plan: 'standard',
+      status: 'active',
+      payment_source: 'credits',
+      cancel_at_period_end: false,
+    });
+
+    await expect(
+      applyPersonalDestroyedCurrentAccessRow(liveRaceCandidate, {
+        confirmSandboxesDestroyed: false,
+        confirmCancelCreditAccess: false,
+        bulk: false,
+      })
+    ).resolves.toBe('skipped_has_live_current_row');
+  });
+
+  it('repairs org destroyed current chain into live successor', async () => {
+    const user = await insertTestUser({ google_user_email: 'org-chain-repair@example.com' });
+    const org = await createTestOrganization('org-chain-repair', user.id, 0);
+    const destroyedA = crypto.randomUUID();
+    const destroyedB = crypto.randomUUID();
+    const live = crypto.randomUUID();
+
+    await db.insert(kiloclaw_instances).values([
+      {
+        id: destroyedA,
+        user_id: user.id,
+        organization_id: org.id,
+        sandbox_id: `ki_${destroyedA.replaceAll('-', '')}`,
+        created_at: '2026-04-01T00:00:00.000Z',
+        destroyed_at: '2026-04-02T00:00:00.000Z',
+      },
+      {
+        id: destroyedB,
+        user_id: user.id,
+        organization_id: org.id,
+        sandbox_id: `ki_${destroyedB.replaceAll('-', '')}`,
+        created_at: '2026-04-03T00:00:00.000Z',
+        destroyed_at: '2026-04-04T00:00:00.000Z',
+      },
+      {
+        id: live,
+        user_id: user.id,
+        organization_id: org.id,
+        sandbox_id: `ki_${live.replaceAll('-', '')}`,
+        created_at: '2026-04-05T00:00:00.000Z',
+      },
+    ]);
+
+    const [subA, subB, liveSub] = await db
+      .insert(kiloclaw_subscriptions)
+      .values([
+        {
+          user_id: user.id,
+          instance_id: destroyedA,
+          plan: 'standard',
+          status: 'active',
+          payment_source: 'credits',
+          cancel_at_period_end: false,
+          created_at: '2026-04-01T00:00:00.000Z',
+        },
+        {
+          user_id: user.id,
+          instance_id: destroyedB,
+          plan: 'standard',
+          status: 'active',
+          payment_source: 'credits',
+          cancel_at_period_end: false,
+          created_at: '2026-04-03T00:00:00.000Z',
+        },
+        {
+          user_id: user.id,
+          instance_id: live,
+          plan: 'standard',
+          status: 'active',
+          payment_source: 'credits',
+          cancel_at_period_end: false,
+          created_at: '2026-04-05T00:00:00.000Z',
+        },
+      ])
+      .returning();
+
+    if (!subA || !subB || !liveSub) {
+      throw new Error('Expected org chain subscription rows');
+    }
+
+    await run('apply-org-destroyed-current-chain');
+
+    const subscriptions = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .orderBy(kiloclaw_subscriptions.created_at);
+
+    expect(subscriptions.map(subscription => subscription.transferred_to_subscription_id)).toEqual([
+      subB.id,
+      liveSub.id,
+      null,
+    ]);
+
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.actor_id, 'kiloclaw-subscription-alignment'));
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subscription_id: subA.id,
+          action: 'reassigned',
+          reason: 'apply_org_destroyed_current_chain_transfer',
+        }),
+        expect.objectContaining({
+          subscription_id: subB.id,
+          action: 'reassigned',
+          reason: 'apply_org_destroyed_current_chain_transfer',
+        }),
+      ])
+    );
   });
 
   it('reassigns duplicate active personal subscription to canonical instance and destroys duplicate', async () => {

--- a/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
+++ b/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
@@ -40,6 +40,7 @@ async function insertPersonalSubscription(params: {
   id: string;
   instanceId: string;
   plan: 'standard' | 'trial';
+  paymentSource?: 'credits' | 'stripe' | null;
   status: 'active' | 'canceled';
   transferredToSubscriptionId?: string | null;
   userId: string;
@@ -50,7 +51,7 @@ async function insertPersonalSubscription(params: {
     instance_id: params.instanceId,
     plan: params.plan,
     status: params.status,
-    payment_source: 'credits',
+    payment_source: params.paymentSource ?? 'credits',
     cancel_at_period_end: false,
     transferred_to_subscription_id: params.transferredToSubscriptionId ?? null,
     created_at: params.createdAt,
@@ -388,6 +389,161 @@ describe('personal subscription destroy collapse', () => {
       .where(eq(kiloclaw_subscription_change_log.actor_id, TEST_ACTOR.actorId));
 
     expect(logs).toHaveLength(0);
+  });
+
+  it('rolls back single-row cancellation when change-log insert fails in transaction', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-cancel-single-rollback@example.com',
+    });
+    const instanceId = crypto.randomUUID();
+    const subscriptionId = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: instanceId,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionId,
+      userId: user.id,
+      instanceId,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    await expect(
+      db.transaction(async tx => {
+        const executor = Object.assign(Object.create(tx), {
+          insert: ((table: typeof kiloclaw_subscription_change_log) => {
+            if (table === kiloclaw_subscription_change_log) {
+              return {
+                values: async () => {
+                  throw new Error('change-log insert failed');
+                },
+              };
+            }
+            return tx.insert(table);
+          }) as typeof tx.insert,
+        });
+
+        await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+          actor: TEST_ACTOR,
+          executor,
+          instanceId,
+          reason: 'destroy_path_inline_collapse',
+          userId: user.id,
+        });
+      })
+    ).rejects.toThrow('change-log insert failed');
+
+    const [subscription] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, subscriptionId));
+    const [instance] = await db
+      .select()
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.id, instanceId));
+
+    expect(subscription?.status).toBe('active');
+    expect(instance?.destroyed_at).toBeNull();
+  });
+
+  it('does not auto-cancel single destroyed Stripe current row on destroy path', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-cancel-single-stripe@example.com',
+    });
+    const instanceId = crypto.randomUUID();
+    const subscriptionId = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: instanceId,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionId,
+      userId: user.id,
+      instanceId,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'standard',
+      status: 'active',
+      paymentSource: 'stripe',
+    });
+
+    await db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId,
+        reason: 'destroy_path_inline_collapse',
+        userId: user.id,
+      });
+    });
+
+    const [subscription] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, subscriptionId));
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscriptionId));
+
+    expect(subscription?.status).toBe('active');
+    expect(logs).toHaveLength(0);
+  });
+
+  it('cancels single destroyed current access row on destroy path', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-cancel-single-current@example.com',
+    });
+    const instanceId = crypto.randomUUID();
+    const subscriptionId = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: instanceId,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionId,
+      userId: user.id,
+      instanceId,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'standard',
+      status: 'active',
+    });
+
+    await db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId,
+        reason: 'destroy_path_inline_collapse',
+        userId: user.id,
+      });
+    });
+
+    const [subscription] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, subscriptionId));
+    const logs = await db
+      .select()
+      .from(kiloclaw_subscription_change_log)
+      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscriptionId));
+
+    expect(subscription?.status).toBe('canceled');
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'canceled',
+          reason: 'destroy_path_cancel_single_current_access_row',
+        }),
+      ])
+    );
   });
 
   it('refuses collapse when multiple alive current personal rows exist', async () => {

--- a/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
+++ b/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
@@ -9,7 +9,7 @@ import {
   kiloclaw_subscription_change_log,
   kiloclaw_subscriptions,
 } from '@kilocode/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 
 import { listCurrentPersonalSubscriptionRows } from '@/lib/kiloclaw/current-personal-subscription';
 import { cleanupDbForTest, db } from '@/lib/drizzle';
@@ -42,6 +42,7 @@ async function insertPersonalSubscription(params: {
   plan: 'standard' | 'trial';
   paymentSource?: 'credits' | 'stripe' | null;
   status: 'active' | 'canceled';
+  stripeSubscriptionId?: string | null;
   transferredToSubscriptionId?: string | null;
   userId: string;
 }) {
@@ -52,6 +53,7 @@ async function insertPersonalSubscription(params: {
     plan: params.plan,
     status: params.status,
     payment_source: params.paymentSource ?? 'credits',
+    stripe_subscription_id: params.stripeSubscriptionId ?? null,
     cancel_at_period_end: false,
     transferred_to_subscription_id: params.transferredToSubscriptionId ?? null,
     created_at: params.createdAt,
@@ -450,48 +452,86 @@ describe('personal subscription destroy collapse', () => {
     expect(instance?.destroyed_at).toBeNull();
   });
 
-  it('does not auto-cancel single destroyed Stripe current row on destroy path', async () => {
-    const user = await insertTestUser({
+  it('does not auto-cancel single destroyed Stripe or hybrid current row on destroy path', async () => {
+    const stripeUser = await insertTestUser({
       google_user_email: 'destroy-cancel-single-stripe@example.com',
     });
-    const instanceId = crypto.randomUUID();
-    const subscriptionId = crypto.randomUUID();
+    const hybridUser = await insertTestUser({
+      google_user_email: 'destroy-cancel-single-hybrid@example.com',
+    });
+    const stripeInstanceId = crypto.randomUUID();
+    const hybridInstanceId = crypto.randomUUID();
+    const stripeSubscriptionId = crypto.randomUUID();
+    const hybridSubscriptionId = crypto.randomUUID();
 
     await insertPersonalInstance({
-      id: instanceId,
-      userId: user.id,
+      id: stripeInstanceId,
+      userId: stripeUser.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: hybridInstanceId,
+      userId: hybridUser.id,
       createdAt: '2026-04-01T00:00:00.000Z',
     });
     await insertPersonalSubscription({
-      id: subscriptionId,
-      userId: user.id,
-      instanceId,
+      id: stripeSubscriptionId,
+      userId: stripeUser.id,
+      instanceId: stripeInstanceId,
       createdAt: '2026-04-01T00:00:00.000Z',
       plan: 'standard',
       status: 'active',
       paymentSource: 'stripe',
+      stripeSubscriptionId: 'sub_destroy_path_stripe',
+    });
+    await insertPersonalSubscription({
+      id: hybridSubscriptionId,
+      userId: hybridUser.id,
+      instanceId: hybridInstanceId,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'standard',
+      status: 'active',
+      paymentSource: 'credits',
+      stripeSubscriptionId: 'sub_destroy_path_hybrid',
     });
 
     await db.transaction(async tx => {
       await markInstanceDestroyedWithPersonalSubscriptionCollapse({
         actor: TEST_ACTOR,
         executor: tx,
-        instanceId,
+        instanceId: stripeInstanceId,
         reason: 'destroy_path_inline_collapse',
-        userId: user.id,
+        userId: stripeUser.id,
+      });
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId: hybridInstanceId,
+        reason: 'destroy_path_inline_collapse',
+        userId: hybridUser.id,
       });
     });
 
-    const [subscription] = await db
+    const subscriptions = await db
       .select()
       .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.id, subscriptionId));
+      .where(inArray(kiloclaw_subscriptions.id, [stripeSubscriptionId, hybridSubscriptionId]));
     const logs = await db
       .select()
       .from(kiloclaw_subscription_change_log)
-      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscriptionId));
+      .where(
+        inArray(kiloclaw_subscription_change_log.subscription_id, [
+          stripeSubscriptionId,
+          hybridSubscriptionId,
+        ])
+      );
 
-    expect(subscription?.status).toBe('active');
+    expect(subscriptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: stripeSubscriptionId, status: 'active' }),
+        expect.objectContaining({ id: hybridSubscriptionId, status: 'active' }),
+      ])
+    );
     expect(logs).toHaveLength(0);
   });
 

--- a/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
+++ b/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
@@ -274,6 +274,7 @@ export type PersonalDestroyedCurrentAccessCandidate = {
   plan: string;
   status: string;
   paymentSource: string | null;
+  stripeSubscriptionId: string | null;
   trialEndsAt: string | null;
   instanceDestroyedAt: string;
   subscriptionCreatedAt: string;
@@ -3438,8 +3439,9 @@ function classifyPersonalDestroyedCurrentAccessRow(row: {
   paymentSource: string | null;
   plan: string;
   status: string;
+  stripeSubscriptionId: string | null;
 }): PersonalDestroyedCurrentAccessAction {
-  if (row.paymentSource === 'stripe') {
+  if (row.paymentSource === 'stripe' || row.stripeSubscriptionId !== null) {
     return 'manual_review_stripe';
   }
   if (row.status === 'past_due') {
@@ -3469,6 +3471,7 @@ export async function listPersonalDestroyedCurrentAccessCandidates(): Promise<
     plan: string;
     status: string;
     payment_source: string | null;
+    stripe_subscription_id: string | null;
     trial_ends_at: string | null;
     instance_destroyed_at: string;
     subscription_created_at: string;
@@ -3482,6 +3485,7 @@ export async function listPersonalDestroyedCurrentAccessCandidates(): Promise<
         s.plan,
         s.status,
         s.payment_source,
+        s.stripe_subscription_id,
         s.suspended_at,
         s.trial_ends_at,
         s.created_at AS subscription_created_at,
@@ -3505,6 +3509,7 @@ export async function listPersonalDestroyedCurrentAccessCandidates(): Promise<
       plan,
       status,
       payment_source,
+      stripe_subscription_id,
       trial_ends_at,
       instance_destroyed_at,
       subscription_created_at,
@@ -3526,6 +3531,7 @@ export async function listPersonalDestroyedCurrentAccessCandidates(): Promise<
       paymentSource: row.payment_source,
       plan: row.plan,
       status: row.status,
+      stripeSubscriptionId: row.stripe_subscription_id,
     }),
     userId: row.user_id,
     subscriptionId: row.subscription_id,
@@ -3534,6 +3540,7 @@ export async function listPersonalDestroyedCurrentAccessCandidates(): Promise<
     plan: row.plan,
     status: row.status,
     paymentSource: row.payment_source,
+    stripeSubscriptionId: row.stripe_subscription_id,
     trialEndsAt: row.trial_ends_at,
     instanceDestroyedAt: row.instance_destroyed_at,
     subscriptionCreatedAt: row.subscription_created_at,
@@ -3583,6 +3590,7 @@ async function previewPersonalDestroyedCurrentAccess() {
           plan: candidate.plan,
           status: candidate.status,
           paymentSource: candidate.paymentSource,
+          stripeSubscriptionId: candidate.stripeSubscriptionId,
           trialEndsAt: candidate.trialEndsAt,
           instanceDestroyedAt: candidate.instanceDestroyedAt,
           subscriptionCreatedAt: candidate.subscriptionCreatedAt,
@@ -3685,6 +3693,7 @@ export async function applyPersonalDestroyedCurrentAccessRow(
       paymentSource: currentRow.subscription.payment_source,
       plan: currentRow.subscription.plan,
       status: currentRow.subscription.status,
+      stripeSubscriptionId: currentRow.subscription.stripe_subscription_id,
     });
     if (action === 'cancel_destroyed_credits_subscription' && !options.confirmCancelCreditAccess) {
       return 'skipped_requires_credit_confirmation' as const;

--- a/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
+++ b/apps/web/src/scripts/db/kiloclaw-subscription-alignment.ts
@@ -17,6 +17,10 @@
  *   pnpm script db kiloclaw-subscription-alignment apply-changelog-baseline
  *   pnpm script db kiloclaw-subscription-alignment preview-multi-row-all-destroyed
  *   pnpm script db kiloclaw-subscription-alignment apply-multi-row-all-destroyed
+ *   pnpm script db kiloclaw-subscription-alignment preview-personal-destroyed-current-access
+ *   pnpm script db kiloclaw-subscription-alignment apply-personal-destroyed-current-access [--confirm-cancel-credit-access]
+ *   pnpm script db kiloclaw-subscription-alignment preview-org-destroyed-current-chain
+ *   pnpm script db kiloclaw-subscription-alignment apply-org-destroyed-current-chain
  *
  * Flags:
  *   --confirm-sandboxes-destroyed   Required for apply-duplicates to write
@@ -26,6 +30,10 @@
  *     itself and would hide the row from apply-duplicates). Without this
  *     flag, apply-duplicates prints a manifest of duplicate sandbox IDs and
  *     exits without writes.
+ *
+ *   --confirm-cancel-credit-access   Required for apply-personal-destroyed-current-access
+ *     to cancel active credit-funded standard/commit rows. Without this flag,
+ *     those rows are reported but not mutated.
  *
  *   --bulk   Enables chunked bulk write path for low-risk, high-volume
  *     backfills. Used by:
@@ -53,7 +61,7 @@
  * it. No instances are touched. Safe to run without flags.
  */
 
-import { and, asc, desc, eq, inArray, isNull, notExists, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNotNull, isNull, notExists, or, sql } from 'drizzle-orm';
 
 import { TRIAL_DURATION_DAYS } from '@/lib/constants';
 import {
@@ -93,7 +101,11 @@ type Mode =
   | 'preview-changelog-baseline'
   | 'apply-changelog-baseline'
   | 'preview-multi-row-all-destroyed'
-  | 'apply-multi-row-all-destroyed';
+  | 'apply-multi-row-all-destroyed'
+  | 'preview-personal-destroyed-current-access'
+  | 'apply-personal-destroyed-current-access'
+  | 'preview-org-destroyed-current-chain'
+  | 'apply-org-destroyed-current-chain';
 
 type PersonalInstanceWithoutRow = {
   instanceId: string;
@@ -246,6 +258,62 @@ type DuplicateActiveInstanceCandidate = {
 
 type MissingChangelogBaselineRow = KiloClawSubscription;
 
+export type PersonalDestroyedCurrentAccessAction =
+  | 'cancel_destroyed_trial'
+  | 'cancel_destroyed_credits_subscription'
+  | 'manual_review_stripe'
+  | 'manual_review_past_due'
+  | 'manual_review_unknown_access';
+
+export type PersonalDestroyedCurrentAccessCandidate = {
+  action: PersonalDestroyedCurrentAccessAction;
+  userId: string;
+  subscriptionId: string;
+  instanceId: string;
+  sandboxId: string;
+  plan: string;
+  status: string;
+  paymentSource: string | null;
+  trialEndsAt: string | null;
+  instanceDestroyedAt: string;
+  subscriptionCreatedAt: string;
+  subscriptionUpdatedAt: string;
+};
+
+export type PersonalDestroyedCurrentAccessApplyOutcome =
+  | 'canceled_trial'
+  | 'canceled_credits'
+  | 'skipped_no_work'
+  | 'skipped_requires_credit_confirmation'
+  | 'skipped_manual_review'
+  | 'skipped_has_live_current_row'
+  | 'skipped_multiple_current_rows'
+  | 'skipped_already_non_access'
+  | 'skipped_already_transferred'
+  | 'error';
+
+type OrgDestroyedCurrentChainSourceRow = {
+  organizationId: string;
+  userId: string;
+  subscriptionId: string;
+  instanceId: string;
+  sandboxId: string;
+  instanceDestroyedAt: string | null;
+  subscriptionCreatedAt: string;
+};
+
+type OrgDestroyedCurrentChainPair = {
+  sourceId: string;
+  targetId: string;
+};
+
+type OrgDestroyedCurrentChainCandidate = {
+  organizationId: string;
+  userId: string;
+  rows: OrgDestroyedCurrentChainSourceRow[];
+  pairs: OrgDestroyedCurrentChainPair[];
+};
+
 const ALIGNMENT_SCRIPT_ACTOR = {
   actorType: 'system',
   actorId: 'kiloclaw-subscription-alignment',
@@ -395,7 +463,7 @@ async function insertAlignmentChangeLog(
   writer: DbOrTx,
   params: {
     subscriptionId: string;
-    action: 'backfilled' | 'reassigned';
+    action: 'backfilled' | 'reassigned' | 'canceled';
     reason: string;
     before: KiloClawSubscription | null;
     after: KiloClawSubscription | null;
@@ -3366,6 +3434,692 @@ async function applyMultiRowAllDestroyedCollapse(options: ApplyOptions) {
   printSection('Users skipped during multi-row-all-destroyed apply', skipped.slice(0, 50));
 }
 
+function classifyPersonalDestroyedCurrentAccessRow(row: {
+  paymentSource: string | null;
+  plan: string;
+  status: string;
+}): PersonalDestroyedCurrentAccessAction {
+  if (row.paymentSource === 'stripe') {
+    return 'manual_review_stripe';
+  }
+  if (row.status === 'past_due') {
+    return 'manual_review_past_due';
+  }
+  if (row.plan === 'trial' && row.status === 'trialing' && row.paymentSource === null) {
+    return 'cancel_destroyed_trial';
+  }
+  if (
+    (row.plan === 'standard' || row.plan === 'commit') &&
+    row.status === 'active' &&
+    row.paymentSource === 'credits'
+  ) {
+    return 'cancel_destroyed_credits_subscription';
+  }
+  return 'manual_review_unknown_access';
+}
+
+export async function listPersonalDestroyedCurrentAccessCandidates(): Promise<
+  PersonalDestroyedCurrentAccessCandidate[]
+> {
+  const { rows } = await db.execute<{
+    user_id: string;
+    subscription_id: string;
+    instance_id: string;
+    sandbox_id: string;
+    plan: string;
+    status: string;
+    payment_source: string | null;
+    trial_ends_at: string | null;
+    instance_destroyed_at: string;
+    subscription_created_at: string;
+    subscription_updated_at: string;
+  }>(sql`
+    WITH current_personal AS (
+      SELECT
+        s.id AS subscription_id,
+        s.user_id,
+        s.instance_id,
+        s.plan,
+        s.status,
+        s.payment_source,
+        s.suspended_at,
+        s.trial_ends_at,
+        s.created_at AS subscription_created_at,
+        s.updated_at AS subscription_updated_at,
+        i.sandbox_id,
+        i.destroyed_at AS instance_destroyed_at,
+        COUNT(*) OVER (PARTITION BY s.user_id) AS current_personal_count,
+        COUNT(*) FILTER (WHERE i.destroyed_at IS NULL) OVER (PARTITION BY s.user_id) AS live_current_personal_count
+      FROM ${kiloclaw_subscriptions} s
+      INNER JOIN ${kiloclaw_instances} i ON i.id = s.instance_id
+      WHERE s.transferred_to_subscription_id IS NULL
+        AND s.instance_id IS NOT NULL
+        AND i.user_id = s.user_id
+        AND i.organization_id IS NULL
+    )
+    SELECT
+      user_id,
+      subscription_id,
+      instance_id,
+      sandbox_id,
+      plan,
+      status,
+      payment_source,
+      trial_ends_at,
+      instance_destroyed_at,
+      subscription_created_at,
+      subscription_updated_at
+    FROM current_personal
+    WHERE current_personal_count = 1
+      AND live_current_personal_count = 0
+      AND instance_destroyed_at IS NOT NULL
+      AND (
+        status = 'active'
+        OR (status = 'past_due' AND suspended_at IS NULL)
+        OR (status = 'trialing' AND trial_ends_at > now())
+      )
+    ORDER BY subscription_created_at DESC, subscription_id DESC
+  `);
+
+  return rows.map(row => ({
+    action: classifyPersonalDestroyedCurrentAccessRow({
+      paymentSource: row.payment_source,
+      plan: row.plan,
+      status: row.status,
+    }),
+    userId: row.user_id,
+    subscriptionId: row.subscription_id,
+    instanceId: row.instance_id,
+    sandboxId: row.sandbox_id,
+    plan: row.plan,
+    status: row.status,
+    paymentSource: row.payment_source,
+    trialEndsAt: row.trial_ends_at,
+    instanceDestroyedAt: row.instance_destroyed_at,
+    subscriptionCreatedAt: row.subscription_created_at,
+    subscriptionUpdatedAt: row.subscription_updated_at,
+  }));
+}
+
+function summarizePersonalDestroyedCurrentAccessCandidates(
+  candidates: PersonalDestroyedCurrentAccessCandidate[]
+): Array<{ action: PersonalDestroyedCurrentAccessAction; count: number }> {
+  const actions: PersonalDestroyedCurrentAccessAction[] = [
+    'cancel_destroyed_trial',
+    'cancel_destroyed_credits_subscription',
+    'manual_review_stripe',
+    'manual_review_past_due',
+    'manual_review_unknown_access',
+  ];
+  return actions.map(action => ({
+    action,
+    count: candidates.filter(candidate => candidate.action === action).length,
+  }));
+}
+
+async function previewPersonalDestroyedCurrentAccess() {
+  const candidates = await listPersonalDestroyedCurrentAccessCandidates();
+
+  console.log('\npersonal-destroyed-current-access preview');
+  console.table(summarizePersonalDestroyedCurrentAccessCandidates(candidates));
+
+  for (const action of [
+    'cancel_destroyed_trial',
+    'cancel_destroyed_credits_subscription',
+    'manual_review_stripe',
+    'manual_review_past_due',
+    'manual_review_unknown_access',
+  ] satisfies PersonalDestroyedCurrentAccessAction[]) {
+    printSection(
+      `Sample rows for ${action}`,
+      candidates
+        .filter(candidate => candidate.action === action)
+        .slice(0, 25)
+        .map(candidate => ({
+          userId: candidate.userId,
+          subscriptionId: candidate.subscriptionId,
+          instanceId: candidate.instanceId,
+          sandboxId: candidate.sandboxId,
+          plan: candidate.plan,
+          status: candidate.status,
+          paymentSource: candidate.paymentSource,
+          trialEndsAt: candidate.trialEndsAt,
+          instanceDestroyedAt: candidate.instanceDestroyedAt,
+          subscriptionCreatedAt: candidate.subscriptionCreatedAt,
+          subscriptionUpdatedAt: candidate.subscriptionUpdatedAt,
+        }))
+    );
+  }
+}
+
+async function lockCurrentPersonalSubscriptionRowsForUser(
+  tx: DrizzleTransaction,
+  userId: string
+): Promise<void> {
+  await tx.execute(sql`
+    SELECT s.id
+    FROM ${kiloclaw_subscriptions} s
+    INNER JOIN ${kiloclaw_instances} i ON i.id = s.instance_id
+    WHERE s.user_id = ${userId}
+      AND s.transferred_to_subscription_id IS NULL
+      AND s.instance_id IS NOT NULL
+      AND i.user_id = s.user_id
+      AND i.organization_id IS NULL
+    FOR UPDATE OF s
+  `);
+}
+
+export async function applyPersonalDestroyedCurrentAccessRow(
+  candidate: PersonalDestroyedCurrentAccessCandidate,
+  options: ApplyOptions
+): Promise<PersonalDestroyedCurrentAccessApplyOutcome> {
+  if (
+    candidate.action === 'cancel_destroyed_credits_subscription' &&
+    !options.confirmCancelCreditAccess
+  ) {
+    return 'skipped_requires_credit_confirmation';
+  }
+  if (candidate.action.startsWith('manual_review_')) {
+    return 'skipped_manual_review';
+  }
+
+  return await db.transaction(async tx => {
+    await lockCurrentPersonalSubscriptionRowsForUser(tx, candidate.userId);
+
+    const [targetSubscription] = await tx
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, candidate.subscriptionId))
+      .limit(1);
+
+    if (!targetSubscription) {
+      return 'skipped_no_work' as const;
+    }
+    if (targetSubscription.transferred_to_subscription_id !== null) {
+      return 'skipped_already_transferred' as const;
+    }
+
+    const currentRows = await tx
+      .select({
+        subscription: kiloclaw_subscriptions,
+        instance: {
+          id: kiloclaw_instances.id,
+          userId: kiloclaw_instances.user_id,
+          sandboxId: kiloclaw_instances.sandbox_id,
+          organizationId: kiloclaw_instances.organization_id,
+          destroyedAt: kiloclaw_instances.destroyed_at,
+        },
+      })
+      .from(kiloclaw_subscriptions)
+      .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+      .where(
+        and(
+          eq(kiloclaw_subscriptions.user_id, candidate.userId),
+          isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
+          isNotNull(kiloclaw_subscriptions.instance_id),
+          eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id),
+          isNull(kiloclaw_instances.organization_id)
+        )
+      );
+
+    const liveCurrentRows = currentRows.filter(row => row.instance.destroyedAt === null);
+    if (liveCurrentRows.length > 0) {
+      return 'skipped_has_live_current_row' as const;
+    }
+    if (currentRows.length !== 1) {
+      return 'skipped_multiple_current_rows' as const;
+    }
+
+    const [currentRow] = currentRows;
+    if (!currentRow || currentRow.subscription.id !== candidate.subscriptionId) {
+      return 'skipped_no_work' as const;
+    }
+    if (currentRow.instance.destroyedAt === null) {
+      return 'skipped_has_live_current_row' as const;
+    }
+    if (!isAccessGrantingSubscription(currentRow.subscription, new Date())) {
+      return 'skipped_already_non_access' as const;
+    }
+
+    const action = classifyPersonalDestroyedCurrentAccessRow({
+      paymentSource: currentRow.subscription.payment_source,
+      plan: currentRow.subscription.plan,
+      status: currentRow.subscription.status,
+    });
+    if (action === 'cancel_destroyed_credits_subscription' && !options.confirmCancelCreditAccess) {
+      return 'skipped_requires_credit_confirmation' as const;
+    }
+    if (action.startsWith('manual_review_')) {
+      return 'skipped_manual_review' as const;
+    }
+    if (action !== candidate.action) {
+      return 'skipped_no_work' as const;
+    }
+
+    const [updated] = await tx
+      .update(kiloclaw_subscriptions)
+      .set({
+        status: 'canceled',
+        suspended_at: null,
+        destruction_deadline: null,
+        auto_resume_requested_at: null,
+        auto_resume_retry_after: null,
+        auto_resume_attempt_count: 0,
+        auto_top_up_triggered_for_period: null,
+        cancel_at_period_end: false,
+        pending_conversion: false,
+        scheduled_plan: null,
+        scheduled_by: null,
+      })
+      .where(
+        and(
+          eq(kiloclaw_subscriptions.id, candidate.subscriptionId),
+          isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+        )
+      )
+      .returning();
+
+    if (!updated) {
+      return 'skipped_already_transferred' as const;
+    }
+
+    await insertAlignmentChangeLog(tx, {
+      subscriptionId: updated.id,
+      action: 'canceled',
+      reason:
+        action === 'cancel_destroyed_trial'
+          ? 'apply_personal_destroyed_current_access_cancel_trial'
+          : 'apply_personal_destroyed_current_access_cancel_credits',
+      before: currentRow.subscription,
+      after: updated,
+    });
+
+    return action === 'cancel_destroyed_trial' ? 'canceled_trial' : 'canceled_credits';
+  });
+}
+
+async function applyPersonalDestroyedCurrentAccess(options: ApplyOptions) {
+  const candidates = await listPersonalDestroyedCurrentAccessCandidates();
+  const results = {
+    users_succeeded: 0,
+    users_skipped_no_work: 0,
+    users_skipped_requires_credit_confirmation: 0,
+    users_skipped_manual_review: 0,
+    users_skipped_race: 0,
+    users_error: 0,
+    rows_canceled_trial: 0,
+    rows_canceled_credits: 0,
+    change_logs_written: 0,
+  };
+  const skipped: Array<{
+    userId: string;
+    subscriptionId: string;
+    instanceId: string;
+    action: PersonalDestroyedCurrentAccessAction;
+    outcome: PersonalDestroyedCurrentAccessApplyOutcome;
+    error?: string;
+  }> = [];
+  const startedAt = Date.now();
+
+  console.log(`\npersonal-destroyed-current-access apply: ${candidates.length} candidate row(s)`);
+
+  for (const [index, candidate] of candidates.entries()) {
+    try {
+      const outcome = await applyPersonalDestroyedCurrentAccessRow(candidate, options);
+      if (outcome === 'canceled_trial') {
+        results.users_succeeded += 1;
+        results.rows_canceled_trial += 1;
+        results.change_logs_written += 1;
+      } else if (outcome === 'canceled_credits') {
+        results.users_succeeded += 1;
+        results.rows_canceled_credits += 1;
+        results.change_logs_written += 1;
+      } else if (outcome === 'skipped_no_work') {
+        results.users_skipped_no_work += 1;
+        skipped.push({ ...candidate, outcome });
+      } else if (outcome === 'skipped_requires_credit_confirmation') {
+        results.users_skipped_requires_credit_confirmation += 1;
+        skipped.push({ ...candidate, outcome });
+      } else if (outcome === 'skipped_manual_review') {
+        results.users_skipped_manual_review += 1;
+        skipped.push({ ...candidate, outcome });
+      } else {
+        results.users_skipped_race += 1;
+        skipped.push({ ...candidate, outcome });
+      }
+    } catch (error) {
+      console.error('personal-destroyed-current-access row failed', {
+        userId: candidate.userId,
+        subscriptionId: candidate.subscriptionId,
+        action: candidate.action,
+        error: describeError(error),
+      });
+      results.users_error += 1;
+      skipped.push({ ...candidate, outcome: 'error', error: describeError(error) });
+    }
+
+    logApplyProgress({
+      label: 'apply-personal-destroyed-current-access',
+      processed: index + 1,
+      total: candidates.length,
+      startedAt,
+      every: 50,
+    });
+  }
+
+  console.log('\npersonal-destroyed-current-access apply results');
+  console.table(Object.entries(results).map(([metric, count]) => ({ metric, count })));
+  printSection(
+    'Rows skipped or errored during personal-destroyed-current-access apply',
+    skipped.slice(0, 50).map(row => ({
+      userId: row.userId,
+      subscriptionId: row.subscriptionId,
+      instanceId: row.instanceId,
+      action: row.action,
+      outcome: row.outcome,
+      error: row.error,
+    }))
+  );
+}
+
+async function listOrgDestroyedCurrentChainSourceRows(): Promise<
+  OrgDestroyedCurrentChainSourceRow[]
+> {
+  return await db
+    .select({
+      organizationId: kiloclaw_instances.organization_id,
+      userId: kiloclaw_subscriptions.user_id,
+      subscriptionId: kiloclaw_subscriptions.id,
+      instanceId: kiloclaw_instances.id,
+      sandboxId: kiloclaw_instances.sandbox_id,
+      instanceDestroyedAt: kiloclaw_instances.destroyed_at,
+      subscriptionCreatedAt: kiloclaw_subscriptions.created_at,
+    })
+    .from(kiloclaw_subscriptions)
+    .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+    .where(
+      and(
+        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
+        isNotNull(kiloclaw_instances.organization_id),
+        eq(kiloclaw_instances.user_id, kiloclaw_subscriptions.user_id)
+      )
+    )
+    .orderBy(
+      asc(kiloclaw_instances.organization_id),
+      asc(kiloclaw_subscriptions.user_id),
+      asc(kiloclaw_subscriptions.created_at),
+      asc(kiloclaw_subscriptions.id)
+    )
+    .then(rows =>
+      rows.flatMap(row => {
+        if (!row.organizationId) return [];
+        return [
+          {
+            organizationId: row.organizationId,
+            userId: row.userId,
+            subscriptionId: row.subscriptionId,
+            instanceId: row.instanceId,
+            sandboxId: row.sandboxId,
+            instanceDestroyedAt: row.instanceDestroyedAt,
+            subscriptionCreatedAt: row.subscriptionCreatedAt,
+          },
+        ];
+      })
+    );
+}
+
+function buildOrgDestroyedCurrentChainCandidatesFromRows(
+  rows: OrgDestroyedCurrentChainSourceRow[]
+): OrgDestroyedCurrentChainCandidate[] {
+  const byOrgUser = new Map<string, OrgDestroyedCurrentChainSourceRow[]>();
+  for (const row of rows) {
+    const key = `${row.organizationId}:${row.userId}`;
+    const existing = byOrgUser.get(key);
+    if (existing) {
+      existing.push(row);
+    } else {
+      byOrgUser.set(key, [row]);
+    }
+  }
+
+  const candidates: OrgDestroyedCurrentChainCandidate[] = [];
+  for (const groupRows of byOrgUser.values()) {
+    const liveRows = groupRows.filter(row => row.instanceDestroyedAt === null);
+    const destroyedRows = groupRows.filter(row => row.instanceDestroyedAt !== null);
+    if (liveRows.length !== 1 || destroyedRows.length === 0 || groupRows.length <= 1) {
+      continue;
+    }
+
+    const orderedRows = [...destroyedRows, liveRows[0]].filter(
+      (row): row is OrgDestroyedCurrentChainSourceRow => !!row
+    );
+    const pairs: OrgDestroyedCurrentChainPair[] = [];
+    for (let index = 0; index < orderedRows.length - 1; index += 1) {
+      const source = orderedRows[index];
+      const target = orderedRows[index + 1];
+      if (!source || !target) continue;
+      pairs.push({ sourceId: source.subscriptionId, targetId: target.subscriptionId });
+    }
+
+    const [firstRow] = orderedRows;
+    if (!firstRow || pairs.length === 0) continue;
+    candidates.push({
+      organizationId: firstRow.organizationId,
+      userId: firstRow.userId,
+      rows: orderedRows,
+      pairs,
+    });
+  }
+
+  return candidates;
+}
+
+async function buildOrgDestroyedCurrentChainCandidates(): Promise<
+  OrgDestroyedCurrentChainCandidate[]
+> {
+  return buildOrgDestroyedCurrentChainCandidatesFromRows(
+    await listOrgDestroyedCurrentChainSourceRows()
+  );
+}
+
+async function previewOrgDestroyedCurrentChain() {
+  const candidates = await buildOrgDestroyedCurrentChainCandidates();
+  const orgCount = new Set(candidates.map(candidate => candidate.organizationId)).size;
+  const userCount = new Set(candidates.map(candidate => candidate.userId)).size;
+  const predecessorRows = candidates.reduce((acc, candidate) => acc + candidate.pairs.length, 0);
+
+  console.log('\norg-destroyed-current-chain preview');
+  console.table([
+    { metric: 'org_user_pairs_affected', count: candidates.length },
+    { metric: 'orgs_affected', count: orgCount },
+    { metric: 'users_affected', count: userCount },
+    { metric: 'predecessor_rows_to_transfer', count: predecessorRows },
+    { metric: 'pairs_to_write', count: predecessorRows },
+  ]);
+  printSection(
+    'Sample org destroyed-current chains',
+    candidates.slice(0, 25).map(candidate => ({
+      organizationId: candidate.organizationId,
+      userId: candidate.userId,
+      rowsInChain: candidate.rows.length,
+      pairsToWrite: candidate.pairs.length,
+      oldestSourceId: candidate.pairs[0]?.sourceId ?? null,
+      finalTargetId: candidate.pairs[candidate.pairs.length - 1]?.targetId ?? null,
+    }))
+  );
+}
+
+async function applyOrgDestroyedCurrentChainCandidate(
+  candidate: OrgDestroyedCurrentChainCandidate
+): Promise<{ outcome: 'succeeded' | 'skipped_no_work' | 'skipped_race'; pairsWritten: number }> {
+  return await db.transaction(async tx => {
+    const lockedRows = await tx
+      .select({
+        organizationId: kiloclaw_instances.organization_id,
+        userId: kiloclaw_subscriptions.user_id,
+        subscription: kiloclaw_subscriptions,
+        instanceId: kiloclaw_instances.id,
+        sandboxId: kiloclaw_instances.sandbox_id,
+        instanceDestroyedAt: kiloclaw_instances.destroyed_at,
+      })
+      .from(kiloclaw_subscriptions)
+      .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+      .where(
+        and(
+          eq(kiloclaw_subscriptions.user_id, candidate.userId),
+          isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
+          eq(kiloclaw_instances.user_id, candidate.userId),
+          eq(kiloclaw_instances.organization_id, candidate.organizationId)
+        )
+      )
+      .orderBy(asc(kiloclaw_subscriptions.created_at), asc(kiloclaw_subscriptions.id))
+      .for('update');
+
+    const sourceRows = lockedRows.flatMap(row => {
+      if (!row.organizationId) return [];
+      return [
+        {
+          organizationId: row.organizationId,
+          userId: row.userId,
+          subscriptionId: row.subscription.id,
+          instanceId: row.instanceId,
+          sandboxId: row.sandboxId,
+          instanceDestroyedAt: row.instanceDestroyedAt,
+          subscriptionCreatedAt: row.subscription.created_at,
+        },
+      ];
+    });
+    const [freshCandidate] = buildOrgDestroyedCurrentChainCandidatesFromRows(sourceRows);
+    if (!freshCandidate) {
+      return { outcome: 'skipped_no_work' as const, pairsWritten: 0 };
+    }
+    if (freshCandidate.pairs.length !== candidate.pairs.length) {
+      return { outcome: 'skipped_race' as const, pairsWritten: 0 };
+    }
+
+    const targetIds = freshCandidate.pairs.map(pair => pair.targetId);
+    const existingReferences = await tx
+      .select({ id: kiloclaw_subscriptions.id })
+      .from(kiloclaw_subscriptions)
+      .where(inArray(kiloclaw_subscriptions.transferred_to_subscription_id, targetIds))
+      .for('update');
+    if (existingReferences.length > 0) {
+      return { outcome: 'skipped_race' as const, pairsWritten: 0 };
+    }
+
+    const bySubscriptionId = new Map(
+      lockedRows.map(row => [row.subscription.id, row.subscription])
+    );
+    let pairsWritten = 0;
+    for (const pair of freshCandidate.pairs) {
+      const before = bySubscriptionId.get(pair.sourceId);
+      if (!before) {
+        throw new Error('Org destroyed-current chain source disappeared during apply');
+      }
+
+      const [after] = await tx
+        .update(kiloclaw_subscriptions)
+        .set({ transferred_to_subscription_id: pair.targetId })
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.id, pair.sourceId),
+            isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
+          )
+        )
+        .returning();
+
+      if (!after) {
+        return { outcome: 'skipped_race' as const, pairsWritten: 0 };
+      }
+
+      await insertAlignmentChangeLog(tx, {
+        subscriptionId: after.id,
+        action: 'reassigned',
+        reason: 'apply_org_destroyed_current_chain_transfer',
+        before,
+        after,
+      });
+      pairsWritten += 1;
+    }
+
+    return { outcome: pairsWritten > 0 ? 'succeeded' : 'skipped_no_work', pairsWritten };
+  });
+}
+
+async function applyOrgDestroyedCurrentChain() {
+  const candidates = await buildOrgDestroyedCurrentChainCandidates();
+  const results = {
+    org_user_pairs_succeeded: 0,
+    org_user_pairs_skipped_no_work: 0,
+    org_user_pairs_skipped_race: 0,
+    org_user_pairs_error: 0,
+    pairs_written: 0,
+    change_logs_written: 0,
+  };
+  const skipped: Array<{
+    organizationId: string;
+    userId: string;
+    outcome: string;
+    error?: string;
+  }> = [];
+  const startedAt = Date.now();
+
+  console.log(`\norg-destroyed-current-chain apply: ${candidates.length} org/user pair(s)`);
+
+  for (const [index, candidate] of candidates.entries()) {
+    try {
+      const result = await applyOrgDestroyedCurrentChainCandidate(candidate);
+      if (result.outcome === 'succeeded') {
+        results.org_user_pairs_succeeded += 1;
+        results.pairs_written += result.pairsWritten;
+        results.change_logs_written += result.pairsWritten;
+      } else if (result.outcome === 'skipped_no_work') {
+        results.org_user_pairs_skipped_no_work += 1;
+        skipped.push({
+          organizationId: candidate.organizationId,
+          userId: candidate.userId,
+          outcome: result.outcome,
+        });
+      } else {
+        results.org_user_pairs_skipped_race += 1;
+        skipped.push({
+          organizationId: candidate.organizationId,
+          userId: candidate.userId,
+          outcome: result.outcome,
+        });
+      }
+    } catch (error) {
+      console.error('org-destroyed-current-chain row failed', {
+        organizationId: candidate.organizationId,
+        userId: candidate.userId,
+        error: describeError(error),
+      });
+      results.org_user_pairs_error += 1;
+      skipped.push({
+        organizationId: candidate.organizationId,
+        userId: candidate.userId,
+        outcome: 'error',
+        error: describeError(error),
+      });
+    }
+
+    logApplyProgress({
+      label: 'apply-org-destroyed-current-chain',
+      processed: index + 1,
+      total: candidates.length,
+      startedAt,
+      every: 50,
+    });
+  }
+
+  console.log('\norg-destroyed-current-chain apply results');
+  console.table(Object.entries(results).map(([metric, count]) => ({ metric, count })));
+  printSection(
+    'Org destroyed-current chains skipped or errored during apply',
+    skipped.slice(0, 50)
+  );
+}
+
 type OrgApplyOutcome = OrgBackfillAction | 'skipped';
 
 const ORG_BACKFILL_REASON: Record<OrgBackfillAction, string> = {
@@ -3523,8 +4277,9 @@ async function applyOrgBackfill() {
   printSection('Org rows skipped during apply', skipped);
 }
 
-type ApplyOptions = {
+export type ApplyOptions = {
   confirmSandboxesDestroyed: boolean;
+  confirmCancelCreditAccess: boolean;
   bulk: boolean;
 };
 
@@ -3545,6 +4300,10 @@ function parseMode(inputMode?: string): Mode {
     case 'apply-changelog-baseline':
     case 'preview-multi-row-all-destroyed':
     case 'apply-multi-row-all-destroyed':
+    case 'preview-personal-destroyed-current-access':
+    case 'apply-personal-destroyed-current-access':
+    case 'preview-org-destroyed-current-chain':
+    case 'apply-org-destroyed-current-chain':
       return mode;
     default:
       throw new Error(`Unsupported mode: ${inputMode}`);
@@ -3554,6 +4313,7 @@ function parseMode(inputMode?: string): Mode {
 function parseApplyOptions(args: string[]): ApplyOptions {
   return {
     confirmSandboxesDestroyed: args.includes('--confirm-sandboxes-destroyed'),
+    confirmCancelCreditAccess: args.includes('--confirm-cancel-credit-access'),
     bulk: args.includes('--bulk'),
   };
 }
@@ -3573,6 +4333,10 @@ const singleModeHandlers: Partial<Record<Mode, ModeHandler>> = {
   'apply-changelog-baseline': applyChangelogBaselineBackfill,
   'preview-multi-row-all-destroyed': previewMultiRowAllDestroyedCollapse,
   'apply-multi-row-all-destroyed': applyMultiRowAllDestroyedCollapse,
+  'preview-personal-destroyed-current-access': previewPersonalDestroyedCurrentAccess,
+  'apply-personal-destroyed-current-access': applyPersonalDestroyedCurrentAccess,
+  'preview-org-destroyed-current-chain': previewOrgDestroyedCurrentChain,
+  'apply-org-destroyed-current-chain': applyOrgDestroyedCurrentChain,
 };
 
 export async function run(...args: string[]) {

--- a/packages/db/src/kiloclaw-personal-subscription-collapse.ts
+++ b/packages/db/src/kiloclaw-personal-subscription-collapse.ts
@@ -82,6 +82,29 @@ function getAliveCurrentRows(rows: PersonalSubscriptionRow[]): PersonalSubscript
   return getCurrentRows(rows).filter(row => row.instance.destroyedAt === null);
 }
 
+function isAccessGrantingSubscription(
+  row: Pick<KiloClawSubscription, 'status' | 'suspended_at' | 'trial_ends_at'>,
+  now: Date
+): boolean {
+  if (row.status === 'active') return true;
+  if (row.status === 'past_due' && !row.suspended_at) return true;
+  if (row.status === 'trialing' && row.trial_ends_at) {
+    return new Date(row.trial_ends_at).getTime() > now.getTime();
+  }
+  return false;
+}
+
+function shouldCancelSingleDestroyedCurrentAccessRow(row: KiloClawSubscription): boolean {
+  if (row.plan === 'trial' && row.status === 'trialing' && row.payment_source === null) {
+    return true;
+  }
+  return (
+    (row.plan === 'standard' || row.plan === 'commit') &&
+    row.status === 'active' &&
+    row.payment_source === 'credits'
+  );
+}
+
 type TransferUpdate = {
   before: KiloClawSubscription;
   transferredToSubscriptionId: string | null;
@@ -98,6 +121,7 @@ type ChangeLogFailureContext = {
 
 type CollapseOptions = {
   changeLogFailurePolicy?: ChangeLogFailurePolicy;
+  cancelSingleCurrentAccessRow?: boolean;
   onChangeLogFailure?: (context: ChangeLogFailureContext) => Promise<void> | void;
 };
 
@@ -118,6 +142,53 @@ function buildTransferUpdates(rows: PersonalSubscriptionRow[]): TransferUpdate[]
   }
 
   return updates;
+}
+
+async function cancelSingleDestroyedCurrentAccessRow(params: {
+  actor: KiloClawSubscriptionChangeActor;
+  executor: PersonalSubscriptionCollapseWriter;
+  reason: string;
+  row: KiloClawSubscription;
+}): Promise<string | null> {
+  if (!isAccessGrantingSubscription(params.row, new Date())) {
+    return null;
+  }
+  if (!shouldCancelSingleDestroyedCurrentAccessRow(params.row)) {
+    return null;
+  }
+
+  const [after] = await params.executor
+    .update(kiloclaw_subscriptions)
+    .set({
+      status: 'canceled',
+      suspended_at: null,
+      destruction_deadline: null,
+      auto_resume_requested_at: null,
+      auto_resume_retry_after: null,
+      auto_resume_attempt_count: 0,
+      auto_top_up_triggered_for_period: null,
+      cancel_at_period_end: false,
+      pending_conversion: false,
+      scheduled_plan: null,
+      scheduled_by: null,
+    })
+    .where(eq(kiloclaw_subscriptions.id, params.row.id))
+    .returning();
+
+  if (!after) {
+    throw new Error(`Failed to cancel destroyed current subscription ${params.row.id}`);
+  }
+
+  await insertKiloClawSubscriptionChangeLog(params.executor, {
+    subscriptionId: after.id,
+    actor: params.actor,
+    action: 'canceled',
+    reason: params.reason,
+    before: params.row,
+    after,
+  });
+
+  return after.id;
 }
 
 async function applyTransferUpdates(
@@ -183,6 +254,7 @@ export async function collapseOrphanPersonalSubscriptionsOnDestroy(params: {
   destroyedInstanceId: string;
   executor: PersonalSubscriptionCollapseWriter;
   onChangeLogFailure?: (context: ChangeLogFailureContext) => Promise<void> | void;
+  cancelSingleCurrentAccessRow?: boolean;
   reason: string;
   userId: string;
 }): Promise<{ updatedSubscriptionIds: string[] }> {
@@ -202,8 +274,27 @@ export async function collapseOrphanPersonalSubscriptionsOnDestroy(params: {
     row => row.instance.id !== params.destroyedInstanceId
   );
 
-  if (currentRows.length <= 1 || aliveRowsAfterDestroy.length > 0) {
+  if (aliveRowsAfterDestroy.length > 0) {
     return { updatedSubscriptionIds: [] };
+  }
+
+  if (currentRows.length === 1) {
+    if (!params.cancelSingleCurrentAccessRow) {
+      return { updatedSubscriptionIds: [] };
+    }
+
+    const [currentRow] = currentRows;
+    if (currentRow?.instance.id !== params.destroyedInstanceId) {
+      return { updatedSubscriptionIds: [] };
+    }
+
+    const canceledSubscriptionId = await cancelSingleDestroyedCurrentAccessRow({
+      actor: params.actor,
+      executor: params.executor,
+      reason: 'destroy_path_cancel_single_current_access_row',
+      row: currentRow.subscription,
+    });
+    return { updatedSubscriptionIds: canceledSubscriptionId ? [canceledSubscriptionId] : [] };
   }
 
   const updates = buildTransferUpdates(personalRows);
@@ -300,6 +391,7 @@ export async function markInstanceDestroyedWithPersonalSubscriptionCollapse(para
       changeLogFailurePolicy: params.changeLogFailurePolicy,
       destroyedInstanceId: destroyedInstance.id,
       executor: params.executor,
+      cancelSingleCurrentAccessRow: true,
       onChangeLogFailure: params.onChangeLogFailure,
       reason: params.reason,
       userId: params.userId,

--- a/packages/db/src/kiloclaw-personal-subscription-collapse.ts
+++ b/packages/db/src/kiloclaw-personal-subscription-collapse.ts
@@ -95,6 +95,9 @@ function isAccessGrantingSubscription(
 }
 
 function shouldCancelSingleDestroyedCurrentAccessRow(row: KiloClawSubscription): boolean {
+  if (row.stripe_subscription_id !== null) {
+    return false;
+  }
   if (row.plan === 'trial' && row.status === 'trialing' && row.payment_source === null) {
     return true;
   }


### PR DESCRIPTION
## Summary
Repairs KiloClaw subscription drift when destroyed instances keep current access-granting subscription rows.

### Why this change is needed
Destroyed personal instances could retain a single current subscription row that continued to grant access, and destroyed org predecessors could remain current after replacement provisioning. These rows made runtime subscription state diverge from instance lifecycle state and left production repair paths without targeted, auditable apply modes.

### How this is addressed
- Cancels safe personal destroyed current access rows on the destroy path while leaving Stripe and ambiguous rows for manual review.
- Adds targeted preview/apply alignment modes for personal destroyed current access rows and org destroyed current chains.
- Transfers destroyed org predecessor subscriptions into deterministic chains ending at the live successor during org bootstrap and script repair.
- Adds transactional guards, change-log writes, and regression coverage for cancellation, transfer, race, and rollback paths.

## Human Verification
- Spec alignment: Read and implemented against `.specs/kiloclaw-billing.md`, `.specs/kiloclaw-datamodel.md`, and `.specs/kiloclaw-controller.md`.
- Tests verified: `pnpm test -- apps/web/src/lib/kiloclaw/kiloclaw-subscription-alignment-script.test.ts apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts` passed with 31 tests.
- Tests verified: `pnpm --filter kiloclaw-billing test -- src/bootstrap.test.ts` passed; Vitest also ran related service tests, 42 tests total.
- Code evaluations: Local review workflow ran security, logic, types, data, resources, and style agents with no findings.
- _Additional verification (to be completed by author)_

## Visual Changes
N/A

## Reviewer Notes
### Human Reviewer
- Validate the business decision to automatically cancel credit-funded personal destroyed current rows while keeping Stripe rows manual-review only.
- Review org predecessor chain ordering and uniqueness handling around `transferred_to_subscription_id`, since it is the highest-risk data invariant.
- Untracked `.kilo/package-lock.json` remains intentionally excluded from this PR.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Personal destroy-path fix is opt-in through `markInstanceDestroyedWithPersonalSubscriptionCollapse(...)` so direct collapse callers retain existing behavior unless they pass the new option.
- Personal script apply locks current personal subscription rows per user, rechecks current/live state, and writes `canceled` change logs inside the transaction.
- Org bootstrap inserts the live successor and transfers destroyed predecessors in one transaction using deterministic created-at/id ordering.
- Org repair script rebuilds chain candidates inside row locks and skips if target transfer references already exist to avoid unique constraint violations.
- Existing `--bulk` and `--confirm-sandboxes-destroyed` behaviors are preserved; `--confirm-cancel-credit-access` gates credit-row cancellation in script apply mode.

</details>