### PR TITLE
feat(kiloclaw): add OpenClaw import dashboard flow

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -109,6 +109,7 @@
     "drizzle-orm": "catalog:",
     "event-source-polyfill": "^1.0.31",
     "eventsource-parser": "^3.0.6",
+    "fflate": "^0.8.2",
     "form-data": "^4.0.5",
     "jotai": "^2.18.1",
     "jotai-minidb": "^0.0.8",

--- a/apps/web/src/app/(app)/claw/components/OpenclawImportCard.tsx
+++ b/apps/web/src/app/(app)/claw/components/OpenclawImportCard.tsx
@@ -112,6 +112,8 @@ export function OpenclawImportCard({
   const zipCommand = useMemo(() => getOpenclawZipCommandForOs(detectedOs), [detectedOs]);
 
   useEffect(() => {
+    isMountedRef.current = true;
+
     return () => {
       isMountedRef.current = false;
       if (copyTimeoutRef.current) {

--- a/apps/web/src/app/(app)/claw/components/OpenclawImportCard.tsx
+++ b/apps/web/src/app/(app)/claw/components/OpenclawImportCard.tsx
@@ -1,0 +1,442 @@
+'use client';
+
+import { Check, Copy, Upload } from 'lucide-react';
+import {
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type DragEvent as ReactDragEvent,
+} from 'react';
+
+import { usePostHog } from 'posthog-js/react';
+import { toast } from 'sonner';
+import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
+import type {
+  KiloClawDashboardStatus,
+  OpenclawWorkspaceImportResponse,
+} from '@/lib/kiloclaw/types';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import {
+  detectOpenclawImportOs,
+  getOpenclawZipCommandForOs,
+  OpenclawWorkspaceZipError,
+  parseOpenclawWorkspaceZipFile,
+  type ParsedOpenclawWorkspaceZip,
+} from './openclaw-import-zip';
+
+type ClawMutations = ReturnType<typeof useKiloClawMutations>;
+
+function hasDraggedFiles(dataTransfer: DataTransfer | null): boolean {
+  if (!dataTransfer) return false;
+  return Array.from(dataTransfer.types).includes('Files');
+}
+
+function getZipErrorMessage(error: OpenclawWorkspaceZipError): string {
+  switch (error.code) {
+    case 'openclaw_import_zip_too_large':
+      return 'zip file must be 5 MB or smaller.';
+    case 'openclaw_import_too_many_files':
+      return 'zip file contains too many files (max 500).';
+    case 'openclaw_import_too_large':
+      return 'Extracted Markdown content must be 5 MB or smaller.';
+    case 'openclaw_import_no_files':
+      return 'zip file contains no valid OpenClaw workspace files.';
+    case 'openclaw_import_invalid_zip':
+      return 'Invalid zip file. Please upload a standard .zip archive.';
+    case 'openclaw_import_invalid_path':
+    case 'openclaw_import_path_case_conflict':
+    case 'openclaw_import_invalid_markdown':
+      return error.message;
+    default:
+      return 'Failed to parse zip file.';
+  }
+}
+
+function summarizeImportResult(result: OpenclawWorkspaceImportResponse): string {
+  const parts: string[] = [];
+
+  if (result.attemptedWriteCount > 0) {
+    parts.push(`${result.writtenCount}/${result.attemptedWriteCount} written`);
+  }
+
+  if (result.attemptedDeleteCount > 0) {
+    parts.push(`${result.deletedCount}/${result.attemptedDeleteCount} deleted`);
+  }
+
+  if (result.failedCount > 0) {
+    parts.push(`${result.failedCount} failed`);
+  }
+
+  return parts.length > 0 ? parts.join(', ') : 'No file changes';
+}
+
+export function OpenclawImportCard({
+  mutations,
+  isRunning,
+  instanceStatus,
+}: {
+  mutations: ClawMutations;
+  isRunning: boolean;
+  instanceStatus: KiloClawDashboardStatus['status'];
+}) {
+  const posthog = usePostHog();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const [isDraggingCard, setIsDraggingCard] = useState(false);
+  const [selectedZipName, setSelectedZipName] = useState<string | null>(null);
+  const [selectedImport, setSelectedImport] = useState<ParsedOpenclawWorkspaceZip | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [isParsing, setIsParsing] = useState(false);
+  const [copiedCommand, setCopiedCommand] = useState(false);
+
+  const detectedOs = useMemo(() => {
+    if (typeof navigator === 'undefined') return 'linux';
+    return detectOpenclawImportOs(navigator.userAgent);
+  }, []);
+
+  const zipCommand = useMemo(() => getOpenclawZipCommandForOs(detectedOs), [detectedOs]);
+
+  function resetSelection() {
+    setSelectedZipName(null);
+    setSelectedImport(null);
+    setImportError(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }
+
+  async function parseZipFile(file: File, source: 'browse' | 'drop') {
+    if (!isRunning) {
+      setImportError('Instance must be running before uploading OpenClaw workspace files.');
+      return;
+    }
+
+    if (!file.name.toLowerCase().endsWith('.zip')) {
+      setSelectedZipName(file.name);
+      setSelectedImport(null);
+      setImportError('Please select a .zip file.');
+      return;
+    }
+
+    setIsParsing(true);
+    setImportError(null);
+
+    try {
+      const parsed = await parseOpenclawWorkspaceZipFile(file);
+      setSelectedZipName(file.name);
+      setSelectedImport(parsed);
+      posthog?.capture('claw_openclaw_import_zip_parsed', {
+        source,
+        zip_name: file.name,
+        zip_size_bytes: file.size,
+        parsed_file_count: parsed.files.length,
+        parsed_utf8_bytes: parsed.totalUtf8Bytes,
+        instance_status: instanceStatus,
+      });
+    } catch (error) {
+      setSelectedZipName(file.name);
+      setSelectedImport(null);
+      if (error instanceof OpenclawWorkspaceZipError) {
+        setImportError(getZipErrorMessage(error));
+        posthog?.capture('claw_openclaw_import_zip_parse_failed', {
+          source,
+          error_code: error.code,
+          instance_status: instanceStatus,
+        });
+      } else {
+        setImportError('Failed to parse zip file.');
+      }
+    } finally {
+      setIsParsing(false);
+    }
+  }
+
+  function handleInputChange(event: ChangeEvent<HTMLInputElement>) {
+    if (!isRunning) {
+      setImportError('Instance must be running before uploading OpenClaw workspace files.');
+      return;
+    }
+
+    const file = event.currentTarget.files?.[0];
+    if (!file) return;
+    void parseZipFile(file, 'browse');
+  }
+
+  function handleCopyCommand() {
+    void navigator.clipboard.writeText(zipCommand.command);
+    setCopiedCommand(true);
+    setTimeout(() => setCopiedCommand(false), 2000);
+  }
+
+  function handleCardDragOver(event: ReactDragEvent<HTMLDivElement>) {
+    if (!hasDraggedFiles(event.dataTransfer)) return;
+    event.preventDefault();
+    if (!isRunning) return;
+    setIsDraggingCard(true);
+  }
+
+  function handleCardDragEnter(event: ReactDragEvent<HTMLDivElement>) {
+    if (!hasDraggedFiles(event.dataTransfer)) return;
+    event.preventDefault();
+    if (!isRunning) return;
+    setIsDraggingCard(true);
+  }
+
+  function handleCardDragLeave(event: ReactDragEvent<HTMLDivElement>) {
+    if (!hasDraggedFiles(event.dataTransfer)) return;
+    const relatedTarget = event.relatedTarget;
+    if (relatedTarget instanceof Node && event.currentTarget.contains(relatedTarget)) {
+      return;
+    }
+    setIsDraggingCard(false);
+  }
+
+  function handleCardDrop(event: ReactDragEvent<HTMLDivElement>) {
+    if (!hasDraggedFiles(event.dataTransfer)) return;
+    event.preventDefault();
+    setIsDraggingCard(false);
+
+    if (!isRunning) {
+      setImportError('Instance must be running before uploading OpenClaw workspace files.');
+      return;
+    }
+
+    const file = event.dataTransfer.files?.[0];
+    if (!file) return;
+    void parseZipFile(file, 'drop');
+  }
+
+  function handleImport() {
+    if (!selectedImport || !isRunning) return;
+
+    posthog?.capture('claw_openclaw_import_confirmed', {
+      file_count: selectedImport.files.length,
+      utf8_bytes: selectedImport.totalUtf8Bytes,
+      instance_status: instanceStatus,
+    });
+
+    mutations.importOpenclawWorkspace.mutate(
+      { files: selectedImport.files },
+      {
+        onSuccess: result => {
+          setConfirmOpen(false);
+          resetSelection();
+
+          const summary = summarizeImportResult(result);
+          if (result.ok) {
+            toast.success('OpenClaw import complete. Restarting KiloClaw.');
+          } else {
+            toast.error(`OpenClaw import complete. Restarting KiloClaw. (${summary})`);
+          }
+
+          mutations.restartOpenClaw.mutate(undefined, {
+            onError: err => {
+              const message = err.message || 'Failed to restart KiloClaw';
+              toast.error(`OpenClaw imported, but failed to restart KiloClaw: ${message}`);
+            },
+          });
+
+          posthog?.capture('claw_openclaw_import_completed', {
+            ok: result.ok,
+            attempted_write_count: result.attemptedWriteCount,
+            written_count: result.writtenCount,
+            attempted_delete_count: result.attemptedDeleteCount,
+            deleted_count: result.deletedCount,
+            failed_count: result.failedCount,
+            instance_status: instanceStatus,
+          });
+        },
+        onError: err => {
+          const message = err.message || 'Import failed';
+          setImportError(message);
+          toast.error(`Failed to import OpenClaw workspace: ${message}`);
+          posthog?.capture('claw_openclaw_import_failed', {
+            error_message: message,
+            instance_status: instanceStatus,
+          });
+        },
+      }
+    );
+  }
+
+  const importPending = mutations.importOpenclawWorkspace.isPending;
+  const canImport = isRunning && !!selectedImport && !isParsing && !importPending;
+  const dropZoneActive = isRunning && isDraggingCard;
+
+  return (
+    <div
+      onDragEnter={handleCardDragEnter}
+      onDragOver={handleCardDragOver}
+      onDragLeave={handleCardDragLeave}
+      onDrop={handleCardDrop}
+      className={`rounded-lg border px-4 py-3 transition-colors ${
+        dropZoneActive ? 'border-primary bg-primary/5' : ''
+      }`}
+    >
+      <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-center gap-3">
+          <Upload className="text-muted-foreground h-5 w-5 shrink-0" />
+          <div>
+            <p className="text-sm font-medium">OpenClaw Import</p>
+            <p className="text-muted-foreground text-xs">
+              Import USER.md, SOUL.md, IDENTITY.md, MEMORY.md, and memory/* from a zip file.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 flex-col items-start gap-1 sm:items-end">
+          <div className="flex items-center gap-2">
+            <Input
+              ref={fileInputRef}
+              type="file"
+              accept=".zip,application/zip"
+              multiple={false}
+              onChange={handleInputChange}
+              className="hidden"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={!isRunning || importPending || isParsing}
+            >
+              Browse...
+            </Button>
+            {selectedZipName && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={resetSelection}
+                disabled={importPending || isParsing}
+              >
+                Clear
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-xs">
+          Extract your existing OpenClaw workspace with this command. It will save
+          openclaw-workspace.zip to your Desktop folder.
+        </p>
+        <div className="relative">
+          <pre className="bg-muted overflow-x-auto rounded-md p-3 pr-10 text-xs">
+            <code>{zipCommand.command}</code>
+          </pre>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="absolute top-1 right-1 h-7 w-7 p-0"
+            onClick={handleCopyCommand}
+          >
+            {copiedCommand ? (
+              <Check className="h-3.5 w-3.5 text-green-500" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+          </Button>
+        </div>
+      </div>
+
+      {isParsing && <p className="text-muted-foreground mt-2 text-xs">Parsing zip file...</p>}
+
+      {importError && (
+        <div className="mt-2 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2">
+          <p className="text-xs text-red-300">{importError}</p>
+        </div>
+      )}
+
+      {selectedImport && (
+        <div className="mt-3 space-y-2">
+          <p className="text-sm font-medium">
+            Preview ({selectedImport.previewPaths.length} files)
+          </p>
+          {selectedZipName && <p className="text-muted-foreground text-xs">{selectedZipName}</p>}
+          <div className="max-h-40 overflow-auto rounded-md border p-2">
+            <ul className="space-y-1 text-xs">
+              {selectedImport.previewPaths.map(path => (
+                <li key={path} className="font-mono">
+                  {path}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-muted-foreground text-xs">
+              Ready to import {selectedImport.files.length} files.
+            </p>
+            <Button
+              type="button"
+              size="sm"
+              disabled={!canImport}
+              onClick={() => setConfirmOpen(true)}
+            >
+              Import
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {!isRunning && (
+        <p className="mt-2 text-xs text-amber-400">
+          Instance must be running before uploading or importing OpenClaw workspace files.
+        </p>
+      )}
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Import OpenClaw Workspace</DialogTitle>
+            <DialogDescription>
+              This will overwrite matching files in your KiloClaw workspace and restart your
+              KiloClaw.
+            </DialogDescription>
+          </DialogHeader>
+
+          {selectedImport && (
+            <div className="space-y-2">
+              <p className="text-sm font-medium">Files to import</p>
+              <div className="max-h-44 overflow-auto rounded-md border p-2">
+                <ul className="space-y-1 text-xs">
+                  {selectedImport.previewPaths.map(path => (
+                    <li key={path} className="font-mono">
+                      {path}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmOpen(false)}
+              disabled={importPending}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleImport} disabled={!canImport}>
+              {importPending ? 'Importing...' : 'Confirm Import & Restart'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/claw/components/OpenclawImportCard.tsx
+++ b/apps/web/src/app/(app)/claw/components/OpenclawImportCard.tsx
@@ -2,6 +2,7 @@
 
 import { Check, Copy, Upload } from 'lucide-react';
 import {
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -91,6 +92,9 @@ export function OpenclawImportCard({
 }) {
   const posthog = usePostHog();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const isMountedRef = useRef(true);
+  const parseAttemptRef = useRef(0);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [isDraggingCard, setIsDraggingCard] = useState(false);
   const [selectedZipName, setSelectedZipName] = useState<string | null>(null);
@@ -106,6 +110,16 @@ export function OpenclawImportCard({
   }, []);
 
   const zipCommand = useMemo(() => getOpenclawZipCommandForOs(detectedOs), [detectedOs]);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current);
+        copyTimeoutRef.current = null;
+      }
+    };
+  }, []);
 
   function resetSelection() {
     setSelectedZipName(null);
@@ -129,11 +143,16 @@ export function OpenclawImportCard({
       return;
     }
 
+    const parseAttempt = parseAttemptRef.current + 1;
+    parseAttemptRef.current = parseAttempt;
+
     setIsParsing(true);
     setImportError(null);
 
     try {
       const parsed = await parseOpenclawWorkspaceZipFile(file);
+      if (!isMountedRef.current || parseAttempt !== parseAttemptRef.current) return;
+
       setSelectedZipName(file.name);
       setSelectedImport(parsed);
       posthog?.capture('claw_openclaw_import_zip_parsed', {
@@ -145,6 +164,8 @@ export function OpenclawImportCard({
         instance_status: instanceStatus,
       });
     } catch (error) {
+      if (!isMountedRef.current || parseAttempt !== parseAttemptRef.current) return;
+
       setSelectedZipName(file.name);
       setSelectedImport(null);
       if (error instanceof OpenclawWorkspaceZipError) {
@@ -158,7 +179,9 @@ export function OpenclawImportCard({
         setImportError('Failed to parse zip file.');
       }
     } finally {
-      setIsParsing(false);
+      if (isMountedRef.current && parseAttempt === parseAttemptRef.current) {
+        setIsParsing(false);
+      }
     }
   }
 
@@ -175,8 +198,17 @@ export function OpenclawImportCard({
 
   function handleCopyCommand() {
     void navigator.clipboard.writeText(zipCommand.command);
+
+    if (copyTimeoutRef.current) {
+      clearTimeout(copyTimeoutRef.current);
+    }
+
     setCopiedCommand(true);
-    setTimeout(() => setCopiedCommand(false), 2000);
+    copyTimeoutRef.current = setTimeout(() => {
+      if (!isMountedRef.current) return;
+      setCopiedCommand(false);
+      copyTimeoutRef.current = null;
+    }, 2000);
   }
 
   function handleCardDragOver(event: ReactDragEvent<HTMLDivElement>) {

--- a/apps/web/src/app/(app)/claw/components/OpenclawImportCard.tsx
+++ b/apps/web/src/app/(app)/claw/components/OpenclawImportCard.tsx
@@ -131,6 +131,9 @@ export function OpenclawImportCard({
   }
 
   async function parseZipFile(file: File, source: 'browse' | 'drop') {
+    const parseAttempt = parseAttemptRef.current + 1;
+    parseAttemptRef.current = parseAttempt;
+
     if (!isRunning) {
       setImportError('Instance must be running before uploading OpenClaw workspace files.');
       return;
@@ -142,9 +145,6 @@ export function OpenclawImportCard({
       setImportError('Please select a .zip file.');
       return;
     }
-
-    const parseAttempt = parseAttemptRef.current + 1;
-    parseAttemptRef.current = parseAttempt;
 
     setIsParsing(true);
     setImportError(null);

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -76,7 +76,7 @@ type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 
 const EXA_SEARCH_UI_MIN_CONTROLLER_VERSION = '2026.4.14';
 const MEMORY_MIN_OPENCLAW_VERSION = '2026.4.5';
-const OPENCLAW_IMPORT_UI_MIN_CONTROLLER_VERSION = '2000.1.1';
+const OPENCLAW_IMPORT_UI_MIN_CONTROLLER_VERSION = '2026.4.22';
 
 // ---------------------------------------------------------------------------
 // 1Password setup guide dialog

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -16,6 +16,7 @@ import {
   X,
 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
+import { OpenclawImportCard } from './OpenclawImportCard';
 
 import { usePostHog } from 'posthog-js/react';
 import { toast } from 'sonner';
@@ -75,6 +76,7 @@ type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 
 const EXA_SEARCH_UI_MIN_CONTROLLER_VERSION = '2026.4.14';
 const MEMORY_MIN_OPENCLAW_VERSION = '2026.4.5';
+const OPENCLAW_IMPORT_UI_MIN_CONTROLLER_VERSION = '2000.1.1';
 
 // ---------------------------------------------------------------------------
 // 1Password setup guide dialog
@@ -1069,6 +1071,10 @@ export function SettingsTab({
     runningVersion ?? trackedVersion,
     MEMORY_MIN_OPENCLAW_VERSION
   );
+  const supportsOpenclawImportUi = calverAtLeast(
+    cleanVersion(controllerVersion?.version),
+    OPENCLAW_IMPORT_UI_MIN_CONTROLLER_VERSION
+  );
 
   const configuredSecrets = config?.configuredSecrets ?? {};
   const kiloExaSearchMode = config?.kiloExaSearchMode ?? null;
@@ -1259,6 +1265,14 @@ export function SettingsTab({
           </div>
         )}
       </div>
+
+      {supportsOpenclawImportUi && (
+        <OpenclawImportCard
+          mutations={mutations}
+          isRunning={isRunning}
+          instanceStatus={status.status}
+        />
+      )}
 
       {/* ── Model Configuration ── */}
       <div>

--- a/apps/web/src/app/(app)/claw/components/openclaw-import-zip.test.ts
+++ b/apps/web/src/app/(app)/claw/components/openclaw-import-zip.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from '@jest/globals';
+import { zipSync, strToU8 } from 'fflate';
+import {
+  detectOpenclawImportOs,
+  getOpenclawZipCommandForOs,
+  parseOpenclawWorkspaceZipBytes,
+} from '@/app/(app)/claw/components/openclaw-import-zip';
+import type { OpenclawWorkspaceZipError } from '@/app/(app)/claw/components/openclaw-import-zip';
+
+function makeZip(entries: Record<string, string | Uint8Array>): Uint8Array {
+  const payload: Record<string, Uint8Array> = {};
+  for (const [name, content] of Object.entries(entries)) {
+    payload[name] = typeof content === 'string' ? strToU8(content) : content;
+  }
+  return zipSync(payload);
+}
+
+describe('parseOpenclawWorkspaceZipBytes', () => {
+  test('parses valid root and recursive memory markdown files', () => {
+    const zip = makeZip({
+      'USER.md': '# User\n',
+      'SOUL.md': '# Soul\n',
+      'IDENTITY.md': '# Identity\n',
+      'MEMORY.md': '# Memory\n',
+      'memory/notes/day-1.md': '- note\n',
+      'memory/deep/path/item.md': '- nested\n',
+    });
+
+    const result = parseOpenclawWorkspaceZipBytes(zip);
+
+    expect(result.files).toEqual([
+      { path: 'workspace/USER.md', content: '# User\n' },
+      { path: 'workspace/SOUL.md', content: '# Soul\n' },
+      { path: 'workspace/IDENTITY.md', content: '# Identity\n' },
+      { path: 'workspace/MEMORY.md', content: '# Memory\n' },
+      { path: 'workspace/memory/notes/day-1.md', content: '- note\n' },
+      { path: 'workspace/memory/deep/path/item.md', content: '- nested\n' },
+    ]);
+    expect(result.previewPaths).toEqual([
+      'IDENTITY.md',
+      'MEMORY.md',
+      'memory/deep/path/item.md',
+      'memory/notes/day-1.md',
+      'SOUL.md',
+      'USER.md',
+    ]);
+  });
+
+  test('ignores hidden/system archive paths', () => {
+    const zip = makeZip({
+      '__MACOSX/._USER.md': 'ignored',
+      '.DS_Store': 'ignored',
+      'USER.md': '# User\n',
+      'memory/.cache/ignored.md': 'ignored',
+      'memory/ok.md': '# ok\n',
+      'thumbs.db': 'ignored',
+    });
+
+    const result = parseOpenclawWorkspaceZipBytes(zip);
+    expect(result.previewPaths).toEqual(['memory/ok.md', 'USER.md']);
+    expect(result.files).toEqual([
+      { path: 'workspace/USER.md', content: '# User\n' },
+      { path: 'workspace/memory/ok.md', content: '# ok\n' },
+    ]);
+  });
+
+  test('rejects unsupported ZIP root shapes', () => {
+    const zip = makeZip({
+      'workspace/USER.md': '# User\n',
+    });
+
+    expect(() => parseOpenclawWorkspaceZipBytes(zip)).toThrow(
+      expect.objectContaining({
+        code: 'openclaw_import_invalid_path',
+      } satisfies Partial<OpenclawWorkspaceZipError>)
+    );
+  });
+
+  test('rejects non-markdown files in memory tree', () => {
+    const zip = makeZip({
+      'memory/note.txt': 'not markdown',
+    });
+
+    expect(() => parseOpenclawWorkspaceZipBytes(zip)).toThrow(
+      expect.objectContaining({
+        code: 'openclaw_import_invalid_path',
+      } satisfies Partial<OpenclawWorkspaceZipError>)
+    );
+  });
+
+  test('rejects case-insensitive path collisions', () => {
+    const zip = makeZip({
+      'memory/Foo.md': '# A',
+      'memory/foo.md': '# B',
+    });
+
+    expect(() => parseOpenclawWorkspaceZipBytes(zip)).toThrow(
+      expect.objectContaining({
+        code: 'openclaw_import_path_case_conflict',
+      } satisfies Partial<OpenclawWorkspaceZipError>)
+    );
+  });
+
+  test('rejects files with control characters', () => {
+    const zip = makeZip({
+      'USER.md': 'hello\u0001world',
+    });
+
+    expect(() => parseOpenclawWorkspaceZipBytes(zip)).toThrow(
+      expect.objectContaining({
+        code: 'openclaw_import_invalid_markdown',
+      } satisfies Partial<OpenclawWorkspaceZipError>)
+    );
+  });
+
+  test('rejects empty/invalid file sets', () => {
+    const zip = makeZip({
+      '__MACOSX/._USER.md': 'ignored',
+      '.DS_Store': 'ignored',
+    });
+
+    expect(() => parseOpenclawWorkspaceZipBytes(zip)).toThrow(
+      expect.objectContaining({
+        code: 'openclaw_import_no_files',
+      } satisfies Partial<OpenclawWorkspaceZipError>)
+    );
+  });
+
+  test('rejects ZIP with too many files', () => {
+    const entries: Record<string, string> = {
+      'USER.md': '# User\n',
+    };
+
+    for (let i = 0; i < 500; i++) {
+      entries[`memory/note-${i}.md`] = `# ${i}\n`;
+    }
+
+    const zip = makeZip(entries);
+
+    expect(() => parseOpenclawWorkspaceZipBytes(zip)).toThrow(
+      expect.objectContaining({
+        code: 'openclaw_import_too_many_files',
+      } satisfies Partial<OpenclawWorkspaceZipError>)
+    );
+  });
+
+  test('rejects file larger than extracted size cap', () => {
+    const tooLarge = 'a'.repeat(5 * 1024 * 1024 + 1);
+    const zip = makeZip({
+      'USER.md': tooLarge,
+    });
+
+    expect(() => parseOpenclawWorkspaceZipBytes(zip)).toThrow(
+      expect.objectContaining({
+        code: 'openclaw_import_too_large',
+      } satisfies Partial<OpenclawWorkspaceZipError>)
+    );
+  });
+});
+
+describe('detectOpenclawImportOs', () => {
+  test('detects windows', () => {
+    expect(detectOpenclawImportOs('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')).toBe('windows');
+  });
+
+  test('detects macos', () => {
+    expect(detectOpenclawImportOs('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')).toBe('macos');
+  });
+
+  test('defaults to linux', () => {
+    expect(detectOpenclawImportOs('Mozilla/5.0 (X11; Linux x86_64)')).toBe('linux');
+    expect(detectOpenclawImportOs('unknown-agent')).toBe('linux');
+  });
+});
+
+describe('getOpenclawZipCommandForOs', () => {
+  test('returns commands for each OS', () => {
+    expect(getOpenclawZipCommandForOs('windows').command).toContain('Compress-Archive');
+
+    const unixCommandSuffix =
+      'o="$HOME/Desktop/openclaw-workspace.zip";rm -f "$o";zip -r "$o" "$@"';
+    expect(getOpenclawZipCommandForOs('macos').command).toContain(unixCommandSuffix);
+    expect(getOpenclawZipCommandForOs('linux').command).toContain(unixCommandSuffix);
+  });
+});

--- a/apps/web/src/app/(app)/claw/components/openclaw-import-zip.ts
+++ b/apps/web/src/app/(app)/claw/components/openclaw-import-zip.ts
@@ -1,19 +1,20 @@
 import { unzipSync } from 'fflate';
+import {
+  OPENCLAW_IMPORT_MAX_EXTRACTED_UTF8_BYTES,
+  OPENCLAW_IMPORT_MAX_FILES,
+  OPENCLAW_IMPORT_MAX_FILE_UTF8_BYTES,
+  OPENCLAW_IMPORT_MAX_ZIP_BYTES,
+  mapOpenclawZipPathToImportPath,
+  normalizeOpenclawImportPath,
+  isOpenclawMarkdownContent,
+} from '@kilocode/worker-utils/openclaw-import';
 
-export const OPENCLAW_IMPORT_MAX_ZIP_BYTES = 5 * 1024 * 1024;
-export const OPENCLAW_IMPORT_MAX_FILES = 500;
-export const OPENCLAW_IMPORT_MAX_EXTRACTED_UTF8_BYTES = 5 * 1024 * 1024;
-export const OPENCLAW_IMPORT_MAX_FILE_UTF8_BYTES = 5 * 1024 * 1024;
-
-const OPENCLAW_IMPORT_ROOT_FILES = new Map([
-  ['USER.md', 'workspace/USER.md'],
-  ['SOUL.md', 'workspace/SOUL.md'],
-  ['IDENTITY.md', 'workspace/IDENTITY.md'],
-  ['MEMORY.md', 'workspace/MEMORY.md'],
-]);
-
-const OPENCLAW_IMPORT_MEMORY_PREFIX = 'memory/';
-const OPENCLAW_IMPORT_TARGET_MEMORY_PREFIX = 'workspace/memory/';
+export {
+  OPENCLAW_IMPORT_MAX_EXTRACTED_UTF8_BYTES,
+  OPENCLAW_IMPORT_MAX_FILES,
+  OPENCLAW_IMPORT_MAX_FILE_UTF8_BYTES,
+  OPENCLAW_IMPORT_MAX_ZIP_BYTES,
+};
 
 export type OpenclawImportOs = 'windows' | 'macos' | 'linux';
 
@@ -59,29 +60,15 @@ const OPENCLAW_ZIP_COMMANDS: Record<OpenclawImportOs, OpenclawZipCommand> = {
 
 const textDecoder = new TextDecoder('utf-8', { fatal: true });
 
-function hasDisallowedControlChars(content: string): boolean {
-  for (const char of content) {
-    const code = char.codePointAt(0);
-    if (code === undefined) continue;
-    if (code === 0x09 || code === 0x0a || code === 0x0d) continue;
-    if ((code >= 0x00 && code <= 0x1f) || code === 0x7f) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 function normalizeArchivePath(path: string): string {
-  const withForwardSlashes = path.replaceAll('\\', '/').replace(/^\.\//, '');
-  const segments = withForwardSlashes.split('/');
-  if (segments.some(segment => segment.length === 0 || segment === '.' || segment === '..')) {
+  try {
+    return normalizeOpenclawImportPath(path);
+  } catch {
     throw new OpenclawWorkspaceZipError(
       'openclaw_import_invalid_path',
       `Unsupported zip file path: ${path}`
     );
   }
-  return segments.join('/');
 }
 
 function isSystemArchivePath(path: string): boolean {
@@ -110,34 +97,15 @@ function normalizeZipEntries(zipEntries: Record<string, Uint8Array>): Array<[str
 }
 
 function mapArchivePathToImportPath(archivePath: string): string {
-  const rootTarget = OPENCLAW_IMPORT_ROOT_FILES.get(archivePath);
-  if (rootTarget) {
-    return rootTarget;
-  }
-
-  if (!archivePath.startsWith(OPENCLAW_IMPORT_MEMORY_PREFIX)) {
+  const mapped = mapOpenclawZipPathToImportPath(archivePath);
+  if (!mapped) {
     throw new OpenclawWorkspaceZipError(
       'openclaw_import_invalid_path',
       `Unsupported zip file path: ${archivePath}`
     );
   }
 
-  const memoryRelativePath = archivePath.slice(OPENCLAW_IMPORT_MEMORY_PREFIX.length);
-  if (!memoryRelativePath || memoryRelativePath.endsWith('/')) {
-    throw new OpenclawWorkspaceZipError(
-      'openclaw_import_invalid_path',
-      `Unsupported zip file path: ${archivePath}`
-    );
-  }
-
-  if (!memoryRelativePath.toLowerCase().endsWith('.md')) {
-    throw new OpenclawWorkspaceZipError(
-      'openclaw_import_invalid_path',
-      `Only Markdown files are allowed under memory/: ${archivePath}`
-    );
-  }
-
-  return `${OPENCLAW_IMPORT_TARGET_MEMORY_PREFIX}${memoryRelativePath}`;
+  return mapped;
 }
 
 function decodeMarkdown(path: string, bytes: Uint8Array): string {
@@ -151,7 +119,7 @@ function decodeMarkdown(path: string, bytes: Uint8Array): string {
     );
   }
 
-  if (hasDisallowedControlChars(decoded)) {
+  if (!isOpenclawMarkdownContent(decoded)) {
     throw new OpenclawWorkspaceZipError(
       'openclaw_import_invalid_markdown',
       `File contains non-text content: ${path}`

--- a/apps/web/src/app/(app)/claw/components/openclaw-import-zip.ts
+++ b/apps/web/src/app/(app)/claw/components/openclaw-import-zip.ts
@@ -1,0 +1,314 @@
+import { unzipSync } from 'fflate';
+
+export const OPENCLAW_IMPORT_MAX_ZIP_BYTES = 5 * 1024 * 1024;
+export const OPENCLAW_IMPORT_MAX_FILES = 500;
+export const OPENCLAW_IMPORT_MAX_EXTRACTED_UTF8_BYTES = 5 * 1024 * 1024;
+export const OPENCLAW_IMPORT_MAX_FILE_UTF8_BYTES = 5 * 1024 * 1024;
+
+const OPENCLAW_IMPORT_ROOT_FILES = new Map([
+  ['USER.md', 'workspace/USER.md'],
+  ['SOUL.md', 'workspace/SOUL.md'],
+  ['IDENTITY.md', 'workspace/IDENTITY.md'],
+  ['MEMORY.md', 'workspace/MEMORY.md'],
+]);
+
+const OPENCLAW_IMPORT_MEMORY_PREFIX = 'memory/';
+const OPENCLAW_IMPORT_TARGET_MEMORY_PREFIX = 'workspace/memory/';
+
+export type OpenclawImportOs = 'windows' | 'macos' | 'linux';
+
+export type OpenclawWorkspaceImportFile = {
+  path: string;
+  content: string;
+};
+
+export type ParsedOpenclawWorkspaceZip = {
+  files: OpenclawWorkspaceImportFile[];
+  previewPaths: string[];
+  totalUtf8Bytes: number;
+};
+
+export type OpenclawZipCommand = {
+  command: string;
+};
+
+export class OpenclawWorkspaceZipError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'OpenclawWorkspaceZipError';
+    this.code = code;
+  }
+}
+
+const OPENCLAW_ZIP_COMMANDS: Record<OpenclawImportOs, OpenclawZipCommand> = {
+  windows: {
+    command:
+      '$w="$HOME\\.openclaw\\workspace";if(-not (Test-Path -LiteralPath $w -PathType Container)){Write-Error "Error: OpenClaw workspace folder not found at $w (expected ~/.openclaw/workspace).";exit 1};$p=@("$w\\USER.md","$w\\SOUL.md","$w\\IDENTITY.md","$w\\MEMORY.md","$w\\memory")|?{Test-Path -LiteralPath $_};Compress-Archive -Path $p -DestinationPath "$HOME\\Desktop\\openclaw-workspace.zip" -Force',
+  },
+  macos: {
+    command:
+      'w="$HOME/.openclaw/workspace";[ -d "$w" ] || { echo "Error: OpenClaw workspace folder not found at $w (expected ~/.openclaw/workspace)." >&2; exit 1; };cd "$w" || exit 1;set --;for f in USER.md SOUL.md IDENTITY.md MEMORY.md memory; do [ -e "$f" ] && set -- "$@" "$f"; done;[ "$#" -gt 0 ] || { echo "Error: No OpenClaw workspace files found at $w." >&2; exit 1; };o="$HOME/Desktop/openclaw-workspace.zip";rm -f "$o";zip -r "$o" "$@"',
+  },
+  linux: {
+    command:
+      'w="$HOME/.openclaw/workspace";[ -d "$w" ] || { echo "Error: OpenClaw workspace folder not found at $w (expected ~/.openclaw/workspace)." >&2; exit 1; };cd "$w" || exit 1;set --;for f in USER.md SOUL.md IDENTITY.md MEMORY.md memory; do [ -e "$f" ] && set -- "$@" "$f"; done;[ "$#" -gt 0 ] || { echo "Error: No OpenClaw workspace files found at $w." >&2; exit 1; };o="$HOME/Desktop/openclaw-workspace.zip";rm -f "$o";zip -r "$o" "$@"',
+  },
+};
+
+const textDecoder = new TextDecoder('utf-8', { fatal: true });
+
+function hasDisallowedControlChars(content: string): boolean {
+  for (const char of content) {
+    const code = char.codePointAt(0);
+    if (code === undefined) continue;
+    if (code === 0x09 || code === 0x0a || code === 0x0d) continue;
+    if ((code >= 0x00 && code <= 0x1f) || code === 0x7f) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function normalizeArchivePath(path: string): string {
+  const withForwardSlashes = path.replaceAll('\\', '/').replace(/^\.\//, '');
+  const segments = withForwardSlashes.split('/');
+  if (segments.some(segment => segment.length === 0 || segment === '.' || segment === '..')) {
+    throw new OpenclawWorkspaceZipError(
+      'openclaw_import_invalid_path',
+      `Unsupported zip file path: ${path}`
+    );
+  }
+  return segments.join('/');
+}
+
+function isSystemArchivePath(path: string): boolean {
+  const parts = path.split('/');
+  const baseName = parts[parts.length - 1]?.toLowerCase() ?? '';
+
+  if (parts.some(part => part === '__MACOSX')) return true;
+  if (parts.some(part => part.startsWith('.'))) return true;
+  if (baseName === 'thumbs.db' || baseName === 'desktop.ini') return true;
+
+  return false;
+}
+
+function normalizeZipEntries(zipEntries: Record<string, Uint8Array>): Array<[string, Uint8Array]> {
+  const normalized: Array<[string, Uint8Array]> = [];
+  for (const [rawPath, bytes] of Object.entries(zipEntries)) {
+    if (rawPath.endsWith('/')) continue;
+
+    const archivePath = normalizeArchivePath(rawPath);
+    if (isSystemArchivePath(archivePath)) continue;
+
+    normalized.push([archivePath, bytes]);
+  }
+
+  return normalized;
+}
+
+function mapArchivePathToImportPath(archivePath: string): string {
+  const rootTarget = OPENCLAW_IMPORT_ROOT_FILES.get(archivePath);
+  if (rootTarget) {
+    return rootTarget;
+  }
+
+  if (!archivePath.startsWith(OPENCLAW_IMPORT_MEMORY_PREFIX)) {
+    throw new OpenclawWorkspaceZipError(
+      'openclaw_import_invalid_path',
+      `Unsupported zip file path: ${archivePath}`
+    );
+  }
+
+  const memoryRelativePath = archivePath.slice(OPENCLAW_IMPORT_MEMORY_PREFIX.length);
+  if (!memoryRelativePath || memoryRelativePath.endsWith('/')) {
+    throw new OpenclawWorkspaceZipError(
+      'openclaw_import_invalid_path',
+      `Unsupported zip file path: ${archivePath}`
+    );
+  }
+
+  if (!memoryRelativePath.toLowerCase().endsWith('.md')) {
+    throw new OpenclawWorkspaceZipError(
+      'openclaw_import_invalid_path',
+      `Only Markdown files are allowed under memory/: ${archivePath}`
+    );
+  }
+
+  return `${OPENCLAW_IMPORT_TARGET_MEMORY_PREFIX}${memoryRelativePath}`;
+}
+
+function decodeMarkdown(path: string, bytes: Uint8Array): string {
+  let decoded: string;
+  try {
+    decoded = textDecoder.decode(bytes);
+  } catch {
+    throw new OpenclawWorkspaceZipError(
+      'openclaw_import_invalid_markdown',
+      `File is not valid UTF-8 Markdown: ${path}`
+    );
+  }
+
+  if (hasDisallowedControlChars(decoded)) {
+    throw new OpenclawWorkspaceZipError(
+      'openclaw_import_invalid_markdown',
+      `File contains non-text content: ${path}`
+    );
+  }
+
+  return decoded;
+}
+
+function parseZipBytes(buffer: Uint8Array): ParsedOpenclawWorkspaceZip {
+  let zipEntries: Record<string, Uint8Array>;
+  let expectedFileCount = 0;
+  let expectedUtf8Bytes = 0;
+
+  try {
+    zipEntries = unzipSync(buffer, {
+      filter(file) {
+        const normalizedRawName = file.name.replaceAll('\\', '/').replace(/^\.\//, '');
+        if (normalizedRawName.endsWith('/')) {
+          return false;
+        }
+
+        const archivePath = normalizeArchivePath(file.name);
+        if (isSystemArchivePath(archivePath)) {
+          return false;
+        }
+
+        expectedFileCount += 1;
+        if (expectedFileCount > OPENCLAW_IMPORT_MAX_FILES) {
+          throw new OpenclawWorkspaceZipError(
+            'openclaw_import_too_many_files',
+            `zip file contains more than ${OPENCLAW_IMPORT_MAX_FILES} files`
+          );
+        }
+
+        mapArchivePathToImportPath(archivePath);
+
+        if (file.originalSize > OPENCLAW_IMPORT_MAX_FILE_UTF8_BYTES) {
+          throw new OpenclawWorkspaceZipError(
+            'openclaw_import_too_large',
+            `File exceeds ${OPENCLAW_IMPORT_MAX_FILE_UTF8_BYTES} bytes: ${archivePath}`
+          );
+        }
+
+        expectedUtf8Bytes += file.originalSize;
+        if (expectedUtf8Bytes > OPENCLAW_IMPORT_MAX_EXTRACTED_UTF8_BYTES) {
+          throw new OpenclawWorkspaceZipError(
+            'openclaw_import_too_large',
+            `Extracted Markdown exceeds ${OPENCLAW_IMPORT_MAX_EXTRACTED_UTF8_BYTES} bytes`
+          );
+        }
+
+        return true;
+      },
+    });
+  } catch (error) {
+    if (error instanceof OpenclawWorkspaceZipError) {
+      throw error;
+    }
+    throw new OpenclawWorkspaceZipError('openclaw_import_invalid_zip', 'Failed to read zip file');
+  }
+
+  const entries = normalizeZipEntries(zipEntries);
+  const files: OpenclawWorkspaceImportFile[] = [];
+  const previewPaths: string[] = [];
+  const seenCaseInsensitivePaths = new Map<string, string>();
+  let totalUtf8Bytes = 0;
+
+  for (const [archivePath, bytes] of entries) {
+    const importPath = mapArchivePathToImportPath(archivePath);
+
+    const caseInsensitivePath = importPath.toLowerCase();
+    const existing = seenCaseInsensitivePaths.get(caseInsensitivePath);
+    if (existing) {
+      throw new OpenclawWorkspaceZipError(
+        'openclaw_import_path_case_conflict',
+        `zip file contains conflicting paths: ${existing} and ${importPath}`
+      );
+    }
+
+    const content = decodeMarkdown(archivePath, bytes);
+    if (bytes.byteLength > OPENCLAW_IMPORT_MAX_FILE_UTF8_BYTES) {
+      throw new OpenclawWorkspaceZipError(
+        'openclaw_import_too_large',
+        `File exceeds ${OPENCLAW_IMPORT_MAX_FILE_UTF8_BYTES} bytes: ${archivePath}`
+      );
+    }
+
+    totalUtf8Bytes += bytes.byteLength;
+    if (totalUtf8Bytes > OPENCLAW_IMPORT_MAX_EXTRACTED_UTF8_BYTES) {
+      throw new OpenclawWorkspaceZipError(
+        'openclaw_import_too_large',
+        `Extracted Markdown exceeds ${OPENCLAW_IMPORT_MAX_EXTRACTED_UTF8_BYTES} bytes`
+      );
+    }
+
+    seenCaseInsensitivePaths.set(caseInsensitivePath, importPath);
+    files.push({ path: importPath, content });
+    previewPaths.push(archivePath);
+  }
+
+  if (files.length === 0) {
+    throw new OpenclawWorkspaceZipError(
+      'openclaw_import_no_files',
+      'zip file contains no valid OpenClaw workspace files'
+    );
+  }
+
+  if (files.length > OPENCLAW_IMPORT_MAX_FILES) {
+    throw new OpenclawWorkspaceZipError(
+      'openclaw_import_too_many_files',
+      `zip file contains more than ${OPENCLAW_IMPORT_MAX_FILES} files`
+    );
+  }
+
+  const sortedPreviewPaths = [...previewPaths].sort((a, b) =>
+    a.toLowerCase().localeCompare(b.toLowerCase())
+  );
+
+  return {
+    files,
+    previewPaths: sortedPreviewPaths,
+    totalUtf8Bytes,
+  };
+}
+
+export async function parseOpenclawWorkspaceZipFile(
+  file: File
+): Promise<ParsedOpenclawWorkspaceZip> {
+  if (file.size > OPENCLAW_IMPORT_MAX_ZIP_BYTES) {
+    throw new OpenclawWorkspaceZipError(
+      'openclaw_import_zip_too_large',
+      `zip file exceeds ${OPENCLAW_IMPORT_MAX_ZIP_BYTES} bytes`
+    );
+  }
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  return parseZipBytes(bytes);
+}
+
+export function parseOpenclawWorkspaceZipBytes(bytes: Uint8Array): ParsedOpenclawWorkspaceZip {
+  if (bytes.byteLength > OPENCLAW_IMPORT_MAX_ZIP_BYTES) {
+    throw new OpenclawWorkspaceZipError(
+      'openclaw_import_zip_too_large',
+      `zip file exceeds ${OPENCLAW_IMPORT_MAX_ZIP_BYTES} bytes`
+    );
+  }
+  return parseZipBytes(bytes);
+}
+
+export function detectOpenclawImportOs(userAgent: string): OpenclawImportOs {
+  const ua = userAgent.toLowerCase();
+  if (ua.includes('windows')) return 'windows';
+  if (ua.includes('macintosh') || ua.includes('mac os')) return 'macos';
+  return 'linux';
+}
+
+export function getOpenclawZipCommandForOs(os: OpenclawImportOs): OpenclawZipCommand {
+  return OPENCLAW_ZIP_COMMANDS[os];
+}

--- a/apps/web/src/app/(app)/claw/components/openclaw-import-zip.ts
+++ b/apps/web/src/app/(app)/claw/components/openclaw-import-zip.ts
@@ -7,7 +7,7 @@ import {
   mapOpenclawZipPathToImportPath,
   normalizeOpenclawImportPath,
   isOpenclawMarkdownContent,
-} from '@kilocode/worker-utils/openclaw-import';
+} from '../../../../../../../services/kiloclaw/controller/src/openclaw-import';
 
 export {
   OPENCLAW_IMPORT_MAX_EXTRACTED_UTF8_BYTES,

--- a/apps/web/src/hooks/useKiloClaw.ts
+++ b/apps/web/src/hooks/useKiloClaw.ts
@@ -314,6 +314,18 @@ export function useKiloClawMutations() {
         },
       })
     ),
+    importOpenclawWorkspace: useMutation(
+      trpc.kiloclaw.importOpenclawWorkspace.mutationOptions({
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.fileTree.queryKey(),
+          });
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.readFile.queryKey(),
+          });
+        },
+      })
+    ),
     patchExecPreset: useMutation(
       trpc.kiloclaw.patchExecPreset.mutationOptions({ onSuccess: invalidateStatus })
     ),

--- a/apps/web/src/hooks/useOrgKiloClaw.ts
+++ b/apps/web/src/hooks/useOrgKiloClaw.ts
@@ -368,6 +368,18 @@ export function useOrgKiloClawMutations(
       },
     })
   );
+  const rawImportOpenclawWorkspace = useMutation(
+    trpc.organizations.kiloclaw.importOpenclawWorkspace.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: trpc.organizations.kiloclaw.fileTree.queryKey(),
+        });
+        await queryClient.invalidateQueries({
+          queryKey: trpc.organizations.kiloclaw.readFile.queryKey(),
+        });
+      },
+    })
+  );
   const rawPatchExecPreset = useMutation(
     trpc.organizations.kiloclaw.patchExecPreset.mutationOptions({ onSuccess: invalidateStatus })
   );
@@ -432,6 +444,7 @@ export function useOrgKiloClawMutations(
     setMyPin: bind(rawSetMyPin),
     removeMyPin: bindVoid(rawRemoveMyPin),
     writeFile: bind(rawWriteFile),
+    importOpenclawWorkspace: bind(rawImportOpenclawWorkspace),
     patchExecPreset: bind(rawPatchExecPreset),
     patchWebSearchConfig: bind(rawPatchWebSearchConfig),
     patchBotIdentity: bind(rawPatchBotIdentity),

--- a/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -23,6 +23,7 @@ import type {
   DevicePairingApproveResponse,
   VolumeSnapshotsResponse,
   DoctorResponse,
+  OpenclawWorkspaceImportResponse,
   KiloCliRunStartResponse,
   KiloCliRunStatusResponse,
   GatewayProcessStatusResponse,
@@ -613,6 +614,18 @@ export class KiloClawInternalClient {
     return this.request(`/api/platform/files/write${params}`, {
       method: 'POST',
       body: JSON.stringify({ userId, path: filePath, content, etag }),
+    });
+  }
+
+  async importOpenclawWorkspace(
+    userId: string,
+    files: Array<{ path: string; content: string }>,
+    instanceId?: string
+  ): Promise<OpenclawWorkspaceImportResponse> {
+    const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
+    return this.request(`/api/platform/files/import-openclaw-workspace${params}`, {
+      method: 'POST',
+      body: JSON.stringify({ userId, files }),
     });
   }
 

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -320,6 +320,24 @@ export type DoctorResponse = {
   output: string;
 };
 
+export type OpenclawWorkspaceImportFailure = {
+  path: string;
+  operation: 'write' | 'delete';
+  error: string;
+  code?: string;
+};
+
+export type OpenclawWorkspaceImportResponse = {
+  ok: boolean;
+  attemptedWriteCount: number;
+  writtenCount: number;
+  attemptedDeleteCount: number;
+  deletedCount: number;
+  failedCount: number;
+  totalUtf8Bytes: number;
+  failures: OpenclawWorkspaceImportFailure[];
+};
+
 /** Response from POST /api/platform/kilo-cli-run/start */
 export type KiloCliRunStartResponse = {
   ok: boolean;

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -101,7 +101,13 @@ import { IMPACT_ORDER_ID_MACRO } from '@/lib/impact';
  * Error codes whose messages may contain raw internal details (e.g. filesystem
  * paths) and should NOT be forwarded to the client.
  */
-const UNSAFE_ERROR_CODES = new Set(['config_read_failed', 'config_replace_failed']);
+const UNSAFE_ERROR_CODES = new Set([
+  'config_read_failed',
+  'config_replace_failed',
+  'openclaw_import_symlink_escape',
+  'openclaw_import_symlink_target',
+  'openclaw_import_target_not_file',
+]);
 const KILOCLAW_USER_SUBSCRIPTION_CHANGE_REASON = {
   cancelRequested: 'user_requested_cancellation',
   reactivated: 'user_reactivated_subscription',
@@ -3381,6 +3387,34 @@ export const kiloclawRouter = createTRPCRouter({
         );
       } catch (err) {
         handleFileOperationError(err, 'write file');
+      }
+    }),
+
+  importOpenclawWorkspace: clawAccessProcedure
+    .input(
+      z.object({
+        files: z
+          .array(
+            z.object({
+              path: z.string().min(1),
+              content: z.string(),
+            })
+          )
+          .min(1)
+          .max(500),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const instance = await getActiveInstance(ctx.user.id);
+        const client = new KiloClawInternalClient();
+        return await client.importOpenclawWorkspace(
+          ctx.user.id,
+          input.files,
+          workerInstanceId(instance)
+        );
+      } catch (err) {
+        handleFileOperationError(err, 'import OpenClaw workspace');
       }
     }),
 

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -53,7 +53,13 @@ import PostHogClient from '@/lib/posthog';
 import { CHANGELOG_ENTRIES } from '@/app/(app)/claw/components/changelog-data';
 
 /** Error codes whose messages may contain raw internal details. */
-const UNSAFE_ERROR_CODES = new Set(['config_read_failed', 'config_replace_failed']);
+const UNSAFE_ERROR_CODES = new Set([
+  'config_read_failed',
+  'config_replace_failed',
+  'openclaw_import_symlink_escape',
+  'openclaw_import_symlink_target',
+  'openclaw_import_target_not_file',
+]);
 
 function getKiloClawApiErrorPayload(err: KiloClawApiError): { message?: string; code?: string } {
   if (!err.responseBody) return {};
@@ -1368,6 +1374,35 @@ export const organizationKiloclawRouter = createTRPCRouter({
         );
       } catch (err) {
         handleFileOperationError(err, 'write file');
+      }
+    }),
+
+  importOpenclawWorkspace: organizationMemberMutationProcedure
+    .input(
+      z.object({
+        organizationId: z.uuid(),
+        files: z
+          .array(
+            z.object({
+              path: z.string().min(1),
+              content: z.string(),
+            })
+          )
+          .min(1)
+          .max(500),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
+        const client = new KiloClawInternalClient();
+        return await client.importOpenclawWorkspace(
+          ctx.user.id,
+          input.files,
+          workerInstanceId(instance)
+        );
+      } catch (err) {
+        handleFileOperationError(err, 'import OpenClaw workspace');
       }
     }),
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -675,6 +675,9 @@ importers:
       eventsource-parser:
         specifier: ^3.0.6
         version: 3.0.6
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
       form-data:
         specifier: ^4.0.5
         version: 4.0.5

--- a/services/kiloclaw/src/durable-objects/gateway-controller-types.ts
+++ b/services/kiloclaw/src/durable-objects/gateway-controller-types.ts
@@ -81,6 +81,24 @@ export const ToolsMdSectionSyncResponseSchema = z.object({
   enabled: z.boolean(),
 });
 
+export const OpenclawWorkspaceImportFailureSchema = z.object({
+  path: z.string(),
+  operation: z.enum(['write', 'delete']),
+  error: z.string(),
+  code: z.string().optional(),
+});
+
+export const OpenclawWorkspaceImportResponseSchema = z.object({
+  ok: z.boolean(),
+  attemptedWriteCount: z.number().int().min(0),
+  writtenCount: z.number().int().min(0),
+  attemptedDeleteCount: z.number().int().min(0),
+  deletedCount: z.number().int().min(0),
+  failedCount: z.number().int().min(0),
+  totalUtf8Bytes: z.number().int().min(0),
+  failures: z.array(OpenclawWorkspaceImportFailureSchema),
+});
+
 export class GatewayControllerError extends Error {
   readonly status: number;
   readonly code: string | null;

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -13,6 +13,7 @@ import {
   EnvPatchResponseSchema,
   ToolsMdSectionSyncResponseSchema,
   OpenclawConfigResponseSchema,
+  OpenclawWorkspaceImportResponseSchema,
   GatewayControllerError,
 } from '../gateway-controller-types';
 import { HEALTH_PROBE_TIMEOUT_SECONDS, HEALTH_PROBE_INTERVAL_MS } from '../../config';
@@ -440,6 +441,26 @@ export async function writeFile(
       'POST',
       FileWriteResponseSchema,
       { path: filePath, content, etag }
+    );
+  } catch (error) {
+    if (isErrorUnknownRoute(error)) return null;
+    throw error;
+  }
+}
+
+export async function importOpenclawWorkspace(
+  state: InstanceMutableState,
+  env: KiloClawEnv,
+  files: Array<{ path: string; content: string }>
+): Promise<z.infer<typeof OpenclawWorkspaceImportResponseSchema> | null> {
+  try {
+    return await callGatewayController(
+      state,
+      env,
+      '/_kilo/files/import-openclaw-workspace',
+      'POST',
+      OpenclawWorkspaceImportResponseSchema,
+      { files }
     );
   } catch (error) {
     if (isErrorUnknownRoute(error)) return null;

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -2821,6 +2821,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     return gateway.writeFile(this.s, this.env, filePath, content, etag);
   }
 
+  async importOpenclawWorkspace(files: Array<{ path: string; content: string }>) {
+    await this.loadState();
+    return gateway.importOpenclawWorkspace(this.s, this.env, files);
+  }
+
   // ── Restart machine (user-facing) ──────────────────────────────────
 
   async restartMachine(options?: {

--- a/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
+++ b/services/kiloclaw/src/routes/platform-sanitize-error.test.ts
@@ -426,3 +426,198 @@ describe('sanitizeError: explicit provider support errors', () => {
     expect(provision).not.toHaveBeenCalled();
   });
 });
+
+describe('openclaw import platform route', () => {
+  function envWithImportOpenclawWorkspace(
+    importOpenclawWorkspace: (files: Array<{ path: string; content: string }>) => Promise<unknown>,
+    getStatus: () => Promise<{ status: string }> | { status: string } = async () => ({
+      status: 'running',
+    })
+  ) {
+    return {
+      KILOCLAW_INSTANCE: {
+        idFromName: (id: string) => id,
+        get: () => ({ importOpenclawWorkspace, getStatus }),
+      },
+      KILOCLAW_AE: { writeDataPoint: vi.fn() },
+      KV_CLAW_CACHE: {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        list: vi.fn().mockResolvedValue({ keys: [], list_complete: true }),
+        getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null }),
+      },
+    } as never;
+  }
+
+  it('returns 400 for malformed body', async () => {
+    const env = envWithImportOpenclawWorkspace(async () => ({ ok: true }));
+
+    const resp = await platform.request(
+      '/files/import-openclaw-workspace',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: 'user-1', files: [{ path: 123, content: true }] }),
+      },
+      env
+    );
+
+    expect(resp.status).toBe(400);
+    await expect(jsonBody(resp)).resolves.toEqual(
+      expect.objectContaining({ error: 'Invalid request' })
+    );
+  });
+
+  it('returns 400 when files exceeds max count', async () => {
+    const importOpenclawWorkspace = vi.fn().mockResolvedValue({ ok: true });
+    const env = envWithImportOpenclawWorkspace(importOpenclawWorkspace);
+
+    const files = Array.from({ length: 501 }, (_, idx) => ({
+      path: `workspace/memory/note-${idx}.md`,
+      content: '# note',
+    }));
+
+    const resp = await platform.request(
+      '/files/import-openclaw-workspace',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: 'user-1', files }),
+      },
+      env
+    );
+
+    expect(resp.status).toBe(400);
+    await expect(jsonBody(resp)).resolves.toEqual(
+      expect.objectContaining({ error: 'Invalid request' })
+    );
+    expect(importOpenclawWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('forwards import payload to DO and returns the response', async () => {
+    const importOpenclawWorkspace = vi.fn().mockResolvedValue({
+      ok: true,
+      attemptedWriteCount: 2,
+      writtenCount: 2,
+      attemptedDeleteCount: 0,
+      deletedCount: 0,
+      failedCount: 0,
+      totalUtf8Bytes: 42,
+      failures: [],
+    });
+
+    const env = envWithImportOpenclawWorkspace(importOpenclawWorkspace);
+
+    const resp = await platform.request(
+      '/files/import-openclaw-workspace?instanceId=11111111-1111-4111-8111-111111111111',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          userId: 'user-1',
+          files: [
+            { path: 'workspace/USER.md', content: '# User' },
+            { path: 'workspace/MEMORY.md', content: '# Memory' },
+          ],
+        }),
+      },
+      env
+    );
+
+    expect(resp.status).toBe(200);
+    await expect(jsonBody(resp)).resolves.toEqual({
+      ok: true,
+      attemptedWriteCount: 2,
+      writtenCount: 2,
+      attemptedDeleteCount: 0,
+      deletedCount: 0,
+      failedCount: 0,
+      totalUtf8Bytes: 42,
+      failures: [],
+    });
+    expect(importOpenclawWorkspace).toHaveBeenCalledWith([
+      { path: 'workspace/USER.md', content: '# User' },
+      { path: 'workspace/MEMORY.md', content: '# Memory' },
+    ]);
+  });
+
+  it('returns 404 controller_route_unavailable when DO returns null', async () => {
+    const env = envWithImportOpenclawWorkspace(async () => null);
+
+    const resp = await platform.request(
+      '/files/import-openclaw-workspace',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          userId: 'user-1',
+          files: [{ path: 'workspace/USER.md', content: '# User' }],
+        }),
+      },
+      env
+    );
+
+    expect(resp.status).toBe(404);
+    await expect(jsonBody(resp)).resolves.toEqual({
+      error: 'OpenClaw import not available (controller too old)',
+      code: 'controller_route_unavailable',
+    });
+  });
+
+  it('returns 503 when instance is not running', async () => {
+    const importOpenclawWorkspace = vi.fn().mockResolvedValue({ ok: true });
+    const env = envWithImportOpenclawWorkspace(importOpenclawWorkspace, async () => ({
+      status: 'stopped',
+    }));
+
+    const resp = await platform.request(
+      '/files/import-openclaw-workspace',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          userId: 'user-1',
+          files: [{ path: 'workspace/USER.md', content: '# User' }],
+        }),
+      },
+      env
+    );
+
+    expect(resp.status).toBe(503);
+    await expect(jsonBody(resp)).resolves.toEqual({
+      error: 'Instance is not running',
+      code: 'instance_not_running',
+    });
+    expect(importOpenclawWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('passes through sanitized openclaw import error code', async () => {
+    const upstream = Object.assign(new Error('Import exceeds byte limit'), {
+      status: 400,
+      code: 'openclaw_import_too_large',
+    });
+    const env = envWithImportOpenclawWorkspace(async () => {
+      throw upstream;
+    });
+
+    const resp = await platform.request(
+      '/files/import-openclaw-workspace',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          userId: 'user-1',
+          files: [{ path: 'workspace/USER.md', content: '# User' }],
+        }),
+      },
+      env
+    );
+
+    expect(resp.status).toBe(400);
+    await expect(jsonBody(resp)).resolves.toEqual({
+      error: 'Import exceeds byte limit',
+      code: 'openclaw_import_too_large',
+    });
+  });
+});

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -777,6 +777,10 @@ const OPENCLAW_CONFIG_ERROR_CODES = new Set([
   'invalid_request_body',
 ]);
 
+function isSafeOpenclawConfigCode(code: string): boolean {
+  return OPENCLAW_CONFIG_ERROR_CODES.has(code) || code.startsWith('openclaw_import_');
+}
+
 function sanitizeOpenclawConfigError(
   err: unknown,
   operation: string
@@ -788,7 +792,7 @@ function sanitizeOpenclawConfigError(
 
   console.error(`[platform] ${operation} failed:`, raw);
 
-  if (code && OPENCLAW_CONFIG_ERROR_CODES.has(code)) {
+  if (code && isSafeOpenclawConfigCode(code)) {
     return { message: normalized, status, code };
   }
 
@@ -1978,6 +1982,19 @@ const WriteFileSchema = z.object({
   etag: z.string().optional(),
 });
 
+const OpenclawWorkspaceImportSchema = z.object({
+  userId: z.string().min(1),
+  files: z
+    .array(
+      z.object({
+        path: z.string().min(1),
+        content: z.string(),
+      })
+    )
+    .min(1)
+    .max(500),
+});
+
 // POST /api/platform/files/write
 platform.post('/files/write', async c => {
   const result = await parseBody(c, WriteFileSchema);
@@ -2005,6 +2022,53 @@ platform.post('/files/write', async c => {
     return c.json(response, 200);
   } catch (err) {
     const { message, status, code } = sanitizeOpenclawConfigError(err, 'files/write');
+    return jsonError(message, status, code);
+  }
+});
+
+// POST /api/platform/files/import-openclaw-workspace
+platform.post('/files/import-openclaw-workspace', async c => {
+  const result = await parseBody(c, OpenclawWorkspaceImportSchema);
+  if ('error' in result) return result.error;
+
+  const iidResult = parseInstanceIdQuery(c);
+  if ('error' in iidResult) return iidResult.error;
+
+  const { userId, files } = result.data;
+
+  try {
+    const status = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
+      stub => stub.getStatus(),
+      'getStatus'
+    );
+
+    if (status.status !== 'running') {
+      return jsonError('Instance is not running', 503, 'instance_not_running');
+    }
+
+    const response = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
+      stub => stub.importOpenclawWorkspace(files),
+      'importOpenclawWorkspace'
+    );
+    if (!response) {
+      return jsonError(
+        'OpenClaw import not available (controller too old)',
+        404,
+        'controller_route_unavailable'
+      );
+    }
+    return c.json(response, 200);
+  } catch (err) {
+    const { message, status, code } = sanitizeOpenclawConfigError(
+      err,
+      'files/import-openclaw-workspace'
+    );
     return jsonError(message, status, code);
   }
 });


### PR DESCRIPTION
## Summary

Adds the OpenClaw import product flow on top of the controller route introduced in the base PR.

Platform + instance wiring:
- Adds platform endpoint for OpenClaw workspace import.
- Validates request shape at platform boundary (including `.max(500)` files defense-in-depth).
- Calls through Durable Object -> gateway controller import route.
- Preserves/propagates sanitized import error codes.
- Restarts the KiloClaw gateway after import completes.

Web dashboard UX:
- Adds **OpenClaw Import** card under OpenClaw Instance settings.
- Card-level drag/drop + browse single-file zip selection UX.
- Confirmation modal text updated to indicate restart.
- Preview list + confirmation flow.
- Import completion toast copy:
  - Success: `OpenClaw import complete. Restarting KiloClaw.`
  - Partial/failures: same prefix plus count breakdown.
- Resets card state back to initial state after import finishes.
- OS-specific helper command text for generating the import zip file.
- Controller-version gating in settings using placeholder `OPENCLAW_IMPORT_UI_MIN_CONTROLLER_VERSION`.

## Verification

- `pnpm format`
- `pnpm --filter kiloclaw test -- src/routes/platform-sanitize-error.test.ts`
- `pnpm --filter web test -- openclaw-import-zip.test.ts`

## Visual Changes
<img width="1163" height="364" alt="Screenshot 2026-04-22 at 12 37 49 AM" src="https://github.com/user-attachments/assets/8e76ba8e-a1c0-492b-a33d-2b185262f2c5" />
<img width="1108" height="364" alt="Screenshot 2026-04-22 at 12 37 55 AM" src="https://github.com/user-attachments/assets/53c506c4-f556-4321-9d19-c71feadb07e6" />
<img width="537" height="342" alt="Screenshot 2026-04-22 at 12 38 09 AM" src="https://github.com/user-attachments/assets/f849cb91-7bdb-4794-8528-58cee6ce414f" />
<img width="912" height="370" alt="Screenshot 2026-04-22 at 12 39 30 AM" src="https://github.com/user-attachments/assets/3ba04c55-7734-49f3-a4cb-19ec15764344" />

## Reviewer Notes

- This is PR 2 in a stacked pair and depends on the controller PR.
- Base branch is `feat/openclaw-import-controller`.
- Placeholder gate constant in web:
  - `apps/web/src/app/(app)/claw/components/SettingsTab.tsx`
  - `OPENCLAW_IMPORT_UI_MIN_CONTROLLER_VERSION = '2000.1.1'`
- Once controller image/version is deployed, update that value before production rollout.
