### PR TITLE
fix(kilo-auto): inject openrouter middle-out transform for minimax-m2.5:free

### DIFF
--- a/apps/web/src/lib/kilo-auto/resolution.test.ts
+++ b/apps/web/src/lib/kilo-auto/resolution.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from '@jest/globals';
+import { applyResolvedAutoModel } from './resolution';
+import { KILO_AUTO_FREE_MODEL, KILO_AUTO_BALANCED_MODEL } from '@/lib/kilo-auto';
+import { minimax_m25_free_model } from '@/lib/ai-gateway/providers/minimax';
+import type {
+  GatewayRequest,
+  OpenRouterChatCompletionRequest,
+} from '@/lib/ai-gateway/providers/openrouter/types';
+
+function chatCompletionsRequest(
+  overrides: Partial<OpenRouterChatCompletionRequest> = {}
+): GatewayRequest {
+  return {
+    kind: 'chat_completions',
+    body: {
+      model: KILO_AUTO_FREE_MODEL.id,
+      messages: [],
+      ...overrides,
+    },
+  };
+}
+
+describe('applyResolvedAutoModel - middle-out transform for minimax-m2.5:free', () => {
+  it('injects transforms: ["middle-out"] when kilo-auto/free resolves to minimax on chat_completions', async () => {
+    const request = chatCompletionsRequest();
+
+    await applyResolvedAutoModel(
+      {
+        model: KILO_AUTO_FREE_MODEL.id,
+        modeHeader: null,
+        featureHeader: null,
+        sessionId: null, // ensures resolution bypasses stepfun routing
+        apiKind: 'chat_completions',
+      },
+      request,
+      Promise.resolve(null),
+      Promise.resolve(0)
+    );
+
+    expect(request.body.model).toBe(minimax_m25_free_model.public_id);
+    expect((request.body as OpenRouterChatCompletionRequest).transforms).toEqual(['middle-out']);
+  });
+
+  it('does not overwrite transforms already set by the caller', async () => {
+    const request = chatCompletionsRequest({ transforms: ['some-custom-transform'] });
+
+    await applyResolvedAutoModel(
+      {
+        model: KILO_AUTO_FREE_MODEL.id,
+        modeHeader: null,
+        featureHeader: null,
+        sessionId: null,
+        apiKind: 'chat_completions',
+      },
+      request,
+      Promise.resolve(null),
+      Promise.resolve(0)
+    );
+
+    expect(request.body.model).toBe(minimax_m25_free_model.public_id);
+    expect((request.body as OpenRouterChatCompletionRequest).transforms).toEqual([
+      'some-custom-transform',
+    ]);
+  });
+
+  it('treats an empty transforms array as unset and injects middle-out', async () => {
+    const request = chatCompletionsRequest({ transforms: [] });
+
+    await applyResolvedAutoModel(
+      {
+        model: KILO_AUTO_FREE_MODEL.id,
+        modeHeader: null,
+        featureHeader: null,
+        sessionId: null,
+        apiKind: 'chat_completions',
+      },
+      request,
+      Promise.resolve(null),
+      Promise.resolve(0)
+    );
+
+    expect((request.body as OpenRouterChatCompletionRequest).transforms).toEqual(['middle-out']);
+  });
+
+  it('does not inject transforms when the resolved model is not minimax-m2.5:free', async () => {
+    const request = chatCompletionsRequest({ model: KILO_AUTO_BALANCED_MODEL.id });
+
+    await applyResolvedAutoModel(
+      {
+        model: KILO_AUTO_BALANCED_MODEL.id,
+        modeHeader: null,
+        featureHeader: null,
+        sessionId: null,
+        apiKind: 'chat_completions',
+      },
+      request,
+      Promise.resolve(null),
+      Promise.resolve(0)
+    );
+
+    expect(request.body.model).not.toBe(minimax_m25_free_model.public_id);
+    expect((request.body as OpenRouterChatCompletionRequest).transforms).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/kilo-auto/resolution.ts
+++ b/apps/web/src/lib/kilo-auto/resolution.ts
@@ -92,6 +92,23 @@ export async function applyResolvedAutoModel(
 ) {
   const resolved = await resolveAutoModel(params, userPromise, balancePromise);
   request.body.model = resolved.model;
+
+  // The minimax/minimax-m2.5:free backing model has a 204,800-token context window that
+  // code-agent workloads (large system prompts + tool definitions + file reads) routinely
+  // clip by single-digit percent margins, causing openrouter to return 400
+  // "context length exceeded". Inject openrouter's `middle-out` transform so over-budget
+  // prompts are auto-compressed upstream instead of rejected. Only applies to chat
+  // completions (the transform is a chat-completions feature), and only when the caller
+  // hasn't already set `transforms` (respect explicit opt-outs / custom transforms).
+  // See incidents/2026-04-21-minimax-m2.5-slo-breach-context-length.md in kilo-org/on-call.
+  if (
+    resolved.model === minimax_m25_free_model.public_id &&
+    request.kind === 'chat_completions' &&
+    !request.body.transforms?.length
+  ) {
+    request.body.transforms = ['middle-out'];
+  }
+
   if (resolved.reasoning) {
     if (request.kind === 'messages') {
       request.body.thinking = { type: resolved.reasoning.enabled ? 'adaptive' : 'disabled' };


### PR DESCRIPTION
## Summary

- Inject openrouter's `transforms: ["middle-out"]` when `kilo-auto/free` resolves to `minimax/minimax-m2.5:free` on chat completions, so over-budget prompts are auto-compressed upstream rather than rejected with HTTP 400 "context length exceeded".
- Only applied when the caller has not already set `transforms` (respects explicit opt-outs / custom transforms).
- Unit tests for the four behaviours: positive injection, no-overwrite, empty-array treated as unset, and no injection when the resolved model is not minimax.

## Why

PAGE `LLM Error Rate SLO Breach` fired 2026-04-21 22:55 UTC for `openrouter / minimax/minimax-m2.5` (12.18% / 6.1x burn / 30min). Follow-up TICKETs at 01:27 and 05:28 UTC overnight. The underlying condition is chronic: minimax-m2.5 SLO TICKETs have been firing every ~4h continuously since **2026-04-19**, with sustained 4–7% error rate on the 360min window.

100% of sampled errors are openrouter 400s of the form:

> "This endpoint's maximum context length is 204800 tokens. However, you requested about 205–212k tokens (~160k text input + ~12k tool input + 32k output). Please reduce the length of either one, or use the context-compression plugin to compress your prompt automatically."

`minimax/minimax-m2.5:free` is the backing model for `kilo-auto/free` (reverted to from `xiaomi/mimo-v2-pro:free` on 2026-04-02 because qwen3.6 was overloaded). It has a 204,800-token context cap. Code-agent workloads (large system prompts + tool definitions + conversation history + file reads) routinely overshoot this cap by single-digit percent margins. Callers don't set `transforms` themselves (99% of affected traffic is `opencode-kilo-provider/7.2.14` + `7.2.17`), so upstream compression never kicks in.

Investigation details, blast radius (25,881 errors in 9h; 61% anon, 39% authenticated; 99.1% from `opencode-kilo-provider/7.2.x`), and alternative fix options are in `incidents/2026-04-21-minimax-m2.5-slo-breach-context-length.md` in `Kilo-Org/on-call`.

## How

`apps/web/src/lib/kilo-auto/resolution.ts` — after `applyResolvedAutoModel` sets the resolved model ID, check if the resolved model is `minimax_m25_free_model.public_id`, the request is `chat_completions`, and no `transforms` are already set. If so, set `request.body.transforms = ['middle-out']`.

No type surface changes. The `transforms?: string[]` field already exists on `OpenRouterChatCompletionRequest`.

Scope is cleanly bounded because `minimax/minimax-m2.5:free` is in `forbiddenFreeModelIds` (`apps/web/src/lib/ai-gateway/forbidden-free-models.ts:25`), so the only path that reaches openrouter with this model ID is via kilo-auto/free — which is exactly what this code path handles.

## Tradeoff

`middle-out` drops content from the middle of prompts when over-budget. For code agents that is typically intermediate tool outputs and older conversation turns — response quality may suffer slightly for heavily-over-budget prompts. This is preferred over the current behaviour (the request fails entirely), especially on a free model where users have no financial incentive to self-truncate.

Users can still opt out by setting `transforms: []` or `transforms: [...something-else]` explicitly.

## Verification

- `pnpm --filter web test -- src/lib/kilo-auto/resolution.test.ts` -> 4/4 passing
- `pnpm --filter web typecheck` -> clean
- `pnpm --filter web lint` -> 0 warnings, 0 errors

## Follow-ups (not in this PR)

- Move `estimateTokenCount` (currently only used in the post-flight error rewriter at `apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts:202`) to the pre-flight path, so we skip wasted roundtrips even when `middle-out` would over-compress.
- Consider raising `STEP_FLASH_ROUTING_PERCENTAGE` (currently 20) to push more kilo-auto/free traffic to `stepfun` (262k context) until context pressure on minimax eases.
- Alert tuning: this alert has been firing every 4h for 3+ days without action - either auto-silence during known-noisy conditions or stratify SLO by "provider availability" vs "client input validity".