### PR TITLE
refactor(claw): centralize onboarding step progress

### DIFF
--- a/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/BotIdentityStep.tsx
@@ -68,9 +68,13 @@ export type BotIdentityStepResult = {
 };
 
 export function BotIdentityStep({
+  currentStep,
+  totalSteps,
   instanceRunning,
   onContinue,
 }: {
+  currentStep: number;
+  totalSteps: number;
   instanceRunning: boolean;
   onContinue: (result: BotIdentityStepResult) => void;
 }) {
@@ -139,8 +143,8 @@ export function BotIdentityStep({
 
   return (
     <OnboardingStepView
-      currentStep={1}
-      totalSteps={4}
+      currentStep={currentStep}
+      totalSteps={totalSteps}
       title="Give your bot an identity"
       description="Make it yours. You can always change this later."
       showProvisioningBanner={!instanceRunning}

--- a/apps/web/src/app/(app)/claw/components/ChannelPairingStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/ChannelPairingStep.tsx
@@ -24,11 +24,15 @@ const CHANNEL_META: Record<PairingChannelId, { label: string; instruction: strin
 };
 
 export function ChannelPairingStep({
+  currentStep,
+  totalSteps,
   channelId,
   mutations,
   onComplete,
   onSkip,
 }: {
+  currentStep: number;
+  totalSteps: number;
   channelId: PairingChannelId;
   mutations: ClawMutations;
   onComplete: () => void;
@@ -96,6 +100,8 @@ export function ChannelPairingStep({
 
   return (
     <ChannelPairingStepView
+      currentStep={currentStep}
+      totalSteps={totalSteps}
       channelId={channelId}
       matchingRequest={displayedRequest ?? null}
       isApproving={isApproving}
@@ -106,6 +112,8 @@ export function ChannelPairingStep({
 }
 
 type ChannelPairingStepViewProps = {
+  currentStep: number;
+  totalSteps: number;
   channelId: PairingChannelId;
   matchingRequest: { code: string; channel: string; id: string } | null;
   isApproving?: boolean;
@@ -114,6 +122,8 @@ type ChannelPairingStepViewProps = {
 };
 
 export function ChannelPairingStepView({
+  currentStep,
+  totalSteps,
   channelId,
   matchingRequest,
   isApproving = false,
@@ -125,8 +135,8 @@ export function ChannelPairingStepView({
   if (matchingRequest) {
     return (
       <OnboardingStepView
-        currentStep={5}
-        totalSteps={5}
+        currentStep={currentStep}
+        totalSteps={totalSteps}
         title={`Pair your ${meta.label} bot`}
         description={meta.instruction}
         contentClassName="gap-6"
@@ -186,8 +196,8 @@ export function ChannelPairingStepView({
 
   return (
     <OnboardingStepView
-      currentStep={5}
-      totalSteps={5}
+      currentStep={currentStep}
+      totalSteps={totalSteps}
       title={`Pair your ${meta.label} bot`}
       description={meta.instruction}
       contentClassName="gap-8"

--- a/apps/web/src/app/(app)/claw/components/ChannelSelectionStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/ChannelSelectionStep.tsx
@@ -95,11 +95,15 @@ function pickChannelTokens(
 }
 
 export function ChannelSelectionStepView({
+  currentStep,
+  totalSteps,
   instanceRunning,
   onSelect,
   onSkip,
   defaultSelected = null,
 }: {
+  currentStep: number;
+  totalSteps: number;
   instanceRunning?: boolean;
   onSelect?: (channelId: ChannelId, tokens: Record<string, string>) => void;
   onSkip?: () => void;
@@ -140,8 +144,8 @@ export function ChannelSelectionStepView({
 
   return (
     <OnboardingStepView
-      currentStep={3}
-      totalSteps={4}
+      currentStep={currentStep}
+      totalSteps={totalSteps}
       title="Where do you want to chat?"
       description="Pick where you'd like to talk to your KiloClaw bot. You can add more channels any time from settings."
       showProvisioningBanner={instanceRunning === false}

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
@@ -8,6 +8,7 @@ import {
   type ClawOnboardingRenderStep,
   getClawOnboardingStepProgress,
   isPairingChannel,
+  type OnboardingStep,
   type PairingChannelId,
 } from './ClawOnboardingFlow.state';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -96,6 +97,7 @@ export function ClawOnboardingFakeWalkthrough({
     ? selectedChannelId
     : 'telegram';
   const hasPairingStep = isPairingChannel(selectedChannelId);
+  const stepProgress = getFakeStepProgress(step, hasPairingStep);
 
   return (
     <div className="container m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
@@ -124,7 +126,7 @@ export function ClawOnboardingFakeWalkthrough({
         selectedChannelId,
         setSelectedChannelId,
         pairingChannelId,
-        hasPairingStep,
+        stepProgress,
         basePath,
       })}
     </div>
@@ -165,15 +167,40 @@ function FakeWalkthroughControls({ currentStep, onStepChange }: FakeWalkthroughC
   );
 }
 
+type StepProgress = ReturnType<typeof getClawOnboardingStepProgress>;
+
 type RenderFakeStepInput = {
   step: ClawOnboardingRenderStep;
   setStep: (step: ClawOnboardingRenderStep) => void;
   selectedChannelId: string | null;
   setSelectedChannelId: (channelId: string | null) => void;
   pairingChannelId: PairingChannelId;
-  hasPairingStep: boolean;
+  stepProgress: StepProgress;
   basePath: string;
 };
+
+function getFakeStepProgress(
+  step: ClawOnboardingRenderStep,
+  hasPairingStep: boolean
+): StepProgress {
+  return getClawOnboardingStepProgress(getFakeOnboardingStep(step), hasPairingStep);
+}
+
+function getFakeOnboardingStep(step: ClawOnboardingRenderStep): OnboardingStep {
+  switch (step) {
+    case 'identity':
+    case 'permissions':
+    case 'channels':
+    case 'provisioning':
+    case 'pairing':
+      return step;
+    case 'create-instance':
+      return 'identity';
+    case 'complete':
+    case 'error':
+      return 'done';
+  }
+}
 
 function renderFakeStep({
   step,
@@ -181,43 +208,34 @@ function renderFakeStep({
   selectedChannelId,
   setSelectedChannelId,
   pairingChannelId,
-  hasPairingStep,
+  stepProgress,
   basePath,
 }: RenderFakeStepInput) {
   switch (step) {
     case 'create-instance':
       return <CreateInstanceCardView onCreate={() => setStep('identity')} />;
     case 'identity': {
-      const { currentStep, totalSteps } = getClawOnboardingStepProgress('identity', hasPairingStep);
       return (
         <BotIdentityStep
-          currentStep={currentStep}
-          totalSteps={totalSteps}
+          {...stepProgress}
           instanceRunning={false}
           onContinue={() => setStep('permissions')}
         />
       );
     }
     case 'permissions': {
-      const { currentStep, totalSteps } = getClawOnboardingStepProgress(
-        'permissions',
-        hasPairingStep
-      );
       return (
         <PermissionStep
-          currentStep={currentStep}
-          totalSteps={totalSteps}
+          {...stepProgress}
           instanceRunning={false}
           onSelect={() => setStep('channels')}
         />
       );
     }
     case 'channels': {
-      const { currentStep, totalSteps } = getClawOnboardingStepProgress('channels', hasPairingStep);
       return (
         <ChannelSelectionStepView
-          currentStep={currentStep}
-          totalSteps={totalSteps}
+          {...stepProgress}
           instanceRunning={false}
           defaultSelected={isPairingChannel(selectedChannelId) ? selectedChannelId : null}
           onSelect={channelId => {
@@ -232,13 +250,9 @@ function renderFakeStep({
       );
     }
     case 'provisioning': {
-      const { currentStep, totalSteps } = getClawOnboardingStepProgress(
-        'provisioning',
-        hasPairingStep
-      );
       return (
         <div className="flex flex-col gap-4">
-          <ProvisioningStepView currentStep={currentStep} totalSteps={totalSteps} />
+          <ProvisioningStepView {...stepProgress} />
           <Card>
             <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
               <p className="text-muted-foreground text-sm">
@@ -264,11 +278,9 @@ function renderFakeStep({
       );
     }
     case 'pairing': {
-      const { currentStep, totalSteps } = getClawOnboardingStepProgress('pairing', hasPairingStep);
       return (
         <ChannelPairingStepView
-          currentStep={currentStep}
-          totalSteps={totalSteps}
+          {...stepProgress}
           channelId={pairingChannelId}
           matchingRequest={{
             channel: pairingChannelId,

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
@@ -6,6 +6,7 @@ import type { PopulatedClawStatus } from './ClawOnboardingFlow.state';
 import {
   CLAW_ONBOARDING_FAKE_STEPS,
   type ClawOnboardingRenderStep,
+  getClawOnboardingStepProgress,
   isPairingChannel,
   type PairingChannelId,
 } from './ClawOnboardingFlow.state';
@@ -94,7 +95,7 @@ export function ClawOnboardingFakeWalkthrough({
   const pairingChannelId: PairingChannelId = isPairingChannel(selectedChannelId)
     ? selectedChannelId
     : 'telegram';
-  const totalSteps = isPairingChannel(selectedChannelId) ? 6 : 5;
+  const hasPairingStep = isPairingChannel(selectedChannelId);
 
   return (
     <div className="container m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
@@ -123,7 +124,7 @@ export function ClawOnboardingFakeWalkthrough({
         selectedChannelId,
         setSelectedChannelId,
         pairingChannelId,
-        totalSteps,
+        hasPairingStep,
         basePath,
       })}
     </div>
@@ -170,7 +171,7 @@ type RenderFakeStepInput = {
   selectedChannelId: string | null;
   setSelectedChannelId: (channelId: string | null) => void;
   pairingChannelId: PairingChannelId;
-  totalSteps: number;
+  hasPairingStep: boolean;
   basePath: string;
 };
 
@@ -180,19 +181,43 @@ function renderFakeStep({
   selectedChannelId,
   setSelectedChannelId,
   pairingChannelId,
-  totalSteps,
+  hasPairingStep,
   basePath,
 }: RenderFakeStepInput) {
   switch (step) {
     case 'create-instance':
       return <CreateInstanceCardView onCreate={() => setStep('identity')} />;
-    case 'identity':
-      return <BotIdentityStep instanceRunning={false} onContinue={() => setStep('permissions')} />;
-    case 'permissions':
-      return <PermissionStep instanceRunning={false} onSelect={() => setStep('channels')} />;
-    case 'channels':
+    case 'identity': {
+      const { currentStep, totalSteps } = getClawOnboardingStepProgress('identity', hasPairingStep);
+      return (
+        <BotIdentityStep
+          currentStep={currentStep}
+          totalSteps={totalSteps}
+          instanceRunning={false}
+          onContinue={() => setStep('permissions')}
+        />
+      );
+    }
+    case 'permissions': {
+      const { currentStep, totalSteps } = getClawOnboardingStepProgress(
+        'permissions',
+        hasPairingStep
+      );
+      return (
+        <PermissionStep
+          currentStep={currentStep}
+          totalSteps={totalSteps}
+          instanceRunning={false}
+          onSelect={() => setStep('channels')}
+        />
+      );
+    }
+    case 'channels': {
+      const { currentStep, totalSteps } = getClawOnboardingStepProgress('channels', hasPairingStep);
       return (
         <ChannelSelectionStepView
+          currentStep={currentStep}
+          totalSteps={totalSteps}
           instanceRunning={false}
           defaultSelected={isPairingChannel(selectedChannelId) ? selectedChannelId : null}
           onSelect={channelId => {
@@ -205,10 +230,15 @@ function renderFakeStep({
           }}
         />
       );
-    case 'provisioning':
+    }
+    case 'provisioning': {
+      const { currentStep, totalSteps } = getClawOnboardingStepProgress(
+        'provisioning',
+        hasPairingStep
+      );
       return (
         <div className="flex flex-col gap-4">
-          <ProvisioningStepView totalSteps={totalSteps} />
+          <ProvisioningStepView currentStep={currentStep} totalSteps={totalSteps} />
           <Card>
             <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
               <p className="text-muted-foreground text-sm">
@@ -232,9 +262,13 @@ function renderFakeStep({
           </Card>
         </div>
       );
-    case 'pairing':
+    }
+    case 'pairing': {
+      const { currentStep, totalSteps } = getClawOnboardingStepProgress('pairing', hasPairingStep);
       return (
         <ChannelPairingStepView
+          currentStep={currentStep}
+          totalSteps={totalSteps}
           channelId={pairingChannelId}
           matchingRequest={{
             channel: pairingChannelId,
@@ -245,6 +279,7 @@ function renderFakeStep({
           onSkip={() => setStep('complete')}
         />
       );
+    }
     case 'complete':
       return <ClawSetupCompleteStep status={fakeStatus} gatewayReady basePath={basePath} />;
     case 'error':

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
@@ -5,6 +5,7 @@ import {
   CLAW_ONBOARDING_PROVISIONING_STATUSES,
   type ClawOnboardingFlowStateInput,
   getClawOnboardingFlowState,
+  getClawOnboardingStepProgress,
   hasPopulatedStatus,
   isPairingChannel,
 } from './ClawOnboardingFlow.state';
@@ -170,16 +171,67 @@ describe('ClawOnboardingFlow state machine', () => {
   });
 
   test('uses five steps only when the selected channel requires pairing', () => {
-    expect(
-      getClawOnboardingFlowState(createInput({ selectedChannelId: 'telegram' })).totalSteps
-    ).toBe(5);
-    expect(
-      getClawOnboardingFlowState(createInput({ selectedChannelId: 'discord' })).totalSteps
-    ).toBe(5);
-    expect(getClawOnboardingFlowState(createInput({ selectedChannelId: 'slack' })).totalSteps).toBe(
-      4
+    const pairingTelegram = getClawOnboardingFlowState(
+      createInput({ selectedChannelId: 'telegram' })
     );
-    expect(getClawOnboardingFlowState(createInput()).totalSteps).toBe(4);
+    expect(pairingTelegram.totalSteps).toBe(5);
+    expect(pairingTelegram.currentStep).toBe(1);
+
+    const pairingDiscord = getClawOnboardingFlowState(
+      createInput({ selectedChannelId: 'discord' })
+    );
+    expect(pairingDiscord.totalSteps).toBe(5);
+    expect(pairingDiscord.currentStep).toBe(1);
+
+    const noPairingSlack = getClawOnboardingFlowState(createInput({ selectedChannelId: 'slack' }));
+    expect(noPairingSlack.totalSteps).toBe(4);
+    expect(noPairingSlack.currentStep).toBe(1);
+
+    const defaultState = getClawOnboardingFlowState(createInput());
+    expect(defaultState.totalSteps).toBe(4);
+    expect(defaultState.currentStep).toBe(1);
+  });
+
+  test('getClawOnboardingStepProgress returns correct current and total steps', () => {
+    expect(getClawOnboardingStepProgress('identity', false)).toEqual({
+      currentStep: 1,
+      totalSteps: 4,
+    });
+    expect(getClawOnboardingStepProgress('permissions', false)).toEqual({
+      currentStep: 2,
+      totalSteps: 4,
+    });
+    expect(getClawOnboardingStepProgress('channels', false)).toEqual({
+      currentStep: 3,
+      totalSteps: 4,
+    });
+    expect(getClawOnboardingStepProgress('provisioning', false)).toEqual({
+      currentStep: 4,
+      totalSteps: 4,
+    });
+    expect(getClawOnboardingStepProgress('done', false)).toEqual({ currentStep: 4, totalSteps: 4 });
+
+    expect(getClawOnboardingStepProgress('identity', true)).toEqual({
+      currentStep: 1,
+      totalSteps: 5,
+    });
+    expect(getClawOnboardingStepProgress('permissions', true)).toEqual({
+      currentStep: 2,
+      totalSteps: 5,
+    });
+    expect(getClawOnboardingStepProgress('channels', true)).toEqual({
+      currentStep: 3,
+      totalSteps: 5,
+    });
+    expect(getClawOnboardingStepProgress('provisioning', true)).toEqual({
+      currentStep: 4,
+      totalSteps: 5,
+    });
+    expect(getClawOnboardingStepProgress('pairing', true)).toEqual({
+      currentStep: 5,
+      totalSteps: 5,
+    });
+    expect(getClawOnboardingStepProgress('done', true)).toEqual({ currentStep: 5, totalSteps: 5 });
   });
 
   test.each(CLAW_ONBOARDING_PROVISIONING_STATUSES)(

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
@@ -15,6 +15,16 @@ export type OnboardingStep =
   | 'pairing'
   | 'done';
 
+export const CLAW_ONBOARDING_WIZARD_STEPS = [
+  'identity',
+  'permissions',
+  'channels',
+  'provisioning',
+  'pairing',
+] as const satisfies OnboardingStep[];
+
+export type ClawOnboardingWizardStep = (typeof CLAW_ONBOARDING_WIZARD_STEPS)[number];
+
 export type ClawOnboardingRenderStep =
   | 'create-instance'
   | 'identity'
@@ -80,6 +90,7 @@ export type ClawOnboardingFlowState = {
   createSetupActive: boolean;
   postProvisioningReady: boolean;
   hasPairingStep: boolean;
+  currentStep: number;
   totalSteps: number;
 };
 
@@ -98,6 +109,24 @@ export function isClawOnboardingErrorStatus(status: PopulatedClawStatus['status'
     if (status === errorStatus) return true;
   }
   return false;
+}
+
+export function getClawOnboardingStepProgress(
+  step: OnboardingStep,
+  hasPairingStep: boolean
+): { currentStep: number; totalSteps: number } {
+  const totalSteps = hasPairingStep
+    ? CLAW_ONBOARDING_WIZARD_STEPS.length
+    : CLAW_ONBOARDING_WIZARD_STEPS.length - 1;
+
+  if (step === 'done') {
+    return { currentStep: totalSteps, totalSteps };
+  }
+
+  const index = CLAW_ONBOARDING_WIZARD_STEPS.indexOf(step);
+  const currentStep = index === -1 ? 0 : index + 1;
+
+  return { currentStep, totalSteps };
 }
 
 export function getClawOnboardingFlowState({
@@ -120,7 +149,7 @@ export function getClawOnboardingFlowState({
   const createSetupActive =
     mode === 'create-first' && (createSetupStarted || instanceStatus !== null);
   const hasPairingStep = isPairingChannel(selectedChannelId);
-  const totalSteps = hasPairingStep ? 5 : 4;
+  const { currentStep, totalSteps } = getClawOnboardingStepProgress(onboardingStep, hasPairingStep);
   const renderStepDecision = getRenderStepDecision({
     mode,
     createSetupStarted,
@@ -141,6 +170,7 @@ export function getClawOnboardingFlowState({
     createSetupActive,
     postProvisioningReady,
     hasPairingStep,
+    currentStep,
     totalSteps,
   } satisfies ClawOnboardingFlowState;
 
@@ -162,6 +192,7 @@ export function getClawOnboardingFlowState({
     createSetupActive,
     postProvisioningReady,
     hasPairingStep,
+    currentStep,
     totalSteps,
     renderStepDecision,
   });
@@ -197,6 +228,7 @@ type ClawOnboardingFlowDebugLogInput = ClawOnboardingFlowStateInput & {
   createSetupActive: boolean;
   postProvisioningReady: boolean;
   hasPairingStep: boolean;
+  currentStep: number;
   totalSteps: number;
   renderStepDecision: RenderStepDecision;
 };
@@ -335,6 +367,7 @@ function logClawOnboardingFlowStateDecision({
   createSetupActive,
   postProvisioningReady,
   hasPairingStep,
+  currentStep,
   totalSteps,
   renderStepDecision,
 }: ClawOnboardingFlowDebugLogInput): void {
@@ -365,6 +398,7 @@ function logClawOnboardingFlowStateDecision({
       createSetupActive,
       postProvisioningReady,
       hasPairingStep,
+      currentStep,
       totalSteps,
     },
     null,

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -233,6 +233,8 @@ function ClawOnboardingFlowInner({
   function renderIdentityStep() {
     return (
       <BotIdentityStep
+        currentStep={flowState.currentStep}
+        totalSteps={flowState.totalSteps}
         instanceRunning={flowState.instanceRunning}
         onContinue={({ identity, weatherLocation }) => {
           posthog?.capture('claw_setup_identity_completed', {
@@ -266,6 +268,8 @@ function ClawOnboardingFlowInner({
   function renderPermissionsStep() {
     return (
       <PermissionStep
+        currentStep={flowState.currentStep}
+        totalSteps={flowState.totalSteps}
         instanceRunning={flowState.instanceRunning}
         onSelect={preset => {
           posthog?.capture('claw_setup_permissions_completed', { preset });
@@ -280,6 +284,8 @@ function ClawOnboardingFlowInner({
   function renderChannelsStep() {
     return (
       <ChannelSelectionStepView
+        currentStep={flowState.currentStep}
+        totalSteps={flowState.totalSteps}
         instanceRunning={flowState.instanceRunning}
         onSelect={(channelId, tokens) => {
           posthog?.capture('claw_setup_channels_completed', {
@@ -306,17 +312,24 @@ function ClawOnboardingFlowInner({
   }
 
   function renderProvisioningStep() {
-    if (mode === 'post-provisioning') return <ProvisioningStepView />;
+    if (mode === 'post-provisioning')
+      return (
+        <ProvisioningStepView
+          currentStep={flowState.currentStep}
+          totalSteps={flowState.totalSteps}
+        />
+      );
     if (selectedPreset === null) return renderPermissionsStep();
 
     return (
       <ProvisioningStep
+        currentStep={flowState.currentStep}
+        totalSteps={flowState.totalSteps}
         preset={selectedPreset}
         channelTokens={channelTokens}
         botIdentity={botIdentity}
         instanceRunning={flowState.instanceRunning}
         mutations={mutations}
-        totalSteps={flowState.totalSteps}
         onComplete={() => {
           posthog?.capture('claw_setup_provisioned');
           posthog?.capture(
@@ -333,6 +346,8 @@ function ClawOnboardingFlowInner({
 
     return (
       <ChannelPairingStep
+        currentStep={flowState.currentStep}
+        totalSteps={flowState.totalSteps}
         channelId={selectedChannelId}
         mutations={mutations}
         onComplete={() => {

--- a/apps/web/src/app/(app)/claw/components/PermissionStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/PermissionStep.tsx
@@ -5,16 +5,20 @@ import { OnboardingStepView } from './OnboardingStepView';
 import { PermissionPresetCards } from './PermissionPresetCards';
 
 export function PermissionStep({
+  currentStep,
+  totalSteps,
   instanceRunning,
   onSelect,
 }: {
+  currentStep: number;
+  totalSteps: number;
   instanceRunning: boolean;
   onSelect: (preset: ExecPreset) => void;
 }) {
   return (
     <OnboardingStepView
-      currentStep={2}
-      totalSteps={4}
+      currentStep={currentStep}
+      totalSteps={totalSteps}
       title="Set Bot Permissions"
       description="Choose how your KiloClaw bot handles actions on your behalf."
       showProvisioningBanner={!instanceRunning}

--- a/apps/web/src/app/(app)/claw/components/ProvisioningStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/ProvisioningStep.tsx
@@ -33,20 +33,22 @@ function playChime() {
 }
 
 export function ProvisioningStep({
+  currentStep,
+  totalSteps,
   preset,
   channelTokens,
   botIdentity,
   instanceRunning,
   mutations,
-  totalSteps = 4,
   onComplete,
 }: {
+  currentStep: number;
+  totalSteps: number;
   preset: ExecPreset;
   channelTokens: Record<string, string> | null;
   botIdentity: BotIdentity | null;
   instanceRunning: boolean;
   mutations: ClawMutations;
-  totalSteps?: number;
   onComplete: () => void;
 }) {
   const completedRef = useRef(false);
@@ -167,10 +169,10 @@ export function ProvisioningStep({
   }, [configReady, isGatewaySettled]);
 
   if (gateway502Expired) {
-    return <ProvisioningErrorView totalSteps={totalSteps} />;
+    return <ProvisioningErrorView currentStep={currentStep} totalSteps={totalSteps} />;
   }
 
-  return <ProvisioningStepView totalSteps={totalSteps} />;
+  return <ProvisioningStepView currentStep={currentStep} totalSteps={totalSteps} />;
 }
 
 const PROVISIONING_PHRASES = [
@@ -211,10 +213,16 @@ const PROVISIONING_PHRASES = [
 ];
 
 /** Error view shown when the gateway returns a 502 during provisioning. */
-export function ProvisioningErrorView({ totalSteps = 4 }: { totalSteps?: number }) {
+export function ProvisioningErrorView({
+  currentStep,
+  totalSteps,
+}: {
+  currentStep: number;
+  totalSteps: number;
+}) {
   return (
     <OnboardingStepView
-      currentStep={4}
+      currentStep={currentStep}
       totalSteps={totalSteps}
       stepLabel="Provisioning failed"
       contentClassName="items-center gap-8"
@@ -246,7 +254,13 @@ export function ProvisioningErrorView({ totalSteps = 4 }: { totalSteps?: number 
 }
 
 /** Pure visual shell — extracted so Storybook can render it without wiring up mutations. */
-export function ProvisioningStepView({ totalSteps = 4 }: { totalSteps?: number }) {
+export function ProvisioningStepView({
+  currentStep,
+  totalSteps,
+}: {
+  currentStep: number;
+  totalSteps: number;
+}) {
   const [phraseIndex, setPhraseIndex] = useState(0);
   const [visible, setVisible] = useState(true);
 
@@ -269,7 +283,7 @@ export function ProvisioningStepView({ totalSteps = 4 }: { totalSteps?: number }
   }, []);
   return (
     <OnboardingStepView
-      currentStep={4}
+      currentStep={currentStep}
       totalSteps={totalSteps}
       stepLabel="Almost there..."
       contentClassName="items-center gap-8"


### PR DESCRIPTION
## Summary
- Centralizes KiloClaw onboarding step order and progress derivation in the flow state machine.
- Removes hard-coded current/total step counts from individual onboarding step components.
- Aligns the development fake walkthrough with the same progress helper used by the real flow.

## Reviewer Notes
No runtime flow behavior should change; this refactor only centralizes step progress calculation and fixes the fake walkthrough's inconsistent total step count.