### PR TITLE
feat(admin): add tabs to bulk-block page with recent blocks history

### DIFF
--- a/apps/web/src/app/admin/components/AbuseBulkBlock.tsx
+++ b/apps/web/src/app/admin/components/AbuseBulkBlock.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -174,8 +175,23 @@ function RecentBlocksTab() {
 const tabTriggerClass =
   'text-muted-foreground hover:text-foreground data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none border-b-2 border-transparent px-0 py-3 text-sm font-medium transition-colors data-[state=active]:border-0 data-[state=active]:border-b-2 data-[state=active]:bg-transparent data-[state=active]:shadow-none';
 
+const DEFAULT_TAB = 'bulk-block';
+
 export function AbuseBulkBlock() {
-  const [activeTab, setActiveTab] = useState('bulk-block');
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const activeTab = searchParams.get('tab') || DEFAULT_TAB;
+
+  function setActiveTab(tab: string) {
+    const params = new URLSearchParams(searchParams);
+    if (tab === DEFAULT_TAB) {
+      params.delete('tab');
+    } else {
+      params.set('tab', tab);
+    }
+    const qs = params.toString();
+    router.push(qs ? `?${qs}` : window.location.pathname);
+  }
 
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab}>

--- a/apps/web/src/app/admin/components/AbuseBulkBlock.tsx
+++ b/apps/web/src/app/admin/components/AbuseBulkBlock.tsx
@@ -18,6 +18,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import Link from 'next/link';
 import type { BulkBlockResponse } from '@/lib/abuse/bulkBlock';
 
 function BulkBlockTab() {
@@ -152,7 +153,12 @@ function RecentBlocksTab() {
                     </TableCell>
                     <TableCell className="text-muted-foreground text-sm">{row.date}</TableCell>
                     <TableCell className="text-right">
-                      {row.blocked_count.toLocaleString()}
+                      <Link
+                        href={`/admin/users?${new URLSearchParams({ notesSearch: row.blocked_reason, sortBy: 'updated_at', sortOrder: 'desc', blockedStatus: 'blocked' })}`}
+                        className="text-primary hover:underline"
+                      >
+                        {row.blocked_count.toLocaleString()}
+                      </Link>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/apps/web/src/app/admin/components/AbuseBulkBlock.tsx
+++ b/apps/web/src/app/admin/components/AbuseBulkBlock.tsx
@@ -152,12 +152,12 @@ function RecentBlocksTab() {
                       </code>
                     </TableCell>
                     <TableCell className="text-muted-foreground text-sm">{row.date}</TableCell>
-                    <TableCell className="text-right">
+                    <TableCell className="p-0 text-right">
                       <Link
                         href={`/admin/users?${new URLSearchParams({ notesSearch: row.blocked_reason, sortBy: 'updated_at', sortOrder: 'desc', blockedStatus: 'blocked' })}`}
-                        className="text-primary hover:underline"
+                        className="text-primary hover:underline block px-4 py-2"
                       >
-                        {row.blocked_count.toLocaleString()}
+                        {row.blocked_count.toLocaleString()} users
                       </Link>
                     </TableCell>
                   </TableRow>

--- a/apps/web/src/app/admin/components/AbuseBulkBlock.tsx
+++ b/apps/web/src/app/admin/components/AbuseBulkBlock.tsx
@@ -1,15 +1,26 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
 import type { BulkBlockResponse } from '@/lib/abuse/bulkBlock';
 
-export function AbuseBulkBlock() {
+function BulkBlockTab() {
   const [rawIds, setRawIds] = useState('');
   const [reason, setReason] = useState('');
   const [result, setResult] = useState<BulkBlockResponse | null>(null);
@@ -98,5 +109,84 @@ export function AbuseBulkBlock() {
         </div>
       </div>
     </div>
+  );
+}
+
+function RecentBlocksTab() {
+  const trpc = useTRPC();
+
+  const { data, isLoading } = useQuery(trpc.admin.bulkBlock.recentBlocks.queryOptions());
+
+  const rows = data ?? [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Recent Bulk Blocks</CardTitle>
+        <CardDescription>
+          Blocked accounts grouped by reason and date (based on last update timestamp).
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="text-muted-foreground py-8 text-center text-sm">Loading…</div>
+        ) : rows.length === 0 ? (
+          <div className="text-muted-foreground py-8 text-center">No blocked accounts found</div>
+        ) : (
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Block Reason</TableHead>
+                  <TableHead>Date</TableHead>
+                  <TableHead className="text-right">Accounts Blocked</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map(row => (
+                  <TableRow key={`${row.blocked_reason}-${row.date}`}>
+                    <TableCell className="font-medium">
+                      <code className="bg-muted rounded px-2 py-1 text-sm">
+                        {row.blocked_reason}
+                      </code>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm">{row.date}</TableCell>
+                    <TableCell className="text-right">
+                      {row.blocked_count.toLocaleString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+const tabTriggerClass =
+  'text-muted-foreground hover:text-foreground data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none border-b-2 border-transparent px-0 py-3 text-sm font-medium transition-colors data-[state=active]:border-0 data-[state=active]:border-b-2 data-[state=active]:bg-transparent data-[state=active]:shadow-none';
+
+export function AbuseBulkBlock() {
+  const [activeTab, setActiveTab] = useState('bulk-block');
+
+  return (
+    <Tabs value={activeTab} onValueChange={setActiveTab}>
+      <TabsList className="h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent p-0">
+        <TabsTrigger value="bulk-block" className={tabTriggerClass}>
+          Bulk Block
+        </TabsTrigger>
+        <TabsTrigger value="recent" className={tabTriggerClass}>
+          Recent Blocks
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="bulk-block" className="mt-4">
+        <BulkBlockTab />
+      </TabsContent>
+      <TabsContent value="recent" className="mt-4">
+        {activeTab === 'recent' && <RecentBlocksTab />}
+      </TabsContent>
+    </Tabs>
   );
 }

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -39,6 +39,7 @@ import { extendClawTrialRouter } from '@/routers/admin/extend-claw-trial-router'
 import { adminCustomLlmRouter } from '@/routers/admin/custom-llm-router';
 import { adminGatewayConfigRouter } from '@/routers/admin/gateway-config-router';
 import { adminBlacklistDomainsRouter } from '@/routers/admin/blacklist-domains-router';
+import { adminBulkBlockRouter } from '@/routers/admin/bulk-block-router';
 import { adminSecurityAdvisorContentRouter } from '@/routers/admin/security-advisor-content-router';
 import { adminWebhookTriggersRouter } from '@/routers/admin-webhook-triggers-router';
 import { adminAlertingRouter } from '@/routers/admin-alerting-router';
@@ -1912,6 +1913,7 @@ export const adminRouter = createTRPCRouter({
   customLlm: adminCustomLlmRouter,
   gatewayConfig: adminGatewayConfigRouter,
   blacklistDomains: adminBlacklistDomainsRouter,
+  bulkBlock: adminBulkBlockRouter,
   securityAdvisorContent: adminSecurityAdvisorContentRouter,
   freeModelUsage: adminFreeModelUsageRouter,
 });

--- a/apps/web/src/routers/admin/bulk-block-router.ts
+++ b/apps/web/src/routers/admin/bulk-block-router.ts
@@ -1,0 +1,26 @@
+import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
+import { db } from '@/lib/drizzle';
+import { kilocode_users } from '@kilocode/db/schema';
+import { sql, count, isNotNull, desc } from 'drizzle-orm';
+
+export const adminBulkBlockRouter = createTRPCRouter({
+  recentBlocks: adminProcedure.query(async () => {
+    const rows = await db
+      .select({
+        blocked_reason: kilocode_users.blocked_reason,
+        date: sql<string>`DATE(${kilocode_users.updated_at})`.as('date'),
+        blocked_count: count().as('blocked_count'),
+      })
+      .from(kilocode_users)
+      .where(isNotNull(kilocode_users.blocked_reason))
+      .groupBy(kilocode_users.blocked_reason, sql`DATE(${kilocode_users.updated_at})`)
+      .orderBy(desc(sql`DATE(${kilocode_users.updated_at})`))
+      .limit(200);
+
+    return rows.map(r => ({
+      blocked_reason: r.blocked_reason ?? '',
+      date: r.date,
+      blocked_count: r.blocked_count,
+    }));
+  }),
+});


### PR DESCRIPTION
## Summary

Add a tabbed interface to the admin bulk-block page (`/admin/bulk-block`), matching the tab pattern used by the blacklisted-domains page. The first tab retains the existing bulk block form. The second tab ("Recent Blocks") shows a table of blocked accounts grouped by block reason and date, with columns: **Block Reason**, **Date**, and **Accounts Blocked**.

Changes:
- New tRPC router `admin.bulkBlock.recentBlocks` that queries `kilocode_users` with `blocked_reason IS NOT NULL`, grouped by reason + `DATE(updated_at)`, limited to 200 rows
- Refactored `AbuseBulkBlock` component to use `Tabs`/`TabsList`/`TabsTrigger`/`TabsContent`
- Registered the new router in `admin-router.ts`

## Verification

- `pnpm --filter web typecheck` passes
- `pnpm format` clean

## Visual Changes

N/A (admin-only page, no screenshot tooling available)

## Reviewer Notes

- The `kilocode_users` table has no `blocked_at` timestamp; the query uses `DATE(updated_at)` as a proxy. If a blocked user's row is updated for another reason, the date may shift.
- Limited to 200 rows to keep the query fast on large tables.

<img width="4770" height="1200" alt="CleanShot 2026-04-22 at 10 24 40@2x" src="https://github.com/user-attachments/assets/22c57b5d-2297-48d0-8478-df9b535cc7fa" />

