### PR TITLE
fix(claw): prevent KiloClaw /new page refetch flashes

### DIFF
--- a/apps/web/src/app/(app)/claw/new/ClawNewClient.state.test.ts
+++ b/apps/web/src/app/(app)/claw/new/ClawNewClient.state.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from '@jest/globals';
+import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
+import { getClawNewStatusQueryForBoundary } from './ClawNewClient.state';
+
+const baseStatus: KiloClawDashboardStatus = {
+  userId: 'user-1',
+  sandboxId: 'sandbox-1',
+  provider: 'fly',
+  runtimeId: 'machine-1',
+  storageId: 'vol-1',
+  region: 'iad',
+  name: null,
+  status: 'running',
+  provisionedAt: 1,
+  lastStartedAt: 2,
+  lastStoppedAt: 3,
+  envVarCount: 1,
+  secretCount: 2,
+  channelCount: 3,
+  flyAppName: null,
+  flyMachineId: null,
+  flyVolumeId: null,
+  flyRegion: null,
+  machineSize: null,
+  openclawVersion: null,
+  imageVariant: null,
+  trackedImageTag: null,
+  trackedImageDigest: null,
+  googleConnected: false,
+  googleOAuthConnected: false,
+  googleOAuthStatus: 'disconnected',
+  googleOAuthAccountEmail: null,
+  googleOAuthCapabilities: [],
+  gmailNotificationsEnabled: false,
+  execSecurity: null,
+  execAsk: null,
+  botName: null,
+  botNature: null,
+  botVibe: null,
+  botEmoji: null,
+  workerUrl: 'https://claw.kilo.ai',
+  instanceId: 'instance-1',
+  inboundEmailAddress: 'amber-river-quiet-maple@kiloclaw.ai',
+  inboundEmailEnabled: true,
+};
+
+function createStatus(instanceId: string | null = 'instance-1'): KiloClawDashboardStatus {
+  return {
+    ...baseStatus,
+    instanceId,
+  };
+}
+
+describe('getClawNewStatusQueryForBoundary', () => {
+  test('keeps cached status rendered after a billing refetch', () => {
+    const status = createStatus('instance-1');
+
+    const result = getClawNewStatusQueryForBoundary({
+      statusQuery: {
+        data: status,
+        dataUpdatedAt: 100,
+        isLoading: false,
+        error: null,
+      },
+      setupFailed: false,
+      billingInstanceId: 'instance-1',
+    });
+
+    expect(result).toEqual({
+      data: status,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  test('loads when there is no status payload to render', () => {
+    const result = getClawNewStatusQueryForBoundary({
+      statusQuery: {
+        data: undefined,
+        dataUpdatedAt: 0,
+        isLoading: false,
+        error: null,
+      },
+      setupFailed: false,
+      billingInstanceId: 'instance-1',
+    });
+
+    expect(result).toEqual({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+  });
+
+  test('lets setup failure render the onboarding error state without loading', () => {
+    const result = getClawNewStatusQueryForBoundary({
+      statusQuery: {
+        data: undefined,
+        dataUpdatedAt: 0,
+        isLoading: true,
+        error: new Error('network issue'),
+      },
+      setupFailed: true,
+      billingInstanceId: 'instance-1',
+    });
+
+    expect(result).toEqual({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  test('keeps cached status rendered when a background refetch errors', () => {
+    const status = createStatus('instance-1');
+
+    const result = getClawNewStatusQueryForBoundary({
+      statusQuery: {
+        data: status,
+        dataUpdatedAt: 100,
+        isLoading: false,
+        error: new Error('network issue'),
+      },
+      setupFailed: false,
+      billingInstanceId: 'instance-1',
+    });
+
+    expect(result).toEqual({
+      data: status,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  test('does not render stale status from a different concrete instance', () => {
+    const result = getClawNewStatusQueryForBoundary({
+      statusQuery: {
+        data: createStatus('instance-1'),
+        dataUpdatedAt: 100,
+        isLoading: false,
+        error: null,
+      },
+      setupFailed: false,
+      billingInstanceId: 'instance-2',
+    });
+
+    expect(result).toEqual({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+  });
+
+  test('does not render stale no-instance status for an active billing instance', () => {
+    const result = getClawNewStatusQueryForBoundary({
+      statusQuery: {
+        data: {
+          ...createStatus(null),
+          status: null,
+        },
+        dataUpdatedAt: 100,
+        isLoading: false,
+        error: null,
+      },
+      setupFailed: false,
+      billingInstanceId: 'instance-1',
+    });
+
+    expect(result).toEqual({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+  });
+
+  test('allows legacy status rows that do not expose an instance id', () => {
+    const status = createStatus(null);
+
+    const result = getClawNewStatusQueryForBoundary({
+      statusQuery: {
+        data: status,
+        dataUpdatedAt: 100,
+        isLoading: false,
+        error: null,
+      },
+      setupFailed: false,
+      billingInstanceId: 'instance-1',
+    });
+
+    expect(result).toEqual({
+      data: status,
+      isLoading: false,
+      error: null,
+    });
+  });
+});

--- a/apps/web/src/app/(app)/claw/new/ClawNewClient.state.ts
+++ b/apps/web/src/app/(app)/claw/new/ClawNewClient.state.ts
@@ -1,0 +1,63 @@
+import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
+import type { StatusQueryLike } from '../components';
+
+type ClawNewStatusBoundaryQuery = StatusQueryLike & {
+  dataUpdatedAt: number;
+};
+
+type GetClawNewStatusQueryForBoundaryInput = {
+  statusQuery: ClawNewStatusBoundaryQuery;
+  setupFailed: boolean;
+  billingInstanceId: string | null;
+};
+
+export function getClawNewStatusQueryForBoundary({
+  statusQuery,
+  setupFailed,
+  billingInstanceId,
+}: GetClawNewStatusQueryForBoundaryInput): StatusQueryLike {
+  if (setupFailed) {
+    return {
+      data: statusQuery.data,
+      isLoading: false,
+      error: null,
+    };
+  }
+
+  const renderableStatus = getRenderableStatus(statusQuery.data, billingInstanceId);
+  if (renderableStatus) {
+    return {
+      data: renderableStatus,
+      isLoading: false,
+      error: null,
+    };
+  }
+
+  if (statusQuery.error) {
+    return {
+      data: undefined,
+      isLoading: false,
+      error: statusQuery.error,
+    };
+  }
+
+  return {
+    data: undefined,
+    isLoading: true,
+    error: null,
+  };
+}
+
+function getRenderableStatus(
+  status: KiloClawDashboardStatus | undefined,
+  billingInstanceId: string | null
+): KiloClawDashboardStatus | undefined {
+  if (!status) return undefined;
+
+  if (billingInstanceId !== null) {
+    if (status.instanceId === null && status.status === null) return undefined;
+    if (status.instanceId !== null && status.instanceId !== billingInstanceId) return undefined;
+  }
+
+  return status;
+}

--- a/apps/web/src/app/(app)/claw/new/ClawNewClient.tsx
+++ b/apps/web/src/app/(app)/claw/new/ClawNewClient.tsx
@@ -13,6 +13,7 @@ import {
 import type { ClawOnboardingRenderStep } from '../components/ClawOnboardingFlow.state';
 import { ClawOnboardingFakeWalkthrough } from '../components/ClawOnboardingFakeWalkthrough';
 import { WelcomePage } from '../components/billing/WelcomePage';
+import { getClawNewStatusQueryForBoundary } from './ClawNewClient.state';
 
 const ClawOnboardingWithBoundary = withStatusQueryBoundary(ClawOnboardingFlow);
 
@@ -30,7 +31,7 @@ function LoadingState() {
 function ClawNewLoader({
   mode,
   createFlowStartedAt,
-  billingUpdatedAt,
+  billingInstanceId,
   onCreateFlowStarted,
   setupFailed,
   onCreateFlowFailed,
@@ -38,7 +39,7 @@ function ClawNewLoader({
   mode: ClawOnboardingMode;
   createFlowStartedAt: number | null;
   setupFailed: boolean;
-  billingUpdatedAt: number;
+  billingInstanceId: string | null;
   onCreateFlowStarted: () => void;
   onCreateFlowFailed: () => void;
 }) {
@@ -62,19 +63,11 @@ function ClawNewLoader({
     );
   }
 
-  const statusQueryForBoundary = setupFailed
-    ? {
-        data: statusQuery.data,
-        isLoading: false,
-        error: null,
-      }
-    : statusQuery.error || statusQuery.dataUpdatedAt >= billingUpdatedAt
-      ? statusQuery
-      : {
-          data: undefined,
-          isLoading: true,
-          error: null,
-        };
+  const statusQueryForBoundary = getClawNewStatusQueryForBoundary({
+    statusQuery,
+    setupFailed,
+    billingInstanceId,
+  });
 
   return (
     <ClawOnboardingWithBoundary
@@ -131,10 +124,6 @@ function ClawNewLiveClient() {
     );
   }
 
-  if (!setupFailed && createFlowStartedAt === null && billingQuery.isFetching) {
-    return <LoadingState />;
-  }
-
   const billing = billingQuery.data;
   const isNewUser =
     billing &&
@@ -151,8 +140,11 @@ function ClawNewLiveClient() {
     );
   }
 
-  const hasActiveInstance =
-    billing?.instance?.exists === true && billing.instance.destroyed === false;
+  const billingInstanceId =
+    billing?.instance?.exists === true && billing.instance.destroyed === false
+      ? billing.instance.id
+      : null;
+  const hasActiveInstance = billingInstanceId !== null;
   const mode: ClawOnboardingMode =
     createFlowStartedAt !== null || !hasActiveInstance ? 'create-first' : 'post-provisioning';
 
@@ -161,7 +153,7 @@ function ClawNewLiveClient() {
       mode={mode}
       createFlowStartedAt={createFlowStartedAt}
       setupFailed={setupFailed}
-      billingUpdatedAt={billingQuery.dataUpdatedAt}
+      billingInstanceId={billingInstanceId}
       onCreateFlowStarted={onCreateFlowStarted}
       onCreateFlowFailed={onCreateFlowFailed}
     />


### PR DESCRIPTION
## Summary
- Prevent `/claw/new` from blanking or swapping to the loading card during background billing/status refetches.
- Extract the status-boundary decision into a focused helper that preserves cached renderable status, ignores non-blocking refetch errors, and guards against stale instance data.
- Add unit coverage for cached refetches, setup failures, stale instance responses, no-instance responses, and legacy status rows.
