### PR TITLE
docs(pr): keep automated checks out of PR verification

### DIFF
--- a/.kilo/command/prepare-pr.md
+++ b/.kilo/command/prepare-pr.md
@@ -30,10 +30,11 @@ Arguments:
    - Include enough context for a reviewer unfamiliar with this code area.
    - Keep it concise and reviewer-friendly.
 
-3. Prefill `## Verification` from this session.
-   - Capture verification already performed in this session (tests, typecheck, lint, builds, manual checks).
-   - Include command names and short pass/fail outcomes when available.
-   - Add a final placeholder bullet for extra user-provided verification details.
+3. Prefill `## Verification` with manual verification only.
+   - Do not list automated checks such as tests, typecheck, lint, builds, formatting, validation commands, or CI status.
+   - Include manually tested paths or behavior from this session when available.
+   - If no manual verification was performed, state that directly and explain why.
+   - Add a final placeholder bullet for extra user-provided manual verification details.
 
 4. Prepare `## Visual Changes`.
    - Detect likely visual/UI changes from changed files (for example: `*.tsx`, `*.jsx`, CSS, Tailwind config, component/page/view files).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ When writing implementation plans, always save them to the `.plans/` directory a
 Follow the PR template in `.github/pull_request_template.md`. Every description must include four sections in order:
 
 1. **`## Summary`** — What changed and why. Outcome-focused, call out architectural changes.
-2. **`## Verification`** — Checks you actually ran. **Never fabricate verification steps.**
+2. **`## Verification`** — Manual verification only. Do not list automated checks such as `pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm validate`, CI, or formatting commands here.
 3. **`## Visual Changes`** — Before/after screenshots, or `N/A`.
 4. **`## Reviewer Notes`** — Risk areas, tricky logic, rollout notes, or `N/A`.
 


### PR DESCRIPTION
## Summary

- Update repository PR instructions so `## Verification` is reserved for manual verification only.
- Align `/prepare-pr` with the PR template by explicitly excluding automated checks, builds, formatting, validation commands, and CI status from PR descriptions.

## Verification

- Manually reviewed the relevant instruction files and confirmed the PR template already asks for manual-only verification.

## Visual Changes

N/A

## Reviewer Notes

- This is an instruction-only change intended to stop agents from posting automated check commands such as `pnpm typecheck` and `pnpm test` in PR bodies.
