### PR TITLE
feat(admin): add confirmed bulk unblock action

### DIFF
--- a/apps/web/src/app/admin/components/AbuseBulkBlock.tsx
+++ b/apps/web/src/app/admin/components/AbuseBulkBlock.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Button } from '@/components/ui/button';
@@ -9,6 +9,16 @@ import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
@@ -20,6 +30,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import Link from 'next/link';
+import { toast } from 'sonner';
 import type { BulkBlockResponse } from '@/lib/abuse/bulkBlock';
 
 function BulkBlockTab() {
@@ -114,61 +125,136 @@ function BulkBlockTab() {
   );
 }
 
+type RecentBlockRow = {
+  blocked_reason: string;
+  date: string;
+  blocked_count: number;
+};
+
 function RecentBlocksTab() {
   const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [unblockTarget, setUnblockTarget] = useState<RecentBlockRow | null>(null);
 
   const { data, isLoading } = useQuery(trpc.admin.bulkBlock.recentBlocks.queryOptions());
+
+  const unblockMutation = useMutation(
+    trpc.admin.bulkBlock.unblockRecentBlock.mutationOptions({
+      onSuccess: result => {
+        setUnblockTarget(null);
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.bulkBlock.recentBlocks.queryKey(),
+        });
+        toast.success(`Unblocked ${result.updatedCount.toLocaleString()} users`);
+      },
+      onError: error => {
+        toast.error(error.message || 'Failed to unblock users');
+      },
+    })
+  );
 
   const rows = data ?? [];
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Recent Bulk Blocks</CardTitle>
-        <CardDescription>
-          Blocked accounts grouped by reason and date (based on last update timestamp).
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        {isLoading ? (
-          <div className="text-muted-foreground py-8 text-center text-sm">Loading…</div>
-        ) : rows.length === 0 ? (
-          <div className="text-muted-foreground py-8 text-center">No blocked accounts found</div>
-        ) : (
-          <div className="rounded-md border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Block Reason</TableHead>
-                  <TableHead>Date</TableHead>
-                  <TableHead className="text-right">Accounts Blocked</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {rows.map(row => (
-                  <TableRow key={`${row.blocked_reason}-${row.date}`}>
-                    <TableCell className="font-medium">
-                      <code className="bg-muted rounded px-2 py-1 text-sm">
-                        {row.blocked_reason}
-                      </code>
-                    </TableCell>
-                    <TableCell className="text-muted-foreground text-sm">{row.date}</TableCell>
-                    <TableCell className="p-0 text-right">
-                      <Link
-                        href={`/admin/users?${new URLSearchParams({ notesSearch: row.blocked_reason, sortBy: 'updated_at', sortOrder: 'desc', blockedStatus: 'blocked' })}`}
-                        className="text-primary hover:underline block px-4 py-2"
-                      >
-                        {row.blocked_count.toLocaleString()} users
-                      </Link>
-                    </TableCell>
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Bulk Blocks</CardTitle>
+          <CardDescription>
+            Blocked accounts grouped by reason and date (based on last update timestamp).
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="text-muted-foreground py-8 text-center text-sm">Loading…</div>
+          ) : rows.length === 0 ? (
+            <div className="text-muted-foreground py-8 text-center">No blocked accounts found</div>
+          ) : (
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Block Reason</TableHead>
+                    <TableHead>Date</TableHead>
+                    <TableHead className="text-right">Accounts Blocked</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+                </TableHeader>
+                <TableBody>
+                  {rows.map(row => (
+                    <TableRow key={`${row.blocked_reason}-${row.date}`}>
+                      <TableCell className="font-medium">
+                        <code className="bg-muted rounded px-2 py-1 text-sm">
+                          {row.blocked_reason}
+                        </code>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground text-sm">{row.date}</TableCell>
+                      <TableCell className="p-0 text-right">
+                        <Link
+                          href={`/admin/users?${new URLSearchParams({ notesSearch: row.blocked_reason, sortBy: 'updated_at', sortOrder: 'desc', blockedStatus: 'blocked' })}`}
+                          className="text-primary hover:underline block px-4 py-2"
+                        >
+                          {row.blocked_count.toLocaleString()} users
+                        </Link>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setUnblockTarget(row)}
+                          disabled={unblockMutation.isPending}
+                        >
+                          Unblock
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+      <AlertDialog
+        open={unblockTarget !== null}
+        onOpenChange={open => {
+          if (!open && !unblockMutation.isPending) {
+            setUnblockTarget(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Unblock this bulk block?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {unblockTarget && (
+                <>
+                  This will unblock {unblockTarget.blocked_count.toLocaleString()} users with reason
+                  &ldquo;{unblockTarget.blocked_reason}&rdquo; from {unblockTarget.date}. This
+                  cannot be undone automatically.
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={unblockMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              disabled={!unblockTarget || unblockMutation.isPending}
+              onClick={() => {
+                if (!unblockTarget) return;
+                unblockMutation.mutate({
+                  blocked_reason: unblockTarget.blocked_reason,
+                  date: unblockTarget.date,
+                });
+              }}
+            >
+              {unblockMutation.isPending ? 'Unblocking...' : 'Confirm unblock'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }
 

--- a/apps/web/src/lib/abuse/bulkBlock.test.ts
+++ b/apps/web/src/lib/abuse/bulkBlock.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from '@jest/globals';
-import { bulkBlockUsers } from '@/lib/abuse/bulkBlock';
+import { bulkBlockUsers, unblockBulkBlockedUsers } from '@/lib/abuse/bulkBlock';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { db } from '@/lib/drizzle';
 import { kilocode_users } from '@kilocode/db/schema';
@@ -63,5 +63,53 @@ describe('bulkBlockUsers (integration)', () => {
     expect(reasons.get(uById2.id)).toBe(reasonB);
     expect(reasons.get(uByEmail1.id)).toBe(reasonB);
     expect(reasons.get(uByEmail2.id)).toBe(reasonB);
+  });
+
+  test('unblocks a grouped bulk block by reason and date only', async () => {
+    const targetDate = '2026-01-15';
+    const reason = `test-unblock-${Date.now()}-${Math.random()}`;
+    const otherReason = `${reason}-other`;
+
+    const targetUser1 = await insertTestUser();
+    const targetUser2 = await insertTestUser();
+    const otherReasonUser = await insertTestUser();
+    const otherDateUser = await insertTestUser();
+
+    await db
+      .update(kilocode_users)
+      .set({ blocked_reason: reason, updated_at: `${targetDate}T12:00:00.000Z` })
+      .where(inArray(kilocode_users.id, [targetUser1.id, targetUser2.id]));
+
+    await db
+      .update(kilocode_users)
+      .set({ blocked_reason: otherReason, updated_at: `${targetDate}T12:00:00.000Z` })
+      .where(inArray(kilocode_users.id, [otherReasonUser.id]));
+
+    await db
+      .update(kilocode_users)
+      .set({ blocked_reason: reason, updated_at: '2026-01-16T12:00:00.000Z' })
+      .where(inArray(kilocode_users.id, [otherDateUser.id]));
+
+    const result = await unblockBulkBlockedUsers(reason, targetDate);
+
+    expect(result.updatedCount).toBe(2);
+
+    const rows = await db
+      .select({ id: kilocode_users.id, blocked_reason: kilocode_users.blocked_reason })
+      .from(kilocode_users)
+      .where(
+        inArray(kilocode_users.id, [
+          targetUser1.id,
+          targetUser2.id,
+          otherReasonUser.id,
+          otherDateUser.id,
+        ])
+      );
+
+    const reasons = new Map(rows.map(r => [r.id, r.blocked_reason]));
+    expect(reasons.get(targetUser1.id)).toBeNull();
+    expect(reasons.get(targetUser2.id)).toBeNull();
+    expect(reasons.get(otherReasonUser.id)).toBe(otherReason);
+    expect(reasons.get(otherDateUser.id)).toBe(reason);
   });
 });

--- a/apps/web/src/lib/abuse/bulkBlock.ts
+++ b/apps/web/src/lib/abuse/bulkBlock.ts
@@ -1,6 +1,6 @@
 import { db } from '@/lib/drizzle';
 import { kilocode_users } from '@kilocode/db/schema';
-import { inArray, or } from 'drizzle-orm';
+import { and, eq, inArray, or, sql } from 'drizzle-orm';
 import { successResult, type CustomResult } from '@/lib/maybe-result';
 
 export type BulkBlockResponse = CustomResult<
@@ -53,4 +53,19 @@ export async function bulkBlockUsers(
     .where(inArray(kilocode_users.id, valid));
 
   return successResult({ updatedCount: idsOrEmails.length });
+}
+
+export async function unblockBulkBlockedUsers(blocked_reason: string, date: string) {
+  const rows = await db
+    .update(kilocode_users)
+    .set({ blocked_reason: null })
+    .where(
+      and(
+        eq(kilocode_users.blocked_reason, blocked_reason.trim()),
+        sql<boolean>`DATE(${kilocode_users.updated_at}) = ${date}`
+      )
+    )
+    .returning({ id: kilocode_users.id });
+
+  return { updatedCount: rows.length };
 }

--- a/apps/web/src/routers/admin/bulk-block-router.ts
+++ b/apps/web/src/routers/admin/bulk-block-router.ts
@@ -1,7 +1,14 @@
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
 import { kilocode_users } from '@kilocode/db/schema';
+import { unblockBulkBlockedUsers } from '@/lib/abuse/bulkBlock';
 import { sql, count, isNotNull, desc } from 'drizzle-orm';
+import * as z from 'zod';
+
+const BulkBlockRowSchema = z.object({
+  blocked_reason: z.string().trim().min(1),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
 
 export const adminBulkBlockRouter = createTRPCRouter({
   recentBlocks: adminProcedure.query(async () => {
@@ -22,5 +29,9 @@ export const adminBulkBlockRouter = createTRPCRouter({
       date: r.date,
       blocked_count: r.blocked_count,
     }));
+  }),
+
+  unblockRecentBlock: adminProcedure.input(BulkBlockRowSchema).mutation(async ({ input }) => {
+    return unblockBulkBlockedUsers(input.blocked_reason, input.date);
   }),
 });


### PR DESCRIPTION
## Summary

- Add an admin-only unblock action to each recent bulk-block row so admins can clear the block reason for that grouped block.
- Require a confirmation dialog before executing the unblock mutation, including the block reason, date, and affected user count.
- Add server-side bulk unblock logic and a regression test that confirms only the matching reason/date group is unblocked.

## Verification

N/A

## Visual Changes

N/A

## Reviewer Notes

- The unblock target uses the same grouping fields as the recent blocks table: `blocked_reason` and `DATE(updated_at)`.
- `updated_at` is still a proxy for block date because there is no dedicated `blocked_at` column.

<img width="4490" height="524" alt="CleanShot 2026-04-22 at 11 21 26@2x" src="https://github.com/user-attachments/assets/88b8a8e8-885a-4679-9a98-8af5ff8e80cd" />

-- 

<img width="1248" height="448" alt="CleanShot 2026-04-22 at 11 21 14@2x" src="https://github.com/user-attachments/assets/a9117f6b-955b-4b02-871c-6af1399d1b67" />
