### PR TITLE
feat(bot): dual-write bot request child sessions

### DIFF
--- a/apps/web/src/app/api/internal/bot-session-callback/[botRequestId]/route.ts
+++ b/apps/web/src/app/api/internal/bot-session-callback/[botRequestId]/route.ts
@@ -9,6 +9,7 @@ import { captureException } from '@sentry/nextjs';
 import { fetchFinalAssistantTextWithRetries } from '@/lib/cloud-agent-next/session-result';
 import { bot } from '@/lib/bot';
 import { MAX_ITERATIONS } from '@/lib/bot/constants';
+import { markBotRequestCloudAgentSessionTerminal } from '@/lib/bot/request-logging';
 import { parseBotCallbackStep } from '@/lib/bot/step-budget';
 import {
   createSyntheticThread,
@@ -26,6 +27,8 @@ type ExecutionCallbackPayload = {
   kiloSessionId?: string;
   lastSeenBranch?: string;
 };
+
+type TerminalCallbackStatus = ExecutionCallbackPayload['status'];
 
 async function getBotRequest(botRequestId: string) {
   const [request] = await db
@@ -78,6 +81,18 @@ async function getSlackBotToken(platformIntegrationId: string | null): Promise<s
 
 function logCallback(message: string, extra?: Record<string, unknown>) {
   console.log('[BotSessionCallback]', message, extra ?? {});
+}
+
+function parseTerminalCallbackStatus(status: unknown): TerminalCallbackStatus | undefined {
+  if (status === 'completed' || status === 'failed' || status === 'interrupted') {
+    return status;
+  }
+
+  if (typeof status === 'string') {
+    return 'failed';
+  }
+
+  return undefined;
 }
 
 /**
@@ -560,6 +575,23 @@ export async function POST(
       platformIntegrationId: requestRow.platform_integration_id,
       completedStepCount,
     });
+
+    const childSessionStatus = parseTerminalCallbackStatus(payload.status);
+    if (childSessionStatus) {
+      after(() =>
+        markBotRequestCloudAgentSessionTerminal({
+          botRequestId,
+          cloudAgentSessionId: callbackSessionId,
+          status: childSessionStatus,
+          executionId: payload.executionId,
+          kiloSessionId: payload.kiloSessionId,
+          errorMessage:
+            childSessionStatus === 'failed' && payload.status !== 'failed'
+              ? `Unknown callback status: ${String(payload.status)}`
+              : payload.errorMessage,
+        })
+      );
+    }
 
     if (
       requestRow.cloud_agent_session_id &&

--- a/apps/web/src/lib/bot/agent-runner.ts
+++ b/apps/web/src/lib/bot/agent-runner.ts
@@ -10,7 +10,11 @@ import {
   formatConversationContextForPrompt,
 } from '@/lib/bot/conversation-context';
 import { buildPrSignature, getRequesterInfo } from '@/lib/bot/pr-signature';
-import { updateBotRequest, linkBotRequestToSession } from '@/lib/bot/request-logging';
+import {
+  linkBotRequestToSession,
+  recordBotRequestCloudAgentSession,
+  updateBotRequest,
+} from '@/lib/bot/request-logging';
 import { getNextBotCallbackStep, getRemainingBotIterations } from '@/lib/bot/step-budget';
 import spawnCloudAgentSession, {
   spawnCloudAgentInputSchema,
@@ -38,6 +42,7 @@ import type { StepResult, ToolSet } from 'ai';
 import { Actions, Card, CardText, LinkButton, Section } from 'chat';
 import { ThreadImpl } from 'chat';
 import type { Author, Message, Thread } from 'chat';
+import { randomUUID } from 'crypto';
 
 export type BotAgentContinuation = {
   finalText: string;
@@ -228,6 +233,7 @@ export async function runBotAgent(params: RunBotAgentParams): Promise<BotAgentCo
   const initialSteps = params.initialSteps ?? [];
   const completedStepCount = Math.max(params.completedStepCount ?? 0, initialSteps.length);
   const remainingIterations = getRemainingBotIterations(completedStepCount);
+  const spawnGroupId = params.botRequestId ? randomUUID() : undefined;
   const collectedSteps: BotRequestStep[] = [];
   let startedCloudAgentSession = false;
 
@@ -259,7 +265,12 @@ export async function runBotAgent(params: RunBotAgentParams): Promise<BotAgentCo
 This tool returns an acknowledgement immediately. The final Cloud Agent result will be posted later in the same thread after the async session completes.`,
         inputSchema: spawnCloudAgentInputSchema,
         execute: async args => {
-          let resolvedSessionId: string | undefined;
+          let resolvedCloudAgentSessionId: string | undefined;
+          let resolvedKiloSessionId: string | undefined;
+          const currentStep = getNextBotCallbackStep({
+            completedStepCount,
+            completedStepsInCurrentRun: collectedSteps.length,
+          });
 
           const result = await spawnCloudAgentSession(
             args,
@@ -270,7 +281,8 @@ This tool returns an acknowledgement immediately. The final Cloud Agent result w
             params.botRequestId,
             ({ kiloSessionId, cloudAgentSessionId }) => {
               startedCloudAgentSession = true;
-              resolvedSessionId = cloudAgentSessionId;
+              resolvedCloudAgentSessionId = cloudAgentSessionId;
+              resolvedKiloSessionId = kiloSessionId;
               params.onSessionReady?.({ kiloSessionId, cloudAgentSessionId, prompt: args.prompt });
               const sessionUrl = buildSessionUrl(kiloSessionId, owner);
               void postSessionLinkEphemeral({
@@ -285,17 +297,27 @@ This tool returns an acknowledgement immediately. The final Cloud Agent result w
             {
               prSignature,
               chatPlatform,
-              currentStep: getNextBotCallbackStep({
-                completedStepCount,
-                completedStepsInCurrentRun: collectedSteps.length,
-              }),
+              currentStep,
             }
           );
 
           // Persist the session link synchronously so callbacks can
           // correlate immediately — must complete before we return.
-          if (params.botRequestId && resolvedSessionId) {
-            await linkBotRequestToSession(params.botRequestId, resolvedSessionId);
+          if (params.botRequestId && resolvedCloudAgentSessionId) {
+            await linkBotRequestToSession(params.botRequestId, resolvedCloudAgentSessionId);
+          }
+
+          if (params.botRequestId && spawnGroupId && resolvedCloudAgentSessionId) {
+            await recordBotRequestCloudAgentSession({
+              botRequestId: params.botRequestId,
+              spawnGroupId,
+              cloudAgentSessionId: resolvedCloudAgentSessionId,
+              kiloSessionId: resolvedKiloSessionId,
+              mode: args.mode,
+              githubRepo: args.githubRepo,
+              gitlabProject: args.gitlabProject,
+              callbackStep: currentStep,
+            });
           }
 
           return result;

--- a/apps/web/src/lib/bot/request-logging.test.ts
+++ b/apps/web/src/lib/bot/request-logging.test.ts
@@ -1,6 +1,7 @@
 import { db } from '@/lib/drizzle';
 import {
   linkBotRequestToSession,
+  markBotRequestCloudAgentSessionTerminal,
   recordBotRequestCloudAgentSession,
 } from '@/lib/bot/request-logging';
 import { insertTestUser } from '@/tests/helpers/user.helper';
@@ -172,6 +173,44 @@ describe('bot request logging', () => {
     expect(row.error_message).toBe('kept terminal error');
     expect(new Date(row.terminal_at ?? '').toISOString()).toBe(terminalAt);
     expect(new Date(row.continuation_started_at ?? '').toISOString()).toBe(continuationStartedAt);
+  });
+
+  it('marks a child Cloud Agent session terminal from callback metadata', async () => {
+    const botRequestId = await createBotRequest();
+    const spawnGroupId = randomUUID();
+    const cloudAgentSessionId = `cas-child-terminal-${randomUUID()}`;
+    const kiloSessionId = `kilo-child-terminal-${randomUUID()}`;
+    const terminalAt = new Date('2026-01-03T04:05:06.000Z').toISOString();
+    createdCloudAgentSessionIds.add(cloudAgentSessionId);
+
+    await recordBotRequestCloudAgentSession({
+      botRequestId,
+      spawnGroupId,
+      cloudAgentSessionId,
+    });
+
+    await markBotRequestCloudAgentSessionTerminal({
+      botRequestId,
+      cloudAgentSessionId,
+      status: 'failed',
+      executionId: 'execution-terminal-test',
+      kiloSessionId,
+      errorMessage: 'session failed',
+      terminalAt,
+    });
+
+    const row = expectSingleRow(
+      await db
+        .select()
+        .from(bot_request_cloud_agent_sessions)
+        .where(eq(bot_request_cloud_agent_sessions.cloud_agent_session_id, cloudAgentSessionId))
+    );
+
+    expect(row.status).toBe('failed');
+    expect(row.execution_id).toBe('execution-terminal-test');
+    expect(row.kilo_session_id).toBe(kiloSessionId);
+    expect(row.error_message).toBe('session failed');
+    expect(new Date(row.terminal_at ?? '').toISOString()).toBe(terminalAt);
   });
 
   it('continues linking the legacy Cloud Agent session column', async () => {

--- a/apps/web/src/lib/bot/request-logging.test.ts
+++ b/apps/web/src/lib/bot/request-logging.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable drizzle/enforce-delete-with-where */
 import { db } from '@/lib/drizzle';
 import {
   linkBotRequestToSession,
@@ -10,29 +9,8 @@ import {
   bot_requests,
   kilocode_users,
 } from '@kilocode/db/schema';
-import { count, eq } from 'drizzle-orm';
+import { count, eq, inArray } from 'drizzle-orm';
 import { randomUUID } from 'crypto';
-
-async function createBotRequest() {
-  const user = await insertTestUser();
-  const [row] = await db
-    .insert(bot_requests)
-    .values({
-      created_by: user.id,
-      platform: 'slack',
-      platform_thread_id: `slack:T123:C456:${randomUUID()}`,
-      platform_message_id: `message-${randomUUID()}`,
-      user_message: 'Please make a change',
-      status: 'pending',
-    })
-    .returning({ id: bot_requests.id });
-
-  if (!row) {
-    throw new Error('Failed to create bot request fixture');
-  }
-
-  return row.id;
-}
 
 function expectSingleRow<T>(rows: T[]): T {
   expect(rows).toHaveLength(1);
@@ -44,21 +22,71 @@ function expectSingleRow<T>(rows: T[]): T {
 }
 
 describe('bot request logging', () => {
+  const createdBotRequestIds = new Set<string>();
+  const createdCloudAgentSessionIds = new Set<string>();
+  const createdUserIds = new Set<string>();
+
+  async function createBotRequest() {
+    const user = await insertTestUser();
+    createdUserIds.add(user.id);
+
+    const [row] = await db
+      .insert(bot_requests)
+      .values({
+        created_by: user.id,
+        platform: 'slack',
+        platform_thread_id: `slack:T123:C456:${randomUUID()}`,
+        platform_message_id: `message-${randomUUID()}`,
+        user_message: 'Please make a change',
+        status: 'pending',
+      })
+      .returning({ id: bot_requests.id });
+
+    if (!row) {
+      throw new Error('Failed to create bot request fixture');
+    }
+
+    createdBotRequestIds.add(row.id);
+    return row.id;
+  }
+
   afterEach(async () => {
-    await db.delete(bot_request_cloud_agent_sessions);
-    await db.delete(bot_requests);
-    await db.delete(kilocode_users);
+    const cloudAgentSessionIds = Array.from(createdCloudAgentSessionIds);
+    if (cloudAgentSessionIds.length > 0) {
+      await db
+        .delete(bot_request_cloud_agent_sessions)
+        .where(
+          inArray(bot_request_cloud_agent_sessions.cloud_agent_session_id, cloudAgentSessionIds)
+        );
+    }
+
+    const botRequestIds = Array.from(createdBotRequestIds);
+    if (botRequestIds.length > 0) {
+      await db.delete(bot_requests).where(inArray(bot_requests.id, botRequestIds));
+    }
+
+    const userIds = Array.from(createdUserIds);
+    if (userIds.length > 0) {
+      await db.delete(kilocode_users).where(inArray(kilocode_users.id, userIds));
+    }
+
+    createdCloudAgentSessionIds.clear();
+    createdBotRequestIds.clear();
+    createdUserIds.clear();
   });
 
   it('records a child Cloud Agent session for an existing bot request', async () => {
     const botRequestId = await createBotRequest();
     const spawnGroupId = randomUUID();
+    const cloudAgentSessionId = `cas-child-insert-${randomUUID()}`;
+    const kiloSessionId = `kilo-child-insert-${randomUUID()}`;
+    createdCloudAgentSessionIds.add(cloudAgentSessionId);
 
     await recordBotRequestCloudAgentSession({
       botRequestId,
       spawnGroupId,
-      cloudAgentSessionId: 'cas-child-insert',
-      kiloSessionId: 'kilo-child-insert',
+      cloudAgentSessionId,
+      kiloSessionId,
       mode: 'code',
       githubRepo: 'kilocode/cloud',
       gitlabProject: 'group/project',
@@ -69,13 +97,13 @@ describe('bot request logging', () => {
       await db
         .select()
         .from(bot_request_cloud_agent_sessions)
-        .where(eq(bot_request_cloud_agent_sessions.cloud_agent_session_id, 'cas-child-insert'))
+        .where(eq(bot_request_cloud_agent_sessions.cloud_agent_session_id, cloudAgentSessionId))
     );
 
     expect(row.bot_request_id).toBe(botRequestId);
     expect(row.spawn_group_id).toBe(spawnGroupId);
-    expect(row.cloud_agent_session_id).toBe('cas-child-insert');
-    expect(row.kilo_session_id).toBe('kilo-child-insert');
+    expect(row.cloud_agent_session_id).toBe(cloudAgentSessionId);
+    expect(row.kilo_session_id).toBe(kiloSessionId);
     expect(row.mode).toBe('code');
     expect(row.github_repo).toBe('kilocode/cloud');
     expect(row.gitlab_project).toBe('group/project');
@@ -87,13 +115,16 @@ describe('bot request logging', () => {
     const botRequestId = await createBotRequest();
     const initialSpawnGroupId = randomUUID();
     const updatedSpawnGroupId = randomUUID();
+    const cloudAgentSessionId = `cas-child-upsert-${randomUUID()}`;
+    const kiloSessionId = `kilo-child-upsert-${randomUUID()}`;
     const terminalAt = new Date('2026-01-02T03:04:05.000Z').toISOString();
     const continuationStartedAt = new Date('2026-01-02T03:05:06.000Z').toISOString();
+    createdCloudAgentSessionIds.add(cloudAgentSessionId);
 
     await recordBotRequestCloudAgentSession({
       botRequestId,
       spawnGroupId: initialSpawnGroupId,
-      cloudAgentSessionId: 'cas-child-upsert',
+      cloudAgentSessionId,
     });
 
     await db
@@ -104,13 +135,13 @@ describe('bot request logging', () => {
         terminal_at: terminalAt,
         continuation_started_at: continuationStartedAt,
       })
-      .where(eq(bot_request_cloud_agent_sessions.cloud_agent_session_id, 'cas-child-upsert'));
+      .where(eq(bot_request_cloud_agent_sessions.cloud_agent_session_id, cloudAgentSessionId));
 
     await recordBotRequestCloudAgentSession({
       botRequestId,
       spawnGroupId: updatedSpawnGroupId,
-      cloudAgentSessionId: 'cas-child-upsert',
-      kiloSessionId: 'kilo-child-upsert',
+      cloudAgentSessionId,
+      kiloSessionId,
       mode: 'ask',
       gitlabProject: 'group/subgroup/project',
       callbackStep: 7,
@@ -120,7 +151,7 @@ describe('bot request logging', () => {
       await db
         .select({ childSessionCount: count() })
         .from(bot_request_cloud_agent_sessions)
-        .where(eq(bot_request_cloud_agent_sessions.cloud_agent_session_id, 'cas-child-upsert'))
+        .where(eq(bot_request_cloud_agent_sessions.cloud_agent_session_id, cloudAgentSessionId))
     );
 
     expect(countRow.childSessionCount).toBe(1);
@@ -129,11 +160,11 @@ describe('bot request logging', () => {
       await db
         .select()
         .from(bot_request_cloud_agent_sessions)
-        .where(eq(bot_request_cloud_agent_sessions.cloud_agent_session_id, 'cas-child-upsert'))
+        .where(eq(bot_request_cloud_agent_sessions.cloud_agent_session_id, cloudAgentSessionId))
     );
 
     expect(row.spawn_group_id).toBe(updatedSpawnGroupId);
-    expect(row.kilo_session_id).toBe('kilo-child-upsert');
+    expect(row.kilo_session_id).toBe(kiloSessionId);
     expect(row.mode).toBe('ask');
     expect(row.gitlab_project).toBe('group/subgroup/project');
     expect(row.callback_step).toBe(7);
@@ -145,13 +176,14 @@ describe('bot request logging', () => {
 
   it('continues linking the legacy Cloud Agent session column', async () => {
     const botRequestId = await createBotRequest();
+    const cloudAgentSessionId = `cas-legacy-link-${randomUUID()}`;
 
-    await linkBotRequestToSession(botRequestId, 'cas-legacy-link');
+    await linkBotRequestToSession(botRequestId, cloudAgentSessionId);
 
     const row = expectSingleRow(
       await db.select().from(bot_requests).where(eq(bot_requests.id, botRequestId))
     );
 
-    expect(row.cloud_agent_session_id).toBe('cas-legacy-link');
+    expect(row.cloud_agent_session_id).toBe(cloudAgentSessionId);
   });
 });

--- a/apps/web/src/lib/bot/request-logging.test.ts
+++ b/apps/web/src/lib/bot/request-logging.test.ts
@@ -1,0 +1,157 @@
+/* eslint-disable drizzle/enforce-delete-with-where */
+import { db } from '@/lib/drizzle';
+import {
+  linkBotRequestToSession,
+  recordBotRequestCloudAgentSession,
+} from '@/lib/bot/request-logging';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import {
+  bot_request_cloud_agent_sessions,
+  bot_requests,
+  kilocode_users,
+} from '@kilocode/db/schema';
+import { count, eq } from 'drizzle-orm';
+import { randomUUID } from 'crypto';
+
+async function createBotRequest() {
+  const user = await insertTestUser();
+  const [row] = await db
+    .insert(bot_requests)
+    .values({
+      created_by: user.id,
+      platform: 'slack',
+      platform_thread_id: `slack:T123:C456:${randomUUID()}`,
+      platform_message_id: `message-${randomUUID()}`,
+      user_message: 'Please make a change',
+      status: 'pending',
+    })
+    .returning({ id: bot_requests.id });
+
+  if (!row) {
+    throw new Error('Failed to create bot request fixture');
+  }
+
+  return row.id;
+}
+
+function expectSingleRow<T>(rows: T[]): T {
+  expect(rows).toHaveLength(1);
+  const [row] = rows;
+  if (!row) {
+    throw new Error('Expected one row');
+  }
+  return row;
+}
+
+describe('bot request logging', () => {
+  afterEach(async () => {
+    await db.delete(bot_request_cloud_agent_sessions);
+    await db.delete(bot_requests);
+    await db.delete(kilocode_users);
+  });
+
+  it('records a child Cloud Agent session for an existing bot request', async () => {
+    const botRequestId = await createBotRequest();
+    const spawnGroupId = randomUUID();
+
+    await recordBotRequestCloudAgentSession({
+      botRequestId,
+      spawnGroupId,
+      cloudAgentSessionId: 'cas-child-insert',
+      kiloSessionId: 'kilo-child-insert',
+      mode: 'code',
+      githubRepo: 'kilocode/cloud',
+      gitlabProject: 'group/project',
+      callbackStep: 3,
+    });
+
+    const row = expectSingleRow(
+      await db
+        .select()
+        .from(bot_request_cloud_agent_sessions)
+        .where(eq(bot_request_cloud_agent_sessions.cloud_agent_session_id, 'cas-child-insert'))
+    );
+
+    expect(row.bot_request_id).toBe(botRequestId);
+    expect(row.spawn_group_id).toBe(spawnGroupId);
+    expect(row.cloud_agent_session_id).toBe('cas-child-insert');
+    expect(row.kilo_session_id).toBe('kilo-child-insert');
+    expect(row.mode).toBe('code');
+    expect(row.github_repo).toBe('kilocode/cloud');
+    expect(row.gitlab_project).toBe('group/project');
+    expect(row.callback_step).toBe(3);
+    expect(row.status).toBe('running');
+  });
+
+  it('upserts duplicate child sessions without changing terminal fields', async () => {
+    const botRequestId = await createBotRequest();
+    const initialSpawnGroupId = randomUUID();
+    const updatedSpawnGroupId = randomUUID();
+    const terminalAt = new Date('2026-01-02T03:04:05.000Z').toISOString();
+    const continuationStartedAt = new Date('2026-01-02T03:05:06.000Z').toISOString();
+
+    await recordBotRequestCloudAgentSession({
+      botRequestId,
+      spawnGroupId: initialSpawnGroupId,
+      cloudAgentSessionId: 'cas-child-upsert',
+    });
+
+    await db
+      .update(bot_request_cloud_agent_sessions)
+      .set({
+        status: 'completed',
+        error_message: 'kept terminal error',
+        terminal_at: terminalAt,
+        continuation_started_at: continuationStartedAt,
+      })
+      .where(eq(bot_request_cloud_agent_sessions.cloud_agent_session_id, 'cas-child-upsert'));
+
+    await recordBotRequestCloudAgentSession({
+      botRequestId,
+      spawnGroupId: updatedSpawnGroupId,
+      cloudAgentSessionId: 'cas-child-upsert',
+      kiloSessionId: 'kilo-child-upsert',
+      mode: 'ask',
+      gitlabProject: 'group/subgroup/project',
+      callbackStep: 7,
+    });
+
+    const countRow = expectSingleRow(
+      await db
+        .select({ childSessionCount: count() })
+        .from(bot_request_cloud_agent_sessions)
+        .where(eq(bot_request_cloud_agent_sessions.cloud_agent_session_id, 'cas-child-upsert'))
+    );
+
+    expect(countRow.childSessionCount).toBe(1);
+
+    const row = expectSingleRow(
+      await db
+        .select()
+        .from(bot_request_cloud_agent_sessions)
+        .where(eq(bot_request_cloud_agent_sessions.cloud_agent_session_id, 'cas-child-upsert'))
+    );
+
+    expect(row.spawn_group_id).toBe(updatedSpawnGroupId);
+    expect(row.kilo_session_id).toBe('kilo-child-upsert');
+    expect(row.mode).toBe('ask');
+    expect(row.gitlab_project).toBe('group/subgroup/project');
+    expect(row.callback_step).toBe(7);
+    expect(row.status).toBe('completed');
+    expect(row.error_message).toBe('kept terminal error');
+    expect(new Date(row.terminal_at ?? '').toISOString()).toBe(terminalAt);
+    expect(new Date(row.continuation_started_at ?? '').toISOString()).toBe(continuationStartedAt);
+  });
+
+  it('continues linking the legacy Cloud Agent session column', async () => {
+    const botRequestId = await createBotRequest();
+
+    await linkBotRequestToSession(botRequestId, 'cas-legacy-link');
+
+    const row = expectSingleRow(
+      await db.select().from(bot_requests).where(eq(bot_requests.id, botRequestId))
+    );
+
+    expect(row.cloud_agent_session_id).toBe('cas-legacy-link');
+  });
+});

--- a/apps/web/src/lib/bot/request-logging.ts
+++ b/apps/web/src/lib/bot/request-logging.ts
@@ -1,11 +1,12 @@
 import 'server-only';
 import { db } from '@/lib/drizzle';
 import { captureException } from '@sentry/nextjs';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { after } from 'next/server';
 import {
   bot_request_cloud_agent_sessions,
   bot_requests,
+  type BotRequestCloudAgentSessionStatus,
   type BotRequestStatus,
   type BotRequestStep,
 } from '@kilocode/db/schema';
@@ -71,6 +72,21 @@ type RecordBotRequestCloudAgentSessionParams = {
   callbackStep?: number;
 };
 
+type TerminalBotRequestCloudAgentSessionStatus = Extract<
+  BotRequestCloudAgentSessionStatus,
+  'completed' | 'failed' | 'interrupted'
+>;
+
+type MarkBotRequestCloudAgentSessionTerminalParams = {
+  botRequestId: string;
+  cloudAgentSessionId: string;
+  status: TerminalBotRequestCloudAgentSessionStatus;
+  executionId?: string;
+  kiloSessionId?: string;
+  errorMessage?: string;
+  terminalAt?: string;
+};
+
 async function performUpdate(id: string, params: UpdateBotRequestParams): Promise<void> {
   try {
     await db
@@ -131,6 +147,37 @@ export async function recordBotRequestCloudAgentSession(
         botRequestId: params.botRequestId,
         spawnGroupId: params.spawnGroupId,
         cloudAgentSessionId: params.cloudAgentSessionId,
+      },
+    });
+  }
+}
+
+export async function markBotRequestCloudAgentSessionTerminal(
+  params: MarkBotRequestCloudAgentSessionTerminalParams
+): Promise<void> {
+  try {
+    await db
+      .update(bot_request_cloud_agent_sessions)
+      .set({
+        status: params.status,
+        terminal_at: params.terminalAt ?? new Date().toISOString(),
+        error_message: params.errorMessage ?? null,
+        ...(params.executionId !== undefined && { execution_id: params.executionId }),
+        ...(params.kiloSessionId !== undefined && { kilo_session_id: params.kiloSessionId }),
+      })
+      .where(
+        and(
+          eq(bot_request_cloud_agent_sessions.bot_request_id, params.botRequestId),
+          eq(bot_request_cloud_agent_sessions.cloud_agent_session_id, params.cloudAgentSessionId)
+        )
+      );
+  } catch (error) {
+    captureException(error, {
+      tags: { component: 'bot-request-log', op: 'mark-child-session-terminal' },
+      extra: {
+        botRequestId: params.botRequestId,
+        cloudAgentSessionId: params.cloudAgentSessionId,
+        status: params.status,
       },
     });
   }

--- a/apps/web/src/lib/bot/request-logging.ts
+++ b/apps/web/src/lib/bot/request-logging.ts
@@ -3,7 +3,12 @@ import { db } from '@/lib/drizzle';
 import { captureException } from '@sentry/nextjs';
 import { eq } from 'drizzle-orm';
 import { after } from 'next/server';
-import { bot_requests, type BotRequestStatus, type BotRequestStep } from '@kilocode/db/schema';
+import {
+  bot_request_cloud_agent_sessions,
+  bot_requests,
+  type BotRequestStatus,
+  type BotRequestStep,
+} from '@kilocode/db/schema';
 
 type CreateBotRequestParams = {
   createdBy: string;
@@ -55,6 +60,17 @@ type UpdateBotRequestParams = {
   responseTimeMs?: number;
 };
 
+type RecordBotRequestCloudAgentSessionParams = {
+  botRequestId: string;
+  spawnGroupId: string;
+  cloudAgentSessionId: string;
+  kiloSessionId?: string;
+  mode?: 'code' | 'ask';
+  githubRepo?: string;
+  gitlabProject?: string;
+  callbackStep?: number;
+};
+
 async function performUpdate(id: string, params: UpdateBotRequestParams): Promise<void> {
   try {
     await db
@@ -78,6 +94,46 @@ async function performUpdate(id: string, params: UpdateBotRequestParams): Promis
  */
 export function updateBotRequest(id: string, params: UpdateBotRequestParams): void {
   after(() => performUpdate(id, params));
+}
+
+export async function recordBotRequestCloudAgentSession(
+  params: RecordBotRequestCloudAgentSessionParams
+): Promise<void> {
+  try {
+    await db
+      .insert(bot_request_cloud_agent_sessions)
+      .values({
+        bot_request_id: params.botRequestId,
+        spawn_group_id: params.spawnGroupId,
+        cloud_agent_session_id: params.cloudAgentSessionId,
+        kilo_session_id: params.kiloSessionId ?? null,
+        mode: params.mode ?? null,
+        github_repo: params.githubRepo ?? null,
+        gitlab_project: params.gitlabProject ?? null,
+        callback_step: params.callbackStep ?? 0,
+      })
+      .onConflictDoUpdate({
+        target: bot_request_cloud_agent_sessions.cloud_agent_session_id,
+        set: {
+          bot_request_id: params.botRequestId,
+          spawn_group_id: params.spawnGroupId,
+          ...(params.kiloSessionId !== undefined && { kilo_session_id: params.kiloSessionId }),
+          ...(params.mode !== undefined && { mode: params.mode }),
+          ...(params.githubRepo !== undefined && { github_repo: params.githubRepo }),
+          ...(params.gitlabProject !== undefined && { gitlab_project: params.gitlabProject }),
+          ...(params.callbackStep !== undefined && { callback_step: params.callbackStep }),
+        },
+      });
+  } catch (error) {
+    captureException(error, {
+      tags: { component: 'bot-request-log', op: 'record-child-session' },
+      extra: {
+        botRequestId: params.botRequestId,
+        spawnGroupId: params.spawnGroupId,
+        cloudAgentSessionId: params.cloudAgentSessionId,
+      },
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Start recording newly spawned Cloud Agent sessions in `bot_request_cloud_agent_sessions`.
- Preserve legacy `bot_requests.cloud_agent_session_id` writes and existing callback behavior.
- Generate one `spawnGroupId` per bot-agent run so future PRs can coordinate sibling sessions.
- Add focused request-logging tests for child-session recording and legacy session linking.

## Reviewer Notes
Legacy callback correlation remains on `bot_requests.cloud_agent_session_id`; child-session recording is best-effort and does not update terminal child-session fields on conflict.