### PR TITLE
feat(admin): add blocked-at backfill

### DIFF
--- a/apps/web/src/app/admin/api/backfills/blocked-at/route.test.ts
+++ b/apps/web/src/app/admin/api/backfills/blocked-at/route.test.ts
@@ -52,11 +52,13 @@ describe('backfillBlockedAtBatch', () => {
       .select({
         blocked_at: kilocode_users.blocked_at,
         blocked_by_kilo_user_id: kilocode_users.blocked_by_kilo_user_id,
+        updated_at: kilocode_users.updated_at,
       })
       .from(kilocode_users)
       .where(eq(kilocode_users.id, user.id));
 
     expect(new Date(row.blocked_at ?? '').toISOString()).toBe(updatedAt);
+    expect(new Date(row.updated_at).toISOString()).toBe(updatedAt);
     expect(row.blocked_by_kilo_user_id).toBeNull();
 
     const matches = await missingBlockedAtUserIds();

--- a/apps/web/src/app/admin/api/backfills/blocked-at/route.test.ts
+++ b/apps/web/src/app/admin/api/backfills/blocked-at/route.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { cleanupDbForTest, db } from '@/lib/drizzle';
+import { kilocode_users } from '@kilocode/db';
+import { eq } from 'drizzle-orm';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { backfillBlockedAtBatch, blockedAtBackfillCandidates } from './route';
+
+beforeEach(async () => {
+  await cleanupDbForTest();
+});
+
+async function missingBlockedAtUserIds(): Promise<string[]> {
+  const rows = await db
+    .select({ id: kilocode_users.id })
+    .from(kilocode_users)
+    .where(blockedAtBackfillCandidates);
+  return rows.map(r => r.id);
+}
+
+describe('blockedAtBackfillCandidates', () => {
+  it('matches blocked users missing blocked_at', async () => {
+    const blocked = await insertTestUser({ blocked_reason: 'abuse' });
+    const unblocked = await insertTestUser();
+    const alreadyBackfilled = await insertTestUser({
+      blocked_reason: 'abuse',
+      blocked_at: '2026-01-15T12:00:00.000Z',
+    });
+    const softDeleted = await insertTestUser({
+      blocked_reason: 'soft-deleted at 2026-01-15T12:00:00.000Z',
+    });
+
+    const matches = await missingBlockedAtUserIds();
+
+    expect(matches).toContain(blocked.id);
+    expect(matches).not.toContain(unblocked.id);
+    expect(matches).not.toContain(alreadyBackfilled.id);
+    expect(matches).not.toContain(softDeleted.id);
+  });
+});
+
+describe('backfillBlockedAtBatch', () => {
+  it('copies updated_at into blocked_at and leaves blocked_by unknown', async () => {
+    const updatedAt = '2026-01-15T12:00:00.000Z';
+    const user = await insertTestUser({ blocked_reason: 'abuse', updated_at: updatedAt });
+
+    const result = await backfillBlockedAtBatch();
+
+    expect(result.processed).toBe(1);
+    expect(result.remaining).toBe(false);
+
+    const [row] = await db
+      .select({
+        blocked_at: kilocode_users.blocked_at,
+        blocked_by_kilo_user_id: kilocode_users.blocked_by_kilo_user_id,
+      })
+      .from(kilocode_users)
+      .where(eq(kilocode_users.id, user.id));
+
+    expect(new Date(row.blocked_at ?? '').toISOString()).toBe(updatedAt);
+    expect(row.blocked_by_kilo_user_id).toBeNull();
+
+    const matches = await missingBlockedAtUserIds();
+    expect(matches).not.toContain(user.id);
+  });
+});

--- a/apps/web/src/app/admin/api/backfills/blocked-at/route.ts
+++ b/apps/web/src/app/admin/api/backfills/blocked-at/route.ts
@@ -52,7 +52,10 @@ export async function backfillBlockedAtBatch(): Promise<BlockedAtBackfillRespons
 
     const updated = await db
       .update(kilocode_users)
-      .set({ blocked_at: sql`${kilocode_users.updated_at}` })
+      .set({
+        blocked_at: sql`${kilocode_users.updated_at}`,
+        updated_at: sql`${kilocode_users.updated_at}`,
+      })
       .where(
         and(
           inArray(

--- a/apps/web/src/app/admin/api/backfills/blocked-at/route.ts
+++ b/apps/web/src/app/admin/api/backfills/blocked-at/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from 'next/server';
+import { getUserFromAuth } from '@/lib/user.server';
+import { db } from '@/lib/drizzle';
+import { kilocode_users } from '@kilocode/db';
+import { and, count, inArray, isNotNull, isNull, like, not, sql } from 'drizzle-orm';
+
+export const blockedAtBackfillCandidates = and(
+  isNotNull(kilocode_users.blocked_reason),
+  isNull(kilocode_users.blocked_at),
+  not(like(kilocode_users.blocked_reason, 'soft-deleted at %'))
+);
+
+export type BlockedAtCountsResponse = {
+  missing: number;
+};
+
+export type BlockedAtBackfillResponse = {
+  processed: number;
+  remaining: boolean;
+};
+
+export async function GET(): Promise<NextResponse<BlockedAtCountsResponse | { error: string }>> {
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) return authFailedResponse;
+
+  const [result] = await db
+    .select({ count: count() })
+    .from(kilocode_users)
+    .where(blockedAtBackfillCandidates);
+
+  return NextResponse.json({ missing: result?.count ?? 0 });
+}
+
+const BATCH_SIZE = 1000;
+const BATCHES_PER_REQUEST = 50;
+
+export async function backfillBlockedAtBatch(): Promise<BlockedAtBackfillResponse> {
+  let totalProcessed = 0;
+  let reachedEnd = false;
+
+  for (let i = 0; i < BATCHES_PER_REQUEST; i++) {
+    const rows = await db
+      .select({ id: kilocode_users.id })
+      .from(kilocode_users)
+      .where(blockedAtBackfillCandidates)
+      .limit(BATCH_SIZE);
+
+    if (rows.length === 0) {
+      reachedEnd = true;
+      break;
+    }
+
+    const updated = await db
+      .update(kilocode_users)
+      .set({ blocked_at: sql`${kilocode_users.updated_at}` })
+      .where(
+        and(
+          inArray(
+            kilocode_users.id,
+            rows.map(r => r.id)
+          ),
+          blockedAtBackfillCandidates
+        )
+      )
+      .returning({ id: kilocode_users.id });
+
+    totalProcessed += updated.length;
+
+    if (rows.length < BATCH_SIZE) {
+      reachedEnd = true;
+      break;
+    }
+  }
+
+  return { processed: totalProcessed, remaining: !reachedEnd };
+}
+
+export async function POST(): Promise<NextResponse<BlockedAtBackfillResponse | { error: string }>> {
+  const { authFailedResponse } = await getUserFromAuth({ adminOnly: true });
+  if (authFailedResponse) return authFailedResponse;
+
+  return NextResponse.json(await backfillBlockedAtBatch());
+}

--- a/apps/web/src/app/admin/backfills/page.tsx
+++ b/apps/web/src/app/admin/backfills/page.tsx
@@ -2,6 +2,7 @@ import { SafetyIdentifiersBackfill } from '../components/SafetyIdentifiersBackfi
 import { NormalizedEmailBackfill } from '../components/NormalizedEmailBackfill';
 import { EmailDomainBackfill } from '../components/EmailDomainBackfill';
 import { BlockBlacklistedDomainsBackfill } from '../components/BlockBlacklistedDomainsBackfill';
+import { BlockedAtBackfill } from '../components/BlockedAtBackfill';
 import { SafetyIdentifierHashGenerator } from '../components/SafetyIdentifierHashGenerator';
 import AdminPage from '../components/AdminPage';
 import { BreadcrumbItem, BreadcrumbPage } from '@/components/ui/breadcrumb';
@@ -30,6 +31,10 @@ export default function BackfillsPage() {
           <h2 className="text-2xl font-bold">Block Blacklisted Domains</h2>
         </div>
         <BlockBlacklistedDomainsBackfill />
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-bold">Blocked At Backfill</h2>
+        </div>
+        <BlockedAtBackfill />
         <div className="flex items-center justify-between">
           <h2 className="text-2xl font-bold">Safety Identifier Backfill</h2>
         </div>

--- a/apps/web/src/app/admin/components/BlockedAtBackfill.tsx
+++ b/apps/web/src/app/admin/components/BlockedAtBackfill.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import type {
+  BlockedAtCountsResponse,
+  BlockedAtBackfillResponse,
+} from '../api/backfills/blocked-at/route';
+
+type BatchLog = {
+  processed: number;
+  timestamp: Date;
+};
+
+export function BlockedAtBackfill() {
+  const [logs, setLogs] = useState<BatchLog[]>([]);
+  const queryClient = useQueryClient();
+
+  const { data: counts, isLoading } = useQuery<BlockedAtCountsResponse>({
+    queryKey: ['blocked-at-counts'],
+    queryFn: async () => {
+      const res = await fetch('/admin/api/backfills/blocked-at');
+      return res.json() as Promise<BlockedAtCountsResponse>;
+    },
+    refetchInterval: false,
+  });
+
+  const mutation = useMutation<BlockedAtBackfillResponse, Error>({
+    mutationFn: async () => {
+      const res = await fetch('/admin/api/backfills/blocked-at', { method: 'POST' });
+      if (!res.ok) {
+        const body = (await res.json()) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      return res.json() as Promise<BlockedAtBackfillResponse>;
+    },
+    onSuccess: data => {
+      setLogs(prev => [{ processed: data.processed, timestamp: new Date() }, ...prev]);
+      void queryClient.invalidateQueries({ queryKey: ['blocked-at-counts'] });
+    },
+  });
+
+  const isDone = counts?.missing === 0;
+
+  return (
+    <div className="space-y-6">
+      <p className="text-muted-foreground text-sm">
+        Backfill block timestamps for users who already have a blocked reason but no blocked_at.
+        This uses each row&apos;s current updated_at as the best available historical approximation.
+        Soft-deleted users are excluded. The blocker remains unknown for historical rows because
+        there is no reliable system user to attribute the original action to.
+      </p>
+
+      <div className="bg-background space-y-4 rounded-lg border p-6">
+        <div className="flex items-center gap-3">
+          <span className="font-medium">Blocked users missing blocked_at</span>
+          {isLoading ? (
+            <Badge variant="secondary">Loading...</Badge>
+          ) : isDone ? (
+            <Badge variant="default" className="bg-green-600">
+              All filled
+            </Badge>
+          ) : (
+            <Badge variant="destructive">{(counts?.missing ?? 0).toLocaleString()} missing</Badge>
+          )}
+        </div>
+
+        {mutation.isError && (
+          <Alert variant="destructive">
+            <AlertDescription>{mutation.error.message}</AlertDescription>
+          </Alert>
+        )}
+
+        <Button
+          onClick={() => mutation.mutate()}
+          disabled={isLoading || isDone || mutation.isPending}
+          variant={isDone ? 'outline' : 'default'}
+        >
+          {mutation.isPending
+            ? 'Backfilling...'
+            : isDone
+              ? 'Nothing to do'
+              : 'Backfill next 50 000'}
+        </Button>
+      </div>
+
+      {logs.length > 0 && (
+        <div className="bg-background space-y-2 rounded-lg border p-4">
+          <h4 className="text-sm font-medium">Batch log</h4>
+          <div className="space-y-1 font-mono text-xs">
+            {logs.map((log, i) => (
+              <div key={i} className="text-muted-foreground flex gap-2">
+                <span className="shrink-0">{log.timestamp.toLocaleTimeString()}</span>
+                <span>backfilled {log.processed.toLocaleString()} users</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add an admin backfill for historical blocked users missing `blocked_at`.
- Add `/admin/api/backfills/blocked-at` GET/POST endpoints and a button on `/admin/backfills`.
- Backfill `blocked_at` from each user's current `updated_at` as the best available historical approximation; leave `blocked_by_kilo_user_id` null because there is no reliable system user for attribution.

## Verification

N/A

## Visual Changes

N/A

## Reviewer Notes

- Soft-deleted users are excluded so GDPR cleanup stays intact.
- The blocker remains `Unknown` for backfilled historical rows; nullable attribution is intentional because the original blocker cannot be recovered.
