### PR TITLE
fix(bot): thread Slack DM responses

### DIFF
--- a/apps/web/src/lib/bot.ts
+++ b/apps/web/src/lib/bot.ts
@@ -1,8 +1,9 @@
-import { Chat, emoji, type ActionEvent, type Message, type Thread } from 'chat';
+import { Chat, ThreadImpl, emoji, type ActionEvent, type Message, type Thread } from 'chat';
 import { createSlackAdapter } from '@chat-adapter/slack';
 import { captureException } from '@sentry/nextjs';
 import { resolveKiloUserId, unlinkKiloUser } from '@/lib/bot-identity';
 import { getPlatformIdentity, getPlatformIntegration } from '@/lib/bot/platform-helpers';
+import { getSlackDmReplyThreadParams } from '@/lib/bot/helpers';
 import { LINK_ACCOUNT_ACTION_PREFIX, promptLinkAccount } from '@/lib/bot/link-account';
 import { createBotRequest, updateBotRequest } from '@/lib/bot/request-logging';
 import { findUserById } from '@/lib/user';
@@ -24,13 +25,28 @@ export const bot = new Chat({
   state: createChatState(),
 });
 
+function getResponseThread(thread: Thread, message: Message): Thread {
+  const slackDmReplyThread = getSlackDmReplyThreadParams(thread, message);
+  if (!slackDmReplyThread) return thread;
+
+  return new ThreadImpl({
+    adapter: bot.getAdapter('slack'),
+    channelId: slackDmReplyThread.channelId,
+    currentMessage: message,
+    id: slackDmReplyThread.threadId,
+    isDM: slackDmReplyThread.isDM,
+    stateAdapter: bot.getState(),
+  });
+}
+
 bot.onNewMention(async function handleIncomingMessage(
   thread: Thread,
   message: Message
 ): Promise<void> {
-  const identity = getPlatformIdentity(thread, message);
+  const responseThread = getResponseThread(thread, message);
+  const identity = getPlatformIdentity(responseThread, message);
   const [platformIntegration, kiloUserId] = await Promise.all([
-    getPlatformIntegration(thread, message),
+    getPlatformIntegration(responseThread, message),
     resolveKiloUserId(bot.getState(), identity),
   ]);
 
@@ -42,7 +58,7 @@ bot.onNewMention(async function handleIncomingMessage(
   }
 
   if (!kiloUserId) {
-    await promptLinkAccount(thread, message, identity);
+    await promptLinkAccount(responseThread, message, identity);
     return;
   }
 
@@ -50,29 +66,35 @@ bot.onNewMention(async function handleIncomingMessage(
 
   if (!user) {
     await unlinkKiloUser(bot.getState(), identity);
-    await promptLinkAccount(thread, message, identity);
+    await promptLinkAccount(responseThread, message, identity);
     return;
   }
 
-  const platform = thread.id.split(':')[0];
+  const platform = responseThread.id.split(':')[0];
   const botRequestId = await createBotRequest({
     createdBy: user.id,
     organizationId: platformIntegration.owned_by_organization_id ?? null,
     platformIntegrationId: platformIntegration.id,
     platform,
-    platformThreadId: thread.id,
+    platformThreadId: responseThread.id,
     platformMessageId: message.id,
     userMessage: message.text,
     modelUsed: undefined,
   });
 
-  const received = thread.createSentMessageFromMessage(message);
+  const received = responseThread.createSentMessageFromMessage(message);
   await received.addReaction(emoji.eyes);
 
   await bot.registerSingleton();
 
   try {
-    await processMessage({ thread, message, platformIntegration, user, botRequestId });
+    await processMessage({
+      thread: responseThread,
+      message,
+      platformIntegration,
+      user,
+      botRequestId,
+    });
   } catch (error) {
     console.error('[Bot] Unhandled error in message handler:', error);
     if (botRequestId) {
@@ -82,7 +104,9 @@ bot.onNewMention(async function handleIncomingMessage(
         errorMessage: errMsg.slice(0, 2000),
       });
     }
-    await thread.post({ markdown: 'Sorry, something went wrong while processing your message.' });
+    await responseThread.post({
+      markdown: 'Sorry, something went wrong while processing your message.',
+    });
   }
 });
 

--- a/apps/web/src/lib/bot/helpers.test.ts
+++ b/apps/web/src/lib/bot/helpers.test.ts
@@ -1,0 +1,80 @@
+import { getSlackDmReplyThreadParams } from '@/lib/bot/helpers';
+import type { SlackEvent } from '@chat-adapter/slack';
+import type { Message, Thread } from 'chat';
+
+type ThreadLike = Pick<Thread, 'channelId' | 'id' | 'isDM'>;
+type MessageLike = Pick<Message, 'id' | 'raw'>;
+
+function slackThread(overrides: Partial<ThreadLike> = {}): ThreadLike {
+  return {
+    channelId: 'slack:D123',
+    id: 'slack:D123:',
+    isDM: true,
+    ...overrides,
+  };
+}
+
+function slackMessage(raw: SlackEvent): MessageLike {
+  return {
+    id: raw.ts ?? '1710000000.000100',
+    raw,
+  };
+}
+
+describe('getSlackDmReplyThreadParams', () => {
+  it('roots top-level Slack DM responses at the triggering message timestamp', () => {
+    const result = getSlackDmReplyThreadParams(
+      slackThread(),
+      slackMessage({
+        channel: 'D123',
+        channel_type: 'im',
+        team: 'T123',
+        text: 'hello',
+        ts: '1710000000.000100',
+        type: 'message',
+        user: 'U123',
+      })
+    );
+
+    expect(result).toEqual({
+      channelId: 'slack:D123',
+      isDM: true,
+      threadId: 'slack:D123:1710000000.000100',
+    });
+  });
+
+  it('leaves Slack DM thread replies unchanged', () => {
+    const result = getSlackDmReplyThreadParams(
+      slackThread({ id: 'slack:D123:1710000000.000100' }),
+      slackMessage({
+        channel: 'D123',
+        channel_type: 'im',
+        team: 'T123',
+        text: 'reply',
+        thread_ts: '1710000000.000100',
+        ts: '1710000001.000200',
+        type: 'message',
+        user: 'U123',
+      })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('leaves Slack channel messages unchanged', () => {
+    const result = getSlackDmReplyThreadParams(
+      slackThread({ channelId: 'slack:C123', id: 'slack:C123:1710000000.000100', isDM: false }),
+      slackMessage({
+        channel: 'C123',
+        channel_type: 'channel',
+        team: 'T123',
+        text: '<@BOT> hello',
+        ts: '1710000000.000100',
+        type: 'app_mention',
+        user: 'U123',
+      })
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/src/lib/bot/helpers.ts
+++ b/apps/web/src/lib/bot/helpers.ts
@@ -1,11 +1,53 @@
 import type { SlackEvent } from '@chat-adapter/slack';
 import type { Thread, Message } from 'chat';
 
+type SlackMessageLike = Pick<Message, 'id' | 'raw'>;
+type ThreadLike = Pick<Thread, 'channelId' | 'id' | 'isDM'>;
+
+export type SlackDmReplyThreadParams = {
+  channelId: string;
+  isDM: true;
+  threadId: string;
+};
+
+function slackChannelFromChannelId(channelId: string): string | undefined {
+  const [platform, channel] = channelId.split(':');
+  if (platform !== 'slack' || !channel) return undefined;
+  return channel;
+}
+
+export function getSlackDmReplyThreadParams(
+  thread: ThreadLike,
+  message: SlackMessageLike
+): SlackDmReplyThreadParams | null {
+  const platform = thread.id.split(':')[0];
+  if (platform !== 'slack' || !thread.isDM) return null;
+
+  const raw = (message as Pick<Message<SlackEvent>, 'id' | 'raw'>).raw;
+  if (raw.channel_type && raw.channel_type !== 'im') return null;
+  if (raw.thread_ts) return null;
+
+  const channel = raw.channel ?? slackChannelFromChannelId(thread.channelId);
+  const messageTs = raw.ts ?? message.id;
+  if (!channel || !messageTs) return null;
+
+  const threadId = `slack:${channel}:${messageTs}`;
+  if (thread.id === threadId) return null;
+
+  return {
+    channelId: `slack:${channel}`,
+    isDM: true,
+    threadId,
+  };
+}
+
 export function isChannelLevelMessage(thread: Thread, message: Message): boolean {
   const platform = thread.id.split(':')[0];
 
   switch (platform) {
     case 'slack': {
+      if (thread.isDM) return false;
+
       const raw = (message as Message<SlackEvent>).raw;
       return !raw.thread_ts || raw.thread_ts === raw.ts;
     }


### PR DESCRIPTION
## Summary
- Route top-level Slack DM bot responses through a synthetic thread rooted at the triggering message timestamp.
- Use the normalized response thread for bot request logging, reactions, account-link prompts, and callback follow-ups so DM behavior matches Slack channels.
- Add coverage for Slack DM thread normalization and channel no-op behavior.

## Verification
N/A - not manually verified in Slack.

## Visual Changes
N/A

## Reviewer Notes
Slack DMs from the Chat SDK arrive with an empty thread timestamp; this change derives the Slack thread id from the message timestamp before processing.