### PR TITLE
fix(claw): shorten setup promo eligibility window

### DIFF
--- a/apps/web/src/lib/kiloclaw/setup-promo.ts
+++ b/apps/web/src/lib/kiloclaw/setup-promo.ts
@@ -6,7 +6,7 @@ export async function userIsWithinFirstKiloClawInstanceWindow(params: {
   userId: string;
   maxAgeHours?: number;
 }): Promise<boolean> {
-  const maxAgeHours = params.maxAgeHours ?? 6;
+  const maxAgeHours = params.maxAgeHours ?? 2;
   const [row] = await readDb
     .select({
       eligible: sql<boolean>`


### PR DESCRIPTION
## Summary
- Shorten the default KiloClaw setup promo eligibility window from 6 hours to 2 hours.

## Verification
- N/A

## Visual Changes
N/A

## Reviewer Notes
- `pnpm typecheck` currently fails on unrelated pre-existing missing module/type errors in AI gateway, cron/email/redis, KiloClaw secret catalog imports, and test globals.
- Push hooks were bypassed with explicit approval because the hook typecheck fails on those unrelated errors.