### PR TITLE
fix(cloud-agent): delay completion callbacks

### DIFF
--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -111,11 +111,17 @@ const HUNG_EXECUTION_TIMEOUT_MS = 5 * 60 * 1000;
  *  Covers the first few reconnection attempts (exponential backoff: 1s, 2s, 4s …). */
 const DISCONNECT_GRACE_MS = 10_000;
 
+/** Delay before building and queueing successful completion callbacks. */
+const COMPLETION_CALLBACK_DELAY_MS = 30_000;
+
 /** DO storage key for persisting disconnect grace state across hibernation. */
 const DISCONNECT_GRACE_KEY = 'disconnect_grace';
 
 /** DO storage key for pending async preparation input. */
 const PENDING_PREPARATION_KEY = 'pending_preparation';
+
+/** DO storage key prefix for delayed successful completion callbacks. */
+const PENDING_COMPLETION_CALLBACK_PREFIX = 'pending_completion_callback:';
 
 /** Stored in DO storage under DISCONNECT_GRACE_KEY while a grace period is active. */
 type DisconnectGraceState = {
@@ -123,6 +129,16 @@ type DisconnectGraceState = {
   disconnectedAt: number;
   wsCloseCode: number;
   wsCloseReason: string;
+};
+
+type TerminalCallbackStatus = 'completed' | 'failed' | 'interrupted';
+
+type PendingCompletionCallback = {
+  executionId: ExecutionId;
+  status: 'completed';
+  dueAt: number;
+  error?: string;
+  gateResult?: 'pass' | 'fail';
 };
 
 /**
@@ -158,9 +174,19 @@ export class CloudAgentSession extends DurableObject {
     return status === 'completed' || status === 'failed' || status === 'interrupted';
   }
 
-  private async enqueueCallbackNotification(
+  private getPendingCompletionCallbackKey(executionId: ExecutionId): string {
+    return `${PENDING_COMPLETION_CALLBACK_PREFIX}${executionId}`;
+  }
+
+  private async scheduleAlarmNoLater(scheduledTimeMs: number): Promise<void> {
+    const currentAlarm = await this.ctx.storage.getAlarm();
+    if (currentAlarm === null || scheduledTimeMs < currentAlarm) {
+      await this.ctx.storage.setAlarm(scheduledTimeMs);
+    }
+  }
+
+  private async scheduleCompletionCallbackNotification(
     executionId: ExecutionId,
-    status: 'completed' | 'failed' | 'interrupted',
     error?: string,
     gateResult?: 'pass' | 'fail'
   ): Promise<void> {
@@ -171,12 +197,41 @@ export class CloudAgentSession extends DurableObject {
       return;
     }
 
-    logger.info('Enqueued callback job', {
+    const dueAt = Date.now() + COMPLETION_CALLBACK_DELAY_MS;
+    const pendingCallback: PendingCompletionCallback = {
+      executionId,
+      status: 'completed',
+      dueAt,
+      ...(error !== undefined ? { error } : {}),
+      ...(gateResult !== undefined ? { gateResult } : {}),
+    };
+
+    await this.ctx.storage.put(this.getPendingCompletionCallbackKey(executionId), pendingCallback);
+    await this.scheduleAlarmNoLater(dueAt);
+
+    logger.info('Scheduled completion callback job', {
       cloudAgentSessionId: metadata.sessionId,
       kiloSessionId: metadata.kiloSessionId,
       executionId,
       callbackUrl: metadata.callbackTarget.url,
+      delayMs: COMPLETION_CALLBACK_DELAY_MS,
+      dueAt,
     });
+  }
+
+  private async sendCallbackNotification(
+    executionId: ExecutionId,
+    status: TerminalCallbackStatus,
+    error?: string,
+    gateResult?: 'pass' | 'fail',
+    opts?: { waitForQueue?: boolean }
+  ): Promise<void> {
+    const metadata = await this.getMetadata();
+    const callbackQueue = (this.env as unknown as WorkerEnv).CALLBACK_QUEUE;
+
+    if (!metadata?.callbackTarget || !callbackQueue) {
+      return;
+    }
 
     const resolvedSessionId = await this.resolveSessionId(metadata.sessionId as SessionId);
     const sessionId = resolvedSessionId ?? metadata.sessionId ?? '';
@@ -199,16 +254,103 @@ export class CloudAgentSession extends DurableObject {
       },
     };
 
-    // Fire-and-forget enqueue - don't block execution completion
-    callbackQueue.send(callbackJob).catch(err => {
+    const sendPromise = callbackQueue.send(callbackJob);
+    if (opts?.waitForQueue === false) {
+      sendPromise.catch(err => {
+        logger
+          .withFields({
+            sessionId,
+            executionId,
+            error: err instanceof Error ? err.message : String(err),
+          })
+          .error('Failed to enqueue callback job');
+      });
+    } else {
+      await sendPromise;
+    }
+
+    logger.info('Enqueued callback job', {
+      cloudAgentSessionId: metadata.sessionId,
+      kiloSessionId: metadata.kiloSessionId,
+      executionId,
+      callbackUrl: metadata.callbackTarget.url,
+    });
+  }
+
+  private async enqueueCallbackNotification(
+    executionId: ExecutionId,
+    status: TerminalCallbackStatus,
+    error?: string,
+    gateResult?: 'pass' | 'fail'
+  ): Promise<void> {
+    try {
+      await this.sendCallbackNotification(executionId, status, error, gateResult, {
+        waitForQueue: false,
+      });
+    } catch (err) {
       logger
         .withFields({
-          sessionId,
+          sessionId: this.sessionId,
           executionId,
           error: err instanceof Error ? err.message : String(err),
         })
         .error('Failed to enqueue callback job');
+    }
+  }
+
+  private async getNextPendingCompletionCallbackDueAt(): Promise<number | null> {
+    const pendingCallbacks = await this.ctx.storage.list<PendingCompletionCallback>({
+      prefix: PENDING_COMPLETION_CALLBACK_PREFIX,
     });
+    let nextDueAt: number | null = null;
+
+    for (const pendingCallback of pendingCallbacks.values()) {
+      if (nextDueAt === null || pendingCallback.dueAt < nextDueAt) {
+        nextDueAt = pendingCallback.dueAt;
+      }
+    }
+
+    return nextDueAt;
+  }
+
+  private async processDueCompletionCallbacks(now: number): Promise<void> {
+    const pendingCallbacks = await this.ctx.storage.list<PendingCompletionCallback>({
+      prefix: PENDING_COMPLETION_CALLBACK_PREFIX,
+    });
+
+    for (const [key, pendingCallback] of pendingCallbacks) {
+      if (pendingCallback.dueAt > now) continue;
+
+      try {
+        await this.sendCallbackNotification(
+          pendingCallback.executionId,
+          pendingCallback.status,
+          pendingCallback.error,
+          pendingCallback.gateResult
+        );
+        await this.ctx.storage.delete(key);
+      } catch (err) {
+        const retryAt = Date.now() + REAPER_ACTIVE_INTERVAL_MS;
+        await this.ctx.storage.put(key, { ...pendingCallback, dueAt: retryAt });
+        logger
+          .withFields({
+            sessionId: this.sessionId,
+            executionId: pendingCallback.executionId,
+            retryAt,
+            error: err instanceof Error ? err.message : String(err),
+          })
+          .error('Failed to enqueue delayed completion callback job');
+      }
+    }
+  }
+
+  private async getNextAlarmTime(now: number, reaperInterval: number): Promise<number> {
+    const reaperAlarm = now + reaperInterval;
+    const pendingCallbackDueAt = await this.getNextPendingCompletionCallbackDueAt();
+    if (pendingCallbackDueAt !== null && pendingCallbackDueAt < reaperAlarm) {
+      return pendingCallbackDueAt;
+    }
+    return reaperAlarm;
   }
 
   constructor(ctx: DurableObjectState, env: Env) {
@@ -1337,6 +1479,8 @@ export class CloudAgentSession extends DurableObject {
         }
       }
 
+      await this.processDueCompletionCallbacks(Date.now());
+
       // Check disconnect grace period first — this alarm may have been
       // rescheduled specifically for the grace deadline.
       await this.checkDisconnectGrace();
@@ -1418,10 +1562,16 @@ export class CloudAgentSession extends DurableObject {
       // reaper retries soon rather than sleeping for an hour.
       nextInterval = REAPER_INTERVAL_MS_DEFAULT;
     }
+    const nextAlarm = await this.getNextAlarmTime(Date.now(), nextInterval);
     logger
-      .withFields({ sessionId: this.sessionId, nextInterval, elapsedMs: Date.now() - now })
+      .withFields({
+        sessionId: this.sessionId,
+        nextInterval,
+        nextAlarm,
+        elapsedMs: Date.now() - now,
+      })
       .info('Rescheduling alarm');
-    await this.ctx.storage.setAlarm(Date.now() + nextInterval);
+    await this.ctx.storage.setAlarm(nextAlarm);
   }
 
   /**
@@ -1783,12 +1933,20 @@ export class CloudAgentSession extends DurableObject {
     const result = await this.executionQueries.updateStatus(params);
 
     if (result.ok && this.isTerminalStatus(params.status) && !opts?.suppressCallback) {
-      await this.enqueueCallbackNotification(
-        params.executionId,
-        params.status,
-        params.error,
-        params.gateResult
-      );
+      if (params.status === 'completed') {
+        await this.scheduleCompletionCallbackNotification(
+          params.executionId,
+          params.error,
+          params.gateResult
+        );
+      } else {
+        await this.enqueueCallbackNotification(
+          params.executionId,
+          params.status,
+          params.error,
+          params.gateResult
+        );
+      }
     }
 
     return result;

--- a/services/cloud-agent-next/test/integration/session/callback-notification.test.ts
+++ b/services/cloud-agent-next/test/integration/session/callback-notification.test.ts
@@ -22,6 +22,16 @@ type CapturedQueue = {
   captured: CallbackJob[];
 };
 
+type StoredPendingCompletionCallback = {
+  executionId: string;
+  status: 'completed';
+  dueAt: number;
+  error?: string;
+  gateResult?: 'pass' | 'fail';
+};
+
+const PENDING_COMPLETION_CALLBACK_PREFIX = 'pending_completion_callback:';
+
 function createCapturedQueue(): CapturedQueue {
   const captured: CallbackJob[] = [];
   return {
@@ -36,6 +46,23 @@ function injectCallbackQueue(instance: CloudAgentSession, queue: CapturedQueue):
   // CALLBACK_QUEUE is not bound in the test wrangler config; inject a
   // capturing fake onto the DO's env so enqueueCallbackNotification runs.
   (instance as unknown as { env: { CALLBACK_QUEUE: CapturedQueue } }).env.CALLBACK_QUEUE = queue;
+}
+
+async function flushPendingCompletionCallback(
+  instance: CloudAgentSession,
+  state: DurableObjectState
+): Promise<void> {
+  const pendingCallbacks = await state.storage.list<StoredPendingCompletionCallback>({
+    prefix: PENDING_COMPLETION_CALLBACK_PREFIX,
+  });
+  expect(pendingCallbacks.size).toBe(1);
+
+  const dueAt = Date.now() - 1;
+  for (const [key, pendingCallback] of pendingCallbacks) {
+    await state.storage.put(key, { ...pendingCallback, dueAt });
+  }
+
+  await instance.alarm();
 }
 
 const kiloSessionId = 'ses_root';
@@ -121,10 +148,7 @@ describe('Callback notification with latest assistant message', () => {
       await prepareSessionWithCallback(instance, sessionId, userId);
       await seedAssistantMessage(state, sessionId, {
         messageId: 'msg_00000000000000000000000010',
-        parts: [
-          { id: 'part_00000000000000000000000001', type: 'text', text: 'Hello ' },
-          { id: 'part_00000000000000000000000002', type: 'text', text: 'world' },
-        ],
+        parts: [{ id: 'part_00000000000000000000000001', type: 'text', text: 'Hello ' }],
       });
 
       const addResult = await instance.addExecution({
@@ -136,6 +160,16 @@ describe('Callback notification with latest assistant message', () => {
 
       await instance.updateExecutionStatus({ executionId, status: 'running' });
       await instance.updateExecutionStatus({ executionId, status: 'completed' });
+      expect(queue.captured).toHaveLength(0);
+
+      await seedAssistantMessage(state, sessionId, {
+        messageId: 'msg_00000000000000000000000010',
+        parts: [
+          { id: 'part_00000000000000000000000001', type: 'text', text: 'Hello ' },
+          { id: 'part_00000000000000000000000002', type: 'text', text: 'world' },
+        ],
+      });
+      await flushPendingCompletionCallback(instance, state);
     });
 
     expect(queue.captured).toHaveLength(1);
@@ -258,6 +292,8 @@ describe('Callback notification with latest assistant message', () => {
       });
       await instance.updateExecutionStatus({ executionId, status: 'running' });
       await instance.updateExecutionStatus({ executionId, status: 'completed' });
+      expect(queue.captured).toHaveLength(0);
+      await flushPendingCompletionCallback(instance, state);
     });
 
     expect(queue.captured).toHaveLength(1);


### PR DESCRIPTION
## Summary
- Add a 30-second Durable Object alarm delay before building and queueing successful completion callbacks.
- Snapshot completion callback payloads after the delay so late ingest events can populate the latest assistant message text.
- Keep failed and interrupted callbacks immediate while preserving retry/reschedule behavior for delayed completion callback enqueue failures.

## Verification
I ran a bot request and verified through the logs that the completion callback was delayed by 30 seconds:

```
Key timestamps:
- Completion callback scheduled:
  - 15:15:36.785Z
  - dueAt: 1776870966785
- Alarm fired:
  - 15:16:06.785Z
- Callback job enqueued:
  - 15:16:06.799Z
- Callback delivered:
  - 15:16:09.096Z
```

## Reviewer Notes
- Successful completion callbacks now depend on the existing CloudAgentSession alarm loop; failed/interrupted terminal callbacks remain immediate.
- The delayed callback is stored in DO storage and rescheduled ahead of the normal idle reaper interval.