### PR TITLE
feat(gastown): instrument container cold-start and mayor availability timing

### DIFF
--- a/services/gastown/container/src/agent-runner.ts
+++ b/services/gastown/container/src/agent-runner.ts
@@ -4,6 +4,7 @@ import { writeFile } from 'node:fs/promises';
 import { cloneRepo, createWorktree, setupRigBrowseWorktree } from './git-manager';
 import { startAgent } from './process-manager';
 import { getCurrentTownConfig } from './control-server';
+import { log } from './logger';
 import type { ManagedAgent, StartAgentRequest } from './types';
 
 /**
@@ -471,6 +472,7 @@ export async function writeMayorSystemPromptToAgentsMd(
 export async function runAgent(originalRequest: StartAgentRequest): Promise<ManagedAgent> {
   let request = originalRequest;
   let workdir: string;
+  const t0 = Date.now();
 
   if (request.role === 'triage' || request.lightweight) {
     // Triage/lightweight agents are pure reasoning — no code changes, no git needed.
@@ -570,6 +572,12 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
 
     // Pre-flight: verify git credentials can authenticate against the remote.
     await verifyGitCredentials(workdir, request.gitUrl, envVars);
+
+    log.info('agent.startup_phase', {
+      agentId: request.agentId,
+      phase: 'git_done',
+      elapsedMs: Date.now() - t0,
+    });
   }
 
   const env = buildAgentEnv(request);

--- a/services/gastown/container/src/control-server.ts
+++ b/services/gastown/container/src/control-server.ts
@@ -9,12 +9,14 @@ import {
   activeAgentCount,
   activeServerCount,
   getUptime,
+  getStartTime,
   stopAll,
   drainAll,
   isDraining,
   getAgentEvents,
   registerEventSink,
 } from './process-manager';
+import { log } from './logger';
 import { startHeartbeat, stopHeartbeat, notifyContainerReady } from './heartbeat';
 import { pushContext as pushDashboardContext } from './dashboard-context';
 import { mergeBranch, setupRigBrowseWorktree } from './git-manager';
@@ -218,6 +220,7 @@ app.get('/health', c => {
     servers: activeServerCount(),
     uptime: getUptime(),
     draining: isDraining() || undefined,
+    startedAt: getStartTime(),
   };
   return c.json(response);
 });
@@ -738,6 +741,15 @@ app.post('/agents/:agentId/pty', async c => {
         console.log(
           `[control-server] Reusing existing PTY session ${running.id} for agent ${agentId}`
         );
+        const reuseAgent = getAgentStatus(agentId);
+        if (reuseAgent) {
+          log.info('agent.pty_connected', {
+            agentId,
+            containerUptimeMs: getUptime(),
+            agentUptimeMs: Date.now() - new Date(reuseAgent.startedAt).getTime(),
+            reused: true,
+          });
+        }
         return c.json(running);
       }
     }
@@ -790,6 +802,14 @@ app.post('/agents/:agentId/pty', async c => {
   console.log(
     `[control-server] Created new PTY session for agent ${agentId}: ${data.slice(0, 200)}`
   );
+  if (createResp.ok) {
+    log.info('agent.pty_connected', {
+      agentId,
+      containerUptimeMs: getUptime(),
+      agentUptimeMs: Date.now() - new Date(agent.startedAt).getTime(),
+      reused: false,
+    });
+  }
   return new Response(data, {
     status: createResp.status,
     headers: { 'Content-Type': 'application/json' },

--- a/services/gastown/container/src/main.ts
+++ b/services/gastown/container/src/main.ts
@@ -1,8 +1,8 @@
 import { startControlServer } from './control-server';
 import { log } from './logger';
-import { bootHydration } from './process-manager';
+import { bootHydration, getUptime } from './process-manager';
 
-log.info('container.cold_start', { uptime: 0, ts: new Date().toISOString() });
+log.info('container.cold_start', { uptime: getUptime(), ts: new Date().toISOString() });
 
 process.on('uncaughtException', err => {
   log.error('container.uncaught_exception', { error: err.message, stack: err.stack });

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -74,6 +74,10 @@ export function getUptime(): number {
   return Date.now() - startTime;
 }
 
+export function getStartTime(): string {
+  return new Date(startTime).toISOString();
+}
+
 async function hydrateDbFromSnapshot(
   agentId: string,
   apiUrl: string,
@@ -943,6 +947,7 @@ export async function startAgent(
 
   const { signal } = startupAbortController;
   let sessionCounted = false;
+  const t0 = Date.now();
   try {
     // 0. Hydrate agent DB from KV snapshot before starting the SDK server
     const apiUrl = agent.gastownApiUrl;
@@ -950,10 +955,23 @@ export async function startAgent(
     if (apiUrl && token) {
       await hydrateDbFromSnapshot(request.agentId, apiUrl, token, request.rigId, request.townId);
     }
+    const tDbDone = Date.now();
+    log.info('agent.startup_phase', {
+      agentId: request.agentId,
+      phase: 'db_hydrated',
+      elapsedMs: tDbDone - t0,
+    });
 
     // 1. Ensure SDK server is running for this workdir
     const { client, port } = await ensureSDKServer(workdir, env);
     agent.serverPort = port;
+    const tSdkDone = Date.now();
+    log.info('agent.startup_phase', {
+      agentId: request.agentId,
+      phase: 'sdk_ready',
+      elapsedMs: tSdkDone - t0,
+      phaseMs: tSdkDone - tDbDone,
+    });
 
     // Check if startup was cancelled while waiting for the SDK server
     if (signal.aborted) {
@@ -1001,6 +1019,14 @@ export async function startAgent(
       );
     }
     agent.sessionId = sessionId;
+    const tSessionDone = Date.now();
+    log.info('agent.startup_phase', {
+      agentId: request.agentId,
+      phase: 'session_created',
+      elapsedMs: tSessionDone - t0,
+      phaseMs: tSessionDone - tSdkDone,
+      resumed,
+    });
 
     // Now check if startup was cancelled while creating the session.
     // agent.sessionId is already set, so the catch block will abort it.
@@ -1066,6 +1092,12 @@ export async function startAgent(
       name: request.name,
       sessionId,
       port,
+    });
+
+    log.info('agent.startup_complete', {
+      agentId: request.agentId,
+      totalMs: Date.now() - t0,
+      containerUptimeMs: getUptime(),
     });
 
     syncRegistry();

--- a/services/gastown/container/src/types.ts
+++ b/services/gastown/container/src/types.ts
@@ -164,6 +164,7 @@ export type HealthResponse = {
   servers: number;
   uptime: number;
   draining?: boolean;
+  startedAt?: string;
 };
 
 // ── Kilo serve instance ─────────────────────────────────────────────────

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -2438,29 +2438,33 @@ export class TownDO extends DurableObject<Env> {
         }
       }
 
-      const started = await dispatch.startAgentInContainer(this.env, this.ctx.storage, {
-        townId,
-        rigId: `mayor-${townId}`,
-        userId: townConfig.owner_user_id ?? rigConfig?.userId ?? townId,
-        agentId: mayor.id,
-        agentName: 'mayor',
-        role: 'mayor',
-        identity: mayor.identity,
-        beadId: '',
-        beadTitle: combinedMessage,
-        beadBody: '',
-        checkpoint: agents.readCheckpoint(this.sql, mayor.id),
-        // conversationHistory is no longer needed — the mayor's kilo.db
-        // is persisted to KV and hydrated on boot, preserving the full
-        // session state across container evictions.
-        gitUrl: rigConfig?.gitUrl ?? '',
-        defaultBranch: rigConfig?.defaultBranch ?? 'main',
-        kilocodeToken,
-        townConfig,
-        rigs: await this.rigListForMayor(),
-      });
+      const { started: mayorStarted } = await dispatch.startAgentInContainer(
+        this.env,
+        this.ctx.storage,
+        {
+          townId,
+          rigId: `mayor-${townId}`,
+          userId: townConfig.owner_user_id ?? rigConfig?.userId ?? townId,
+          agentId: mayor.id,
+          agentName: 'mayor',
+          role: 'mayor',
+          identity: mayor.identity,
+          beadId: '',
+          beadTitle: combinedMessage,
+          beadBody: '',
+          checkpoint: agents.readCheckpoint(this.sql, mayor.id),
+          // conversationHistory is no longer needed — the mayor's kilo.db
+          // is persisted to KV and hydrated on boot, preserving the full
+          // session state across container evictions.
+          gitUrl: rigConfig?.gitUrl ?? '',
+          defaultBranch: rigConfig?.defaultBranch ?? 'main',
+          kilocodeToken,
+          townConfig,
+          rigs: await this.rigListForMayor(),
+        }
+      );
 
-      if (started) {
+      if (mayorStarted) {
         agents.updateAgentStatus(this.sql, mayor.id, 'working');
         this._mayorWorkingSince = Date.now();
         sessionStatus = 'starting';
@@ -2542,29 +2546,33 @@ export class TownDO extends DurableObject<Env> {
 
     // Start with an empty prompt — the mayor will be idle but its container
     // and SDK server will be running, ready for PTY connections.
-    const started = await dispatch.startAgentInContainer(this.env, this.ctx.storage, {
-      townId,
-      rigId: `mayor-${townId}`,
-      userId:
-        townConfig.owner_user_id ?? rigConfig?.userId ?? townConfig.created_by_user_id ?? townId,
-      agentId: mayor.id,
-      agentName: 'mayor',
-      role: 'mayor',
-      identity: mayor.identity,
-      beadId: '',
-      beadTitle: 'Mayor ready. Waiting for instructions.',
-      beadBody: '',
-      checkpoint: agents.readCheckpoint(this.sql, mayor.id),
-      // conversationHistory is no longer needed — kilo.db persistence
-      // handles session continuity across container evictions.
-      gitUrl: rigConfig?.gitUrl ?? '',
-      defaultBranch: rigConfig?.defaultBranch ?? 'main',
-      kilocodeToken,
-      townConfig,
-      rigs: await this.rigListForMayor(),
-    });
+    const { started: mayorStarted } = await dispatch.startAgentInContainer(
+      this.env,
+      this.ctx.storage,
+      {
+        townId,
+        rigId: `mayor-${townId}`,
+        userId:
+          townConfig.owner_user_id ?? rigConfig?.userId ?? townConfig.created_by_user_id ?? townId,
+        agentId: mayor.id,
+        agentName: 'mayor',
+        role: 'mayor',
+        identity: mayor.identity,
+        beadId: '',
+        beadTitle: 'Mayor ready. Waiting for instructions.',
+        beadBody: '',
+        checkpoint: agents.readCheckpoint(this.sql, mayor.id),
+        // conversationHistory is no longer needed — kilo.db persistence
+        // handles session continuity across container evictions.
+        gitUrl: rigConfig?.gitUrl ?? '',
+        defaultBranch: rigConfig?.defaultBranch ?? 'main',
+        kilocodeToken,
+        townConfig,
+        rigs: await this.rigListForMayor(),
+      }
+    );
 
-    if (started) {
+    if (mayorStarted) {
       agents.updateAgentStatus(this.sql, mayor.id, 'working');
       this._mayorWorkingSince = Date.now();
       return { agentId: mayor.id, sessionStatus: 'starting' };
@@ -4168,28 +4176,32 @@ export class TownDO extends DurableObject<Env> {
     // maybeDispatchTriageAgent with the correct triage system prompt.
     beadOps.updateBeadStatus(this.sql, triageBead.bead_id, 'in_progress', triageAgent.id);
 
-    const started = await dispatch.startAgentInContainer(this.env, this.ctx.storage, {
-      townId: this.townId,
-      rigId,
-      userId: rigConfig.userId,
-      agentId: triageAgent.id,
-      agentName: triageAgent.name,
-      role: 'polecat',
-      identity: triageAgent.identity,
-      beadId: triageBead.bead_id,
-      beadTitle: triageBead.title,
-      beadBody: triageBead.body ?? '',
-      checkpoint: null,
-      gitUrl: rigConfig.gitUrl,
-      defaultBranch: rigConfig.defaultBranch,
-      kilocodeToken,
-      townConfig,
-      systemPromptOverride: systemPrompt,
-      platformIntegrationId: rigConfig.platformIntegrationId,
-      lightweight: true,
-    });
+    const { started: triageStarted } = await dispatch.startAgentInContainer(
+      this.env,
+      this.ctx.storage,
+      {
+        townId: this.townId,
+        rigId,
+        userId: rigConfig.userId,
+        agentId: triageAgent.id,
+        agentName: triageAgent.name,
+        role: 'polecat',
+        identity: triageAgent.identity,
+        beadId: triageBead.bead_id,
+        beadTitle: triageBead.title,
+        beadBody: triageBead.body ?? '',
+        checkpoint: null,
+        gitUrl: rigConfig.gitUrl,
+        defaultBranch: rigConfig.defaultBranch,
+        kilocodeToken,
+        townConfig,
+        systemPromptOverride: systemPrompt,
+        platformIntegrationId: rigConfig.platformIntegrationId,
+        lightweight: true,
+      }
+    );
 
-    if (started) {
+    if (triageStarted) {
       // Mark the agent as working so the duplicate-guard on the next
       // alarm tick sees it and skips dispatch.
       agents.updateAgentStatus(this.sql, triageAgent.id, 'working');
@@ -4370,12 +4382,48 @@ export class TownDO extends DurableObject<Env> {
         headers['X-Drain-Nonce'] = this._drainNonce;
         headers['X-Town-Id'] = townId;
       }
-      await container.fetch('http://container/health', {
-        signal: AbortSignal.timeout(5_000),
-        headers,
-      });
+      const t0 = Date.now();
+      try {
+        const healthResp = await container.fetch('http://container/health', {
+          signal: AbortSignal.timeout(5_000),
+          headers,
+        });
+        const healthPingMs = Date.now() - t0;
+        writeEvent(this.env, {
+          event: 'container.health_ping',
+          townId,
+          healthPingMs,
+          healthPingStatus: 'ok',
+        });
+        if (healthResp.ok) {
+          const rawBody: unknown = await healthResp.json().catch(() => null);
+          const HealthBody = z
+            .object({ startedAt: z.string().optional(), uptime: z.number().optional() })
+            .passthrough();
+          const body = HealthBody.safeParse(rawBody);
+          if (body.success && body.data.startedAt) {
+            const containerStartedAt = new Date(body.data.startedAt).getTime();
+            writeEvent(this.env, {
+              event: 'container.ready_observed',
+              townId,
+              containerStartedAt: body.data.startedAt,
+              timeSinceContainerStartMs: Date.now() - containerStartedAt,
+              uptimeMs: body.data.uptime ?? 0,
+            });
+          }
+        }
+      } catch {
+        const healthPingMs = Date.now() - t0;
+        writeEvent(this.env, {
+          event: 'container.health_ping',
+          townId,
+          healthPingMs,
+          healthPingStatus: 'timeout',
+        });
+        // Container is starting up or unavailable — alarm will retry
+      }
     } catch {
-      // Container is starting up or unavailable — alarm will retry
+      // Outer try: buildContainerConfig or getTownContainerStub failed
     }
   }
 

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -4389,13 +4389,21 @@ export class TownDO extends DurableObject<Env> {
           headers,
         });
         const durationMs = Date.now() - t0;
-        writeEvent(this.env, {
-          event: 'container.health_ping',
-          townId,
-          durationMs,
-          healthPingStatus: 'ok',
-        });
-        if (healthResp.ok) {
+        if (!healthResp.ok) {
+          writeEvent(this.env, {
+            event: 'container.health_ping',
+            townId,
+            durationMs,
+            statusCode: healthResp.status,
+            error: `non-ok status ${healthResp.status}`,
+          });
+        } else {
+          writeEvent(this.env, {
+            event: 'container.health_ping',
+            townId,
+            durationMs,
+            statusCode: healthResp.status,
+          });
           const rawBody: unknown = await healthResp.json().catch(() => null);
           const HealthBody = z
             .object({ startedAt: z.string().optional(), uptime: z.number().optional() })
@@ -4417,7 +4425,6 @@ export class TownDO extends DurableObject<Env> {
           event: 'container.health_ping',
           townId,
           durationMs,
-          healthPingStatus: 'timeout',
           error: 'timeout',
         });
         // Container is starting up or unavailable — alarm will retry

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -4388,11 +4388,11 @@ export class TownDO extends DurableObject<Env> {
           signal: AbortSignal.timeout(5_000),
           headers,
         });
-        const healthPingMs = Date.now() - t0;
+        const durationMs = Date.now() - t0;
         writeEvent(this.env, {
           event: 'container.health_ping',
           townId,
-          healthPingMs,
+          durationMs,
           healthPingStatus: 'ok',
         });
         if (healthResp.ok) {
@@ -4407,18 +4407,18 @@ export class TownDO extends DurableObject<Env> {
               event: 'container.ready_observed',
               townId,
               containerStartedAt: body.data.startedAt,
-              timeSinceContainerStartMs: Date.now() - containerStartedAt,
-              uptimeMs: body.data.uptime ?? 0,
+              durationMs: Date.now() - containerStartedAt,
             });
           }
         }
       } catch {
-        const healthPingMs = Date.now() - t0;
+        const durationMs = Date.now() - t0;
         writeEvent(this.env, {
           event: 'container.health_ping',
           townId,
-          healthPingMs,
+          durationMs,
           healthPingStatus: 'timeout',
+          error: 'timeout',
         });
         // Container is starting up or unavailable — alarm will retry
       }

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -403,7 +403,7 @@ export async function startAgentInContainer(
         `${TOWN_LOG} startAgentInContainer: ABORTING — failed to mint any auth token for agent ${params.agentId}. ` +
           'The agent would start without credentials and be unable to call back to the worker.'
       );
-      return false;
+      return { started: false, containerFetchMs: 0 };
     }
 
     // Build env vars from town config
@@ -521,17 +521,7 @@ export async function startAgentInContainer(
       }),
     });
 
-    const containerFetchMs = Date.now() - fetchStart;
-    writeEvent(env, {
-      event: 'container.agent_start_fetch',
-      townId: params.townId,
-      rigId: params.rigId,
-      agentId: params.agentId,
-      containerFetchMs,
-      statusCode: response.status,
-      wasSuccess: response.ok,
-    });
-
+    const durationMs = Date.now() - fetchStart;
     if (!response.ok) {
       const text = await response.text().catch(() => '(unreadable)');
       // "Already running" means a previous dispatch succeeded — the agent
@@ -541,7 +531,15 @@ export async function startAgentInContainer(
         console.log(
           `${TOWN_LOG} startAgentInContainer: agent ${params.agentId} already running — treating as success`
         );
-        return { started: true, containerFetchMs };
+        writeEvent(env, {
+          event: 'container.agent_start_fetch',
+          townId: params.townId,
+          rigId: params.rigId,
+          agentId: params.agentId,
+          durationMs,
+          statusCode: response.status,
+        });
+        return { started: true, containerFetchMs: durationMs };
       }
       const errorMsg = `(${response.status}) ${text.slice(0, 300)}`;
       console.error(
@@ -549,8 +547,26 @@ export async function startAgentInContainer(
           `agent=${params.agentId} role=${params.role}: ${errorMsg}`
       );
       lastStartError = errorMsg;
+      writeEvent(env, {
+        event: 'container.agent_start_fetch',
+        townId: params.townId,
+        rigId: params.rigId,
+        agentId: params.agentId,
+        durationMs,
+        statusCode: response.status,
+        error: errorMsg,
+      });
+      return { started: false, containerFetchMs: durationMs };
     }
-    return { started: response.ok, containerFetchMs };
+    writeEvent(env, {
+      event: 'container.agent_start_fetch',
+      townId: params.townId,
+      rigId: params.rigId,
+      agentId: params.agentId,
+      durationMs,
+      statusCode: response.status,
+    });
+    return { started: true, containerFetchMs: durationMs };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`${TOWN_LOG} startAgentInContainer: EXCEPTION for agent ${params.agentId}:`, err);

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -9,6 +9,7 @@ import { buildPolecatSystemPrompt } from '../../prompts/polecat-system.prompt';
 import { buildMayorSystemPrompt } from '../../prompts/mayor-system.prompt';
 import type { TownConfig, RigOverrideConfig } from '../../types';
 import { buildContainerConfig, resolveModel, resolveSmallModel, resolveRigConfig } from './config';
+import { writeEvent } from '../../util/analytics.util';
 
 const TOWN_LOG = '[Town.do]';
 
@@ -378,7 +379,7 @@ export async function startAgentInContainer(
       platformIntegrationId?: string;
     }>;
   }
-): Promise<boolean> {
+): Promise<{ started: boolean; containerFetchMs: number }> {
   lastStartError = null;
   console.log(
     `${TOWN_LOG} startAgentInContainer: agentId=${params.agentId} role=${params.role} name=${params.agentName}`
@@ -454,6 +455,7 @@ export async function startAgentInContainer(
     const rigOverride = params.rigOverride ?? null;
     const effectiveConfig = resolveRigConfig(params.townConfig, rigOverride);
 
+    const fetchStart = Date.now();
     const response = await container.fetch('http://container/agents/start', {
       method: 'POST',
       signal: AbortSignal.timeout(60_000),
@@ -519,6 +521,17 @@ export async function startAgentInContainer(
       }),
     });
 
+    const containerFetchMs = Date.now() - fetchStart;
+    writeEvent(env, {
+      event: 'container.agent_start_fetch',
+      townId: params.townId,
+      rigId: params.rigId,
+      agentId: params.agentId,
+      containerFetchMs,
+      statusCode: response.status,
+      wasSuccess: response.ok,
+    });
+
     if (!response.ok) {
       const text = await response.text().catch(() => '(unreadable)');
       // "Already running" means a previous dispatch succeeded — the agent
@@ -528,7 +541,7 @@ export async function startAgentInContainer(
         console.log(
           `${TOWN_LOG} startAgentInContainer: agent ${params.agentId} already running — treating as success`
         );
-        return true;
+        return { started: true, containerFetchMs };
       }
       const errorMsg = `(${response.status}) ${text.slice(0, 300)}`;
       console.error(
@@ -537,12 +550,12 @@ export async function startAgentInContainer(
       );
       lastStartError = errorMsg;
     }
-    return response.ok;
+    return { started: response.ok, containerFetchMs };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`${TOWN_LOG} startAgentInContainer: EXCEPTION for agent ${params.agentId}:`, err);
     lastStartError = `EXCEPTION: ${message.slice(0, 300)}`;
-    return false;
+    return { started: false, containerFetchMs: 0 };
   }
 }
 

--- a/services/gastown/src/dos/town/scheduling.ts
+++ b/services/gastown/src/dos/town/scheduling.ts
@@ -126,27 +126,31 @@ export async function dispatchAgent(
 
     const rigRecord = rigs.getRig(ctx.sql, rigId);
 
-    const started = await dispatch.startAgentInContainer(ctx.env, ctx.storage, {
-      townId: ctx.townId,
-      rigId,
-      userId: rigConfig.userId,
-      agentId: agent.id,
-      agentName: agent.name,
-      role: agent.role,
-      identity: agent.identity,
-      beadId: bead.bead_id,
-      beadTitle: bead.title,
-      beadBody: bead.body ?? '',
-      checkpoint: agent.checkpoint,
-      gitUrl: rigConfig.gitUrl,
-      defaultBranch: rigConfig.defaultBranch,
-      kilocodeToken,
-      townConfig,
-      rigOverride: rigRecord?.config ?? null,
-      platformIntegrationId: rigConfig.platformIntegrationId,
-      convoyFeatureBranch: convoyFeatureBranch ?? undefined,
-      systemPromptOverride: options?.systemPromptOverride,
-    });
+    const { started, containerFetchMs } = await dispatch.startAgentInContainer(
+      ctx.env,
+      ctx.storage,
+      {
+        townId: ctx.townId,
+        rigId,
+        userId: rigConfig.userId,
+        agentId: agent.id,
+        agentName: agent.name,
+        role: agent.role,
+        identity: agent.identity,
+        beadId: bead.bead_id,
+        beadTitle: bead.title,
+        beadBody: bead.body ?? '',
+        checkpoint: agent.checkpoint,
+        gitUrl: rigConfig.gitUrl,
+        defaultBranch: rigConfig.defaultBranch,
+        kilocodeToken,
+        townConfig,
+        rigOverride: rigRecord?.config ?? null,
+        platformIntegrationId: rigConfig.platformIntegrationId,
+        convoyFeatureBranch: convoyFeatureBranch ?? undefined,
+        systemPromptOverride: options?.systemPromptOverride,
+      }
+    );
 
     if (started) {
       // Reset dispatch_attempts on successful start — but NOT for refineries.
@@ -172,6 +176,7 @@ export async function dispatchAgent(
         agentId: agent.id,
         beadId: bead.bead_id,
         role: agent.role,
+        containerFetchMs,
       });
     } else {
       // Container start returned false — but the container may have

--- a/services/gastown/src/dos/town/scheduling.ts
+++ b/services/gastown/src/dos/town/scheduling.ts
@@ -176,7 +176,7 @@ export async function dispatchAgent(
         agentId: agent.id,
         beadId: bead.bead_id,
         role: agent.role,
-        containerFetchMs,
+        durationMs: containerFetchMs,
       });
     } else {
       // Container start returned false — but the container may have

--- a/services/gastown/src/util/analytics.util.ts
+++ b/services/gastown/src/util/analytics.util.ts
@@ -44,13 +44,10 @@ export type GastownEventData = {
   durationMs?: number;
   value?: number;
   label?: string;
-  // Timing fields for container cold-start instrumentation
-  containerFetchMs?: number;
-  healthPingMs?: number;
-  timeSinceContainerStartMs?: number;
-  uptimeMs?: number;
+  // Container cold-start instrumentation fields.
+  // Use durationMs for all timing (event name disambiguates the metric).
+  // Use error (absence = success) instead of a wasSuccess boolean.
   statusCode?: number;
-  wasSuccess?: boolean;
   containerStartedAt?: string;
   healthPingStatus?: string;
   // Additional doubles for reconciler_tick events (double3–double10).
@@ -105,12 +102,7 @@ export function writeEvent(
         data.double8 ?? 0, // double8
         data.double9 ?? 0, // double9
         data.double10 ?? 0, // double10
-        data.containerFetchMs ?? 0, // double11
-        data.healthPingMs ?? 0, // double12
-        data.timeSinceContainerStartMs ?? 0, // double13
-        data.uptimeMs ?? 0, // double14
-        data.statusCode ?? 0, // double15
-        data.wasSuccess !== undefined ? (data.wasSuccess ? 1 : 0) : 0, // double16
+        data.statusCode ?? 0, // double11
       ],
       indexes: [data.event],
     });

--- a/services/gastown/src/util/analytics.util.ts
+++ b/services/gastown/src/util/analytics.util.ts
@@ -44,6 +44,15 @@ export type GastownEventData = {
   durationMs?: number;
   value?: number;
   label?: string;
+  // Timing fields for container cold-start instrumentation
+  containerFetchMs?: number;
+  healthPingMs?: number;
+  timeSinceContainerStartMs?: number;
+  uptimeMs?: number;
+  statusCode?: number;
+  wasSuccess?: boolean;
+  containerStartedAt?: string;
+  healthPingStatus?: string;
   // Additional doubles for reconciler_tick events (double3–double10).
   // Analytics Engine supports up to 20 doubles per data point.
   double3?: number;
@@ -82,6 +91,8 @@ export function writeEvent(
         data.role ?? '', // blob12
         data.beadType ?? '', // blob13
         data.reason ?? '', // blob14
+        data.healthPingStatus ?? '', // blob15
+        data.containerStartedAt ?? '', // blob16
       ],
       doubles: [
         data.durationMs ?? 0, // double1
@@ -94,6 +105,12 @@ export function writeEvent(
         data.double8 ?? 0, // double8
         data.double9 ?? 0, // double9
         data.double10 ?? 0, // double10
+        data.containerFetchMs ?? 0, // double11
+        data.healthPingMs ?? 0, // double12
+        data.timeSinceContainerStartMs ?? 0, // double13
+        data.uptimeMs ?? 0, // double14
+        data.statusCode ?? 0, // double15
+        data.wasSuccess !== undefined ? (data.wasSuccess ? 1 : 0) : 0, // double16
       ],
       indexes: [data.event],
     });

--- a/services/gastown/src/util/analytics.util.ts
+++ b/services/gastown/src/util/analytics.util.ts
@@ -45,11 +45,10 @@ export type GastownEventData = {
   value?: number;
   label?: string;
   // Container cold-start instrumentation fields.
-  // Use durationMs for all timing (event name disambiguates the metric).
+  // Use durationMs for timing (event name disambiguates the metric).
   // Use error (absence = success) instead of a wasSuccess boolean.
   statusCode?: number;
   containerStartedAt?: string;
-  healthPingStatus?: string;
   // Additional doubles for reconciler_tick events (double3–double10).
   // Analytics Engine supports up to 20 doubles per data point.
   double3?: number;
@@ -88,8 +87,7 @@ export function writeEvent(
         data.role ?? '', // blob12
         data.beadType ?? '', // blob13
         data.reason ?? '', // blob14
-        data.healthPingStatus ?? '', // blob15
-        data.containerStartedAt ?? '', // blob16
+        data.containerStartedAt ?? '', // blob15
       ],
       doubles: [
         data.durationMs ?? 0, // double1


### PR DESCRIPTION
## Summary

- **Part 1 (Town DO side):** Wraps `container.fetch('/agents/start')` in `container-dispatch.ts` with timestamps and emits a `container.agent_start_fetch` AE event with `containerFetchMs`, `statusCode`, and `wasSuccess`. Also wraps the health ping in `ensureContainerReady()` (Town.do.ts) with timing and emits `container.health_ping` (distinguishing `ok` from `timeout`) and `container.ready_observed` (with `timeSinceContainerStartMs` correlating Town DO clock to container boot time using `startedAt` from the health response).
- **Part 2 (Container side — `startTime` transmission):** Adds `getStartTime()` export to `process-manager.ts`, adds `startedAt` field to `HealthResponse` type and the `/health` endpoint, and fixes the hardcoded `uptime: 0` in `main.ts` to use `getUptime()`.
- **Part 3 (Mayor availability milestones):** Adds `agent.startup_phase` structured logs in `startAgent()` (process-manager.ts) for `db_hydrated`, `sdk_ready`, and `session_created` phases with per-phase and cumulative `elapsedMs`. Adds `git_done` phase log in `runAgent()` (agent-runner.ts). Adds `agent.startup_complete` log. Adds `agent.pty_connected` log in `POST /agents/:agentId/pty` for both reuse and creation paths.
- **Part 4 (agent.spawned AE event):** Threads `containerFetchMs` from `startAgentInContainer()` result (changed return type from `boolean` to `{ started, containerFetchMs }`) through `dispatchAgent()` in scheduling.ts into the `agent.spawned` AE event. Updates all three direct callers of `startAgentInContainer` in Town.do.ts to destructure the new return type.

## Verification

- TypeScript compilation not run (per environment constraints), but all type changes are consistent: `HealthResponse` gets `startedAt?: string`, `GastownEventData` gets new timing fields, `startAgentInContainer` return type updated from `Promise<boolean>` to `Promise<{ started: boolean; containerFetchMs: number }>`, and all callers updated accordingly.
- Code follows existing patterns: uses `writeEvent()` for AE events, uses `log.info()` for structured container logs, uses Zod `.safeParse()` for the health response body IO boundary.

## Visual Changes

N/A

## Reviewer Notes

- The outer `try/catch` in `ensureContainerReady()` now has a nested `try/catch` for the health fetch itself. The outer catch handles `buildContainerConfig`/`getTownContainerStub` failures (as before); the inner catch handles the fetch timeout/error and emits the `container.health_ping` timeout event before re-swallowing the error.
- `main.ts` uses `getUptime()` from `process-manager.ts` instead of a `const` before imports (TypeScript prohibits variable declarations before import statements in ESM).
- `analytics.util.ts` adds 2 new blobs (blob15=healthPingStatus, blob16=containerStartedAt) and 6 new doubles (double11–double16) for the timing fields. This stays within AE's 20-blob/20-double limit.