### PR TITLE
KiloClaw - Persist onboarding config during provisioning

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -13,6 +13,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useClawServiceDegraded } from '../hooks/useClawHooks';
+import { useOnboardingSaves } from '../hooks/useOnboardingSaves';
 import { useGatewayUrl } from '../hooks/useGatewayUrl';
 import { BillingWrapper } from './billing/BillingWrapper';
 import { BotIdentityStep } from './BotIdentityStep';
@@ -120,6 +121,7 @@ function ClawOnboardingFlowInner({
   const [channelTokens, setChannelTokens] = useState<Record<string, string> | null>(null);
   const [selectedChannelId, setSelectedChannelId] = useState<string | null>(null);
   const [localCreateSetupStarted, setLocalCreateSetupStarted] = useState(false);
+  const [onboardingSaveSession, setOnboardingSaveSession] = useState(0);
   const hasCapturedIdentityView = useRef(false);
   const hasCapturedDoneView = useRef(false);
   const createSetupStarted = createFlowStarted || localCreateSetupStarted;
@@ -158,6 +160,21 @@ function ClawOnboardingFlowInner({
   useFeatureFlagVariantKey('button-vs-card');
   const posthog = usePostHog();
 
+  // Save bot identity, exec preset, and channel tokens as soon as the instance
+  // row exists. This closes the tab-close window where customizations entered
+  // during the provisioning spinner could otherwise be lost with the unmounted
+  // ProvisioningStep.
+  const onboardingSaves = useOnboardingSaves({
+    hasInstance: flowState.instanceStatus !== null,
+    botIdentity,
+    selectedPreset,
+    channelTokens,
+    resetKey: `${onboardingSaveSession}:${
+      flowState.instanceStatus?.instanceId ?? flowState.instanceStatus?.sandboxId ?? 'pending'
+    }`,
+    mutations,
+  });
+
   useEffect(() => {
     if (flowState.renderStep !== 'identity' || hasCapturedIdentityView.current) return;
     hasCapturedIdentityView.current = true;
@@ -187,8 +204,10 @@ function ClawOnboardingFlowInner({
 
   const handleCreateFlowStarted = useCallback(() => {
     setLocalCreateSetupStarted(true);
+    setOnboardingSaveSession(value => value + 1);
+    resetWizardSelections();
     onCreateFlowStarted?.();
-  }, [onCreateFlowStarted]);
+  }, [onCreateFlowStarted, resetWizardSelections]);
 
   const handleCreateFlowFailed = useCallback(() => {
     setLocalCreateSetupStarted(false);
@@ -319,11 +338,8 @@ function ClawOnboardingFlowInner({
       <ProvisioningStep
         currentStep={flowState.currentStep}
         totalSteps={flowState.totalSteps}
-        preset={selectedPreset}
-        channelTokens={channelTokens}
-        botIdentity={botIdentity}
+        onboardingSavesReady={onboardingSaves.ready}
         instanceRunning={flowState.instanceRunning}
-        mutations={mutations}
         onComplete={() => {
           posthog?.capture('claw_setup_provisioned');
           posthog?.capture(

--- a/apps/web/src/app/(app)/claw/components/ProvisioningStep.tsx
+++ b/apps/web/src/app/(app)/claw/components/ProvisioningStep.tsx
@@ -2,16 +2,8 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { AlertTriangle, Volume2 } from 'lucide-react';
-import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { useClawGatewayReady } from '../hooks/useClawHooks';
-import {
-  type BotIdentity,
-  type ExecPreset,
-  type ClawMutations,
-  execPresetToConfig,
-  channelTokensToConfigPatch,
-} from './claw.types';
 import { OnboardingStepView } from './OnboardingStepView';
 
 /** Play a short chime via the Web Audio API. */
@@ -35,98 +27,22 @@ function playChime() {
 export function ProvisioningStep({
   currentStep,
   totalSteps,
-  preset,
-  channelTokens,
-  botIdentity,
+  onboardingSavesReady,
   instanceRunning,
-  mutations,
   onComplete,
 }: {
   currentStep: number;
   totalSteps: number;
-  preset: ExecPreset;
-  channelTokens: Record<string, string> | null;
-  botIdentity: BotIdentity | null;
+  onboardingSavesReady: boolean;
   instanceRunning: boolean;
-  mutations: ClawMutations;
   onComplete: () => void;
 }) {
-  const completedRef = useRef(false);
-  const [configReady, setConfigReady] = useState(false);
-
-  // Keep stable references to callbacks so the effect only re-runs
-  // when data values change, not when the parent re-renders or mutation
-  // state transitions (pending→error) produce new object references.
+  // Bot identity, exec preset, and channel token saves start from
+  // `ClawOnboardingFlow` as soon as the instance row exists. This component
+  // waits for those durable writes plus gateway ready+settled before it chimes
+  // and advances.
   const onCompleteRef = useRef(onComplete);
   onCompleteRef.current = onComplete;
-  const patchOpenclawConfigRef = useRef(mutations.patchOpenclawConfig.mutate);
-  patchOpenclawConfigRef.current = mutations.patchOpenclawConfig.mutate;
-  const patchChannelsRef = useRef(mutations.patchChannels.mutate);
-  patchChannelsRef.current = mutations.patchChannels.mutate;
-  const patchExecPresetRef = useRef(mutations.patchExecPreset.mutate);
-  patchExecPresetRef.current = mutations.patchExecPreset.mutate;
-  const patchBotIdentityRef = useRef(mutations.patchBotIdentity.mutate);
-  patchBotIdentityRef.current = mutations.patchBotIdentity.mutate;
-  const channelTokensRef = useRef(channelTokens);
-  channelTokensRef.current = channelTokens;
-  const botIdentityRef = useRef(botIdentity);
-  botIdentityRef.current = botIdentity;
-
-  useEffect(() => {
-    if (!instanceRunning || completedRef.current) return;
-    completedRef.current = true;
-
-    // Build the full openclaw.json patch: exec preset + channel config.
-    const configPatch: Record<string, unknown> = {};
-
-    if (preset !== 'always-ask') {
-      const { security, ask } = execPresetToConfig(preset);
-      configPatch.tools = { exec: { security, ask } };
-    }
-
-    const channelPatch = channelTokensToConfigPatch(channelTokensRef.current);
-    if (channelPatch) Object.assign(configPatch, channelPatch);
-
-    // Also persist channel tokens to durable storage so they survive
-    // machine restarts. Fire-and-forget — the live config patch above
-    // is what matters for the immediate user experience.
-    const tokens = channelTokensRef.current;
-    if (tokens && Object.keys(tokens).length > 0) {
-      patchChannelsRef.current(tokens);
-    }
-
-    // Persist exec permissions preset to durable storage so it survives
-    // machine restarts/redeploys. Fire-and-forget — same pattern as channels.
-    if (preset !== 'always-ask') {
-      const { security, ask } = execPresetToConfig(preset);
-      patchExecPresetRef.current({ security, ask });
-    }
-
-    if (botIdentityRef.current) {
-      patchBotIdentityRef.current({
-        botName: botIdentityRef.current.botName,
-        botNature: botIdentityRef.current.botNature,
-        botVibe: botIdentityRef.current.botVibe,
-        botEmoji: botIdentityRef.current.botEmoji,
-      });
-    }
-
-    if (Object.keys(configPatch).length === 0) {
-      setConfigReady(true);
-      return;
-    }
-
-    patchOpenclawConfigRef.current(
-      { patch: configPatch },
-      {
-        onSuccess: () => setConfigReady(true),
-        onError: (err: { message: string }) => {
-          completedRef.current = false;
-          toast.error(err.message);
-        },
-      }
-    );
-  }, [instanceRunning, preset]);
 
   // Poll the gateway /ready endpoint to know when channels are fully set up
   // and the system's CPU load has settled after boot.
@@ -159,14 +75,14 @@ export function ProvisioningStep({
     return () => clearTimeout(timer);
   }, [gatewayReady]);
 
-  // Advance to the next step when config is applied, gateway reports ready,
-  // and boot CPU pressure has subsided (settled === true).
+  // Advance to the next step when required onboarding saves have succeeded,
+  // the gateway reports ready, and boot CPU pressure has subsided.
   useEffect(() => {
-    if (configReady && isGatewaySettled) {
+    if (onboardingSavesReady && isGatewaySettled) {
       playChime();
       onCompleteRef.current();
     }
-  }, [configReady, isGatewaySettled]);
+  }, [onboardingSavesReady, isGatewaySettled]);
 
   if (gateway502Expired) {
     return <ProvisioningErrorView currentStep={currentStep} totalSteps={totalSteps} />;

--- a/apps/web/src/app/(app)/claw/hooks/useOnboardingSaves.test.ts
+++ b/apps/web/src/app/(app)/claw/hooks/useOnboardingSaves.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from '@jest/globals';
+
+import type { BotIdentity } from '../components/claw.types';
+import {
+  areOnboardingSavesReady,
+  planOnboardingSaves,
+  type OnboardingSaveFlags,
+  type OnboardingSaveStatuses,
+} from './useOnboardingSaves';
+
+const IDENTITY: BotIdentity = {
+  botName: 'Pinchy',
+  botNature: 'crab assistant',
+  botVibe: 'playful and sharp',
+  botEmoji: '🦀',
+};
+
+function freshCompleted(): OnboardingSaveFlags {
+  return { botIdentity: false, execPreset: false, channels: false };
+}
+
+function freshStatuses(overrides: Partial<OnboardingSaveStatuses> = {}): OnboardingSaveStatuses {
+  return { botIdentity: 'idle', execPreset: 'idle', channels: 'idle', ...overrides };
+}
+
+describe('planOnboardingSaves', () => {
+  test('saves nothing when the instance row does not exist yet', () => {
+    const plan = planOnboardingSaves({
+      hasInstance: false,
+      botIdentity: IDENTITY,
+      selectedPreset: 'never-ask',
+      channelTokens: { telegramBotToken: 'abc' },
+      completed: freshCompleted(),
+    });
+
+    expect(plan).toEqual({});
+  });
+
+  test('saves bot identity as soon as the instance exists and identity is present', () => {
+    const plan = planOnboardingSaves({
+      hasInstance: true,
+      botIdentity: IDENTITY,
+      selectedPreset: null,
+      channelTokens: null,
+      completed: freshCompleted(),
+    });
+
+    expect(plan.botIdentity).toEqual(IDENTITY);
+    expect(plan.execPreset).toBeUndefined();
+    expect(plan.channels).toBeUndefined();
+  });
+
+  test('saves exec preset only when the user chose never-ask', () => {
+    const plan = planOnboardingSaves({
+      hasInstance: true,
+      botIdentity: null,
+      selectedPreset: 'never-ask',
+      channelTokens: null,
+      completed: freshCompleted(),
+    });
+
+    expect(plan.execPreset).toEqual({ security: 'full', ask: 'off' });
+  });
+
+  test('skips exec preset when the user chose always-ask (gateway default)', () => {
+    const plan = planOnboardingSaves({
+      hasInstance: true,
+      botIdentity: null,
+      selectedPreset: 'always-ask',
+      channelTokens: null,
+      completed: freshCompleted(),
+    });
+
+    expect(plan.execPreset).toBeUndefined();
+  });
+
+  test('saves channels when tokens are present', () => {
+    const plan = planOnboardingSaves({
+      hasInstance: true,
+      botIdentity: null,
+      selectedPreset: null,
+      channelTokens: { telegramBotToken: 'abc' },
+      completed: freshCompleted(),
+    });
+
+    expect(plan.channels).toEqual({ telegramBotToken: 'abc' });
+  });
+
+  test('skips channels when the user did not enter any tokens', () => {
+    const plan = planOnboardingSaves({
+      hasInstance: true,
+      botIdentity: null,
+      selectedPreset: null,
+      channelTokens: {},
+      completed: freshCompleted(),
+    });
+
+    expect(plan.channels).toBeUndefined();
+  });
+
+  test('starts all three saves together once everything is ready', () => {
+    const plan = planOnboardingSaves({
+      hasInstance: true,
+      botIdentity: IDENTITY,
+      selectedPreset: 'never-ask',
+      channelTokens: { telegramBotToken: 'abc' },
+      completed: freshCompleted(),
+    });
+
+    expect(plan.botIdentity).toEqual(IDENTITY);
+    expect(plan.execPreset).toEqual({ security: 'full', ask: 'off' });
+    expect(plan.channels).toEqual({ telegramBotToken: 'abc' });
+  });
+
+  test('does not restart a save that has already completed', () => {
+    const plan = planOnboardingSaves({
+      hasInstance: true,
+      botIdentity: IDENTITY,
+      selectedPreset: 'never-ask',
+      channelTokens: { telegramBotToken: 'abc' },
+      completed: { botIdentity: true, execPreset: true, channels: true },
+    });
+
+    expect(plan).toEqual({});
+  });
+
+  test('does not restart a save that is already in flight', () => {
+    const plan = planOnboardingSaves({
+      hasInstance: true,
+      botIdentity: IDENTITY,
+      selectedPreset: 'never-ask',
+      channelTokens: { telegramBotToken: 'abc' },
+      completed: freshCompleted(),
+      inFlight: { botIdentity: true, execPreset: false, channels: false },
+    });
+
+    expect(plan.botIdentity).toBeUndefined();
+    expect(plan.execPreset).toEqual({ security: 'full', ask: 'off' });
+    expect(plan.channels).toEqual({ telegramBotToken: 'abc' });
+  });
+
+  test('starts only the incomplete saves when re-evaluated', () => {
+    const plan = planOnboardingSaves({
+      hasInstance: true,
+      botIdentity: IDENTITY,
+      selectedPreset: 'never-ask',
+      channelTokens: { telegramBotToken: 'abc' },
+      completed: { botIdentity: true, execPreset: false, channels: false },
+    });
+
+    expect(plan.botIdentity).toBeUndefined();
+    expect(plan.execPreset).toEqual({ security: 'full', ask: 'off' });
+    expect(plan.channels).toEqual({ telegramBotToken: 'abc' });
+  });
+});
+
+describe('areOnboardingSavesReady', () => {
+  test('is false until the instance exists', () => {
+    expect(
+      areOnboardingSavesReady({
+        hasInstance: false,
+        botIdentity: IDENTITY,
+        selectedPreset: 'never-ask',
+        channelTokens: { telegramBotToken: 'abc' },
+        statuses: freshStatuses({
+          botIdentity: 'success',
+          execPreset: 'success',
+          channels: 'success',
+        }),
+      })
+    ).toBe(false);
+  });
+
+  test('requires every required save to succeed', () => {
+    expect(
+      areOnboardingSavesReady({
+        hasInstance: true,
+        botIdentity: IDENTITY,
+        selectedPreset: 'never-ask',
+        channelTokens: { telegramBotToken: 'abc' },
+        statuses: freshStatuses({
+          botIdentity: 'success',
+          execPreset: 'pending',
+          channels: 'success',
+        }),
+      })
+    ).toBe(false);
+  });
+
+  test('treats skipped optional saves as ready', () => {
+    expect(
+      areOnboardingSavesReady({
+        hasInstance: true,
+        botIdentity: IDENTITY,
+        selectedPreset: 'always-ask',
+        channelTokens: null,
+        statuses: freshStatuses({ botIdentity: 'success' }),
+      })
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/app/(app)/claw/hooks/useOnboardingSaves.ts
+++ b/apps/web/src/app/(app)/claw/hooks/useOnboardingSaves.ts
@@ -1,0 +1,340 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+import {
+  execPresetToConfig,
+  type BotIdentity,
+  type ClawMutations,
+  type ExecPreset,
+} from '../components/claw.types';
+
+/**
+ * Onboarding save operations.
+ *
+ * The setup wizard stores bot identity, exec preset, and channel tokens as soon
+ * as an instance row exists. These are normal save mutations: the DO persists
+ * the requested values immediately and replays any needed config to the machine
+ * when the gateway is available.
+ *
+ * This hook keeps those saves alive outside `ProvisioningStep`, which may
+ * unmount while the provisioning spinner is showing. Each mutation retries until
+ * its durable write succeeds, and `ready` lets the provisioning screen wait for
+ * the required saves before completing.
+ */
+
+export type OnboardingSaveFlags = {
+  botIdentity: boolean;
+  execPreset: boolean;
+  channels: boolean;
+};
+
+type OnboardingSaveName = keyof OnboardingSaveFlags;
+
+export type OnboardingSaveStatus = 'idle' | 'pending' | 'success' | 'error';
+
+export type OnboardingSaveStatuses = Record<OnboardingSaveName, OnboardingSaveStatus>;
+
+export type OnboardingSavePlan = {
+  botIdentity?: BotIdentity;
+  execPreset?: { security: string; ask: string };
+  channels?: Record<string, string>;
+};
+
+export type OnboardingSavesState = {
+  ready: boolean;
+  pending: boolean;
+  statuses: OnboardingSaveStatuses;
+};
+
+const SAVE_NAMES: readonly OnboardingSaveName[] = ['botIdentity', 'execPreset', 'channels'];
+const ONBOARDING_SAVE_RETRY_MS = 2_000;
+
+function createSaveFlags(): OnboardingSaveFlags {
+  return { botIdentity: false, execPreset: false, channels: false };
+}
+
+function createSaveStatuses(): OnboardingSaveStatuses {
+  return { botIdentity: 'idle', execPreset: 'idle', channels: 'idle' };
+}
+
+function hasChannelTokens(
+  channelTokens: Record<string, string> | null
+): channelTokens is Record<string, string> {
+  return channelTokens !== null && Object.keys(channelTokens).length > 0;
+}
+
+export function getRequiredOnboardingSaves({
+  hasInstance,
+  botIdentity,
+  selectedPreset,
+  channelTokens,
+}: {
+  hasInstance: boolean;
+  botIdentity: BotIdentity | null;
+  selectedPreset: ExecPreset | null;
+  channelTokens: Record<string, string> | null;
+}): OnboardingSaveFlags {
+  if (!hasInstance) return createSaveFlags();
+
+  return {
+    botIdentity: botIdentity !== null,
+    execPreset: selectedPreset !== null && selectedPreset !== 'always-ask',
+    channels: hasChannelTokens(channelTokens),
+  };
+}
+
+export function areOnboardingSavesReady({
+  hasInstance,
+  botIdentity,
+  selectedPreset,
+  channelTokens,
+  statuses,
+}: {
+  hasInstance: boolean;
+  botIdentity: BotIdentity | null;
+  selectedPreset: ExecPreset | null;
+  channelTokens: Record<string, string> | null;
+  statuses: OnboardingSaveStatuses;
+}): boolean {
+  if (!hasInstance) return false;
+
+  const required = getRequiredOnboardingSaves({
+    hasInstance,
+    botIdentity,
+    selectedPreset,
+    channelTokens,
+  });
+
+  return SAVE_NAMES.every(name => !required[name] || statuses[name] === 'success');
+}
+
+/**
+ * Pure decision logic: given the current onboarding inputs and save latches,
+ * return the set of saves that should start now. A save is only included if
+ * (a) the instance row exists, (b) its input is present, (c) it has not yet
+ * succeeded in this onboarding session, and (d) it is not already in flight.
+ *
+ * `always-ask` is the gateway default, so we skip the exec preset save when the
+ * user explicitly selects it -- no write needed.
+ */
+export function planOnboardingSaves({
+  hasInstance,
+  botIdentity,
+  selectedPreset,
+  channelTokens,
+  completed,
+  inFlight = createSaveFlags(),
+}: {
+  hasInstance: boolean;
+  botIdentity: BotIdentity | null;
+  selectedPreset: ExecPreset | null;
+  channelTokens: Record<string, string> | null;
+  completed: OnboardingSaveFlags;
+  inFlight?: OnboardingSaveFlags;
+}): OnboardingSavePlan {
+  const plan: OnboardingSavePlan = {};
+  if (!hasInstance) return plan;
+
+  if (!completed.botIdentity && !inFlight.botIdentity && botIdentity) {
+    plan.botIdentity = botIdentity;
+  }
+  if (
+    !completed.execPreset &&
+    !inFlight.execPreset &&
+    selectedPreset &&
+    selectedPreset !== 'always-ask'
+  ) {
+    plan.execPreset = execPresetToConfig(selectedPreset);
+  }
+  if (!completed.channels && !inFlight.channels && hasChannelTokens(channelTokens)) {
+    plan.channels = channelTokens;
+  }
+
+  return plan;
+}
+
+export function useOnboardingSaves({
+  hasInstance,
+  botIdentity,
+  selectedPreset,
+  channelTokens,
+  resetKey,
+  mutations,
+}: {
+  hasInstance: boolean;
+  botIdentity: BotIdentity | null;
+  selectedPreset: ExecPreset | null;
+  channelTokens: Record<string, string> | null;
+  resetKey: string;
+  mutations: ClawMutations;
+}): OnboardingSavesState {
+  const completedRef = useRef<OnboardingSaveFlags>(createSaveFlags());
+  const inFlightRef = useRef<OnboardingSaveFlags>(createSaveFlags());
+  const errorToastShownRef = useRef<OnboardingSaveFlags>(createSaveFlags());
+  const retryTimersRef = useRef<Partial<Record<OnboardingSaveName, ReturnType<typeof setTimeout>>>>(
+    {}
+  );
+  const activeResetKeyRef = useRef(resetKey);
+  const [statuses, setStatuses] = useState<OnboardingSaveStatuses>(createSaveStatuses);
+  const [retryTick, setRetryTick] = useState(0);
+
+  const clearRetryTimer = useCallback((name: OnboardingSaveName) => {
+    const timer = retryTimersRef.current[name];
+    if (timer) {
+      clearTimeout(timer);
+      delete retryTimersRef.current[name];
+    }
+  }, []);
+
+  const clearRetryTimers = useCallback(() => {
+    for (const name of SAVE_NAMES) {
+      clearRetryTimer(name);
+    }
+  }, [clearRetryTimer]);
+
+  const setSaveStatus = useCallback((name: OnboardingSaveName, status: OnboardingSaveStatus) => {
+    setStatuses(current => {
+      if (current[name] === status) return current;
+      return { ...current, [name]: status };
+    });
+  }, []);
+
+  const scheduleRetry = useCallback(
+    (name: OnboardingSaveName, requestResetKey: string) => {
+      clearRetryTimer(name);
+      retryTimersRef.current[name] = setTimeout(() => {
+        if (activeResetKeyRef.current !== requestResetKey) return;
+        setRetryTick(value => value + 1);
+      }, ONBOARDING_SAVE_RETRY_MS);
+    },
+    [clearRetryTimer]
+  );
+
+  const markSaveSucceeded = useCallback(
+    (name: OnboardingSaveName, requestResetKey: string) => {
+      if (activeResetKeyRef.current !== requestResetKey) return;
+      clearRetryTimer(name);
+      completedRef.current[name] = true;
+      errorToastShownRef.current[name] = false;
+      setSaveStatus(name, 'success');
+    },
+    [clearRetryTimer, setSaveStatus]
+  );
+
+  const markSaveFailed = useCallback(
+    (name: OnboardingSaveName, requestResetKey: string, err: { message: string }) => {
+      if (activeResetKeyRef.current !== requestResetKey) return;
+      if (!errorToastShownRef.current[name]) {
+        toast.error(err.message);
+        errorToastShownRef.current[name] = true;
+      }
+      setSaveStatus(name, 'error');
+      scheduleRetry(name, requestResetKey);
+    },
+    [scheduleRetry, setSaveStatus]
+  );
+
+  const markSaveSettled = useCallback((name: OnboardingSaveName, requestResetKey: string) => {
+    if (activeResetKeyRef.current !== requestResetKey) return;
+    inFlightRef.current[name] = false;
+  }, []);
+
+  // Keep mutations in a ref so the effect re-runs only when inputs change,
+  // not on every react-query state transition that produces a new
+  // mutations object reference.
+  const mutationsRef = useRef(mutations);
+  mutationsRef.current = mutations;
+
+  useEffect(() => {
+    if (activeResetKeyRef.current === resetKey) return;
+
+    activeResetKeyRef.current = resetKey;
+    completedRef.current = createSaveFlags();
+    inFlightRef.current = createSaveFlags();
+    errorToastShownRef.current = createSaveFlags();
+    clearRetryTimers();
+    setStatuses(createSaveStatuses());
+  }, [clearRetryTimers, resetKey]);
+
+  useEffect(() => () => clearRetryTimers(), [clearRetryTimers]);
+
+  useEffect(() => {
+    const requestResetKey = resetKey;
+    const plan = planOnboardingSaves({
+      hasInstance,
+      botIdentity,
+      selectedPreset,
+      channelTokens,
+      completed: completedRef.current,
+      inFlight: inFlightRef.current,
+    });
+
+    if (plan.botIdentity) {
+      inFlightRef.current.botIdentity = true;
+      clearRetryTimer('botIdentity');
+      setSaveStatus('botIdentity', 'pending');
+      mutationsRef.current.patchBotIdentity.mutate(
+        {
+          botName: plan.botIdentity.botName,
+          botNature: plan.botIdentity.botNature,
+          botVibe: plan.botIdentity.botVibe,
+          botEmoji: plan.botIdentity.botEmoji,
+        },
+        {
+          onSuccess: () => markSaveSucceeded('botIdentity', requestResetKey),
+          onError: err => markSaveFailed('botIdentity', requestResetKey, err),
+          onSettled: () => markSaveSettled('botIdentity', requestResetKey),
+        }
+      );
+    }
+
+    if (plan.execPreset) {
+      inFlightRef.current.execPreset = true;
+      clearRetryTimer('execPreset');
+      setSaveStatus('execPreset', 'pending');
+      mutationsRef.current.patchExecPreset.mutate(plan.execPreset, {
+        onSuccess: () => markSaveSucceeded('execPreset', requestResetKey),
+        onError: err => markSaveFailed('execPreset', requestResetKey, err),
+        onSettled: () => markSaveSettled('execPreset', requestResetKey),
+      });
+    }
+
+    if (plan.channels) {
+      inFlightRef.current.channels = true;
+      clearRetryTimer('channels');
+      setSaveStatus('channels', 'pending');
+      mutationsRef.current.patchChannels.mutate(plan.channels, {
+        onSuccess: () => markSaveSucceeded('channels', requestResetKey),
+        onError: err => markSaveFailed('channels', requestResetKey, err),
+        onSettled: () => markSaveSettled('channels', requestResetKey),
+      });
+    }
+  }, [
+    hasInstance,
+    botIdentity,
+    selectedPreset,
+    channelTokens,
+    resetKey,
+    retryTick,
+    clearRetryTimer,
+    markSaveFailed,
+    markSaveSettled,
+    markSaveSucceeded,
+    setSaveStatus,
+  ]);
+
+  const resetInProgress = activeResetKeyRef.current !== resetKey;
+  const readinessStatuses = resetInProgress ? createSaveStatuses() : statuses;
+  const ready = areOnboardingSavesReady({
+    hasInstance,
+    botIdentity,
+    selectedPreset,
+    channelTokens,
+    statuses: readinessStatuses,
+  });
+  const pending = SAVE_NAMES.some(name => readinessStatuses[name] === 'pending');
+
+  return { ready, pending, statuses: readinessStatuses };
+}

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -2858,6 +2858,30 @@ describe('updateChannels', () => {
     expectStructuredWarn(warnSpy, 'updateChannels: gateway patch failed');
     vi.unstubAllGlobals();
   });
+
+  it('keeps channelsApplyPending when live channel patch cannot decrypt stored tokens', async () => {
+    const env = {
+      ...createFakeEnv(),
+      FLY_APP_NAME: 'channels-app',
+      AGENT_ENV_VARS_PRIVATE_KEY: '',
+    };
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { instance, storage } = createInstance(undefined, env);
+    await seedRunning(storage, { flyMachineId: 'machine-1', sandboxId: 'sandbox-1' });
+
+    await instance.updateChannels({ telegramBotToken: fakeEnvelope });
+
+    expect(
+      fetchMock.mock.calls.some(
+        (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/_kilo/config/patch')
+      )
+    ).toBe(false);
+    expect(storage._store.get('channelsApplyPending')).toBe(true);
+    expectStructuredWarn(warnSpy, 'updateChannels: gateway patch failed');
+    vi.unstubAllGlobals();
+  });
 });
 
 // ============================================================================
@@ -8523,19 +8547,22 @@ describe('channel config patch builder', () => {
     });
   });
 
-  it('returns null for empty channels, missing private key, or partial slack state', () => {
+  it('returns null for empty channels or partial slack state', () => {
     const env = createFakeEnv();
 
     expect(buildChannelConfigPatch(env, null)).toBeNull();
-    expect(
+    expect(buildChannelConfigPatch(env, { slackBotToken: fakeEnvelope })).toBeNull();
+  });
+
+  it('throws when stored channels need decrypting but the worker has no private key', () => {
+    expect(() =>
       buildChannelConfigPatch(
-        { ...env, AGENT_ENV_VARS_PRIVATE_KEY: undefined },
+        { ...createFakeEnv(), AGENT_ENV_VARS_PRIVATE_KEY: undefined },
         {
           telegramBotToken: fakeEnvelope,
         }
       )
-    ).toBeNull();
-    expect(buildChannelConfigPatch(env, { slackBotToken: fakeEnvelope })).toBeNull();
+    ).toThrow('AGENT_ENV_VARS_PRIVATE_KEY is required to build live channel config patch');
   });
 });
 
@@ -8704,6 +8731,48 @@ describe('flushPendingConfigToGateway: alarm retry for pending identity/exec/cha
 
     await instance.alarm();
 
+    expect(storage._store.get('channelsApplyPending')).toBe(true);
+    expectStructuredWarn(warnSpy, 'flushPendingConfigToGateway: channels failed');
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps pending channel config set when alarm retry cannot decrypt stored tokens', async () => {
+    const env = {
+      ...createFakeEnv(),
+      FLY_APP_NAME: 'flush-app',
+      AGENT_ENV_VARS_PRIVATE_KEY: '',
+    };
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { instance, storage } = createInstance(undefined, env);
+    await seedRunning(storage, {
+      flyMachineId: 'machine-1',
+      sandboxId: 'sandbox-1',
+      channels: {
+        telegramBotToken: {
+          encryptedData: 'telegram-token',
+          encryptedDEK: 'dek',
+          algorithm: 'rsa-aes-256-gcm',
+          version: 1,
+        },
+      },
+      channelsApplyPending: true,
+    });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      state: 'started',
+      config: { mounts: [{ volume: 'vol-1', path: '/root' }] },
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    expect(
+      fetchMock.mock.calls.some(
+        (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/_kilo/config/patch')
+      )
+    ).toBe(false);
     expect(storage._store.get('channelsApplyPending')).toBe(true);
     expectStructuredWarn(warnSpy, 'flushPendingConfigToGateway: channels failed');
     vi.unstubAllGlobals();

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -90,6 +90,29 @@ vi.mock('../utils/env-encryption', () => ({
   encryptEnvValue: vi.fn((_key: string, value: string) => `enc:v1:fake_${value}`),
 }));
 
+vi.mock('../utils/encryption', async () => {
+  const actual = await vi.importActual('../utils/encryption');
+  return {
+    ...actual,
+    decryptChannelTokens: vi.fn((channels: Record<string, { encryptedData: string }>) => {
+      const result: Record<string, string> = {};
+      if (channels.telegramBotToken) {
+        result.TELEGRAM_BOT_TOKEN = channels.telegramBotToken.encryptedData;
+      }
+      if (channels.discordBotToken) {
+        result.DISCORD_BOT_TOKEN = channels.discordBotToken.encryptedData;
+      }
+      if (channels.slackBotToken) {
+        result.SLACK_BOT_TOKEN = channels.slackBotToken.encryptedData;
+      }
+      if (channels.slackAppToken) {
+        result.SLACK_APP_TOKEN = channels.slackAppToken.encryptedData;
+      }
+      return result;
+    }),
+  };
+});
+
 // -- Mock stream-chat client --
 vi.mock('../stream-chat/client', () => ({
   setupDefaultStreamChatChannel: vi.fn().mockResolvedValue({
@@ -103,6 +126,7 @@ vi.mock('../stream-chat/client', () => ({
 }));
 
 import { KiloClawInstance } from './kiloclaw-instance';
+import { buildChannelConfigPatch } from './kiloclaw-instance/channel-config';
 import * as flyClient from '../fly/client';
 import { FlyApiError } from '../fly/client';
 import * as db from '../db';
@@ -211,6 +235,7 @@ function createFakeEnv() {
       get: vi.fn().mockReturnValue(appStub),
     } as unknown,
     HYPERDRIVE: { connectionString: 'postgresql://fake' } as unknown,
+    AGENT_ENV_VARS_PRIVATE_KEY: 'test-private-key',
     KV_CLAW_CACHE: {
       get: vi.fn().mockResolvedValue(null),
       put: vi.fn().mockResolvedValue(undefined),
@@ -2581,7 +2606,7 @@ describe('updateChannels', () => {
     version: 1 as const,
   };
 
-  it('sets a telegram token on a provisioned instance', async () => {
+  it('sets a telegram token on a provisioned instance and queues live apply', async () => {
     const { instance, storage } = createInstance();
     await seedProvisioned(storage);
 
@@ -2591,19 +2616,21 @@ describe('updateChannels', () => {
     expect(result.discord).toBe(false);
     const channels = storage._store.get('channels') as Record<string, unknown>;
     expect(channels.telegramBotToken).toEqual(fakeEnvelope);
+    expect(storage._store.get('channelsApplyPending')).toBe(true);
   });
 
-  it('removes a telegram token when null is passed', async () => {
+  it('removes a telegram token and clears pending apply when no channels remain', async () => {
     const { instance, storage } = createInstance();
     await seedProvisioned(storage, {
       channels: { telegramBotToken: fakeEnvelope },
+      channelsApplyPending: true,
     });
 
     const result = await instance.updateChannels({ telegramBotToken: null });
 
     expect(result.telegram).toBe(false);
-    // channels should be null when all tokens are removed
     expect(storage._store.get('channels')).toBeNull();
+    expect(storage._store.get('channelsApplyPending')).toBe(false);
   });
 
   it('merges with existing channels — setting telegram preserves discord', async () => {
@@ -2672,6 +2699,164 @@ describe('updateChannels', () => {
     expect(channels.discordBotToken).toEqual(discordEnvelope);
     expect(secrets.TELEGRAM_BOT_TOKEN).toEqual(fakeEnvelope);
     expect(secrets.DISCORD_BOT_TOKEN).toEqual(discordEnvelope);
+  });
+
+  it('calls /_kilo/config/patch with full stored channel state on running instances', async () => {
+    const env = createFakeEnv();
+    env.FLY_APP_NAME = 'channels-app';
+    const discordEnvelope = { ...fakeEnvelope, encryptedData: 'discord-data' };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { instance, storage } = createInstance(undefined, env);
+    await seedRunning(storage, {
+      flyMachineId: 'machine-1',
+      sandboxId: 'sandbox-1',
+      channels: { telegramBotToken: fakeEnvelope },
+      encryptedSecrets: { TELEGRAM_BOT_TOKEN: fakeEnvelope },
+      channelsApplyPending: true,
+    });
+
+    await instance.updateChannels({ discordBotToken: discordEnvelope });
+
+    const patchCall = fetchMock.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/_kilo/config/patch')
+    );
+    expect(patchCall).toBeDefined();
+    const [, init] = patchCall as [unknown, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      channels: {
+        telegram: {
+          botToken: 'data',
+          enabled: true,
+          dmPolicy: 'pairing',
+        },
+        discord: {
+          token: 'discord-data',
+          enabled: true,
+          dm: { policy: 'pairing' },
+        },
+      },
+      plugins: {
+        entries: {
+          telegram: { enabled: true },
+          discord: { enabled: true },
+        },
+      },
+    });
+    expect(storage._store.get('channelsApplyPending')).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it('live-patches mixed channel removals and additions from current stored state', async () => {
+    const env = createFakeEnv();
+    env.FLY_APP_NAME = 'channels-app';
+    const discordEnvelope = { ...fakeEnvelope, encryptedData: 'discord-data' };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { instance, storage } = createInstance(undefined, env);
+    await seedRunning(storage, {
+      flyMachineId: 'machine-1',
+      sandboxId: 'sandbox-1',
+      channels: { telegramBotToken: fakeEnvelope },
+      encryptedSecrets: { TELEGRAM_BOT_TOKEN: fakeEnvelope },
+      channelsApplyPending: true,
+    });
+
+    await instance.updateChannels({
+      telegramBotToken: null,
+      discordBotToken: discordEnvelope,
+    });
+
+    const channels = storage._store.get('channels') as Record<string, unknown>;
+    expect(channels.telegramBotToken).toBeUndefined();
+    expect(channels.discordBotToken).toEqual(discordEnvelope);
+    const patchCall = fetchMock.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/_kilo/config/patch')
+    );
+    expect(patchCall).toBeDefined();
+    const [, init] = patchCall as [unknown, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      channels: {
+        discord: {
+          token: 'discord-data',
+          enabled: true,
+          dm: { policy: 'pairing' },
+        },
+      },
+      plugins: {
+        entries: {
+          discord: { enabled: true },
+        },
+      },
+    });
+    expect(storage._store.get('channelsApplyPending')).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps pending channel apply when a removal leaves queued channel config', async () => {
+    const env = createFakeEnv();
+    env.FLY_APP_NAME = 'channels-app';
+    const discordEnvelope = { ...fakeEnvelope, encryptedData: 'discord-data' };
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { instance, storage } = createInstance(undefined, env);
+    await seedRunning(storage, {
+      flyMachineId: 'machine-1',
+      sandboxId: 'sandbox-1',
+      channels: {
+        telegramBotToken: fakeEnvelope,
+        discordBotToken: discordEnvelope,
+      },
+      encryptedSecrets: {
+        TELEGRAM_BOT_TOKEN: fakeEnvelope,
+        DISCORD_BOT_TOKEN: discordEnvelope,
+      },
+      channelsApplyPending: true,
+    });
+
+    await instance.updateChannels({ telegramBotToken: null });
+
+    const channels = storage._store.get('channels') as Record<string, unknown>;
+    expect(channels.telegramBotToken).toBeUndefined();
+    expect(channels.discordBotToken).toEqual(discordEnvelope);
+    expect(storage._store.get('channelsApplyPending')).toBe(true);
+    expect(
+      fetchMock.mock.calls.some(
+        (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/_kilo/config/patch')
+      )
+    ).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps channelsApplyPending when live channel patch fails on running instances', async () => {
+    const env = createFakeEnv();
+    env.FLY_APP_NAME = 'channels-app';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'boom' }), {
+        status: 503,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { instance, storage } = createInstance(undefined, env);
+    await seedRunning(storage, { flyMachineId: 'machine-1', sandboxId: 'sandbox-1' });
+
+    await instance.updateChannels({ telegramBotToken: fakeEnvelope });
+
+    expect(storage._store.get('channelsApplyPending')).toBe(true);
+    expectStructuredWarn(warnSpy, 'updateChannels: gateway patch failed');
+    vi.unstubAllGlobals();
   });
 });
 
@@ -8084,6 +8269,96 @@ describe('updateExecPreset', () => {
     expect(result.execSecurity).toBe('full');
     expect(result.execAsk).toBe('off');
   });
+
+  it('sets execPresetApplyPending while status=starting and does not call the gateway', async () => {
+    const env = createFakeEnv();
+    env.FLY_APP_NAME = 'exec-app';
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { instance, storage } = createInstance(undefined, env);
+    await seedStarting(storage, { flyMachineId: 'machine-1', sandboxId: 'sandbox-1' });
+
+    await instance.updateExecPreset({ security: 'full', ask: 'off' });
+
+    expect(storage._store.get('execSecurity')).toBe('full');
+    expect(storage._store.get('execAsk')).toBe('off');
+    expect(storage._store.get('execPresetApplyPending')).toBe(true);
+    expect(
+      fetchMock.mock.calls.some(
+        (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/_kilo/config/patch')
+      )
+    ).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it('calls /_kilo/config/patch and clears the pending flag on running instances', async () => {
+    const env = createFakeEnv();
+    env.FLY_APP_NAME = 'exec-app';
+    const calls: string[] = [];
+    const fetchMock = vi.fn().mockImplementation(() => {
+      calls.push('fetch');
+      return Promise.resolve(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { instance, storage } = createInstance(undefined, env);
+    storage.put = (entries: Record<string, unknown>) => {
+      if ('execPresetApplyPending' in entries) {
+        calls.push(`put:${String(entries.execPresetApplyPending)}`);
+      } else {
+        calls.push('put');
+      }
+      for (const [key, value] of Object.entries(entries)) {
+        storage._store.set(key, value);
+      }
+    };
+    await seedRunning(storage, {
+      flyMachineId: 'machine-1',
+      sandboxId: 'sandbox-1',
+      execPresetApplyPending: true,
+    });
+
+    await instance.updateExecPreset({ security: 'full', ask: 'off' });
+
+    const patchCall = fetchMock.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/_kilo/config/patch')
+    );
+    expect(patchCall).toBeDefined();
+    const [, init] = patchCall as [unknown, RequestInit];
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({
+      tools: { exec: { security: 'full', ask: 'off' } },
+    });
+    expect(calls).toEqual(['put:true', 'fetch', 'put:false']);
+    expect(storage._store.get('execPresetApplyPending')).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it('sets execPresetApplyPending when the gateway rejects the patch on a running instance', async () => {
+    const env = createFakeEnv();
+    env.FLY_APP_NAME = 'exec-app';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'boom' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { instance, storage } = createInstance(undefined, env);
+    await seedRunning(storage, { flyMachineId: 'machine-1', sandboxId: 'sandbox-1' });
+
+    await instance.updateExecPreset({ security: 'full', ask: 'off' });
+
+    expect(storage._store.get('execSecurity')).toBe('full');
+    expect(storage._store.get('execPresetApplyPending')).toBe(true);
+    expectStructuredWarn(warnSpy, 'updateExecPreset: gateway patch failed');
+    vi.unstubAllGlobals();
+  });
 });
 
 describe('updateBotIdentity', () => {
@@ -8113,18 +8388,33 @@ describe('updateBotIdentity', () => {
   it('writes IDENTITY.md on running instances', async () => {
     const env = createFakeEnv();
     env.FLY_APP_NAME = 'bot-app';
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ ok: true, path: 'workspace/IDENTITY.md' }), {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      })
-    );
+    const calls: string[] = [];
+    const fetchMock = vi.fn().mockImplementation(() => {
+      calls.push('fetch');
+      return Promise.resolve(
+        new Response(JSON.stringify({ ok: true, path: 'workspace/IDENTITY.md' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    });
     vi.stubGlobal('fetch', fetchMock);
     const { instance, storage } = createInstance(undefined, env);
+    storage.put = (entries: Record<string, unknown>) => {
+      if ('botIdentityApplyPending' in entries) {
+        calls.push(`put:${String(entries.botIdentityApplyPending)}`);
+      } else {
+        calls.push('put');
+      }
+      for (const [key, value] of Object.entries(entries)) {
+        storage._store.set(key, value);
+      }
+    };
     await seedProvisioned(storage, {
       status: 'running',
       flyMachineId: 'machine-1',
       sandboxId: 'sandbox-1',
+      botIdentityApplyPending: true,
     });
 
     await instance.updateBotIdentity({ botName: 'Milo' });
@@ -8141,6 +8431,281 @@ describe('updateBotIdentity', () => {
         }),
       })
     );
+    expect(calls).toEqual(['put:true', 'fetch', 'put:false']);
+    expect(storage._store.get('botIdentityApplyPending')).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it('sets botIdentityApplyPending while status=starting and does not call the gateway', async () => {
+    const env = createFakeEnv();
+    env.FLY_APP_NAME = 'bot-app';
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { instance, storage } = createInstance(undefined, env);
+    await seedStarting(storage, { flyMachineId: 'machine-1', sandboxId: 'sandbox-1' });
+
+    await instance.updateBotIdentity({ botName: 'Milo' });
+
+    expect(storage._store.get('botName')).toBe('Milo');
+    expect(storage._store.get('botIdentityApplyPending')).toBe(true);
+    expect(
+      fetchMock.mock.calls.some(
+        (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/_kilo/bot-identity')
+      )
+    ).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it('sets botIdentityApplyPending when the gateway rejects the write on a running instance', async () => {
+    const env = createFakeEnv();
+    env.FLY_APP_NAME = 'bot-app';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'boom' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { instance, storage } = createInstance(undefined, env);
+    await seedRunning(storage, { flyMachineId: 'machine-1', sandboxId: 'sandbox-1' });
+
+    await instance.updateBotIdentity({ botName: 'Milo' });
+
+    expect(storage._store.get('botName')).toBe('Milo');
+    expect(storage._store.get('botIdentityApplyPending')).toBe(true);
+    expectStructuredWarn(warnSpy, 'updateBotIdentity: gateway write failed');
+    vi.unstubAllGlobals();
+  });
+});
+
+describe('channel config patch builder', () => {
+  const fakeEnvelope = {
+    encryptedData: 'data',
+    encryptedDEK: 'dek',
+    algorithm: 'rsa-aes-256-gcm' as const,
+    version: 1 as const,
+  };
+
+  it('builds telegram, discord, and slack config patches from stored channels', () => {
+    const patch = buildChannelConfigPatch(createFakeEnv(), {
+      telegramBotToken: { ...fakeEnvelope, encryptedData: 'telegram-token' },
+      discordBotToken: { ...fakeEnvelope, encryptedData: 'discord-token' },
+      slackBotToken: { ...fakeEnvelope, encryptedData: 'slack-bot-token' },
+      slackAppToken: { ...fakeEnvelope, encryptedData: 'slack-app-token' },
+    });
+
+    expect(patch).toEqual({
+      channels: {
+        telegram: {
+          botToken: 'telegram-token',
+          enabled: true,
+          dmPolicy: 'pairing',
+        },
+        discord: {
+          token: 'discord-token',
+          enabled: true,
+          dm: { policy: 'pairing' },
+        },
+        slack: {
+          botToken: 'slack-bot-token',
+          appToken: 'slack-app-token',
+          enabled: true,
+        },
+      },
+      plugins: {
+        entries: {
+          telegram: { enabled: true },
+          discord: { enabled: true },
+          slack: { enabled: true },
+        },
+      },
+    });
+  });
+
+  it('returns null for empty channels, missing private key, or partial slack state', () => {
+    const env = createFakeEnv();
+
+    expect(buildChannelConfigPatch(env, null)).toBeNull();
+    expect(
+      buildChannelConfigPatch(
+        { ...env, AGENT_ENV_VARS_PRIVATE_KEY: undefined },
+        {
+          telegramBotToken: fakeEnvelope,
+        }
+      )
+    ).toBeNull();
+    expect(buildChannelConfigPatch(env, { slackBotToken: fakeEnvelope })).toBeNull();
+  });
+});
+
+describe('flushPendingConfigToGateway: alarm retry for pending identity/exec/channels', () => {
+  it('flushes pending bot identity and exec preset when alarm ticks on a running instance', async () => {
+    const env = createFakeEnv();
+    env.FLY_APP_NAME = 'flush-app';
+    const fetchMock = vi.fn().mockImplementation((url: unknown) => {
+      if (typeof url === 'string' && url.includes('/_kilo/bot-identity')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ ok: true, path: 'workspace/IDENTITY.md' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        );
+      }
+      if (typeof url === 'string' && url.includes('/_kilo/config/patch')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { instance, storage } = createInstance(undefined, env);
+    await seedRunning(storage, {
+      flyMachineId: 'machine-1',
+      sandboxId: 'sandbox-1',
+      botName: 'Milo',
+      botNature: 'Ops copilot',
+      botIdentityApplyPending: true,
+      execSecurity: 'full',
+      execAsk: 'off',
+      execPresetApplyPending: true,
+    });
+
+    // getMachine lets the Fly reconcile path no-op; we only care about the
+    // pre-reconcile flush block.
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      state: 'started',
+      config: { mounts: [{ volume: 'vol-1', path: '/root' }] },
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    const botCall = fetchMock.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/_kilo/bot-identity')
+    );
+    expect(botCall).toBeDefined();
+    const [, botInit] = botCall as [unknown, RequestInit];
+    expect(JSON.parse(botInit.body as string)).toEqual({
+      botName: 'Milo',
+      botNature: 'Ops copilot',
+      botVibe: null,
+      botEmoji: null,
+    });
+    const patchCall = fetchMock.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/_kilo/config/patch')
+    );
+    expect(patchCall).toBeDefined();
+    const [, patchInit] = patchCall as [unknown, RequestInit];
+    expect(JSON.parse(patchInit.body as string)).toEqual({
+      tools: { exec: { security: 'full', ask: 'off' } },
+    });
+
+    expect(storage._store.get('botIdentityApplyPending')).toBe(false);
+    expect(storage._store.get('execPresetApplyPending')).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it('flushes pending channel config on alarm and clears the pending flag', async () => {
+    const env = createFakeEnv();
+    env.FLY_APP_NAME = 'flush-app';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { instance, storage } = createInstance(undefined, env);
+    await seedRunning(storage, {
+      flyMachineId: 'machine-1',
+      sandboxId: 'sandbox-1',
+      channels: {
+        telegramBotToken: {
+          encryptedData: 'telegram-token',
+          encryptedDEK: 'dek',
+          algorithm: 'rsa-aes-256-gcm',
+          version: 1,
+        },
+      },
+      encryptedSecrets: {
+        TELEGRAM_BOT_TOKEN: {
+          encryptedData: 'telegram-token',
+          encryptedDEK: 'dek',
+          algorithm: 'rsa-aes-256-gcm',
+          version: 1,
+        },
+      },
+      channelsApplyPending: true,
+    });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      state: 'started',
+      config: { mounts: [{ volume: 'vol-1', path: '/root' }] },
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    const patchCall = fetchMock.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('/_kilo/config/patch')
+    );
+    expect(patchCall).toBeDefined();
+    const [, init] = patchCall as [unknown, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      channels: {
+        telegram: {
+          botToken: 'telegram-token',
+          enabled: true,
+          dmPolicy: 'pairing',
+        },
+      },
+      plugins: { entries: { telegram: { enabled: true } } },
+    });
+    expect(storage._store.get('channelsApplyPending')).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps pending channel config set when alarm retry fails', async () => {
+    const env = createFakeEnv();
+    env.FLY_APP_NAME = 'flush-app';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'down' }), {
+        status: 503,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { instance, storage } = createInstance(undefined, env);
+    await seedRunning(storage, {
+      flyMachineId: 'machine-1',
+      sandboxId: 'sandbox-1',
+      channels: {
+        telegramBotToken: {
+          encryptedData: 'telegram-token',
+          encryptedDEK: 'dek',
+          algorithm: 'rsa-aes-256-gcm',
+          version: 1,
+        },
+      },
+      channelsApplyPending: true,
+    });
+
+    (flyClient.getMachine as Mock).mockResolvedValue({
+      state: 'started',
+      config: { mounts: [{ volume: 'vol-1', path: '/root' }] },
+    });
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.alarm();
+
+    expect(storage._store.get('channelsApplyPending')).toBe(true);
+    expectStructuredWarn(warnSpy, 'flushPendingConfigToGateway: channels failed');
     vi.unstubAllGlobals();
   });
 });

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/channel-config.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/channel-config.ts
@@ -1,0 +1,83 @@
+import type { KiloClawEnv } from '../../types';
+import type { PersistedState } from '../../schemas/instance-config';
+import { decryptChannelTokens } from '../../utils/encryption';
+
+export type ChannelConfigPatch = {
+  channels: {
+    telegram?: {
+      botToken: string;
+      enabled: true;
+      dmPolicy: string;
+    };
+    discord?: {
+      token: string;
+      enabled: true;
+      dm: {
+        policy: string;
+      };
+    };
+    slack?: {
+      botToken: string;
+      appToken: string;
+      enabled: true;
+    };
+  };
+  plugins: {
+    entries: {
+      telegram?: { enabled: true };
+      discord?: { enabled: true };
+      slack?: { enabled: true };
+    };
+  };
+};
+
+/**
+ * Builds the additive live channel patch sent to controller /_kilo/config/patch.
+ * Keep this in sync with controller/src/config-writer.ts channel semantics.
+ */
+export function buildChannelConfigPatch(
+  env: Pick<KiloClawEnv, 'AGENT_ENV_VARS_PRIVATE_KEY' | 'TELEGRAM_DM_POLICY' | 'DISCORD_DM_POLICY'>,
+  channels: PersistedState['channels']
+): ChannelConfigPatch | null {
+  if (!channels) return null;
+  if (!env.AGENT_ENV_VARS_PRIVATE_KEY) return null;
+
+  const channelEnv = decryptChannelTokens(channels, env.AGENT_ENV_VARS_PRIVATE_KEY);
+  const patch: ChannelConfigPatch = {
+    channels: {},
+    plugins: { entries: {} },
+  };
+
+  if (channelEnv.TELEGRAM_BOT_TOKEN) {
+    const dmPolicy = env.TELEGRAM_DM_POLICY || 'pairing';
+    patch.channels.telegram = {
+      botToken: channelEnv.TELEGRAM_BOT_TOKEN,
+      enabled: true,
+      dmPolicy,
+    };
+    patch.plugins.entries.telegram = { enabled: true };
+  }
+
+  if (channelEnv.DISCORD_BOT_TOKEN) {
+    const dmPolicy = env.DISCORD_DM_POLICY || 'pairing';
+    patch.channels.discord = {
+      token: channelEnv.DISCORD_BOT_TOKEN,
+      enabled: true,
+      dm: {
+        policy: dmPolicy,
+      },
+    };
+    patch.plugins.entries.discord = { enabled: true };
+  }
+
+  if (channelEnv.SLACK_BOT_TOKEN && channelEnv.SLACK_APP_TOKEN) {
+    patch.channels.slack = {
+      botToken: channelEnv.SLACK_BOT_TOKEN,
+      appToken: channelEnv.SLACK_APP_TOKEN,
+      enabled: true,
+    };
+    patch.plugins.entries.slack = { enabled: true };
+  }
+
+  return Object.keys(patch.channels).length > 0 ? patch : null;
+}

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/channel-config.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/channel-config.ts
@@ -1,6 +1,6 @@
 import type { KiloClawEnv } from '../../types';
 import type { PersistedState } from '../../schemas/instance-config';
-import { decryptChannelTokens } from '../../utils/encryption';
+import { decryptChannelTokens, EncryptionConfigurationError } from '../../utils/encryption';
 
 export type ChannelConfigPatch = {
   channels: {
@@ -40,7 +40,11 @@ export function buildChannelConfigPatch(
   channels: PersistedState['channels']
 ): ChannelConfigPatch | null {
   if (!channels) return null;
-  if (!env.AGENT_ENV_VARS_PRIVATE_KEY) return null;
+  if (!env.AGENT_ENV_VARS_PRIVATE_KEY) {
+    throw new EncryptionConfigurationError(
+      'AGENT_ENV_VARS_PRIVATE_KEY is required to build live channel config patch'
+    );
+  }
 
   const channelEnv = decryptChannelTokens(channels, env.AGENT_ENV_VARS_PRIVATE_KEY);
   const patch: ChannelConfigPatch = {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -73,6 +73,7 @@ import { nextAlarmTime, doLog, doError, doWarn, toLoggable, createReconcileConte
 import { attemptMetadataRecovery } from './reconcile';
 import { buildUserEnvVars, resolveImageTag, resolveRuntimeImageRef } from './config';
 import * as gateway from './gateway';
+import { buildChannelConfigPatch } from './channel-config';
 import * as pairing from './pairing';
 import * as kiloCliRun from './kilo-cli-run';
 import {
@@ -993,6 +994,87 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     });
   }
 
+  /**
+   * Flush DO-side config that was patched while the gateway wasn't reachable
+   * (status !== 'running') to the live gateway now.
+   *
+   * Called:
+   * - From _startInner after status transitions to 'running' (covers the
+   *   common onboarding path where a client patches during 'starting').
+   * - From the alarm retry block when flags stayed set because the inline
+   *   gateway call failed, or because the starting→running transition was
+   *   driven by reconcileStarting instead of _startInner.
+   *
+   * No-op when nothing is pending. On per-field failure the flag stays true
+   * so the next alarm retries.
+   */
+  private async flushPendingConfigToGateway(reason: string): Promise<void> {
+    if (this.s.status !== 'running' || !getRuntimeId(this.s)) return;
+
+    const pending: Partial<PersistedState> = {};
+
+    if (this.s.botIdentityApplyPending) {
+      try {
+        await gateway.writeBotIdentity(this.s, this.env, {
+          botName: this.s.botName,
+          botNature: this.s.botNature,
+          botVibe: this.s.botVibe,
+          botEmoji: this.s.botEmoji,
+        });
+        this.s.botIdentityApplyPending = false;
+        pending.botIdentityApplyPending = false;
+        doLog(this.s, 'flushPendingConfigToGateway: bot identity applied', { reason });
+      } catch (err) {
+        doWarn(this.s, 'flushPendingConfigToGateway: bot identity failed; will retry', {
+          reason,
+          error: toLoggable(err),
+        });
+      }
+    }
+
+    if (this.s.execPresetApplyPending) {
+      try {
+        await gateway.patchOpenclawConfig(this.s, this.env, {
+          tools: {
+            exec: {
+              security: this.s.execSecurity,
+              ask: this.s.execAsk,
+            },
+          },
+        });
+        this.s.execPresetApplyPending = false;
+        pending.execPresetApplyPending = false;
+        doLog(this.s, 'flushPendingConfigToGateway: exec preset applied', { reason });
+      } catch (err) {
+        doWarn(this.s, 'flushPendingConfigToGateway: exec preset failed; will retry', {
+          reason,
+          error: toLoggable(err),
+        });
+      }
+    }
+
+    if (this.s.channelsApplyPending) {
+      try {
+        const patch = buildChannelConfigPatch(this.env, this.s.channels);
+        if (patch) {
+          await gateway.patchOpenclawConfig(this.s, this.env, patch);
+        }
+        this.s.channelsApplyPending = false;
+        pending.channelsApplyPending = false;
+        doLog(this.s, 'flushPendingConfigToGateway: channels applied', { reason });
+      } catch (err) {
+        doWarn(this.s, 'flushPendingConfigToGateway: channels failed; will retry', {
+          reason,
+          error: toLoggable(err),
+        });
+      }
+    }
+
+    if (Object.keys(pending).length > 0) {
+      await this.ctx.storage.put(pending);
+    }
+  }
+
   async updateExecPreset(patch: {
     security?: string;
     ask?: string;
@@ -1010,8 +1092,34 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       pending.execAsk = patch.ask;
     }
 
-    if (Object.keys(pending).length > 0) {
-      await this.ctx.storage.put(pending);
+    if (Object.keys(pending).length === 0) {
+      return {
+        execSecurity: this.s.execSecurity,
+        execAsk: this.s.execAsk,
+      };
+    }
+
+    this.s.execPresetApplyPending = true;
+    pending.execPresetApplyPending = true;
+    await this.ctx.storage.put(storageUpdate(pending));
+
+    if (this.s.status === 'running') {
+      try {
+        await gateway.patchOpenclawConfig(this.s, this.env, {
+          tools: {
+            exec: {
+              security: this.s.execSecurity,
+              ask: this.s.execAsk,
+            },
+          },
+        });
+        this.s.execPresetApplyPending = false;
+        await this.ctx.storage.put(storageUpdate({ execPresetApplyPending: false }));
+      } catch (err) {
+        doWarn(this.s, 'updateExecPreset: gateway patch failed; deferring to alarm', {
+          error: toLoggable(err),
+        });
+      }
     }
 
     return {
@@ -1073,17 +1181,36 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       pending.botEmoji = patch.botEmoji;
     }
 
-    if (Object.keys(pending).length > 0) {
-      await this.ctx.storage.put(pending);
-    }
-
-    if (this.s.status === 'running' && Object.keys(pending).length > 0) {
-      await gateway.writeBotIdentity(this.s, this.env, {
+    if (Object.keys(pending).length === 0) {
+      return {
         botName: this.s.botName,
         botNature: this.s.botNature,
         botVibe: this.s.botVibe,
         botEmoji: this.s.botEmoji,
-      });
+      };
+    }
+
+    this.s.botIdentityApplyPending = true;
+    pending.botIdentityApplyPending = true;
+    await this.ctx.storage.put(storageUpdate(pending));
+
+    if (this.s.status === 'running') {
+      try {
+        await gateway.writeBotIdentity(this.s, this.env, {
+          botName: this.s.botName,
+          botNature: this.s.botNature,
+          botVibe: this.s.botVibe,
+          botEmoji: this.s.botEmoji,
+        });
+        this.s.botIdentityApplyPending = false;
+        await this.ctx.storage.put(storageUpdate({ botIdentityApplyPending: false }));
+      } catch (err) {
+        // Gateway reachable only after flyMachineId + controller up; on
+        // transient failure, keep the alarm retry path queued.
+        doWarn(this.s, 'updateBotIdentity: gateway write failed; deferring to alarm', {
+          error: toLoggable(err),
+        });
+      }
     }
 
     return {
@@ -1106,13 +1233,52 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     slackApp: boolean;
   }> {
     const secretsPatch: Record<string, EncryptedEnvelope | null> = {};
+    let includesRemoval = false;
+    let includesAddition = false;
     for (const [key, value] of Object.entries(patch)) {
       if (value !== undefined) {
         secretsPatch[key] = value;
+        if (value === null) {
+          includesRemoval = true;
+        } else {
+          includesAddition = true;
+        }
       }
     }
 
     const { configured } = await this.updateSecrets(secretsPatch);
+
+    const pending: Partial<PersistedState> = {};
+    if (Object.keys(secretsPatch).length > 0) {
+      if (includesAddition && this.s.status === 'running' && getRuntimeId(this.s)) {
+        try {
+          const configPatch = buildChannelConfigPatch(this.env, this.s.channels);
+          if (configPatch) {
+            await gateway.patchOpenclawConfig(this.s, this.env, configPatch);
+          }
+          this.s.channelsApplyPending = false;
+          pending.channelsApplyPending = false;
+        } catch (err) {
+          doWarn(this.s, 'updateChannels: gateway patch failed; deferring to alarm', {
+            error: toLoggable(err),
+          });
+          this.s.channelsApplyPending = true;
+          pending.channelsApplyPending = true;
+        }
+      } else if (includesAddition) {
+        this.s.channelsApplyPending = true;
+        pending.channelsApplyPending = true;
+      } else if (includesRemoval && (!this.s.channelsApplyPending || !this.s.channels)) {
+        // Removals are not live-applied, but do not erase a pending additive replay
+        // while other channel config remains queued for the gateway.
+        this.s.channelsApplyPending = false;
+        pending.channelsApplyPending = false;
+      }
+    }
+
+    if (Object.keys(pending).length > 0) {
+      await this.ctx.storage.put(pending);
+    }
 
     return {
       telegram: configured.includes('telegramBotToken'),
@@ -1764,6 +1930,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     });
 
     await this.syncGoogleWorkspaceConfig('instance_started');
+    await this.flushPendingConfigToGateway('instance_started');
 
     this.emitEvent({
       event: 'instance.started',
@@ -3119,6 +3286,19 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
     if (this.s.googleWorkspaceConfigSyncPending && this.s.status === 'running') {
       await this.syncGoogleWorkspaceConfig('alarm_retry');
+    }
+
+    // Flushes patches that landed in DO state while status was not 'running'
+    // (Window B of the onboarding timing analysis). Covers both the rare path
+    // where reconcileStarting — not _startInner — flipped status to 'running'
+    // in a prior alarm tick, and the case where an inline gateway call failed.
+    if (
+      (this.s.botIdentityApplyPending ||
+        this.s.execPresetApplyPending ||
+        this.s.channelsApplyPending) &&
+      this.s.status === 'running'
+    ) {
+      await this.flushPendingConfigToGateway('alarm_retry');
     }
 
     if (this.s.status !== 'recovering') {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
@@ -285,10 +285,13 @@ export async function loadState(ctx: DurableObjectState, s: InstanceMutableState
     s.gmailPushOidcEmail = d.gmailPushOidcEmail;
     s.execSecurity = d.execSecurity;
     s.execAsk = d.execAsk;
+    s.execPresetApplyPending = d.execPresetApplyPending;
     s.botName = d.botName;
     s.botNature = d.botNature;
     s.botVibe = d.botVibe;
     s.botEmoji = d.botEmoji;
+    s.botIdentityApplyPending = d.botIdentityApplyPending;
+    s.channelsApplyPending = d.channelsApplyPending;
     s.previousVolumeId = d.previousVolumeId;
     s.restoreStartedAt = d.restoreStartedAt;
     s.preRestoreStatus = d.preRestoreStatus;
@@ -383,10 +386,13 @@ export function resetMutableState(s: InstanceMutableState): void {
   s.gmailPushOidcEmail = null;
   s.execSecurity = null;
   s.execAsk = null;
+  s.execPresetApplyPending = false;
   s.botName = null;
   s.botNature = null;
   s.botVibe = null;
   s.botEmoji = null;
+  s.botIdentityApplyPending = false;
+  s.channelsApplyPending = false;
   s.previousVolumeId = null;
   s.restoreStartedAt = null;
   s.preRestoreStatus = null;
@@ -472,10 +478,13 @@ export function createMutableState(): InstanceMutableState {
     gmailPushOidcEmail: null,
     execSecurity: null,
     execAsk: null,
+    execPresetApplyPending: false,
     botName: null,
     botNature: null,
     botVibe: null,
     botEmoji: null,
+    botIdentityApplyPending: false,
+    channelsApplyPending: false,
     previousVolumeId: null,
     restoreStartedAt: null,
     preRestoreStatus: null,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
@@ -116,10 +116,13 @@ export type InstanceMutableState = {
   gmailPushOidcEmail: string | null;
   execSecurity: string | null;
   execAsk: string | null;
+  execPresetApplyPending: boolean;
   botName: string | null;
   botNature: string | null;
   botVibe: string | null;
   botEmoji: string | null;
+  botIdentityApplyPending: boolean;
+  channelsApplyPending: boolean;
   // Snapshot restore tracking
   previousVolumeId: string | null;
   restoreStartedAt: string | null;

--- a/services/kiloclaw/src/schemas/instance-config.ts
+++ b/services/kiloclaw/src/schemas/instance-config.ts
@@ -341,10 +341,20 @@ export const PersistedStateSchema = z.object({
   // null = use defaults (security: 'allowlist', ask: 'on-miss').
   execSecurity: z.string().nullable().default(null),
   execAsk: z.string().nullable().default(null),
+  // Set when updateExecPreset patched DO state but the gateway write was skipped
+  // or failed (e.g. status !== 'running'). Cleared when flushed on start or via
+  // alarm retry. See flushPendingConfigToGateway.
+  execPresetApplyPending: z.boolean().default(false),
   botName: z.string().nullable().default(null),
   botNature: z.string().nullable().default(null),
   botVibe: z.string().nullable().default(null),
   botEmoji: z.string().nullable().default(null),
+  // Set when updateBotIdentity patched DO state but the gateway write was
+  // skipped or failed. Cleared when flushed on start or via alarm retry.
+  botIdentityApplyPending: z.boolean().default(false),
+  // Set when additive channel updates were persisted but the running gateway
+  // config patch was skipped or failed. Removals intentionally do not set this.
+  channelsApplyPending: z.boolean().default(false),
   // Snapshot restore: tracks the volume before the most recent restore for admin revert path.
   previousVolumeId: z.string().nullable().default(null),
   // Snapshot restore: timestamp set at enqueue time. Used by alarm for stuck-restore detection


### PR DESCRIPTION
## Summary
- Persist onboarding bot identity, exec preset, and channel selections as soon as the KiloClaw instance row exists so provisioning-time customizations survive unmounts or tab closes.
- Add pending apply flags and alarm flushing in the KiloClaw Durable Object so config writes skipped before gateway readiness are replayed once the instance is running.
- Cover onboarding save planning, channel patch building, and pending gateway retry behavior with tests.
