### PR TITLE
fix(models): remove Seed 2.0 Pro from preferred list

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -35,7 +35,6 @@ export const preferredModels = [
   KILO_AUTO_FREE_MODEL.id,
   'inclusionai/ling-2.6-flash:free',
   'nvidia/nemotron-3-super-120b-a12b:free',
-  seed_20_pro_free_model.status === 'public' ? seed_20_pro_free_model.public_id : null,
   grok_code_fast_1_optimized_free_model.status === 'public'
     ? grok_code_fast_1_optimized_free_model.public_id
     : null,


### PR DESCRIPTION
## Summary
- Remove `bytedance-seed/dola-seed-2.0-pro:free` from `preferredModels` so it is no longer treated as a recommended model.
- Keep the model definition in `kiloExclusiveModels` unchanged so it remains available where explicitly selected.

## Verification
- Confirmed the preferred model list in `apps/web/src/lib/ai-gateway/models.ts` no longer includes Seed 2.0 Pro.

## Visual Changes
- N/A

## Reviewer Notes
- N/A