### PR TITLE
fix(kiloclaw): export legacy gog tokens with --out flag

### DIFF
--- a/scripts/changed-workspaces.sh
+++ b/scripts/changed-workspaces.sh
@@ -32,7 +32,7 @@ if [ -n "$base" ]; then
 fi
 
 # Read workspace dirs using pnpm (handles glob expansion in pnpm-workspace.yaml)
-workspace_dirs=$(pnpm ls --json -r --depth -1 2>/dev/null | node -e "
+workspace_dirs=$(pnpm ls --json -r --depth -1 | node -e "
   const pkgs = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
   for (const p of pkgs) {
     if (!p.path) continue;
@@ -59,8 +59,9 @@ for dir in $workspace_dirs; do
   has_test=$(node -e "const p=require('./$dir/package.json'); console.log(p.scripts?.test ? '1' : '')" 2>/dev/null)
   [ -n "$has_test" ] || continue
 
-  # Skip workspaces whose test script exists but has no test files
-  test_file_count=$(find "$dir" -type f \( -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.test.js' -o -name '*.test.jsx' -o -name '*.spec.ts' -o -name '*.spec.tsx' -o -name '*.spec.js' -o -name '*.spec.jsx' \) -not -path '*/node_modules/*' 2>/dev/null | head -1)
+  # Skip workspaces whose test script exists but has no test files.
+  # Use -print -quit to avoid SIGPIPE failures from find|head under pipefail.
+  test_file_count=$(find "$dir" -type f \( -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.test.js' -o -name '*.test.jsx' -o -name '*.spec.ts' -o -name '*.spec.tsx' -o -name '*.spec.js' -o -name '*.spec.jsx' \) -not -path '*/node_modules/*' -print -quit 2>/dev/null)
   [ -n "$test_file_count" ] || continue
 
   # Check for file changes (if we have a merge base)

--- a/services/kiloclaw/controller/src/legacy-google-migration.test.ts
+++ b/services/kiloclaw/controller/src/legacy-google-migration.test.ts
@@ -1,14 +1,17 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import type { SpawnSyncReturns } from 'node:child_process';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const { execFileSyncMock } = vi.hoisted(() => ({
+const { execFileSyncMock, spawnSyncMock } = vi.hoisted(() => ({
   execFileSyncMock: vi.fn(),
+  spawnSyncMock: vi.fn(),
 }));
 
 vi.mock('node:child_process', () => ({
   execFileSync: execFileSyncMock,
+  spawnSync: spawnSyncMock,
 }));
 
 import { migrateLegacyGoogleCredentialsToBroker } from './legacy-google-migration';
@@ -16,6 +19,8 @@ import { migrateLegacyGoogleCredentialsToBroker } from './legacy-google-migratio
 type ExecMockOptions = {
   credsPath: string;
   rejectOutFlag?: boolean;
+  rejectOverwriteFlag?: boolean;
+  failOutExport?: boolean;
 };
 
 const testTmpDirs: string[] = [];
@@ -34,8 +39,20 @@ function createCredentialsFile(): string {
   return credsPath;
 }
 
-function setupExecFileSyncMock(options: ExecMockOptions) {
-  return execFileSyncMock.mockImplementation((command, args) => {
+function spawnResult(overrides: Partial<SpawnSyncReturns<string>> = {}): SpawnSyncReturns<string> {
+  return {
+    pid: 1,
+    output: ['', '', ''],
+    stdout: '',
+    stderr: '',
+    status: 0,
+    signal: null,
+    ...overrides,
+  };
+}
+
+function setupChildProcessMocks(options: ExecMockOptions) {
+  execFileSyncMock.mockImplementation((command, args) => {
     if (command !== '/usr/local/bin/gog.real' || !args) {
       throw new Error(`unexpected command invocation: ${String(command)}`);
     }
@@ -48,39 +65,6 @@ function setupExecFileSyncMock(options: ExecMockOptions) {
       });
     }
 
-    if (argv[0] === 'auth' && argv[1] === 'tokens' && argv[2] === 'export') {
-      const hasOutFlag = argv.includes('--out');
-      if (hasOutFlag && options.rejectOutFlag) {
-        throw new Error('unknown flag --out');
-      }
-
-      let outPath = '';
-      if (hasOutFlag) {
-        const outFlagIndex = argv.indexOf('--out');
-        if (outFlagIndex >= 0) {
-          outPath = argv[outFlagIndex + 1] ?? '';
-        }
-      } else {
-        outPath = argv[4] ?? '';
-      }
-
-      if (!outPath) {
-        throw new Error('missing export output path');
-      }
-
-      fs.writeFileSync(
-        outPath,
-        JSON.stringify({
-          email: 'user@gmail.com',
-          client: 'default',
-          services: ['calendar'],
-          scopes: ['https://www.googleapis.com/auth/calendar.readonly'],
-          refresh_token: 'refresh-token',
-        })
-      );
-      return '';
-    }
-
     if (argv[0] === 'auth' && argv[1] === 'credentials' && argv[2] === 'list') {
       return JSON.stringify({
         clients: [{ client: 'default', path: options.credsPath }],
@@ -89,12 +73,68 @@ function setupExecFileSyncMock(options: ExecMockOptions) {
 
     throw new Error(`unexpected gog invocation: ${argv.join(' ')}`);
   });
+
+  return spawnSyncMock.mockImplementation((command, args) => {
+    if (command !== '/usr/local/bin/gog.real' || !args) {
+      throw new Error(`unexpected spawn invocation: ${String(command)}`);
+    }
+
+    const argv = [...args];
+    if (argv[0] !== 'auth' || argv[1] !== 'tokens' || argv[2] !== 'export') {
+      throw new Error(`unexpected spawn invocation: ${argv.join(' ')}`);
+    }
+
+    const hasOutFlag = argv.includes('--out');
+    const hasOverwriteFlag = argv.includes('--overwrite');
+
+    if (hasOutFlag && options.rejectOutFlag) {
+      return spawnResult({ status: 1, stderr: 'unknown flag: --out' });
+    }
+
+    if (hasOutFlag && options.failOutExport) {
+      return spawnResult({
+        status: 4,
+        stderr: 'Secret not found in keyring (refresh token missing). Run: gog auth add <email>',
+      });
+    }
+
+    if (!hasOutFlag && hasOverwriteFlag && options.rejectOverwriteFlag) {
+      return spawnResult({ status: 1, stderr: 'unknown flag: --overwrite' });
+    }
+
+    let outPath = '';
+    if (hasOutFlag) {
+      const outFlagIndex = argv.indexOf('--out');
+      if (outFlagIndex >= 0) {
+        outPath = argv[outFlagIndex + 1] ?? '';
+      }
+    } else {
+      outPath = argv[4] ?? '';
+    }
+
+    if (!outPath) {
+      return spawnResult({ status: 1, stderr: 'empty outPath' });
+    }
+
+    fs.writeFileSync(
+      outPath,
+      JSON.stringify({
+        email: 'user@gmail.com',
+        client: 'default',
+        services: ['calendar'],
+        scopes: ['https://www.googleapis.com/auth/calendar.readonly'],
+        refresh_token: 'refresh-token',
+      })
+    );
+    return spawnResult({ status: 0 });
+  });
 }
 
 describe('migrateLegacyGoogleCredentialsToBroker', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     execFileSyncMock.mockReset();
+    spawnSyncMock.mockReset();
     for (const dir of testTmpDirs.splice(0)) {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -102,7 +142,7 @@ describe('migrateLegacyGoogleCredentialsToBroker', () => {
 
   it('uses --out when exporting legacy tokens', async () => {
     const credsPath = createCredentialsFile();
-    const execSpy = setupExecFileSyncMock({ credsPath });
+    const spawnSpy = setupChildProcessMocks({ credsPath });
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
 
     const result = await migrateLegacyGoogleCredentialsToBroker({
@@ -118,7 +158,7 @@ describe('migrateLegacyGoogleCredentialsToBroker', () => {
       reason: 'migrated',
     });
 
-    const exportCalls = execSpy.mock.calls
+    const exportCalls = spawnSpy.mock.calls
       .map(([, args]) => (args ? [...args] : []))
       .filter(args => args[0] === 'auth' && args[1] === 'tokens' && args[2] === 'export');
 
@@ -129,7 +169,7 @@ describe('migrateLegacyGoogleCredentialsToBroker', () => {
 
   it('falls back to positional export args when --out is rejected', async () => {
     const credsPath = createCredentialsFile();
-    const execSpy = setupExecFileSyncMock({ credsPath, rejectOutFlag: true });
+    const spawnSpy = setupChildProcessMocks({ credsPath, rejectOutFlag: true });
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
 
     const result = await migrateLegacyGoogleCredentialsToBroker({
@@ -145,7 +185,7 @@ describe('migrateLegacyGoogleCredentialsToBroker', () => {
       reason: 'migrated',
     });
 
-    const exportCalls = execSpy.mock.calls
+    const exportCalls = spawnSpy.mock.calls
       .map(([, args]) => (args ? [...args] : []))
       .filter(args => args[0] === 'auth' && args[1] === 'tokens' && args[2] === 'export');
 
@@ -154,5 +194,63 @@ describe('migrateLegacyGoogleCredentialsToBroker', () => {
     expect(exportCalls[1]).not.toContain('--out');
     expect(exportCalls[1][4]).toContain('gog-legacy-');
     expect(exportCalls[1][4]).toMatch(/token\.json$/);
+  });
+
+  it('does not fallback to positional args for non-flag export failures', async () => {
+    const credsPath = createCredentialsFile();
+    const spawnSpy = setupChildProcessMocks({ credsPath, failOutExport: true });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
+
+    const result = await migrateLegacyGoogleCredentialsToBroker({
+      apiKey: 'api-key',
+      gatewayToken: 'gateway-token',
+      sandboxId: 'sandbox-id',
+      checkinUrl: 'https://example.com/api/controller/checkin',
+    });
+
+    expect(result).toEqual({
+      attempted: true,
+      migrated: false,
+      reason: 'token_export_failed',
+    });
+
+    const exportCalls = spawnSpy.mock.calls
+      .map(([, args]) => (args ? [...args] : []))
+      .filter(args => args[0] === 'auth' && args[1] === 'tokens' && args[2] === 'export');
+
+    expect(exportCalls).toHaveLength(1);
+    expect(exportCalls[0]).toContain('--out');
+  });
+
+  it('falls back to --force when positional --overwrite is unsupported', async () => {
+    const credsPath = createCredentialsFile();
+    const spawnSpy = setupChildProcessMocks({
+      credsPath,
+      rejectOutFlag: true,
+      rejectOverwriteFlag: true,
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
+
+    const result = await migrateLegacyGoogleCredentialsToBroker({
+      apiKey: 'api-key',
+      gatewayToken: 'gateway-token',
+      sandboxId: 'sandbox-id',
+      checkinUrl: 'https://example.com/api/controller/checkin',
+    });
+
+    expect(result).toEqual({
+      attempted: true,
+      migrated: true,
+      reason: 'migrated',
+    });
+
+    const exportCalls = spawnSpy.mock.calls
+      .map(([, args]) => (args ? [...args] : []))
+      .filter(args => args[0] === 'auth' && args[1] === 'tokens' && args[2] === 'export');
+
+    expect(exportCalls).toHaveLength(3);
+    expect(exportCalls[0]).toContain('--out');
+    expect(exportCalls[1]).toContain('--overwrite');
+    expect(exportCalls[2]).toContain('--force');
   });
 });

--- a/services/kiloclaw/controller/src/legacy-google-migration.test.ts
+++ b/services/kiloclaw/controller/src/legacy-google-migration.test.ts
@@ -1,0 +1,158 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { execFileSyncMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFileSync: execFileSyncMock,
+}));
+
+import { migrateLegacyGoogleCredentialsToBroker } from './legacy-google-migration';
+
+type ExecMockOptions = {
+  credsPath: string;
+  rejectOutFlag?: boolean;
+};
+
+const testTmpDirs: string[] = [];
+
+function createCredentialsFile(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'legacy-google-migration-test-'));
+  testTmpDirs.push(dir);
+  const credsPath = path.join(dir, 'credentials.json');
+  fs.writeFileSync(
+    credsPath,
+    JSON.stringify({
+      client_id: 'client-id',
+      client_secret: 'client-secret',
+    })
+  );
+  return credsPath;
+}
+
+function setupExecFileSyncMock(options: ExecMockOptions) {
+  return execFileSyncMock.mockImplementation((command, args) => {
+    if (command !== '/usr/local/bin/gog.real' || !args) {
+      throw new Error(`unexpected command invocation: ${String(command)}`);
+    }
+
+    const argv = [...args];
+
+    if (argv[0] === 'auth' && argv[1] === 'list') {
+      return JSON.stringify({
+        accounts: [{ email: 'user@gmail.com' }],
+      });
+    }
+
+    if (argv[0] === 'auth' && argv[1] === 'tokens' && argv[2] === 'export') {
+      const hasOutFlag = argv.includes('--out');
+      if (hasOutFlag && options.rejectOutFlag) {
+        throw new Error('unknown flag --out');
+      }
+
+      let outPath = '';
+      if (hasOutFlag) {
+        const outFlagIndex = argv.indexOf('--out');
+        if (outFlagIndex >= 0) {
+          outPath = argv[outFlagIndex + 1] ?? '';
+        }
+      } else {
+        outPath = argv[4] ?? '';
+      }
+
+      if (!outPath) {
+        throw new Error('missing export output path');
+      }
+
+      fs.writeFileSync(
+        outPath,
+        JSON.stringify({
+          email: 'user@gmail.com',
+          client: 'default',
+          services: ['calendar'],
+          scopes: ['https://www.googleapis.com/auth/calendar.readonly'],
+          refresh_token: 'refresh-token',
+        })
+      );
+      return '';
+    }
+
+    if (argv[0] === 'auth' && argv[1] === 'credentials' && argv[2] === 'list') {
+      return JSON.stringify({
+        clients: [{ client: 'default', path: options.credsPath }],
+      });
+    }
+
+    throw new Error(`unexpected gog invocation: ${argv.join(' ')}`);
+  });
+}
+
+describe('migrateLegacyGoogleCredentialsToBroker', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    execFileSyncMock.mockReset();
+    for (const dir of testTmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses --out when exporting legacy tokens', async () => {
+    const credsPath = createCredentialsFile();
+    const execSpy = setupExecFileSyncMock({ credsPath });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
+
+    const result = await migrateLegacyGoogleCredentialsToBroker({
+      apiKey: 'api-key',
+      gatewayToken: 'gateway-token',
+      sandboxId: 'sandbox-id',
+      checkinUrl: 'https://example.com/api/controller/checkin',
+    });
+
+    expect(result).toEqual({
+      attempted: true,
+      migrated: true,
+      reason: 'migrated',
+    });
+
+    const exportCalls = execSpy.mock.calls
+      .map(([, args]) => (args ? [...args] : []))
+      .filter(args => args[0] === 'auth' && args[1] === 'tokens' && args[2] === 'export');
+
+    expect(exportCalls).toHaveLength(1);
+    expect(exportCalls[0]).toContain('--out');
+    expect(exportCalls[0][4]).toBe('--out');
+  });
+
+  it('falls back to positional export args when --out is rejected', async () => {
+    const credsPath = createCredentialsFile();
+    const execSpy = setupExecFileSyncMock({ credsPath, rejectOutFlag: true });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
+
+    const result = await migrateLegacyGoogleCredentialsToBroker({
+      apiKey: 'api-key',
+      gatewayToken: 'gateway-token',
+      sandboxId: 'sandbox-id',
+      checkinUrl: 'https://example.com/api/controller/checkin',
+    });
+
+    expect(result).toEqual({
+      attempted: true,
+      migrated: true,
+      reason: 'migrated',
+    });
+
+    const exportCalls = execSpy.mock.calls
+      .map(([, args]) => (args ? [...args] : []))
+      .filter(args => args[0] === 'auth' && args[1] === 'tokens' && args[2] === 'export');
+
+    expect(exportCalls).toHaveLength(2);
+    expect(exportCalls[0]).toContain('--out');
+    expect(exportCalls[1]).not.toContain('--out');
+    expect(exportCalls[1][4]).toContain('gog-legacy-');
+    expect(exportCalls[1][4]).toMatch(/token\.json$/);
+  });
+});

--- a/services/kiloclaw/controller/src/legacy-google-migration.ts
+++ b/services/kiloclaw/controller/src/legacy-google-migration.ts
@@ -66,6 +66,36 @@ function runGogJson(args: string[], env: NodeJS.ProcessEnv): Record<string, unkn
   return JSON.parse(output) as Record<string, unknown>;
 }
 
+function exportTokenToFile(email: string, outPath: string, env: NodeJS.ProcessEnv): boolean {
+  try {
+    execFileSync(
+      '/usr/local/bin/gog.real',
+      ['auth', 'tokens', 'export', email, '--out', outPath, '--overwrite'],
+      {
+        env,
+        encoding: 'utf8',
+      }
+    );
+    return true;
+  } catch {
+    // Backward-compatible fallback for older gog.real versions that still accept
+    // positional output-path arguments.
+    try {
+      execFileSync(
+        '/usr/local/bin/gog.real',
+        ['auth', 'tokens', 'export', email, outPath, '--overwrite'],
+        {
+          env,
+          encoding: 'utf8',
+        }
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
 function mapServicesToCapabilities(services: readonly string[]): string[] {
   const capabilities = new Set<string>();
   for (const service of services) {
@@ -159,23 +189,15 @@ export async function migrateLegacyGoogleCredentialsToBroker(
   const tmpPath = path.join(tmpDir, 'token.json');
 
   try {
-    try {
-      execFileSync(
-        '/usr/local/bin/gog.real',
-        ['auth', 'tokens', 'export', email, tmpPath, '--overwrite'],
-        {
-          env: gogEnv,
-          encoding: 'utf8',
-        }
-      );
-
-      try {
-        fs.chmodSync(tmpPath, 0o600);
-      } catch {
-        // best effort: continue migration even if chmod is unsupported
-      }
-    } catch {
+    const exported = exportTokenToFile(email, tmpPath, gogEnv);
+    if (!exported) {
       return { attempted: true, migrated: false, reason: 'token_export_failed' };
+    }
+
+    try {
+      fs.chmodSync(tmpPath, 0o600);
+    } catch {
+      // best effort: continue migration even if chmod is unsupported
     }
 
     const exportPayload = JSON.parse(fs.readFileSync(tmpPath, 'utf8')) as GogTokenExportJson;

--- a/services/kiloclaw/controller/src/legacy-google-migration.ts
+++ b/services/kiloclaw/controller/src/legacy-google-migration.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync, type SpawnSyncReturns } from 'node:child_process';
 
 type GogAuthListJson = {
   accounts?: Array<{
@@ -66,34 +66,66 @@ function runGogJson(args: string[], env: NodeJS.ProcessEnv): Record<string, unkn
   return JSON.parse(output) as Record<string, unknown>;
 }
 
-function exportTokenToFile(email: string, outPath: string, env: NodeJS.ProcessEnv): boolean {
+function combinedCommandOutput(result: SpawnSyncReturns<string>): string {
+  return [result.stdout, result.stderr, result.error?.message]
+    .filter((part): part is string => typeof part === 'string' && part.trim().length > 0)
+    .join('\n');
+}
+
+function runGogExport(args: string[], env: NodeJS.ProcessEnv): string {
+  const result = spawnSync('/usr/local/bin/gog.real', args, {
+    env,
+    encoding: 'utf8',
+  });
+
+  return combinedCommandOutput(result);
+}
+
+function hasFile(pathToCheck: string): boolean {
   try {
-    execFileSync(
-      '/usr/local/bin/gog.real',
-      ['auth', 'tokens', 'export', email, '--out', outPath, '--overwrite'],
-      {
-        env,
-        encoding: 'utf8',
-      }
-    );
-    return true;
+    return fs.statSync(pathToCheck).isFile();
   } catch {
-    // Backward-compatible fallback for older gog.real versions that still accept
-    // positional output-path arguments.
-    try {
-      execFileSync(
-        '/usr/local/bin/gog.real',
-        ['auth', 'tokens', 'export', email, outPath, '--overwrite'],
-        {
-          env,
-          encoding: 'utf8',
-        }
-      );
-      return true;
-    } catch {
-      return false;
-    }
+    return false;
   }
+}
+
+function isUnsupportedFlag(output: string, flagName: '--out' | '--overwrite'): boolean {
+  const normalized = output.toLowerCase();
+  if (!normalized.includes(flagName)) return false;
+
+  return (
+    normalized.includes('unknown flag') ||
+    normalized.includes('unknown option') ||
+    normalized.includes('unrecognized option') ||
+    normalized.includes('flag provided but not defined')
+  );
+}
+
+function exportTokenToFile(email: string, outPath: string, env: NodeJS.ProcessEnv): boolean {
+  const firstAttemptOutput = runGogExport(
+    ['auth', 'tokens', 'export', email, '--out', outPath, '--overwrite'],
+    env
+  );
+  if (hasFile(outPath)) {
+    return true;
+  }
+
+  if (!isUnsupportedFlag(firstAttemptOutput, '--out')) return false;
+
+  // Backward-compatible fallback for older gog.real versions that still accept
+  // positional output-path arguments.
+  const secondAttemptOutput = runGogExport(
+    ['auth', 'tokens', 'export', email, outPath, '--overwrite'],
+    env
+  );
+  if (hasFile(outPath)) {
+    return true;
+  }
+
+  if (!isUnsupportedFlag(secondAttemptOutput, '--overwrite')) return false;
+
+  runGogExport(['auth', 'tokens', 'export', email, outPath, '--force'], env);
+  return hasFile(outPath);
 }
 
 function mapServicesToCapabilities(services: readonly string[]): string[] {


### PR DESCRIPTION
## Summary

- Fixes legacy Google migration token export for newer `gog.real` CLIs.
- Updates migration to call `gog.real auth tokens export <email> --out <path> --overwrite` instead of passing the output path positionally.
- Adds a backward-compatible fallback that retries positional output-path export if `--out` is rejected.
- Adds targeted unit coverage for both the `--out` path and fallback path.
- Expected outcome: instances that previously emitted `token_export_failed` due to CLI argument mismatch can migrate on next startup/restart.

## Verification

- On affected instances, reproduced that positional export fails with `unexpected argument <tmpfile>`.
- On affected instances, confirmed `--out` export succeeds and returns a payload with `refresh_token`.
- Confirmed migration runs during startup, so restarting upgraded instances re-attempts migration using the fixed export path.

## Visual Changes

N/A

## Reviewer Notes

- No schema/database/API surface changes.
- Failure behavior remains unchanged if both export forms fail (`token_export_failed`).
- Fallback is intentionally narrow to support mixed `gog.real` versions.
