### PR TITLE
fix(web): align Exa default UI with Brave configuration

### DIFF
--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -1084,10 +1084,6 @@ export function SettingsTab({
   const exaSearchDisplayMode =
     kiloExaSearchMode ?? (activeWebSearchProvider === 'kilo-exa' ? 'kilo-proxy' : 'disabled');
   const braveSearchEnabled = braveSearchConfigured && activeWebSearchProvider === 'brave';
-  const hasCustomActiveSearchProvider =
-    activeWebSearchProvider !== null &&
-    activeWebSearchProvider !== 'brave' &&
-    activeWebSearchProvider !== 'kilo-exa';
   const toolEntries = getEntriesByCategory('tool');
   const googleCalendarConnectHref = useMemo(() => {
     const params = new URLSearchParams({ capabilities: 'calendar_read' });
@@ -1385,17 +1381,6 @@ export function SettingsTab({
         <div>
           <h2 className="text-foreground mb-3 text-base font-semibold">Search</h2>
           <div className="space-y-3">
-            {hasCustomActiveSearchProvider && (
-              <div className="text-muted-foreground rounded-md border px-3 py-2 text-xs">
-                Active provider: <code>{activeWebSearchProvider}</code>. This provider is managed
-                directly in OpenClaw config.
-              </div>
-            )}
-            {activeWebSearchProvider === null && (
-              <div className="text-muted-foreground rounded-md border px-3 py-2 text-xs">
-                Active provider unavailable. Start the instance to read live OpenClaw config.
-              </div>
-            )}
             {toolEntries
               .filter(e => e.id === 'brave-search')
               .map(entry => (

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -1079,10 +1079,11 @@ export function SettingsTab({
   const configuredSecrets = config?.configuredSecrets ?? {};
   const kiloExaSearchMode = config?.kiloExaSearchMode ?? null;
   const braveSearchConfigured = configuredSecrets['brave-search'] ?? false;
+  const exaDefaultSelected =
+    supportsExaSearchUi && kiloExaSearchMode === null && !braveSearchConfigured;
   const exaSearchConfigured =
-    supportsExaSearchUi && (kiloExaSearchMode === 'kilo-proxy' || kiloExaSearchMode === null);
-  const exaSearchDisplayMode =
-    supportsExaSearchUi && kiloExaSearchMode === null ? 'kilo-proxy' : kiloExaSearchMode;
+    supportsExaSearchUi && (kiloExaSearchMode === 'kilo-proxy' || exaDefaultSelected);
+  const exaSearchDisplayMode = exaDefaultSelected ? 'kilo-proxy' : kiloExaSearchMode;
   const braveSearchEnabled = braveSearchConfigured && !exaSearchConfigured;
   const toolEntries = getEntriesByCategory('tool');
   const googleCalendarConnectHref = useMemo(() => {

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -1079,12 +1079,15 @@ export function SettingsTab({
   const configuredSecrets = config?.configuredSecrets ?? {};
   const kiloExaSearchMode = config?.kiloExaSearchMode ?? null;
   const braveSearchConfigured = configuredSecrets['brave-search'] ?? false;
-  const exaDefaultSelected =
-    supportsExaSearchUi && kiloExaSearchMode === null && !braveSearchConfigured;
-  const exaSearchConfigured =
-    supportsExaSearchUi && (kiloExaSearchMode === 'kilo-proxy' || exaDefaultSelected);
-  const exaSearchDisplayMode = exaDefaultSelected ? 'kilo-proxy' : kiloExaSearchMode;
-  const braveSearchEnabled = braveSearchConfigured && !exaSearchConfigured;
+  const activeWebSearchProvider = config?.activeWebSearchProvider ?? null;
+  const exaSearchConfigured = supportsExaSearchUi && activeWebSearchProvider === 'kilo-exa';
+  const exaSearchDisplayMode =
+    kiloExaSearchMode ?? (activeWebSearchProvider === 'kilo-exa' ? 'kilo-proxy' : 'disabled');
+  const braveSearchEnabled = braveSearchConfigured && activeWebSearchProvider === 'brave';
+  const hasCustomActiveSearchProvider =
+    activeWebSearchProvider !== null &&
+    activeWebSearchProvider !== 'brave' &&
+    activeWebSearchProvider !== 'kilo-exa';
   const toolEntries = getEntriesByCategory('tool');
   const googleCalendarConnectHref = useMemo(() => {
     const params = new URLSearchParams({ capabilities: 'calendar_read' });
@@ -1382,6 +1385,17 @@ export function SettingsTab({
         <div>
           <h2 className="text-foreground mb-3 text-base font-semibold">Search</h2>
           <div className="space-y-3">
+            {hasCustomActiveSearchProvider && (
+              <div className="text-muted-foreground rounded-md border px-3 py-2 text-xs">
+                Active provider: <code>{activeWebSearchProvider}</code>. This provider is managed
+                directly in OpenClaw config.
+              </div>
+            )}
+            {activeWebSearchProvider === null && (
+              <div className="text-muted-foreground rounded-md border px-3 py-2 text-xs">
+                Active provider unavailable. Start the instance to read live OpenClaw config.
+              </div>
+            )}
             {toolEntries
               .filter(e => e.id === 'brave-search')
               .map(entry => (

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -302,6 +302,8 @@ export type UserConfigResponse = {
   configuredSecrets: Record<string, boolean>;
   /** Search mode selected for Kilo-integrated Exa. */
   kiloExaSearchMode: 'kilo-proxy' | 'disabled' | null;
+  /** Active web search provider from live OpenClaw config, if available. */
+  activeWebSearchProvider: string | null;
   /** Env var names of user-defined custom (non-catalog) secrets. */
   customSecretKeys: string[];
   /** Metadata for custom secrets (config paths, etc.). */

--- a/services/kiloclaw/src/routes/kiloclaw.test.ts
+++ b/services/kiloclaw/src/routes/kiloclaw.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildConfiguredSecrets } from './kiloclaw';
+import { buildConfiguredSecrets, deriveActiveWebSearchProvider } from './kiloclaw';
 
 describe('buildConfiguredSecrets', () => {
   const envelope = {
@@ -126,5 +126,67 @@ describe('buildConfiguredSecrets', () => {
       },
     });
     expect(result.telegram).toBe(false);
+  });
+});
+
+describe('deriveActiveWebSearchProvider', () => {
+  it('returns the provider from live openclaw config', () => {
+    const provider = deriveActiveWebSearchProvider({
+      tools: {
+        web: {
+          search: {
+            provider: 'custom-provider',
+          },
+        },
+      },
+    });
+
+    expect(provider).toBe('custom-provider');
+  });
+
+  it('trims provider values and returns null for blank providers', () => {
+    const trimmed = deriveActiveWebSearchProvider({
+      tools: {
+        web: {
+          search: {
+            provider: '  brave  ',
+          },
+        },
+      },
+    });
+    const blank = deriveActiveWebSearchProvider({
+      tools: {
+        web: {
+          search: {
+            provider: '   ',
+          },
+        },
+      },
+    });
+
+    expect(trimmed).toBe('brave');
+    expect(blank).toBeNull();
+  });
+
+  it('returns null when config shape is missing', () => {
+    expect(deriveActiveWebSearchProvider(null)).toBeNull();
+    expect(deriveActiveWebSearchProvider({})).toBeNull();
+    expect(deriveActiveWebSearchProvider({ tools: {} })).toBeNull();
+    expect(deriveActiveWebSearchProvider({ tools: { web: {} } })).toBeNull();
+    expect(deriveActiveWebSearchProvider({ tools: { web: { search: {} } } })).toBeNull();
+  });
+
+  it('returns null when provider is non-string', () => {
+    const provider = deriveActiveWebSearchProvider({
+      tools: {
+        web: {
+          search: {
+            provider: 123,
+          },
+        },
+      },
+    });
+
+    expect(provider).toBeNull();
   });
 });

--- a/services/kiloclaw/src/routes/kiloclaw.ts
+++ b/services/kiloclaw/src/routes/kiloclaw.ts
@@ -46,6 +46,10 @@ kiloclaw.get('/config', c =>
     }
 
     const config = await stub.getConfig();
+    const activeWebSearchProvider = await stub
+      .getOpenclawConfig()
+      .then(openclawConfig => deriveActiveWebSearchProvider(extractOpenclawConfig(openclawConfig)))
+      .catch(() => null);
 
     return c.json({
       envVarKeys: config.envVars ? Object.keys(config.envVars) : [],
@@ -57,6 +61,7 @@ kiloclaw.get('/config', c =>
       kilocodeApiKeyExpiresAt: config.kilocodeApiKeyExpiresAt ?? null,
       configuredSecrets: buildConfiguredSecrets(config),
       kiloExaSearchMode: config.webSearch?.exaMode ?? null,
+      activeWebSearchProvider,
       customSecretKeys: config.encryptedSecrets
         ? Object.keys(config.encryptedSecrets).filter(isCustomSecretEnvVar)
         : [],
@@ -67,6 +72,28 @@ kiloclaw.get('/config', c =>
     });
   })
 );
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function extractOpenclawConfig(value: unknown): unknown {
+  if (!isRecord(value)) return null;
+  return value.config;
+}
+
+function deriveActiveWebSearchProvider(openclawConfig: unknown): string | null {
+  if (!isRecord(openclawConfig)) return null;
+  if (!isRecord(openclawConfig.tools)) return null;
+  if (!isRecord(openclawConfig.tools.web)) return null;
+  if (!isRecord(openclawConfig.tools.web.search)) return null;
+
+  const provider = openclawConfig.tools.web.search.provider;
+  if (typeof provider !== 'string') return null;
+
+  const trimmedProvider = provider.trim();
+  return trimmedProvider.length > 0 ? trimmedProvider : null;
+}
 
 // GET /api/kiloclaw/status -- user's instance status from the DO
 kiloclaw.get('/status', c =>
@@ -145,4 +172,4 @@ function buildConfiguredSecrets(config: {
   return result;
 }
 
-export { kiloclaw, buildConfiguredSecrets };
+export { kiloclaw, buildConfiguredSecrets, deriveActiveWebSearchProvider };


### PR DESCRIPTION
## Summary

Aligns the settings UI’s Exa/Brave state inference with controller behavior for unset Exa mode.

When `kiloExaSearchMode` is `null`, the UI now treats Exa as the default only if Brave is not configured. This prevents the settings page from presenting Exa as active for users with valid Brave configuration and unset Exa mode.

## Verification

- [ ] No manual verification performed.

## Visual Changes

N/A

## Reviewer Notes

This is a UI-only follow-up on top of the controller branch.
It adjusts derived state used by badges/toggles in Settings and does not change backend behavior.
