### PR TITLE
fix(kiloclaw): preserve Brave config when provider is unset

### DIFF
--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -169,7 +169,7 @@ describe('generateBaseConfig', () => {
     expect(config.plugins.entries['kiloclaw-customizer'].config.webSearch.enabled).toBe(true);
   });
 
-  it('does not auto-assign kilo-exa when provider is missing and Brave is configured', () => {
+  it('prefers brave when provider is missing and Brave is configured', () => {
     const existing = JSON.stringify({ tools: { web: { search: {} } } });
     const { deps } = fakeDeps(existing);
     const env = {
@@ -178,8 +178,9 @@ describe('generateBaseConfig', () => {
     };
     const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
 
-    expect(config.tools.web.search.provider).toBeUndefined();
-    expect(config.plugins.entries['kiloclaw-customizer'].config.webSearch.enabled).toBeUndefined();
+    expect(config.tools.web.search.provider).toBe('brave');
+    expect(config.tools.web.search.enabled).toBe(true);
+    expect(config.plugins.entries['kiloclaw-customizer'].config.webSearch.enabled).toBe(false);
   });
 
   it('auto-assigns kilo-exa even when web search was explicitly disabled but provider is missing', () => {
@@ -1388,7 +1389,7 @@ describe('writeBaseConfig', () => {
     expect(config.tools?.web?.search?.enabled).toBe(true);
   });
 
-  it('does not auto-assign Exa on restore path when Brave is configured', () => {
+  it('prefers Brave on restore path when provider is missing and Brave is configured', () => {
     const { deps, written } = fakeDeps();
     const env: Record<string, string | undefined> = {
       ...minimalEnv(),
@@ -1399,7 +1400,8 @@ describe('writeBaseConfig', () => {
     writeBaseConfig(env, '/tmp/openclaw.json', deps);
 
     const config = JSON.parse(written[0].data);
-    expect(config.tools?.web?.search?.provider).toBeUndefined();
+    expect(config.tools?.web?.search?.provider).toBe('brave');
+    expect(config.plugins.entries['kiloclaw-customizer'].config.webSearch.enabled).toBe(false);
   });
 
   it('throws if KILOCODE_API_KEY is missing', () => {

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -218,6 +218,27 @@ describe('generateBaseConfig', () => {
     expect(config.plugins.entries['kiloclaw-customizer'].config.webSearch.enabled).toBe(true);
   });
 
+  it('preserves explicit custom provider when mode is unset and Brave is configured', () => {
+    const existing = JSON.stringify({
+      tools: {
+        web: {
+          search: {
+            provider: 'custom-provider',
+          },
+        },
+      },
+    });
+    const { deps } = fakeDeps(existing);
+    const env = {
+      ...minimalEnv(),
+      BRAVE_API_KEY: 'BSA' + 'A'.repeat(20),
+    };
+    const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
+
+    expect(config.tools.web.search.provider).toBe('custom-provider');
+    expect(config.plugins.entries['kiloclaw-customizer'].config.webSearch.enabled).toBe(false);
+  });
+
   it('selects kilo-exa provider when KILO_EXA_SEARCH_MODE=kilo-proxy', () => {
     const { deps } = fakeDeps();
     const env = { ...minimalEnv(), KILO_EXA_SEARCH_MODE: 'kilo-proxy' };

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -169,6 +169,19 @@ describe('generateBaseConfig', () => {
     expect(config.plugins.entries['kiloclaw-customizer'].config.webSearch.enabled).toBe(true);
   });
 
+  it('does not auto-assign kilo-exa when provider is missing and Brave is configured', () => {
+    const existing = JSON.stringify({ tools: { web: { search: {} } } });
+    const { deps } = fakeDeps(existing);
+    const env = {
+      ...minimalEnv(),
+      BRAVE_API_KEY: 'BSA' + 'A'.repeat(20),
+    };
+    const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
+
+    expect(config.tools.web.search.provider).toBeUndefined();
+    expect(config.plugins.entries['kiloclaw-customizer'].config.webSearch.enabled).toBeUndefined();
+  });
+
   it('auto-assigns kilo-exa even when web search was explicitly disabled but provider is missing', () => {
     const existing = JSON.stringify({
       tools: {
@@ -1373,6 +1386,20 @@ describe('writeBaseConfig', () => {
     const config = JSON.parse(written[0].data);
     expect(config.tools?.web?.search?.provider).toBe('kilo-exa');
     expect(config.tools?.web?.search?.enabled).toBe(true);
+  });
+
+  it('does not auto-assign Exa on restore path when Brave is configured', () => {
+    const { deps, written } = fakeDeps();
+    const env: Record<string, string | undefined> = {
+      ...minimalEnv(),
+      BRAVE_API_KEY: 'BSA' + 'A'.repeat(20),
+    };
+    delete env.KILOCLAW_FRESH_INSTALL;
+
+    writeBaseConfig(env, '/tmp/openclaw.json', deps);
+
+    const config = JSON.parse(written[0].data);
+    expect(config.tools?.web?.search?.provider).toBeUndefined();
   });
 
   it('throws if KILOCODE_API_KEY is missing', () => {

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -347,6 +347,8 @@ export function generateBaseConfig(
 
   const kiloExaSearchMode = resolveKiloExaSearchMode(env.KILO_EXA_SEARCH_MODE);
   const shouldForceExa = kiloExaSearchMode === 'kilo-proxy';
+  const shouldPreferBrave =
+    kiloExaSearchMode === 'unset' && !hasExplicitSearchProvider && braveConfigured;
   const shouldAutoAssignExa =
     kiloExaSearchMode === 'unset' && !hasExplicitSearchProvider && !braveConfigured;
   if (shouldForceExa || shouldAutoAssignExa) {
@@ -359,6 +361,13 @@ export function generateBaseConfig(
     if (shouldAutoAssignExa) {
       console.log('[config-writer] Auto-assigned web search provider to kilo-exa (mode=unset)');
     }
+  } else if (shouldPreferBrave) {
+    customizerWebSearchConfig.enabled = false;
+    config.tools = config.tools ?? {};
+    config.tools.web = config.tools.web ?? {};
+    config.tools.web.search = config.tools.web.search ?? {};
+    config.tools.web.search.enabled = true;
+    config.tools.web.search.provider = 'brave';
   } else if (kiloExaSearchMode === 'disabled') {
     customizerWebSearchConfig.enabled = false;
 

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -346,6 +346,8 @@ export function generateBaseConfig(
   const braveConfigured = Boolean(env.BRAVE_API_KEY?.trim());
 
   const kiloExaSearchMode = resolveKiloExaSearchMode(env.KILO_EXA_SEARCH_MODE);
+  // Only assign dashboard-managed defaults when provider is unset.
+  // Preserve any explicit provider value, including user-defined custom providers.
   const shouldForceExa = kiloExaSearchMode === 'kilo-proxy';
   const shouldPreferBrave =
     kiloExaSearchMode === 'unset' && !hasExplicitSearchProvider && braveConfigured;

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -343,10 +343,12 @@ export function generateBaseConfig(
   const searchProvider = config.tools?.web?.search?.provider;
   const hasExplicitSearchProvider =
     typeof searchProvider === 'string' && searchProvider.trim().length > 0;
+  const braveConfigured = Boolean(env.BRAVE_API_KEY?.trim());
 
   const kiloExaSearchMode = resolveKiloExaSearchMode(env.KILO_EXA_SEARCH_MODE);
   const shouldForceExa = kiloExaSearchMode === 'kilo-proxy';
-  const shouldAutoAssignExa = kiloExaSearchMode === 'unset' && !hasExplicitSearchProvider;
+  const shouldAutoAssignExa =
+    kiloExaSearchMode === 'unset' && !hasExplicitSearchProvider && !braveConfigured;
   if (shouldForceExa || shouldAutoAssignExa) {
     customizerWebSearchConfig.enabled = true;
     config.tools = config.tools ?? {};
@@ -360,7 +362,6 @@ export function generateBaseConfig(
   } else if (kiloExaSearchMode === 'disabled') {
     customizerWebSearchConfig.enabled = false;
 
-    const braveConfigured = Boolean(env.BRAVE_API_KEY?.trim());
     if (
       braveConfigured &&
       (!hasExplicitSearchProvider || config.tools?.web?.search?.provider === KILO_EXA_PROVIDER_ID)


### PR DESCRIPTION
## Summary

Preserves user-configured Brave search on image upgrades when the web search provider field is unset.

The controller config patcher no longer auto-assigns `kilo-exa` when `KILO_EXA_SEARCH_MODE` is unset if `BRAVE_API_KEY` is already configured. This keeps existing Brave configurations from being implicitly overridden during bootstrap/doctor/restore patching.

Added regression coverage for both normal config generation and restore-path config generation.

## Verification

- [ ] No manual verification performed.

## Visual Changes

N/A

## Reviewer Notes

Primary risk area is `generateBaseConfig()` web-search steering logic in controller boot patching.
Behavior for explicit providers and explicit Exa mode values is unchanged.
