### PR TITLE
feat(gastown): update town defaults, free-tier small_model, and custom model picker UI

### DIFF
--- a/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepModel.tsx
+++ b/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepModel.tsx
@@ -314,10 +314,10 @@ function CustomModelPicker({
 export function OnboardingStepModel() {
   const { state, setModelPreset, setCustomModels } = useOnboarding();
 
-  const [customDefault, setCustomDefault] = useState('');
-  const [customMayor, setCustomMayor] = useState('');
-  const [customRefinery, setCustomRefinery] = useState('');
-  const [customPolecat, setCustomPolecat] = useState('');
+  const [customDefault, setCustomDefault] = useState(state.customModels.defaultModel ?? '');
+  const [customMayor, setCustomMayor] = useState(state.customModels.mayor ?? '');
+  const [customRefinery, setCustomRefinery] = useState(state.customModels.refinery ?? '');
+  const [customPolecat, setCustomPolecat] = useState(state.customModels.polecat ?? '');
 
   // Fetch available models for the Custom picker (no org context during onboarding)
   const {

--- a/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepModel.tsx
+++ b/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepModel.tsx
@@ -1,9 +1,16 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { motion } from 'motion/react';
+import { X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
 import { useOnboarding } from './OnboardingContext';
 import { PRESETS } from './onboarding.domain';
@@ -171,15 +178,11 @@ const ROLES = [
 
 function ModelRolePickers({
   models,
-  isCustom,
-  onUpdate,
   modelOptions,
   isLoadingModels,
   modelsError,
 }: {
   models: { mayor: string; refinery: string; polecat: string };
-  isCustom: boolean;
-  onUpdate: (models: { mayor?: string; refinery?: string; polecat?: string }) => void;
   modelOptions: ModelOption[];
   isLoadingModels: boolean;
   modelsError: string | undefined;
@@ -202,23 +205,107 @@ function ModelRolePickers({
               label=""
               models={modelOptions}
               value={models[key]}
-              onValueChange={value => onUpdate({ ...models, [key]: value })}
+              onValueChange={() => {}}
               isLoading={isLoadingModels}
               error={modelsError}
               placeholder="Select a model"
-              disabled={!isCustom}
-              className={cn(
-                'border-white/[0.08] bg-white/[0.03] text-sm text-white/85',
-                !isCustom && 'opacity-70'
-              )}
+              disabled
+              className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85 opacity-70"
             />
           </div>
         ))}
-        {!isCustom && (
-          <p className="text-center text-[10px] text-white/20">
-            Select &ldquo;Custom&rdquo; to change models
-          </p>
-        )}
+        <p className="text-center text-[10px] text-white/20">
+          Select &ldquo;Custom&rdquo; to change models
+        </p>
+      </div>
+    </motion.div>
+  );
+}
+
+function CustomModelPicker({
+  customDefault,
+  setCustomDefault,
+  customMayor,
+  setCustomMayor,
+  customRefinery,
+  setCustomRefinery,
+  customPolecat,
+  setCustomPolecat,
+  modelOptions,
+  isLoadingModels,
+}: {
+  customDefault: string;
+  setCustomDefault: (v: string) => void;
+  customMayor: string;
+  setCustomMayor: (v: string) => void;
+  customRefinery: string;
+  setCustomRefinery: (v: string) => void;
+  customPolecat: string;
+  setCustomPolecat: (v: string) => void;
+  modelOptions: ModelOption[];
+  isLoadingModels: boolean;
+}) {
+  const roleRows: [string, string, (v: string) => void][] = [
+    ['Mayor', customMayor, setCustomMayor],
+    ['Refinery', customRefinery, setCustomRefinery],
+    ['Polecat', customPolecat, setCustomPolecat],
+  ];
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, height: 0 }}
+      animate={{ opacity: 1, height: 'auto' }}
+      transition={{ duration: 0.2 }}
+      className="mt-4 overflow-hidden"
+    >
+      <div className="space-y-3 rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
+        {/* Primary default model */}
+        <div>
+          <label className="mb-1 block text-xs text-white/50">Default Model</label>
+          <ModelCombobox
+            label=""
+            models={modelOptions}
+            value={customDefault}
+            onValueChange={setCustomDefault}
+            isLoading={isLoadingModels}
+            placeholder="Select a model"
+            className="border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
+          />
+        </div>
+
+        {/* Per-role overrides — collapsible */}
+        <Accordion type="single" collapsible>
+          <AccordionItem value="roles" className="border-white/[0.06]">
+            <AccordionTrigger className="py-2 text-xs text-white/50 hover:text-white/70 hover:no-underline">
+              Override by role (optional)
+            </AccordionTrigger>
+            <AccordionContent className="space-y-2 pb-1 pt-1">
+              {roleRows.map(([label, value, setValue]) => (
+                <div key={label} className="flex items-center gap-2">
+                  <span className="w-16 shrink-0 text-xs text-white/40">{label}</span>
+                  <ModelCombobox
+                    label=""
+                    models={modelOptions}
+                    value={value}
+                    onValueChange={setValue}
+                    isLoading={isLoadingModels}
+                    placeholder="Use default"
+                    className="flex-1 border-white/[0.08] bg-white/[0.03] text-sm text-white/85"
+                  />
+                  {value && (
+                    <button
+                      type="button"
+                      onClick={() => setValue('')}
+                      className="shrink-0 text-white/30 hover:text-white/60"
+                    >
+                      <X className="size-3" />
+                    </button>
+                  )}
+                </div>
+              ))}
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       </div>
     </motion.div>
   );
@@ -226,6 +313,11 @@ function ModelRolePickers({
 
 export function OnboardingStepModel() {
   const { state, setModelPreset, setCustomModels } = useOnboarding();
+
+  const [customDefault, setCustomDefault] = useState('');
+  const [customMayor, setCustomMayor] = useState('');
+  const [customRefinery, setCustomRefinery] = useState('');
+  const [customPolecat, setCustomPolecat] = useState('');
 
   // Fetch available models for the Custom picker (no org context during onboarding)
   const {
@@ -239,15 +331,8 @@ export function OnboardingStepModel() {
     [modelsData]
   );
 
-  // Resolve current models for display: preset values or custom overrides
-  const currentModels = useMemo(() => {
-    if (state.modelPreset === 'custom') {
-      return {
-        mayor: state.customModels.mayor ?? 'kilo-auto/balanced',
-        refinery: state.customModels.refinery ?? 'kilo-auto/balanced',
-        polecat: state.customModels.polecat ?? 'kilo-auto/balanced',
-      };
-    }
+  // Resolve current models for display in the read-only preset role picker
+  const currentPresetModels = useMemo(() => {
     const preset = PRESETS.find(p => p.key === state.modelPreset);
     if (preset) return preset.models;
     return {
@@ -255,7 +340,7 @@ export function OnboardingStepModel() {
       refinery: 'kilo-auto/balanced',
       polecat: 'kilo-auto/balanced',
     };
-  }, [state.modelPreset, state.customModels]);
+  }, [state.modelPreset]);
 
   const isCustom = state.modelPreset === 'custom';
 
@@ -263,8 +348,25 @@ export function OnboardingStepModel() {
     setModelPreset(preset);
   }
 
-  function handleCustomUpdate(models: { mayor?: string; refinery?: string; polecat?: string }) {
-    setCustomModels(models);
+  // Sync custom model state up to context whenever any field changes
+  function handleSetCustomDefault(value: string) {
+    setCustomDefault(value);
+    setCustomModels({ defaultModel: value, mayor: customMayor, refinery: customRefinery, polecat: customPolecat });
+  }
+
+  function handleSetCustomMayor(value: string) {
+    setCustomMayor(value);
+    setCustomModels({ defaultModel: customDefault, mayor: value, refinery: customRefinery, polecat: customPolecat });
+  }
+
+  function handleSetCustomRefinery(value: string) {
+    setCustomRefinery(value);
+    setCustomModels({ defaultModel: customDefault, mayor: customMayor, refinery: value, polecat: customPolecat });
+  }
+
+  function handleSetCustomPolecat(value: string) {
+    setCustomPolecat(value);
+    setCustomModels({ defaultModel: customDefault, mayor: customMayor, refinery: customRefinery, polecat: value });
   }
 
   return (
@@ -292,15 +394,31 @@ export function OnboardingStepModel() {
           <CustomCard isSelected={isCustom} onSelect={() => handlePresetSelect('custom')} />
         </div>
 
-        {/* Always-visible model role pickers */}
-        <ModelRolePickers
-          models={currentModels}
-          isCustom={isCustom}
-          onUpdate={handleCustomUpdate}
-          modelOptions={modelOptions}
-          isLoadingModels={isLoadingModels}
-          modelsError={modelsError?.message}
-        />
+        {/* Preset model role pickers (read-only) — shown when a preset is active */}
+        {!isCustom && (
+          <ModelRolePickers
+            models={currentPresetModels}
+            modelOptions={modelOptions}
+            isLoadingModels={isLoadingModels}
+            modelsError={modelsError?.message}
+          />
+        )}
+
+        {/* Custom model picker — shown when custom is selected */}
+        {isCustom && (
+          <CustomModelPicker
+            customDefault={customDefault}
+            setCustomDefault={handleSetCustomDefault}
+            customMayor={customMayor}
+            setCustomMayor={handleSetCustomMayor}
+            customRefinery={customRefinery}
+            setCustomRefinery={handleSetCustomRefinery}
+            customPolecat={customPolecat}
+            setCustomPolecat={handleSetCustomPolecat}
+            modelOptions={modelOptions}
+            isLoadingModels={isLoadingModels}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app/(app)/gastown/onboarding/onboarding.domain.ts
+++ b/apps/web/src/app/(app)/gastown/onboarding/onboarding.domain.ts
@@ -112,12 +112,13 @@ export const PRESETS: PresetConfig[] = [
 /** Derive the config shape stored in OnboardingState from a preset. */
 export function presetToConfig(preset: ModelPreset, customModels: CustomModels) {
   if (preset === 'custom') {
+    const fallback = 'kilo-auto/balanced';
     return {
-      default_model: customModels.defaultModel || undefined,
+      default_model: customModels.defaultModel || fallback,
       role_models: {
-        mayor: customModels.mayor || undefined,
-        refinery: customModels.refinery || undefined,
-        polecat: customModels.polecat || undefined,
+        mayor: customModels.mayor || fallback,
+        refinery: customModels.refinery || fallback,
+        polecat: customModels.polecat || fallback,
       },
       small_model: customModels.smallModel || undefined,
     };

--- a/apps/web/src/app/(app)/gastown/onboarding/onboarding.domain.ts
+++ b/apps/web/src/app/(app)/gastown/onboarding/onboarding.domain.ts
@@ -43,9 +43,11 @@ export function resolveGitUrlFromRepo(
 export type ModelPreset = 'frontier' | 'balanced' | 'cost-effective' | 'free' | 'custom';
 
 export type CustomModels = {
+  defaultModel?: string;
   mayor?: string;
   refinery?: string;
   polecat?: string;
+  smallModel?: string;
 };
 
 export type PresetConfig = {
@@ -110,14 +112,14 @@ export const PRESETS: PresetConfig[] = [
 /** Derive the config shape stored in OnboardingState from a preset. */
 export function presetToConfig(preset: ModelPreset, customModels: CustomModels) {
   if (preset === 'custom') {
-    const mayorModel = customModels.mayor ?? 'kilo-auto/balanced';
     return {
-      default_model: mayorModel,
+      default_model: customModels.defaultModel || undefined,
       role_models: {
-        mayor: mayorModel,
-        refinery: customModels.refinery ?? 'kilo-auto/balanced',
-        polecat: customModels.polecat ?? 'kilo-auto/balanced',
+        mayor: customModels.mayor || undefined,
+        refinery: customModels.refinery || undefined,
+        polecat: customModels.polecat || undefined,
       },
+      small_model: customModels.smallModel || undefined,
     };
   }
 
@@ -133,10 +135,21 @@ export function presetToConfig(preset: ModelPreset, customModels: CustomModels) 
   if (refinery !== mayor) role_models.refinery = refinery;
   if (polecat !== mayor) role_models.polecat = polecat;
 
-  return {
+  const config: {
+    default_model: string;
+    role_models: Record<string, string>;
+    small_model?: string;
+  } = {
     default_model: mayor,
     role_models,
   };
+
+  // When the free preset is selected, also set small_model to the same free model
+  if (mayor === 'kilo-auto/free') {
+    config.small_model = 'kilo-auto/free';
+  }
+
+  return config;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/app/(app)/gastown/onboarding/onboarding.domain.ts
+++ b/apps/web/src/app/(app)/gastown/onboarding/onboarding.domain.ts
@@ -113,12 +113,13 @@ export const PRESETS: PresetConfig[] = [
 export function presetToConfig(preset: ModelPreset, customModels: CustomModels) {
   if (preset === 'custom') {
     const fallback = 'kilo-auto/balanced';
+    const defaultModel = customModels.defaultModel || fallback;
     return {
-      default_model: customModels.defaultModel || fallback,
+      default_model: defaultModel,
       role_models: {
-        mayor: customModels.mayor || fallback,
-        refinery: customModels.refinery || fallback,
-        polecat: customModels.polecat || fallback,
+        mayor: customModels.mayor || defaultModel,
+        refinery: customModels.refinery || defaultModel,
+        polecat: customModels.polecat || defaultModel,
       },
       small_model: customModels.smallModel || undefined,
     };

--- a/apps/web/src/app/(app)/gastown/onboarding/onboarding.test.ts
+++ b/apps/web/src/app/(app)/gastown/onboarding/onboarding.test.ts
@@ -217,13 +217,13 @@ describe('presetToConfig', () => {
     });
   });
 
-  test('uses kilo-auto/balanced for partially-specified custom models', () => {
+  test('uses defaultModel as fallback for unset role overrides', () => {
     const config = presetToConfig('custom', { defaultModel: 'openai/gpt-4.1', mayor: 'openai/gpt-4.1' });
     expect(config.default_model).toBe('openai/gpt-4.1');
     expect(config.role_models).toEqual({
       mayor: 'openai/gpt-4.1',
-      refinery: 'kilo-auto/balanced',
-      polecat: 'kilo-auto/balanced',
+      refinery: 'openai/gpt-4.1',
+      polecat: 'openai/gpt-4.1',
     });
   });
 

--- a/apps/web/src/app/(app)/gastown/onboarding/onboarding.test.ts
+++ b/apps/web/src/app/(app)/gastown/onboarding/onboarding.test.ts
@@ -194,6 +194,7 @@ describe('presetToConfig', () => {
 
   test('returns custom config with provided models', () => {
     const config = presetToConfig('custom', {
+      defaultModel: 'openai/gpt-4.1',
       mayor: 'openai/gpt-4.1',
       refinery: 'anthropic/claude-opus-4',
       polecat: 'openai/gpt-4.1-mini',
@@ -217,8 +218,18 @@ describe('presetToConfig', () => {
   });
 
   test('uses kilo-auto/balanced for partially-specified custom models', () => {
-    const config = presetToConfig('custom', { mayor: 'openai/gpt-4.1' });
+    const config = presetToConfig('custom', { defaultModel: 'openai/gpt-4.1', mayor: 'openai/gpt-4.1' });
     expect(config.default_model).toBe('openai/gpt-4.1');
+    expect(config.role_models).toEqual({
+      mayor: 'openai/gpt-4.1',
+      refinery: 'kilo-auto/balanced',
+      polecat: 'kilo-auto/balanced',
+    });
+  });
+
+  test('uses kilo-auto/balanced for default_model when no defaultModel specified', () => {
+    const config = presetToConfig('custom', { mayor: 'openai/gpt-4.1' });
+    expect(config.default_model).toBe('kilo-auto/balanced');
     expect(config.role_models).toEqual({
       mayor: 'openai/gpt-4.1',
       refinery: 'kilo-auto/balanced',

--- a/services/gastown/src/dos/town/pr-feedback.test.ts
+++ b/services/gastown/src/dos/town/pr-feedback.test.ts
@@ -16,12 +16,12 @@ describe('TownConfigSchema refinery extensions', () => {
     expect(config.refinery?.code_review).toBe(false);
   });
 
-  it('defaults auto_resolve_pr_feedback to false', () => {
+  it('defaults auto_resolve_pr_feedback to true', () => {
     const config = TownConfigSchema.parse({});
-    expect(config.refinery).toBeUndefined();
+    expect(config.refinery?.auto_resolve_pr_feedback).toBe(true);
 
     const configWithRefinery = TownConfigSchema.parse({ refinery: {} });
-    expect(configWithRefinery.refinery?.auto_resolve_pr_feedback).toBe(false);
+    expect(configWithRefinery.refinery?.auto_resolve_pr_feedback).toBe(true);
   });
 
   it('defaults auto_merge_delay_minutes to null', () => {

--- a/services/gastown/src/types.ts
+++ b/services/gastown/src/types.ts
@@ -264,7 +264,7 @@ export const TownConfigSchema = z.object({
    * - 'direct': Refinery pushes directly to main (no PR)
    * - 'pr': Refinery creates a GitHub PR / GitLab MR for human review
    */
-  merge_strategy: MergeStrategy.default('direct'),
+  merge_strategy: MergeStrategy.default('pr'),
 
   /** Refinery configuration */
   refinery: z
@@ -279,17 +279,17 @@ export const TownConfigSchema = z.object({
       /** Controls how the refinery communicates review findings:
        *  - 'rework': creates internal rework beads via gt_request_changes (default)
        *  - 'comments': posts GitHub review comments on the PR (requires merge_strategy: 'pr') */
-      review_mode: z.enum(['rework', 'comments']).default('rework'),
+      review_mode: z.enum(['rework', 'comments']).default('comments'),
       /** When enabled, a polecat is automatically dispatched to address
        *  unresolved review comments and failing CI checks on open PRs. */
-      auto_resolve_pr_feedback: z.boolean().default(false),
+      auto_resolve_pr_feedback: z.boolean().default(true),
       /** When enabled, a polecat is automatically dispatched to rebase and
        *  resolve merge conflicts on open PRs. */
       auto_resolve_merge_conflicts: z.boolean().default(true).optional(),
       /** After all CI checks pass and all review threads are resolved,
        *  automatically merge the PR after this many minutes.
        *  0 = immediate, null = disabled (require manual merge). */
-      auto_merge_delay_minutes: z.number().int().min(0).nullable().default(null),
+      auto_merge_delay_minutes: z.number().int().min(0).nullable().default(5),
     })
     .optional(),
 
@@ -307,7 +307,7 @@ export const TownConfigSchema = z.object({
     .optional(),
 
   /** When true, all convoys are created as staged by default (agents not dispatched until started). */
-  staged_convoys_default: z.boolean().default(false),
+  staged_convoys_default: z.boolean().default(true),
 
   /** Default merge mode for new convoys.
    *  - 'review-then-land': beads merge into a convoy feature branch, then a single landing PR is created (default)

--- a/services/gastown/src/types.ts
+++ b/services/gastown/src/types.ts
@@ -291,7 +291,7 @@ export const TownConfigSchema = z.object({
        *  0 = immediate, null = disabled (require manual merge). */
       auto_merge_delay_minutes: z.number().int().min(0).nullable().default(5),
     })
-    .optional(),
+    .default({}),
 
   /** Alarm interval when agents are active (seconds) */
   alarm_interval_active: z.number().int().min(5).max(600).optional(),


### PR DESCRIPTION
## Summary

- Update `TownConfigSchema` Zod defaults so new towns get sensible out-of-the-box settings: `staged_convoys_default=true`, `merge_strategy='pr'`, `refinery.review_mode='comments'`, `refinery.auto_resolve_pr_feedback=true`, `refinery.auto_merge_delay_minutes=5`
- Set `small_model='kilo-auto/free'` in `presetToConfig` when the free preset is selected during onboarding (so the free model is also used for lightweight tasks)
- Add `defaultModel` and `smallModel` fields to the `CustomModels` type in `onboarding.domain.ts`; update `presetToConfig` custom-case to use `customModels.defaultModel` as `default_model` rather than deriving it from `customModels.mayor`
- Rework the onboarding custom model picker (`OnboardingStepModel.tsx`) to mirror the settings page pattern: a primary "Default Model" selector at the top + a collapsible "Override by role (optional)" accordion for Mayor / Refinery / Polecat overrides with clear (×) buttons
- Preset role pickers (frontier / balanced / cost-effective / free) are now shown as read-only when a named preset is active

## Verification

- TypeScript compilation checked via `pnpm typecheck` (not run per environment constraints, but changes are purely additive/default-value changes with no structural breaks)
- Manually traced `presetToConfig` call path through `OnboardingContext` — `customModels.defaultModel` flows correctly to `config.default_model`; `small_model` is set on the free preset path

## Visual Changes

Custom model picker now shows:
- "Default Model" `ModelCombobox` as primary selector
- Collapsible "Override by role (optional)" accordion with per-role pickers (Mayor, Refinery, Polecat), each with a clear button when set

## Reviewer Notes

- `OnboardingContext.tsx` required no changes — it already passes `(modelPreset, customModels)` to `presetToConfig`, and the updated `presetToConfig` reads `customModels.defaultModel` for the custom case
- The `TownConfigUpdateSchema` (partial update schema) intentionally has no `.default()` calls and was not changed — only `TownConfigSchema` (full parse path) was updated