### PR TITLE
fix(claw): preserve location when wttr is down

### DIFF
--- a/apps/web/src/app/(app)/claw/components/WeatherLocationInput.tsx
+++ b/apps/web/src/app/(app)/claw/components/WeatherLocationInput.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
 
 export type WeatherLocationSource = 'browser' | 'text' | 'skip';
 
@@ -39,13 +40,16 @@ export const WeatherLocationInput = forwardRef<
   const trpc = useTRPC();
   const validateLocation = useMutation(trpc.kiloclaw.validateWeatherLocation.mutationOptions());
   const [locationInput, setLocationInput] = useState('');
-  const [currentWeatherText, setCurrentWeatherText] = useState<string | null>(null);
+  const [locationFeedback, setLocationFeedback] = useState<{
+    message: string;
+    status: 'validated' | 'service_unavailable';
+  } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLocating, setIsLocating] = useState(false);
   const inputPending = disabled || validateLocation.isPending || isLocating;
 
   function clearSelection() {
-    setCurrentWeatherText(null);
+    setLocationFeedback(null);
     onSelectionChange(null);
   }
 
@@ -63,7 +67,7 @@ export const WeatherLocationInput = forwardRef<
       const result = await validateLocation.mutateAsync({ location });
       const selection = { location: result.location, source } satisfies WeatherLocationSelection;
       setLocationInput(result.location);
-      setCurrentWeatherText(result.currentWeatherText);
+      setLocationFeedback({ message: result.currentWeatherText, status: result.status });
       setError(null);
       onSelectionChange(selection);
       return selection;
@@ -187,9 +191,16 @@ export const WeatherLocationInput = forwardRef<
           </div>
         </form>
 
-        {currentWeatherText ? (
-          <p className="animate-in fade-in slide-in-from-top-1 text-muted-foreground pointer-events-none absolute top-full right-0 left-0 z-10 mt-1.5 px-1 text-sm duration-300">
-            {currentWeatherText}
+        {locationFeedback ? (
+          <p
+            className={cn(
+              'animate-in fade-in slide-in-from-top-1 pointer-events-none absolute top-full right-0 left-0 z-10 mt-1.5 px-1 text-sm duration-300',
+              locationFeedback.status === 'service_unavailable'
+                ? 'text-amber-700 dark:text-amber-400'
+                : 'text-muted-foreground'
+            )}
+          >
+            {locationFeedback.message}
           </p>
         ) : null}
         {error ? <p className="mt-1.5 px-1 text-sm text-red-600">{error}</p> : null}

--- a/apps/web/src/routers/kiloclaw-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-router.test.ts
@@ -101,6 +101,7 @@ let createCaller: (ctx: { user: Awaited<ReturnType<typeof insertTestUser>> }) =>
   validateWeatherLocation: (input: { location: string }) => Promise<{
     location: string;
     currentWeatherText: string;
+    status: 'validated' | 'service_unavailable';
   }>;
   cycleInboundEmailAddress: () => Promise<{ inboundEmailAddress: string }>;
   destroy: () => Promise<{ ok: true }>;
@@ -117,6 +118,9 @@ beforeAll(async () => {
 function wttrFormat3Response(text: string, status = 200): Response {
   return new Response(text, { status, headers: { 'Content-Type': 'text/plain' } });
 }
+
+const WTTR_SERVICE_UNAVAILABLE_MESSAGE =
+  "wttr.in is down right now. We'll store your location as entered.";
 
 function wttrLocationResponse(params: {
   areaName: string;
@@ -186,6 +190,7 @@ describe('kiloclawRouter validateWeatherLocation', () => {
     expect(result).toEqual({
       location: 'Amsterdam, The Netherlands',
       currentWeatherText: '☁️   +7°C',
+      status: 'validated',
     });
   });
 
@@ -217,6 +222,7 @@ describe('kiloclawRouter validateWeatherLocation', () => {
     expect(result).toEqual({
       location: 'Groningen, The Netherlands',
       currentWeatherText: '☀️   +9°C',
+      status: 'validated',
     });
   });
 
@@ -232,19 +238,21 @@ describe('kiloclawRouter validateWeatherLocation', () => {
     );
   });
 
-  it('rejects malformed wttr format=3 responses', async () => {
+  it('stores the typed location when wttr returns a malformed service response', async () => {
     const user = await insertTestUser({
       google_user_email: `kiloclaw-weather-malformed-test-${Math.random()}@example.com`,
     });
     fetchSpy.mockResolvedValue(wttrFormat3Response('☁️   +7°C'));
     const caller = createCaller({ user });
 
-    await expect(caller.validateWeatherLocation({ location: 'Amsterdam' })).rejects.toThrow(
-      'Weather location could not be found.'
-    );
+    await expect(caller.validateWeatherLocation({ location: ' Amsterdam ' })).resolves.toEqual({
+      location: 'Amsterdam',
+      currentWeatherText: WTTR_SERVICE_UNAVAILABLE_MESSAGE,
+      status: 'service_unavailable',
+    });
   });
 
-  it('returns a timeout error when wttr validation times out', async () => {
+  it('stores the typed location when wttr validation times out', async () => {
     const user = await insertTestUser({
       google_user_email: `kiloclaw-weather-timeout-test-${Math.random()}@example.com`,
     });
@@ -252,20 +260,50 @@ describe('kiloclawRouter validateWeatherLocation', () => {
     fetchSpy.mockRejectedValue(timeoutError);
     const caller = createCaller({ user });
 
-    await expect(caller.validateWeatherLocation({ location: 'Amsterdam' })).rejects.toThrow(
-      'Weather location validation timed out.'
-    );
+    await expect(caller.validateWeatherLocation({ location: 'Amsterdam' })).resolves.toEqual({
+      location: 'Amsterdam',
+      currentWeatherText: WTTR_SERVICE_UNAVAILABLE_MESSAGE,
+      status: 'service_unavailable',
+    });
   });
 
-  it('returns an unavailable error when wttr validation fails upstream', async () => {
+  it('stores the typed location when wttr validation fails upstream', async () => {
     const user = await insertTestUser({
       google_user_email: `kiloclaw-weather-upstream-test-${Math.random()}@example.com`,
     });
     fetchSpy.mockRejectedValue(new Error('network down'));
     const caller = createCaller({ user });
 
-    await expect(caller.validateWeatherLocation({ location: 'Amsterdam' })).rejects.toThrow(
-      'Weather location validation is unavailable.'
+    await expect(caller.validateWeatherLocation({ location: 'Amsterdam' })).resolves.toEqual({
+      location: 'Amsterdam',
+      currentWeatherText: WTTR_SERVICE_UNAVAILABLE_MESSAGE,
+      status: 'service_unavailable',
+    });
+  });
+
+  it('stores the typed location when wttr returns a service error', async () => {
+    const user = await insertTestUser({
+      google_user_email: `kiloclaw-weather-service-error-test-${Math.random()}@example.com`,
+    });
+    fetchSpy.mockResolvedValue(wttrFormat3Response('Bad Gateway', 502));
+    const caller = createCaller({ user });
+
+    await expect(caller.validateWeatherLocation({ location: 'Amsterdam' })).resolves.toEqual({
+      location: 'Amsterdam',
+      currentWeatherText: WTTR_SERVICE_UNAVAILABLE_MESSAGE,
+      status: 'service_unavailable',
+    });
+  });
+
+  it('rejects non-service wttr errors as unknown locations', async () => {
+    const user = await insertTestUser({
+      google_user_email: `kiloclaw-weather-not-found-status-test-${Math.random()}@example.com`,
+    });
+    fetchSpy.mockResolvedValue(wttrFormat3Response('Not Found', 404));
+    const caller = createCaller({ user });
+
+    await expect(caller.validateWeatherLocation({ location: 'not-a-real-place' })).rejects.toThrow(
+      'Weather location could not be found.'
     );
   });
 });

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -567,7 +567,17 @@ const userTimezoneSchema = z
 const userLocationSchema = z.string().trim().min(1).max(200);
 const weatherLocationInputSchema = z.object({ location: userLocationSchema });
 const WTTR_LOCATION_TIMEOUT_MS = 4_000;
+const WTTR_SERVICE_UNAVAILABLE_MESSAGE =
+  "wttr.in is down right now. We'll store your location as entered.";
 const COORDINATE_LOCATION_PATTERN = /^-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?$/;
+
+type WeatherLocationValidationResult = {
+  location: string;
+  currentWeatherText: string;
+  status: 'validated' | 'service_unavailable';
+};
+
+type WttrFetchResult = { ok: true; response: Response } | { ok: false };
 
 const wttrValueSchema = z.object({ value: z.string().trim().min(1) });
 const wttrNearestAreaSchema = z.object({
@@ -658,27 +668,44 @@ function isTimeoutError(error: unknown): boolean {
   return error.name === 'TimeoutError' || error.name === 'AbortError';
 }
 
-async function fetchWttr(location: string, query: string): Promise<Response> {
+function wttrServiceUnavailableResult(location: string): WeatherLocationValidationResult {
+  return {
+    location,
+    currentWeatherText: WTTR_SERVICE_UNAVAILABLE_MESSAGE,
+    status: 'service_unavailable',
+  };
+}
+
+function isWttrServiceUnavailableStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+function weatherLocationNotFound(): never {
+  throw new TRPCError({
+    code: 'BAD_REQUEST',
+    message: 'Weather location could not be found.',
+  });
+}
+
+async function fetchWttr(location: string, query: string): Promise<WttrFetchResult> {
   try {
-    return await fetch(`https://wttr.in/${encodeURIComponent(location)}?${query}`, {
-      headers: {
-        Accept: 'text/plain, application/json;q=0.9, */*;q=0.8',
-        'User-Agent': 'curl/8.7.1',
-      },
-      signal: AbortSignal.timeout(WTTR_LOCATION_TIMEOUT_MS),
-    });
+    return {
+      ok: true,
+      response: await fetch(`https://wttr.in/${encodeURIComponent(location)}?${query}`, {
+        headers: {
+          Accept: 'text/plain, application/json;q=0.9, */*;q=0.8',
+          'User-Agent': 'curl/8.7.1',
+        },
+        signal: AbortSignal.timeout(WTTR_LOCATION_TIMEOUT_MS),
+      }),
+    };
   } catch (error) {
-    if (isTimeoutError(error)) {
-      throw new TRPCError({
-        code: 'TIMEOUT',
-        message: 'Weather location validation timed out. Please try again or skip weather setup.',
+    if (!isTimeoutError(error)) {
+      sentryLogger('kiloclaw-weather', 'warning')('wttr.in validation unavailable', {
+        location_query: query,
       });
     }
-    throw new TRPCError({
-      code: 'INTERNAL_SERVER_ERROR',
-      message:
-        'Weather location validation is unavailable. Please try again or skip weather setup.',
-    });
+    return { ok: false };
   }
 }
 
@@ -687,36 +714,45 @@ async function fetchReadableLocationName(
   preferredAreaName: string
 ): Promise<string | null> {
   try {
-    const response = await fetchWttr(location, 'format=j1');
-    if (!response.ok) return null;
-    return normalizeWeatherLocation(await response.json(), preferredAreaName);
+    const result = await fetchWttr(location, 'format=j1');
+    if (!result.ok || !result.response.ok) return null;
+    return normalizeWeatherLocation(await result.response.json(), preferredAreaName);
   } catch {
     return null;
   }
 }
 
-async function validateWeatherLocation(
-  location: string
-): Promise<{ location: string; currentWeatherText: string }> {
-  const response = await fetchWttr(location, 'format=3');
+async function validateWeatherLocation(location: string): Promise<WeatherLocationValidationResult> {
+  const result = await fetchWttr(location, 'format=3');
+  if (!result.ok) return wttrServiceUnavailableResult(location);
 
+  const response = result.response;
   if (!response.ok) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: 'Weather location could not be found.',
-    });
+    if (isWttrServiceUnavailableStatus(response.status)) {
+      return wttrServiceUnavailableResult(location);
+    }
+    weatherLocationNotFound();
   }
 
-  const parsed = parseWttrFormat3(await response.text());
+  let responseText: string;
+  try {
+    responseText = await response.text();
+  } catch {
+    return wttrServiceUnavailableResult(location);
+  }
+
+  const parsed = parseWttrFormat3(responseText);
   if (!parsed) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: 'Weather location could not be found.',
-    });
+    if (hasUnknownLocationMarker(responseText)) weatherLocationNotFound();
+    return wttrServiceUnavailableResult(location);
   }
 
   const resolvedLocation = await fetchReadableLocationName(location, parsed.location);
-  return { ...parsed, ...(resolvedLocation ? { location: resolvedLocation } : undefined) };
+  return {
+    ...parsed,
+    status: 'validated',
+    ...(resolvedLocation ? { location: resolvedLocation } : undefined),
+  };
 }
 
 // TODO: Replace with catalog-driven schema. This hardcoded list must be kept


### PR DESCRIPTION
## Summary

- Let onboarding continue when wttr.in times out, returns a service error, or sends a malformed outage response.
- Store the user's typed location as-is for outage fallbacks while preserving unknown-location validation for non-service errors.
- Show an inline wttr-down notice in the weather location input so users understand weather lookup is unavailable.

## Verification

- Manually verified (see visual changes)

## Visual Changes

<img width="1344" height="354" alt="CleanShot 2026-04-23 at 09 18 56@2x" src="https://github.com/user-attachments/assets/a666b90e-aaee-4731-a2d4-8f979025c93d" />

## Reviewer Notes

- The response now includes a `status` field so the client can distinguish validated weather from the service-unavailable fallback.
- Non-service wttr responses such as 404 still reject the location instead of storing likely-invalid input.