### PR TITLE
feat(bot): gate Slack bot migration rollout

### DIFF
--- a/apps/web/src/app/api/chat/link-account/route.ts
+++ b/apps/web/src/app/api/chat/link-account/route.ts
@@ -5,7 +5,7 @@ import { db } from '@/lib/drizzle';
 import { isOrganizationMember } from '@/lib/organizations/organizations';
 import { getUserFromAuth } from '@/lib/user.server';
 import { platform_integrations } from '@kilocode/db';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 
 function errorPage(title: string, message: string, status: number): Response {
   return new Response(
@@ -27,7 +27,6 @@ function errorPage(title: string, message: string, status: number): Response {
  * an org member; for user-owned integrations only the owner may link.
  */
 async function verifyIntegrationAccess(
-  platform: string,
   teamId: string,
   kiloUserId: string
 ): Promise<{ ok: true } | { ok: false; error: string }> {
@@ -36,7 +35,7 @@ async function verifyIntegrationAccess(
     .from(platform_integrations)
     .where(
       and(
-        eq(platform_integrations.platform, platform),
+        inArray(platform_integrations.platform, ['slack', 'slack-next']),
         eq(platform_integrations.platform_installation_id, teamId)
       )
     )
@@ -97,10 +96,6 @@ export async function GET(request: Request) {
     );
   }
 
-  // TODO(remon): Remove this hack once we've replaced the old slack integration
-  let platform = identity.platform;
-  if (identity.platform === 'slack') platform = 'slack-next';
-
   // Authenticate — redirect to sign-in if no session, then back here
   const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
   if (authFailedResponse) {
@@ -110,7 +105,7 @@ export async function GET(request: Request) {
   }
 
   // Verify the user is allowed to link to this integration
-  const access = await verifyIntegrationAccess(platform, identity.teamId, user.id);
+  const access = await verifyIntegrationAccess(identity.teamId, user.id);
   if (!access.ok) {
     return errorPage('Access Denied', access.error, 403);
   }

--- a/apps/web/src/app/api/chat/webhooks/[platform]/route.ts
+++ b/apps/web/src/app/api/chat/webhooks/[platform]/route.ts
@@ -1,19 +1,12 @@
-import { after } from 'next/server';
-import { bot } from '@/lib/bot';
+import { handleBotWebhookRequest } from '@/lib/bot/webhook-handler';
 
 export const maxDuration = 800;
 
-type Platform = keyof typeof bot.webhooks;
 type RouteContext = {
   params: Promise<{ platform: string }>;
 };
+
 export async function POST(request: Request, context: RouteContext) {
   const { platform } = await context.params;
-  const handler = bot.webhooks[platform as Platform];
-  if (!handler) {
-    return new Response('Unknown platform', { status: 404 });
-  }
-  return handler(request, {
-    waitUntil: task => after(() => task),
-  });
+  return handleBotWebhookRequest(platform, request);
 }

--- a/apps/web/src/app/slack/interactivity/route.ts
+++ b/apps/web/src/app/slack/interactivity/route.ts
@@ -1,5 +1,10 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import {
+  cloneRequestWithBody,
+  handleLegacySlackBotWebhookRequest,
+} from '@/lib/bot/webhook-handler';
+import { shouldRouteSlackInteractivityToNewBotInfra } from '@/lib/bot/slack-rollout';
 import { verifySlackRequest } from '@/lib/slack/verify-request';
 
 /**
@@ -15,6 +20,10 @@ export async function POST(request: NextRequest) {
   if (!verifySlackRequest(rawBody, timestamp, signature)) {
     console.error('[Slack:Interactivity] Invalid Slack signature');
     return new NextResponse('Invalid signature', { status: 401 });
+  }
+
+  if (await shouldRouteSlackInteractivityToNewBotInfra(rawBody)) {
+    return handleLegacySlackBotWebhookRequest(cloneRequestWithBody(request, rawBody));
   }
 
   return new NextResponse(null, { status: 200 });

--- a/apps/web/src/app/slack/webhook/route.ts
+++ b/apps/web/src/app/slack/webhook/route.ts
@@ -2,6 +2,11 @@ import type { NextRequest } from 'next/server';
 import { after, NextResponse } from 'next/server';
 import type { AppMentionEvent, GenericMessageEvent } from '@slack/types';
 import { WebClient } from '@slack/web-api';
+import {
+  cloneRequestWithBody,
+  handleLegacySlackBotWebhookRequest,
+} from '@/lib/bot/webhook-handler';
+import { shouldRouteSlackEventsApiBodyToNewBotInfra } from '@/lib/bot/slack-rollout';
 import { processKiloBotMessage } from '@/lib/slack-bot';
 import { markdownToSlackMrkdwn } from '@/lib/slack/markdownToSlackMrkdwn';
 import { logSlackBotRequest } from '@/lib/slack-bot-logging';
@@ -115,6 +120,10 @@ export async function POST(request: NextRequest) {
   }
 
   const body = JSON.parse(rawBody);
+
+  if (await shouldRouteSlackEventsApiBodyToNewBotInfra(body)) {
+    return handleLegacySlackBotWebhookRequest(cloneRequestWithBody(request, rawBody));
+  }
 
   // Handle Slack URL verification challenge
   // This is required when first setting up the Events API

--- a/apps/web/src/app/slack/webhook/route.ts
+++ b/apps/web/src/app/slack/webhook/route.ts
@@ -6,7 +6,10 @@ import {
   cloneRequestWithBody,
   handleLegacySlackBotWebhookRequest,
 } from '@/lib/bot/webhook-handler';
-import { shouldRouteSlackEventsApiBodyToNewBotInfra } from '@/lib/bot/slack-rollout';
+import {
+  getSlackTeamIdFromEventsApiBody,
+  shouldRouteSlackEventsApiBodyToNewBotInfra,
+} from '@/lib/bot/slack-rollout';
 import { processKiloBotMessage } from '@/lib/slack-bot';
 import { markdownToSlackMrkdwn } from '@/lib/slack/markdownToSlackMrkdwn';
 import { logSlackBotRequest } from '@/lib/slack-bot-logging';
@@ -121,10 +124,6 @@ export async function POST(request: NextRequest) {
 
   const body = JSON.parse(rawBody);
 
-  if (await shouldRouteSlackEventsApiBodyToNewBotInfra(body)) {
-    return handleLegacySlackBotWebhookRequest(cloneRequestWithBody(request, rawBody));
-  }
-
   // Handle Slack URL verification challenge
   // This is required when first setting up the Events API
   if (body.type === 'url_verification') {
@@ -132,10 +131,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ challenge: body.challenge });
   }
 
+  if (await shouldRouteSlackEventsApiBodyToNewBotInfra(body)) {
+    return handleLegacySlackBotWebhookRequest(cloneRequestWithBody(request, rawBody));
+  }
+
   // Handle event callbacks
   if (body.type === 'event_callback') {
     const event = body.event;
-    const teamId = body.team_id as string;
+    const teamId = getSlackTeamIdFromEventsApiBody(body);
     console.log('[SlackBot:Webhook] Event received:', event?.type, 'from team:', teamId);
 
     if (isExternalWorkspaceEvent(event)) {

--- a/apps/web/src/lib/bot.ts
+++ b/apps/web/src/lib/bot.ts
@@ -8,6 +8,98 @@ import { createBotRequest, updateBotRequest } from '@/lib/bot/request-logging';
 import { findUserById } from '@/lib/user';
 import { processMessage } from '@/lib/bot/run';
 import { createChatState } from '@/lib/bot/state';
+import { SLACK_SIGNING_SECRET } from '@/lib/config.server';
+
+function createKiloBot(slackAdapter: ReturnType<typeof createSlackAdapter>) {
+  const chatBot = new Chat({
+    // TODO(remon): Update names before going live
+    userName: process.env.NODE_ENV === 'production' ? 'Pound' : 'Sjors Bot',
+    adapters: {
+      slack: slackAdapter,
+    },
+    state: createChatState(),
+  });
+
+  chatBot.onNewMention(async function handleIncomingMessage(
+    thread: Thread,
+    message: Message
+  ): Promise<void> {
+    const identity = getPlatformIdentity(thread, message);
+    const [platformIntegration, kiloUserId] = await Promise.all([
+      getPlatformIntegration(thread, message),
+      resolveKiloUserId(chatBot.getState(), identity),
+    ]);
+
+    if (!platformIntegration) {
+      captureException(new Error('No active platform integration found'), {
+        extra: { platform: identity.platform, teamId: identity.teamId },
+      });
+      return;
+    }
+
+    if (!kiloUserId) {
+      await promptLinkAccount(thread, message, identity);
+      return;
+    }
+
+    const user = await findUserById(kiloUserId);
+
+    if (!user) {
+      await unlinkKiloUser(chatBot.getState(), identity);
+      await promptLinkAccount(thread, message, identity);
+      return;
+    }
+
+    const platform = thread.id.split(':')[0];
+    const botRequestId = await createBotRequest({
+      createdBy: user.id,
+      organizationId: platformIntegration.owned_by_organization_id ?? null,
+      platformIntegrationId: platformIntegration.id,
+      platform,
+      platformThreadId: thread.id,
+      platformMessageId: message.id,
+      userMessage: message.text,
+      modelUsed: undefined,
+    });
+
+    const received = thread.createSentMessageFromMessage(message);
+    await received.addReaction(emoji.eyes);
+
+    await chatBot.registerSingleton();
+
+    try {
+      await processMessage({ thread, message, platformIntegration, user, botRequestId });
+    } catch (error) {
+      console.error('[Bot] Unhandled error in message handler:', error);
+      if (botRequestId) {
+        const errMsg = error instanceof Error ? error.message : String(error);
+        updateBotRequest(botRequestId, {
+          status: 'error',
+          errorMessage: errMsg.slice(0, 2000),
+        });
+      }
+      await thread.post({ markdown: 'Sorry, something went wrong while processing your message.' });
+    }
+  });
+
+  // When the user clicks the "Link Account" LinkButton, Slack fires a
+  // block_actions event *in addition to* opening the URL in the browser.
+  // For ephemeral messages the adapter encodes the response_url into the
+  // messageId, so deleteMessage sends `{ delete_original: true }` — removing
+  // the ephemeral card from the user's view.
+  chatBot.onAction(async function handleLinkAccountClick(event: ActionEvent): Promise<void> {
+    if (!event.actionId.startsWith(LINK_ACCOUNT_ACTION_PREFIX)) return;
+
+    try {
+      await event.adapter.deleteMessage(event.threadId, event.messageId);
+    } catch (error) {
+      // Not critical — the ephemeral message will disappear on its own eventually
+      console.warn('[Bot] Failed to delete link-account ephemeral:', error);
+    }
+  });
+
+  return chatBot;
+}
 
 const slackAdapter = createSlackAdapter({
   clientId: process.env.SLACK_NEXT_CLIENT_ID,
@@ -15,89 +107,9 @@ const slackAdapter = createSlackAdapter({
   signingSecret: process.env.SLACK_NEXT_SIGNING_SECRET,
 });
 
-export const bot = new Chat({
-  // TODO(remon): Update names before going live
-  userName: process.env.NODE_ENV === 'production' ? 'Pound' : 'Sjors Bot',
-  adapters: {
-    slack: slackAdapter,
-  },
-  state: createChatState(),
+const legacySlackAdapter = createSlackAdapter({
+  signingSecret: SLACK_SIGNING_SECRET,
 });
 
-bot.onNewMention(async function handleIncomingMessage(
-  thread: Thread,
-  message: Message
-): Promise<void> {
-  const identity = getPlatformIdentity(thread, message);
-  const [platformIntegration, kiloUserId] = await Promise.all([
-    getPlatformIntegration(thread, message),
-    resolveKiloUserId(bot.getState(), identity),
-  ]);
-
-  if (!platformIntegration) {
-    captureException(new Error('No active platform integration found'), {
-      extra: { platform: identity.platform, teamId: identity.teamId },
-    });
-    return;
-  }
-
-  if (!kiloUserId) {
-    await promptLinkAccount(thread, message, identity);
-    return;
-  }
-
-  const user = await findUserById(kiloUserId);
-
-  if (!user) {
-    await unlinkKiloUser(bot.getState(), identity);
-    await promptLinkAccount(thread, message, identity);
-    return;
-  }
-
-  const platform = thread.id.split(':')[0];
-  const botRequestId = await createBotRequest({
-    createdBy: user.id,
-    organizationId: platformIntegration.owned_by_organization_id ?? null,
-    platformIntegrationId: platformIntegration.id,
-    platform,
-    platformThreadId: thread.id,
-    platformMessageId: message.id,
-    userMessage: message.text,
-    modelUsed: undefined,
-  });
-
-  const received = thread.createSentMessageFromMessage(message);
-  await received.addReaction(emoji.eyes);
-
-  await bot.registerSingleton();
-
-  try {
-    await processMessage({ thread, message, platformIntegration, user, botRequestId });
-  } catch (error) {
-    console.error('[Bot] Unhandled error in message handler:', error);
-    if (botRequestId) {
-      const errMsg = error instanceof Error ? error.message : String(error);
-      updateBotRequest(botRequestId, {
-        status: 'error',
-        errorMessage: errMsg.slice(0, 2000),
-      });
-    }
-    await thread.post({ markdown: 'Sorry, something went wrong while processing your message.' });
-  }
-});
-
-// When the user clicks the "Link Account" LinkButton, Slack fires a
-// block_actions event *in addition to* opening the URL in the browser.
-// For ephemeral messages the adapter encodes the response_url into the
-// messageId, so deleteMessage sends `{ delete_original: true }` — removing
-// the ephemeral card from the user's view.
-bot.onAction(async function handleLinkAccountClick(event: ActionEvent): Promise<void> {
-  if (!event.actionId.startsWith(LINK_ACCOUNT_ACTION_PREFIX)) return;
-
-  try {
-    await event.adapter.deleteMessage(event.threadId, event.messageId);
-  } catch (error) {
-    // Not critical — the ephemeral message will disappear on its own eventually
-    console.warn('[Bot] Failed to delete link-account ephemeral:', error);
-  }
-});
+export const bot = createKiloBot(slackAdapter);
+export const legacySlackBot = createKiloBot(legacySlackAdapter);

--- a/apps/web/src/lib/bot/platform-helpers.ts
+++ b/apps/web/src/lib/bot/platform-helpers.ts
@@ -1,6 +1,7 @@
 import type { PlatformIdentity } from '@/lib/bot-identity';
+import { isSlackBotNewInfraIntegrationIdAllowed } from '@/lib/bot/slack-rollout';
 import { db } from '@/lib/drizzle';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import { type SlackEvent } from '@chat-adapter/slack';
 import { platform_integrations } from '@kilocode/db';
@@ -29,19 +30,25 @@ export function getPlatformIdentity(thread: Thread, message: Message): PlatformI
   }
 }
 
-async function getSlackNextInstallation(teamId: string) {
-  const [integration] = await db
+async function getSlackPlatformIntegration(teamId: string) {
+  const integrations = await db
     .select()
     .from(platform_integrations)
     .where(
       and(
-        eq(platform_integrations.platform, PLATFORM.SLACK_NEXT),
+        inArray(platform_integrations.platform, [PLATFORM.SLACK_NEXT, PLATFORM.SLACK]),
         eq(platform_integrations.platform_installation_id, teamId)
       )
-    )
-    .limit(1);
+    );
 
-  return integration;
+  const legacyIntegration = integrations.find(
+    integration =>
+      integration.platform === PLATFORM.SLACK &&
+      isSlackBotNewInfraIntegrationIdAllowed(integration.id)
+  );
+  if (legacyIntegration) return legacyIntegration;
+
+  return integrations.find(integration => integration.platform === PLATFORM.SLACK_NEXT) ?? null;
 }
 
 export async function getPlatformIntegration(thread: Thread, message: Message) {
@@ -49,7 +56,7 @@ export async function getPlatformIntegration(thread: Thread, message: Message) {
 
   switch (platform) {
     case 'slack':
-      return await getSlackNextInstallation(getSlackTeamId(message as Message<SlackEvent>));
+      return await getSlackPlatformIntegration(getSlackTeamId(message as Message<SlackEvent>));
     default:
       throw new Error(`PlatformNotSupported: ${platform}`);
   }

--- a/apps/web/src/lib/bot/slack-installation-sync.ts
+++ b/apps/web/src/lib/bot/slack-installation-sync.ts
@@ -2,6 +2,7 @@ import 'server-only';
 import { Chat } from 'chat';
 import { createSlackAdapter } from '@chat-adapter/slack';
 import type { OAuthV2Response } from '@slack/oauth';
+import type { PlatformIntegration } from '@kilocode/db/schema';
 import { SLACK_SIGNING_SECRET } from '@/lib/config.server';
 import { createChatState } from './state';
 import { extractSdkInstallationData } from './slack-installation-sync-mapping';
@@ -21,13 +22,59 @@ const syncBot = new Chat({
   state: createChatState(),
 });
 
-export async function syncOldSlackInstallationToSdk(oauthResponse: OAuthV2Response): Promise<void> {
-  const data = extractSdkInstallationData(oauthResponse);
+type SlackInstallationMetadata = {
+  accessToken?: string;
+  botUserId?: string;
+};
+
+function getSlackInstallationMetadata(value: unknown): SlackInstallationMetadata {
+  if (typeof value !== 'object' || value === null) return {};
+
+  const accessToken = 'access_token' in value ? value.access_token : undefined;
+  const botUserId = 'bot_user_id' in value ? value.bot_user_id : undefined;
+
+  return {
+    accessToken: typeof accessToken === 'string' ? accessToken : undefined,
+    botUserId: typeof botUserId === 'string' ? botUserId : undefined,
+  };
+}
+
+async function syncSdkInstallation(params: {
+  teamId: string;
+  botToken: string;
+  botUserId?: string;
+  teamName?: string;
+}): Promise<void> {
   await syncBot.initialize();
   const adapter = syncBot.getAdapter('slack');
-  await adapter.setInstallation(data.teamId, {
-    botToken: data.botToken,
-    botUserId: data.botUserId,
-    teamName: data.teamName,
+  await adapter.setInstallation(params.teamId, {
+    botToken: params.botToken,
+    botUserId: params.botUserId,
+    teamName: params.teamName,
   });
+}
+
+export async function syncOldSlackInstallationToSdk(oauthResponse: OAuthV2Response): Promise<void> {
+  const data = extractSdkInstallationData(oauthResponse);
+  await syncSdkInstallation(data);
+}
+
+export async function syncSlackPlatformIntegrationToSdk(
+  integration: PlatformIntegration
+): Promise<boolean> {
+  const teamId = integration.platform_installation_id;
+  const metadata = getSlackInstallationMetadata(integration.metadata);
+
+  if (!teamId || !metadata.accessToken) {
+    return false;
+  }
+
+  await syncSdkInstallation({
+    teamId,
+    botToken: metadata.accessToken,
+    botUserId: metadata.botUserId,
+    teamName: integration.platform_account_login ?? undefined,
+  });
+
+  return true;
 }

--- a/apps/web/src/lib/bot/slack-rollout.test.ts
+++ b/apps/web/src/lib/bot/slack-rollout.test.ts
@@ -1,0 +1,26 @@
+import {
+  getSlackTeamIdFromEventsApiBody,
+  getSlackTeamIdFromInteractivityRawBody,
+  parseSlackBotNewInfraIntegrationIds,
+} from './slack-rollout';
+
+describe('Slack bot rollout routing helpers', () => {
+  it('parses comma-separated integration IDs with trimming and de-duping', () => {
+    expect(parseSlackBotNewInfraIntegrationIds(' id-1, id-2 ,, id-1 ')).toEqual(['id-1', 'id-2']);
+  });
+
+  it('extracts team IDs from Events API envelopes', () => {
+    expect(getSlackTeamIdFromEventsApiBody({ team_id: 'T123' })).toBe('T123');
+    expect(getSlackTeamIdFromEventsApiBody({ event: { team: 'T456' } })).toBe('T456');
+    expect(getSlackTeamIdFromEventsApiBody({ event: {} })).toBeNull();
+  });
+
+  it('extracts team IDs from interactivity payloads', () => {
+    const rawBody = new URLSearchParams({
+      payload: JSON.stringify({ team: { id: 'T789' } }),
+    }).toString();
+
+    expect(getSlackTeamIdFromInteractivityRawBody(rawBody)).toBe('T789');
+    expect(getSlackTeamIdFromInteractivityRawBody('payload=not-json')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/bot/slack-rollout.test.ts
+++ b/apps/web/src/lib/bot/slack-rollout.test.ts
@@ -11,8 +11,12 @@ describe('Slack bot rollout routing helpers', () => {
 
   it('extracts team IDs from Events API envelopes', () => {
     expect(getSlackTeamIdFromEventsApiBody({ team_id: 'T123' })).toBe('T123');
-    expect(getSlackTeamIdFromEventsApiBody({ event: { team: 'T456' } })).toBe('T456');
-    expect(getSlackTeamIdFromEventsApiBody({ event: {} })).toBeNull();
+    expect(() => getSlackTeamIdFromEventsApiBody({ event: { team: 'T456' } })).toThrow(
+      'Expected Slack Events API body.team_id'
+    );
+    expect(() => getSlackTeamIdFromEventsApiBody({ event: {} })).toThrow(
+      'Expected Slack Events API body.team_id'
+    );
   });
 
   it('extracts team IDs from interactivity payloads', () => {
@@ -21,6 +25,11 @@ describe('Slack bot rollout routing helpers', () => {
     }).toString();
 
     expect(getSlackTeamIdFromInteractivityRawBody(rawBody)).toBe('T789');
-    expect(getSlackTeamIdFromInteractivityRawBody('payload=not-json')).toBeNull();
+    expect(() => getSlackTeamIdFromInteractivityRawBody('payload=not-json')).toThrow();
+    expect(() =>
+      getSlackTeamIdFromInteractivityRawBody(
+        new URLSearchParams({ payload: JSON.stringify({ team_id: 'T999' }) }).toString()
+      )
+    ).toThrow('Expected Slack interactivity payload.team');
   });
 });

--- a/apps/web/src/lib/bot/slack-rollout.ts
+++ b/apps/web/src/lib/bot/slack-rollout.ts
@@ -36,8 +36,6 @@ export function parseSlackBotNewInfraIntegrationIds(value: string | undefined): 
 export function getSlackBotNewInfraIntegrationIds(): string[] {
   const ids = parseSlackBotNewInfraIntegrationIds(process.env[ROUTED_INTEGRATION_IDS_ENV]);
 
-  console.info(ids);
-
   if (ids.length > MAX_ROUTED_INTEGRATIONS) {
     console.error(
       `[SlackBot:Routing] ${ROUTED_INTEGRATION_IDS_ENV} contains ${ids.length} IDs; refusing to route more than ${MAX_ROUTED_INTEGRATIONS} integrations to the new bot infra`
@@ -70,7 +68,6 @@ export function getSlackTeamIdFromInteractivityRawBody(rawBody: string): string 
 export async function findSlackIntegrationRoutedToNewInfra(teamId: string) {
   const allowedIntegrationIds = getSlackBotNewInfraIntegrationIds();
 
-  console.info(allowedIntegrationIds);
   if (allowedIntegrationIds.length === 0) return null;
 
   const [integration] = await db

--- a/apps/web/src/lib/bot/slack-rollout.ts
+++ b/apps/web/src/lib/bot/slack-rollout.ts
@@ -1,0 +1,138 @@
+import 'server-only';
+import { db } from '@/lib/drizzle';
+import { PLATFORM } from '@/lib/integrations/core/constants';
+import { platform_integrations } from '@kilocode/db/schema';
+import { and, eq, inArray } from 'drizzle-orm';
+
+const ROUTED_INTEGRATION_IDS_ENV = 'SLACK_BOT_NEW_INFRA_PLATFORM_INTEGRATION_IDS';
+const MAX_ROUTED_INTEGRATIONS = 2;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+export function parseSlackBotNewInfraIntegrationIds(value: string | undefined): string[] {
+  if (!value) return [];
+
+  const ids = new Set<string>();
+  for (const id of value.split(',')) {
+    const trimmed = id.trim();
+    if (trimmed) ids.add(trimmed);
+  }
+
+  return Array.from(ids);
+}
+
+export function getSlackBotNewInfraIntegrationIds(): string[] {
+  const ids = parseSlackBotNewInfraIntegrationIds(process.env[ROUTED_INTEGRATION_IDS_ENV]);
+
+  console.info(ids);
+
+  if (ids.length > MAX_ROUTED_INTEGRATIONS) {
+    console.error(
+      `[SlackBot:Routing] ${ROUTED_INTEGRATION_IDS_ENV} contains ${ids.length} IDs; refusing to route more than ${MAX_ROUTED_INTEGRATIONS} integrations to the new bot infra`
+    );
+    return [];
+  }
+
+  return ids;
+}
+
+export function isSlackBotNewInfraIntegrationIdAllowed(integrationId: string): boolean {
+  return getSlackBotNewInfraIntegrationIds().includes(integrationId);
+}
+
+export function getSlackTeamIdFromEventsApiBody(body: unknown): string | null {
+  if (!isRecord(body)) return null;
+
+  const topLevelTeamId = getString(body.team_id);
+  if (topLevelTeamId) return topLevelTeamId;
+
+  const event = body.event;
+  if (!isRecord(event)) return null;
+
+  return getString(event.team);
+}
+
+export function getSlackTeamIdFromInteractivityRawBody(rawBody: string): string | null {
+  const payload = new URLSearchParams(rawBody).get('payload');
+  if (!payload) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(payload);
+    if (!isRecord(parsed)) return null;
+
+    const team = parsed.team;
+    if (isRecord(team)) {
+      const teamId = getString(team.id);
+      if (teamId) return teamId;
+    }
+
+    return getString(parsed.team_id);
+  } catch {
+    return null;
+  }
+}
+
+export async function findSlackIntegrationRoutedToNewInfra(teamId: string) {
+  const allowedIntegrationIds = getSlackBotNewInfraIntegrationIds();
+
+  console.info(allowedIntegrationIds);
+  if (allowedIntegrationIds.length === 0) return null;
+
+  const [integration] = await db
+    .select()
+    .from(platform_integrations)
+    .where(
+      and(
+        eq(platform_integrations.platform, PLATFORM.SLACK),
+        eq(platform_integrations.platform_installation_id, teamId),
+        inArray(platform_integrations.id, allowedIntegrationIds)
+      )
+    )
+    .limit(1);
+
+  if (!integration) {
+    return null;
+  }
+
+  try {
+    const { syncSlackPlatformIntegrationToSdk } = await import('@/lib/bot/slack-installation-sync');
+    const synced = await syncSlackPlatformIntegrationToSdk(integration);
+    if (synced) return integration;
+
+    console.error(
+      '[SlackBot:Routing] Refusing to route integration to new bot infra because the SDK installation could not be synced',
+      { integrationId: integration.id, teamId }
+    );
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error('[SlackBot:Routing] Failed to sync SDK installation for new bot infra routing', {
+      errorMessage,
+      integrationId: integration.id,
+      teamId,
+    });
+  }
+
+  return null;
+}
+
+export async function shouldRouteSlackEventsApiBodyToNewBotInfra(body: unknown): Promise<boolean> {
+  const teamId = getSlackTeamIdFromEventsApiBody(body);
+  if (!teamId) return false;
+
+  return Boolean(await findSlackIntegrationRoutedToNewInfra(teamId));
+}
+
+export async function shouldRouteSlackInteractivityToNewBotInfra(
+  rawBody: string
+): Promise<boolean> {
+  const teamId = getSlackTeamIdFromInteractivityRawBody(rawBody);
+  if (!teamId) return false;
+
+  return Boolean(await findSlackIntegrationRoutedToNewInfra(teamId));
+}

--- a/apps/web/src/lib/bot/slack-rollout.ts
+++ b/apps/web/src/lib/bot/slack-rollout.ts
@@ -11,8 +11,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-function getString(value: unknown): string | null {
-  return typeof value === 'string' && value.length > 0 ? value : null;
+function requireRecord(value: unknown, description: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`Expected ${description}`);
+  return value;
+}
+
+function requireString(value: unknown, description: string): string {
+  if (typeof value === 'string' && value.length > 0) return value;
+  throw new Error(`Expected ${description}`);
 }
 
 export function parseSlackBotNewInfraIntegrationIds(value: string | undefined): string[] {
@@ -46,36 +52,19 @@ export function isSlackBotNewInfraIntegrationIdAllowed(integrationId: string): b
   return getSlackBotNewInfraIntegrationIds().includes(integrationId);
 }
 
-export function getSlackTeamIdFromEventsApiBody(body: unknown): string | null {
-  if (!isRecord(body)) return null;
-
-  const topLevelTeamId = getString(body.team_id);
-  if (topLevelTeamId) return topLevelTeamId;
-
-  const event = body.event;
-  if (!isRecord(event)) return null;
-
-  return getString(event.team);
+export function getSlackTeamIdFromEventsApiBody(body: unknown): string {
+  const parsedBody = requireRecord(body, 'Slack Events API body');
+  return requireString(parsedBody.team_id, 'Slack Events API body.team_id');
 }
 
-export function getSlackTeamIdFromInteractivityRawBody(rawBody: string): string | null {
+export function getSlackTeamIdFromInteractivityRawBody(rawBody: string): string {
   const payload = new URLSearchParams(rawBody).get('payload');
-  if (!payload) return null;
+  if (!payload) throw new Error('Expected Slack interactivity payload');
 
-  try {
-    const parsed: unknown = JSON.parse(payload);
-    if (!isRecord(parsed)) return null;
-
-    const team = parsed.team;
-    if (isRecord(team)) {
-      const teamId = getString(team.id);
-      if (teamId) return teamId;
-    }
-
-    return getString(parsed.team_id);
-  } catch {
-    return null;
-  }
+  const parsed: unknown = JSON.parse(payload);
+  const parsedPayload = requireRecord(parsed, 'Slack interactivity payload');
+  const team = requireRecord(parsedPayload.team, 'Slack interactivity payload.team');
+  return requireString(team.id, 'Slack interactivity payload.team.id');
 }
 
 export async function findSlackIntegrationRoutedToNewInfra(teamId: string) {
@@ -123,8 +112,6 @@ export async function findSlackIntegrationRoutedToNewInfra(teamId: string) {
 
 export async function shouldRouteSlackEventsApiBodyToNewBotInfra(body: unknown): Promise<boolean> {
   const teamId = getSlackTeamIdFromEventsApiBody(body);
-  if (!teamId) return false;
-
   return Boolean(await findSlackIntegrationRoutedToNewInfra(teamId));
 }
 
@@ -132,7 +119,5 @@ export async function shouldRouteSlackInteractivityToNewBotInfra(
   rawBody: string
 ): Promise<boolean> {
   const teamId = getSlackTeamIdFromInteractivityRawBody(rawBody);
-  if (!teamId) return false;
-
   return Boolean(await findSlackIntegrationRoutedToNewInfra(teamId));
 }

--- a/apps/web/src/lib/bot/state.ts
+++ b/apps/web/src/lib/bot/state.ts
@@ -2,9 +2,6 @@ import { createRedisState } from '@chat-adapter/state-redis';
 import { createMemoryState } from '@chat-adapter/state-memory';
 import type { StateAdapter } from 'chat';
 
-let chatState: StateAdapter | undefined;
-
 export function createChatState(): StateAdapter {
-  chatState ??= process.env.REDIS_URL ? createRedisState() : createMemoryState();
-  return chatState;
+  return process.env.REDIS_URL ? createRedisState() : createMemoryState();
 }

--- a/apps/web/src/lib/bot/state.ts
+++ b/apps/web/src/lib/bot/state.ts
@@ -2,6 +2,9 @@ import { createRedisState } from '@chat-adapter/state-redis';
 import { createMemoryState } from '@chat-adapter/state-memory';
 import type { StateAdapter } from 'chat';
 
+let chatState: StateAdapter | undefined;
+
 export function createChatState(): StateAdapter {
-  return process.env.REDIS_URL ? createRedisState() : createMemoryState();
+  chatState ??= process.env.REDIS_URL ? createRedisState() : createMemoryState();
+  return chatState;
 }

--- a/apps/web/src/lib/bot/webhook-handler.ts
+++ b/apps/web/src/lib/bot/webhook-handler.ts
@@ -1,0 +1,39 @@
+import 'server-only';
+import { after } from 'next/server';
+import { bot, legacySlackBot } from '@/lib/bot';
+
+type Platform = keyof typeof bot.webhooks;
+
+export function cloneRequestWithBody(request: Request, body: BodyInit): Request {
+  return new Request(request.url, {
+    method: request.method,
+    headers: request.headers,
+    body,
+  });
+}
+
+function handleWebhook(
+  chatBot: typeof bot,
+  platform: string,
+  request: Request
+): Response | Promise<Response> {
+  const handler = chatBot.webhooks[platform as Platform];
+  if (!handler) {
+    return new Response('Unknown platform', { status: 404 });
+  }
+
+  return handler(request, {
+    waitUntil: task => after(() => task),
+  });
+}
+
+export function handleBotWebhookRequest(
+  platform: string,
+  request: Request
+): Response | Promise<Response> {
+  return handleWebhook(bot, platform, request);
+}
+
+export function handleLegacySlackBotWebhookRequest(request: Request): Response | Promise<Response> {
+  return handleWebhook(legacySlackBot, 'slack', request);
+}


### PR DESCRIPTION
## Summary
- Adds a two-integration allowlist for routing legacy Slack webhook and interactivity traffic into the new Chat SDK bot infrastructure.
- Reuses legacy Slack installation credentials and signing verification while syncing allowed installations into Chat SDK state before routing.
- Centralizes bot webhook handling so legacy and new Slack endpoints share the new bot execution path safely during canary testing.

## Verification
N/A - backend-only webhook routing change.

## Visual Changes
N/A

## Reviewer Notes
- Canary rollout is controlled by `SLACK_BOT_NEW_INFRA_PLATFORM_INTEGRATION_IDS`; if more than two IDs are configured, routing fails closed to the legacy infra.
- Allowed legacy Slack integrations are selected by `platform_integrations.id`, not just Slack team ID, to avoid accidentally migrating duplicate team installs.