### PR TITLE
chore(kiloclaw-billing): sync wrangler trial inactivity config

### DIFF
--- a/services/kiloclaw-billing/wrangler.jsonc
+++ b/services/kiloclaw-billing/wrangler.jsonc
@@ -6,6 +6,7 @@
   "compatibility_date": "2026-04-07",
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": false,
+  "preview_urls": false,
   "logpush": true,
   "dev": {
     "port": 8807,
@@ -23,6 +24,15 @@
   },
   "vars": {
     "KILOCODE_BACKEND_BASE_URL": "https://app.kilo.ai",
+    "TRIAL_INACTIVITY_STOP_ENABLED": "true",
+    "TRIAL_INACTIVITY_STOP_DRY_RUN": "false",
+    "SNOWFLAKE_ACCOUNT_HOST": "fyc17898.us-east-1.snowflakecomputing.com",
+    "SNOWFLAKE_JWT_ACCOUNT_IDENTIFIER": "FYC17898",
+    "SNOWFLAKE_USERNAME": "KILOCODE_USER",
+    "SNOWFLAKE_ROLE": "KILOCODE_ROLE",
+    "SNOWFLAKE_WAREHOUSE": "WH_KILOCODE",
+    "SNOWFLAKE_DATABASE": "KILO_DW",
+    "SNOWFLAKE_SCHEMA": "DBT_PROD",
   },
   "hyperdrive": [
     {
@@ -65,6 +75,7 @@
     {
       "binding": "KILOCLAW",
       "service": "kiloclaw",
+      "environment": "production",
     },
   ],
   // Secrets:
@@ -73,4 +84,6 @@
   // - STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID: canonical Stripe intro price ID shared with standard-plan reporting
   // - INTERNAL_API_SECRET: auth for the Next.js billing side-effect endpoint
   // - KILOCLAW_INTERNAL_API_SECRET: auth for /api/platform/* on the kiloclaw worker
+  // - SNOWFLAKE_PRIVATE_KEY_PEM: Snowflake JWT private key in raw PEM format
+  // - SNOWFLAKE_PUBLIC_KEY_FINGERPRINT: Snowflake JWT public key fingerprint
 }


### PR DESCRIPTION
## Summary
Keeps the KiloClaw billing worker's Wrangler config aligned with the production trial inactivity rollout settings.

### Why this change is needed
The production worker had already been updated through dashboard and deploy-time configuration changes for the trial inactivity rollout. Leaving `wrangler.jsonc` behind meant future deploys would keep warning about config drift and could overwrite the live Snowflake vars, queue bindings, or service binding behavior.

### How this is addressed
- Adds the production trial inactivity rollout vars and Snowflake plaintext vars to `wrangler.jsonc` so deploys manage them from code.
- Pins the `KILOCLAW` service binding to the production environment and disables preview URLs to match the current deployed worker configuration.
- Documents the Snowflake private key and fingerprint secrets alongside the existing billing worker secrets.

## Human Verification
- Reviewed the live `kiloclaw-billing` worker bindings, queues, secrets, and vars with Wrangler before updating the checked-in config.
- Ran `node ../../node_modules/.pnpm/node_modules/wrangler/wrangler-dist/cli.js deploy --dry-run` from `services/kiloclaw-billing` and confirmed the expected queue bindings and trial inactivity/Snowflake vars.
- _Additional verification (to be completed by author)_

## Visual Changes
N/A

## Reviewer Notes
### Human Reviewer
- Review the single `services/kiloclaw-billing/wrangler.jsonc` diff.
- This change only updates deployment configuration. It does not change billing worker runtime logic.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Aligns `services/kiloclaw-billing/wrangler.jsonc` with the production worker state that was previously managed through dashboard edits and deploy-time vars.
- Preserves the production `KILOCLAW` service binding environment and adds the Snowflake/trial inactivity plaintext vars so future deploys stop warning about overwriting them.
- Keeps Snowflake key material split correctly: account/database/schema/user/role/warehouse stay in `vars`, while the PEM key and fingerprint remain secrets.

</details>
