### PR TITLE
chore(kiloclaw): rename OpenClaw Security Advisor → ShellSecurity in …

### DIFF
--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -1019,6 +1019,12 @@ describe('TOOLS.md section configs', () => {
     // it), but a duplicate top-level bullet would mean the agent sees it
     // twice in workspace context.
     expect(section).not.toContain('- **`gateway.control_ui.insecure_auth`**');
+    // Plugin is ShellSecurity as of the rename from
+    // @kilocode/openclaw-security-advisor → @kilocode/shell-security.
+    // Pin the new name so a drive-by edit can't silently regress to the
+    // old "OpenClaw Security Advisor" copy.
+    expect(section).toContain('ShellSecurity plugin bundled with KiloClaw');
+    expect(section).not.toContain('OpenClaw Security Advisor');
   });
 
   it('Plugin Install: references the CLI command and plugins.allow field', () => {

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -790,7 +790,7 @@ You can interact with the \`Linear\` MCP server using your \`mcporter\` skill.
 
 // Additional KiloClaw-mitigated OpenClaw audit findings beyond the
 // gateway.control_ui.insecure_auth one already documented in the base
-// TOOLS.md. Mirrors the list in apps/web/src/lib/security-advisor/
+// TOOLS.md. Mirrors the list in apps/web/src/lib/shell-security/
 // kiloclaw-mitigations.ts — the server-side /security-checkup path
 // suppresses these before grading, but when a user runs `openclaw doctor`
 // directly the findings still show and the agent needs the same context
@@ -816,7 +816,7 @@ When running \`openclaw doctor\` or \`openclaw security audit\`, the following f
 
 1. Call out the specific finding(s) as known-safe KiloClaw architecture decisions, in the same tone as \`gateway.control_ui.insecure_auth\` above.
 2. Explain WHY each is safe using the per-finding rationale above.
-3. Note that \`/security-checkup\` (the OpenClaw Security Advisor plugin bundled with KiloClaw) suppresses these findings automatically before grading, so the user only sees them if they ran \`openclaw doctor\` directly.
+3. Note that \`/security-checkup\` (the ShellSecurity plugin bundled with KiloClaw) suppresses these findings automatically before grading, so the user only sees them if they ran \`openclaw doctor\` directly.
 <!-- END:kiloclaw-mitigations -->`,
 };
 


### PR DESCRIPTION


## Summary
- Our openclaw-security-advisor OpenClaw plugin changed names
- Backfill and update the various markdown docs in the image with new name

## Verification

<!-- Only list manually tested paths, not automated tests. If you didn't run any manual tests, point that out, and explain why. -->

- [x] Linters
- [x] Deployed and tested with a dev image

## Visual Changes

N/A

## Reviewer Notes
- This is purely just name updates in markdown docs. No functional changes.