### PR TITLE
fix(slack): clean up Chat SDK on disconnect

### DIFF
--- a/apps/web/src/lib/bot-identity.ts
+++ b/apps/web/src/lib/bot-identity.ts
@@ -4,6 +4,23 @@ import type { StateAdapter } from 'chat';
 import { NEXTAUTH_SECRET } from '@/lib/config.server';
 import { botIdentityRedisKey } from '@/lib/redis-keys';
 
+const CHAT_SDK_CACHE_KEY_PREFIX = 'chat-sdk:cache:';
+const REDIS_SCAN_BATCH_SIZE = 100;
+const REDIS_DELETE_BATCH_SIZE = 100;
+
+type RedisScanClient = {
+  scanIterator(options: { MATCH: string; COUNT: number }): AsyncIterable<string | string[]>;
+  del(keys: string[]): Promise<unknown>;
+};
+
+type StateAdapterWithRedisClient = StateAdapter & {
+  getClient(): RedisScanClient;
+};
+
+function hasRedisClient(state: StateAdapter): state is StateAdapterWithRedisClient {
+  return 'getClient' in state && typeof state.getClient === 'function';
+}
+
 /**
  * Platform identity coordinates — the minimum info needed to identify
  * a user on any chat platform (Slack, Discord, Teams, Google Chat, etc.).
@@ -50,6 +67,48 @@ export async function unlinkKiloUser(
 ): Promise<void> {
   const { platform, teamId, userId } = identity;
   await state.delete(botIdentityRedisKey(platform, teamId, userId));
+}
+
+export async function unlinkTeamKiloUsers(
+  state: StateAdapter,
+  platform: string,
+  teamId: string
+): Promise<number> {
+  if (!hasRedisClient(state)) {
+    return 0;
+  }
+
+  const client = state.getClient();
+  const pattern = `${CHAT_SDK_CACHE_KEY_PREFIX}${botIdentityRedisKey(platform, teamId, '*')}`;
+  let pendingKeys: string[] = [];
+  let deletedKeys = 0;
+
+  async function deletePendingKeys(): Promise<void> {
+    if (pendingKeys.length === 0) return;
+
+    const keysToDelete = pendingKeys;
+    pendingKeys = [];
+    deletedKeys += keysToDelete.length;
+    await client.del(keysToDelete);
+  }
+
+  for await (const scannedKeys of client.scanIterator({
+    MATCH: pattern,
+    COUNT: REDIS_SCAN_BATCH_SIZE,
+  })) {
+    if (Array.isArray(scannedKeys)) {
+      pendingKeys.push(...scannedKeys);
+    } else {
+      pendingKeys.push(scannedKeys);
+    }
+
+    if (pendingKeys.length >= REDIS_DELETE_BATCH_SIZE) {
+      await deletePendingKeys();
+    }
+  }
+
+  await deletePendingKeys();
+  return deletedKeys;
 }
 
 // -- HMAC-signed link tokens --------------------------------------------------

--- a/apps/web/src/lib/integrations/slack-service.test.ts
+++ b/apps/web/src/lib/integrations/slack-service.test.ts
@@ -1,0 +1,95 @@
+process.env.NEXTAUTH_SECRET ||= 'test-nextauth-secret';
+process.env.TURNSTILE_SECRET_KEY ||= 'test-turnstile-secret';
+
+const mockLimit = jest.fn();
+const mockDeleteWhere = jest.fn();
+const mockAuthRevoke = jest.fn();
+
+jest.mock('@/lib/drizzle', () => ({
+  db: {
+    select: jest.fn(() => ({
+      from: jest.fn(() => ({
+        where: jest.fn(() => ({
+          limit: mockLimit,
+        })),
+      })),
+    })),
+    delete: jest.fn(() => ({
+      where: mockDeleteWhere,
+    })),
+  },
+}));
+
+jest.mock('@slack/web-api', () => ({
+  WebClient: jest.fn(() => ({
+    auth: {
+      revoke: mockAuthRevoke,
+    },
+  })),
+}));
+
+import type { Owner } from '@/lib/integrations/core/types';
+import { uninstallApp } from './slack-service';
+
+const owner = { type: 'user', id: 'user-1' } satisfies Owner;
+
+function buildSlackIntegration(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'integration-1',
+    integration_status: 'active',
+    metadata: { access_token: 'xoxb-token' },
+    platform_installation_id: 'T123',
+    platform_account_id: 'T123',
+    ...overrides,
+  };
+}
+
+describe('slack-service uninstallApp', () => {
+  beforeEach(() => {
+    mockLimit.mockReset();
+    mockDeleteWhere.mockReset();
+    mockAuthRevoke.mockReset();
+    mockAuthRevoke.mockResolvedValue({ ok: true });
+    mockDeleteWhere.mockResolvedValue(undefined);
+  });
+
+  it('deletes the Chat SDK Slack installation before removing the platform integration row', async () => {
+    mockLimit.mockResolvedValue([buildSlackIntegration()]);
+    const deleteChatSdkInstallation = jest.fn(async (_teamId: string): Promise<void> => {});
+
+    await expect(uninstallApp(owner, { deleteChatSdkInstallation })).resolves.toEqual({
+      success: true,
+    });
+
+    expect(deleteChatSdkInstallation).toHaveBeenCalledWith('T123');
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+    expect(deleteChatSdkInstallation.mock.invocationCallOrder[0]).toBeLessThan(
+      mockDeleteWhere.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('does not remove the platform integration row when Chat SDK cleanup fails', async () => {
+    mockLimit.mockResolvedValue([buildSlackIntegration()]);
+    const deleteChatSdkInstallation = jest.fn(async (_teamId: string): Promise<void> => {
+      throw new Error('redis unavailable');
+    });
+
+    await expect(uninstallApp(owner, { deleteChatSdkInstallation })).rejects.toThrow(
+      'redis unavailable'
+    );
+
+    expect(mockDeleteWhere).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the platform account ID for older rows without an installation ID', async () => {
+    mockLimit.mockResolvedValue([
+      buildSlackIntegration({ platform_installation_id: null, platform_account_id: 'T456' }),
+    ]);
+    const deleteChatSdkInstallation = jest.fn(async (_teamId: string): Promise<void> => {});
+
+    await uninstallApp(owner, { deleteChatSdkInstallation });
+
+    expect(deleteChatSdkInstallation).toHaveBeenCalledWith('T456');
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/integrations/slack-service.test.ts
+++ b/apps/web/src/lib/integrations/slack-service.test.ts
@@ -53,22 +53,29 @@ describe('slack-service uninstallApp', () => {
     mockDeleteWhere.mockResolvedValue(undefined);
   });
 
-  it('deletes the Chat SDK Slack installation before removing the platform integration row', async () => {
+  it('deletes Chat SDK Slack state before removing the platform integration row', async () => {
     mockLimit.mockResolvedValue([buildSlackIntegration()]);
     const deleteChatSdkInstallation = jest.fn(async (_teamId: string): Promise<void> => {});
+    const deleteChatSdkIdentityCache = jest.fn(async (_teamId: string): Promise<void> => {});
 
-    await expect(uninstallApp(owner, { deleteChatSdkInstallation })).resolves.toEqual({
+    await expect(
+      uninstallApp(owner, { deleteChatSdkInstallation, deleteChatSdkIdentityCache })
+    ).resolves.toEqual({
       success: true,
     });
 
     expect(deleteChatSdkInstallation).toHaveBeenCalledWith('T123');
+    expect(deleteChatSdkIdentityCache).toHaveBeenCalledWith('T123');
     expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
     expect(deleteChatSdkInstallation.mock.invocationCallOrder[0]).toBeLessThan(
+      deleteChatSdkIdentityCache.mock.invocationCallOrder[0]
+    );
+    expect(deleteChatSdkIdentityCache.mock.invocationCallOrder[0]).toBeLessThan(
       mockDeleteWhere.mock.invocationCallOrder[0]
     );
   });
 
-  it('does not remove the platform integration row when Chat SDK cleanup fails', async () => {
+  it('does not remove the platform integration row when Chat SDK installation cleanup fails', async () => {
     mockLimit.mockResolvedValue([buildSlackIntegration()]);
     const deleteChatSdkInstallation = jest.fn(async (_teamId: string): Promise<void> => {
       throw new Error('redis unavailable');
@@ -78,6 +85,21 @@ describe('slack-service uninstallApp', () => {
       'redis unavailable'
     );
 
+    expect(mockDeleteWhere).not.toHaveBeenCalled();
+  });
+
+  it('does not remove the platform integration row when Chat SDK identity cleanup fails', async () => {
+    mockLimit.mockResolvedValue([buildSlackIntegration()]);
+    const deleteChatSdkInstallation = jest.fn(async (_teamId: string): Promise<void> => {});
+    const deleteChatSdkIdentityCache = jest.fn(async (_teamId: string): Promise<void> => {
+      throw new Error('redis unavailable');
+    });
+
+    await expect(
+      uninstallApp(owner, { deleteChatSdkInstallation, deleteChatSdkIdentityCache })
+    ).rejects.toThrow('redis unavailable');
+
+    expect(deleteChatSdkInstallation).toHaveBeenCalledWith('T123');
     expect(mockDeleteWhere).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/lib/integrations/slack-service.ts
+++ b/apps/web/src/lib/integrations/slack-service.ts
@@ -46,6 +46,7 @@ const SLACK_REDIRECT_URI = `${APP_URL}/api/integrations/slack/callback`;
 
 type SlackUninstallOptions = {
   deleteChatSdkInstallation?: (teamId: string) => Promise<void>;
+  deleteChatSdkIdentityCache?: (teamId: string) => Promise<void>;
 };
 
 function getOwnershipConditions(owner: Owner) {
@@ -231,7 +232,7 @@ export async function uninstallApp(owner: Owner, options: SlackUninstallOptions 
   }
 
   const teamId = integration.platform_installation_id ?? integration.platform_account_id;
-  if (options.deleteChatSdkInstallation) {
+  if (options.deleteChatSdkInstallation || options.deleteChatSdkIdentityCache) {
     if (!teamId) {
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
@@ -239,7 +240,8 @@ export async function uninstallApp(owner: Owner, options: SlackUninstallOptions 
       });
     }
 
-    await options.deleteChatSdkInstallation(teamId);
+    await options.deleteChatSdkInstallation?.(teamId);
+    await options.deleteChatSdkIdentityCache?.(teamId);
   }
 
   await db.delete(platform_integrations).where(eq(platform_integrations.id, integration.id));

--- a/apps/web/src/lib/integrations/slack-service.ts
+++ b/apps/web/src/lib/integrations/slack-service.ts
@@ -44,6 +44,10 @@ export const SLACK_SCOPES = [
 
 const SLACK_REDIRECT_URI = `${APP_URL}/api/integrations/slack/callback`;
 
+type SlackUninstallOptions = {
+  deleteChatSdkInstallation?: (teamId: string) => Promise<void>;
+};
+
 function getOwnershipConditions(owner: Owner) {
   return owner.type === 'user'
     ? [
@@ -206,7 +210,7 @@ export async function upsertSlackInstallation({
 /**
  * Uninstall Slack integration for an owner
  */
-export async function uninstallApp(owner: Owner) {
+export async function uninstallApp(owner: Owner, options: SlackUninstallOptions = {}) {
   const integration = await getInstallation(owner);
 
   if (!integration || integration.integration_status !== INTEGRATION_STATUS.ACTIVE) {
@@ -224,6 +228,18 @@ export async function uninstallApp(owner: Owner) {
     } catch (error) {
       console.error('Failed to revoke Slack token:', error);
     }
+  }
+
+  const teamId = integration.platform_installation_id ?? integration.platform_account_id;
+  if (options.deleteChatSdkInstallation) {
+    if (!teamId) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Slack installation is missing a team ID',
+      });
+    }
+
+    await options.deleteChatSdkInstallation(teamId);
   }
 
   await db.delete(platform_integrations).where(eq(platform_integrations.id, integration.id));

--- a/apps/web/src/routers/slack-router.ts
+++ b/apps/web/src/routers/slack-router.ts
@@ -11,6 +11,12 @@ import {
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { requireActiveSubscriptionOrTrial } from '@/lib/organizations/trial-middleware';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
+import { bot } from '@/lib/bot';
+
+async function deleteChatSdkSlackInstallation(teamId: string): Promise<void> {
+  await bot.initialize();
+  await bot.getAdapter('slack').deleteInstallation(teamId);
+}
 
 export const slackRouter = createTRPCRouter({
   // Get Slack installation status
@@ -61,7 +67,9 @@ export const slackRouter = createTRPCRouter({
       await requireActiveSubscriptionOrTrial(input.organizationId);
     }
     const owner = await resolveAuthorizedOwner(ctx, input?.organizationId);
-    const result = await slackService.uninstallApp(owner);
+    const result = await slackService.uninstallApp(owner, {
+      deleteChatSdkInstallation: deleteChatSdkSlackInstallation,
+    });
 
     if (input?.organizationId) {
       await createAuditLog({

--- a/apps/web/src/routers/slack-router.ts
+++ b/apps/web/src/routers/slack-router.ts
@@ -12,10 +12,16 @@ import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { requireActiveSubscriptionOrTrial } from '@/lib/organizations/trial-middleware';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
 import { bot } from '@/lib/bot';
+import { unlinkTeamKiloUsers } from '@/lib/bot-identity';
 
 async function deleteChatSdkSlackInstallation(teamId: string): Promise<void> {
   await bot.initialize();
   await bot.getAdapter('slack').deleteInstallation(teamId);
+}
+
+async function deleteChatSdkSlackIdentityCache(teamId: string): Promise<void> {
+  await bot.initialize();
+  await unlinkTeamKiloUsers(bot.getState(), 'slack', teamId);
 }
 
 export const slackRouter = createTRPCRouter({
@@ -69,6 +75,7 @@ export const slackRouter = createTRPCRouter({
     const owner = await resolveAuthorizedOwner(ctx, input?.organizationId);
     const result = await slackService.uninstallApp(owner, {
       deleteChatSdkInstallation: deleteChatSdkSlackInstallation,
+      deleteChatSdkIdentityCache: deleteChatSdkSlackIdentityCache,
     });
 
     if (input?.organizationId) {

--- a/apps/web/src/routers/slack-router.ts
+++ b/apps/web/src/routers/slack-router.ts
@@ -11,16 +11,21 @@ import {
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { requireActiveSubscriptionOrTrial } from '@/lib/organizations/trial-middleware';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
-import { bot } from '@/lib/bot';
 import { unlinkTeamKiloUsers } from '@/lib/bot-identity';
 
-async function deleteChatSdkSlackInstallation(teamId: string): Promise<void> {
+async function getInitializedBot() {
+  const { bot } = await import('@/lib/bot');
   await bot.initialize();
+  return bot;
+}
+
+async function deleteChatSdkSlackInstallation(teamId: string): Promise<void> {
+  const bot = await getInitializedBot();
   await bot.getAdapter('slack').deleteInstallation(teamId);
 }
 
 async function deleteChatSdkSlackIdentityCache(teamId: string): Promise<void> {
-  await bot.initialize();
+  const bot = await getInitializedBot();
   await unlinkTeamKiloUsers(bot.getState(), 'slack', teamId);
 }
 


### PR DESCRIPTION
## Summary
- Clean up the Chat SDK Slack workspace installation when a Slack integration is disconnected.
- Keep the platform integration row if Chat SDK cleanup fails, avoiding mismatched database and SDK state.
- Add unit coverage for successful cleanup, cleanup failure, and legacy rows without `platform_installation_id`.

## Verification
N/A - no manual verification performed; backend cleanup behavior is covered by automated tests.

## Visual Changes
N/A

## Reviewer Notes
- The disconnect path now deletes Chat SDK state before deleting `platform_integrations`, so transient Redis/state failures leave the integration row available for retry.