### PR TITLE
fix(kiloclaw): prewarm bundled plugin runtime deps at image build

### DIFF
--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -71,14 +71,20 @@ RUN npm install -g openclaw@2026.4.9 \
 
 # Bake bundled plugin runtime deps into the image so first boot is pure
 # startup — no npm install from `openclaw doctor` on shared-cpu Fly machines.
-RUN cd /usr/local/lib/node_modules/openclaw \
+# pipefail + materialized spec list so a failed manifest discovery breaks
+# the build instead of silently shipping an image with no bundled deps.
+RUN set -eo pipefail \
+    && cd /usr/local/lib/node_modules/openclaw \
     && jq -r '((.dependencies // {}) + (.optionalDependencies // {})) | to_entries[] | "\(.key)@\(.value)"' \
          dist/extensions/*/package.json \
        | grep -v '@workspace:' \
-       | sort -u \
-       | xargs -r npm install --omit=dev --no-save --package-lock=false \
-                              --ignore-scripts --legacy-peer-deps \
-                              --no-fund --no-audit \
+       | sort -u > /tmp/bundled-plugin-specs.txt \
+    && test -s /tmp/bundled-plugin-specs.txt \
+    && xargs -a /tmp/bundled-plugin-specs.txt npm install \
+           --omit=dev --no-save --package-lock=false \
+           --ignore-scripts --legacy-peer-deps \
+           --no-fund --no-audit \
+    && rm -f /tmp/bundled-plugin-specs.txt \
     && rm -rf /root/.npm
 
 # Install ClawHub CLI

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -71,20 +71,19 @@ RUN npm install -g openclaw@2026.4.9 \
 
 # Bake bundled plugin runtime deps into the image so first boot is pure
 # startup — no npm install from `openclaw doctor` on shared-cpu Fly machines.
-# pipefail + materialized spec list so a failed manifest discovery breaks
-# the build instead of silently shipping an image with no bundled deps.
-RUN set -eo pipefail \
-    && cd /usr/local/lib/node_modules/openclaw \
-    && jq -r '((.dependencies // {}) + (.optionalDependencies // {})) | to_entries[] | "\(.key)@\(.value)"' \
-         dist/extensions/*/package.json \
-       | grep -v '@workspace:' \
-       | sort -u > /tmp/bundled-plugin-specs.txt \
+# Each step writes to a temp file and is chained with && so failures break
+# the build (Debian's /bin/sh is dash, no pipefail). jq does the workspace:
+# filter so no pipe is needed between jq and sort.
+RUN cd /usr/local/lib/node_modules/openclaw \
+    && jq -r '((.dependencies // {}) + (.optionalDependencies // {})) | to_entries[] | select(.value | startswith("workspace:") | not) | "\(.key)@\(.value)"' \
+         dist/extensions/*/package.json > /tmp/bundled-plugin-specs.raw \
+    && sort -u /tmp/bundled-plugin-specs.raw > /tmp/bundled-plugin-specs.txt \
     && test -s /tmp/bundled-plugin-specs.txt \
     && xargs -a /tmp/bundled-plugin-specs.txt npm install \
            --omit=dev --no-save --package-lock=false \
            --ignore-scripts --legacy-peer-deps \
            --no-fund --no-audit \
-    && rm -f /tmp/bundled-plugin-specs.txt \
+    && rm -f /tmp/bundled-plugin-specs.raw /tmp/bundled-plugin-specs.txt \
     && rm -rf /root/.npm
 
 # Install ClawHub CLI

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -63,6 +63,19 @@ RUN npm install -g openclaw@2026.4.9 \
     && echo "OK: patched DISCOVERY_TIMEOUT_MS 5e3 -> 60e3 in $(basename "$PM_FILE")" \
     && openclaw --version
 
+# Bake bundled plugin runtime deps into the image so first boot is pure
+# startup — no 30-90s npm install from `openclaw doctor` on shared-cpu Fly
+# machines.
+RUN cd /usr/local/lib/node_modules/openclaw \
+    && jq -r '((.dependencies // {}) + (.optionalDependencies // {})) | to_entries[] | "\(.key)@\(.value)"' \
+         dist/extensions/*/package.json \
+       | grep -v '@workspace:' \
+       | sort -u \
+       | xargs -r npm install --omit=dev --no-save --package-lock=false \
+                              --ignore-scripts --legacy-peer-deps \
+                              --no-fund --no-audit \
+    && rm -rf /root/.npm
+
 # Install ClawHub CLI
 RUN npm install -g clawhub
 

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -42,9 +42,9 @@ RUN apt-get update \
     && npm --version
 
 # Route npm's git-backed deps (GitHub refs, ssh:// transitive deps like
-# baileys → libsignal-node) through https so we don't need an ssh client in
-# the image. --system writes to /etc/gitconfig, which the Fly Volume at /root
-# doesn't shadow, so it persists at runtime too.
+# baileys → libsignal-node) through https during the build so we don't need
+# an ssh client in the image. The final stage removes /etc/gitconfig so this
+# build-only config does not ship in the runtime image.
 RUN git config --system url."https://github.com/".insteadOf "ssh://git@github.com/"
 
 # Install pnpm globally
@@ -167,9 +167,12 @@ RUN cd /tmp/controller-build \
 FROM runtime AS final
 
 # Install prebuilt customizer plugin package from builder stage.
+# Also drop /etc/gitconfig (set earlier for the build's ssh→https rewrite) so
+# it doesn't persist in the runtime image.
 COPY --from=customizer-builder /tmp/kiloclaw-customizer.tgz /tmp/kiloclaw-customizer.tgz
 RUN npm install -g --legacy-peer-deps /tmp/kiloclaw-customizer.tgz \
     && rm -f /tmp/kiloclaw-customizer.tgz \
+    && rm -f /etc/gitconfig \
     && rm -rf /root/.npm
 
 # Copy the compiled controller from the builder stage

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -41,6 +41,12 @@ RUN apt-get update \
     && node --version \
     && npm --version
 
+# Route npm's git-backed deps (GitHub refs, ssh:// transitive deps like
+# baileys → libsignal-node) through https so we don't need an ssh client in
+# the image. --system writes to /etc/gitconfig, which the Fly Volume at /root
+# doesn't shadow, so it persists at runtime too.
+RUN git config --system url."https://github.com/".insteadOf "ssh://git@github.com/"
+
 # Install pnpm globally
 RUN npm install -g pnpm
 
@@ -64,8 +70,7 @@ RUN npm install -g openclaw@2026.4.9 \
     && openclaw --version
 
 # Bake bundled plugin runtime deps into the image so first boot is pure
-# startup — no 30-90s npm install from `openclaw doctor` on shared-cpu Fly
-# machines.
+# startup — no npm install from `openclaw doctor` on shared-cpu Fly machines.
 RUN cd /usr/local/lib/node_modules/openclaw \
     && jq -r '((.dependencies // {}) + (.optionalDependencies // {})) | to_entries[] | "\(.key)@\(.value)"' \
          dist/extensions/*/package.json \


### PR DESCRIPTION
## Summary

OpenClaw 4.9 installs its bundled plugin runtime deps lazily — the `postinstall` hook in `openclaw/scripts/postinstall-bundled-plugins.mjs` runs `npm install` without `--ignore-scripts`, so native addons (e.g. `@discordjs/opus`) silently fail and the try/catch swallows the error. `openclaw doctor --fix` then refills the gap at first boot, which stretches cold-boot latency from seconds into several minutes on smaller shared-cpu Fly machines.

This PR bakes every bundled plugin's runtime deps into the image layer at build time. The jq pipeline walks `dist/extensions/*/package.json`, dedupes via `sort -u`, and installs with the same flags doctor uses (`--ignore-scripts --legacy-peer-deps`). 

## Verification

https://github.com/Kilo-Org/cloud/actions/runs/24847185423


## Visual Changes

N/A

## Reviewer Notes

Interestingly when the cached layer got invalidated, streamchat also failed to install (also requiring a ssh client) so that *might* actually have also been broken for a bit and just hadn't bubbled up yet due to layer caching?