### PR TITLE
feat: add inclusionai/ling-2.6-1t:free to auto free models

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -30,6 +30,7 @@ import { grok_code_fast_1_optimized_free_model } from '@/lib/ai-gateway/provider
 export const PRIMARY_DEFAULT_MODEL = CLAUDE_SONNET_CURRENT_MODEL_ID;
 
 export const autoFreeModels = [
+  'inclusionai/ling-2.6-1t:free',
   'inclusionai/ling-2.6-flash:free',
   'nvidia/nemotron-3-super-120b-a12b:free',
   'tencent/hy3-preview:free',


### PR DESCRIPTION
## Summary

Add the newly released `inclusionai/ling-2.6-1t:free` model to the auto free models list. This model was released on OpenRouter on April 23, 2026.

## Changes

- Added `'inclusionai/ling-2.6-1t:free'` to the `autoFreeModels` array in `apps/web/src/lib/ai-gateway/models.ts`

## Impact

- The model is automatically recognized as a free model (via the `:free` suffix check in `isFreeModel()`)
- It's included in the `preferredModels` list (via the spread operator `...autoFreeModels`)
- It will be available as a candidate when users select the `kilo-auto/free` model
- Follows the same pattern as `inclusionai/ling-2.6-flash:free` which was already in the list

## Verification

- TypeScript type checking passes
- The model ID ends with `:free`, so it's automatically handled by the existing free model detection logic

## Branch

- Based on: `main`
- Head: `feat/add-ling-2-6-1t-free-model`