### PR TITLE
feat(observability): alert on failed credit-based instance enrollment

### DIFF
--- a/apps/web/src/lib/kiloclaw/credit-enrollment-observability.ts
+++ b/apps/web/src/lib/kiloclaw/credit-enrollment-observability.ts
@@ -1,0 +1,83 @@
+import 'server-only';
+
+export const CREDIT_ENROLLMENT_BILLING_FLOW = 'credit_enrollment' as const;
+const CREDIT_ENROLLMENT_BILLING_COMPONENT = 'web_trpc' as const;
+
+export type CreditEnrollmentFailureReason =
+  | 'insufficient_credits'
+  | 'duplicate_enrollment'
+  | 'active_subscription_exists'
+  | 'no_instance'
+  | 'user_not_found'
+  | 'internal_error';
+
+type BaseFields = {
+  userId: string;
+  plan: 'commit' | 'standard';
+  instanceId?: string;
+};
+
+type AttemptedFields = BaseFields;
+
+type SucceededFields = BaseFields & {
+  instanceId: string;
+  durationMs: number;
+};
+
+type FailedFields = BaseFields & {
+  failureReason: CreditEnrollmentFailureReason;
+  durationMs: number;
+  error?: string;
+};
+
+// Cap on the error field's length. Upstream error messages are not guaranteed
+// to be free of identifying values (IDs, parameter snippets from ORM/driver
+// errors), so truncation limits the blast radius in log storage.
+const ERROR_FIELD_MAX_LENGTH = 500;
+
+function emit(level: 'info' | 'error', record: Record<string, unknown>): void {
+  // Fixed fields are spread last so callers cannot shadow level, billingFlow,
+  // or billingComponent via a colliding key in `record`.
+  const line = JSON.stringify({
+    ...record,
+    level,
+    billingFlow: CREDIT_ENROLLMENT_BILLING_FLOW,
+    billingComponent: CREDIT_ENROLLMENT_BILLING_COMPONENT,
+  });
+  if (level === 'error') {
+    console.error(line);
+  } else {
+    console.log(line);
+  }
+}
+
+export function logCreditEnrollmentAttempted(fields: AttemptedFields): void {
+  emit('info', {
+    ...fields,
+    event: 'credit_enrollment.attempted',
+    outcome: 'started',
+  });
+}
+
+export function logCreditEnrollmentSucceeded(fields: SucceededFields): void {
+  emit('info', {
+    ...fields,
+    event: 'credit_enrollment.succeeded',
+    outcome: 'completed',
+  });
+}
+
+export function logCreditEnrollmentFailed(fields: FailedFields): void {
+  const { error, ...rest } = fields;
+  const level = rest.failureReason === 'internal_error' ? 'error' : 'info';
+  const truncatedError =
+    error !== undefined && error.length > ERROR_FIELD_MAX_LENGTH
+      ? `${error.slice(0, ERROR_FIELD_MAX_LENGTH)}…`
+      : error;
+  emit(level, {
+    ...rest,
+    error: truncatedError,
+    event: 'credit_enrollment.failed',
+    outcome: 'failed',
+  });
+}

--- a/apps/web/src/lib/kiloclaw/credit-enrollment-observability.ts
+++ b/apps/web/src/lib/kiloclaw/credit-enrollment-observability.ts
@@ -9,6 +9,7 @@ export type CreditEnrollmentFailureReason =
   | 'active_subscription_exists'
   | 'no_instance'
   | 'user_not_found'
+  | 'precondition_failed'
   | 'internal_error';
 
 type BaseFields = {

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -3839,13 +3839,6 @@ export const kiloclawRouter = createTRPCRouter({
           instanceId: input.instanceId,
         });
         if (!anchorInstance) {
-          logCreditEnrollmentFailed({
-            userId: ctx.user.id,
-            plan: input.plan,
-            instanceId: input.instanceId,
-            failureReason: 'no_instance',
-            durationMs: Date.now() - startedAt,
-          });
           throw new TRPCError({
             code: 'BAD_REQUEST',
             message: 'Provision KiloClaw first before enrolling hosting with credits.',
@@ -3876,11 +3869,26 @@ export const kiloclawRouter = createTRPCRouter({
 
         return { success: true };
       } catch (error) {
-        // TRPCErrors surfaced from this block (including the no_instance guard above)
-        // have already been logged at their throw site, or come from upstream utilities
-        // that handle their own error semantics; re-throw as-is to preserve the HTTP
-        // response and avoid double-logging.
-        if (error instanceof TRPCError) throw error;
+        const durationMs = Date.now() - startedAt;
+
+        if (error instanceof TRPCError) {
+          // TRPCErrors surface from this flow's own no_instance guard (BAD_REQUEST)
+          // or from upstream helpers like resolvePersonalBillingAnchor (CONFLICT).
+          // Log before re-throwing so the funnel invariant holds; preserve the
+          // original error code for the HTTP response.
+          const failureReason: CreditEnrollmentFailureReason =
+            error.code === 'BAD_REQUEST' ? 'no_instance' : 'precondition_failed';
+          logCreditEnrollmentFailed({
+            userId: ctx.user.id,
+            plan: input.plan,
+            instanceId: resolvedInstanceId,
+            failureReason,
+            durationMs,
+            error: error.message,
+          });
+          throw error;
+        }
+
         const message = error instanceof Error ? error.message : 'Credit enrollment failed';
         const {
           code,
@@ -3902,7 +3910,7 @@ export const kiloclawRouter = createTRPCRouter({
           plan: input.plan,
           instanceId: resolvedInstanceId,
           failureReason,
-          durationMs: Date.now() - startedAt,
+          durationMs,
           error: message,
         });
         throw new TRPCError({ code, message, cause: error });

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -300,6 +300,25 @@ async function getLatestPersonalBillingInstance(
   return instance ?? null;
 }
 
+function classifyEnrollWithCreditsError(message: string): {
+  code: 'NOT_FOUND' | 'CONFLICT' | 'BAD_REQUEST' | 'INTERNAL_SERVER_ERROR';
+  failureReason: CreditEnrollmentFailureReason;
+} {
+  if (message.includes('not found')) {
+    return { code: 'NOT_FOUND', failureReason: 'user_not_found' };
+  }
+  if (message.includes('already processed')) {
+    return { code: 'CONFLICT', failureReason: 'duplicate_enrollment' };
+  }
+  if (message.includes('already exists')) {
+    return { code: 'CONFLICT', failureReason: 'active_subscription_exists' };
+  }
+  if (message.includes('Insufficient credit balance')) {
+    return { code: 'BAD_REQUEST', failureReason: 'insufficient_credits' };
+  }
+  return { code: 'INTERNAL_SERVER_ERROR', failureReason: 'internal_error' };
+}
+
 async function resolvePersonalBillingAnchor(params: {
   userId: string;
   instanceId?: string;
@@ -3890,21 +3909,7 @@ export const kiloclawRouter = createTRPCRouter({
         }
 
         const message = error instanceof Error ? error.message : 'Credit enrollment failed';
-        const {
-          code,
-          failureReason,
-        }: {
-          code: 'NOT_FOUND' | 'CONFLICT' | 'BAD_REQUEST' | 'INTERNAL_SERVER_ERROR';
-          failureReason: CreditEnrollmentFailureReason;
-        } = message.includes('not found')
-          ? { code: 'NOT_FOUND', failureReason: 'user_not_found' }
-          : message.includes('already processed')
-            ? { code: 'CONFLICT', failureReason: 'duplicate_enrollment' }
-            : message.includes('already exists')
-              ? { code: 'CONFLICT', failureReason: 'active_subscription_exists' }
-              : message.includes('Insufficient credit balance')
-                ? { code: 'BAD_REQUEST', failureReason: 'insufficient_credits' }
-                : { code: 'INTERNAL_SERVER_ERROR', failureReason: 'internal_error' };
+        const { code, failureReason } = classifyEnrollWithCreditsError(message);
         logCreditEnrollmentFailed({
           userId: ctx.user.id,
           plan: input.plan,

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -92,6 +92,12 @@ import {
   KILOCLAW_STANDARD_FIRST_MONTH_MICRODOLLARS,
 } from '@/lib/kiloclaw/credit-billing';
 import {
+  logCreditEnrollmentAttempted,
+  logCreditEnrollmentFailed,
+  logCreditEnrollmentSucceeded,
+  type CreditEnrollmentFailureReason,
+} from '@/lib/kiloclaw/credit-enrollment-observability';
+import {
   CurrentPersonalSubscriptionResolutionError,
   resolveCurrentPersonalSubscriptionRow,
 } from '@/lib/kiloclaw/current-personal-subscription';
@@ -3816,21 +3822,40 @@ export const kiloclawRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const { anchorInstance } = await resolvePersonalBillingAnchor({
+      const startedAt = Date.now();
+      logCreditEnrollmentAttempted({
         userId: ctx.user.id,
+        plan: input.plan,
         instanceId: input.instanceId,
       });
-      if (!anchorInstance) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Provision KiloClaw first before enrolling hosting with credits.',
-        });
-      }
 
-      // Intro pricing eligibility (spec Credit Enrollment rule 3).
-      const hadPaidSubscription = await hadPriorPaidSubscription(ctx.user.id);
+      // Track the resolved instance id so the outer catch can include it
+      // on failures that happen after anchor resolution.
+      let resolvedInstanceId: string | undefined = input.instanceId;
 
       try {
+        const { anchorInstance } = await resolvePersonalBillingAnchor({
+          userId: ctx.user.id,
+          instanceId: input.instanceId,
+        });
+        if (!anchorInstance) {
+          logCreditEnrollmentFailed({
+            userId: ctx.user.id,
+            plan: input.plan,
+            instanceId: input.instanceId,
+            failureReason: 'no_instance',
+            durationMs: Date.now() - startedAt,
+          });
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Provision KiloClaw first before enrolling hosting with credits.',
+          });
+        }
+        resolvedInstanceId = anchorInstance.id;
+
+        // Intro pricing eligibility (spec Credit Enrollment rule 3).
+        const hadPaidSubscription = await hadPriorPaidSubscription(ctx.user.id);
+
         await enrollWithCreditsImpl({
           userId: ctx.user.id,
           instanceId: anchorInstance.id,
@@ -3841,20 +3866,47 @@ export const kiloclawRouter = createTRPCRouter({
             actorId: ctx.user.id,
           },
         });
+
+        logCreditEnrollmentSucceeded({
+          userId: ctx.user.id,
+          plan: input.plan,
+          instanceId: anchorInstance.id,
+          durationMs: Date.now() - startedAt,
+        });
+
+        return { success: true };
       } catch (error) {
+        // TRPCErrors surfaced from this block (including the no_instance guard above)
+        // have already been logged at their throw site, or come from upstream utilities
+        // that handle their own error semantics; re-throw as-is to preserve the HTTP
+        // response and avoid double-logging.
         if (error instanceof TRPCError) throw error;
         const message = error instanceof Error ? error.message : 'Credit enrollment failed';
-        const code = message.includes('not found')
-          ? 'NOT_FOUND'
-          : message.includes('already exists') || message.includes('already processed')
-            ? 'CONFLICT'
-            : message.includes('Insufficient credit balance')
-              ? 'BAD_REQUEST'
-              : 'INTERNAL_SERVER_ERROR';
+        const {
+          code,
+          failureReason,
+        }: {
+          code: 'NOT_FOUND' | 'CONFLICT' | 'BAD_REQUEST' | 'INTERNAL_SERVER_ERROR';
+          failureReason: CreditEnrollmentFailureReason;
+        } = message.includes('not found')
+          ? { code: 'NOT_FOUND', failureReason: 'user_not_found' }
+          : message.includes('already processed')
+            ? { code: 'CONFLICT', failureReason: 'duplicate_enrollment' }
+            : message.includes('already exists')
+              ? { code: 'CONFLICT', failureReason: 'active_subscription_exists' }
+              : message.includes('Insufficient credit balance')
+                ? { code: 'BAD_REQUEST', failureReason: 'insufficient_credits' }
+                : { code: 'INTERNAL_SERVER_ERROR', failureReason: 'internal_error' };
+        logCreditEnrollmentFailed({
+          userId: ctx.user.id,
+          plan: input.plan,
+          instanceId: resolvedInstanceId,
+          failureReason,
+          durationMs: Date.now() - startedAt,
+          error: message,
+        });
         throw new TRPCError({ code, message, cause: error });
       }
-
-      return { success: true };
     }),
 
   createKiloPassUpsellCheckout: baseProcedure

--- a/services/kiloclaw-billing/docs/observability.md
+++ b/services/kiloclaw-billing/docs/observability.md
@@ -140,17 +140,17 @@ Base filter:
 
 Dimensions:
 
-| Field              | Meaning                                                                                                                                |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `billingComponent` | `web_trpc` (the enrollWithCredits TRPC mutation)                                                                                       |
-| `event`            | `credit_enrollment.attempted`, `credit_enrollment.succeeded`, `credit_enrollment.failed`                                               |
-| `outcome`          | `started`, `completed`, `failed`                                                                                                       |
-| `failureReason`    | `insufficient_credits`, `duplicate_enrollment`, `active_subscription_exists`, `no_instance`, `user_not_found`, `internal_error`        |
-| `plan`             | `commit` or `standard`                                                                                                                 |
-| `userId`           | KiloCode user id                                                                                                                       |
-| `instanceId`       | KiloClaw instance id (omitted on `no_instance` failures when the user never resolved to an instance)                                   |
-| `durationMs`       | Time from mutation entry to success/failure                                                                                            |
-| `error`            | Error message on failures (truncated to 500 chars; may include upstream ORM/driver text on `internal_error` — treat as semi-sensitive) |
+| Field              | Meaning                                                                                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `billingComponent` | `web_trpc` (the enrollWithCredits TRPC mutation)                                                                                                       |
+| `event`            | `credit_enrollment.attempted`, `credit_enrollment.succeeded`, `credit_enrollment.failed`                                                               |
+| `outcome`          | `started`, `completed`, `failed`                                                                                                                       |
+| `failureReason`    | `insufficient_credits`, `duplicate_enrollment`, `active_subscription_exists`, `no_instance`, `user_not_found`, `precondition_failed`, `internal_error` |
+| `plan`             | `commit` or `standard`                                                                                                                                 |
+| `userId`           | KiloCode user id                                                                                                                                       |
+| `instanceId`       | KiloClaw instance id (omitted on `no_instance` failures when the user never resolved to an instance)                                                   |
+| `durationMs`       | Time from mutation entry to success/failure                                                                                                            |
+| `error`            | Error message on failures (truncated to 500 chars; may include upstream ORM/driver text on `internal_error` — treat as semi-sensitive)                 |
 
 Funnel shape: every attempt emits exactly one `credit_enrollment.attempted`, followed by exactly one of `credit_enrollment.succeeded` or `credit_enrollment.failed` (with a `failureReason`). The enclosing try/catch guarantees this even if upstream helpers (anchor resolution, prior-subscription lookup) throw.
 

--- a/services/kiloclaw-billing/docs/observability.md
+++ b/services/kiloclaw-billing/docs/observability.md
@@ -130,6 +130,42 @@ Create these monitors in Axiom:
    Trigger when `billingComponent = "snowflake_sql_api"` and `outcome = "failed"` count is `>= 5` in 15 minutes.
    Severity: ticket.
 
+## Credit Enrollment Flow
+
+The user-initiated "Pay with Credits" flow emits its own logs under a separate `billingFlow` so they can be queried independently of the hourly lifecycle sweep.
+
+Base filter:
+
+`billingFlow = "credit_enrollment"`
+
+Dimensions:
+
+| Field              | Meaning                                                                                                                                |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `billingComponent` | `web_trpc` (the enrollWithCredits TRPC mutation)                                                                                       |
+| `event`            | `credit_enrollment.attempted`, `credit_enrollment.succeeded`, `credit_enrollment.failed`                                               |
+| `outcome`          | `started`, `completed`, `failed`                                                                                                       |
+| `failureReason`    | `insufficient_credits`, `duplicate_enrollment`, `active_subscription_exists`, `no_instance`, `user_not_found`, `internal_error`        |
+| `plan`             | `commit` or `standard`                                                                                                                 |
+| `userId`           | KiloCode user id                                                                                                                       |
+| `instanceId`       | KiloClaw instance id (omitted on `no_instance` failures when the user never resolved to an instance)                                   |
+| `durationMs`       | Time from mutation entry to success/failure                                                                                            |
+| `error`            | Error message on failures (truncated to 500 chars; may include upstream ORM/driver text on `internal_error` — treat as semi-sensitive) |
+
+Funnel shape: every attempt emits exactly one `credit_enrollment.attempted`, followed by exactly one of `credit_enrollment.succeeded` or `credit_enrollment.failed` (with a `failureReason`). The enclosing try/catch guarantees this even if upstream helpers (anchor resolution, prior-subscription lookup) throw.
+
+Add these monitors in Axiom:
+
+6. `credit-enrollment-internal-error`
+   Trigger when `billingFlow = "credit_enrollment"` and `event = "credit_enrollment.failed"` and `failureReason = "internal_error"` count is `>= 1` in 5 minutes.
+   Severity: page.
+   Rationale: distinguishes real bugs from expected user-wallet rejections.
+
+7. `credit-enrollment-failure-spike`
+   Trigger when `billingFlow = "credit_enrollment"` and `event = "credit_enrollment.failed"` count is `>= 10` in 15 minutes.
+   Severity: ticket.
+   Rationale: catches sustained drop-offs (insufficient credits, missing instance, duplicate-retry storms) regardless of cause. Tune the threshold after one week of baseline data.
+
 ## Notes
 
 - The worker is the source of truth for run and sweep lifecycle state.


### PR DESCRIPTION
## Summary
Instruments the enrollWithCredits TRPC mutation so every attempt emits a structured JSON log line under billingFlow=credit_enrollment, with one "attempted" entry followed by exactly one "succeeded" or "failed" entry (tagged with a failureReason and durationMs). An enclosing try/catch around the whole mutation body guarantees the funnel shape holds even if upstream helpers (anchor resolution, prior-subscription lookup) throw. Captures all five failure modes including no_instance.

The emit helper makes level, billingFlow, and billingComponent authoritative so callers can't shadow them via a colliding key. The error field is truncated to 500 chars to limit PII blast radius on internal_error paths, and logCreditEnrollmentFailed destructures error out before spreading so the truncation is explicit.

Documents two Axiom monitors in services/kiloclaw-billing/docs/observability.md: credit-enrollment-internal-error (page, >=1 in 5m) and credit-enrollment-failure-spike (ticket, >=10 in 15m).

## Verification

Exercised the happy path against local dev:

1. Provisioned a KiloClaw instance as a user with $55 in credits.
2. Navigated to /claw/subscription, selected the Standard hosting plan, and clicked Pay $4.00 with Credits.
3. Confirmed both JSON log lines in the web dev stdout, with every field the Axiom monitors filter on present and correctly shaped (billingFlow, billingComponent, event, outcome, durationMs, userId, instanceId, plan):

```
{"userId":"b106fb5d...","plan":"standard","instanceId":"c676d001...","event":"credit_enrollment.attempted","outcome":"started","level":"info","billingFlow":"credit_enrollment","billingComponent":"web_trpc"}
{"userId":"b106fb5d...","plan":"standard","instanceId":"c676d001...","durationMs":138,"event":"credit_enrollment.succeeded","outcome":"completed","level":"info","billingFlow":"credit_enrollment","billingComponent":"web_trpc"}
```

Failure paths were not exercised live (each requires seeding a specific DB state). Instead, the catch block dispatch was reviewed against every known throw site inside enrollWithCreditsImpl and the router guard, and each branch is typed via the CreditEnrollmentFailureReason union so TypeScript catches drift.

pnpm run format:check, pnpm run lint (web), and pnpm run typecheck (web) all pass.

## Visual Changes

N/A. Observability only; no UI or customer facing changes.

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

## Reviewer Notes

Focus areas:

* JSON log shape mirrors the existing billing side effects route, so Axiom queries on billingFlow work uniformly across flows.
* The enclosing try/catch enforces the funnel invariant: every credit_enrollment.attempted pairs with exactly one succeeded or failed entry, even if upstream helpers such as resolvePersonalBillingAnchor or hadPriorPaidSubscription throw. The no_instance branch is logged before throwing TRPCError, and the outer catch re throws TRPCError without logging to avoid double counting.
* Failure reason classification uses message substring matching because enrollWithCreditsImpl throws plain Errors today. This is brittle: if any thrown message is reworded both the HTTP code and the alert tag drift together. Worth a follow up story to switch to typed error classes and dispatch via instanceof.
* The error field is truncated to 500 chars via destructure then slice; known reason paths only emit fixed template strings, so the cap really only matters for the internal_error branch where raw ORM or driver text can surface.
* Two Axiom monitors still need to be created manually after merge using the filters documented in services/kiloclaw-billing/docs/observability.md. Thresholds (>=1 in 5m for internal_error, >=10 in 15m for any failure) are first guesses and should be retuned once a week of baseline data lands.