### PR TITLE
feat(models): replace gpt-5.4 with gpt-5.5 in preferred models

### DIFF
--- a/apps/web/src/app/api/models/up/route.ts
+++ b/apps/web/src/app/api/models/up/route.ts
@@ -56,6 +56,7 @@ const HEALTH_CHECK_EXCLUSIONS = new Set([
   // We don't control when this model may be retracted by OpenRouter.
   'openrouter/elephant-alpha',
   'openai/gpt-5.4',
+  'openai/gpt-5.5',
 ]);
 
 function emptyMetrics(): Omit<ModelHealthMetrics, 'monitored'> {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -47,7 +47,7 @@ export const preferredModels = [
   CLAUDE_OPUS_CURRENT_MODEL_ID,
   KIMI_CURRENT_MODEL_ID,
   CLAUDE_SONNET_CURRENT_MODEL_ID,
-  'openai/gpt-5.4',
+  'openai/gpt-5.5',
   'google/gemini-3.1-pro-preview',
   MINIMAX_CURRENT_MODEL_ID,
   qwen36_plus_model.public_id,

--- a/apps/web/src/tests/openrouter-models-config.test.ts
+++ b/apps/web/src/tests/openrouter-models-config.test.ts
@@ -6,7 +6,7 @@ describe('OpenRouter Models Config', () => {
     const expectedModels = [
       'google/gemini-3.1-pro-preview',
       'anthropic/claude-sonnet-4.6',
-      'openai/gpt-5.4',
+      'openai/gpt-5.5',
     ];
 
     expectedModels.forEach(model => {


### PR DESCRIPTION
Swap the recommended OpenAI entry to gpt-5.5 now that it is public. Keep both gpt-5.4 and gpt-5.5 in HEALTH_CHECK_EXCLUSIONS while traffic on the new model is too spiky to alert on reliably.
