### PR TITLE
fix(kiloclaw): preserve web search preference on upgrade

### DIFF
--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -896,6 +896,44 @@ describe('runOnboardOrDoctor', () => {
     expect(env.KILOCLAW_FRESH_INSTALL).toBe('false');
     expect(harness.renameCalls.some(call => call.to.endsWith('/workspace/IDENTITY.md'))).toBe(true);
   });
+
+  it('does not auto-assign kilo-exa on doctor path when BRAVE_API_KEY is configured', () => {
+    const harness = fakeDeps();
+    (harness.deps.existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p.endsWith('openclaw.json')) return true;
+      return false;
+    });
+    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+      JSON.stringify({
+        gateway: { port: 3001 },
+        tools: { web: { search: {} } },
+      })
+    );
+
+    const env: Record<string, string | undefined> = {
+      KILOCODE_API_KEY: 'test-key',
+      OPENCLAW_GATEWAY_TOKEN: 'test-token',
+      AUTO_APPROVE_DEVICES: 'true',
+      BRAVE_API_KEY: 'BSA' + 'A'.repeat(20),
+    };
+
+    runOnboardOrDoctor(env, harness.deps);
+
+    const doctorCall = harness.execCalls.find(
+      c => c.cmd === 'openclaw' && c.args.includes('doctor')
+    );
+    expect(doctorCall).toBeDefined();
+
+    const configWrite = harness.writeCalls.find(call => call.data.trim().startsWith('{'));
+    expect(configWrite).toBeDefined();
+    if (!configWrite) {
+      throw new Error('Expected openclaw config to be written on doctor path');
+    }
+    const config = JSON.parse(configWrite.data) as {
+      tools?: { web?: { search?: { provider?: string } } };
+    };
+    expect(config.tools?.web?.search?.provider).toBeUndefined();
+  });
 });
 
 // ---- updateToolsMdSection ----

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -169,7 +169,7 @@ describe('generateBaseConfig', () => {
     expect(config.plugins.entries['kiloclaw-customizer'].config.webSearch.enabled).toBe(true);
   });
 
-  it('auto-assigns kilo-exa even when web search was explicitly disabled but provider is missing', () => {
+  it('does not auto-assign kilo-exa when web search is explicitly disabled and provider is missing', () => {
     const existing = JSON.stringify({
       tools: {
         web: {
@@ -182,9 +182,22 @@ describe('generateBaseConfig', () => {
     const { deps } = fakeDeps(existing);
     const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);
 
-    expect(config.tools.web.search.provider).toBe('kilo-exa');
-    expect(config.tools.web.search.enabled).toBe(true);
-    expect(config.plugins.entries['kiloclaw-customizer'].config.webSearch.enabled).toBe(true);
+    expect(config.tools.web.search.provider).toBeUndefined();
+    expect(config.tools.web.search.enabled).toBe(false);
+    expect(config.plugins.entries['kiloclaw-customizer'].config.webSearch.enabled).toBeUndefined();
+  });
+
+  it('does not auto-assign kilo-exa when BRAVE_API_KEY is configured and provider is missing', () => {
+    const existing = JSON.stringify({ tools: { web: { search: {} } } });
+    const { deps } = fakeDeps(existing);
+    const env = {
+      ...minimalEnv(),
+      BRAVE_API_KEY: 'BSA' + 'A'.repeat(20),
+    };
+    const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
+
+    expect(config.tools.web.search.provider).toBeUndefined();
+    expect(config.plugins.entries['kiloclaw-customizer'].config.webSearch.enabled).toBeUndefined();
   });
 
   it('preserves explicit kilo-exa provider when mode is unset', () => {
@@ -1373,6 +1386,20 @@ describe('writeBaseConfig', () => {
     const config = JSON.parse(written[0].data);
     expect(config.tools?.web?.search?.provider).toBe('kilo-exa');
     expect(config.tools?.web?.search?.enabled).toBe(true);
+  });
+
+  it('does not auto-assign Exa web search provider on restore path when BRAVE_API_KEY is configured', () => {
+    const { deps, written } = fakeDeps();
+    const env: Record<string, string | undefined> = {
+      ...minimalEnv(),
+      BRAVE_API_KEY: 'BSA' + 'A'.repeat(20),
+    };
+    delete env.KILOCLAW_FRESH_INSTALL;
+
+    writeBaseConfig(env, '/tmp/openclaw.json', deps);
+
+    const config = JSON.parse(written[0].data);
+    expect(config.tools?.web?.search?.provider).toBeUndefined();
   });
 
   it('throws if KILOCODE_API_KEY is missing', () => {

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -343,10 +343,14 @@ export function generateBaseConfig(
   const searchProvider = config.tools?.web?.search?.provider;
   const hasExplicitSearchProvider =
     typeof searchProvider === 'string' && searchProvider.trim().length > 0;
+  const hasExplicitSearchDisabled = config.tools?.web?.search?.enabled === false;
+  const braveConfigured = Boolean(env.BRAVE_API_KEY?.trim());
+  const hasExplicitSearchPreference =
+    hasExplicitSearchProvider || hasExplicitSearchDisabled || braveConfigured;
 
   const kiloExaSearchMode = resolveKiloExaSearchMode(env.KILO_EXA_SEARCH_MODE);
   const shouldForceExa = kiloExaSearchMode === 'kilo-proxy';
-  const shouldAutoAssignExa = kiloExaSearchMode === 'unset' && !hasExplicitSearchProvider;
+  const shouldAutoAssignExa = kiloExaSearchMode === 'unset' && !hasExplicitSearchPreference;
   if (shouldForceExa || shouldAutoAssignExa) {
     customizerWebSearchConfig.enabled = true;
     config.tools = config.tools ?? {};
@@ -360,7 +364,6 @@ export function generateBaseConfig(
   } else if (kiloExaSearchMode === 'disabled') {
     customizerWebSearchConfig.enabled = false;
 
-    const braveConfigured = Boolean(env.BRAVE_API_KEY?.trim());
     if (
       braveConfigured &&
       (!hasExplicitSearchProvider || config.tools?.web?.search?.provider === KILO_EXA_PROVIDER_ID)


### PR DESCRIPTION
## Summary
- Prevent Exa auto-assignment during config patching when the user already has an explicit web-search preference, including Brave API key configuration or an explicitly disabled search setting.
- Keep forced `kilo-proxy` behavior unchanged while narrowing auto-assignment in `unset` mode to truly unconfigured cases only.
- Add regression coverage for both config generation and doctor/restore upgrade paths to ensure existing Brave-based setups are not clobbered.

## Verification
- Reproduced the upgrade scenario in unit tests where `tools.web.search.provider` is unset and `BRAVE_API_KEY` is present; verified provider remains untouched.
- Verified doctor-path patching does not assign `kilo-exa` when Brave is configured.

## Visual Changes
- N/A

## Reviewer Notes
- This change intentionally does not attempt rollback for already-clobbered instances and does not introduce an auto-assigned marker.