### PR TITLE
feat(gastown): add createBead/startBead/enrichBead tRPC procedures and gt:held reconciler exclusion

### DIFF
--- a/create-bead-ui-convoy.md
+++ b/create-bead-ui-convoy.md
@@ -1,0 +1,22 @@
+# Create Bead UI Convoy — Shared Context
+
+## Bead 1: Backend (createBead tRPC + Workers AI enrichment)
+
+### Status: completed
+
+### Deviations from plan
+
+- `HELD_LABEL` and `HELD_LABEL_LIKE` constants are exported from `patrol.ts` (not alongside `TRIAGE_LABEL_LIKE` in reconciler.ts — that's just the consumer). This matches the existing pattern where `TRIAGE_LABEL_LIKE` is defined in `patrol.ts` and imported in `reconciler.ts`.
+- Labels in the database are stored as JSON arrays (e.g. `'["gt:held","bug"]'`), so `HELD_LABEL_LIKE` uses the pattern `%"gt:held"%` (with quotes), matching the same pattern used by `TRIAGE_LABEL_LIKE = '%"gt:triage-request"%'`.
+- `slingBead()` already supports `labels?: string[]` in its input type — no change needed there. The `sling` tRPC procedure needed updating to accept `labels` and pass it through.
+- The `enrichBead` procedure uses `ctx.env.AI.run(...)`. The AI binding is typed as `Ai` (Cloudflare Workers AI SDK) in `worker-configuration.d.ts`. The `run()` call for text generation models returns `{ response?: string }`.
+- `createHeldBead` and `notifyMayorOfNewBead` are added as public RPC methods on `TownDO` (not private helpers), since they need to be called from the tRPC router via `townStub`.
+- For `startBead`, the labels are updated via `beadOps.updateBeadFields()` — filtering out `gt:held`. Then `escalateToActiveCadence()` is called to arm the alarm.
+
+### Notes for future implementors
+
+- The `createBead` tRPC procedure creates an `open` bead with `gt:held` label (unless `startImmediately=true`). The reconciler's Rule 1 excludes beads with `gt:held` label from dispatch.
+- The `startBead` tRPC procedure removes `gt:held` from labels and arms the reconciler alarm via `townStub.startHeldBead()`.
+- The `enrichBead` procedure calls Workers AI (`@cf/meta/llama-3.1-8b-instruct`) to suggest title + labels. It returns `null` if the AI response is unparseable.
+- All three new tRPC procedures follow the `gastownProcedure` pattern with `verifyRigOwnership` (createBead, startBead) or `verifyTownOwnership` (enrichBead) for authorization.
+- The mayor is notified via `townStub.notifyMayorOfNewBead()` when `startImmediately=false`.

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -2399,6 +2399,75 @@ export class TownDO extends DurableObject<Env> {
     return { bead, agent: hookedAgent };
   }
 
+  /**
+   * Create an open bead with the given labels, without arming the reconciler alarm.
+   * The caller is responsible for including `gt:held` in the labels if the bead
+   * should not be dispatched immediately.
+   */
+  async createHeldBead(input: {
+    rigId: string;
+    title: string;
+    body?: string;
+    labels?: string[];
+  }): Promise<Bead> {
+    const bead = beadOps.createBead(this.sql, {
+      type: 'issue',
+      title: input.title,
+      body: input.body,
+      rig_id: input.rigId,
+      labels: input.labels,
+    });
+
+    events.insertEvent(this.sql, 'bead_created', {
+      bead_id: bead.bead_id,
+      payload: { bead_type: 'issue', rig_id: input.rigId, has_blockers: false },
+    });
+
+    return bead;
+  }
+
+  /**
+   * Notify the mayor about a newly created held bead.
+   * The mayor can then explore the codebase, plan, decompose into a convoy, or start it.
+   */
+  async notifyMayorOfNewBead(
+    beadId: string,
+    rigId: string,
+    title: string,
+    body?: string
+  ): Promise<void> {
+    const descriptionLine = body
+      ? `Description: ${body.slice(0, 500)}${body.length > 500 ? '...' : ''}`
+      : '';
+    const messageParts = [
+      `A user just created a new bead in rig ${rigId}:`,
+      `ID: ${beadId}`,
+      `Title: "${title}"`,
+      descriptionLine,
+      ``,
+      `The bead is currently held (tagged gt:held) and will not be dispatched until started.`,
+      `Would you like to explore the codebase and flesh out a detailed plan, decompose it into a staged convoy, or start it immediately?`,
+      `When you reply, create a message bead with parent_bead_id: "${beadId}" so it appears in the bead drawer.`,
+      `To start the bead immediately, remove the gt:held label via gt_bead_update.`,
+    ];
+    const message = messageParts.filter(Boolean).join('\n');
+    await this.sendMayorMessage(message);
+  }
+
+  /**
+   * Remove the `gt:held` label from a bead and arm the reconciler alarm so the
+   * bead is picked up on the next tick.
+   */
+  async startHeldBead(beadId: string): Promise<Bead> {
+    const bead = beadOps.getBead(this.sql, beadId);
+    if (!bead) throw new Error(`Bead ${beadId} not found`);
+
+    const updatedLabels = (bead.labels ?? []).filter(l => l !== patrol.HELD_LABEL);
+    const updated = beadOps.updateBeadFields(this.sql, beadId, { labels: updatedLabels }, 'system');
+    await this.escalateToActiveCadence();
+    return updated;
+  }
+
   /** Build the rig list for mayor agent startup (browse worktree setup on fresh containers). */
   private async rigListForMayor(): Promise<
     Array<{

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -2457,10 +2457,16 @@ export class TownDO extends DurableObject<Env> {
   /**
    * Remove the `gt:held` label from a bead and arm the reconciler alarm so the
    * bead is picked up on the next tick.
+   *
+   * @param rigId - The rig the caller has verified ownership of. The bead must
+   *   belong to this rig to prevent cross-rig label removal within the same town.
    */
-  async startHeldBead(beadId: string): Promise<Bead> {
+  async startHeldBead(beadId: string, rigId: string): Promise<Bead> {
     const bead = beadOps.getBead(this.sql, beadId);
     if (!bead) throw new Error(`Bead ${beadId} not found`);
+    if (bead.rig_id !== rigId) {
+      throw new Error(`Bead ${beadId} does not belong to rig ${rigId}`);
+    }
 
     const updatedLabels = (bead.labels ?? []).filter(l => l !== patrol.HELD_LABEL);
     const updated = beadOps.updateBeadFields(this.sql, beadId, { labels: updatedLabels }, 'system');

--- a/services/gastown/src/dos/town/patrol.ts
+++ b/services/gastown/src/dos/town/patrol.ts
@@ -59,6 +59,12 @@ export const TRIAGE_BATCH_LABEL = 'gt:triage';
 /** SQL LIKE pattern for querying triage request beads by label. */
 export const TRIAGE_LABEL_LIKE = `%"${TRIAGE_REQUEST_LABEL}"%`;
 
+/** Label used to mark beads that should not yet be dispatched by the reconciler. */
+export const HELD_LABEL = 'gt:held';
+
+/** SQL LIKE pattern for querying held beads by label. */
+export const HELD_LABEL_LIKE = `%"${HELD_LABEL}"%`;
+
 /** Create a triage request bead for the LLM triage agent to resolve. */
 export function createTriageRequest(
   sql: SqlStorage,

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -25,6 +25,7 @@ import {
   GUPP_FORCE_STOP_MS,
   AGENT_GC_RETENTION_MS,
   TRIAGE_LABEL_LIKE,
+  HELD_LABEL_LIKE,
   createTriageRequest,
 } from './patrol';
 import { MAX_DISPATCH_ATTEMPTS } from './scheduling';
@@ -880,6 +881,7 @@ export function reconcileBeads(
           AND b.${beads.columns.assignee_agent_bead_id} IS NULL
           AND b.${beads.columns.rig_id} IS NOT NULL
           AND b.${beads.columns.labels} NOT LIKE ?
+          AND b.${beads.columns.labels} NOT LIKE ?
           AND NOT EXISTS (
             SELECT 1 FROM ${bead_dependencies} bd
             INNER JOIN ${beads} blocker ON blocker.${beads.columns.bead_id} = bd.${bead_dependencies.columns.depends_on_bead_id}
@@ -895,7 +897,7 @@ export function reconcileBeads(
               AND cm.${convoy_metadata.columns.staged} = 1
           )
       `,
-      [TRIAGE_LABEL_LIKE]
+      [TRIAGE_LABEL_LIKE, HELD_LABEL_LIKE]
     ),
   ]);
 

--- a/services/gastown/src/gastown.worker.ts
+++ b/services/gastown/src/gastown.worker.ts
@@ -1043,6 +1043,7 @@ app.use(
     endpoint: '/trpc',
     createContext: (_opts: unknown, c: Context<GastownEnv>) => ({
       env: c.env,
+      executionCtx: c.executionCtx,
       userId: c.get('kiloUserId') ?? '',
       isAdmin: c.get('kiloIsAdmin') ?? false,
       apiTokenPepper: c.get('kiloApiTokenPepper') ?? null,

--- a/services/gastown/src/trpc/init.ts
+++ b/services/gastown/src/trpc/init.ts
@@ -5,6 +5,7 @@ import type { JwtOrgMembership } from '../middleware/auth.middleware';
 
 export type TRPCContext = {
   env: Env;
+  executionCtx: ExecutionContext;
   userId: string;
   isAdmin: boolean;
   apiTokenPepper: string | null;

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -817,6 +817,7 @@ export const gastownRouter = router({
         title: z.string().min(1),
         body: z.string().optional(),
         model: z.string().default('kilo/kilo-auto/frontier'),
+        labels: z.array(z.string()).optional(),
       })
     )
     .output(RpcSlingResultOutput)
@@ -844,8 +845,110 @@ export const gastownRouter = router({
         rigId: rig.id,
         title: input.title,
         body: input.body,
+        labels: input.labels,
         metadata: { model: input.model, slung_by: user.id },
       });
+    }),
+
+  createBead: gastownProcedure
+    .input(
+      z.object({
+        rigId: z.string().uuid(),
+        title: z.string().min(1),
+        body: z.string().optional(),
+        labels: z.array(z.string()).optional(),
+        startImmediately: z.boolean().default(false),
+        townId: z.string().uuid().optional(),
+      })
+    )
+    .output(RpcBeadOutput)
+    .mutation(async ({ ctx, input }) => {
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
+      const townStub = getTownDOStub(ctx.env, rig.town_id);
+
+      const labels = input.startImmediately
+        ? (input.labels ?? [])
+        : ['gt:held', ...(input.labels ?? [])];
+
+      const bead = await townStub.createHeldBead({
+        rigId: rig.id,
+        title: input.title,
+        body: input.body,
+        labels,
+      });
+
+      if (input.startImmediately) {
+        await townStub.startHeldBead(bead.bead_id);
+      } else {
+        // Fire-and-forget mayor notification — don't block the response
+        townStub
+          .notifyMayorOfNewBead(bead.bead_id, rig.id, input.title, input.body)
+          .catch(err => console.warn('[gastown-trpc] createBead: mayor notification failed', err));
+      }
+
+      return bead;
+    }),
+
+  startBead: gastownProcedure
+    .input(
+      z.object({
+        rigId: z.string().uuid(),
+        beadId: z.string().uuid(),
+        townId: z.string().uuid().optional(),
+      })
+    )
+    .output(RpcBeadOutput)
+    .mutation(async ({ ctx, input }) => {
+      const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
+      const townStub = getTownDOStub(ctx.env, rig.town_id);
+      return townStub.startHeldBead(input.beadId);
+    }),
+
+  enrichBead: gastownProcedure
+    .input(
+      z.object({
+        body: z.string().min(10),
+        townId: z.string().uuid(),
+      })
+    )
+    .output(
+      z
+        .object({
+          title: z.string(),
+          labels: z.array(z.string()),
+        })
+        .nullable()
+    )
+    .mutation(async ({ ctx, input }) => {
+      await verifyTownOwnership(ctx.env, ctx, input.townId);
+
+      const result = await ctx.env.AI.run('@cf/meta/llama-3.1-8b-instruct', {
+        prompt: `You are a software project assistant. Given this task description, suggest a concise title (max 8 words) and 1-3 relevant labels from: [bug, feature, refactor, docs, test, chore, performance, security, ui, backend, infrastructure].\n\nTask description:\n${input.body}\n\nRespond with JSON only: { "title": "...", "labels": ["..."] }`,
+        max_tokens: 100,
+      });
+
+      const responseText =
+        result && typeof result === 'object' && 'response' in result
+          ? (result as { response?: string }).response
+          : null;
+
+      if (!responseText) return null;
+
+      try {
+        // Strip markdown code fences if present
+        const cleaned = responseText
+          .replace(/^```(?:json)?\s*/i, '')
+          .replace(/\s*```\s*$/, '')
+          .trim();
+        const parsed = JSON.parse(cleaned) as unknown;
+        const schema = z.object({
+          title: z.string(),
+          labels: z.array(z.string()),
+        });
+        return schema.parse(parsed);
+      } catch {
+        return null;
+      }
     }),
 
   // ── Mayor ───────────────────────────────────────────────────────────

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -878,12 +878,15 @@ export const gastownRouter = router({
       });
 
       if (input.startImmediately) {
-        await townStub.startHeldBead(bead.bead_id);
+        await townStub.startHeldBead(bead.bead_id, rig.id);
       } else {
-        // Fire-and-forget mayor notification — don't block the response
-        townStub
-          .notifyMayorOfNewBead(bead.bead_id, rig.id, input.title, input.body)
-          .catch(err => console.warn('[gastown-trpc] createBead: mayor notification failed', err));
+        // Mayor notification can start a container — use waitUntil so the Worker
+        // stays alive until the RPC completes without blocking the HTTP response.
+        ctx.executionCtx.waitUntil(
+          townStub
+            .notifyMayorOfNewBead(bead.bead_id, rig.id, input.title, input.body)
+            .catch(err => console.warn('[gastown-trpc] createBead: mayor notification failed', err))
+        );
       }
 
       return bead;
@@ -901,7 +904,7 @@ export const gastownRouter = router({
     .mutation(async ({ ctx, input }) => {
       const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId, input.townId);
       const townStub = getTownDOStub(ctx.env, rig.town_id);
-      return townStub.startHeldBead(input.beadId);
+      return townStub.startHeldBead(input.beadId, rig.id);
     }),
 
   enrichBead: gastownProcedure


### PR DESCRIPTION
## Summary

- Add `HELD_LABEL` (`gt:held`) and `HELD_LABEL_LIKE` constants to `patrol.ts`; add import + second `NOT LIKE` clause to reconciler Rule 1 so held beads are never auto-dispatched
- Add `createHeldBead()`, `notifyMayorOfNewBead()`, and `startHeldBead()` RPC methods to `TownDO`
- Add three new tRPC procedures: `createBead` (creates open bead, optionally held), `startBead` (removes `gt:held`, arms alarm), and `enrichBead` (Workers AI title/label suggestions via `@cf/meta/llama-3.1-8b-instruct`)
- Update existing `sling` procedure to accept optional `labels` array, threading it through to `slingBead()`
- Create `create-bead-ui-convoy.md` shared context file for subsequent convoy polecats

## Verification

- Manually verify by calling `trpc.gastown.createBead` with `startImmediately: false` — bead should appear as `open` with `gt:held` label, not be dispatched, and the mayor should receive a notification message
- Call `trpc.gastown.startBead` — `gt:held` label removed, reconciler alarm armed on next tick
- Call `trpc.gastown.enrichBead` with a body string — returns `{ title, labels }` or `null` on parse failure

## Visual Changes

N/A — backend only

## Reviewer Notes

- Labels are stored as JSON arrays in SQLite (`'["gt:held","bug"]'`), so `HELD_LABEL_LIKE` uses `%"gt:held"%` (with quotes) matching the existing `TRIAGE_LABEL_LIKE` pattern
- `notifyMayorOfNewBead` is fire-and-forget from the tRPC procedure to avoid blocking the create response
- `enrichBead` strips markdown code fences from the AI response before JSON parsing, since LLMs sometimes wrap JSON in fences