### PR TITLE
feat(kiloclaw): add Morning Briefing plugin and dashboard controls

### DIFF
--- a/.github/workflows/deploy-kiloclaw.yml
+++ b/.github/workflows/deploy-kiloclaw.yml
@@ -60,7 +60,7 @@ jobs:
         working-directory: services/kiloclaw
         run: |
           # Validate all expected paths exist before hashing
-          for path in Dockerfile controller container plugins/kiloclaw-customizer skills \
+          for path in Dockerfile controller container plugins/kiloclaw-customizer plugins/kiloclaw-morning-briefing skills \
                       openclaw-pairing-list.js openclaw-device-pairing-list.js; do
             if [ ! -e "$path" ]; then
               echo "::error::Required path not found: $path"
@@ -69,7 +69,7 @@ jobs:
           done
 
           CONTENT_HASH=$(
-            find Dockerfile controller/ container/ plugins/kiloclaw-customizer/ skills/ \
+            find Dockerfile controller/ container/ plugins/kiloclaw-customizer/ plugins/kiloclaw-morning-briefing/ skills/ \
               openclaw-pairing-list.js openclaw-device-pairing-list.js \
               -type f \
               | sort \

--- a/.github/workflows/push-dev-kiloclaw.yml
+++ b/.github/workflows/push-dev-kiloclaw.yml
@@ -40,7 +40,7 @@ jobs:
         id: content-hash
         working-directory: services/kiloclaw
         run: |
-          for path in Dockerfile controller container plugins/kiloclaw-customizer skills \
+          for path in Dockerfile controller container plugins/kiloclaw-customizer plugins/kiloclaw-morning-briefing skills \
                       openclaw-pairing-list.js openclaw-device-pairing-list.js; do
             if [ ! -e "$path" ]; then
               echo "::error::Required path not found: $path"
@@ -49,7 +49,7 @@ jobs:
           done
 
           CONTENT_HASH=$(
-            find Dockerfile controller/ container/ plugins/kiloclaw-customizer/ skills/ \
+            find Dockerfile controller/ container/ plugins/kiloclaw-customizer/ plugins/kiloclaw-morning-briefing/ skills/ \
               openclaw-pairing-list.js openclaw-device-pairing-list.js \
               -type f \
               | sort \

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -527,9 +527,9 @@ function MorningBriefingCard({
           <Button
             size="sm"
             variant="outline"
-            disabled={mutations.setupMorningBriefing.isPending}
+            disabled={mutations.enableMorningBriefing.isPending}
             onClick={() => {
-              mutations.setupMorningBriefing.mutate(
+              mutations.enableMorningBriefing.mutate(
                 {},
                 {
                   onSuccess: () => toast.success('Morning Briefing enabled'),
@@ -538,7 +538,7 @@ function MorningBriefingCard({
               );
             }}
           >
-            {mutations.setupMorningBriefing.isPending ? 'Enabling...' : 'Enable / Setup'}
+            {mutations.enableMorningBriefing.isPending ? 'Enabling...' : 'Enable'}
           </Button>
           <Button
             size="sm"

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -558,9 +558,7 @@ function MorningBriefingCard({
   const reconcileState = briefingStatus?.reconcileState ?? 'idle';
   const lastReconcileAction = briefingStatus?.lastReconcileAction ?? null;
   const isWarmupState =
-    isRunning &&
-    (briefingStatus?.code === 'gateway_warming_up' ||
-      (actionsReady === false && reconcileState === 'in_progress'));
+    isRunning && (actionsReady === false || briefingStatus?.code === 'gateway_warming_up');
   const isTransitioning =
     reconcileState === 'in_progress' ||
     mutations.enableMorningBriefing.isPending ||

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -622,7 +622,8 @@ function MorningBriefingCard({
         ? 'No sources are connected yet. Configure GitHub, Linear, or Web Search to generate richer briefings.'
         : `Connected sources: ${joinFriendlyList(readySources)}. Disconnected sources: ${joinFriendlyList(missingSources)}.`;
   const showScheduleDetails = !isWarmupState && hasSchedule && desiredEnabled;
-  const canUseBriefingControls = actionsReady && desiredEnabled;
+  const controlsEnabled = actionsReady && !isWarmupState;
+  const canUseBriefingControls = controlsEnabled && desiredEnabled;
 
   return (
     <div className="rounded-lg border px-4 py-3">
@@ -647,7 +648,9 @@ function MorningBriefingCard({
           <Button
             size="sm"
             variant="outline"
-            disabled={!actionsReady || desiredEnabled || mutations.enableMorningBriefing.isPending}
+            disabled={
+              !controlsEnabled || desiredEnabled || mutations.enableMorningBriefing.isPending
+            }
             onClick={() => {
               mutations.enableMorningBriefing.mutate(
                 {},
@@ -664,7 +667,7 @@ function MorningBriefingCard({
             size="sm"
             variant="outline"
             disabled={
-              !actionsReady || !desiredEnabled || mutations.disableMorningBriefing.isPending
+              !controlsEnabled || !desiredEnabled || mutations.disableMorningBriefing.isPending
             }
             onClick={() => {
               mutations.disableMorningBriefing.mutate(undefined, {

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -26,7 +26,13 @@ import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombob
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { calverAtLeast, cleanVersion } from '@/lib/kiloclaw/version';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
-import { useClawConfig, useClawMyPin, useClawGoogleSetupCommand } from '../hooks/useClawHooks';
+import {
+  useClawConfig,
+  useClawMyPin,
+  useClawGoogleSetupCommand,
+  useClawMorningBriefingStatus,
+  useClawReadMorningBriefing,
+} from '../hooks/useClawHooks';
 import { useClawUpdateAvailable } from '../hooks/useClawUpdateAvailable';
 import { useClawContext } from './ClawContext';
 
@@ -444,6 +450,165 @@ function GoogleAccountCard({
         }}
       />
     </>
+  );
+}
+
+function MorningBriefingCard({
+  mutations,
+  briefingStatus,
+  fallbackReadiness,
+}: {
+  mutations: ClawMutations;
+  briefingStatus:
+    | {
+        enabled?: boolean;
+        cron?: string;
+        timezone?: string;
+        lastGeneratedDate?: string | null;
+        sourceReadiness?: {
+          github: { configured: boolean; summary: string };
+          linear: { configured: boolean; summary: string };
+          web: { configured: boolean; summary: string };
+        };
+      }
+    | undefined;
+  fallbackReadiness: {
+    githubConfigured: boolean;
+    linearConfigured: boolean;
+    webConfigured: boolean;
+  };
+}) {
+  const [requestedDay, setRequestedDay] = useState<'today' | 'yesterday' | null>(null);
+  const { data: readData, isFetching: isReading } = useClawReadMorningBriefing(requestedDay, true);
+
+  const sourceReadiness =
+    briefingStatus?.sourceReadiness ??
+    ({
+      github: {
+        configured: fallbackReadiness.githubConfigured,
+        summary: fallbackReadiness.githubConfigured
+          ? 'Configured in Developer Tools'
+          : 'Not configured',
+      },
+      linear: {
+        configured: fallbackReadiness.linearConfigured,
+        summary: fallbackReadiness.linearConfigured
+          ? 'Configured in Developer Tools'
+          : 'Not configured',
+      },
+      web: {
+        configured: fallbackReadiness.webConfigured,
+        summary: fallbackReadiness.webConfigured
+          ? 'Configured in Search settings'
+          : 'Not configured',
+      },
+    } as const);
+
+  return (
+    <div className="rounded-lg border px-4 py-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <p className="text-sm font-medium">Morning Briefing</p>
+            <Badge variant={briefingStatus?.enabled ? 'default' : 'secondary'}>
+              {briefingStatus?.enabled ? 'Enabled' : 'Disabled'}
+            </Badge>
+          </div>
+          <p className="text-muted-foreground text-xs">
+            {briefingStatus?.cron && briefingStatus?.timezone
+              ? `Schedule: ${briefingStatus.cron} (${briefingStatus.timezone})`
+              : 'Schedule not configured'}
+          </p>
+          <p className="text-muted-foreground text-xs">
+            Last generated: {briefingStatus?.lastGeneratedDate ?? '(none)'}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={mutations.setupMorningBriefing.isPending}
+            onClick={() => {
+              mutations.setupMorningBriefing.mutate(
+                {},
+                {
+                  onSuccess: () => toast.success('Morning Briefing enabled'),
+                  onError: err => toast.error(`Failed to enable Morning Briefing: ${err.message}`),
+                }
+              );
+            }}
+          >
+            {mutations.setupMorningBriefing.isPending ? 'Enabling...' : 'Enable / Setup'}
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={mutations.disableMorningBriefing.isPending}
+            onClick={() => {
+              mutations.disableMorningBriefing.mutate(undefined, {
+                onSuccess: () => toast.success('Morning Briefing disabled'),
+                onError: err => toast.error(`Failed to disable Morning Briefing: ${err.message}`),
+              });
+            }}
+          >
+            {mutations.disableMorningBriefing.isPending ? 'Disabling...' : 'Disable'}
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={mutations.runMorningBriefing.isPending}
+            onClick={() => {
+              mutations.runMorningBriefing.mutate(undefined, {
+                onSuccess: data => {
+                  const date = data.date ? ` for ${data.date}` : '';
+                  toast.success(`Morning Briefing generated${date}`);
+                },
+                onError: err => toast.error(`Failed to run Morning Briefing: ${err.message}`),
+              });
+            }}
+          >
+            {mutations.runMorningBriefing.isPending ? 'Running...' : 'Run Now'}
+          </Button>
+          <Button size="sm" variant="outline" onClick={() => setRequestedDay('today')}>
+            View Today
+          </Button>
+          <Button size="sm" variant="outline" onClick={() => setRequestedDay('yesterday')}>
+            View Yesterday
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-3 grid gap-2 text-xs sm:grid-cols-3">
+        <div className="rounded border px-2 py-1">
+          <span className="font-medium">GitHub:</span>{' '}
+          {sourceReadiness.github.configured ? 'Ready' : 'Not ready'}
+        </div>
+        <div className="rounded border px-2 py-1">
+          <span className="font-medium">Linear:</span>{' '}
+          {sourceReadiness.linear.configured ? 'Ready' : 'Not ready'}
+        </div>
+        <div className="rounded border px-2 py-1">
+          <span className="font-medium">Web Search:</span>{' '}
+          {sourceReadiness.web.configured ? 'Ready' : 'Not ready'}
+        </div>
+      </div>
+
+      {requestedDay && (
+        <div className="mt-3">
+          {isReading ? (
+            <p className="text-muted-foreground text-xs">Loading saved briefing...</p>
+          ) : readData?.markdown ? (
+            <pre className="bg-muted max-h-56 overflow-auto rounded p-3 text-xs whitespace-pre-wrap">
+              {readData.markdown}
+            </pre>
+          ) : (
+            <p className="text-muted-foreground text-xs">
+              No saved briefing for {requestedDay === 'today' ? 'today' : 'yesterday'}.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -1015,6 +1180,7 @@ export function SettingsTab({
     isControllerVersionError,
   } = useClawUpdateAvailable(status);
   const { data: myPin } = useClawMyPin();
+  const { data: morningBriefingStatus } = useClawMorningBriefingStatus(true);
   const [confirmDestroy, setConfirmDestroy] = useState(false);
   const [confirmRestore, setConfirmRestore] = useState(false);
   const hasModelSelectionError = isRunning && isControllerVersionError;
@@ -1559,6 +1725,15 @@ export function SettingsTab({
             gmailNotificationsEnabled={status.gmailNotificationsEnabled}
             mutations={mutations}
             onRedeploy={onRedeploy}
+          />
+          <MorningBriefingCard
+            mutations={mutations}
+            briefingStatus={morningBriefingStatus}
+            fallbackReadiness={{
+              githubConfigured: configuredSecrets.github ?? false,
+              linearConfigured: configuredSecrets.linear ?? false,
+              webConfigured: braveSearchConfigured || exaSearchConfigured,
+            }}
           />
         </div>
       </div>

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -557,8 +557,7 @@ function MorningBriefingCard({
   const observedEnabled = briefingStatus?.observedEnabled ?? briefingStatus?.enabled ?? false;
   const reconcileState = briefingStatus?.reconcileState ?? 'idle';
   const lastReconcileAction = briefingStatus?.lastReconcileAction ?? null;
-  const isWarmupState =
-    isRunning && (actionsReady === false || briefingStatus?.code === 'gateway_warming_up');
+  const isWarmupState = isRunning && actionsReady === false;
   const isTransitioning =
     reconcileState === 'in_progress' ||
     mutations.enableMorningBriefing.isPending ||
@@ -720,7 +719,7 @@ function MorningBriefingCard({
         </p>
       )}
 
-      {!desiredEnabled && actionsReady && (
+      {!desiredEnabled && controlsEnabled && (
         <p className="text-muted-foreground mt-2 text-xs">
           Enable Morning Briefing to get a personalized briefing everyday.
         </p>

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -116,6 +116,13 @@ function formatMorningBriefingSchedule(cron: string, timezone: string): string {
   return `Automatically runs daily at ${timeLabel} ${timezoneLabel}`;
 }
 
+function joinFriendlyList(items: string[]): string {
+  if (items.length === 0) return '';
+  if (items.length === 1) return items[0];
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
+}
+
 // ---------------------------------------------------------------------------
 // 1Password setup guide dialog
 // ---------------------------------------------------------------------------
@@ -495,6 +502,11 @@ function MorningBriefingCard({
   briefingStatus:
     | {
         enabled?: boolean;
+        desiredEnabled?: boolean;
+        observedEnabled?: boolean | null;
+        reconcileState?: 'idle' | 'in_progress' | 'succeeded' | 'failed';
+        lastReconcileAction?: 'enable' | 'disable' | null;
+        code?: string;
         cron?: string;
         timezone?: string;
         lastGeneratedDate?: string | null;
@@ -538,30 +550,93 @@ function MorningBriefingCard({
       },
     } as const);
 
+  const hasSchedule = Boolean(briefingStatus?.cron && briefingStatus?.timezone);
+  const desiredEnabled = briefingStatus?.desiredEnabled ?? briefingStatus?.enabled ?? false;
+  const observedEnabled = briefingStatus?.observedEnabled ?? briefingStatus?.enabled ?? false;
+  const reconcileState = briefingStatus?.reconcileState ?? 'idle';
+  const lastReconcileAction = briefingStatus?.lastReconcileAction ?? null;
+  const isWarmupState = briefingStatus?.code === 'gateway_warming_up' || !actionsReady;
+  const isTransitioning =
+    reconcileState === 'in_progress' ||
+    mutations.enableMorningBriefing.isPending ||
+    mutations.disableMorningBriefing.isPending;
+
+  const statusLabel = (() => {
+    if (isWarmupState) {
+      return 'Instance Warming Up';
+    }
+
+    if (mutations.enableMorningBriefing.isPending) {
+      return 'Enabling';
+    }
+    if (mutations.disableMorningBriefing.isPending) {
+      return 'Disabling';
+    }
+
+    if (reconcileState === 'in_progress') {
+      if (lastReconcileAction === 'enable') {
+        return observedEnabled === true ? 'Enabled' : 'Enabling';
+      }
+      if (lastReconcileAction === 'disable') {
+        return observedEnabled === false ? 'Disabled' : 'Disabling';
+      }
+      if (desiredEnabled && observedEnabled !== true) {
+        return 'Enabling';
+      }
+      if (!desiredEnabled && observedEnabled === true) {
+        return 'Disabling';
+      }
+    }
+
+    return observedEnabled ? 'Enabled' : 'Disabled';
+  })();
+  const statusVariant =
+    observedEnabled || (isTransitioning && desiredEnabled) ? 'default' : 'secondary';
+
+  const readySources = [
+    sourceReadiness.github.configured ? 'GitHub' : null,
+    sourceReadiness.linear.configured ? 'Linear' : null,
+    sourceReadiness.web.configured ? 'Web Search' : null,
+  ].filter((value): value is string => value !== null);
+  const missingSources = [
+    sourceReadiness.github.configured ? null : 'GitHub',
+    sourceReadiness.linear.configured ? null : 'Linear',
+    sourceReadiness.web.configured ? null : 'Web Search',
+  ].filter((value): value is string => value !== null);
+
+  const sourceSummaryText =
+    readySources.length === 3
+      ? 'All sources are connected: GitHub, Linear, and Web Search.'
+      : readySources.length === 0
+        ? 'No sources are connected yet. Configure GitHub, Linear, or Web Search to generate richer briefings.'
+        : `Connected sources: ${joinFriendlyList(readySources)}. Disconnected sources: ${joinFriendlyList(missingSources)}.`;
+  const showScheduleDetails = !isWarmupState && hasSchedule && desiredEnabled;
+  const canUseBriefingControls = actionsReady && desiredEnabled;
+
   return (
     <div className="rounded-lg border px-4 py-3">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <div className="flex items-center gap-2">
             <p className="text-sm font-medium">Morning Briefing</p>
-            <Badge variant={briefingStatus?.enabled ? 'default' : 'secondary'}>
-              {briefingStatus?.enabled ? 'Enabled' : 'Disabled'}
-            </Badge>
+            <Badge variant={statusVariant}>{statusLabel}</Badge>
           </div>
-          <p className="text-muted-foreground text-xs">
-            {briefingStatus?.cron && briefingStatus?.timezone
-              ? formatMorningBriefingSchedule(briefingStatus.cron, briefingStatus.timezone)
-              : 'Schedule not configured'}
-          </p>
-          <p className="text-muted-foreground text-xs">
-            Last generated: {briefingStatus?.lastGeneratedDate ?? '(none)'}
-          </p>
+          {showScheduleDetails && briefingStatus?.cron && briefingStatus?.timezone && (
+            <p className="text-muted-foreground text-xs">
+              {formatMorningBriefingSchedule(briefingStatus.cron, briefingStatus.timezone)}
+            </p>
+          )}
+          {showScheduleDetails && (
+            <p className="text-muted-foreground text-xs">
+              Last generated: {briefingStatus?.lastGeneratedDate ?? '(none)'}
+            </p>
+          )}
         </div>
         <div className="flex flex-wrap gap-2">
           <Button
             size="sm"
             variant="outline"
-            disabled={!actionsReady || mutations.enableMorningBriefing.isPending}
+            disabled={!actionsReady || desiredEnabled || mutations.enableMorningBriefing.isPending}
             onClick={() => {
               mutations.enableMorningBriefing.mutate(
                 {},
@@ -577,7 +652,9 @@ function MorningBriefingCard({
           <Button
             size="sm"
             variant="outline"
-            disabled={!actionsReady || mutations.disableMorningBriefing.isPending}
+            disabled={
+              !actionsReady || !desiredEnabled || mutations.disableMorningBriefing.isPending
+            }
             onClick={() => {
               mutations.disableMorningBriefing.mutate(undefined, {
                 onSuccess: () => toast.success('Morning Briefing disabled'),
@@ -590,7 +667,7 @@ function MorningBriefingCard({
           <Button
             size="sm"
             variant="outline"
-            disabled={!actionsReady || mutations.runMorningBriefing.isPending}
+            disabled={!canUseBriefingControls || mutations.runMorningBriefing.isPending}
             onClick={() => {
               mutations.runMorningBriefing.mutate(undefined, {
                 onSuccess: data => {
@@ -603,10 +680,20 @@ function MorningBriefingCard({
           >
             {mutations.runMorningBriefing.isPending ? 'Running...' : 'Run Now'}
           </Button>
-          <Button size="sm" variant="outline" onClick={() => setRequestedDay('today')}>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!canUseBriefingControls}
+            onClick={() => setRequestedDay('today')}
+          >
             View Today
           </Button>
-          <Button size="sm" variant="outline" onClick={() => setRequestedDay('yesterday')}>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!canUseBriefingControls}
+            onClick={() => setRequestedDay('yesterday')}
+          >
             View Yesterday
           </Button>
         </div>
@@ -614,25 +701,18 @@ function MorningBriefingCard({
 
       {!actionsReady && (
         <p className="text-muted-foreground mt-2 text-xs">
-          Instance is still warming up. Morning Briefing actions will enable once the gateway is
-          fully ready.
+          Instance is still warming up. Morning Briefing controls will become available once the
+          gateway is fully ready.
         </p>
       )}
 
-      <div className="mt-3 grid gap-2 text-xs sm:grid-cols-3">
-        <div className="rounded border px-2 py-1">
-          <span className="font-medium">GitHub:</span>{' '}
-          {sourceReadiness.github.configured ? 'Ready' : 'Not ready'}
-        </div>
-        <div className="rounded border px-2 py-1">
-          <span className="font-medium">Linear:</span>{' '}
-          {sourceReadiness.linear.configured ? 'Ready' : 'Not ready'}
-        </div>
-        <div className="rounded border px-2 py-1">
-          <span className="font-medium">Web Search:</span>{' '}
-          {sourceReadiness.web.configured ? 'Ready' : 'Not ready'}
-        </div>
-      </div>
+      {!desiredEnabled && actionsReady && (
+        <p className="text-muted-foreground mt-2 text-xs">
+          Enable Morning Briefing to get a personalized briefing everyday.
+        </p>
+      )}
+
+      <p className="text-muted-foreground mt-3 text-xs">{sourceSummaryText}</p>
 
       {requestedDay && (
         <div className="mt-3">
@@ -1313,6 +1393,7 @@ export function SettingsTab({
       : '/api/integrations/google/disconnect';
   }, [organizationId]);
   const canSeeGoogleCalendar = !!user?.is_admin;
+  const canSeeMorningBriefing = !!user?.is_admin;
 
   function handleCycleInboundEmailAddress() {
     mutations.cycleInboundEmailAddress.mutate(undefined, {
@@ -1768,18 +1849,20 @@ export function SettingsTab({
             mutations={mutations}
             onRedeploy={onRedeploy}
           />
-          <MorningBriefingCard
-            mutations={mutations}
-            briefingStatus={morningBriefingStatus}
-            actionsReady={
-              isRunning && gatewayReady?.ready === true && gatewayReady?.settled === true
-            }
-            fallbackReadiness={{
-              githubConfigured: configuredSecrets.github ?? false,
-              linearConfigured: configuredSecrets.linear ?? false,
-              webConfigured: braveSearchConfigured || exaSearchConfigured,
-            }}
-          />
+          {canSeeMorningBriefing && (
+            <MorningBriefingCard
+              mutations={mutations}
+              briefingStatus={morningBriefingStatus}
+              actionsReady={
+                isRunning && gatewayReady?.ready === true && gatewayReady?.settled === true
+              }
+              fallbackReadiness={{
+                githubConfigured: configuredSecrets.github ?? false,
+                linearConfigured: configuredSecrets.linear ?? false,
+                webConfigured: braveSearchConfigured || exaSearchConfigured,
+              }}
+            />
+          )}
         </div>
       </div>
 

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -496,6 +496,7 @@ function MorningBriefingCard({
   mutations,
   briefingStatus,
   fallbackReadiness,
+  isRunning,
   actionsReady,
 }: {
   mutations: ClawMutations;
@@ -522,6 +523,7 @@ function MorningBriefingCard({
     linearConfigured: boolean;
     webConfigured: boolean;
   };
+  isRunning: boolean;
   actionsReady: boolean;
 }) {
   const [requestedDay, setRequestedDay] = useState<'today' | 'yesterday' | null>(null);
@@ -555,7 +557,10 @@ function MorningBriefingCard({
   const observedEnabled = briefingStatus?.observedEnabled ?? briefingStatus?.enabled ?? false;
   const reconcileState = briefingStatus?.reconcileState ?? 'idle';
   const lastReconcileAction = briefingStatus?.lastReconcileAction ?? null;
-  const isWarmupState = briefingStatus?.code === 'gateway_warming_up' || !actionsReady;
+  const isWarmupState =
+    isRunning &&
+    (briefingStatus?.code === 'gateway_warming_up' ||
+      (actionsReady === false && reconcileState === 'in_progress'));
   const isTransitioning =
     reconcileState === 'in_progress' ||
     mutations.enableMorningBriefing.isPending ||
@@ -564,6 +569,10 @@ function MorningBriefingCard({
   const statusLabel = (() => {
     if (isWarmupState) {
       return 'Instance Warming Up';
+    }
+
+    if (!isRunning) {
+      return 'Instance Stopped';
     }
 
     if (mutations.enableMorningBriefing.isPending) {
@@ -591,7 +600,11 @@ function MorningBriefingCard({
     return observedEnabled ? 'Enabled' : 'Disabled';
   })();
   const statusVariant =
-    observedEnabled || (isTransitioning && desiredEnabled) ? 'default' : 'secondary';
+    statusLabel === 'Instance Stopped'
+      ? 'secondary'
+      : observedEnabled || (isTransitioning && desiredEnabled)
+        ? 'default'
+        : 'secondary';
 
   const readySources = [
     sourceReadiness.github.configured ? 'GitHub' : null,
@@ -1853,6 +1866,7 @@ export function SettingsTab({
             <MorningBriefingCard
               mutations={mutations}
               briefingStatus={morningBriefingStatus}
+              isRunning={isRunning}
               actionsReady={
                 isRunning && gatewayReady?.ready === true && gatewayReady?.settled === true
               }

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -30,6 +30,7 @@ import {
   useClawConfig,
   useClawMyPin,
   useClawGoogleSetupCommand,
+  useClawGatewayReady,
   useClawMorningBriefingStatus,
   useClawReadMorningBriefing,
 } from '../hooks/useClawHooks';
@@ -83,6 +84,37 @@ type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 const EXA_SEARCH_UI_MIN_CONTROLLER_VERSION = '2026.4.14';
 const MEMORY_MIN_OPENCLAW_VERSION = '2026.4.5';
 const OPENCLAW_IMPORT_UI_MIN_CONTROLLER_VERSION = '2026.4.22';
+
+function formatMorningBriefingSchedule(cron: string, timezone: string): string {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    return `Schedule: ${cron} (${timezone})`;
+  }
+
+  const [minuteRaw, hourRaw, dayOfMonth, month, dayOfWeek] = parts;
+  const minute = Number.parseInt(minuteRaw, 10);
+  const hour24 = Number.parseInt(hourRaw, 10);
+
+  const isDaily = dayOfMonth === '*' && month === '*' && dayOfWeek === '*';
+  const isValidTime =
+    Number.isInteger(minute) &&
+    Number.isInteger(hour24) &&
+    minute >= 0 &&
+    minute <= 59 &&
+    hour24 >= 0 &&
+    hour24 <= 23;
+
+  if (!isDaily || !isValidTime) {
+    return `Schedule: ${cron} (${timezone})`;
+  }
+
+  const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+  const meridiem = hour24 >= 12 ? 'PM' : 'AM';
+  const timeLabel = `${hour12}:${String(minute).padStart(2, '0')} ${meridiem}`;
+  const timezoneLabel = timezone === 'America/Chicago' ? 'CT' : timezone;
+
+  return `Automatically runs daily at ${timeLabel} ${timezoneLabel}`;
+}
 
 // ---------------------------------------------------------------------------
 // 1Password setup guide dialog
@@ -457,6 +489,7 @@ function MorningBriefingCard({
   mutations,
   briefingStatus,
   fallbackReadiness,
+  actionsReady,
 }: {
   mutations: ClawMutations;
   briefingStatus:
@@ -477,6 +510,7 @@ function MorningBriefingCard({
     linearConfigured: boolean;
     webConfigured: boolean;
   };
+  actionsReady: boolean;
 }) {
   const [requestedDay, setRequestedDay] = useState<'today' | 'yesterday' | null>(null);
   const { data: readData, isFetching: isReading } = useClawReadMorningBriefing(requestedDay, true);
@@ -516,7 +550,7 @@ function MorningBriefingCard({
           </div>
           <p className="text-muted-foreground text-xs">
             {briefingStatus?.cron && briefingStatus?.timezone
-              ? `Schedule: ${briefingStatus.cron} (${briefingStatus.timezone})`
+              ? formatMorningBriefingSchedule(briefingStatus.cron, briefingStatus.timezone)
               : 'Schedule not configured'}
           </p>
           <p className="text-muted-foreground text-xs">
@@ -527,7 +561,7 @@ function MorningBriefingCard({
           <Button
             size="sm"
             variant="outline"
-            disabled={mutations.enableMorningBriefing.isPending}
+            disabled={!actionsReady || mutations.enableMorningBriefing.isPending}
             onClick={() => {
               mutations.enableMorningBriefing.mutate(
                 {},
@@ -543,7 +577,7 @@ function MorningBriefingCard({
           <Button
             size="sm"
             variant="outline"
-            disabled={mutations.disableMorningBriefing.isPending}
+            disabled={!actionsReady || mutations.disableMorningBriefing.isPending}
             onClick={() => {
               mutations.disableMorningBriefing.mutate(undefined, {
                 onSuccess: () => toast.success('Morning Briefing disabled'),
@@ -556,7 +590,7 @@ function MorningBriefingCard({
           <Button
             size="sm"
             variant="outline"
-            disabled={mutations.runMorningBriefing.isPending}
+            disabled={!actionsReady || mutations.runMorningBriefing.isPending}
             onClick={() => {
               mutations.runMorningBriefing.mutate(undefined, {
                 onSuccess: data => {
@@ -577,6 +611,13 @@ function MorningBriefingCard({
           </Button>
         </div>
       </div>
+
+      {!actionsReady && (
+        <p className="text-muted-foreground mt-2 text-xs">
+          Instance is still warming up. Morning Briefing actions will enable once the gateway is
+          fully ready.
+        </p>
+      )}
 
       <div className="mt-3 grid gap-2 text-xs sm:grid-cols-3">
         <div className="rounded border px-2 py-1">
@@ -1181,6 +1222,7 @@ export function SettingsTab({
   } = useClawUpdateAvailable(status);
   const { data: myPin } = useClawMyPin();
   const { data: morningBriefingStatus } = useClawMorningBriefingStatus(true);
+  const { data: gatewayReady } = useClawGatewayReady(isRunning);
   const [confirmDestroy, setConfirmDestroy] = useState(false);
   const [confirmRestore, setConfirmRestore] = useState(false);
   const hasModelSelectionError = isRunning && isControllerVersionError;
@@ -1729,6 +1771,9 @@ export function SettingsTab({
           <MorningBriefingCard
             mutations={mutations}
             briefingStatus={morningBriefingStatus}
+            actionsReady={
+              isRunning && gatewayReady?.ready === true && gatewayReady?.settled === true
+            }
             fallbackReadiness={{
               githubConfigured: configuredSecrets.github ?? false,
               linearConfigured: configuredSecrets.linear ?? false,

--- a/apps/web/src/app/(app)/claw/components/changelog-data.ts
+++ b/apps/web/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,13 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-04-23',
+    description:
+      'Added Morning Briefing for KiloClaw-hosted OpenClaw instances. The new bundled plugin can schedule daily briefings, run on demand, and save/read today and yesterday briefing Markdown files from persistent instance storage. Dashboard settings now include Morning Briefing status, source readiness, and controls.',
+    category: 'feature',
+    deployHint: 'redeploy_required',
+  },
+  {
     date: '2026-04-20',
     description:
       'Added support for Vector Search, Embedding Models, and Dreaming in Memory configuration. Vector Search lets your agent find relevant context across its memory files using semantic embeddings instead of plain keyword matches. Pick the Embedding Model that generates those vectors to trade off quality, speed, and cost. Dreaming runs in the background and promotes strong short-term signals into durable long-term memory, so the agent remembers what matters across sessions.',

--- a/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
+++ b/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
@@ -97,9 +97,18 @@ export function useClawMorningBriefingStatus(enabled: boolean) {
   const trpc = useTRPC();
   const { organizationId } = useClawContext();
 
+  const getRefetchInterval = (data: unknown): number => {
+    const maybeCode =
+      typeof data === 'object' && data !== null && 'code' in data
+        ? (data as { code?: unknown }).code
+        : undefined;
+    return maybeCode === 'gateway_warming_up' ? 10_000 : 30_000;
+  };
+
   const personal = useQuery({
     ...trpc.kiloclaw.getMorningBriefingStatus.queryOptions(undefined, {
-      refetchInterval: enabled ? 30_000 : false,
+      refetchInterval: query => (enabled ? getRefetchInterval(query.state.data) : false),
+      retry: false,
     }),
     enabled: enabled && !organizationId,
   });
@@ -107,7 +116,10 @@ export function useClawMorningBriefingStatus(enabled: boolean) {
   const org = useQuery({
     ...trpc.organizations.kiloclaw.getMorningBriefingStatus.queryOptions(
       { organizationId: organizationId ?? '' },
-      { refetchInterval: enabled ? 30_000 : false }
+      {
+        refetchInterval: query => (enabled ? getRefetchInterval(query.state.data) : false),
+        retry: false,
+      }
     ),
     enabled: enabled && !!organizationId,
   });

--- a/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
+++ b/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
@@ -93,6 +93,53 @@ export function useClawControllerVersion(enabled: boolean) {
   return organizationId ? org : personal;
 }
 
+export function useClawMorningBriefingStatus(enabled: boolean) {
+  const trpc = useTRPC();
+  const { organizationId } = useClawContext();
+
+  const personal = useQuery({
+    ...trpc.kiloclaw.getMorningBriefingStatus.queryOptions(undefined, {
+      refetchInterval: enabled ? 30_000 : false,
+    }),
+    enabled: enabled && !organizationId,
+  });
+
+  const org = useQuery({
+    ...trpc.organizations.kiloclaw.getMorningBriefingStatus.queryOptions(
+      { organizationId: organizationId ?? '' },
+      { refetchInterval: enabled ? 30_000 : false }
+    ),
+    enabled: enabled && !!organizationId,
+  });
+
+  return organizationId ? org : personal;
+}
+
+export function useClawReadMorningBriefing(day: 'today' | 'yesterday' | null, enabled: boolean) {
+  const trpc = useTRPC();
+  const { organizationId } = useClawContext();
+
+  const personal = useQuery({
+    ...trpc.kiloclaw.readMorningBriefing.queryOptions(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by enabled
+      { day: day! },
+      { refetchOnWindowFocus: false }
+    ),
+    enabled: enabled && day !== null && !organizationId,
+  });
+
+  const org = useQuery({
+    ...trpc.organizations.kiloclaw.readMorningBriefing.queryOptions(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by enabled
+      { organizationId: organizationId ?? '', day: day! },
+      { refetchOnWindowFocus: false }
+    ),
+    enabled: enabled && day !== null && !!organizationId,
+  });
+
+  return organizationId ? org : personal;
+}
+
 // Pairing
 
 export function useClawPairing(enabled = true) {

--- a/apps/web/src/hooks/useKiloClaw.ts
+++ b/apps/web/src/hooks/useKiloClaw.ts
@@ -101,6 +101,16 @@ export function useControllerVersion(enabled: boolean) {
   );
 }
 
+export function useMorningBriefingStatus(enabled: boolean) {
+  const trpc = useTRPC();
+  return useQuery(
+    trpc.kiloclaw.getMorningBriefingStatus.queryOptions(undefined, {
+      enabled,
+      refetchInterval: enabled ? 30_000 : false,
+    })
+  );
+}
+
 export function useKiloCliRunStatus(runId: string | null) {
   const trpc = useTRPC();
   return useQuery(
@@ -346,6 +356,33 @@ export function useKiloClawMutations() {
     ),
     setGmailNotifications: useMutation(
       trpc.kiloclaw.setGmailNotifications.mutationOptions({ onSuccess: invalidateStatus })
+    ),
+    setupMorningBriefing: useMutation(
+      trpc.kiloclaw.setupMorningBriefing.mutationOptions({
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.getMorningBriefingStatus.queryKey(),
+          });
+        },
+      })
+    ),
+    disableMorningBriefing: useMutation(
+      trpc.kiloclaw.disableMorningBriefing.mutationOptions({
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.getMorningBriefingStatus.queryKey(),
+          });
+        },
+      })
+    ),
+    runMorningBriefing: useMutation(
+      trpc.kiloclaw.runMorningBriefing.mutationOptions({
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.getMorningBriefingStatus.queryKey(),
+          });
+        },
+      })
     ),
     rename: useMutation(
       trpc.kiloclaw.renameInstance.mutationOptions({ onSuccess: invalidateStatus })

--- a/apps/web/src/hooks/useKiloClaw.ts
+++ b/apps/web/src/hooks/useKiloClaw.ts
@@ -357,8 +357,8 @@ export function useKiloClawMutations() {
     setGmailNotifications: useMutation(
       trpc.kiloclaw.setGmailNotifications.mutationOptions({ onSuccess: invalidateStatus })
     ),
-    setupMorningBriefing: useMutation(
-      trpc.kiloclaw.setupMorningBriefing.mutationOptions({
+    enableMorningBriefing: useMutation(
+      trpc.kiloclaw.enableMorningBriefing.mutationOptions({
         onSuccess: async () => {
           await queryClient.invalidateQueries({
             queryKey: trpc.kiloclaw.getMorningBriefingStatus.queryKey(),

--- a/apps/web/src/hooks/useKiloClaw.ts
+++ b/apps/web/src/hooks/useKiloClaw.ts
@@ -381,6 +381,9 @@ export function useKiloClawMutations() {
           await queryClient.invalidateQueries({
             queryKey: trpc.kiloclaw.getMorningBriefingStatus.queryKey(),
           });
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.readMorningBriefing.queryKey({ day: 'today' }),
+          });
         },
       })
     ),

--- a/apps/web/src/hooks/useOrgKiloClaw.ts
+++ b/apps/web/src/hooks/useOrgKiloClaw.ts
@@ -433,8 +433,8 @@ export function useOrgKiloClawMutations(
   const rawCancelKiloCliRun = useMutation(
     trpc.organizations.kiloclaw.cancelKiloCliRun.mutationOptions({ onSuccess: invalidateStatus })
   );
-  const rawSetupMorningBriefing = useMutation(
-    trpc.organizations.kiloclaw.setupMorningBriefing.mutationOptions({
+  const rawEnableMorningBriefing = useMutation(
+    trpc.organizations.kiloclaw.enableMorningBriefing.mutationOptions({
       onSuccess: async () => {
         await queryClient.invalidateQueries({
           queryKey: trpc.organizations.kiloclaw.getMorningBriefingStatus.queryKey({
@@ -494,7 +494,7 @@ export function useOrgKiloClawMutations(
     patchOpenclawConfig: bind(rawPatchOpenclawConfig),
     disconnectGoogle: bindVoid(rawDisconnectGoogle),
     setGmailNotifications: bind(rawSetGmailNotifications),
-    setupMorningBriefing: bind(rawSetupMorningBriefing),
+    enableMorningBriefing: bind(rawEnableMorningBriefing),
     disableMorningBriefing: bindVoid(rawDisableMorningBriefing),
     runMorningBriefing: bindVoid(rawRunMorningBriefing),
     startKiloCliRun: bind(rawStartKiloCliRun),

--- a/apps/web/src/hooks/useOrgKiloClaw.ts
+++ b/apps/web/src/hooks/useOrgKiloClaw.ts
@@ -463,6 +463,12 @@ export function useOrgKiloClawMutations(
             organizationId,
           }),
         });
+        await queryClient.invalidateQueries({
+          queryKey: trpc.organizations.kiloclaw.readMorningBriefing.queryKey({
+            organizationId,
+            day: 'today',
+          }),
+        });
       },
     })
   );

--- a/apps/web/src/hooks/useOrgKiloClaw.ts
+++ b/apps/web/src/hooks/useOrgKiloClaw.ts
@@ -106,6 +106,16 @@ export function useOrgControllerVersion(organizationId: string, enabled: boolean
   );
 }
 
+export function useOrgMorningBriefingStatus(organizationId: string, enabled: boolean) {
+  const trpc = useTRPC();
+  return useQuery(
+    trpc.organizations.kiloclaw.getMorningBriefingStatus.queryOptions(
+      { organizationId },
+      { enabled, refetchInterval: enabled ? 30_000 : false }
+    )
+  );
+}
+
 export function useOrgKiloClawServiceDegraded(organizationId: string) {
   const trpc = useTRPC();
   return useQuery(
@@ -423,6 +433,39 @@ export function useOrgKiloClawMutations(
   const rawCancelKiloCliRun = useMutation(
     trpc.organizations.kiloclaw.cancelKiloCliRun.mutationOptions({ onSuccess: invalidateStatus })
   );
+  const rawSetupMorningBriefing = useMutation(
+    trpc.organizations.kiloclaw.setupMorningBriefing.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: trpc.organizations.kiloclaw.getMorningBriefingStatus.queryKey({
+            organizationId,
+          }),
+        });
+      },
+    })
+  );
+  const rawDisableMorningBriefing = useMutation(
+    trpc.organizations.kiloclaw.disableMorningBriefing.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: trpc.organizations.kiloclaw.getMorningBriefingStatus.queryKey({
+            organizationId,
+          }),
+        });
+      },
+    })
+  );
+  const rawRunMorningBriefing = useMutation(
+    trpc.organizations.kiloclaw.runMorningBriefing.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: trpc.organizations.kiloclaw.getMorningBriefingStatus.queryKey({
+            organizationId,
+          }),
+        });
+      },
+    })
+  );
 
   const mutations = {
     start: bindVoid(rawStart),
@@ -451,6 +494,9 @@ export function useOrgKiloClawMutations(
     patchOpenclawConfig: bind(rawPatchOpenclawConfig),
     disconnectGoogle: bindVoid(rawDisconnectGoogle),
     setGmailNotifications: bind(rawSetGmailNotifications),
+    setupMorningBriefing: bind(rawSetupMorningBriefing),
+    disableMorningBriefing: bindVoid(rawDisableMorningBriefing),
+    runMorningBriefing: bindVoid(rawRunMorningBriefing),
     startKiloCliRun: bind(rawStartKiloCliRun),
     cancelKiloCliRun: bind(rawCancelKiloCliRun),
     rename: bind(rawRename),

--- a/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -288,14 +288,14 @@ export class KiloClawInternalClient {
     });
   }
 
-  async setupMorningBriefing(
+  async enableMorningBriefing(
     userId: string,
     input?: { cron?: string; timezone?: string },
     instanceId?: string
   ): Promise<MorningBriefingActionResponse> {
     const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
     return this.request(
-      `/api/platform/morning-briefing/setup${params}`,
+      `/api/platform/morning-briefing/enable${params}`,
       {
         method: 'POST',
         body: JSON.stringify({ userId, ...input }),

--- a/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -37,6 +37,9 @@ import type {
   GatewayReadyResponse,
   ControllerVersionResponse,
   OpenclawConfigResponse,
+  MorningBriefingStatusResponse,
+  MorningBriefingActionResponse,
+  MorningBriefingReadResponse,
   GoogleCredentialsInput,
   GoogleCredentialsResponse,
   GoogleOAuthConnectionInput,
@@ -270,6 +273,77 @@ export class KiloClawInternalClient {
         method: 'POST',
         body: JSON.stringify({ userId, message, instanceId }),
       },
+      { userId }
+    );
+  }
+
+  async getMorningBriefingStatus(
+    userId: string,
+    instanceId?: string
+  ): Promise<MorningBriefingStatusResponse> {
+    const params = new URLSearchParams({ userId });
+    if (instanceId) params.set('instanceId', instanceId);
+    return this.request(`/api/platform/morning-briefing/status?${params.toString()}`, undefined, {
+      userId,
+    });
+  }
+
+  async setupMorningBriefing(
+    userId: string,
+    input?: { cron?: string; timezone?: string },
+    instanceId?: string
+  ): Promise<MorningBriefingActionResponse> {
+    const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
+    return this.request(
+      `/api/platform/morning-briefing/setup${params}`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ userId, ...input }),
+      },
+      { userId }
+    );
+  }
+
+  async disableMorningBriefing(
+    userId: string,
+    instanceId?: string
+  ): Promise<MorningBriefingActionResponse> {
+    const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
+    return this.request(
+      `/api/platform/morning-briefing/disable${params}`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ userId }),
+      },
+      { userId }
+    );
+  }
+
+  async runMorningBriefing(
+    userId: string,
+    instanceId?: string
+  ): Promise<MorningBriefingActionResponse> {
+    const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
+    return this.request(
+      `/api/platform/morning-briefing/run${params}`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ userId }),
+      },
+      { userId }
+    );
+  }
+
+  async readMorningBriefing(
+    userId: string,
+    day: 'today' | 'yesterday',
+    instanceId?: string
+  ): Promise<MorningBriefingReadResponse> {
+    const params = new URLSearchParams({ userId });
+    if (instanceId) params.set('instanceId', instanceId);
+    return this.request(
+      `/api/platform/morning-briefing/read/${day}?${params.toString()}`,
+      undefined,
       { userId }
     );
   }

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -403,6 +403,48 @@ export type OpenclawConfigResponse = {
   etag: string;
 };
 
+export type MorningBriefingSourceReadiness = {
+  configured: boolean;
+  summary: string;
+};
+
+export type MorningBriefingStatusResponse = {
+  ok: boolean;
+  enabled?: boolean;
+  cron?: string;
+  timezone?: string;
+  cronJobId?: string | null;
+  lastGeneratedDate?: string | null;
+  lastGeneratedAt?: string | null;
+  sourceReadiness?: {
+    github: MorningBriefingSourceReadiness;
+    linear: MorningBriefingSourceReadiness;
+    web: MorningBriefingSourceReadiness;
+  };
+  error?: string;
+};
+
+export type MorningBriefingActionResponse = {
+  ok: boolean;
+  enabled?: boolean;
+  cron?: string;
+  timezone?: string;
+  cronJobId?: string | null;
+  date?: string;
+  filePath?: string;
+  failures?: string[];
+  error?: string;
+};
+
+export type MorningBriefingReadResponse = {
+  ok: boolean;
+  dateKey?: string;
+  filePath?: string;
+  exists?: boolean;
+  markdown?: string | null;
+  error?: string;
+};
+
 /** Input to POST /api/platform/google-credentials */
 export type GoogleCredentialsInput = {
   googleCredentials: {

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -417,6 +417,7 @@ export type MorningBriefingStatusResponse = {
   lastGeneratedDate?: string | null;
   lastGeneratedAt?: string | null;
   reconcileState?: 'idle' | 'in_progress' | 'succeeded' | 'failed';
+  lastReconcileAction?: 'enable' | 'disable' | null;
   desiredEnabled?: boolean;
   observedEnabled?: boolean | null;
   lastReconcileAt?: string | null;

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -416,11 +416,18 @@ export type MorningBriefingStatusResponse = {
   cronJobId?: string | null;
   lastGeneratedDate?: string | null;
   lastGeneratedAt?: string | null;
+  reconcileState?: 'idle' | 'in_progress' | 'succeeded' | 'failed';
+  desiredEnabled?: boolean;
+  observedEnabled?: boolean | null;
+  lastReconcileAt?: string | null;
+  lastReconcileError?: string | null;
   sourceReadiness?: {
     github: MorningBriefingSourceReadiness;
     linear: MorningBriefingSourceReadiness;
     web: MorningBriefingSourceReadiness;
   };
+  code?: string;
+  retryAfterSec?: number;
   error?: string;
 };
 
@@ -433,6 +440,8 @@ export type MorningBriefingActionResponse = {
   date?: string;
   filePath?: string;
   failures?: string[];
+  code?: string;
+  retryAfterSec?: number;
   error?: string;
 };
 

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2463,6 +2463,45 @@ export const kiloclawRouter = createTRPCRouter({
       }
     }),
 
+  getMorningBriefingStatus: clawAccessProcedure.query(async ({ ctx }) => {
+    const instance = await getActiveInstance(ctx.user.id);
+    const client = new KiloClawInternalClient();
+    return client.getMorningBriefingStatus(ctx.user.id, workerInstanceId(instance));
+  }),
+
+  setupMorningBriefing: clawAccessProcedure
+    .input(
+      z.object({
+        cron: z.string().min(1).optional(),
+        timezone: z.string().min(1).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const instance = await getActiveInstance(ctx.user.id);
+      const client = new KiloClawInternalClient();
+      return client.setupMorningBriefing(ctx.user.id, input, workerInstanceId(instance));
+    }),
+
+  disableMorningBriefing: clawAccessProcedure.mutation(async ({ ctx }) => {
+    const instance = await getActiveInstance(ctx.user.id);
+    const client = new KiloClawInternalClient();
+    return client.disableMorningBriefing(ctx.user.id, workerInstanceId(instance));
+  }),
+
+  runMorningBriefing: clawAccessProcedure.mutation(async ({ ctx }) => {
+    const instance = await getActiveInstance(ctx.user.id);
+    const client = new KiloClawInternalClient();
+    return client.runMorningBriefing(ctx.user.id, workerInstanceId(instance));
+  }),
+
+  readMorningBriefing: clawAccessProcedure
+    .input(z.object({ day: z.enum(['today', 'yesterday']) }))
+    .query(async ({ ctx, input }) => {
+      const instance = await getActiveInstance(ctx.user.id);
+      const client = new KiloClawInternalClient();
+      return client.readMorningBriefing(ctx.user.id, input.day, workerInstanceId(instance));
+    }),
+
   // Instance lifecycle
   start: clawAccessProcedure.mutation(async ({ ctx }) => {
     const instance = await getActiveInstance(ctx.user.id);

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2469,7 +2469,7 @@ export const kiloclawRouter = createTRPCRouter({
     return client.getMorningBriefingStatus(ctx.user.id, workerInstanceId(instance));
   }),
 
-  setupMorningBriefing: clawAccessProcedure
+  enableMorningBriefing: clawAccessProcedure
     .input(
       z.object({
         cron: z.string().min(1).optional(),
@@ -2479,7 +2479,7 @@ export const kiloclawRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const instance = await getActiveInstance(ctx.user.id);
       const client = new KiloClawInternalClient();
-      return client.setupMorningBriefing(ctx.user.id, input, workerInstanceId(instance));
+      return client.enableMorningBriefing(ctx.user.id, input, workerInstanceId(instance));
     }),
 
   disableMorningBriefing: clawAccessProcedure.mutation(async ({ ctx }) => {

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -1154,6 +1154,57 @@ export const organizationKiloclawRouter = createTRPCRouter({
       }
     }),
 
+  getMorningBriefingStatus: organizationMemberProcedure.query(async ({ ctx, input }) => {
+    const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
+    const client = new KiloClawInternalClient();
+    return client.getMorningBriefingStatus(ctx.user.id, workerInstanceId(instance));
+  }),
+
+  setupMorningBriefing: organizationMemberMutationProcedure
+    .input(
+      z.object({
+        organizationId: z.uuid(),
+        cron: z.string().min(1).optional(),
+        timezone: z.string().min(1).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
+      const client = new KiloClawInternalClient();
+      return client.setupMorningBriefing(
+        ctx.user.id,
+        {
+          cron: input.cron,
+          timezone: input.timezone,
+        },
+        workerInstanceId(instance)
+      );
+    }),
+
+  disableMorningBriefing: organizationMemberMutationProcedure
+    .input(z.object({ organizationId: z.uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
+      const client = new KiloClawInternalClient();
+      return client.disableMorningBriefing(ctx.user.id, workerInstanceId(instance));
+    }),
+
+  runMorningBriefing: organizationMemberMutationProcedure
+    .input(z.object({ organizationId: z.uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
+      const client = new KiloClawInternalClient();
+      return client.runMorningBriefing(ctx.user.id, workerInstanceId(instance));
+    }),
+
+  readMorningBriefing: organizationMemberProcedure
+    .input(z.object({ organizationId: z.uuid(), day: z.enum(['today', 'yesterday']) }))
+    .query(async ({ ctx, input }) => {
+      const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
+      const client = new KiloClawInternalClient();
+      return client.readMorningBriefing(ctx.user.id, input.day, workerInstanceId(instance));
+    }),
+
   // ── Google integration ────────────────────────────────────────
 
   getGoogleSetupCommand: organizationMemberProcedure.query(async ({ ctx, input }) => {

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -1160,7 +1160,7 @@ export const organizationKiloclawRouter = createTRPCRouter({
     return client.getMorningBriefingStatus(ctx.user.id, workerInstanceId(instance));
   }),
 
-  setupMorningBriefing: organizationMemberMutationProcedure
+  enableMorningBriefing: organizationMemberMutationProcedure
     .input(
       z.object({
         organizationId: z.uuid(),
@@ -1171,7 +1171,7 @@ export const organizationKiloclawRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
       const client = new KiloClawInternalClient();
-      return client.setupMorningBriefing(
+      return client.enableMorningBriefing(
         ctx.user.id,
         {
           cron: input.cron,

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -130,7 +130,7 @@ RUN GOBIN=/usr/local/bin go install github.com/steipete/gogcli/cmd/gog@v0.12.0 \
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
     && uv --version
 
-# ── Builder stage: package customizer plugin ───────────────────────────
+# ── Builder stage: package custom plugins ───────────────────────────
 # Build the vendored plugin tarball in an isolated stage so dev-time
 # dependencies do not inflate the runtime image layers.
 FROM runtime AS customizer-builder
@@ -142,6 +142,16 @@ RUN cd /tmp/kiloclaw-customizer \
     && mv "${PKG_TGZ}" /tmp/kiloclaw-customizer.tgz \
     && cd / \
     && rm -rf /tmp/kiloclaw-customizer /root/.npm
+
+FROM runtime AS morning-briefing-builder
+
+COPY plugins/kiloclaw-morning-briefing/ /tmp/kiloclaw-morning-briefing/
+RUN cd /tmp/kiloclaw-morning-briefing \
+    && npm install --include=dev --legacy-peer-deps --no-fund --no-audit \
+    && PKG_TGZ="$(npm pack --silent)" \
+    && mv "${PKG_TGZ}" /tmp/kiloclaw-morning-briefing.tgz \
+    && cd / \
+    && rm -rf /tmp/kiloclaw-morning-briefing /root/.npm
 
 # ── Builder stage: compile the controller with Bun ────────────────────
 # Bun is only needed to bundle the controller TypeScript into a single JS
@@ -175,8 +185,10 @@ FROM runtime AS final
 # Also drop /etc/gitconfig (set earlier for the build's ssh→https rewrite) so
 # it doesn't persist in the runtime image.
 COPY --from=customizer-builder /tmp/kiloclaw-customizer.tgz /tmp/kiloclaw-customizer.tgz
-RUN npm install -g --legacy-peer-deps /tmp/kiloclaw-customizer.tgz \
+COPY --from=morning-briefing-builder /tmp/kiloclaw-morning-briefing.tgz /tmp/kiloclaw-morning-briefing.tgz
+RUN npm install -g --legacy-peer-deps /tmp/kiloclaw-customizer.tgz /tmp/kiloclaw-morning-briefing.tgz \
     && rm -f /tmp/kiloclaw-customizer.tgz \
+    && rm -f /tmp/kiloclaw-morning-briefing.tgz \
     && rm -f /etc/gitconfig \
     && rm -rf /root/.npm
 

--- a/services/kiloclaw/Dockerfile.local
+++ b/services/kiloclaw/Dockerfile.local
@@ -134,7 +134,7 @@ EXPOSE 18789
 # feature flags) lives in the controller's bootstrap module — no shell wrapper needed.
 CMD ["node", "/usr/local/bin/kiloclaw-controller.js"]
 
-# Build customizer plugin tarball in isolated stage so dev dependencies
+# Build custom plugins tarballs in isolated stages so dev dependencies
 # are not persisted in the runtime image.
 FROM runtime AS customizer-builder
 
@@ -146,9 +146,21 @@ RUN cd /tmp/kiloclaw-customizer \
     && cd / \
     && rm -rf /tmp/kiloclaw-customizer /root/.npm
 
+FROM runtime AS morning-briefing-builder
+
+COPY plugins/kiloclaw-morning-briefing/ /tmp/kiloclaw-morning-briefing/
+RUN cd /tmp/kiloclaw-morning-briefing \
+    && npm install --include=dev --legacy-peer-deps --no-fund --no-audit \
+    && PKG_TGZ="$(npm pack --silent)" \
+    && mv "${PKG_TGZ}" /tmp/kiloclaw-morning-briefing.tgz \
+    && cd / \
+    && rm -rf /tmp/kiloclaw-morning-briefing /root/.npm
+
 FROM runtime AS final
 
 COPY --from=customizer-builder /tmp/kiloclaw-customizer.tgz /tmp/kiloclaw-customizer.tgz
-RUN npm install -g --legacy-peer-deps /tmp/kiloclaw-customizer.tgz \
+COPY --from=morning-briefing-builder /tmp/kiloclaw-morning-briefing.tgz /tmp/kiloclaw-morning-briefing.tgz
+RUN npm install -g --legacy-peer-deps /tmp/kiloclaw-customizer.tgz /tmp/kiloclaw-morning-briefing.tgz \
     && rm -f /tmp/kiloclaw-customizer.tgz \
+    && rm -f /tmp/kiloclaw-morning-briefing.tgz \
     && rm -rf /root/.npm

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -615,15 +615,25 @@ describe('generateBaseConfig', () => {
     expect(config.plugins.load.paths).toContain(
       '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-customizer'
     );
+    expect(config.plugins.entries['kiloclaw-morning-briefing'].enabled).toBe(true);
+    expect(config.plugins.load.paths).toContain(
+      '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-morning-briefing'
+    );
   });
 
   it('does not duplicate KiloClaw customizer plugin path on repeated generateBaseConfig calls', () => {
     const existing = JSON.stringify({
       plugins: {
         load: {
-          paths: ['/usr/local/lib/node_modules/@kiloclaw/kiloclaw-customizer'],
+          paths: [
+            '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-customizer',
+            '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-morning-briefing',
+          ],
         },
-        entries: { 'kiloclaw-customizer': { enabled: true } },
+        entries: {
+          'kiloclaw-customizer': { enabled: true },
+          'kiloclaw-morning-briefing': { enabled: true },
+        },
       },
     });
     const { deps } = fakeDeps(existing);
@@ -632,6 +642,8 @@ describe('generateBaseConfig', () => {
     const pluginPath = '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-customizer';
     const paths = config.plugins.load.paths as string[];
     expect(paths.filter(p => p === pluginPath)).toHaveLength(1);
+    const morningPluginPath = '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-morning-briefing';
+    expect(paths.filter(p => p === morningPluginPath)).toHaveLength(1);
   });
 
   it('adds KiloClaw customizer to an existing plugin allowlist', () => {
@@ -644,6 +656,7 @@ describe('generateBaseConfig', () => {
     const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);
 
     expect(config.plugins.allow).toContain('kiloclaw-customizer');
+    expect(config.plugins.allow).toContain('kiloclaw-morning-briefing');
   });
 
   it('configures Telegram channel', () => {

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -75,6 +75,9 @@ const ONBOARD_FLAGS = [
 
 const KILOCLAW_CUSTOMIZER_PLUGIN_ID = 'kiloclaw-customizer';
 const KILOCLAW_CUSTOMIZER_PLUGIN_PATH = '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-customizer';
+const KILOCLAW_MORNING_BRIEFING_PLUGIN_ID = 'kiloclaw-morning-briefing';
+const KILOCLAW_MORNING_BRIEFING_PLUGIN_PATH =
+  '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-morning-briefing';
 const KILO_EXA_PROVIDER_ID = 'kilo-exa';
 
 type KiloExaSearchMode = 'kilo-proxy' | 'disabled';
@@ -401,6 +404,19 @@ export function generateBaseConfig(
 
   customizerPluginConfig.webSearch = customizerWebSearchConfig;
   config.plugins.entries[KILOCLAW_CUSTOMIZER_PLUGIN_ID].config = customizerPluginConfig;
+
+  if (!(config.plugins.load.paths as string[]).includes(KILOCLAW_MORNING_BRIEFING_PLUGIN_PATH)) {
+    (config.plugins.load.paths as string[]).push(KILOCLAW_MORNING_BRIEFING_PLUGIN_PATH);
+  }
+  if (
+    Array.isArray(config.plugins.allow) &&
+    !config.plugins.allow.includes(KILOCLAW_MORNING_BRIEFING_PLUGIN_ID)
+  ) {
+    config.plugins.allow.push(KILOCLAW_MORNING_BRIEFING_PLUGIN_ID);
+  }
+  config.plugins.entries[KILOCLAW_MORNING_BRIEFING_PLUGIN_ID] =
+    config.plugins.entries[KILOCLAW_MORNING_BRIEFING_PLUGIN_ID] ?? {};
+  config.plugins.entries[KILOCLAW_MORNING_BRIEFING_PLUGIN_ID].enabled = true;
 
   // Telegram
   if (env.TELEGRAM_BOT_TOKEN) {

--- a/services/kiloclaw/controller/src/index.ts
+++ b/services/kiloclaw/controller/src/index.ts
@@ -23,6 +23,7 @@ import { registerGmailPushRoute } from './routes/gmail-push';
 import { registerInboundEmailRoute } from './routes/inbound-email';
 import { registerFileRoutes } from './routes/files';
 import { registerKiloCliRunRoutes } from './routes/kilo-cli-run';
+import { registerMorningBriefingRoutes } from './routes/morning-briefing';
 import { CONTROLLER_COMMIT, CONTROLLER_VERSION } from './version';
 import { writeKiloCliConfig } from './kilo-cli-config';
 import { writeGogCredentials } from './gog-credentials';
@@ -378,6 +379,7 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
   const honoApp = new Hono();
   registerHealthRoute(honoApp, supervisor, config.expectedToken, controllerState);
   registerGatewayRoutes(honoApp, supervisor, config.expectedToken);
+  registerMorningBriefingRoutes(honoApp, supervisor, config.expectedToken);
   registerConfigRoutes(honoApp, supervisor, config.expectedToken);
   registerPairingRoutes(honoApp, pairingCache, config.expectedToken);
   registerEnvRoutes(honoApp, supervisor, config.expectedToken);

--- a/services/kiloclaw/controller/src/routes/morning-briefing.test.ts
+++ b/services/kiloclaw/controller/src/routes/morning-briefing.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { registerMorningBriefingRoutes } from './morning-briefing';
+import type { Supervisor } from '../supervisor';
+
+function createRunningSupervisor(): Supervisor {
+  const state = 'running' as const;
+  return {
+    start: vi.fn(async () => true),
+    stop: vi.fn(async () => true),
+    restart: vi.fn(async () => true),
+    shutdown: vi.fn(async () => undefined),
+    signal: vi.fn(() => true),
+    getState: vi.fn(() => state),
+    getStats: vi.fn(() => ({
+      state,
+      pid: 1,
+      uptime: 1,
+      restarts: 0,
+      lastExit: null,
+    })),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('morning briefing controller routes', () => {
+  it('enforces bearer auth before proxying', async () => {
+    const app = new Hono();
+    registerMorningBriefingRoutes(app, createRunningSupervisor(), 'expected-token');
+
+    const response = await app.request('/_kilo/morning-briefing/status');
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('forwards expected gateway token to proxied route', async () => {
+    const app = new Hono();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    registerMorningBriefingRoutes(app, createRunningSupervisor(), 'expected-token');
+
+    const response = await app.request('/_kilo/morning-briefing/enable', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer expected-token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ cron: '0 7 * * *', timezone: 'America/Chicago' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:3001/api/plugins/kiloclaw-morning-briefing/enable',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          authorization: 'Bearer expected-token',
+          'content-type': 'application/json',
+        }),
+      })
+    );
+  });
+});

--- a/services/kiloclaw/controller/src/routes/morning-briefing.ts
+++ b/services/kiloclaw/controller/src/routes/morning-briefing.ts
@@ -1,0 +1,116 @@
+import type { Hono } from 'hono';
+import { timingSafeTokenEqual } from '../auth';
+import { getBearerToken } from './gateway';
+import type { Supervisor } from '../supervisor';
+
+const MORNING_BRIEFING_PREFIX = '/api/plugins/kiloclaw-morning-briefing';
+
+async function readJsonBody(c: { req: { json: () => Promise<unknown> } }): Promise<unknown> {
+  try {
+    return await c.req.json();
+  } catch {
+    return {};
+  }
+}
+
+async function proxyMorningBriefingRoute(params: {
+  supervisor: Supervisor;
+  path: string;
+  method: 'GET' | 'POST';
+  body?: unknown;
+}): Promise<Response> {
+  if (params.supervisor.getState() !== 'running') {
+    return new Response(JSON.stringify({ error: 'Gateway not running' }), {
+      status: 503,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  try {
+    return await fetch(`http://127.0.0.1:3001${MORNING_BRIEFING_PREFIX}${params.path}`, {
+      method: params.method,
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: params.body !== undefined ? JSON.stringify(params.body) : undefined,
+    });
+  } catch (error) {
+    console.error('[controller] morning briefing proxy failed:', error);
+    return new Response(JSON.stringify({ error: 'Failed to reach gateway' }), {
+      status: 502,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+}
+
+export function registerMorningBriefingRoutes(
+  app: Hono,
+  supervisor: Supervisor,
+  expectedToken: string
+): void {
+  app.use('/_kilo/morning-briefing/*', async (c, next) => {
+    const token = getBearerToken(c.req.header('authorization'));
+    if (!timingSafeTokenEqual(token, expectedToken)) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+    await next();
+  });
+
+  app.get('/_kilo/morning-briefing/status', async c => {
+    const response = await proxyMorningBriefingRoute({
+      supervisor,
+      path: '/status',
+      method: 'GET',
+    });
+    return response;
+  });
+
+  app.post('/_kilo/morning-briefing/setup', async c => {
+    const body = await readJsonBody(c);
+    const response = await proxyMorningBriefingRoute({
+      supervisor,
+      path: '/setup',
+      method: 'POST',
+      body,
+    });
+    return response;
+  });
+
+  app.post('/_kilo/morning-briefing/disable', async c => {
+    const response = await proxyMorningBriefingRoute({
+      supervisor,
+      path: '/disable',
+      method: 'POST',
+      body: {},
+    });
+    return response;
+  });
+
+  app.post('/_kilo/morning-briefing/run', async c => {
+    const response = await proxyMorningBriefingRoute({
+      supervisor,
+      path: '/run',
+      method: 'POST',
+      body: {},
+    });
+    return response;
+  });
+
+  app.get('/_kilo/morning-briefing/read/today', async c => {
+    const response = await proxyMorningBriefingRoute({
+      supervisor,
+      path: '/read/today',
+      method: 'GET',
+    });
+    return response;
+  });
+
+  app.get('/_kilo/morning-briefing/read/yesterday', async c => {
+    const response = await proxyMorningBriefingRoute({
+      supervisor,
+      path: '/read/yesterday',
+      method: 'GET',
+    });
+    return response;
+  });
+}

--- a/services/kiloclaw/controller/src/routes/morning-briefing.ts
+++ b/services/kiloclaw/controller/src/routes/morning-briefing.ts
@@ -15,6 +15,7 @@ async function readJsonBody(c: { req: { json: () => Promise<unknown> } }): Promi
 
 async function proxyMorningBriefingRoute(params: {
   supervisor: Supervisor;
+  gatewayToken: string;
   path: string;
   method: 'GET' | 'POST';
   body?: unknown;
@@ -30,6 +31,7 @@ async function proxyMorningBriefingRoute(params: {
     return await fetch(`http://127.0.0.1:3001${MORNING_BRIEFING_PREFIX}${params.path}`, {
       method: params.method,
       headers: {
+        authorization: `Bearer ${params.gatewayToken}`,
         'content-type': 'application/json',
       },
       body: params.body !== undefined ? JSON.stringify(params.body) : undefined,
@@ -59,17 +61,19 @@ export function registerMorningBriefingRoutes(
   app.get('/_kilo/morning-briefing/status', async c => {
     const response = await proxyMorningBriefingRoute({
       supervisor,
+      gatewayToken: expectedToken,
       path: '/status',
       method: 'GET',
     });
     return response;
   });
 
-  app.post('/_kilo/morning-briefing/setup', async c => {
+  app.post('/_kilo/morning-briefing/enable', async c => {
     const body = await readJsonBody(c);
     const response = await proxyMorningBriefingRoute({
       supervisor,
-      path: '/setup',
+      gatewayToken: expectedToken,
+      path: '/enable',
       method: 'POST',
       body,
     });
@@ -79,6 +83,7 @@ export function registerMorningBriefingRoutes(
   app.post('/_kilo/morning-briefing/disable', async c => {
     const response = await proxyMorningBriefingRoute({
       supervisor,
+      gatewayToken: expectedToken,
       path: '/disable',
       method: 'POST',
       body: {},
@@ -89,6 +94,7 @@ export function registerMorningBriefingRoutes(
   app.post('/_kilo/morning-briefing/run', async c => {
     const response = await proxyMorningBriefingRoute({
       supervisor,
+      gatewayToken: expectedToken,
       path: '/run',
       method: 'POST',
       body: {},
@@ -99,6 +105,7 @@ export function registerMorningBriefingRoutes(
   app.get('/_kilo/morning-briefing/read/today', async c => {
     const response = await proxyMorningBriefingRoute({
       supervisor,
+      gatewayToken: expectedToken,
       path: '/read/today',
       method: 'GET',
     });
@@ -108,6 +115,7 @@ export function registerMorningBriefingRoutes(
   app.get('/_kilo/morning-briefing/read/yesterday', async c => {
     const response = await proxyMorningBriefingRoute({
       supervisor,
+      gatewayToken: expectedToken,
       path: '/read/yesterday',
       method: 'GET',
     });

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/README.md
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/README.md
@@ -1,0 +1,29 @@
+# KiloClaw Morning Briefing
+
+Bundled OpenClaw plugin for daily issue/news briefings in KiloClaw instances.
+
+## Commands
+
+- `/briefing setup`
+- `/briefing status`
+- `/briefing run`
+- `/briefing today`
+- `/briefing yesterday`
+- `/briefing disable`
+
+## Tooling
+
+- `morning_briefing_generate`
+- `morning_briefing_read`
+- `morning_briefing_handle_command`
+
+## Storage
+
+Writes Markdown files under:
+
+- `<OPENCLAW_STATE_DIR>/morning-briefing/briefings/YYYY-MM-DD.md`
+
+Plus metadata under:
+
+- `<OPENCLAW_STATE_DIR>/morning-briefing/config.json`
+- `<OPENCLAW_STATE_DIR>/morning-briefing/status.json`

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/README.md
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/README.md
@@ -4,7 +4,7 @@ Bundled OpenClaw plugin for daily issue/news briefings in KiloClaw instances.
 
 ## Commands
 
-- `/briefing setup`
+- `/briefing enable`
 - `/briefing status`
 - `/briefing run`
 - `/briefing today`

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/openclaw.plugin.json
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/openclaw.plugin.json
@@ -1,0 +1,17 @@
+{
+  "id": "kiloclaw-morning-briefing",
+  "name": "KiloClawMorningBriefing",
+  "description": "Daily Morning Briefing plugin for KiloClaw-hosted OpenClaw",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "defaultCron": {
+        "type": "string"
+      },
+      "defaultTimezone": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/package.json
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@kiloclaw/kiloclaw-morning-briefing",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "KiloClaw Morning Briefing plugin for OpenClaw",
+  "files": [
+    "dist",
+    "openclaw.plugin.json",
+    "README.md"
+  ],
+  "openclaw": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "scripts": {
+    "prepack": "npm run build",
+    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node22 --external:openclaw --external:openclaw/* --outfile=dist/index.js",
+    "clean": "rm -rf dist",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.24-beta.2"
+  },
+  "devDependencies": {
+    "@sinclair/typebox": "^0.34.41",
+    "esbuild": "^0.25.2",
+    "vitest": "^4.1.0"
+  }
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBriefingMarkdown,
+  formatDateKey,
+  offsetDays,
+  resolveBriefingPath,
+} from './briefing-utils';
+
+describe('briefing-utils', () => {
+  it('formats date keys as YYYY-MM-DD', () => {
+    expect(formatDateKey(new Date('2026-04-23T10:00:00Z'))).toBe('2026-04-23');
+  });
+
+  it('resolves today/yesterday offsets', () => {
+    const base = new Date('2026-04-23T12:00:00Z');
+    expect(formatDateKey(offsetDays(base, 0))).toBe('2026-04-23');
+    expect(formatDateKey(offsetDays(base, -1))).toBe('2026-04-22');
+  });
+
+  it('creates markdown with status and sections', () => {
+    const markdown = buildBriefingMarkdown({
+      date: new Date('2026-04-23T12:00:00Z'),
+      generatedAt: new Date('2026-04-23T07:00:01Z'),
+      statuses: [
+        { source: 'github', configured: true, ok: true, summary: 'Fetched 3 issues' },
+        { source: 'linear', configured: true, ok: false, summary: 'Validation pending' },
+        { source: 'web', configured: false, ok: false, summary: 'No search provider configured' },
+      ],
+      sections: [
+        { title: 'GitHub', lines: ['- Item 1'] },
+        { title: 'Linear', lines: [] },
+      ],
+      failures: ['Linear adapter validation pending'],
+    });
+
+    expect(markdown).toContain('# Morning Briefing - 2026-04-23');
+    expect(markdown).toContain('## Source Status');
+    expect(markdown).toContain('- github: [ok] Fetched 3 issues');
+    expect(markdown).toContain('## GitHub');
+    expect(markdown).toContain('- Item 1');
+    expect(markdown).toContain('## Failures / Skipped');
+  });
+
+  it('builds date-based file paths', () => {
+    const filePath = resolveBriefingPath('/tmp/briefings', new Date('2026-04-23T12:00:00Z'));
+    expect(filePath.endsWith('/briefings/2026-04-23.md')).toBe(true);
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.ts
@@ -1,0 +1,71 @@
+import path from 'node:path';
+
+export type BriefingSourceStatus = {
+  source: 'github' | 'linear' | 'web';
+  configured: boolean;
+  ok: boolean;
+  summary: string;
+};
+
+export type BriefingDocumentSection = {
+  title: string;
+  lines: string[];
+};
+
+export function formatDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function offsetDays(base: Date, offset: number): Date {
+  const copy = new Date(base.getTime());
+  copy.setDate(copy.getDate() + offset);
+  return copy;
+}
+
+export function resolveBriefingPath(briefingsDir: string, date: Date): string {
+  return path.join(briefingsDir, `${formatDateKey(date)}.md`);
+}
+
+export function buildBriefingMarkdown(params: {
+  date: Date;
+  generatedAt: Date;
+  statuses: BriefingSourceStatus[];
+  sections: BriefingDocumentSection[];
+  failures: string[];
+}): string {
+  const dateKey = formatDateKey(params.date);
+  const lines: string[] = [];
+  lines.push(`# Morning Briefing - ${dateKey}`);
+  lines.push('');
+  lines.push('## Source Status');
+  for (const status of params.statuses) {
+    const marker = status.ok ? '[ok]' : status.configured ? '[error]' : '[skipped]';
+    lines.push(`- ${status.source}: ${marker} ${status.summary}`);
+  }
+
+  for (const section of params.sections) {
+    if (section.lines.length === 0) {
+      continue;
+    }
+    lines.push('');
+    lines.push(`## ${section.title}`);
+    lines.push(...section.lines);
+  }
+
+  if (params.failures.length > 0) {
+    lines.push('');
+    lines.push('## Failures / Skipped');
+    for (const failure of params.failures) {
+      lines.push(`- ${failure}`);
+    }
+  }
+
+  lines.push('');
+  lines.push(`_Generated at ${params.generatedAt.toISOString()}_`);
+  lines.push('');
+
+  return lines.join('\n');
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.ts
@@ -39,12 +39,6 @@ export function buildBriefingMarkdown(params: {
   const dateKey = formatDateKey(params.date);
   const lines: string[] = [];
   lines.push(`# Morning Briefing - ${dateKey}`);
-  lines.push('');
-  lines.push('## Source Status');
-  for (const status of params.statuses) {
-    const marker = status.ok ? '[ok]' : status.configured ? '[error]' : '[skipped]';
-    lines.push(`- ${status.source}: ${marker} ${status.summary}`);
-  }
 
   for (const section of params.sections) {
     if (section.lines.length === 0) {
@@ -61,6 +55,13 @@ export function buildBriefingMarkdown(params: {
     for (const failure of params.failures) {
       lines.push(`- ${failure}`);
     }
+  }
+
+  lines.push('');
+  lines.push('## Source Status');
+  for (const status of params.statuses) {
+    const marker = status.ok ? '[ok]' : status.configured ? '[error]' : '[skipped]';
+    lines.push(`- ${status.source}: ${marker} ${status.summary}`);
   }
 
   lines.push('');

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/command-fallback-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/command-fallback-utils.test.ts
@@ -3,7 +3,7 @@ import { extractBriefingArgsFromText } from './command-fallback-utils';
 
 describe('command-fallback-utils', () => {
   it('extracts subcommand args from a plain slash command', () => {
-    expect(extractBriefingArgsFromText('/briefing setup')).toBe('setup');
+    expect(extractBriefingArgsFromText('/briefing enable')).toBe('enable');
   });
 
   it('extracts args from control-ui wrapped inbound metadata text', () => {

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/command-fallback-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/command-fallback-utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { extractBriefingArgsFromText } from './command-fallback-utils';
+
+describe('command-fallback-utils', () => {
+  it('extracts subcommand args from a plain slash command', () => {
+    expect(extractBriefingArgsFromText('/briefing setup')).toBe('setup');
+  });
+
+  it('extracts args from control-ui wrapped inbound metadata text', () => {
+    const wrapped = [
+      'Sender (untrusted metadata):',
+      '```json',
+      '{"label":"openclaw-control-ui"}',
+      '```',
+      '',
+      '[Thu 2026-04-23 19:49 CDT] /briefing yesterday',
+    ].join('\n');
+
+    expect(extractBriefingArgsFromText(wrapped)).toBe('yesterday');
+  });
+
+  it('returns empty args for bare /briefing', () => {
+    expect(extractBriefingArgsFromText('/briefing')).toBe('');
+  });
+
+  it('returns null when no briefing command exists', () => {
+    expect(extractBriefingArgsFromText('hello there')).toBeNull();
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/command-fallback-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/command-fallback-utils.ts
@@ -1,0 +1,14 @@
+export function extractBriefingArgsFromText(input: string): string | null {
+  const text = input.trim();
+  if (!text) {
+    return null;
+  }
+
+  const match = text.match(/\/briefing(?:\s+([^\n\r]*))?/i);
+  if (!match) {
+    return null;
+  }
+
+  const args = typeof match[1] === 'string' ? match[1].trim() : '';
+  return args;
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/cron-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/cron-utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { pickCanonicalCronJobId, selectMorningBriefingJobs } from './cron-utils';
+
+describe('cron-utils', () => {
+  it('selects only briefing jobs with matching tool allowlist', () => {
+    const jobs = selectMorningBriefingJobs(
+      {
+        jobs: [
+          {
+            id: 'a',
+            name: 'KiloClaw Morning Briefing',
+            enabled: true,
+            payload: { toolsAllow: ['morning_briefing_generate'] },
+          },
+          {
+            id: 'b',
+            name: 'KiloClaw Morning Briefing',
+            enabled: true,
+            payload: { toolsAllow: ['something_else'] },
+          },
+        ],
+      },
+      'KiloClaw Morning Briefing',
+      'morning_briefing_generate'
+    );
+
+    expect(jobs.map(job => job.id)).toEqual(['a']);
+  });
+
+  it('prefers configured id when present', () => {
+    const canonical = pickCanonicalCronJobId(
+      [
+        { id: 'old', enabled: true, updatedAtMs: 1, createdAtMs: 1 },
+        { id: 'new', enabled: true, updatedAtMs: 2, createdAtMs: 2 },
+      ],
+      'old'
+    );
+
+    expect(canonical).toBe('old');
+  });
+
+  it('otherwise picks latest updated job', () => {
+    const canonical = pickCanonicalCronJobId(
+      [
+        { id: 'old', enabled: true, updatedAtMs: 1, createdAtMs: 1 },
+        { id: 'new', enabled: true, updatedAtMs: 2, createdAtMs: 2 },
+      ],
+      null
+    );
+
+    expect(canonical).toBe('new');
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/cron-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/cron-utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { pickCanonicalCronJobId, selectMorningBriefingJobs } from './cron-utils';
+import {
+  filterEnabledBriefingJobs,
+  pickCanonicalCronJobId,
+  selectMorningBriefingJobs,
+} from './cron-utils';
 
 describe('cron-utils', () => {
   it('selects only briefing jobs with matching tool allowlist', () => {
@@ -49,5 +53,14 @@ describe('cron-utils', () => {
     );
 
     expect(canonical).toBe('new');
+  });
+
+  it('filters only enabled briefing jobs', () => {
+    const filtered = filterEnabledBriefingJobs([
+      { id: 'enabled', enabled: true, updatedAtMs: 1, createdAtMs: 1 },
+      { id: 'disabled', enabled: false, updatedAtMs: 1, createdAtMs: 1 },
+    ]);
+
+    expect(filtered.map(job => job.id)).toEqual(['enabled']);
   });
 });

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/cron-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/cron-utils.ts
@@ -1,0 +1,66 @@
+export type MorningBriefingCronJob = {
+  id: string;
+  enabled: boolean;
+  updatedAtMs: number;
+  createdAtMs: number;
+};
+
+function asObject(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((entry): entry is string => typeof entry === 'string');
+}
+
+export function selectMorningBriefingJobs(
+  payload: unknown,
+  jobName: string,
+  toolName: string
+): MorningBriefingCronJob[] {
+  const root = asObject(payload);
+  const jobs = Array.isArray(root.jobs) ? root.jobs : [];
+  return jobs
+    .map(raw => asObject(raw))
+    .filter(job => {
+      if (typeof job.name !== 'string' || job.name !== jobName) {
+        return false;
+      }
+      const payloadObj = asObject(job.payload);
+      const toolsAllow = toStringArray(payloadObj.toolsAllow);
+      return toolsAllow.includes(toolName);
+    })
+    .map(job => ({
+      id: typeof job.id === 'string' ? job.id : '',
+      enabled: job.enabled === true,
+      updatedAtMs: typeof job.updatedAtMs === 'number' ? job.updatedAtMs : 0,
+      createdAtMs: typeof job.createdAtMs === 'number' ? job.createdAtMs : 0,
+    }))
+    .filter(job => job.id.length > 0);
+}
+
+export function pickCanonicalCronJobId(
+  jobs: MorningBriefingCronJob[],
+  preferredId: string | null
+): string | null {
+  if (preferredId && jobs.some(job => job.id === preferredId)) {
+    return preferredId;
+  }
+
+  const sorted = [...jobs].sort((a, b) => {
+    if (b.updatedAtMs !== a.updatedAtMs) {
+      return b.updatedAtMs - a.updatedAtMs;
+    }
+    if (b.createdAtMs !== a.createdAtMs) {
+      return b.createdAtMs - a.createdAtMs;
+    }
+    return a.id.localeCompare(b.id);
+  });
+
+  return sorted[0]?.id ?? null;
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/cron-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/cron-utils.ts
@@ -64,3 +64,9 @@ export function pickCanonicalCronJobId(
 
   return sorted[0]?.id ?? null;
 }
+
+export function filterEnabledBriefingJobs(
+  jobs: MorningBriefingCronJob[]
+): MorningBriefingCronJob[] {
+  return jobs.filter(job => job.enabled);
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/enable-input-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/enable-input-utils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { parseEnableArgs } from './enable-input-utils';
+
+describe('enable-input-utils', () => {
+  it('parses simple command args with cron only', () => {
+    expect(parseEnableArgs('0 7 * * *')).toEqual({ cron: '0 7 * * *' });
+  });
+
+  it('parses command args with cron and timezone', () => {
+    expect(parseEnableArgs('0 7 * * * America/Chicago')).toEqual({
+      cron: '0 7 * * *',
+      timezone: 'America/Chicago',
+    });
+  });
+
+  it('keeps timezone intact when it has spaces', () => {
+    expect(parseEnableArgs('0 7 * * * America/Argentina/Buenos_Aires')).toEqual({
+      cron: '0 7 * * *',
+      timezone: 'America/Argentina/Buenos_Aires',
+    });
+  });
+
+  it('returns empty object for blank input', () => {
+    expect(parseEnableArgs('')).toEqual({});
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/enable-input-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/enable-input-utils.ts
@@ -1,0 +1,27 @@
+export type EnableInput = { cron?: string; timezone?: string };
+
+export function parseEnableArgs(args: string | undefined): EnableInput {
+  const text = (args ?? '').trim();
+  if (!text) {
+    return {};
+  }
+  const tokens = text.split(/\s+/).filter(Boolean);
+
+  if (tokens.length >= 5) {
+    const cron = tokens.slice(0, 5).join(' ');
+    const timezone = tokens.slice(5).join(' ');
+    return {
+      cron,
+      timezone: timezone.length > 0 ? timezone : undefined,
+    };
+  }
+
+  if (tokens.length === 1) {
+    return { cron: tokens[0] };
+  }
+
+  return {
+    cron: tokens[0],
+    timezone: tokens.slice(1).join(' '),
+  };
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
@@ -1,0 +1,314 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@sinclair/typebox', () => ({
+  Type: {
+    Object: (value: unknown) => value,
+    Optional: (value: unknown) => value,
+    String: (value: unknown) => value,
+    Union: (value: unknown) => value,
+    Literal: (value: unknown) => value,
+  },
+}));
+
+vi.mock('openclaw/plugin-sdk/plugin-entry', () => ({
+  definePluginEntry: (entry: unknown) => entry,
+}));
+
+type CronJob = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  updatedAtMs: number;
+  createdAtMs: number;
+  payload: {
+    toolsAllow: string[];
+  };
+};
+
+type TestHarness = {
+  stateDir: string;
+  commandHandler: (ctx: { args?: string }) => Promise<{ text: string }>;
+  statusHttpHandler: (_req: unknown, res: FakeResponse) => Promise<void>;
+  cronJobs: CronJob[];
+  runCommandWithTimeout: ReturnType<typeof vi.fn>;
+};
+
+class FakeResponse {
+  statusCode = 200;
+  private headers = new Map<string, string>();
+  body = '';
+
+  setHeader(name: string, value: string): void {
+    this.headers.set(name.toLowerCase(), value);
+  }
+
+  end(chunk?: string): void {
+    this.body = chunk ?? '';
+  }
+}
+
+async function createHarness(options?: {
+  disableCommandFails?: boolean;
+  preloadedConfig?: Record<string, unknown>;
+  preloadedStatus?: Record<string, unknown>;
+}): Promise<TestHarness> {
+  const { default: morningBriefingPlugin } = await import('./index');
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), 'morning-briefing-'));
+  const pluginDir = path.join(stateDir, 'morning-briefing');
+  await fs.mkdir(pluginDir, { recursive: true });
+
+  if (options?.preloadedConfig) {
+    await fs.writeFile(
+      path.join(pluginDir, 'config.json'),
+      JSON.stringify(options.preloadedConfig, null, 2),
+      'utf8'
+    );
+  }
+  if (options?.preloadedStatus) {
+    await fs.writeFile(
+      path.join(pluginDir, 'status.json'),
+      JSON.stringify(options.preloadedStatus, null, 2),
+      'utf8'
+    );
+  }
+
+  let sequence = 0;
+  const cronJobs: CronJob[] = [];
+  const runCommandWithTimeout = vi.fn(async (argv: string[]) => {
+    if (argv[0] === 'gh' && argv[1] === 'auth' && argv[2] === 'status') {
+      return { stdout: '', stderr: 'not authenticated', code: 1 };
+    }
+
+    if (argv[0] === 'openclaw' && argv[1] === 'cron') {
+      const subcommand = argv[2];
+
+      if (subcommand === 'list') {
+        return {
+          stdout: JSON.stringify({ jobs: cronJobs }),
+          stderr: '',
+          code: 0,
+        };
+      }
+
+      if (subcommand === 'add') {
+        const id = `job-${++sequence}`;
+        const now = Date.now();
+        cronJobs.push({
+          id,
+          name: 'KiloClaw Morning Briefing',
+          enabled: true,
+          updatedAtMs: now,
+          createdAtMs: now,
+          payload: { toolsAllow: ['morning_briefing_generate'] },
+        });
+        return { stdout: JSON.stringify({ id }), stderr: '', code: 0 };
+      }
+
+      if (subcommand === 'edit') {
+        const id = argv[3] ?? '';
+        const job = cronJobs.find(entry => entry.id === id);
+        if (!job) {
+          return { stdout: '', stderr: 'missing job', code: 1 };
+        }
+        job.updatedAtMs = Date.now();
+        job.enabled = true;
+        return { stdout: JSON.stringify({ id }), stderr: '', code: 0 };
+      }
+
+      if (subcommand === 'disable') {
+        const id = argv[3] ?? '';
+        if (options?.disableCommandFails) {
+          return { stdout: '', stderr: 'disable failed', code: 1 };
+        }
+        const job = cronJobs.find(entry => entry.id === id);
+        if (job) {
+          job.enabled = false;
+          job.updatedAtMs = Date.now();
+        }
+        return { stdout: '', stderr: '', code: 0 };
+      }
+
+      if (subcommand === 'remove') {
+        const id = argv[3] ?? '';
+        const index = cronJobs.findIndex(entry => entry.id === id);
+        if (index >= 0) {
+          cronJobs.splice(index, 1);
+        }
+        return { stdout: JSON.stringify({ ok: true }), stderr: '', code: 0 };
+      }
+    }
+
+    return { stdout: '', stderr: '', code: 0 };
+  });
+
+  let commandHandler: ((ctx: { args?: string }) => Promise<{ text: string }>) | null = null;
+  let statusHttpHandler: ((_req: unknown, res: FakeResponse) => Promise<void>) | null = null;
+
+  morningBriefingPlugin.register({
+    runtime: {
+      state: { resolveStateDir: () => stateDir },
+      system: { runCommandWithTimeout },
+      webSearch: {
+        listProviders: () => [],
+        search: async () => ({ provider: 'none', result: {} }),
+      },
+    },
+    config: {
+      agents: { defaults: { userTimezone: 'America/Chicago' } },
+    },
+    logger: { warn: vi.fn() },
+    registerCommand: (def: { handler: (ctx: { args?: string }) => Promise<{ text: string }> }) => {
+      commandHandler = def.handler;
+    },
+    registerHttpRoute: (route: {
+      path: string;
+      handler: (_req: unknown, res: FakeResponse) => Promise<void>;
+    }) => {
+      if (route.path.endsWith('/status')) {
+        statusHttpHandler = route.handler;
+      }
+    },
+    registerTool: vi.fn(),
+    on: vi.fn(),
+  } as never);
+
+  if (!commandHandler || !statusHttpHandler) {
+    throw new Error('Failed to register command or status handler');
+  }
+
+  return {
+    stateDir,
+    commandHandler,
+    statusHttpHandler,
+    cronJobs,
+    runCommandWithTimeout,
+  };
+}
+
+async function readJson(filePath: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await fs.readFile(filePath, 'utf8')) as Record<string, unknown>;
+}
+
+async function waitForReconcileState(
+  stateDir: string,
+  expectedState: 'succeeded' | 'failed',
+  timeoutMs = 2000
+): Promise<Record<string, unknown>> {
+  const statusPath = path.join(stateDir, 'morning-briefing', 'status.json');
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const status = await readJson(statusPath);
+      if (status.reconcileState === expectedState) {
+        return status;
+      }
+    } catch {
+      // ignore until file exists
+    }
+    await new Promise(resolve => setTimeout(resolve, 20));
+  }
+
+  throw new Error(`Timed out waiting for reconcileState=${expectedState}`);
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+});
+
+describe('morning briefing lifecycle', () => {
+  it('enable command converges to enabled state via reconcile', async () => {
+    const harness = await createHarness();
+
+    const response = await harness.commandHandler({ args: 'enable' });
+    expect(response.text).toContain('Morning Briefing enable requested.');
+
+    const status = await waitForReconcileState(harness.stateDir, 'succeeded');
+    const config = await readJson(path.join(harness.stateDir, 'morning-briefing', 'config.json'));
+
+    expect(config.enabled).toBe(true);
+    expect(config.cronJobId).toBeTypeOf('string');
+    expect(status.observedEnabled).toBe(true);
+    expect(status.lastReconcileAction).toBe('enable');
+  });
+
+  it('disable reconcile succeeds when only disabled jobs remain listed', async () => {
+    const harness = await createHarness();
+
+    await harness.commandHandler({ args: 'enable' });
+    await waitForReconcileState(harness.stateDir, 'succeeded');
+
+    const disableResponse = await harness.commandHandler({ args: 'disable' });
+    expect(disableResponse.text).toContain('Morning Briefing disable requested.');
+
+    const status = await waitForReconcileState(harness.stateDir, 'succeeded');
+    const config = await readJson(path.join(harness.stateDir, 'morning-briefing', 'config.json'));
+
+    expect(config.enabled).toBe(false);
+    expect(status.observedEnabled).toBe(false);
+    expect(status.lastReconcileAction).toBe('disable');
+    expect(harness.cronJobs.length).toBeGreaterThan(0);
+    expect(harness.cronJobs.every(job => job.enabled === false)).toBe(true);
+  });
+
+  it('startup reconcile resumes from persisted diverged state', async () => {
+    const now = new Date().toISOString();
+    const harness = await createHarness({
+      preloadedConfig: {
+        enabled: false,
+        cronJobId: 'job-existing',
+        cron: '0 7 * * *',
+        timezone: 'America/Chicago',
+        updatedAt: now,
+      },
+      preloadedStatus: {
+        lastGeneratedDate: null,
+        lastGeneratedAt: null,
+        lastPath: null,
+        sourceSummary: [],
+        failures: [],
+        observedEnabled: true,
+        reconcileState: 'idle',
+        lastReconcileAt: null,
+        lastReconcileError: null,
+        lastReconcileDurationMs: null,
+        lastReconcileAction: null,
+      },
+    });
+
+    harness.cronJobs.push({
+      id: 'job-existing',
+      name: 'KiloClaw Morning Briefing',
+      enabled: true,
+      updatedAtMs: Date.now(),
+      createdAtMs: Date.now(),
+      payload: { toolsAllow: ['morning_briefing_generate'] },
+    });
+
+    const status = await waitForReconcileState(harness.stateDir, 'succeeded');
+    expect(status.observedEnabled).toBe(false);
+    expect(status.lastReconcileAction).toBe('disable');
+  });
+
+  it('status payload exposes reconcile failure details', async () => {
+    const harness = await createHarness({ disableCommandFails: true });
+
+    await harness.commandHandler({ args: 'enable' });
+    await waitForReconcileState(harness.stateDir, 'succeeded');
+
+    await harness.commandHandler({ args: 'disable' });
+    await waitForReconcileState(harness.stateDir, 'failed');
+
+    const response = new FakeResponse();
+    await harness.statusHttpHandler({}, response);
+
+    expect(response.statusCode).toBe(200);
+    const payload = JSON.parse(response.body) as Record<string, unknown>;
+    expect(payload.ok).toBe(true);
+    expect(payload.reconcileState).toBe('failed');
+    expect(typeof payload.lastReconcileError).toBe('string');
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -389,7 +389,7 @@ async function ensureCronJob(
   const nestedId = typeof createdJob.id === 'string' ? createdJob.id : '';
   const resolvedId = topLevelId || nestedId;
   if (!resolvedId) {
-    throw new Error('Unable to resolve cron job id after setup');
+    throw new Error('Unable to resolve cron job id after enable');
   }
 
   await removeDuplicateBriefingCronJobs(api, resolvedId);
@@ -899,7 +899,7 @@ export default definePluginEntry({
   name: 'KiloClawMorningBriefing',
   description: 'Morning briefing plugin for KiloClaw-hosted OpenClaw instances',
   register(api) {
-    const setupFromCommand = async (args: string | undefined) => {
+    const enableFromCommand = async (args: string | undefined) => {
       const paths = getStatePaths(api);
       await ensureStorage(paths);
 
@@ -964,9 +964,9 @@ export default definePluginEntry({
       const args = argsText.trim();
       const [subcommand = 'status'] = args.split(/\s+/).filter(Boolean);
 
-      if (subcommand === 'setup') {
-        const trailing = args.replace(/^setup\s*/, '');
-        const config = await setupFromCommand(trailing);
+      if (subcommand === 'enable') {
+        const trailing = args.replace(/^enable\s*/, '');
+        const config = await enableFromCommand(trailing);
         return [
           'Morning Briefing enabled.',
           `- schedule: ${config.cron}`,
@@ -1164,7 +1164,7 @@ export default definePluginEntry({
     });
 
     api.registerHttpRoute({
-      path: '/api/plugins/kiloclaw-morning-briefing/setup',
+      path: '/api/plugins/kiloclaw-morning-briefing/enable',
       auth: 'gateway',
       match: 'exact',
       handler: async (req, res) => {
@@ -1173,7 +1173,7 @@ export default definePluginEntry({
           const cron = typeof body.cron === 'string' ? body.cron.trim() : undefined;
           const timezone = typeof body.timezone === 'string' ? body.timezone.trim() : undefined;
           const suffix = [cron, timezone].filter(Boolean).join(' ');
-          const result = await setupFromCommand(suffix);
+          const result = await enableFromCommand(suffix);
           sendJson(res, 200, {
             ok: true,
             enabled: result.enabled,
@@ -1277,7 +1277,7 @@ export default definePluginEntry({
     api.on('before_prompt_build', () => ({
       appendSystemContext: [
         'Morning Briefing plugin is installed.',
-        'Use /briefing setup|status|run|today|yesterday|disable for command-driven control.',
+        'Use /briefing enable|status|run|today|yesterday|disable for command-driven control.',
         'If inbound text contains /briefing but command routing did not execute, call morning_briefing_handle_command exactly once with the full raw inbound message.',
         'Never emulate /briefing by manually calling generic cron/file tools.',
       ].join('\n'),

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -942,7 +942,9 @@ export default definePluginEntry({
     let reconcileInFlight: Promise<void> | null = null;
     let queuedReconcileAction: 'enable' | 'disable' | null = null;
 
-    const reconcileDesiredState = async (action: 'enable' | 'disable'): Promise<void> => {
+    const reconcileDesiredState = async (
+      action: 'enable' | 'disable'
+    ): Promise<'succeeded' | 'failed'> => {
       const paths = getStatePaths(api);
       await ensureStorage(paths);
       const startedAt = Date.now();
@@ -972,7 +974,7 @@ export default definePluginEntry({
             lastReconcileDurationMs: Date.now() - startedAt,
             lastReconcileAction: action,
           });
-          return;
+          return 'succeeded';
         }
 
         const jobs = await listBriefingCronJobs(api);
@@ -1013,6 +1015,7 @@ export default definePluginEntry({
           lastReconcileDurationMs: Date.now() - startedAt,
           lastReconcileAction: action,
         });
+        return 'succeeded';
       } catch (error) {
         await patchStoredStatus(paths, {
           reconcileState: 'failed',
@@ -1021,6 +1024,7 @@ export default definePluginEntry({
           lastReconcileDurationMs: Date.now() - startedAt,
           lastReconcileAction: action,
         });
+        return 'failed';
       }
     };
 
@@ -1033,7 +1037,7 @@ export default definePluginEntry({
         let nextAction: 'enable' | 'disable' | null = initialAction;
 
         while (nextAction) {
-          await reconcileDesiredState(nextAction);
+          const reconcileResult = await reconcileDesiredState(nextAction);
 
           const queuedAction = queuedReconcileAction;
           queuedReconcileAction = null;
@@ -1045,11 +1049,14 @@ export default definePluginEntry({
             readStoredStatus(paths),
           ]);
 
-          nextAction = resolveNextReconcileAction({
-            queuedAction,
-            desiredEnabled: config.enabled,
-            observedEnabled: status.observedEnabled,
-          });
+          nextAction =
+            reconcileResult === 'failed'
+              ? queuedAction
+              : resolveNextReconcileAction({
+                  queuedAction,
+                  desiredEnabled: config.enabled,
+                  observedEnabled: status.observedEnabled,
+                });
         }
       };
 

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -1,0 +1,1286 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { Type } from '@sinclair/typebox';
+import { definePluginEntry } from 'openclaw/plugin-sdk/plugin-entry';
+import {
+  buildBriefingMarkdown,
+  formatDateKey,
+  offsetDays,
+  resolveBriefingPath,
+} from './briefing-utils';
+import { pickCanonicalCronJobId, selectMorningBriefingJobs } from './cron-utils';
+import { extractBriefingArgsFromText } from './command-fallback-utils';
+import { normalizeLinearIssues, summarizeLinearCallFailure } from './linear-utils';
+import { normalizeWebResults } from './web-utils';
+
+const PLUGIN_ID = 'kiloclaw-morning-briefing';
+const CRON_JOB_NAME = 'KiloClaw Morning Briefing';
+const CRON_PROMPT =
+  'Call the tool morning_briefing_generate exactly once with no arguments. Do not call any other tool.';
+const DEFAULT_CRON = '0 7 * * *';
+const DEFAULT_TIMEZONE = 'UTC';
+
+type BriefingPluginConfig = {
+  defaultCron?: string;
+  defaultTimezone?: string;
+};
+
+type StoredConfig = {
+  enabled: boolean;
+  cronJobId: string | null;
+  cron: string;
+  timezone: string;
+  updatedAt: string;
+};
+
+type StoredStatus = {
+  lastGeneratedDate: string | null;
+  lastGeneratedAt: string | null;
+  lastPath: string | null;
+  sourceSummary: Array<{ source: string; configured: boolean; ok: boolean; summary: string }>;
+  failures: string[];
+};
+
+type SourceCollectionResult = {
+  source: 'github' | 'linear' | 'web';
+  configured: boolean;
+  ok: boolean;
+  summary: string;
+  sectionLines: string[];
+};
+
+function asObject(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function resolvePluginConfig(raw: unknown): BriefingPluginConfig {
+  const obj = asObject(raw);
+  return {
+    defaultCron: typeof obj.defaultCron === 'string' ? obj.defaultCron : undefined,
+    defaultTimezone: typeof obj.defaultTimezone === 'string' ? obj.defaultTimezone : undefined,
+  };
+}
+
+async function readRequestBody(req: import('node:http').IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const raw = Buffer.concat(chunks).toString('utf8').trim();
+  if (!raw) {
+    return {};
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+function sendJson(
+  res: import('node:http').ServerResponse,
+  statusCode: number,
+  body: Record<string, unknown>
+): void {
+  res.statusCode = statusCode;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+function getStatePaths(api: { runtime: { state: { resolveStateDir: () => string } } }): {
+  rootDir: string;
+  briefingsDir: string;
+  configPath: string;
+  statusPath: string;
+} {
+  const stateDir = api.runtime.state.resolveStateDir();
+  const rootDir = path.join(stateDir, 'morning-briefing');
+  return {
+    rootDir,
+    briefingsDir: path.join(rootDir, 'briefings'),
+    configPath: path.join(rootDir, 'config.json'),
+    statusPath: path.join(rootDir, 'status.json'),
+  };
+}
+
+async function ensureStorage(paths: { rootDir: string; briefingsDir: string }): Promise<void> {
+  await fs.mkdir(paths.rootDir, { recursive: true });
+  await fs.mkdir(paths.briefingsDir, { recursive: true });
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T | null> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await fs.writeFile(filePath, JSON.stringify(value, null, 2), 'utf8');
+}
+
+async function runCommand(
+  api: {
+    runtime: {
+      system: {
+        runCommandWithTimeout: (
+          argv: string[],
+          options: { timeoutMs: number; cwd?: string }
+        ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+      };
+    };
+  },
+  argv: string[],
+  timeoutMs = 30_000
+): Promise<{ stdout: string; stderr: string }> {
+  const result = await api.runtime.system.runCommandWithTimeout(argv, {
+    timeoutMs,
+  });
+  if (result.code !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim() || 'Command failed';
+    throw new Error(`${argv.join(' ')} failed: ${message}`);
+  }
+  return { stdout: result.stdout, stderr: result.stderr };
+}
+
+async function runCronJson(
+  api: {
+    runtime: {
+      system: {
+        runCommandWithTimeout: (
+          argv: string[],
+          options: { timeoutMs: number; cwd?: string }
+        ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+      };
+    };
+  },
+  argv: string[]
+): Promise<Record<string, unknown>> {
+  const [subcommand = ''] = argv;
+  const jsonUnsupported = subcommand === 'disable';
+  const command = jsonUnsupported
+    ? ['openclaw', 'cron', ...argv]
+    : ['openclaw', 'cron', ...argv, '--json'];
+  const { stdout } = await runCommand(api, command, 60_000);
+  try {
+    return asObject(JSON.parse(stdout));
+  } catch {
+    return {};
+  }
+}
+
+async function runCronCommand(
+  api: {
+    runtime: {
+      system: {
+        runCommandWithTimeout: (
+          argv: string[],
+          options: { timeoutMs: number; cwd?: string }
+        ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+      };
+    };
+  },
+  argv: string[]
+): Promise<void> {
+  await runCommand(api, ['openclaw', 'cron', ...argv], 60_000);
+}
+
+type CronJobRef = {
+  id: string;
+  enabled: boolean;
+  updatedAtMs: number;
+  createdAtMs: number;
+};
+
+async function listBriefingCronJobs(api: {
+  runtime: {
+    system: {
+      runCommandWithTimeout: (
+        argv: string[],
+        options: { timeoutMs: number; cwd?: string }
+      ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+    };
+  };
+}): Promise<CronJobRef[]> {
+  const listResult = await runCronJson(api, ['list']);
+  return selectMorningBriefingJobs(listResult, CRON_JOB_NAME, 'morning_briefing_generate');
+}
+
+async function removeDuplicateBriefingCronJobs(
+  api: {
+    runtime: {
+      system: {
+        runCommandWithTimeout: (
+          argv: string[],
+          options: { timeoutMs: number; cwd?: string }
+        ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+      };
+    };
+    logger: { warn?: (message: string) => void };
+  },
+  canonicalId: string
+): Promise<void> {
+  const jobs = await listBriefingCronJobs(api);
+  for (const job of jobs) {
+    if (job.id === canonicalId) {
+      continue;
+    }
+    try {
+      await runCronJson(api, ['remove', job.id]);
+    } catch (error) {
+      api.logger.warn?.(
+        `Morning briefing: failed to remove duplicate cron ${job.id} (${String(error)})`
+      );
+    }
+  }
+}
+
+function resolveDefaults(api: {
+  config: {
+    agents?: {
+      defaults?: {
+        userTimezone?: string;
+      };
+    };
+  };
+  pluginConfig?: Record<string, unknown>;
+}): { cron: string; timezone: string } {
+  const pluginConfig = resolvePluginConfig(api.pluginConfig);
+  return {
+    cron: pluginConfig.defaultCron?.trim() || DEFAULT_CRON,
+    timezone:
+      pluginConfig.defaultTimezone?.trim() ||
+      api.config.agents?.defaults?.userTimezone ||
+      DEFAULT_TIMEZONE,
+  };
+}
+
+async function readStoredConfig(
+  api: {
+    runtime: { state: { resolveStateDir: () => string } };
+    config: {
+      agents?: {
+        defaults?: {
+          userTimezone?: string;
+        };
+      };
+    };
+    pluginConfig?: Record<string, unknown>;
+  },
+  paths: { configPath: string }
+): Promise<StoredConfig> {
+  const defaults = resolveDefaults(api);
+  const existing = await readJsonFile<StoredConfig>(paths.configPath);
+  if (!existing) {
+    return {
+      enabled: false,
+      cronJobId: null,
+      cron: defaults.cron,
+      timezone: defaults.timezone,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+  return {
+    enabled: existing.enabled === true,
+    cronJobId:
+      typeof existing.cronJobId === 'string' && existing.cronJobId ? existing.cronJobId : null,
+    cron: typeof existing.cron === 'string' && existing.cron ? existing.cron : defaults.cron,
+    timezone:
+      typeof existing.timezone === 'string' && existing.timezone
+        ? existing.timezone
+        : defaults.timezone,
+    updatedAt:
+      typeof existing.updatedAt === 'string' ? existing.updatedAt : new Date().toISOString(),
+  };
+}
+
+async function readStoredStatus(paths: { statusPath: string }): Promise<StoredStatus> {
+  const existing = await readJsonFile<StoredStatus>(paths.statusPath);
+  if (!existing) {
+    return {
+      lastGeneratedDate: null,
+      lastGeneratedAt: null,
+      lastPath: null,
+      sourceSummary: [],
+      failures: [],
+    };
+  }
+  return {
+    lastGeneratedDate:
+      typeof existing.lastGeneratedDate === 'string' ? existing.lastGeneratedDate : null,
+    lastGeneratedAt: typeof existing.lastGeneratedAt === 'string' ? existing.lastGeneratedAt : null,
+    lastPath: typeof existing.lastPath === 'string' ? existing.lastPath : null,
+    sourceSummary: Array.isArray(existing.sourceSummary)
+      ? existing.sourceSummary.filter(entry => typeof entry === 'object' && entry !== null)
+      : [],
+    failures: Array.isArray(existing.failures)
+      ? existing.failures.filter(value => typeof value === 'string')
+      : [],
+  };
+}
+
+async function ensureCronJob(
+  api: {
+    runtime: {
+      system: {
+        runCommandWithTimeout: (
+          argv: string[],
+          options: { timeoutMs: number; cwd?: string }
+        ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+      };
+    };
+    logger: { warn?: (message: string) => void };
+  },
+  config: StoredConfig
+): Promise<{ cronJobId: string; cron: string; timezone: string }> {
+  const existingJobs = await listBriefingCronJobs(api);
+  let cronJobId = pickCanonicalCronJobId(existingJobs, config.cronJobId);
+
+  if (cronJobId !== null) {
+    try {
+      await runCronJson(api, [
+        'edit',
+        cronJobId,
+        '--session',
+        'isolated',
+        '--message',
+        CRON_PROMPT,
+        '--cron',
+        config.cron,
+        '--tz',
+        config.timezone,
+        '--tools',
+        'morning_briefing_generate',
+        '--no-deliver',
+      ]);
+      await removeDuplicateBriefingCronJobs(api, cronJobId);
+      return { cronJobId, cron: config.cron, timezone: config.timezone };
+    } catch (error) {
+      api.logger.warn?.(
+        `Morning briefing: existing cron edit failed (${String(error)}), recreating.`
+      );
+      cronJobId = null;
+    }
+  }
+
+  const createResult = await runCronJson(api, [
+    'add',
+    '--name',
+    CRON_JOB_NAME,
+    '--session',
+    'isolated',
+    '--message',
+    CRON_PROMPT,
+    '--cron',
+    config.cron,
+    '--tz',
+    config.timezone,
+    '--tools',
+    'morning_briefing_generate',
+    '--no-deliver',
+  ]);
+
+  const topLevelId = typeof createResult.id === 'string' ? createResult.id : '';
+  const createdJob = asObject(createResult.job);
+  const nestedId = typeof createdJob.id === 'string' ? createdJob.id : '';
+  const resolvedId = topLevelId || nestedId;
+  if (!resolvedId) {
+    throw new Error('Unable to resolve cron job id after setup');
+  }
+
+  await removeDuplicateBriefingCronJobs(api, resolvedId);
+
+  return {
+    cronJobId: resolvedId,
+    cron: config.cron,
+    timezone: config.timezone,
+  };
+}
+
+async function resolveGithubReady(api: {
+  runtime: {
+    system: {
+      runCommandWithTimeout: (
+        argv: string[],
+        options: { timeoutMs: number; cwd?: string }
+      ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+    };
+  };
+}): Promise<{ configured: boolean; summary: string }> {
+  const result = await api.runtime.system.runCommandWithTimeout(['gh', 'auth', 'status'], {
+    timeoutMs: 10_000,
+  });
+  if (result.code !== 0) {
+    return {
+      configured: false,
+      summary: 'GitHub CLI is not authenticated',
+    };
+  }
+  return {
+    configured: true,
+    summary: 'GitHub CLI authentication is available',
+  };
+}
+
+async function resolveWebSearchReady(api: {
+  runtime: {
+    webSearch: {
+      listProviders: (params?: { config?: unknown }) => Array<{ id?: string }>;
+    };
+  };
+  config: unknown;
+}): Promise<{ configured: boolean; summary: string }> {
+  const providers = api.runtime.webSearch.listProviders({ config: api.config });
+  if (!Array.isArray(providers) || providers.length === 0) {
+    return {
+      configured: false,
+      summary: 'No web search provider is configured',
+    };
+  }
+  return {
+    configured: true,
+    summary: `Web search provider ready (${providers.length} provider${providers.length === 1 ? '' : 's'})`,
+  };
+}
+
+function resolveLinearReady(): { configured: boolean; summary: string } {
+  const hasLinearKey =
+    typeof process.env.LINEAR_API_KEY === 'string' && process.env.LINEAR_API_KEY.trim().length > 0;
+  if (!hasLinearKey) {
+    return {
+      configured: false,
+      summary: 'Linear API key is not configured',
+    };
+  }
+  return {
+    configured: true,
+    summary: 'Linear API key is configured',
+  };
+}
+
+function normalizeGithubIssues(
+  payload: unknown
+): Array<{ title: string; url: string; updatedAt?: string }> {
+  if (!Array.isArray(payload)) {
+    return [];
+  }
+  return payload
+    .map(raw => asObject(raw))
+    .map(item => ({
+      title: typeof item.title === 'string' ? item.title : '(untitled)',
+      url: typeof item.url === 'string' ? item.url : '',
+      updatedAt: typeof item.updatedAt === 'string' ? item.updatedAt : undefined,
+    }))
+    .filter(item => item.url.length > 0);
+}
+
+async function collectGithub(api: {
+  runtime: {
+    system: {
+      runCommandWithTimeout: (
+        argv: string[],
+        options: { timeoutMs: number; cwd?: string }
+      ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+    };
+  };
+}): Promise<SourceCollectionResult> {
+  const readiness = await resolveGithubReady(api);
+  if (!readiness.configured) {
+    return {
+      source: 'github',
+      configured: false,
+      ok: false,
+      summary: readiness.summary,
+      sectionLines: [],
+    };
+  }
+
+  try {
+    const { stdout } = await runCommand(
+      api,
+      [
+        'gh',
+        'search',
+        'issues',
+        'is:open sort:updated-desc',
+        '--limit',
+        '12',
+        '--json',
+        'title,url,updatedAt',
+      ],
+      20_000
+    );
+    const items = normalizeGithubIssues(JSON.parse(stdout));
+    if (items.length === 0) {
+      return {
+        source: 'github',
+        configured: true,
+        ok: true,
+        summary: 'No open issues found in accessible repositories',
+        sectionLines: ['- No open issues found.'],
+      };
+    }
+    const lines = items.slice(0, 8).map(item => {
+      const updatedSuffix = item.updatedAt ? ` (updated ${item.updatedAt})` : '';
+      return `- [${item.title}](${item.url})${updatedSuffix}`;
+    });
+    return {
+      source: 'github',
+      configured: true,
+      ok: true,
+      summary: `Fetched ${items.length} open GitHub issues`,
+      sectionLines: lines,
+    };
+  } catch (error) {
+    return {
+      source: 'github',
+      configured: true,
+      ok: false,
+      summary: `GitHub query failed: ${error instanceof Error ? error.message : String(error)}`,
+      sectionLines: [],
+    };
+  }
+}
+
+async function collectWebSearch(api: {
+  runtime: {
+    webSearch: {
+      listProviders: (params?: { config?: unknown }) => Array<{ id?: string }>;
+      search: (params: { args: Record<string, unknown>; config?: unknown }) => Promise<{
+        provider: string;
+        result: Record<string, unknown>;
+      }>;
+    };
+  };
+  config: unknown;
+}): Promise<SourceCollectionResult> {
+  const readiness = await resolveWebSearchReady(api);
+  if (!readiness.configured) {
+    return {
+      source: 'web',
+      configured: false,
+      ok: false,
+      summary: readiness.summary,
+      sectionLines: [],
+    };
+  }
+
+  try {
+    const response = await api.runtime.webSearch.search({
+      config: api.config,
+      args: {
+        query:
+          'top engineering updates and breaking software infrastructure news from the last 24 hours',
+        count: 6,
+      },
+    });
+    const results = normalizeWebResults(response.result);
+    if (results.length === 0) {
+      return {
+        source: 'web',
+        configured: true,
+        ok: true,
+        summary: 'Web search returned no results',
+        sectionLines: ['- No web-search results returned.'],
+      };
+    }
+    return {
+      source: 'web',
+      configured: true,
+      ok: true,
+      summary: `Fetched ${results.length} web results (${response.provider})`,
+      sectionLines: results
+        .slice(0, 6)
+        .map(item =>
+          item.summary.length > 0
+            ? `- [${item.title}](${item.url}) - ${item.summary}`
+            : `- [${item.title}](${item.url})`
+        ),
+    };
+  } catch (error) {
+    return {
+      source: 'web',
+      configured: true,
+      ok: false,
+      summary: `Web search failed: ${error instanceof Error ? error.message : String(error)}`,
+      sectionLines: [],
+    };
+  }
+}
+
+async function collectLinear(api: {
+  runtime: {
+    state: { resolveStateDir: () => string };
+    system: {
+      runCommandWithTimeout: (
+        argv: string[],
+        options: { timeoutMs: number; cwd?: string }
+      ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+    };
+  };
+}): Promise<SourceCollectionResult> {
+  const readiness = resolveLinearReady();
+  if (!readiness.configured) {
+    return {
+      source: 'linear',
+      configured: false,
+      ok: false,
+      summary: readiness.summary,
+      sectionLines: [],
+    };
+  }
+
+  const workspaceDir = path.join(api.runtime.state.resolveStateDir(), 'workspace');
+  const result = await api.runtime.system.runCommandWithTimeout(
+    [
+      'mcporter',
+      'call',
+      'linear',
+      'list_issues',
+      'limit:8',
+      'orderBy:updatedAt',
+      '--output',
+      'json',
+    ],
+    {
+      timeoutMs: 25_000,
+      cwd: workspaceDir,
+    }
+  );
+
+  if (result.code !== 0) {
+    return {
+      source: 'linear',
+      configured: true,
+      ok: false,
+      summary: summarizeLinearCallFailure(result.stdout, result.stderr),
+      sectionLines: [],
+    };
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(result.stdout);
+  } catch {
+    return {
+      source: 'linear',
+      configured: true,
+      ok: false,
+      summary: 'Linear returned non-JSON output',
+      sectionLines: [],
+    };
+  }
+
+  const issues = normalizeLinearIssues(payload);
+  if (issues.length === 0) {
+    return {
+      source: 'linear',
+      configured: true,
+      ok: true,
+      summary: 'No Linear issues matched the default query',
+      sectionLines: ['- No Linear issues returned.'],
+    };
+  }
+
+  return {
+    source: 'linear',
+    configured: true,
+    ok: true,
+    summary: `Fetched ${issues.length} Linear issues`,
+    sectionLines: issues.map(issue => {
+      const updatedSuffix = issue.updatedAt ? ` (updated ${issue.updatedAt})` : '';
+      return `- [${issue.id}](${issue.url}) ${issue.title} - ${issue.status}${updatedSuffix}`;
+    }),
+  };
+}
+
+async function generateBriefing(
+  api: {
+    runtime: {
+      state: { resolveStateDir: () => string };
+      system: {
+        runCommandWithTimeout: (
+          argv: string[],
+          options: { timeoutMs: number; cwd?: string }
+        ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+      };
+      webSearch: {
+        listProviders: (params?: { config?: unknown }) => Array<{ id?: string }>;
+        search: (params: { args: Record<string, unknown>; config?: unknown }) => Promise<{
+          provider: string;
+          result: Record<string, unknown>;
+        }>;
+      };
+    };
+    config: unknown;
+  },
+  date: Date
+): Promise<{
+  dateKey: string;
+  filePath: string;
+  markdown: string;
+  sources: SourceCollectionResult[];
+  failures: string[];
+}> {
+  const paths = getStatePaths(api);
+  await ensureStorage(paths);
+
+  const [github, linear, web] = await Promise.all([
+    collectGithub(api),
+    collectLinear(api),
+    collectWebSearch(api),
+  ]);
+  const sources = [github, linear, web];
+  const successes = sources.filter(source => source.ok);
+
+  if (successes.length === 0) {
+    throw new Error(
+      'No usable briefing sources are available. Configure at least one of GitHub, Linear, or web search.'
+    );
+  }
+
+  const failures = sources
+    .filter(source => !source.ok)
+    .map(source => `${source.source}: ${source.summary}`);
+  const markdown = buildBriefingMarkdown({
+    date,
+    generatedAt: new Date(),
+    statuses: sources.map(source => ({
+      source: source.source,
+      configured: source.configured,
+      ok: source.ok,
+      summary: source.summary,
+    })),
+    sections: [
+      { title: 'GitHub', lines: github.sectionLines },
+      { title: 'Linear', lines: linear.sectionLines },
+      { title: 'Web Search', lines: web.sectionLines },
+    ],
+    failures,
+  });
+
+  const filePath = resolveBriefingPath(paths.briefingsDir, date);
+  await fs.writeFile(filePath, markdown, 'utf8');
+
+  const dateKey = formatDateKey(date);
+  await writeJsonFile(paths.statusPath, {
+    lastGeneratedDate: dateKey,
+    lastGeneratedAt: new Date().toISOString(),
+    lastPath: filePath,
+    sourceSummary: sources.map(source => ({
+      source: source.source,
+      configured: source.configured,
+      ok: source.ok,
+      summary: source.summary,
+    })),
+    failures,
+  } satisfies StoredStatus);
+
+  return {
+    dateKey,
+    filePath,
+    markdown,
+    sources,
+    failures,
+  };
+}
+
+async function readBriefingByDate(
+  api: { runtime: { state: { resolveStateDir: () => string } } },
+  date: Date
+): Promise<{ dateKey: string; filePath: string; exists: boolean; markdown: string | null }> {
+  const paths = getStatePaths(api);
+  await ensureStorage(paths);
+  const filePath = resolveBriefingPath(paths.briefingsDir, date);
+  try {
+    const markdown = await fs.readFile(filePath, 'utf8');
+    return {
+      dateKey: formatDateKey(date),
+      filePath,
+      exists: true,
+      markdown,
+    };
+  } catch {
+    return {
+      dateKey: formatDateKey(date),
+      filePath,
+      exists: false,
+      markdown: null,
+    };
+  }
+}
+
+async function getStatusSnapshot(api: {
+  runtime: {
+    state: { resolveStateDir: () => string };
+    system: {
+      runCommandWithTimeout: (
+        argv: string[],
+        options: { timeoutMs: number; cwd?: string }
+      ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+    };
+    webSearch: {
+      listProviders: (params?: { config?: unknown }) => Array<{ id?: string }>;
+    };
+  };
+  config: {
+    agents?: {
+      defaults?: {
+        userTimezone?: string;
+      };
+    };
+  };
+  pluginConfig?: Record<string, unknown>;
+}): Promise<{
+  enabled: boolean;
+  cron: string;
+  timezone: string;
+  cronJobId: string | null;
+  lastGeneratedDate: string | null;
+  lastGeneratedAt: string | null;
+  sourceReadiness: {
+    github: { configured: boolean; summary: string };
+    linear: { configured: boolean; summary: string };
+    web: { configured: boolean; summary: string };
+  };
+}> {
+  const paths = getStatePaths(api);
+  await ensureStorage(paths);
+  const config = await readStoredConfig(api, paths);
+  const status = await readStoredStatus(paths);
+  const [github, web, cronJobs] = await Promise.all([
+    resolveGithubReady(api),
+    resolveWebSearchReady(api),
+    listBriefingCronJobs(api),
+  ]);
+  const linear = resolveLinearReady();
+  const canonicalJobId = pickCanonicalCronJobId(cronJobs, config.cronJobId);
+  const hasEnabledJob = cronJobs.some(job => job.enabled);
+
+  return {
+    enabled: hasEnabledJob,
+    cron: config.cron,
+    timezone: config.timezone,
+    cronJobId: canonicalJobId,
+    lastGeneratedDate: status.lastGeneratedDate,
+    lastGeneratedAt: status.lastGeneratedAt,
+    sourceReadiness: {
+      github,
+      linear,
+      web,
+    },
+  };
+}
+
+function parseSetupArgs(args: string | undefined): { cron?: string; timezone?: string } {
+  const text = (args ?? '').trim();
+  if (!text) {
+    return {};
+  }
+  const tokens = text.split(/\s+/).filter(Boolean);
+  if (tokens.length === 1) {
+    return { cron: tokens[0] };
+  }
+  if (tokens.length >= 2) {
+    return {
+      cron: tokens[0],
+      timezone: tokens[1],
+    };
+  }
+  return {};
+}
+
+export default definePluginEntry({
+  id: PLUGIN_ID,
+  name: 'KiloClawMorningBriefing',
+  description: 'Morning briefing plugin for KiloClaw-hosted OpenClaw instances',
+  register(api) {
+    const setupFromCommand = async (args: string | undefined) => {
+      const paths = getStatePaths(api);
+      await ensureStorage(paths);
+
+      const current = await readStoredConfig(api, paths);
+      const parsed = parseSetupArgs(args);
+      const nextConfig: StoredConfig = {
+        ...current,
+        enabled: true,
+        cron: parsed.cron?.trim() || current.cron,
+        timezone: parsed.timezone?.trim() || current.timezone,
+        updatedAt: new Date().toISOString(),
+      };
+
+      const ensured = await ensureCronJob(api, nextConfig);
+      const finalConfig: StoredConfig = {
+        ...nextConfig,
+        cronJobId: ensured.cronJobId,
+      };
+      await writeJsonFile(paths.configPath, finalConfig);
+      return finalConfig;
+    };
+
+    const disableFromCommand = async () => {
+      const paths = getStatePaths(api);
+      await ensureStorage(paths);
+      const current = await readStoredConfig(api, paths);
+      const jobs = await listBriefingCronJobs(api);
+      const disableErrors: string[] = [];
+      for (const job of jobs) {
+        try {
+          await runCronCommand(api, ['disable', job.id]);
+        } catch (error) {
+          disableErrors.push(
+            `Failed to disable cron ${job.id}: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      }
+
+      const remainingEnabledJobs = await listBriefingCronJobs(api);
+      if (disableErrors.length > 0 || remainingEnabledJobs.length > 0) {
+        const issues: string[] = [];
+        issues.push(...disableErrors);
+        if (remainingEnabledJobs.length > 0) {
+          issues.push(
+            `Cron jobs still enabled after disable: ${remainingEnabledJobs.map(job => job.id).join(', ')}`
+          );
+        }
+        throw new Error(issues.join(' | '));
+      }
+
+      const nextConfig: StoredConfig = {
+        ...current,
+        enabled: false,
+        cronJobId: null,
+        updatedAt: new Date().toISOString(),
+      };
+      await writeJsonFile(paths.configPath, nextConfig);
+      return nextConfig;
+    };
+
+    const runBriefingCommand = async (argsText: string) => {
+      const args = argsText.trim();
+      const [subcommand = 'status'] = args.split(/\s+/).filter(Boolean);
+
+      if (subcommand === 'setup') {
+        const trailing = args.replace(/^setup\s*/, '');
+        const config = await setupFromCommand(trailing);
+        return [
+          'Morning Briefing enabled.',
+          `- schedule: ${config.cron}`,
+          `- timezone: ${config.timezone}`,
+          `- cron job id: ${config.cronJobId ?? '(unknown)'}`,
+        ].join('\n');
+      }
+
+      if (subcommand === 'disable') {
+        const config = await disableFromCommand();
+        return [
+          'Morning Briefing disabled.',
+          `- schedule retained: ${config.cron} (${config.timezone})`,
+        ].join('\n');
+      }
+
+      if (subcommand === 'run') {
+        const result = await generateBriefing(api, new Date());
+        return [
+          `Generated briefing for ${result.dateKey}.`,
+          `- file: ${result.filePath}`,
+          ...result.failures.map(failure => `- note: ${failure}`),
+        ].join('\n');
+      }
+
+      if (subcommand === 'today' || subcommand === 'yesterday') {
+        const targetDate = offsetDays(new Date(), subcommand === 'today' ? 0 : -1);
+        const briefing = await readBriefingByDate(api, targetDate);
+        if (!briefing.exists || !briefing.markdown) {
+          return `No saved briefing for ${briefing.dateKey}.`;
+        }
+        return briefing.markdown;
+      }
+
+      const status = await getStatusSnapshot(api);
+      return [
+        'Morning Briefing status:',
+        `- enabled: ${status.enabled ? 'yes' : 'no'}`,
+        `- schedule: ${status.cron} (${status.timezone})`,
+        `- cron job id: ${status.cronJobId ?? '(none)'}`,
+        `- last generated: ${status.lastGeneratedDate ?? '(none)'}`,
+        `- github: ${status.sourceReadiness.github.configured ? 'ready' : 'not ready'} (${status.sourceReadiness.github.summary})`,
+        `- linear: ${status.sourceReadiness.linear.configured ? 'configured' : 'not configured'} (${status.sourceReadiness.linear.summary})`,
+        `- web search: ${status.sourceReadiness.web.configured ? 'ready' : 'not ready'} (${status.sourceReadiness.web.summary})`,
+      ].join('\n');
+    };
+
+    api.registerCommand({
+      name: 'briefing',
+      description: 'Manage and run KiloClaw Morning Briefings',
+      acceptsArgs: true,
+      handler: async ctx => {
+        return {
+          text: await runBriefingCommand(ctx.args ?? ''),
+        };
+      },
+    });
+
+    api.registerTool({
+      name: 'morning_briefing_handle_command',
+      description:
+        'Deterministically handles /briefing commands from raw inbound text when slash routing fails.',
+      parameters: Type.Object(
+        {
+          message: Type.String({
+            description:
+              'Raw inbound user text that may include wrapper metadata and a /briefing command.',
+            minLength: 1,
+          }),
+        },
+        { additionalProperties: false }
+      ),
+      async execute(_toolCallId, params) {
+        const commandArgs = extractBriefingArgsFromText(params.message);
+        if (commandArgs === null) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'No /briefing command found in the provided message.',
+              },
+            ],
+          };
+        }
+
+        const resultText = await runBriefingCommand(commandArgs);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: resultText,
+            },
+          ],
+        };
+      },
+    });
+
+    api.registerTool({
+      name: 'morning_briefing_generate',
+      description:
+        "Generate today's morning briefing from configured sources and persist it as Markdown.",
+      parameters: Type.Object(
+        {
+          date: Type.Optional(
+            Type.String({
+              description: 'Optional local date key in YYYY-MM-DD format',
+              pattern: '^\\d{4}-\\d{2}-\\d{2}$',
+            })
+          ),
+        },
+        { additionalProperties: false }
+      ),
+      async execute(_toolCallId, params) {
+        const dateValue = typeof params.date === 'string' ? params.date : undefined;
+        const targetDate = dateValue ? new Date(`${dateValue}T08:00:00`) : new Date();
+        const result = await generateBriefing(api, targetDate);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: [
+                `Morning briefing generated for ${result.dateKey}.`,
+                `Saved to ${result.filePath}.`,
+                ...result.failures.map(failure => `Note: ${failure}`),
+              ].join('\n'),
+            },
+          ],
+        };
+      },
+    });
+
+    api.registerTool({
+      name: 'morning_briefing_read',
+      description: 'Read a saved morning briefing Markdown file for a specific date.',
+      parameters: Type.Object(
+        {
+          day: Type.Optional(
+            Type.Union([
+              Type.Literal('today'),
+              Type.Literal('yesterday'),
+              Type.String({ pattern: '^\\d{4}-\\d{2}-\\d{2}$' }),
+            ])
+          ),
+        },
+        { additionalProperties: false }
+      ),
+      async execute(_toolCallId, params) {
+        const rawDay = typeof params.day === 'string' ? params.day : 'today';
+        const date =
+          rawDay === 'yesterday'
+            ? offsetDays(new Date(), -1)
+            : rawDay === 'today'
+              ? new Date()
+              : new Date(`${rawDay}T08:00:00`);
+        const briefing = await readBriefingByDate(api, date);
+        if (!briefing.exists || !briefing.markdown) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `No briefing exists for ${briefing.dateKey}.`,
+              },
+            ],
+          };
+        }
+        return {
+          content: [
+            {
+              type: 'text',
+              text: briefing.markdown,
+            },
+          ],
+        };
+      },
+    });
+
+    api.registerHttpRoute({
+      path: '/api/plugins/kiloclaw-morning-briefing/status',
+      auth: 'gateway',
+      match: 'exact',
+      handler: async (_req, res) => {
+        try {
+          const snapshot = await getStatusSnapshot(api);
+          sendJson(res, 200, {
+            ok: true,
+            ...snapshot,
+          });
+        } catch (error) {
+          sendJson(res, 500, {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+    });
+
+    api.registerHttpRoute({
+      path: '/api/plugins/kiloclaw-morning-briefing/setup',
+      auth: 'gateway',
+      match: 'exact',
+      handler: async (req, res) => {
+        try {
+          const body = asObject(await readRequestBody(req));
+          const cron = typeof body.cron === 'string' ? body.cron.trim() : undefined;
+          const timezone = typeof body.timezone === 'string' ? body.timezone.trim() : undefined;
+          const suffix = [cron, timezone].filter(Boolean).join(' ');
+          const result = await setupFromCommand(suffix);
+          sendJson(res, 200, {
+            ok: true,
+            enabled: result.enabled,
+            cron: result.cron,
+            timezone: result.timezone,
+            cronJobId: result.cronJobId,
+          });
+        } catch (error) {
+          sendJson(res, 500, {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+    });
+
+    api.registerHttpRoute({
+      path: '/api/plugins/kiloclaw-morning-briefing/disable',
+      auth: 'gateway',
+      match: 'exact',
+      handler: async (_req, res) => {
+        try {
+          const result = await disableFromCommand();
+          sendJson(res, 200, {
+            ok: true,
+            enabled: result.enabled,
+            cron: result.cron,
+            timezone: result.timezone,
+          });
+        } catch (error) {
+          sendJson(res, 500, {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+    });
+
+    api.registerHttpRoute({
+      path: '/api/plugins/kiloclaw-morning-briefing/run',
+      auth: 'gateway',
+      match: 'exact',
+      handler: async (_req, res) => {
+        try {
+          const result = await generateBriefing(api, new Date());
+          sendJson(res, 200, {
+            ok: true,
+            date: result.dateKey,
+            filePath: result.filePath,
+            failures: result.failures,
+          });
+        } catch (error) {
+          sendJson(res, 500, {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+    });
+
+    api.registerHttpRoute({
+      path: '/api/plugins/kiloclaw-morning-briefing/read/today',
+      auth: 'gateway',
+      match: 'exact',
+      handler: async (_req, res) => {
+        try {
+          const result = await readBriefingByDate(api, new Date());
+          sendJson(res, 200, {
+            ok: true,
+            ...result,
+          });
+        } catch (error) {
+          sendJson(res, 500, {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+    });
+
+    api.registerHttpRoute({
+      path: '/api/plugins/kiloclaw-morning-briefing/read/yesterday',
+      auth: 'gateway',
+      match: 'exact',
+      handler: async (_req, res) => {
+        try {
+          const result = await readBriefingByDate(api, offsetDays(new Date(), -1));
+          sendJson(res, 200, {
+            ok: true,
+            ...result,
+          });
+        } catch (error) {
+          sendJson(res, 500, {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+    });
+
+    api.on('before_prompt_build', () => ({
+      appendSystemContext: [
+        'Morning Briefing plugin is installed.',
+        'Use /briefing setup|status|run|today|yesterday|disable for command-driven control.',
+        'If inbound text contains /briefing but command routing did not execute, call morning_briefing_handle_command exactly once with the full raw inbound message.',
+        'Never emulate /briefing by manually calling generic cron/file tools.',
+      ].join('\n'),
+    }));
+  },
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -8,9 +8,15 @@ import {
   offsetDays,
   resolveBriefingPath,
 } from './briefing-utils';
-import { pickCanonicalCronJobId, selectMorningBriefingJobs } from './cron-utils';
+import {
+  filterEnabledBriefingJobs,
+  pickCanonicalCronJobId,
+  selectMorningBriefingJobs,
+} from './cron-utils';
 import { extractBriefingArgsFromText } from './command-fallback-utils';
+import { type EnableInput, parseEnableArgs } from './enable-input-utils';
 import { normalizeLinearIssues, summarizeLinearCallFailure } from './linear-utils';
+import { resolveNextReconcileAction } from './reconcile-queue-utils';
 import { normalizeWebResults } from './web-utils';
 
 const PLUGIN_ID = 'kiloclaw-morning-briefing';
@@ -928,30 +934,13 @@ async function getStatusSnapshot(api: {
   };
 }
 
-function parseSetupArgs(args: string | undefined): { cron?: string; timezone?: string } {
-  const text = (args ?? '').trim();
-  if (!text) {
-    return {};
-  }
-  const tokens = text.split(/\s+/).filter(Boolean);
-  if (tokens.length === 1) {
-    return { cron: tokens[0] };
-  }
-  if (tokens.length >= 2) {
-    return {
-      cron: tokens[0],
-      timezone: tokens[1],
-    };
-  }
-  return {};
-}
-
 export default definePluginEntry({
   id: PLUGIN_ID,
   name: 'KiloClawMorningBriefing',
   description: 'Morning briefing plugin for KiloClaw-hosted OpenClaw instances',
   register(api) {
     let reconcileInFlight: Promise<void> | null = null;
+    let queuedReconcileAction: 'enable' | 'disable' | null = null;
 
     const reconcileDesiredState = async (action: 'enable' | 'disable'): Promise<void> => {
       const paths = getStatePaths(api);
@@ -997,7 +986,7 @@ export default definePluginEntry({
             );
           }
         }
-        const remainingEnabledJobs = await listBriefingCronJobs(api);
+        const remainingEnabledJobs = filterEnabledBriefingJobs(await listBriefingCronJobs(api));
         if (disableErrors.length > 0 || remainingEnabledJobs.length > 0) {
           const issues: string[] = [];
           issues.push(...disableErrors);
@@ -1037,9 +1026,34 @@ export default definePluginEntry({
 
     const triggerReconcile = (action: 'enable' | 'disable') => {
       if (reconcileInFlight) {
+        queuedReconcileAction = action;
         return;
       }
-      reconcileInFlight = reconcileDesiredState(action).finally(() => {
+      const runReconcileLoop = async (initialAction: 'enable' | 'disable') => {
+        let nextAction: 'enable' | 'disable' | null = initialAction;
+
+        while (nextAction) {
+          await reconcileDesiredState(nextAction);
+
+          const queuedAction = queuedReconcileAction;
+          queuedReconcileAction = null;
+
+          const paths = getStatePaths(api);
+          await ensureStorage(paths);
+          const [config, status] = await Promise.all([
+            readStoredConfig(api, paths),
+            readStoredStatus(paths),
+          ]);
+
+          nextAction = resolveNextReconcileAction({
+            queuedAction,
+            desiredEnabled: config.enabled,
+            observedEnabled: status.observedEnabled,
+          });
+        }
+      };
+
+      reconcileInFlight = runReconcileLoop(action).finally(() => {
         reconcileInFlight = null;
       });
       void reconcileInFlight.catch(error => {
@@ -1047,17 +1061,16 @@ export default definePluginEntry({
       });
     };
 
-    const enableFromCommand = async (args: string | undefined) => {
+    const enableFromInput = async (input: EnableInput) => {
       const paths = getStatePaths(api);
       await ensureStorage(paths);
 
       const current = await readStoredConfig(api, paths);
-      const parsed = parseSetupArgs(args);
       const nextConfig: StoredConfig = {
         ...current,
         enabled: true,
-        cron: parsed.cron?.trim() || current.cron,
-        timezone: parsed.timezone?.trim() || current.timezone,
+        cron: input.cron?.trim() || current.cron,
+        timezone: input.timezone?.trim() || current.timezone,
         updatedAt: new Date().toISOString(),
       };
 
@@ -1069,6 +1082,10 @@ export default definePluginEntry({
       });
       triggerReconcile('enable');
       return nextConfig;
+    };
+
+    const enableFromCommand = async (args: string | undefined) => {
+      return enableFromInput(parseEnableArgs(args));
     };
 
     const disableFromCommand = async () => {
@@ -1323,8 +1340,7 @@ export default definePluginEntry({
           const body = asObject(await readRequestBody(req));
           const cron = typeof body.cron === 'string' ? body.cron.trim() : undefined;
           const timezone = typeof body.timezone === 'string' ? body.timezone.trim() : undefined;
-          const suffix = [cron, timezone].filter(Boolean).join(' ');
-          const result = await enableFromCommand(suffix);
+          const result = await enableFromInput({ cron, timezone });
           const status = await readStoredStatus(getStatePaths(api));
           sendJson(res, 200, {
             ok: true,

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -895,6 +895,7 @@ async function getStatusSnapshot(api: {
   reconcileState: 'idle' | 'in_progress' | 'succeeded' | 'failed';
   lastReconcileAt: string | null;
   lastReconcileError: string | null;
+  lastReconcileAction: 'enable' | 'disable' | null;
   desiredEnabled: boolean;
   observedEnabled: boolean | null;
 }> {
@@ -921,6 +922,7 @@ async function getStatusSnapshot(api: {
     reconcileState: status.reconcileState,
     lastReconcileAt: status.lastReconcileAt,
     lastReconcileError: status.lastReconcileError,
+    lastReconcileAction: status.lastReconcileAction,
     desiredEnabled: config.enabled,
     observedEnabled: status.observedEnabled,
   };
@@ -1095,7 +1097,11 @@ export default definePluginEntry({
         readStoredConfig(api, paths),
         readStoredStatus(paths),
       ]);
-      if (status.reconcileState === 'in_progress' || status.observedEnabled !== config.enabled) {
+      const shouldReconcile =
+        status.reconcileState === 'in_progress' ||
+        config.enabled ||
+        (status.observedEnabled !== null && status.observedEnabled !== config.enabled);
+      if (shouldReconcile) {
         triggerReconcile(config.enabled ? 'enable' : 'disable');
       }
     })();

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -39,6 +39,12 @@ type StoredStatus = {
   lastPath: string | null;
   sourceSummary: Array<{ source: string; configured: boolean; ok: boolean; summary: string }>;
   failures: string[];
+  observedEnabled: boolean | null;
+  reconcileState: 'idle' | 'in_progress' | 'succeeded' | 'failed';
+  lastReconcileAt: string | null;
+  lastReconcileError: string | null;
+  lastReconcileDurationMs: number | null;
+  lastReconcileAction: 'enable' | 'disable' | null;
 };
 
 type SourceCollectionResult = {
@@ -307,6 +313,12 @@ async function readStoredStatus(paths: { statusPath: string }): Promise<StoredSt
       lastPath: null,
       sourceSummary: [],
       failures: [],
+      observedEnabled: null,
+      reconcileState: 'idle',
+      lastReconcileAt: null,
+      lastReconcileError: null,
+      lastReconcileDurationMs: null,
+      lastReconcileAction: null,
     };
   }
   return {
@@ -320,7 +332,39 @@ async function readStoredStatus(paths: { statusPath: string }): Promise<StoredSt
     failures: Array.isArray(existing.failures)
       ? existing.failures.filter(value => typeof value === 'string')
       : [],
+    observedEnabled:
+      typeof existing.observedEnabled === 'boolean' ? existing.observedEnabled : null,
+    reconcileState:
+      existing.reconcileState === 'in_progress' ||
+      existing.reconcileState === 'succeeded' ||
+      existing.reconcileState === 'failed'
+        ? existing.reconcileState
+        : 'idle',
+    lastReconcileAt: typeof existing.lastReconcileAt === 'string' ? existing.lastReconcileAt : null,
+    lastReconcileError:
+      typeof existing.lastReconcileError === 'string' ? existing.lastReconcileError : null,
+    lastReconcileDurationMs:
+      typeof existing.lastReconcileDurationMs === 'number'
+        ? existing.lastReconcileDurationMs
+        : null,
+    lastReconcileAction:
+      existing.lastReconcileAction === 'enable' || existing.lastReconcileAction === 'disable'
+        ? existing.lastReconcileAction
+        : null,
   };
+}
+
+async function patchStoredStatus(
+  paths: { statusPath: string },
+  patch: Partial<StoredStatus>
+): Promise<StoredStatus> {
+  const current = await readStoredStatus(paths);
+  const next: StoredStatus = {
+    ...current,
+    ...patch,
+  };
+  await writeJsonFile(paths.statusPath, next);
+  return next;
 }
 
 async function ensureCronJob(
@@ -768,6 +812,7 @@ async function generateBriefing(
 
   const dateKey = formatDateKey(date);
   await writeJsonFile(paths.statusPath, {
+    ...(await readStoredStatus(paths)),
     lastGeneratedDate: dateKey,
     lastGeneratedAt: new Date().toISOString(),
     lastPath: filePath,
@@ -847,25 +892,25 @@ async function getStatusSnapshot(api: {
     linear: { configured: boolean; summary: string };
     web: { configured: boolean; summary: string };
   };
+  reconcileState: 'idle' | 'in_progress' | 'succeeded' | 'failed';
+  lastReconcileAt: string | null;
+  lastReconcileError: string | null;
+  desiredEnabled: boolean;
+  observedEnabled: boolean | null;
 }> {
   const paths = getStatePaths(api);
   await ensureStorage(paths);
   const config = await readStoredConfig(api, paths);
   const status = await readStoredStatus(paths);
-  const [github, web, cronJobs] = await Promise.all([
-    resolveGithubReady(api),
-    resolveWebSearchReady(api),
-    listBriefingCronJobs(api),
-  ]);
+  const [github, web] = await Promise.all([resolveGithubReady(api), resolveWebSearchReady(api)]);
   const linear = resolveLinearReady();
-  const canonicalJobId = pickCanonicalCronJobId(cronJobs, config.cronJobId);
-  const hasEnabledJob = cronJobs.some(job => job.enabled);
+  const enabled = status.observedEnabled ?? config.enabled;
 
   return {
-    enabled: hasEnabledJob,
+    enabled,
     cron: config.cron,
     timezone: config.timezone,
-    cronJobId: canonicalJobId,
+    cronJobId: config.cronJobId,
     lastGeneratedDate: status.lastGeneratedDate,
     lastGeneratedAt: status.lastGeneratedAt,
     sourceReadiness: {
@@ -873,6 +918,11 @@ async function getStatusSnapshot(api: {
       linear,
       web,
     },
+    reconcileState: status.reconcileState,
+    lastReconcileAt: status.lastReconcileAt,
+    lastReconcileError: status.lastReconcileError,
+    desiredEnabled: config.enabled,
+    observedEnabled: status.observedEnabled,
   };
 }
 
@@ -899,6 +949,102 @@ export default definePluginEntry({
   name: 'KiloClawMorningBriefing',
   description: 'Morning briefing plugin for KiloClaw-hosted OpenClaw instances',
   register(api) {
+    let reconcileInFlight: Promise<void> | null = null;
+
+    const reconcileDesiredState = async (action: 'enable' | 'disable'): Promise<void> => {
+      const paths = getStatePaths(api);
+      await ensureStorage(paths);
+      const startedAt = Date.now();
+
+      await patchStoredStatus(paths, {
+        reconcileState: 'in_progress',
+        lastReconcileError: null,
+        lastReconcileAction: action,
+      });
+
+      try {
+        const config = await readStoredConfig(api, paths);
+
+        if (config.enabled) {
+          const ensured = await ensureCronJob(api, config);
+          const finalConfig: StoredConfig = {
+            ...config,
+            cronJobId: ensured.cronJobId,
+            updatedAt: new Date().toISOString(),
+          };
+          await writeJsonFile(paths.configPath, finalConfig);
+          await patchStoredStatus(paths, {
+            observedEnabled: true,
+            reconcileState: 'succeeded',
+            lastReconcileAt: new Date().toISOString(),
+            lastReconcileError: null,
+            lastReconcileDurationMs: Date.now() - startedAt,
+            lastReconcileAction: action,
+          });
+          return;
+        }
+
+        const jobs = await listBriefingCronJobs(api);
+        const disableErrors: string[] = [];
+        for (const job of jobs) {
+          try {
+            await runCronCommand(api, ['disable', job.id]);
+          } catch (error) {
+            disableErrors.push(
+              `Failed to disable cron ${job.id}: ${error instanceof Error ? error.message : String(error)}`
+            );
+          }
+        }
+        const remainingEnabledJobs = await listBriefingCronJobs(api);
+        if (disableErrors.length > 0 || remainingEnabledJobs.length > 0) {
+          const issues: string[] = [];
+          issues.push(...disableErrors);
+          if (remainingEnabledJobs.length > 0) {
+            issues.push(
+              `Cron jobs still enabled after disable: ${remainingEnabledJobs.map(job => job.id).join(', ')}`
+            );
+          }
+          throw new Error(issues.join(' | '));
+        }
+
+        const finalConfig: StoredConfig = {
+          ...config,
+          enabled: false,
+          cronJobId: null,
+          updatedAt: new Date().toISOString(),
+        };
+        await writeJsonFile(paths.configPath, finalConfig);
+        await patchStoredStatus(paths, {
+          observedEnabled: false,
+          reconcileState: 'succeeded',
+          lastReconcileAt: new Date().toISOString(),
+          lastReconcileError: null,
+          lastReconcileDurationMs: Date.now() - startedAt,
+          lastReconcileAction: action,
+        });
+      } catch (error) {
+        await patchStoredStatus(paths, {
+          reconcileState: 'failed',
+          lastReconcileAt: new Date().toISOString(),
+          lastReconcileError: error instanceof Error ? error.message : String(error),
+          lastReconcileDurationMs: Date.now() - startedAt,
+          lastReconcileAction: action,
+        });
+      }
+    };
+
+    const triggerReconcile = (action: 'enable' | 'disable') => {
+      if (reconcileInFlight) {
+        return;
+      }
+      reconcileInFlight = reconcileDesiredState(action).finally(() => {
+        reconcileInFlight = null;
+      });
+      void reconcileInFlight.catch(error => {
+        api.logger.warn?.(`Morning briefing reconcile failed: ${String(error)}`);
+      });
+    };
+
     const enableFromCommand = async (args: string | undefined) => {
       const paths = getStatePaths(api);
       await ensureStorage(paths);
@@ -913,52 +1059,46 @@ export default definePluginEntry({
         updatedAt: new Date().toISOString(),
       };
 
-      const ensured = await ensureCronJob(api, nextConfig);
-      const finalConfig: StoredConfig = {
-        ...nextConfig,
-        cronJobId: ensured.cronJobId,
-      };
-      await writeJsonFile(paths.configPath, finalConfig);
-      return finalConfig;
+      await writeJsonFile(paths.configPath, nextConfig);
+      await patchStoredStatus(paths, {
+        reconcileState: 'in_progress',
+        lastReconcileError: null,
+        lastReconcileAction: 'enable',
+      });
+      triggerReconcile('enable');
+      return nextConfig;
     };
 
     const disableFromCommand = async () => {
       const paths = getStatePaths(api);
       await ensureStorage(paths);
       const current = await readStoredConfig(api, paths);
-      const jobs = await listBriefingCronJobs(api);
-      const disableErrors: string[] = [];
-      for (const job of jobs) {
-        try {
-          await runCronCommand(api, ['disable', job.id]);
-        } catch (error) {
-          disableErrors.push(
-            `Failed to disable cron ${job.id}: ${error instanceof Error ? error.message : String(error)}`
-          );
-        }
-      }
-
-      const remainingEnabledJobs = await listBriefingCronJobs(api);
-      if (disableErrors.length > 0 || remainingEnabledJobs.length > 0) {
-        const issues: string[] = [];
-        issues.push(...disableErrors);
-        if (remainingEnabledJobs.length > 0) {
-          issues.push(
-            `Cron jobs still enabled after disable: ${remainingEnabledJobs.map(job => job.id).join(', ')}`
-          );
-        }
-        throw new Error(issues.join(' | '));
-      }
-
       const nextConfig: StoredConfig = {
         ...current,
         enabled: false,
-        cronJobId: null,
         updatedAt: new Date().toISOString(),
       };
       await writeJsonFile(paths.configPath, nextConfig);
+      await patchStoredStatus(paths, {
+        reconcileState: 'in_progress',
+        lastReconcileError: null,
+        lastReconcileAction: 'disable',
+      });
+      triggerReconcile('disable');
       return nextConfig;
     };
+
+    void (async () => {
+      const paths = getStatePaths(api);
+      await ensureStorage(paths);
+      const [config, status] = await Promise.all([
+        readStoredConfig(api, paths),
+        readStoredStatus(paths),
+      ]);
+      if (status.reconcileState === 'in_progress' || status.observedEnabled !== config.enabled) {
+        triggerReconcile(config.enabled ? 'enable' : 'disable');
+      }
+    })();
 
     const runBriefingCommand = async (argsText: string) => {
       const args = argsText.trim();
@@ -967,19 +1107,22 @@ export default definePluginEntry({
       if (subcommand === 'enable') {
         const trailing = args.replace(/^enable\s*/, '');
         const config = await enableFromCommand(trailing);
+        const status = await readStoredStatus(getStatePaths(api));
         return [
-          'Morning Briefing enabled.',
+          'Morning Briefing enable requested.',
           `- schedule: ${config.cron}`,
           `- timezone: ${config.timezone}`,
-          `- cron job id: ${config.cronJobId ?? '(unknown)'}`,
+          `- apply state: ${status.reconcileState}`,
         ].join('\n');
       }
 
       if (subcommand === 'disable') {
         const config = await disableFromCommand();
+        const status = await readStoredStatus(getStatePaths(api));
         return [
-          'Morning Briefing disabled.',
+          'Morning Briefing disable requested.',
           `- schedule retained: ${config.cron} (${config.timezone})`,
+          `- apply state: ${status.reconcileState}`,
         ].join('\n');
       }
 
@@ -1007,6 +1150,8 @@ export default definePluginEntry({
         `- enabled: ${status.enabled ? 'yes' : 'no'}`,
         `- schedule: ${status.cron} (${status.timezone})`,
         `- cron job id: ${status.cronJobId ?? '(none)'}`,
+        `- desired enabled: ${status.desiredEnabled ? 'yes' : 'no'}`,
+        `- reconcile state: ${status.reconcileState}`,
         `- last generated: ${status.lastGeneratedDate ?? '(none)'}`,
         `- github: ${status.sourceReadiness.github.configured ? 'ready' : 'not ready'} (${status.sourceReadiness.github.summary})`,
         `- linear: ${status.sourceReadiness.linear.configured ? 'configured' : 'not configured'} (${status.sourceReadiness.linear.summary})`,
@@ -1174,12 +1319,15 @@ export default definePluginEntry({
           const timezone = typeof body.timezone === 'string' ? body.timezone.trim() : undefined;
           const suffix = [cron, timezone].filter(Boolean).join(' ');
           const result = await enableFromCommand(suffix);
+          const status = await readStoredStatus(getStatePaths(api));
           sendJson(res, 200, {
             ok: true,
             enabled: result.enabled,
             cron: result.cron,
             timezone: result.timezone,
             cronJobId: result.cronJobId,
+            reconcileState: status.reconcileState,
+            message: 'Enable requested. Reconciliation is running in background.',
           });
         } catch (error) {
           sendJson(res, 500, {
@@ -1197,11 +1345,14 @@ export default definePluginEntry({
       handler: async (_req, res) => {
         try {
           const result = await disableFromCommand();
+          const status = await readStoredStatus(getStatePaths(api));
           sendJson(res, 200, {
             ok: true,
             enabled: result.enabled,
             cron: result.cron,
             timezone: result.timezone,
+            reconcileState: status.reconcileState,
+            message: 'Disable requested. Reconciliation is running in background.',
           });
         } catch (error) {
           sendJson(res, 500, {

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeLinearIssues, summarizeLinearCallFailure } from './linear-utils';
+
+describe('linear-utils', () => {
+  it('normalizes list_issues payload into concise issue summaries', () => {
+    const issues = normalizeLinearIssues({
+      issues: [
+        {
+          id: 'TES-1',
+          title: 'Get familiar with Linear',
+          status: 'Todo',
+          url: 'https://linear.app/example/issue/TES-1',
+          updatedAt: '2026-04-23T22:28:59.657Z',
+        },
+      ],
+    });
+
+    expect(issues).toEqual([
+      {
+        id: 'TES-1',
+        title: 'Get familiar with Linear',
+        status: 'Todo',
+        url: 'https://linear.app/example/issue/TES-1',
+        updatedAt: '2026-04-23T22:28:59.657Z',
+      },
+    ]);
+  });
+
+  it('summarizes auth errors from mcporter JSON payloads', () => {
+    const summary = summarizeLinearCallFailure(
+      JSON.stringify({
+        server: 'linear',
+        tool: 'list_issues',
+        error: 'SSE error: Non-200 status code (401)',
+        issue: { kind: 'auth', statusCode: 401 },
+      }),
+      ''
+    );
+
+    expect(summary).toBe('Linear authentication failed (check LINEAR_API_KEY and redeploy)');
+  });
+
+  it('falls back to combined stderr/stdout for non-JSON errors', () => {
+    const summary = summarizeLinearCallFailure('', 'mcporter: Unknown tool list_issues_typo');
+    expect(summary).toContain('Unknown tool');
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.ts
@@ -1,0 +1,65 @@
+export type LinearIssueSummary = {
+  id: string;
+  title: string;
+  status: string;
+  url: string;
+  updatedAt?: string;
+};
+
+function asObject(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export function normalizeLinearIssues(payload: unknown): LinearIssueSummary[] {
+  const root = asObject(payload);
+  const issues = Array.isArray(root.issues) ? root.issues : [];
+  return issues
+    .map(raw => asObject(raw))
+    .map(issue => ({
+      id: typeof issue.id === 'string' ? issue.id : '',
+      title: typeof issue.title === 'string' ? issue.title : '(untitled)',
+      status: typeof issue.status === 'string' ? issue.status : 'Unknown',
+      url: typeof issue.url === 'string' ? issue.url : '',
+      updatedAt: typeof issue.updatedAt === 'string' ? issue.updatedAt : undefined,
+    }))
+    .filter(issue => issue.id.length > 0);
+}
+
+export function summarizeLinearCallFailure(stdout: string, stderr: string): string {
+  const parsed = tryParseJson(stdout);
+  if (parsed) {
+    const issue = asObject(parsed.issue);
+    const kind = typeof issue.kind === 'string' ? issue.kind : null;
+    const statusCode = typeof issue.statusCode === 'number' ? issue.statusCode : null;
+    if (kind === 'auth' || statusCode === 401) {
+      return 'Linear authentication failed (check LINEAR_API_KEY and redeploy)';
+    }
+    if (kind === 'offline') {
+      return 'Linear MCP server is unavailable or timed out';
+    }
+    if (typeof parsed.error === 'string' && parsed.error.trim().length > 0) {
+      return parsed.error.trim();
+    }
+  }
+
+  const combined = [stderr.trim(), stdout.trim()].filter(Boolean).join(' | ').trim();
+  if (!combined) {
+    return 'Linear query failed';
+  }
+  return combined.length > 220 ? `${combined.slice(0, 217)}...` : combined;
+}
+
+function tryParseJson(raw: string): Record<string, unknown> | null {
+  const text = raw.trim();
+  if (!text) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(text);
+    return asObject(parsed);
+  } catch {
+    return null;
+  }
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/reconcile-queue-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/reconcile-queue-utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { resolveNextReconcileAction } from './reconcile-queue-utils';
+
+describe('reconcile-queue-utils', () => {
+  it('prefers queued action while a reconcile loop is active', () => {
+    expect(
+      resolveNextReconcileAction({
+        queuedAction: 'disable',
+        desiredEnabled: true,
+        observedEnabled: true,
+      })
+    ).toBe('disable');
+  });
+
+  it('requests follow-up reconcile when observed diverges from desired', () => {
+    expect(
+      resolveNextReconcileAction({
+        queuedAction: null,
+        desiredEnabled: false,
+        observedEnabled: true,
+      })
+    ).toBe('disable');
+  });
+
+  it('returns null when state is already converged', () => {
+    expect(
+      resolveNextReconcileAction({
+        queuedAction: null,
+        desiredEnabled: true,
+        observedEnabled: true,
+      })
+    ).toBeNull();
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/reconcile-queue-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/reconcile-queue-utils.ts
@@ -1,0 +1,21 @@
+export type ReconcileAction = 'enable' | 'disable';
+
+export function resolveNextReconcileAction(params: {
+  queuedAction: ReconcileAction | null;
+  desiredEnabled: boolean;
+  observedEnabled: boolean | null;
+}): ReconcileAction | null {
+  if (params.queuedAction) {
+    return params.queuedAction;
+  }
+
+  if (params.observedEnabled === null) {
+    return null;
+  }
+
+  if (params.observedEnabled !== params.desiredEnabled) {
+    return params.desiredEnabled ? 'enable' : 'disable';
+  }
+
+  return null;
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/web-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/web-utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeWebResults } from './web-utils';
+
+describe('web-utils', () => {
+  it('strips external wrapper markers and truncates noisy summaries', () => {
+    const results = normalizeWebResults({
+      results: [
+        {
+          title:
+            '<<<EXTERNAL_UNTRUSTED_CONTENT id="x">>>\nSource: Web Search\n---\nVercel Flags is now generally available\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id="x">>>',
+          url: 'https://vercel.com/changelog/vercel-flags-ga',
+          description:
+            '<<<EXTERNAL_UNTRUSTED_CONTENT id="y">>>\nSource: Web Search\n---\n# Vercel Flags is now generally available\n[...]\nPublished: April 16, 2026\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id="y">>>',
+        },
+      ],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe('Vercel Flags is now generally available');
+    expect(results[0].summary.includes('EXTERNAL_UNTRUSTED_CONTENT')).toBe(false);
+  });
+
+  it('falls back to hostname when title is empty', () => {
+    const results = normalizeWebResults({
+      results: [
+        {
+          url: 'https://example.com/news',
+          summary: 'Simple summary',
+        },
+      ],
+    });
+
+    expect(results[0].title).toBe('example.com');
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/web-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/web-utils.ts
@@ -1,0 +1,66 @@
+export type WebResultSummary = {
+  title: string;
+  url: string;
+  summary: string;
+};
+
+function asObject(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stripUntrustedWrappers(text: string): string {
+  return text
+    .replace(/<<<EXTERNAL_UNTRUSTED_CONTENT[^>]*>>>/g, ' ')
+    .replace(/<<<END_EXTERNAL_UNTRUSTED_CONTENT[^>]*>>>/g, ' ')
+    .replace(/Source:\s*Web Search/gi, ' ')
+    .replace(/\[\.\.\.\]/g, ' ')
+    .replace(/---/g, ' ');
+}
+
+function normalizeText(text: string): string {
+  return stripUntrustedWrappers(text).replace(/\s+/g, ' ').trim();
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max - 3).trimEnd()}...`;
+}
+
+function hostnameFromUrl(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return 'result';
+  }
+}
+
+export function normalizeWebResults(payload: unknown): WebResultSummary[] {
+  const root = asObject(payload);
+  const results = Array.isArray(root.results) ? root.results : [];
+  return results
+    .map(raw => asObject(raw))
+    .map(item => {
+      const url = typeof item.url === 'string' ? item.url : '';
+      const rawTitle = typeof item.title === 'string' ? item.title : '';
+      const rawSummary =
+        typeof item.summary === 'string'
+          ? item.summary
+          : typeof item.description === 'string'
+            ? item.description
+            : '';
+      const normalizedTitle = normalizeText(rawTitle);
+      const normalizedSummary = normalizeText(rawSummary);
+      const title = truncate(normalizedTitle || hostnameFromUrl(url) || '(untitled)', 140);
+      const summary = truncate(normalizedSummary, 280);
+      return {
+        title,
+        url,
+        summary,
+      };
+    })
+    .filter(item => item.url.length > 0);
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/vitest.config.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/services/kiloclaw/src/durable-objects/gateway-controller-types.ts
+++ b/services/kiloclaw/src/durable-objects/gateway-controller-types.ts
@@ -113,6 +113,7 @@ export const MorningBriefingStatusResponseSchema = z.object({
   lastGeneratedDate: z.string().nullable().optional(),
   lastGeneratedAt: z.string().nullable().optional(),
   reconcileState: z.enum(['idle', 'in_progress', 'succeeded', 'failed']).optional(),
+  lastReconcileAction: z.enum(['enable', 'disable']).nullable().optional(),
   desiredEnabled: z.boolean().optional(),
   observedEnabled: z.boolean().nullable().optional(),
   lastReconcileAt: z.string().nullable().optional(),

--- a/services/kiloclaw/src/durable-objects/gateway-controller-types.ts
+++ b/services/kiloclaw/src/durable-objects/gateway-controller-types.ts
@@ -99,6 +99,50 @@ export const OpenclawWorkspaceImportResponseSchema = z.object({
   failures: z.array(OpenclawWorkspaceImportFailureSchema),
 });
 
+const MorningBriefingSourceReadinessSchema = z.object({
+  configured: z.boolean(),
+  summary: z.string(),
+});
+
+export const MorningBriefingStatusResponseSchema = z.object({
+  ok: z.boolean(),
+  enabled: z.boolean().optional(),
+  cron: z.string().optional(),
+  timezone: z.string().optional(),
+  cronJobId: z.string().nullable().optional(),
+  lastGeneratedDate: z.string().nullable().optional(),
+  lastGeneratedAt: z.string().nullable().optional(),
+  sourceReadiness: z
+    .object({
+      github: MorningBriefingSourceReadinessSchema,
+      linear: MorningBriefingSourceReadinessSchema,
+      web: MorningBriefingSourceReadinessSchema,
+    })
+    .optional(),
+  error: z.string().optional(),
+});
+
+export const MorningBriefingActionResponseSchema = z.object({
+  ok: z.boolean(),
+  enabled: z.boolean().optional(),
+  cron: z.string().optional(),
+  timezone: z.string().optional(),
+  cronJobId: z.string().nullable().optional(),
+  date: z.string().optional(),
+  filePath: z.string().optional(),
+  failures: z.array(z.string()).optional(),
+  error: z.string().optional(),
+});
+
+export const MorningBriefingReadResponseSchema = z.object({
+  ok: z.boolean(),
+  dateKey: z.string().optional(),
+  filePath: z.string().optional(),
+  exists: z.boolean().optional(),
+  markdown: z.string().nullable().optional(),
+  error: z.string().optional(),
+});
+
 export class GatewayControllerError extends Error {
   readonly status: number;
   readonly code: string | null;

--- a/services/kiloclaw/src/durable-objects/gateway-controller-types.ts
+++ b/services/kiloclaw/src/durable-objects/gateway-controller-types.ts
@@ -112,6 +112,11 @@ export const MorningBriefingStatusResponseSchema = z.object({
   cronJobId: z.string().nullable().optional(),
   lastGeneratedDate: z.string().nullable().optional(),
   lastGeneratedAt: z.string().nullable().optional(),
+  reconcileState: z.enum(['idle', 'in_progress', 'succeeded', 'failed']).optional(),
+  desiredEnabled: z.boolean().optional(),
+  observedEnabled: z.boolean().nullable().optional(),
+  lastReconcileAt: z.string().nullable().optional(),
+  lastReconcileError: z.string().nullable().optional(),
   sourceReadiness: z
     .object({
       github: MorningBriefingSourceReadinessSchema,
@@ -119,6 +124,8 @@ export const MorningBriefingStatusResponseSchema = z.object({
       web: MorningBriefingSourceReadinessSchema,
     })
     .optional(),
+  code: z.string().optional(),
+  retryAfterSec: z.number().int().positive().optional(),
   error: z.string().optional(),
 });
 
@@ -131,6 +138,8 @@ export const MorningBriefingActionResponseSchema = z.object({
   date: z.string().optional(),
   filePath: z.string().optional(),
   failures: z.array(z.string()).optional(),
+  code: z.string().optional(),
+  retryAfterSec: z.number().int().positive().optional(),
   error: z.string().optional(),
 });
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { deriveGatewayToken } from '../../auth/gateway-token';
 import { createMutableState } from './state';
-import { getGatewayProcessStatus, waitForHealthy } from './gateway';
+import { getGatewayProcessStatus, getMorningBriefingStatus, waitForHealthy } from './gateway';
 
 type FetchMock = ReturnType<
   typeof vi.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>
@@ -110,6 +110,36 @@ describe('gateway controller routing', () => {
     expect(rootUrl).toBe('https://test-app.fly.dev/');
     expect(rootInit?.headers).toMatchObject({
       'fly-force-instance-id': 'machine-1',
+    });
+  });
+
+  it('returns warm-up payload for morning-briefing status when gateway is warming up', async () => {
+    const state = createMutableState();
+    state.provider = 'fly';
+    state.sandboxId = 'sandbox-1';
+    state.flyAppName = 'test-app';
+    state.flyMachineId = 'machine-1';
+
+    const fetchMock: FetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Gateway not running' }), {
+        status: 503,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await getMorningBriefingStatus(state, {
+      GATEWAY_TOKEN_SECRET: 'gateway-secret',
+      FLY_APP_NAME: 'fallback-app',
+    } as never);
+
+    expect(result).toEqual({
+      ok: true,
+      enabled: false,
+      reconcileState: 'in_progress',
+      error: 'Gateway warming up, retrying shortly.',
+      code: 'gateway_warming_up',
+      retryAfterSec: 2,
     });
   });
 });

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -279,6 +279,8 @@ function isMorningBriefingWarmupControllerError(error: unknown): boolean {
 
   const message = error.message.toLowerCase();
   return (
+    message.includes('instance has no machine id') ||
+    message.includes('instance not provisioned') ||
     message.includes('gateway not running') ||
     message.includes('failed to reach gateway') ||
     message.includes('operation was aborted due to timeout') ||

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -13,6 +13,9 @@ import {
   EnvPatchResponseSchema,
   ToolsMdSectionSyncResponseSchema,
   OpenclawConfigResponseSchema,
+  MorningBriefingStatusResponseSchema,
+  MorningBriefingActionResponseSchema,
+  MorningBriefingReadResponseSchema,
   OpenclawWorkspaceImportResponseSchema,
   GatewayControllerError,
 } from '../gateway-controller-types';
@@ -461,6 +464,101 @@ export async function importOpenclawWorkspace(
       'POST',
       OpenclawWorkspaceImportResponseSchema,
       { files }
+    );
+  } catch (error) {
+    if (isErrorUnknownRoute(error)) return null;
+    throw error;
+  }
+}
+
+export async function getMorningBriefingStatus(
+  state: InstanceMutableState,
+  env: KiloClawEnv
+): Promise<z.infer<typeof MorningBriefingStatusResponseSchema> | null> {
+  try {
+    return await callGatewayController(
+      state,
+      env,
+      '/_kilo/morning-briefing/status',
+      'GET',
+      MorningBriefingStatusResponseSchema
+    );
+  } catch (error) {
+    if (isErrorUnknownRoute(error)) return null;
+    throw error;
+  }
+}
+
+export async function setupMorningBriefing(
+  state: InstanceMutableState,
+  env: KiloClawEnv,
+  input: { cron?: string; timezone?: string }
+): Promise<z.infer<typeof MorningBriefingActionResponseSchema> | null> {
+  try {
+    return await callGatewayController(
+      state,
+      env,
+      '/_kilo/morning-briefing/setup',
+      'POST',
+      MorningBriefingActionResponseSchema,
+      input
+    );
+  } catch (error) {
+    if (isErrorUnknownRoute(error)) return null;
+    throw error;
+  }
+}
+
+export async function disableMorningBriefing(
+  state: InstanceMutableState,
+  env: KiloClawEnv
+): Promise<z.infer<typeof MorningBriefingActionResponseSchema> | null> {
+  try {
+    return await callGatewayController(
+      state,
+      env,
+      '/_kilo/morning-briefing/disable',
+      'POST',
+      MorningBriefingActionResponseSchema,
+      {}
+    );
+  } catch (error) {
+    if (isErrorUnknownRoute(error)) return null;
+    throw error;
+  }
+}
+
+export async function runMorningBriefing(
+  state: InstanceMutableState,
+  env: KiloClawEnv
+): Promise<z.infer<typeof MorningBriefingActionResponseSchema> | null> {
+  try {
+    return await callGatewayController(
+      state,
+      env,
+      '/_kilo/morning-briefing/run',
+      'POST',
+      MorningBriefingActionResponseSchema,
+      {}
+    );
+  } catch (error) {
+    if (isErrorUnknownRoute(error)) return null;
+    throw error;
+  }
+}
+
+export async function readMorningBriefing(
+  state: InstanceMutableState,
+  env: KiloClawEnv,
+  day: 'today' | 'yesterday'
+): Promise<z.infer<typeof MorningBriefingReadResponseSchema> | null> {
+  try {
+    return await callGatewayController(
+      state,
+      env,
+      `/_kilo/morning-briefing/read/${day}`,
+      'GET',
+      MorningBriefingReadResponseSchema
     );
   } catch (error) {
     if (isErrorUnknownRoute(error)) return null;

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -489,7 +489,7 @@ export async function getMorningBriefingStatus(
   }
 }
 
-export async function setupMorningBriefing(
+export async function enableMorningBriefing(
   state: InstanceMutableState,
   env: KiloClawEnv,
   input: { cron?: string; timezone?: string }
@@ -498,7 +498,7 @@ export async function setupMorningBriefing(
     return await callGatewayController(
       state,
       env,
-      '/_kilo/morning-briefing/setup',
+      '/_kilo/morning-briefing/enable',
       'POST',
       MorningBriefingActionResponseSchema,
       input

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -69,7 +69,8 @@ export async function callGatewayController<T>(
   path: string,
   method: 'GET' | 'POST',
   responseSchema: ZodType<T>,
-  jsonBody?: unknown
+  jsonBody?: unknown,
+  options?: { timeoutMs?: number }
 ): Promise<T> {
   const { routingTarget, sandboxId } = await requireGatewayControllerContext(state, env);
 
@@ -90,11 +91,14 @@ export async function callGatewayController<T>(
   }
 
   let response: Response;
+  const timeoutMs = options?.timeoutMs ?? 30_000;
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
   try {
     response = await fetch(url, {
       method,
       headers,
       body: jsonBody !== undefined ? JSON.stringify(jsonBody) : undefined,
+      signal: timeoutSignal,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -481,7 +485,9 @@ export async function getMorningBriefingStatus(
       env,
       '/_kilo/morning-briefing/status',
       'GET',
-      MorningBriefingStatusResponseSchema
+      MorningBriefingStatusResponseSchema,
+      undefined,
+      { timeoutMs: 3_000 }
     );
   } catch (error) {
     if (isErrorUnknownRoute(error)) return null;
@@ -501,7 +507,8 @@ export async function enableMorningBriefing(
       '/_kilo/morning-briefing/enable',
       'POST',
       MorningBriefingActionResponseSchema,
-      input
+      input,
+      { timeoutMs: 8_000 }
     );
   } catch (error) {
     if (isErrorUnknownRoute(error)) return null;
@@ -520,7 +527,8 @@ export async function disableMorningBriefing(
       '/_kilo/morning-briefing/disable',
       'POST',
       MorningBriefingActionResponseSchema,
-      {}
+      {},
+      { timeoutMs: 8_000 }
     );
   } catch (error) {
     if (isErrorUnknownRoute(error)) return null;

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -272,6 +272,20 @@ export function isErrorUnknownRoute(error: unknown): boolean {
   );
 }
 
+function isMorningBriefingWarmupControllerError(error: unknown): boolean {
+  if (!(error instanceof GatewayControllerError)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  return (
+    message.includes('gateway not running') ||
+    message.includes('failed to reach gateway') ||
+    message.includes('operation was aborted due to timeout') ||
+    message.includes('gateway controller request failed (401)')
+  );
+}
+
 export async function getControllerVersion(
   state: InstanceMutableState,
   env: KiloClawEnv
@@ -491,6 +505,16 @@ export async function getMorningBriefingStatus(
     );
   } catch (error) {
     if (isErrorUnknownRoute(error)) return null;
+    if (isMorningBriefingWarmupControllerError(error)) {
+      return {
+        ok: true,
+        enabled: false,
+        reconcileState: 'in_progress',
+        error: 'Gateway warming up, retrying shortly.',
+        code: 'gateway_warming_up',
+        retryAfterSec: 2,
+      };
+    }
     throw error;
   }
 }

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -487,7 +487,7 @@ export async function getMorningBriefingStatus(
       'GET',
       MorningBriefingStatusResponseSchema,
       undefined,
-      { timeoutMs: 3_000 }
+      { timeoutMs: 5_000 }
     );
   } catch (error) {
     if (isErrorUnknownRoute(error)) return null;

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -3079,6 +3079,31 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     return gateway.importOpenclawWorkspace(this.s, this.env, files);
   }
 
+  async getMorningBriefingStatus() {
+    await this.loadState();
+    return gateway.getMorningBriefingStatus(this.s, this.env);
+  }
+
+  async setupMorningBriefing(input: { cron?: string; timezone?: string }) {
+    await this.loadState();
+    return gateway.setupMorningBriefing(this.s, this.env, input);
+  }
+
+  async disableMorningBriefing() {
+    await this.loadState();
+    return gateway.disableMorningBriefing(this.s, this.env);
+  }
+
+  async runMorningBriefing() {
+    await this.loadState();
+    return gateway.runMorningBriefing(this.s, this.env);
+  }
+
+  async readMorningBriefing(day: 'today' | 'yesterday') {
+    await this.loadState();
+    return gateway.readMorningBriefing(this.s, this.env, day);
+  }
+
   // ── Restart machine (user-facing) ──────────────────────────────────
 
   async restartMachine(options?: {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -3084,9 +3084,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     return gateway.getMorningBriefingStatus(this.s, this.env);
   }
 
-  async setupMorningBriefing(input: { cron?: string; timezone?: string }) {
+  async enableMorningBriefing(input: { cron?: string; timezone?: string }) {
     await this.loadState();
-    return gateway.setupMorningBriefing(this.s, this.env, input);
+    return gateway.enableMorningBriefing(this.s, this.env, input);
   }
 
   async disableMorningBriefing() {

--- a/services/kiloclaw/src/routes/platform-morning-briefing.test.ts
+++ b/services/kiloclaw/src/routes/platform-morning-briefing.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { platform } from './platform';
+
+vi.mock('cloudflare:workers', () => ({
+  DurableObject: class {},
+  waitUntil: (promise: Promise<unknown>) => promise,
+}));
+
+function baseEnv(stub: Record<string, unknown>) {
+  return {
+    KILOCLAW_INSTANCE: {
+      idFromName: (id: string) => id,
+      get: () => stub,
+    },
+    KILOCLAW_AE: { writeDataPoint: vi.fn() },
+    KV_CLAW_CACHE: {
+      get: vi.fn().mockResolvedValue(null),
+      put: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockResolvedValue({ keys: [], list_complete: true }),
+      getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null }),
+    },
+  } as never;
+}
+
+describe('platform morning-briefing warm-up handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('retries enable when gateway is warming up and then succeeds', async () => {
+    const enableMorningBriefing = vi
+      .fn<() => Promise<{ ok: boolean; enabled: boolean }>>()
+      .mockRejectedValueOnce(new Error('Gateway not running'))
+      .mockResolvedValueOnce({ ok: true, enabled: true });
+    const env = baseEnv({ enableMorningBriefing });
+
+    const requestPromise = platform.request(
+      '/morning-briefing/enable',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: 'user-1' }),
+      },
+      env
+    );
+
+    await vi.runAllTimersAsync();
+    const response = await requestPromise;
+
+    expect(response.status).toBe(200);
+    expect(enableMorningBriefing).toHaveBeenCalledTimes(2);
+    expect(await response.json()).toMatchObject({ ok: true, enabled: true });
+  });
+
+  it('retries disable when gateway is warming up and then succeeds', async () => {
+    const disableMorningBriefing = vi
+      .fn<() => Promise<{ ok: boolean; enabled: boolean }>>()
+      .mockRejectedValueOnce(new Error('Failed to reach gateway'))
+      .mockResolvedValueOnce({ ok: true, enabled: false });
+    const env = baseEnv({ disableMorningBriefing });
+
+    const requestPromise = platform.request(
+      '/morning-briefing/disable',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: 'user-1' }),
+      },
+      env
+    );
+
+    await vi.runAllTimersAsync();
+    const response = await requestPromise;
+
+    expect(response.status).toBe(200);
+    expect(disableMorningBriefing).toHaveBeenCalledTimes(2);
+    expect(await response.json()).toMatchObject({ ok: true, enabled: false });
+  });
+
+  it('returns warm-up payload for status timeout instead of 500', async () => {
+    const getMorningBriefingStatus = vi
+      .fn<() => Promise<unknown>>()
+      .mockRejectedValue(
+        new Error('Gateway controller request failed: The operation was aborted due to timeout')
+      );
+    const env = baseEnv({ getMorningBriefingStatus });
+
+    const response = await platform.request('/morning-briefing/status?userId=user-1', {}, env);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      code: 'gateway_warming_up',
+      retryAfterSec: 2,
+      reconcileState: 'in_progress',
+    });
+  });
+});

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -1911,6 +1911,175 @@ platform.patch('/openclaw-config', async c => {
   }
 });
 
+const MorningBriefingSetupSchema = z.object({
+  userId: z.string().min(1),
+  cron: z.string().min(1).optional(),
+  timezone: z.string().min(1).optional(),
+});
+
+// GET /api/platform/morning-briefing/status?userId=...
+platform.get('/morning-briefing/status', async c => {
+  const userId = setValidatedQueryUserId(c);
+  if (!userId) {
+    return c.json({ error: 'userId query parameter is required' }, 400);
+  }
+
+  const iidResult = parseInstanceIdQuery(c);
+  if ('error' in iidResult) return iidResult.error;
+
+  try {
+    const result = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
+      stub => stub.getMorningBriefingStatus(),
+      'getMorningBriefingStatus'
+    );
+    if (!result) {
+      return jsonError(
+        'Morning Briefing unavailable (controller too old)',
+        404,
+        'controller_route_unavailable'
+      );
+    }
+    return c.json(result, 200);
+  } catch (err) {
+    const { message, status, code } = sanitizeOpenclawConfigError(err, 'morning-briefing/status');
+    return jsonError(message, status, code);
+  }
+});
+
+// POST /api/platform/morning-briefing/setup
+platform.post('/morning-briefing/setup', async c => {
+  const result = await parseBody(c, MorningBriefingSetupSchema);
+  if ('error' in result) return result.error;
+
+  const iidResult = parseInstanceIdQuery(c);
+  if ('error' in iidResult) return iidResult.error;
+
+  const { userId, cron, timezone } = result.data;
+  try {
+    const response = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
+      stub => stub.setupMorningBriefing({ cron, timezone }),
+      'setupMorningBriefing'
+    );
+    if (!response) {
+      return jsonError(
+        'Morning Briefing unavailable (controller too old)',
+        404,
+        'controller_route_unavailable'
+      );
+    }
+    return c.json(response, 200);
+  } catch (err) {
+    const { message, status, code } = sanitizeOpenclawConfigError(err, 'morning-briefing/setup');
+    return jsonError(message, status, code);
+  }
+});
+
+// POST /api/platform/morning-briefing/disable
+platform.post('/morning-briefing/disable', async c => {
+  const result = await parseBody(c, UserIdRequestSchema);
+  if ('error' in result) return result.error;
+
+  const iidResult = parseInstanceIdQuery(c);
+  if ('error' in iidResult) return iidResult.error;
+
+  try {
+    const response = await withResolvedDORetry(
+      c.env,
+      result.data.userId,
+      iidResult.instanceId,
+      stub => stub.disableMorningBriefing(),
+      'disableMorningBriefing'
+    );
+    if (!response) {
+      return jsonError(
+        'Morning Briefing unavailable (controller too old)',
+        404,
+        'controller_route_unavailable'
+      );
+    }
+    return c.json(response, 200);
+  } catch (err) {
+    const { message, status, code } = sanitizeOpenclawConfigError(err, 'morning-briefing/disable');
+    return jsonError(message, status, code);
+  }
+});
+
+// POST /api/platform/morning-briefing/run
+platform.post('/morning-briefing/run', async c => {
+  const result = await parseBody(c, UserIdRequestSchema);
+  if ('error' in result) return result.error;
+
+  const iidResult = parseInstanceIdQuery(c);
+  if ('error' in iidResult) return iidResult.error;
+
+  try {
+    const response = await withResolvedDORetry(
+      c.env,
+      result.data.userId,
+      iidResult.instanceId,
+      stub => stub.runMorningBriefing(),
+      'runMorningBriefing'
+    );
+    if (!response) {
+      return jsonError(
+        'Morning Briefing unavailable (controller too old)',
+        404,
+        'controller_route_unavailable'
+      );
+    }
+    return c.json(response, 200);
+  } catch (err) {
+    const { message, status, code } = sanitizeOpenclawConfigError(err, 'morning-briefing/run');
+    return jsonError(message, status, code);
+  }
+});
+
+// GET /api/platform/morning-briefing/read/{today|yesterday}?userId=...
+platform.get('/morning-briefing/read/:day', async c => {
+  const userId = setValidatedQueryUserId(c);
+  if (!userId) {
+    return c.json({ error: 'userId query parameter is required' }, 400);
+  }
+
+  const day = c.req.param('day');
+  if (day !== 'today' && day !== 'yesterday') {
+    return c.json({ error: 'day must be today or yesterday' }, 400);
+  }
+
+  const iidResult = parseInstanceIdQuery(c);
+  if ('error' in iidResult) return iidResult.error;
+
+  try {
+    const response = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
+      stub => stub.readMorningBriefing(day),
+      'readMorningBriefing'
+    );
+    if (!response) {
+      return jsonError(
+        'Morning Briefing unavailable (controller too old)',
+        404,
+        'controller_route_unavailable'
+      );
+    }
+    return c.json(response, 200);
+  } catch (err) {
+    const { message, status, code } = sanitizeOpenclawConfigError(
+      err,
+      `morning-briefing/read/${day}`
+    );
+    return jsonError(message, status, code);
+  }
+});
+
 // GET /api/platform/files/tree?userId=...
 platform.get('/files/tree', async c => {
   const userId = setValidatedQueryUserId(c);

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -1923,6 +1923,7 @@ function isMorningBriefingWarmupError(err: unknown): boolean {
   return (
     normalized.includes('Gateway not running') ||
     normalized.includes('Failed to reach gateway') ||
+    normalized.includes('operation was aborted due to timeout') ||
     normalized.includes('Gateway controller request failed (401)')
   );
 }

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -1949,8 +1949,8 @@ platform.get('/morning-briefing/status', async c => {
   }
 });
 
-// POST /api/platform/morning-briefing/setup
-platform.post('/morning-briefing/setup', async c => {
+// POST /api/platform/morning-briefing/enable
+platform.post('/morning-briefing/enable', async c => {
   const result = await parseBody(c, MorningBriefingSetupSchema);
   if ('error' in result) return result.error;
 
@@ -1963,8 +1963,8 @@ platform.post('/morning-briefing/setup', async c => {
       c.env,
       userId,
       iidResult.instanceId,
-      stub => stub.setupMorningBriefing({ cron, timezone }),
-      'setupMorningBriefing'
+      stub => stub.enableMorningBriefing({ cron, timezone }),
+      'enableMorningBriefing'
     );
     if (!response) {
       return jsonError(
@@ -1975,7 +1975,7 @@ platform.post('/morning-briefing/setup', async c => {
     }
     return c.json(response, 200);
   } catch (err) {
-    const { message, status, code } = sanitizeOpenclawConfigError(err, 'morning-briefing/setup');
+    const { message, status, code } = sanitizeOpenclawConfigError(err, 'morning-briefing/enable');
     return jsonError(message, status, code);
   }
 });

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -1917,6 +1917,42 @@ const MorningBriefingSetupSchema = z.object({
   timezone: z.string().min(1).optional(),
 });
 
+function isMorningBriefingWarmupError(err: unknown): boolean {
+  const raw = err instanceof Error ? err.message : String(err);
+  const normalized = raw.replace(/^(?:[A-Za-z]+Error:\s*)+/, '');
+  return (
+    normalized.includes('Gateway not running') ||
+    normalized.includes('Failed to reach gateway') ||
+    normalized.includes('Gateway controller request failed (401)')
+  );
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function withMorningBriefingWarmupRetry<T>(operation: () => Promise<T>): Promise<T> {
+  const delaysMs = [0, 750, 1500];
+  let lastError: unknown = null;
+
+  for (const delayMs of delaysMs) {
+    if (delayMs > 0) {
+      await sleep(delayMs);
+    }
+
+    try {
+      return await operation();
+    } catch (err) {
+      lastError = err;
+      if (!isMorningBriefingWarmupError(err)) {
+        throw err;
+      }
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error('Gateway warming up');
+}
+
 // GET /api/platform/morning-briefing/status?userId=...
 platform.get('/morning-briefing/status', async c => {
   const userId = setValidatedQueryUserId(c);
@@ -1944,6 +1980,19 @@ platform.get('/morning-briefing/status', async c => {
     }
     return c.json(result, 200);
   } catch (err) {
+    if (isMorningBriefingWarmupError(err)) {
+      return c.json(
+        {
+          ok: true,
+          enabled: false,
+          reconcileState: 'in_progress',
+          error: 'Gateway warming up, retrying shortly.',
+          code: 'gateway_warming_up',
+          retryAfterSec: 2,
+        },
+        200
+      );
+    }
     const { message, status, code } = sanitizeOpenclawConfigError(err, 'morning-briefing/status');
     return jsonError(message, status, code);
   }
@@ -1959,12 +2008,14 @@ platform.post('/morning-briefing/enable', async c => {
 
   const { userId, cron, timezone } = result.data;
   try {
-    const response = await withResolvedDORetry(
-      c.env,
-      userId,
-      iidResult.instanceId,
-      stub => stub.enableMorningBriefing({ cron, timezone }),
-      'enableMorningBriefing'
+    const response = await withMorningBriefingWarmupRetry(() =>
+      withResolvedDORetry(
+        c.env,
+        userId,
+        iidResult.instanceId,
+        stub => stub.enableMorningBriefing({ cron, timezone }),
+        'enableMorningBriefing'
+      )
     );
     if (!response) {
       return jsonError(
@@ -1975,6 +2026,9 @@ platform.post('/morning-briefing/enable', async c => {
     }
     return c.json(response, 200);
   } catch (err) {
+    if (isMorningBriefingWarmupError(err)) {
+      return jsonError('Gateway warming up, retrying shortly.', 503, 'gateway_warming_up');
+    }
     const { message, status, code } = sanitizeOpenclawConfigError(err, 'morning-briefing/enable');
     return jsonError(message, status, code);
   }
@@ -1989,12 +2043,14 @@ platform.post('/morning-briefing/disable', async c => {
   if ('error' in iidResult) return iidResult.error;
 
   try {
-    const response = await withResolvedDORetry(
-      c.env,
-      result.data.userId,
-      iidResult.instanceId,
-      stub => stub.disableMorningBriefing(),
-      'disableMorningBriefing'
+    const response = await withMorningBriefingWarmupRetry(() =>
+      withResolvedDORetry(
+        c.env,
+        result.data.userId,
+        iidResult.instanceId,
+        stub => stub.disableMorningBriefing(),
+        'disableMorningBriefing'
+      )
     );
     if (!response) {
       return jsonError(
@@ -2005,6 +2061,9 @@ platform.post('/morning-briefing/disable', async c => {
     }
     return c.json(response, 200);
   } catch (err) {
+    if (isMorningBriefingWarmupError(err)) {
+      return jsonError('Gateway warming up, retrying shortly.', 503, 'gateway_warming_up');
+    }
     const { message, status, code } = sanitizeOpenclawConfigError(err, 'morning-briefing/disable');
     return jsonError(message, status, code);
   }


### PR DESCRIPTION
## Summary
- Add a new bundled OpenClaw plugin at `services/kiloclaw/plugins/kiloclaw-morning-briefing` that owns Morning Briefing command/tool behavior (`/briefing enable|status|run|today|yesterday|disable`) with persisted Markdown outputs and source collection for GitHub, Linear (mcporter), and web search.
- Wire KiloClaw runtime integration end-to-end: include the plugin in Docker images/config writer defaults, add controller proxy routes, add platform/DO/client/router plumbing, and expose dashboard controls + status in Settings.
- Harden lifecycle behavior for hosted instances by adding warm-up aware handling, reconciled enable/disable state tracking, cron reconciliation safeguards, and improved UX copy/state presentation in the dashboard.

## Verification
- Provisioned fresh dev instances and manually exercised Morning Briefing command flow in chat (`/briefing status`, `/briefing enable`, `/briefing run`, `/briefing today`, `/briefing yesterday`, `/briefing disable`) against deployed branch builds.
- Verified dashboard controls for Enable/Disable/Run/View behavior, warm-up gating, and status token transitions during startup and post-redeploy scenarios.
- Validated generated briefing content readability and persistence on-instance, including improved web-search formatting and expected missing-file behavior for yesterday retrieval.

## Visual Changes
- Updated Settings > Productivity Morning Briefing card with revised status token behavior, conditional schedule/last-generated text, source readiness sentence, and action-state gating.

## Reviewer Notes
- This PR is intentionally broad because Morning Briefing ships in one pass: plugin package + controller/worker integration + dashboard UX.
- Startup race handling now prefers graceful warm-up semantics over hard failures for status/enable/disable paths; look at `services/kiloclaw/src/routes/platform.ts` and `services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts` for the lifecycle model.
- The feature is admin-gated in the Settings UI (`canSeeMorningBriefing`) and currently hidden for non-admin users.