### PR TITLE
feat(kiloclaw): bundle Morning Briefing plugin into instance image

### DIFF
--- a/.github/workflows/deploy-kiloclaw.yml
+++ b/.github/workflows/deploy-kiloclaw.yml
@@ -60,7 +60,7 @@ jobs:
         working-directory: services/kiloclaw
         run: |
           # Validate all expected paths exist before hashing
-          for path in Dockerfile controller container plugins/kiloclaw-customizer skills \
+          for path in Dockerfile controller container plugins/kiloclaw-customizer plugins/kiloclaw-morning-briefing skills \
                       openclaw-pairing-list.js openclaw-device-pairing-list.js; do
             if [ ! -e "$path" ]; then
               echo "::error::Required path not found: $path"
@@ -69,7 +69,7 @@ jobs:
           done
 
           CONTENT_HASH=$(
-            find Dockerfile controller/ container/ plugins/kiloclaw-customizer/ skills/ \
+            find Dockerfile controller/ container/ plugins/kiloclaw-customizer/ plugins/kiloclaw-morning-briefing/ skills/ \
               openclaw-pairing-list.js openclaw-device-pairing-list.js \
               -type f \
               | sort \

--- a/.github/workflows/push-dev-kiloclaw.yml
+++ b/.github/workflows/push-dev-kiloclaw.yml
@@ -40,7 +40,7 @@ jobs:
         id: content-hash
         working-directory: services/kiloclaw
         run: |
-          for path in Dockerfile controller container plugins/kiloclaw-customizer skills \
+          for path in Dockerfile controller container plugins/kiloclaw-customizer plugins/kiloclaw-morning-briefing skills \
                       openclaw-pairing-list.js openclaw-device-pairing-list.js; do
             if [ ! -e "$path" ]; then
               echo "::error::Required path not found: $path"
@@ -49,7 +49,7 @@ jobs:
           done
 
           CONTENT_HASH=$(
-            find Dockerfile controller/ container/ plugins/kiloclaw-customizer/ skills/ \
+            find Dockerfile controller/ container/ plugins/kiloclaw-customizer/ plugins/kiloclaw-morning-briefing/ skills/ \
               openclaw-pairing-list.js openclaw-device-pairing-list.js \
               -type f \
               | sort \

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -130,7 +130,7 @@ RUN GOBIN=/usr/local/bin go install github.com/steipete/gogcli/cmd/gog@v0.12.0 \
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
     && uv --version
 
-# ── Builder stage: package customizer plugin ───────────────────────────
+# ── Builder stage: package custom plugins ───────────────────────────
 # Build the vendored plugin tarball in an isolated stage so dev-time
 # dependencies do not inflate the runtime image layers.
 FROM runtime AS customizer-builder
@@ -142,6 +142,16 @@ RUN cd /tmp/kiloclaw-customizer \
     && mv "${PKG_TGZ}" /tmp/kiloclaw-customizer.tgz \
     && cd / \
     && rm -rf /tmp/kiloclaw-customizer /root/.npm
+
+FROM runtime AS morning-briefing-builder
+
+COPY plugins/kiloclaw-morning-briefing/ /tmp/kiloclaw-morning-briefing/
+RUN cd /tmp/kiloclaw-morning-briefing \
+    && npm install --include=dev --legacy-peer-deps --no-fund --no-audit \
+    && PKG_TGZ="$(npm pack --silent)" \
+    && mv "${PKG_TGZ}" /tmp/kiloclaw-morning-briefing.tgz \
+    && cd / \
+    && rm -rf /tmp/kiloclaw-morning-briefing /root/.npm
 
 # ── Builder stage: compile the controller with Bun ────────────────────
 # Bun is only needed to bundle the controller TypeScript into a single JS
@@ -175,8 +185,10 @@ FROM runtime AS final
 # Also drop /etc/gitconfig (set earlier for the build's ssh→https rewrite) so
 # it doesn't persist in the runtime image.
 COPY --from=customizer-builder /tmp/kiloclaw-customizer.tgz /tmp/kiloclaw-customizer.tgz
-RUN npm install -g --legacy-peer-deps /tmp/kiloclaw-customizer.tgz \
+COPY --from=morning-briefing-builder /tmp/kiloclaw-morning-briefing.tgz /tmp/kiloclaw-morning-briefing.tgz
+RUN npm install -g --legacy-peer-deps /tmp/kiloclaw-customizer.tgz /tmp/kiloclaw-morning-briefing.tgz \
     && rm -f /tmp/kiloclaw-customizer.tgz \
+    && rm -f /tmp/kiloclaw-morning-briefing.tgz \
     && rm -f /etc/gitconfig \
     && rm -rf /root/.npm
 

--- a/services/kiloclaw/Dockerfile.local
+++ b/services/kiloclaw/Dockerfile.local
@@ -134,7 +134,7 @@ EXPOSE 18789
 # feature flags) lives in the controller's bootstrap module — no shell wrapper needed.
 CMD ["node", "/usr/local/bin/kiloclaw-controller.js"]
 
-# Build customizer plugin tarball in isolated stage so dev dependencies
+# Build custom plugins tarballs in isolated stages so dev dependencies
 # are not persisted in the runtime image.
 FROM runtime AS customizer-builder
 
@@ -146,9 +146,21 @@ RUN cd /tmp/kiloclaw-customizer \
     && cd / \
     && rm -rf /tmp/kiloclaw-customizer /root/.npm
 
+FROM runtime AS morning-briefing-builder
+
+COPY plugins/kiloclaw-morning-briefing/ /tmp/kiloclaw-morning-briefing/
+RUN cd /tmp/kiloclaw-morning-briefing \
+    && npm install --include=dev --legacy-peer-deps --no-fund --no-audit \
+    && PKG_TGZ="$(npm pack --silent)" \
+    && mv "${PKG_TGZ}" /tmp/kiloclaw-morning-briefing.tgz \
+    && cd / \
+    && rm -rf /tmp/kiloclaw-morning-briefing /root/.npm
+
 FROM runtime AS final
 
 COPY --from=customizer-builder /tmp/kiloclaw-customizer.tgz /tmp/kiloclaw-customizer.tgz
-RUN npm install -g --legacy-peer-deps /tmp/kiloclaw-customizer.tgz \
+COPY --from=morning-briefing-builder /tmp/kiloclaw-morning-briefing.tgz /tmp/kiloclaw-morning-briefing.tgz
+RUN npm install -g --legacy-peer-deps /tmp/kiloclaw-customizer.tgz /tmp/kiloclaw-morning-briefing.tgz \
     && rm -f /tmp/kiloclaw-customizer.tgz \
+    && rm -f /tmp/kiloclaw-morning-briefing.tgz \
     && rm -rf /root/.npm

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -615,15 +615,25 @@ describe('generateBaseConfig', () => {
     expect(config.plugins.load.paths).toContain(
       '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-customizer'
     );
+    expect(config.plugins.entries['kiloclaw-morning-briefing'].enabled).toBe(true);
+    expect(config.plugins.load.paths).toContain(
+      '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-morning-briefing'
+    );
   });
 
   it('does not duplicate KiloClaw customizer plugin path on repeated generateBaseConfig calls', () => {
     const existing = JSON.stringify({
       plugins: {
         load: {
-          paths: ['/usr/local/lib/node_modules/@kiloclaw/kiloclaw-customizer'],
+          paths: [
+            '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-customizer',
+            '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-morning-briefing',
+          ],
         },
-        entries: { 'kiloclaw-customizer': { enabled: true } },
+        entries: {
+          'kiloclaw-customizer': { enabled: true },
+          'kiloclaw-morning-briefing': { enabled: true },
+        },
       },
     });
     const { deps } = fakeDeps(existing);
@@ -632,6 +642,8 @@ describe('generateBaseConfig', () => {
     const pluginPath = '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-customizer';
     const paths = config.plugins.load.paths as string[];
     expect(paths.filter(p => p === pluginPath)).toHaveLength(1);
+    const morningPluginPath = '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-morning-briefing';
+    expect(paths.filter(p => p === morningPluginPath)).toHaveLength(1);
   });
 
   it('adds KiloClaw customizer to an existing plugin allowlist', () => {
@@ -644,6 +656,7 @@ describe('generateBaseConfig', () => {
     const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);
 
     expect(config.plugins.allow).toContain('kiloclaw-customizer');
+    expect(config.plugins.allow).toContain('kiloclaw-morning-briefing');
   });
 
   it('configures Telegram channel', () => {

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -75,6 +75,9 @@ const ONBOARD_FLAGS = [
 
 const KILOCLAW_CUSTOMIZER_PLUGIN_ID = 'kiloclaw-customizer';
 const KILOCLAW_CUSTOMIZER_PLUGIN_PATH = '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-customizer';
+const KILOCLAW_MORNING_BRIEFING_PLUGIN_ID = 'kiloclaw-morning-briefing';
+const KILOCLAW_MORNING_BRIEFING_PLUGIN_PATH =
+  '/usr/local/lib/node_modules/@kiloclaw/kiloclaw-morning-briefing';
 const KILO_EXA_PROVIDER_ID = 'kilo-exa';
 
 type KiloExaSearchMode = 'kilo-proxy' | 'disabled';
@@ -401,6 +404,19 @@ export function generateBaseConfig(
 
   customizerPluginConfig.webSearch = customizerWebSearchConfig;
   config.plugins.entries[KILOCLAW_CUSTOMIZER_PLUGIN_ID].config = customizerPluginConfig;
+
+  if (!(config.plugins.load.paths as string[]).includes(KILOCLAW_MORNING_BRIEFING_PLUGIN_PATH)) {
+    (config.plugins.load.paths as string[]).push(KILOCLAW_MORNING_BRIEFING_PLUGIN_PATH);
+  }
+  if (
+    Array.isArray(config.plugins.allow) &&
+    !config.plugins.allow.includes(KILOCLAW_MORNING_BRIEFING_PLUGIN_ID)
+  ) {
+    config.plugins.allow.push(KILOCLAW_MORNING_BRIEFING_PLUGIN_ID);
+  }
+  config.plugins.entries[KILOCLAW_MORNING_BRIEFING_PLUGIN_ID] =
+    config.plugins.entries[KILOCLAW_MORNING_BRIEFING_PLUGIN_ID] ?? {};
+  config.plugins.entries[KILOCLAW_MORNING_BRIEFING_PLUGIN_ID].enabled = true;
 
   // Telegram
   if (env.TELEGRAM_BOT_TOKEN) {

--- a/services/kiloclaw/controller/src/index.ts
+++ b/services/kiloclaw/controller/src/index.ts
@@ -23,6 +23,7 @@ import { registerGmailPushRoute } from './routes/gmail-push';
 import { registerInboundEmailRoute } from './routes/inbound-email';
 import { registerFileRoutes } from './routes/files';
 import { registerKiloCliRunRoutes } from './routes/kilo-cli-run';
+import { registerMorningBriefingRoutes } from './routes/morning-briefing';
 import { CONTROLLER_COMMIT, CONTROLLER_VERSION } from './version';
 import { writeKiloCliConfig } from './kilo-cli-config';
 import { writeGogCredentials } from './gog-credentials';
@@ -378,6 +379,7 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
   const honoApp = new Hono();
   registerHealthRoute(honoApp, supervisor, config.expectedToken, controllerState);
   registerGatewayRoutes(honoApp, supervisor, config.expectedToken);
+  registerMorningBriefingRoutes(honoApp, supervisor, config.expectedToken);
   registerConfigRoutes(honoApp, supervisor, config.expectedToken);
   registerPairingRoutes(honoApp, pairingCache, config.expectedToken);
   registerEnvRoutes(honoApp, supervisor, config.expectedToken);

--- a/services/kiloclaw/controller/src/routes/morning-briefing.test.ts
+++ b/services/kiloclaw/controller/src/routes/morning-briefing.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { registerMorningBriefingRoutes } from './morning-briefing';
+import type { Supervisor } from '../supervisor';
+
+function createRunningSupervisor(): Supervisor {
+  const state = 'running' as const;
+  return {
+    start: vi.fn(async () => true),
+    stop: vi.fn(async () => true),
+    restart: vi.fn(async () => true),
+    shutdown: vi.fn(async () => undefined),
+    signal: vi.fn(() => true),
+    getState: vi.fn(() => state),
+    getStats: vi.fn(() => ({
+      state,
+      pid: 1,
+      uptime: 1,
+      restarts: 0,
+      lastExit: null,
+    })),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('morning briefing controller routes', () => {
+  it('enforces bearer auth before proxying', async () => {
+    const app = new Hono();
+    registerMorningBriefingRoutes(app, createRunningSupervisor(), 'expected-token');
+
+    const response = await app.request('/_kilo/morning-briefing/status');
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('forwards expected gateway token to proxied route', async () => {
+    const app = new Hono();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    registerMorningBriefingRoutes(app, createRunningSupervisor(), 'expected-token');
+
+    const response = await app.request('/_kilo/morning-briefing/enable', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer expected-token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ cron: '0 7 * * *', timezone: 'America/Chicago' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:3001/api/plugins/kiloclaw-morning-briefing/enable',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          authorization: 'Bearer expected-token',
+          'content-type': 'application/json',
+        }),
+      })
+    );
+  });
+});

--- a/services/kiloclaw/controller/src/routes/morning-briefing.ts
+++ b/services/kiloclaw/controller/src/routes/morning-briefing.ts
@@ -1,0 +1,124 @@
+import type { Hono } from 'hono';
+import { timingSafeTokenEqual } from '../auth';
+import { getBearerToken } from './gateway';
+import type { Supervisor } from '../supervisor';
+
+const MORNING_BRIEFING_PREFIX = '/api/plugins/kiloclaw-morning-briefing';
+
+async function readJsonBody(c: { req: { json: () => Promise<unknown> } }): Promise<unknown> {
+  try {
+    return await c.req.json();
+  } catch {
+    return {};
+  }
+}
+
+async function proxyMorningBriefingRoute(params: {
+  supervisor: Supervisor;
+  gatewayToken: string;
+  path: string;
+  method: 'GET' | 'POST';
+  body?: unknown;
+}): Promise<Response> {
+  if (params.supervisor.getState() !== 'running') {
+    return new Response(JSON.stringify({ error: 'Gateway not running' }), {
+      status: 503,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  try {
+    return await fetch(`http://127.0.0.1:3001${MORNING_BRIEFING_PREFIX}${params.path}`, {
+      method: params.method,
+      headers: {
+        authorization: `Bearer ${params.gatewayToken}`,
+        'content-type': 'application/json',
+      },
+      body: params.body !== undefined ? JSON.stringify(params.body) : undefined,
+    });
+  } catch (error) {
+    console.error('[controller] morning briefing proxy failed:', error);
+    return new Response(JSON.stringify({ error: 'Failed to reach gateway' }), {
+      status: 502,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+}
+
+export function registerMorningBriefingRoutes(
+  app: Hono,
+  supervisor: Supervisor,
+  expectedToken: string
+): void {
+  app.use('/_kilo/morning-briefing/*', async (c, next) => {
+    const token = getBearerToken(c.req.header('authorization'));
+    if (!timingSafeTokenEqual(token, expectedToken)) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+    await next();
+  });
+
+  app.get('/_kilo/morning-briefing/status', async c => {
+    const response = await proxyMorningBriefingRoute({
+      supervisor,
+      gatewayToken: expectedToken,
+      path: '/status',
+      method: 'GET',
+    });
+    return response;
+  });
+
+  app.post('/_kilo/morning-briefing/enable', async c => {
+    const body = await readJsonBody(c);
+    const response = await proxyMorningBriefingRoute({
+      supervisor,
+      gatewayToken: expectedToken,
+      path: '/enable',
+      method: 'POST',
+      body,
+    });
+    return response;
+  });
+
+  app.post('/_kilo/morning-briefing/disable', async c => {
+    const response = await proxyMorningBriefingRoute({
+      supervisor,
+      gatewayToken: expectedToken,
+      path: '/disable',
+      method: 'POST',
+      body: {},
+    });
+    return response;
+  });
+
+  app.post('/_kilo/morning-briefing/run', async c => {
+    const response = await proxyMorningBriefingRoute({
+      supervisor,
+      gatewayToken: expectedToken,
+      path: '/run',
+      method: 'POST',
+      body: {},
+    });
+    return response;
+  });
+
+  app.get('/_kilo/morning-briefing/read/today', async c => {
+    const response = await proxyMorningBriefingRoute({
+      supervisor,
+      gatewayToken: expectedToken,
+      path: '/read/today',
+      method: 'GET',
+    });
+    return response;
+  });
+
+  app.get('/_kilo/morning-briefing/read/yesterday', async c => {
+    const response = await proxyMorningBriefingRoute({
+      supervisor,
+      gatewayToken: expectedToken,
+      path: '/read/yesterday',
+      method: 'GET',
+    });
+    return response;
+  });
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/README.md
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/README.md
@@ -1,0 +1,29 @@
+# KiloClaw Morning Briefing
+
+Bundled OpenClaw plugin for daily issue/news briefings in KiloClaw instances.
+
+## Commands
+
+- `/briefing enable`
+- `/briefing status`
+- `/briefing run`
+- `/briefing today`
+- `/briefing yesterday`
+- `/briefing disable`
+
+## Tooling
+
+- `morning_briefing_generate`
+- `morning_briefing_read`
+- `morning_briefing_handle_command`
+
+## Storage
+
+Writes Markdown files under:
+
+- `<OPENCLAW_STATE_DIR>/morning-briefing/briefings/YYYY-MM-DD.md`
+
+Plus metadata under:
+
+- `<OPENCLAW_STATE_DIR>/morning-briefing/config.json`
+- `<OPENCLAW_STATE_DIR>/morning-briefing/status.json`

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/openclaw.plugin.json
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/openclaw.plugin.json
@@ -1,0 +1,17 @@
+{
+  "id": "kiloclaw-morning-briefing",
+  "name": "KiloClawMorningBriefing",
+  "description": "Daily Morning Briefing plugin for KiloClaw-hosted OpenClaw",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "defaultCron": {
+        "type": "string"
+      },
+      "defaultTimezone": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/package.json
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@kiloclaw/kiloclaw-morning-briefing",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "KiloClaw Morning Briefing plugin for OpenClaw",
+  "files": [
+    "dist",
+    "openclaw.plugin.json",
+    "README.md"
+  ],
+  "openclaw": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "scripts": {
+    "prepack": "npm run build",
+    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node22 --external:openclaw --external:openclaw/* --outfile=dist/index.js",
+    "clean": "rm -rf dist",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.24-beta.2"
+  },
+  "devDependencies": {
+    "@sinclair/typebox": "^0.34.41",
+    "esbuild": "^0.25.2",
+    "vitest": "^4.1.0"
+  }
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.test.ts
@@ -2,24 +2,26 @@ import { describe, expect, it } from 'vitest';
 import {
   buildBriefingMarkdown,
   formatDateKey,
-  offsetDays,
+  offsetDateKey,
   resolveBriefingPath,
 } from './briefing-utils';
 
 describe('briefing-utils', () => {
-  it('formats date keys as YYYY-MM-DD', () => {
-    expect(formatDateKey(new Date('2026-04-23T10:00:00Z'))).toBe('2026-04-23');
+  it('formats date keys as YYYY-MM-DD in configured timezone', () => {
+    expect(formatDateKey(new Date('2026-04-23T03:30:00Z'), 'America/Los_Angeles')).toBe(
+      '2026-04-22'
+    );
   });
 
-  it('resolves today/yesterday offsets', () => {
+  it('resolves today/yesterday offsets in configured timezone', () => {
     const base = new Date('2026-04-23T12:00:00Z');
-    expect(formatDateKey(offsetDays(base, 0))).toBe('2026-04-23');
-    expect(formatDateKey(offsetDays(base, -1))).toBe('2026-04-22');
+    expect(offsetDateKey(base, 0, 'America/New_York')).toBe('2026-04-23');
+    expect(offsetDateKey(base, -1, 'America/New_York')).toBe('2026-04-22');
   });
 
   it('creates markdown with status and sections', () => {
     const markdown = buildBriefingMarkdown({
-      date: new Date('2026-04-23T12:00:00Z'),
+      dateKey: '2026-04-23',
       generatedAt: new Date('2026-04-23T07:00:01Z'),
       statuses: [
         { source: 'github', configured: true, ok: true, summary: 'Fetched 3 issues' },
@@ -42,7 +44,7 @@ describe('briefing-utils', () => {
   });
 
   it('builds date-based file paths', () => {
-    const filePath = resolveBriefingPath('/tmp/briefings', new Date('2026-04-23T12:00:00Z'));
+    const filePath = resolveBriefingPath('/tmp/briefings', '2026-04-23');
     expect(filePath.endsWith('/briefings/2026-04-23.md')).toBe(true);
   });
 });

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBriefingMarkdown,
+  formatDateKey,
+  offsetDays,
+  resolveBriefingPath,
+} from './briefing-utils';
+
+describe('briefing-utils', () => {
+  it('formats date keys as YYYY-MM-DD', () => {
+    expect(formatDateKey(new Date('2026-04-23T10:00:00Z'))).toBe('2026-04-23');
+  });
+
+  it('resolves today/yesterday offsets', () => {
+    const base = new Date('2026-04-23T12:00:00Z');
+    expect(formatDateKey(offsetDays(base, 0))).toBe('2026-04-23');
+    expect(formatDateKey(offsetDays(base, -1))).toBe('2026-04-22');
+  });
+
+  it('creates markdown with status and sections', () => {
+    const markdown = buildBriefingMarkdown({
+      date: new Date('2026-04-23T12:00:00Z'),
+      generatedAt: new Date('2026-04-23T07:00:01Z'),
+      statuses: [
+        { source: 'github', configured: true, ok: true, summary: 'Fetched 3 issues' },
+        { source: 'linear', configured: true, ok: false, summary: 'Validation pending' },
+        { source: 'web', configured: false, ok: false, summary: 'No search provider configured' },
+      ],
+      sections: [
+        { title: 'GitHub', lines: ['- Item 1'] },
+        { title: 'Linear', lines: [] },
+      ],
+      failures: ['Linear adapter validation pending'],
+    });
+
+    expect(markdown).toContain('# Morning Briefing - 2026-04-23');
+    expect(markdown).toContain('## Source Status');
+    expect(markdown).toContain('- github: [ok] Fetched 3 issues');
+    expect(markdown).toContain('## GitHub');
+    expect(markdown).toContain('- Item 1');
+    expect(markdown).toContain('## Failures / Skipped');
+  });
+
+  it('builds date-based file paths', () => {
+    const filePath = resolveBriefingPath('/tmp/briefings', new Date('2026-04-23T12:00:00Z'));
+    expect(filePath.endsWith('/briefings/2026-04-23.md')).toBe(true);
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.ts
@@ -12,33 +12,51 @@ export type BriefingDocumentSection = {
   lines: string[];
 };
 
-export function formatDateKey(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
+function readPart(parts: Intl.DateTimeFormatPart[], partType: 'year' | 'month' | 'day'): string {
+  const match = parts.find(part => part.type === partType);
+  if (!match) {
+    throw new Error(`Unable to format ${partType} from date`);
+  }
+  return match.value;
+}
+
+export function formatDateKey(date: Date, timezone: string): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+
+  const year = readPart(parts, 'year');
+  const month = readPart(parts, 'month');
+  const day = readPart(parts, 'day');
   return `${year}-${month}-${day}`;
 }
 
-export function offsetDays(base: Date, offset: number): Date {
-  const copy = new Date(base.getTime());
-  copy.setDate(copy.getDate() + offset);
-  return copy;
+export function offsetDateKey(base: Date, offset: number, timezone: string): string {
+  const [year, month, day] = formatDateKey(base, timezone).split('-').map(Number);
+  const copy = new Date(Date.UTC(year, month - 1, day));
+  copy.setUTCDate(copy.getUTCDate() + offset);
+  const offsetYear = copy.getUTCFullYear();
+  const offsetMonth = String(copy.getUTCMonth() + 1).padStart(2, '0');
+  const offsetDay = String(copy.getUTCDate()).padStart(2, '0');
+  return `${offsetYear}-${offsetMonth}-${offsetDay}`;
 }
 
-export function resolveBriefingPath(briefingsDir: string, date: Date): string {
-  return path.join(briefingsDir, `${formatDateKey(date)}.md`);
+export function resolveBriefingPath(briefingsDir: string, dateKey: string): string {
+  return path.join(briefingsDir, `${dateKey}.md`);
 }
 
 export function buildBriefingMarkdown(params: {
-  date: Date;
+  dateKey: string;
   generatedAt: Date;
   statuses: BriefingSourceStatus[];
   sections: BriefingDocumentSection[];
   failures: string[];
 }): string {
-  const dateKey = formatDateKey(params.date);
   const lines: string[] = [];
-  lines.push(`# Morning Briefing - ${dateKey}`);
+  lines.push(`# Morning Briefing - ${params.dateKey}`);
 
   for (const section of params.sections) {
     if (section.lines.length === 0) {

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/briefing-utils.ts
@@ -1,0 +1,72 @@
+import path from 'node:path';
+
+export type BriefingSourceStatus = {
+  source: 'github' | 'linear' | 'web';
+  configured: boolean;
+  ok: boolean;
+  summary: string;
+};
+
+export type BriefingDocumentSection = {
+  title: string;
+  lines: string[];
+};
+
+export function formatDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function offsetDays(base: Date, offset: number): Date {
+  const copy = new Date(base.getTime());
+  copy.setDate(copy.getDate() + offset);
+  return copy;
+}
+
+export function resolveBriefingPath(briefingsDir: string, date: Date): string {
+  return path.join(briefingsDir, `${formatDateKey(date)}.md`);
+}
+
+export function buildBriefingMarkdown(params: {
+  date: Date;
+  generatedAt: Date;
+  statuses: BriefingSourceStatus[];
+  sections: BriefingDocumentSection[];
+  failures: string[];
+}): string {
+  const dateKey = formatDateKey(params.date);
+  const lines: string[] = [];
+  lines.push(`# Morning Briefing - ${dateKey}`);
+
+  for (const section of params.sections) {
+    if (section.lines.length === 0) {
+      continue;
+    }
+    lines.push('');
+    lines.push(`## ${section.title}`);
+    lines.push(...section.lines);
+  }
+
+  if (params.failures.length > 0) {
+    lines.push('');
+    lines.push('## Failures / Skipped');
+    for (const failure of params.failures) {
+      lines.push(`- ${failure}`);
+    }
+  }
+
+  lines.push('');
+  lines.push('## Source Status');
+  for (const status of params.statuses) {
+    const marker = status.ok ? '[ok]' : status.configured ? '[error]' : '[skipped]';
+    lines.push(`- ${status.source}: ${marker} ${status.summary}`);
+  }
+
+  lines.push('');
+  lines.push(`_Generated at ${params.generatedAt.toISOString()}_`);
+  lines.push('');
+
+  return lines.join('\n');
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/command-fallback-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/command-fallback-utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { extractBriefingArgsFromText } from './command-fallback-utils';
+
+describe('command-fallback-utils', () => {
+  it('extracts subcommand args from a plain slash command', () => {
+    expect(extractBriefingArgsFromText('/briefing enable')).toBe('enable');
+  });
+
+  it('extracts args from control-ui wrapped inbound metadata text', () => {
+    const wrapped = [
+      'Sender (untrusted metadata):',
+      '```json',
+      '{"label":"openclaw-control-ui"}',
+      '```',
+      '',
+      '[Thu 2026-04-23 19:49 CDT] /briefing yesterday',
+    ].join('\n');
+
+    expect(extractBriefingArgsFromText(wrapped)).toBe('yesterday');
+  });
+
+  it('returns empty args for bare /briefing', () => {
+    expect(extractBriefingArgsFromText('/briefing')).toBe('');
+  });
+
+  it('returns null when no briefing command exists', () => {
+    expect(extractBriefingArgsFromText('hello there')).toBeNull();
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/command-fallback-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/command-fallback-utils.ts
@@ -1,0 +1,14 @@
+export function extractBriefingArgsFromText(input: string): string | null {
+  const text = input.trim();
+  if (!text) {
+    return null;
+  }
+
+  const match = text.match(/\/briefing(?:\s+([^\n\r]*))?/i);
+  if (!match) {
+    return null;
+  }
+
+  const args = typeof match[1] === 'string' ? match[1].trim() : '';
+  return args;
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/cron-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/cron-utils.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  filterEnabledBriefingJobs,
+  pickCanonicalCronJobId,
+  selectMorningBriefingJobs,
+} from './cron-utils';
+
+describe('cron-utils', () => {
+  it('selects only briefing jobs with matching tool allowlist', () => {
+    const jobs = selectMorningBriefingJobs(
+      {
+        jobs: [
+          {
+            id: 'a',
+            name: 'KiloClaw Morning Briefing',
+            enabled: true,
+            payload: { toolsAllow: ['morning_briefing_generate'] },
+          },
+          {
+            id: 'b',
+            name: 'KiloClaw Morning Briefing',
+            enabled: true,
+            payload: { toolsAllow: ['something_else'] },
+          },
+        ],
+      },
+      'KiloClaw Morning Briefing',
+      'morning_briefing_generate'
+    );
+
+    expect(jobs.map(job => job.id)).toEqual(['a']);
+  });
+
+  it('prefers configured id when present', () => {
+    const canonical = pickCanonicalCronJobId(
+      [
+        { id: 'old', enabled: true, updatedAtMs: 1, createdAtMs: 1 },
+        { id: 'new', enabled: true, updatedAtMs: 2, createdAtMs: 2 },
+      ],
+      'old'
+    );
+
+    expect(canonical).toBe('old');
+  });
+
+  it('otherwise picks latest updated job', () => {
+    const canonical = pickCanonicalCronJobId(
+      [
+        { id: 'old', enabled: true, updatedAtMs: 1, createdAtMs: 1 },
+        { id: 'new', enabled: true, updatedAtMs: 2, createdAtMs: 2 },
+      ],
+      null
+    );
+
+    expect(canonical).toBe('new');
+  });
+
+  it('filters only enabled briefing jobs', () => {
+    const filtered = filterEnabledBriefingJobs([
+      { id: 'enabled', enabled: true, updatedAtMs: 1, createdAtMs: 1 },
+      { id: 'disabled', enabled: false, updatedAtMs: 1, createdAtMs: 1 },
+    ]);
+
+    expect(filtered.map(job => job.id)).toEqual(['enabled']);
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/cron-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/cron-utils.ts
@@ -1,0 +1,72 @@
+export type MorningBriefingCronJob = {
+  id: string;
+  enabled: boolean;
+  updatedAtMs: number;
+  createdAtMs: number;
+};
+
+function asObject(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((entry): entry is string => typeof entry === 'string');
+}
+
+export function selectMorningBriefingJobs(
+  payload: unknown,
+  jobName: string,
+  toolName: string
+): MorningBriefingCronJob[] {
+  const root = asObject(payload);
+  const jobs = Array.isArray(root.jobs) ? root.jobs : [];
+  return jobs
+    .map(raw => asObject(raw))
+    .filter(job => {
+      if (typeof job.name !== 'string' || job.name !== jobName) {
+        return false;
+      }
+      const payloadObj = asObject(job.payload);
+      const toolsAllow = toStringArray(payloadObj.toolsAllow);
+      return toolsAllow.includes(toolName);
+    })
+    .map(job => ({
+      id: typeof job.id === 'string' ? job.id : '',
+      enabled: job.enabled === true,
+      updatedAtMs: typeof job.updatedAtMs === 'number' ? job.updatedAtMs : 0,
+      createdAtMs: typeof job.createdAtMs === 'number' ? job.createdAtMs : 0,
+    }))
+    .filter(job => job.id.length > 0);
+}
+
+export function pickCanonicalCronJobId(
+  jobs: MorningBriefingCronJob[],
+  preferredId: string | null
+): string | null {
+  if (preferredId && jobs.some(job => job.id === preferredId)) {
+    return preferredId;
+  }
+
+  const sorted = [...jobs].sort((a, b) => {
+    if (b.updatedAtMs !== a.updatedAtMs) {
+      return b.updatedAtMs - a.updatedAtMs;
+    }
+    if (b.createdAtMs !== a.createdAtMs) {
+      return b.createdAtMs - a.createdAtMs;
+    }
+    return a.id.localeCompare(b.id);
+  });
+
+  return sorted[0]?.id ?? null;
+}
+
+export function filterEnabledBriefingJobs(
+  jobs: MorningBriefingCronJob[]
+): MorningBriefingCronJob[] {
+  return jobs.filter(job => job.enabled);
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/enable-input-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/enable-input-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseEnableArgs } from './enable-input-utils';
+import { isValidTimezone, parseEnableArgs } from './enable-input-utils';
 
 describe('enable-input-utils', () => {
   it('parses simple command args with cron only', () => {
@@ -22,5 +22,10 @@ describe('enable-input-utils', () => {
 
   it('returns empty object for blank input', () => {
     expect(parseEnableArgs('')).toEqual({});
+  });
+
+  it('validates IANA timezone names', () => {
+    expect(isValidTimezone('America/Chicago')).toBe(true);
+    expect(isValidTimezone('America/Chcago')).toBe(false);
   });
 });

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/enable-input-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/enable-input-utils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { parseEnableArgs } from './enable-input-utils';
+
+describe('enable-input-utils', () => {
+  it('parses simple command args with cron only', () => {
+    expect(parseEnableArgs('0 7 * * *')).toEqual({ cron: '0 7 * * *' });
+  });
+
+  it('parses command args with cron and timezone', () => {
+    expect(parseEnableArgs('0 7 * * * America/Chicago')).toEqual({
+      cron: '0 7 * * *',
+      timezone: 'America/Chicago',
+    });
+  });
+
+  it('keeps timezone intact when it has spaces', () => {
+    expect(parseEnableArgs('0 7 * * * America/Argentina/Buenos_Aires')).toEqual({
+      cron: '0 7 * * *',
+      timezone: 'America/Argentina/Buenos_Aires',
+    });
+  });
+
+  it('returns empty object for blank input', () => {
+    expect(parseEnableArgs('')).toEqual({});
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/enable-input-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/enable-input-utils.ts
@@ -1,0 +1,27 @@
+export type EnableInput = { cron?: string; timezone?: string };
+
+export function parseEnableArgs(args: string | undefined): EnableInput {
+  const text = (args ?? '').trim();
+  if (!text) {
+    return {};
+  }
+  const tokens = text.split(/\s+/).filter(Boolean);
+
+  if (tokens.length >= 5) {
+    const cron = tokens.slice(0, 5).join(' ');
+    const timezone = tokens.slice(5).join(' ');
+    return {
+      cron,
+      timezone: timezone.length > 0 ? timezone : undefined,
+    };
+  }
+
+  if (tokens.length === 1) {
+    return { cron: tokens[0] };
+  }
+
+  return {
+    cron: tokens[0],
+    timezone: tokens.slice(1).join(' '),
+  };
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/enable-input-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/enable-input-utils.ts
@@ -1,5 +1,14 @@
 export type EnableInput = { cron?: string; timezone?: string };
 
+export function isValidTimezone(value: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: value }).format(new Date(0));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function parseEnableArgs(args: string | undefined): EnableInput {
   const text = (args ?? '').trim();
   if (!text) {

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
@@ -335,4 +335,35 @@ describe('morning briefing lifecycle', () => {
     const response = await harness.commandHandler({ args: 'today' });
     expect(response.text).toBe('tokyo briefing');
   });
+
+  it('rejects enable when timezone is invalid', async () => {
+    const harness = await createHarness();
+
+    await expect(
+      harness.commandHandler({ args: 'enable 0 7 * * * America/Chcago' })
+    ).rejects.toThrow('Invalid timezone: America/Chcago');
+  });
+
+  it('falls back to UTC date key when persisted timezone is invalid', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-23T00:30:00.000Z'));
+
+    const now = new Date().toISOString();
+    const harness = await createHarness({
+      preloadedConfig: {
+        enabled: false,
+        cronJobId: null,
+        cron: '0 7 * * *',
+        timezone: 'America/Chcago',
+        updatedAt: now,
+      },
+    });
+
+    const briefingsDir = path.join(harness.stateDir, 'morning-briefing', 'briefings');
+    await fs.mkdir(briefingsDir, { recursive: true });
+    await fs.writeFile(path.join(briefingsDir, '2026-04-23.md'), 'utc fallback briefing', 'utf8');
+
+    const response = await harness.commandHandler({ args: 'today' });
+    expect(response.text).toBe('utc fallback briefing');
+  });
 });

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
@@ -216,6 +216,7 @@ async function waitForReconcileState(
 }
 
 afterEach(async () => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -310,5 +311,28 @@ describe('morning briefing lifecycle', () => {
     expect(payload.ok).toBe(true);
     expect(payload.reconcileState).toBe('failed');
     expect(typeof payload.lastReconcileError).toBe('string');
+  });
+
+  it('uses configured timezone for /briefing today', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-23T16:30:00.000Z'));
+
+    const now = new Date().toISOString();
+    const harness = await createHarness({
+      preloadedConfig: {
+        enabled: false,
+        cronJobId: null,
+        cron: '0 7 * * *',
+        timezone: 'Asia/Tokyo',
+        updatedAt: now,
+      },
+    });
+
+    const briefingsDir = path.join(harness.stateDir, 'morning-briefing', 'briefings');
+    await fs.mkdir(briefingsDir, { recursive: true });
+    await fs.writeFile(path.join(briefingsDir, '2026-04-24.md'), 'tokyo briefing', 'utf8');
+
+    const response = await harness.commandHandler({ args: 'today' });
+    expect(response.text).toBe('tokyo briefing');
   });
 });

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
@@ -366,4 +366,41 @@ describe('morning briefing lifecycle', () => {
     const response = await harness.commandHandler({ args: 'today' });
     expect(response.text).toBe('utc fallback briefing');
   });
+
+  it('normalizes invalid persisted timezone on enable without override', async () => {
+    const now = new Date().toISOString();
+    const harness = await createHarness({
+      preloadedConfig: {
+        enabled: false,
+        cronJobId: null,
+        cron: '0 7 * * *',
+        timezone: 'America/Chcago',
+        updatedAt: now,
+      },
+    });
+
+    const response = await harness.commandHandler({ args: 'enable' });
+    expect(response.text).toContain('- timezone: UTC');
+
+    await waitForReconcileState(harness.stateDir, 'succeeded');
+    const config = await readJson(path.join(harness.stateDir, 'morning-briefing', 'config.json'));
+    expect(config.timezone).toBe('UTC');
+  });
+
+  it('normalizes invalid persisted timezone during startup reconcile', async () => {
+    const now = new Date().toISOString();
+    const harness = await createHarness({
+      preloadedConfig: {
+        enabled: true,
+        cronJobId: null,
+        cron: '0 7 * * *',
+        timezone: 'America/Chcago',
+        updatedAt: now,
+      },
+    });
+
+    await waitForReconcileState(harness.stateDir, 'succeeded');
+    const config = await readJson(path.join(harness.stateDir, 'morning-briefing', 'config.json'));
+    expect(config.timezone).toBe('UTC');
+  });
 });

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
@@ -32,6 +32,7 @@ type TestHarness = {
   stateDir: string;
   commandHandler: (ctx: { args?: string }) => Promise<{ text: string }>;
   statusHttpHandler: (_req: unknown, res: FakeResponse) => Promise<void>;
+  enableHttpHandler: (req: unknown, res: FakeResponse) => Promise<void>;
   cronJobs: CronJob[];
   runCommandWithTimeout: ReturnType<typeof vi.fn>;
 };
@@ -48,6 +49,14 @@ class FakeResponse {
   end(chunk?: string): void {
     this.body = chunk ?? '';
   }
+}
+
+function createJsonRequest(body: Record<string, unknown>): AsyncIterable<string> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield JSON.stringify(body);
+    },
+  };
 }
 
 async function createHarness(options?: {
@@ -146,6 +155,7 @@ async function createHarness(options?: {
 
   let commandHandler: ((ctx: { args?: string }) => Promise<{ text: string }>) | null = null;
   let statusHttpHandler: ((_req: unknown, res: FakeResponse) => Promise<void>) | null = null;
+  let enableHttpHandler: ((req: unknown, res: FakeResponse) => Promise<void>) | null = null;
 
   morningBriefingPlugin.register({
     runtime: {
@@ -169,20 +179,23 @@ async function createHarness(options?: {
     }) => {
       if (route.path.endsWith('/status')) {
         statusHttpHandler = route.handler;
+      } else if (route.path.endsWith('/enable')) {
+        enableHttpHandler = route.handler;
       }
     },
     registerTool: vi.fn(),
     on: vi.fn(),
   } as never);
 
-  if (!commandHandler || !statusHttpHandler) {
-    throw new Error('Failed to register command or status handler');
+  if (!commandHandler || !statusHttpHandler || !enableHttpHandler) {
+    throw new Error('Failed to register command or HTTP handlers');
   }
 
   return {
     stateDir,
     commandHandler,
     statusHttpHandler,
+    enableHttpHandler,
     cronJobs,
     runCommandWithTimeout,
   };
@@ -342,6 +355,21 @@ describe('morning briefing lifecycle', () => {
     await expect(
       harness.commandHandler({ args: 'enable 0 7 * * * America/Chcago' })
     ).rejects.toThrow('Invalid timezone: America/Chcago');
+  });
+
+  it('returns 400 for invalid timezone in enable HTTP route', async () => {
+    const harness = await createHarness();
+    const response = new FakeResponse();
+
+    await harness.enableHttpHandler(
+      createJsonRequest({ cron: '0 7 * * *', timezone: 'America/Chcago' }),
+      response
+    );
+
+    expect(response.statusCode).toBe(400);
+    const payload = JSON.parse(response.body) as Record<string, unknown>;
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toBe('Invalid timezone: America/Chcago');
   });
 
   it('falls back to UTC date key when persisted timezone is invalid', async () => {

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.lifecycle.test.ts
@@ -1,0 +1,314 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@sinclair/typebox', () => ({
+  Type: {
+    Object: (value: unknown) => value,
+    Optional: (value: unknown) => value,
+    String: (value: unknown) => value,
+    Union: (value: unknown) => value,
+    Literal: (value: unknown) => value,
+  },
+}));
+
+vi.mock('openclaw/plugin-sdk/plugin-entry', () => ({
+  definePluginEntry: (entry: unknown) => entry,
+}));
+
+type CronJob = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  updatedAtMs: number;
+  createdAtMs: number;
+  payload: {
+    toolsAllow: string[];
+  };
+};
+
+type TestHarness = {
+  stateDir: string;
+  commandHandler: (ctx: { args?: string }) => Promise<{ text: string }>;
+  statusHttpHandler: (_req: unknown, res: FakeResponse) => Promise<void>;
+  cronJobs: CronJob[];
+  runCommandWithTimeout: ReturnType<typeof vi.fn>;
+};
+
+class FakeResponse {
+  statusCode = 200;
+  private headers = new Map<string, string>();
+  body = '';
+
+  setHeader(name: string, value: string): void {
+    this.headers.set(name.toLowerCase(), value);
+  }
+
+  end(chunk?: string): void {
+    this.body = chunk ?? '';
+  }
+}
+
+async function createHarness(options?: {
+  disableCommandFails?: boolean;
+  preloadedConfig?: Record<string, unknown>;
+  preloadedStatus?: Record<string, unknown>;
+}): Promise<TestHarness> {
+  const { default: morningBriefingPlugin } = await import('./index');
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), 'morning-briefing-'));
+  const pluginDir = path.join(stateDir, 'morning-briefing');
+  await fs.mkdir(pluginDir, { recursive: true });
+
+  if (options?.preloadedConfig) {
+    await fs.writeFile(
+      path.join(pluginDir, 'config.json'),
+      JSON.stringify(options.preloadedConfig, null, 2),
+      'utf8'
+    );
+  }
+  if (options?.preloadedStatus) {
+    await fs.writeFile(
+      path.join(pluginDir, 'status.json'),
+      JSON.stringify(options.preloadedStatus, null, 2),
+      'utf8'
+    );
+  }
+
+  let sequence = 0;
+  const cronJobs: CronJob[] = [];
+  const runCommandWithTimeout = vi.fn(async (argv: string[]) => {
+    if (argv[0] === 'gh' && argv[1] === 'auth' && argv[2] === 'status') {
+      return { stdout: '', stderr: 'not authenticated', code: 1 };
+    }
+
+    if (argv[0] === 'openclaw' && argv[1] === 'cron') {
+      const subcommand = argv[2];
+
+      if (subcommand === 'list') {
+        return {
+          stdout: JSON.stringify({ jobs: cronJobs }),
+          stderr: '',
+          code: 0,
+        };
+      }
+
+      if (subcommand === 'add') {
+        const id = `job-${++sequence}`;
+        const now = Date.now();
+        cronJobs.push({
+          id,
+          name: 'KiloClaw Morning Briefing',
+          enabled: true,
+          updatedAtMs: now,
+          createdAtMs: now,
+          payload: { toolsAllow: ['morning_briefing_generate'] },
+        });
+        return { stdout: JSON.stringify({ id }), stderr: '', code: 0 };
+      }
+
+      if (subcommand === 'edit') {
+        const id = argv[3] ?? '';
+        const job = cronJobs.find(entry => entry.id === id);
+        if (!job) {
+          return { stdout: '', stderr: 'missing job', code: 1 };
+        }
+        job.updatedAtMs = Date.now();
+        job.enabled = true;
+        return { stdout: JSON.stringify({ id }), stderr: '', code: 0 };
+      }
+
+      if (subcommand === 'disable') {
+        const id = argv[3] ?? '';
+        if (options?.disableCommandFails) {
+          return { stdout: '', stderr: 'disable failed', code: 1 };
+        }
+        const job = cronJobs.find(entry => entry.id === id);
+        if (job) {
+          job.enabled = false;
+          job.updatedAtMs = Date.now();
+        }
+        return { stdout: '', stderr: '', code: 0 };
+      }
+
+      if (subcommand === 'remove') {
+        const id = argv[3] ?? '';
+        const index = cronJobs.findIndex(entry => entry.id === id);
+        if (index >= 0) {
+          cronJobs.splice(index, 1);
+        }
+        return { stdout: JSON.stringify({ ok: true }), stderr: '', code: 0 };
+      }
+    }
+
+    return { stdout: '', stderr: '', code: 0 };
+  });
+
+  let commandHandler: ((ctx: { args?: string }) => Promise<{ text: string }>) | null = null;
+  let statusHttpHandler: ((_req: unknown, res: FakeResponse) => Promise<void>) | null = null;
+
+  morningBriefingPlugin.register({
+    runtime: {
+      state: { resolveStateDir: () => stateDir },
+      system: { runCommandWithTimeout },
+      webSearch: {
+        listProviders: () => [],
+        search: async () => ({ provider: 'none', result: {} }),
+      },
+    },
+    config: {
+      agents: { defaults: { userTimezone: 'America/Chicago' } },
+    },
+    logger: { warn: vi.fn() },
+    registerCommand: (def: { handler: (ctx: { args?: string }) => Promise<{ text: string }> }) => {
+      commandHandler = def.handler;
+    },
+    registerHttpRoute: (route: {
+      path: string;
+      handler: (_req: unknown, res: FakeResponse) => Promise<void>;
+    }) => {
+      if (route.path.endsWith('/status')) {
+        statusHttpHandler = route.handler;
+      }
+    },
+    registerTool: vi.fn(),
+    on: vi.fn(),
+  } as never);
+
+  if (!commandHandler || !statusHttpHandler) {
+    throw new Error('Failed to register command or status handler');
+  }
+
+  return {
+    stateDir,
+    commandHandler,
+    statusHttpHandler,
+    cronJobs,
+    runCommandWithTimeout,
+  };
+}
+
+async function readJson(filePath: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await fs.readFile(filePath, 'utf8')) as Record<string, unknown>;
+}
+
+async function waitForReconcileState(
+  stateDir: string,
+  expectedState: 'succeeded' | 'failed',
+  timeoutMs = 2000
+): Promise<Record<string, unknown>> {
+  const statusPath = path.join(stateDir, 'morning-briefing', 'status.json');
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const status = await readJson(statusPath);
+      if (status.reconcileState === expectedState) {
+        return status;
+      }
+    } catch {
+      // ignore until file exists
+    }
+    await new Promise(resolve => setTimeout(resolve, 20));
+  }
+
+  throw new Error(`Timed out waiting for reconcileState=${expectedState}`);
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+});
+
+describe('morning briefing lifecycle', () => {
+  it('enable command converges to enabled state via reconcile', async () => {
+    const harness = await createHarness();
+
+    const response = await harness.commandHandler({ args: 'enable' });
+    expect(response.text).toContain('Morning Briefing enable requested.');
+
+    const status = await waitForReconcileState(harness.stateDir, 'succeeded');
+    const config = await readJson(path.join(harness.stateDir, 'morning-briefing', 'config.json'));
+
+    expect(config.enabled).toBe(true);
+    expect(config.cronJobId).toBeTypeOf('string');
+    expect(status.observedEnabled).toBe(true);
+    expect(status.lastReconcileAction).toBe('enable');
+  });
+
+  it('disable reconcile succeeds when only disabled jobs remain listed', async () => {
+    const harness = await createHarness();
+
+    await harness.commandHandler({ args: 'enable' });
+    await waitForReconcileState(harness.stateDir, 'succeeded');
+
+    const disableResponse = await harness.commandHandler({ args: 'disable' });
+    expect(disableResponse.text).toContain('Morning Briefing disable requested.');
+
+    const status = await waitForReconcileState(harness.stateDir, 'succeeded');
+    const config = await readJson(path.join(harness.stateDir, 'morning-briefing', 'config.json'));
+
+    expect(config.enabled).toBe(false);
+    expect(status.observedEnabled).toBe(false);
+    expect(status.lastReconcileAction).toBe('disable');
+    expect(harness.cronJobs.length).toBeGreaterThan(0);
+    expect(harness.cronJobs.every(job => job.enabled === false)).toBe(true);
+  });
+
+  it('startup reconcile resumes from persisted diverged state', async () => {
+    const now = new Date().toISOString();
+    const harness = await createHarness({
+      preloadedConfig: {
+        enabled: false,
+        cronJobId: 'job-existing',
+        cron: '0 7 * * *',
+        timezone: 'America/Chicago',
+        updatedAt: now,
+      },
+      preloadedStatus: {
+        lastGeneratedDate: null,
+        lastGeneratedAt: null,
+        lastPath: null,
+        sourceSummary: [],
+        failures: [],
+        observedEnabled: true,
+        reconcileState: 'idle',
+        lastReconcileAt: null,
+        lastReconcileError: null,
+        lastReconcileDurationMs: null,
+        lastReconcileAction: null,
+      },
+    });
+
+    harness.cronJobs.push({
+      id: 'job-existing',
+      name: 'KiloClaw Morning Briefing',
+      enabled: true,
+      updatedAtMs: Date.now(),
+      createdAtMs: Date.now(),
+      payload: { toolsAllow: ['morning_briefing_generate'] },
+    });
+
+    const status = await waitForReconcileState(harness.stateDir, 'succeeded');
+    expect(status.observedEnabled).toBe(false);
+    expect(status.lastReconcileAction).toBe('disable');
+  });
+
+  it('status payload exposes reconcile failure details', async () => {
+    const harness = await createHarness({ disableCommandFails: true });
+
+    await harness.commandHandler({ args: 'enable' });
+    await waitForReconcileState(harness.stateDir, 'succeeded');
+
+    await harness.commandHandler({ args: 'disable' });
+    await waitForReconcileState(harness.stateDir, 'failed');
+
+    const response = new FakeResponse();
+    await harness.statusHttpHandler({}, response);
+
+    expect(response.statusCode).toBe(200);
+    const payload = JSON.parse(response.body) as Record<string, unknown>;
+    expect(payload.ok).toBe(true);
+    expect(payload.reconcileState).toBe('failed');
+    expect(typeof payload.lastReconcileError).toBe('string');
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -1,0 +1,1466 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { Type } from '@sinclair/typebox';
+import { definePluginEntry } from 'openclaw/plugin-sdk/plugin-entry';
+import {
+  buildBriefingMarkdown,
+  formatDateKey,
+  offsetDays,
+  resolveBriefingPath,
+} from './briefing-utils';
+import {
+  filterEnabledBriefingJobs,
+  pickCanonicalCronJobId,
+  selectMorningBriefingJobs,
+} from './cron-utils';
+import { extractBriefingArgsFromText } from './command-fallback-utils';
+import { type EnableInput, parseEnableArgs } from './enable-input-utils';
+import { normalizeLinearIssues, summarizeLinearCallFailure } from './linear-utils';
+import { resolveNextReconcileAction } from './reconcile-queue-utils';
+import { normalizeWebResults } from './web-utils';
+
+const PLUGIN_ID = 'kiloclaw-morning-briefing';
+const CRON_JOB_NAME = 'KiloClaw Morning Briefing';
+const CRON_PROMPT =
+  'Call the tool morning_briefing_generate exactly once with no arguments. Do not call any other tool.';
+const DEFAULT_CRON = '0 7 * * *';
+const DEFAULT_TIMEZONE = 'UTC';
+
+type BriefingPluginConfig = {
+  defaultCron?: string;
+  defaultTimezone?: string;
+};
+
+type StoredConfig = {
+  enabled: boolean;
+  cronJobId: string | null;
+  cron: string;
+  timezone: string;
+  updatedAt: string;
+};
+
+type StoredStatus = {
+  lastGeneratedDate: string | null;
+  lastGeneratedAt: string | null;
+  lastPath: string | null;
+  sourceSummary: Array<{ source: string; configured: boolean; ok: boolean; summary: string }>;
+  failures: string[];
+  observedEnabled: boolean | null;
+  reconcileState: 'idle' | 'in_progress' | 'succeeded' | 'failed';
+  lastReconcileAt: string | null;
+  lastReconcileError: string | null;
+  lastReconcileDurationMs: number | null;
+  lastReconcileAction: 'enable' | 'disable' | null;
+};
+
+type SourceCollectionResult = {
+  source: 'github' | 'linear' | 'web';
+  configured: boolean;
+  ok: boolean;
+  summary: string;
+  sectionLines: string[];
+};
+
+function asObject(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function resolvePluginConfig(raw: unknown): BriefingPluginConfig {
+  const obj = asObject(raw);
+  return {
+    defaultCron: typeof obj.defaultCron === 'string' ? obj.defaultCron : undefined,
+    defaultTimezone: typeof obj.defaultTimezone === 'string' ? obj.defaultTimezone : undefined,
+  };
+}
+
+async function readRequestBody(req: import('node:http').IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const raw = Buffer.concat(chunks).toString('utf8').trim();
+  if (!raw) {
+    return {};
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+function sendJson(
+  res: import('node:http').ServerResponse,
+  statusCode: number,
+  body: Record<string, unknown>
+): void {
+  res.statusCode = statusCode;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+function getStatePaths(api: { runtime: { state: { resolveStateDir: () => string } } }): {
+  rootDir: string;
+  briefingsDir: string;
+  configPath: string;
+  statusPath: string;
+} {
+  const stateDir = api.runtime.state.resolveStateDir();
+  const rootDir = path.join(stateDir, 'morning-briefing');
+  return {
+    rootDir,
+    briefingsDir: path.join(rootDir, 'briefings'),
+    configPath: path.join(rootDir, 'config.json'),
+    statusPath: path.join(rootDir, 'status.json'),
+  };
+}
+
+async function ensureStorage(paths: { rootDir: string; briefingsDir: string }): Promise<void> {
+  await fs.mkdir(paths.rootDir, { recursive: true });
+  await fs.mkdir(paths.briefingsDir, { recursive: true });
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T | null> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await fs.writeFile(filePath, JSON.stringify(value, null, 2), 'utf8');
+}
+
+async function runCommand(
+  api: {
+    runtime: {
+      system: {
+        runCommandWithTimeout: (
+          argv: string[],
+          options: { timeoutMs: number; cwd?: string }
+        ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+      };
+    };
+  },
+  argv: string[],
+  timeoutMs = 30_000
+): Promise<{ stdout: string; stderr: string }> {
+  const result = await api.runtime.system.runCommandWithTimeout(argv, {
+    timeoutMs,
+  });
+  if (result.code !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim() || 'Command failed';
+    throw new Error(`${argv.join(' ')} failed: ${message}`);
+  }
+  return { stdout: result.stdout, stderr: result.stderr };
+}
+
+async function runCronJson(
+  api: {
+    runtime: {
+      system: {
+        runCommandWithTimeout: (
+          argv: string[],
+          options: { timeoutMs: number; cwd?: string }
+        ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+      };
+    };
+  },
+  argv: string[]
+): Promise<Record<string, unknown>> {
+  const [subcommand = ''] = argv;
+  const jsonUnsupported = subcommand === 'disable';
+  const command = jsonUnsupported
+    ? ['openclaw', 'cron', ...argv]
+    : ['openclaw', 'cron', ...argv, '--json'];
+  const { stdout } = await runCommand(api, command, 60_000);
+  try {
+    return asObject(JSON.parse(stdout));
+  } catch {
+    return {};
+  }
+}
+
+async function runCronCommand(
+  api: {
+    runtime: {
+      system: {
+        runCommandWithTimeout: (
+          argv: string[],
+          options: { timeoutMs: number; cwd?: string }
+        ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+      };
+    };
+  },
+  argv: string[]
+): Promise<void> {
+  await runCommand(api, ['openclaw', 'cron', ...argv], 60_000);
+}
+
+type CronJobRef = {
+  id: string;
+  enabled: boolean;
+  updatedAtMs: number;
+  createdAtMs: number;
+};
+
+async function listBriefingCronJobs(api: {
+  runtime: {
+    system: {
+      runCommandWithTimeout: (
+        argv: string[],
+        options: { timeoutMs: number; cwd?: string }
+      ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+    };
+  };
+}): Promise<CronJobRef[]> {
+  const listResult = await runCronJson(api, ['list']);
+  return selectMorningBriefingJobs(listResult, CRON_JOB_NAME, 'morning_briefing_generate');
+}
+
+async function removeDuplicateBriefingCronJobs(
+  api: {
+    runtime: {
+      system: {
+        runCommandWithTimeout: (
+          argv: string[],
+          options: { timeoutMs: number; cwd?: string }
+        ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+      };
+    };
+    logger: { warn?: (message: string) => void };
+  },
+  canonicalId: string
+): Promise<void> {
+  const jobs = await listBriefingCronJobs(api);
+  for (const job of jobs) {
+    if (job.id === canonicalId) {
+      continue;
+    }
+    try {
+      await runCronJson(api, ['remove', job.id]);
+    } catch (error) {
+      api.logger.warn?.(
+        `Morning briefing: failed to remove duplicate cron ${job.id} (${String(error)})`
+      );
+    }
+  }
+}
+
+function resolveDefaults(api: {
+  config: {
+    agents?: {
+      defaults?: {
+        userTimezone?: string;
+      };
+    };
+  };
+  pluginConfig?: Record<string, unknown>;
+}): { cron: string; timezone: string } {
+  const pluginConfig = resolvePluginConfig(api.pluginConfig);
+  return {
+    cron: pluginConfig.defaultCron?.trim() || DEFAULT_CRON,
+    timezone:
+      pluginConfig.defaultTimezone?.trim() ||
+      api.config.agents?.defaults?.userTimezone ||
+      DEFAULT_TIMEZONE,
+  };
+}
+
+async function readStoredConfig(
+  api: {
+    runtime: { state: { resolveStateDir: () => string } };
+    config: {
+      agents?: {
+        defaults?: {
+          userTimezone?: string;
+        };
+      };
+    };
+    pluginConfig?: Record<string, unknown>;
+  },
+  paths: { configPath: string }
+): Promise<StoredConfig> {
+  const defaults = resolveDefaults(api);
+  const existing = await readJsonFile<StoredConfig>(paths.configPath);
+  if (!existing) {
+    return {
+      enabled: false,
+      cronJobId: null,
+      cron: defaults.cron,
+      timezone: defaults.timezone,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+  return {
+    enabled: existing.enabled === true,
+    cronJobId:
+      typeof existing.cronJobId === 'string' && existing.cronJobId ? existing.cronJobId : null,
+    cron: typeof existing.cron === 'string' && existing.cron ? existing.cron : defaults.cron,
+    timezone:
+      typeof existing.timezone === 'string' && existing.timezone
+        ? existing.timezone
+        : defaults.timezone,
+    updatedAt:
+      typeof existing.updatedAt === 'string' ? existing.updatedAt : new Date().toISOString(),
+  };
+}
+
+async function readStoredStatus(paths: { statusPath: string }): Promise<StoredStatus> {
+  const existing = await readJsonFile<StoredStatus>(paths.statusPath);
+  if (!existing) {
+    return {
+      lastGeneratedDate: null,
+      lastGeneratedAt: null,
+      lastPath: null,
+      sourceSummary: [],
+      failures: [],
+      observedEnabled: null,
+      reconcileState: 'idle',
+      lastReconcileAt: null,
+      lastReconcileError: null,
+      lastReconcileDurationMs: null,
+      lastReconcileAction: null,
+    };
+  }
+  return {
+    lastGeneratedDate:
+      typeof existing.lastGeneratedDate === 'string' ? existing.lastGeneratedDate : null,
+    lastGeneratedAt: typeof existing.lastGeneratedAt === 'string' ? existing.lastGeneratedAt : null,
+    lastPath: typeof existing.lastPath === 'string' ? existing.lastPath : null,
+    sourceSummary: Array.isArray(existing.sourceSummary)
+      ? existing.sourceSummary.filter(entry => typeof entry === 'object' && entry !== null)
+      : [],
+    failures: Array.isArray(existing.failures)
+      ? existing.failures.filter(value => typeof value === 'string')
+      : [],
+    observedEnabled:
+      typeof existing.observedEnabled === 'boolean' ? existing.observedEnabled : null,
+    reconcileState:
+      existing.reconcileState === 'in_progress' ||
+      existing.reconcileState === 'succeeded' ||
+      existing.reconcileState === 'failed'
+        ? existing.reconcileState
+        : 'idle',
+    lastReconcileAt: typeof existing.lastReconcileAt === 'string' ? existing.lastReconcileAt : null,
+    lastReconcileError:
+      typeof existing.lastReconcileError === 'string' ? existing.lastReconcileError : null,
+    lastReconcileDurationMs:
+      typeof existing.lastReconcileDurationMs === 'number'
+        ? existing.lastReconcileDurationMs
+        : null,
+    lastReconcileAction:
+      existing.lastReconcileAction === 'enable' || existing.lastReconcileAction === 'disable'
+        ? existing.lastReconcileAction
+        : null,
+  };
+}
+
+async function patchStoredStatus(
+  paths: { statusPath: string },
+  patch: Partial<StoredStatus>
+): Promise<StoredStatus> {
+  const current = await readStoredStatus(paths);
+  const next: StoredStatus = {
+    ...current,
+    ...patch,
+  };
+  await writeJsonFile(paths.statusPath, next);
+  return next;
+}
+
+async function ensureCronJob(
+  api: {
+    runtime: {
+      system: {
+        runCommandWithTimeout: (
+          argv: string[],
+          options: { timeoutMs: number; cwd?: string }
+        ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+      };
+    };
+    logger: { warn?: (message: string) => void };
+  },
+  config: StoredConfig
+): Promise<{ cronJobId: string; cron: string; timezone: string }> {
+  const existingJobs = await listBriefingCronJobs(api);
+  let cronJobId = pickCanonicalCronJobId(existingJobs, config.cronJobId);
+
+  if (cronJobId !== null) {
+    try {
+      await runCronJson(api, [
+        'edit',
+        cronJobId,
+        '--session',
+        'isolated',
+        '--message',
+        CRON_PROMPT,
+        '--cron',
+        config.cron,
+        '--tz',
+        config.timezone,
+        '--tools',
+        'morning_briefing_generate',
+        '--no-deliver',
+      ]);
+      await removeDuplicateBriefingCronJobs(api, cronJobId);
+      return { cronJobId, cron: config.cron, timezone: config.timezone };
+    } catch (error) {
+      api.logger.warn?.(
+        `Morning briefing: existing cron edit failed (${String(error)}), recreating.`
+      );
+      cronJobId = null;
+    }
+  }
+
+  const createResult = await runCronJson(api, [
+    'add',
+    '--name',
+    CRON_JOB_NAME,
+    '--session',
+    'isolated',
+    '--message',
+    CRON_PROMPT,
+    '--cron',
+    config.cron,
+    '--tz',
+    config.timezone,
+    '--tools',
+    'morning_briefing_generate',
+    '--no-deliver',
+  ]);
+
+  const topLevelId = typeof createResult.id === 'string' ? createResult.id : '';
+  const createdJob = asObject(createResult.job);
+  const nestedId = typeof createdJob.id === 'string' ? createdJob.id : '';
+  const resolvedId = topLevelId || nestedId;
+  if (!resolvedId) {
+    throw new Error('Unable to resolve cron job id after enable');
+  }
+
+  await removeDuplicateBriefingCronJobs(api, resolvedId);
+
+  return {
+    cronJobId: resolvedId,
+    cron: config.cron,
+    timezone: config.timezone,
+  };
+}
+
+async function resolveGithubReady(api: {
+  runtime: {
+    system: {
+      runCommandWithTimeout: (
+        argv: string[],
+        options: { timeoutMs: number; cwd?: string }
+      ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+    };
+  };
+}): Promise<{ configured: boolean; summary: string }> {
+  const result = await api.runtime.system.runCommandWithTimeout(['gh', 'auth', 'status'], {
+    timeoutMs: 10_000,
+  });
+  if (result.code !== 0) {
+    return {
+      configured: false,
+      summary: 'GitHub CLI is not authenticated',
+    };
+  }
+  return {
+    configured: true,
+    summary: 'GitHub CLI authentication is available',
+  };
+}
+
+async function resolveWebSearchReady(api: {
+  runtime: {
+    webSearch: {
+      listProviders: (params?: { config?: unknown }) => Array<{ id?: string }>;
+    };
+  };
+  config: unknown;
+}): Promise<{ configured: boolean; summary: string }> {
+  const providers = api.runtime.webSearch.listProviders({ config: api.config });
+  if (!Array.isArray(providers) || providers.length === 0) {
+    return {
+      configured: false,
+      summary: 'No web search provider is configured',
+    };
+  }
+  return {
+    configured: true,
+    summary: `Web search provider ready (${providers.length} provider${providers.length === 1 ? '' : 's'})`,
+  };
+}
+
+function resolveLinearReady(): { configured: boolean; summary: string } {
+  const hasLinearKey =
+    typeof process.env.LINEAR_API_KEY === 'string' && process.env.LINEAR_API_KEY.trim().length > 0;
+  if (!hasLinearKey) {
+    return {
+      configured: false,
+      summary: 'Linear API key is not configured',
+    };
+  }
+  return {
+    configured: true,
+    summary: 'Linear API key is configured',
+  };
+}
+
+function normalizeGithubIssues(
+  payload: unknown
+): Array<{ title: string; url: string; updatedAt?: string }> {
+  if (!Array.isArray(payload)) {
+    return [];
+  }
+  return payload
+    .map(raw => asObject(raw))
+    .map(item => ({
+      title: typeof item.title === 'string' ? item.title : '(untitled)',
+      url: typeof item.url === 'string' ? item.url : '',
+      updatedAt: typeof item.updatedAt === 'string' ? item.updatedAt : undefined,
+    }))
+    .filter(item => item.url.length > 0);
+}
+
+async function collectGithub(api: {
+  runtime: {
+    system: {
+      runCommandWithTimeout: (
+        argv: string[],
+        options: { timeoutMs: number; cwd?: string }
+      ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+    };
+  };
+}): Promise<SourceCollectionResult> {
+  const readiness = await resolveGithubReady(api);
+  if (!readiness.configured) {
+    return {
+      source: 'github',
+      configured: false,
+      ok: false,
+      summary: readiness.summary,
+      sectionLines: [],
+    };
+  }
+
+  try {
+    const { stdout } = await runCommand(
+      api,
+      [
+        'gh',
+        'search',
+        'issues',
+        'is:open sort:updated-desc',
+        '--limit',
+        '12',
+        '--json',
+        'title,url,updatedAt',
+      ],
+      20_000
+    );
+    const items = normalizeGithubIssues(JSON.parse(stdout));
+    if (items.length === 0) {
+      return {
+        source: 'github',
+        configured: true,
+        ok: true,
+        summary: 'No open issues found in accessible repositories',
+        sectionLines: ['- No open issues found.'],
+      };
+    }
+    const lines = items.slice(0, 8).map(item => {
+      const updatedSuffix = item.updatedAt ? ` (updated ${item.updatedAt})` : '';
+      return `- [${item.title}](${item.url})${updatedSuffix}`;
+    });
+    return {
+      source: 'github',
+      configured: true,
+      ok: true,
+      summary: `Fetched ${items.length} open GitHub issues`,
+      sectionLines: lines,
+    };
+  } catch (error) {
+    return {
+      source: 'github',
+      configured: true,
+      ok: false,
+      summary: `GitHub query failed: ${error instanceof Error ? error.message : String(error)}`,
+      sectionLines: [],
+    };
+  }
+}
+
+async function collectWebSearch(api: {
+  runtime: {
+    webSearch: {
+      listProviders: (params?: { config?: unknown }) => Array<{ id?: string }>;
+      search: (params: { args: Record<string, unknown>; config?: unknown }) => Promise<{
+        provider: string;
+        result: Record<string, unknown>;
+      }>;
+    };
+  };
+  config: unknown;
+}): Promise<SourceCollectionResult> {
+  const readiness = await resolveWebSearchReady(api);
+  if (!readiness.configured) {
+    return {
+      source: 'web',
+      configured: false,
+      ok: false,
+      summary: readiness.summary,
+      sectionLines: [],
+    };
+  }
+
+  try {
+    const response = await api.runtime.webSearch.search({
+      config: api.config,
+      args: {
+        query:
+          'top engineering updates and breaking software infrastructure news from the last 24 hours',
+        count: 6,
+      },
+    });
+    const results = normalizeWebResults(response.result);
+    if (results.length === 0) {
+      return {
+        source: 'web',
+        configured: true,
+        ok: true,
+        summary: 'Web search returned no results',
+        sectionLines: ['- No web-search results returned.'],
+      };
+    }
+    return {
+      source: 'web',
+      configured: true,
+      ok: true,
+      summary: `Fetched ${results.length} web results (${response.provider})`,
+      sectionLines: results
+        .slice(0, 6)
+        .map(item =>
+          item.summary.length > 0
+            ? `- [${item.title}](${item.url}) - ${item.summary}`
+            : `- [${item.title}](${item.url})`
+        ),
+    };
+  } catch (error) {
+    return {
+      source: 'web',
+      configured: true,
+      ok: false,
+      summary: `Web search failed: ${error instanceof Error ? error.message : String(error)}`,
+      sectionLines: [],
+    };
+  }
+}
+
+async function collectLinear(api: {
+  runtime: {
+    state: { resolveStateDir: () => string };
+    system: {
+      runCommandWithTimeout: (
+        argv: string[],
+        options: { timeoutMs: number; cwd?: string }
+      ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+    };
+  };
+}): Promise<SourceCollectionResult> {
+  const readiness = resolveLinearReady();
+  if (!readiness.configured) {
+    return {
+      source: 'linear',
+      configured: false,
+      ok: false,
+      summary: readiness.summary,
+      sectionLines: [],
+    };
+  }
+
+  const workspaceDir = path.join(api.runtime.state.resolveStateDir(), 'workspace');
+  const result = await api.runtime.system.runCommandWithTimeout(
+    [
+      'mcporter',
+      'call',
+      'linear',
+      'list_issues',
+      'limit:8',
+      'orderBy:updatedAt',
+      '--output',
+      'json',
+    ],
+    {
+      timeoutMs: 25_000,
+      cwd: workspaceDir,
+    }
+  );
+
+  if (result.code !== 0) {
+    return {
+      source: 'linear',
+      configured: true,
+      ok: false,
+      summary: summarizeLinearCallFailure(result.stdout, result.stderr),
+      sectionLines: [],
+    };
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(result.stdout);
+  } catch {
+    return {
+      source: 'linear',
+      configured: true,
+      ok: false,
+      summary: 'Linear returned non-JSON output',
+      sectionLines: [],
+    };
+  }
+
+  const issues = normalizeLinearIssues(payload);
+  if (issues.length === 0) {
+    return {
+      source: 'linear',
+      configured: true,
+      ok: true,
+      summary: 'No Linear issues matched the default query',
+      sectionLines: ['- No Linear issues returned.'],
+    };
+  }
+
+  return {
+    source: 'linear',
+    configured: true,
+    ok: true,
+    summary: `Fetched ${issues.length} Linear issues`,
+    sectionLines: issues.map(issue => {
+      const updatedSuffix = issue.updatedAt ? ` (updated ${issue.updatedAt})` : '';
+      return `- [${issue.id}](${issue.url}) ${issue.title} - ${issue.status}${updatedSuffix}`;
+    }),
+  };
+}
+
+async function generateBriefing(
+  api: {
+    runtime: {
+      state: { resolveStateDir: () => string };
+      system: {
+        runCommandWithTimeout: (
+          argv: string[],
+          options: { timeoutMs: number; cwd?: string }
+        ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+      };
+      webSearch: {
+        listProviders: (params?: { config?: unknown }) => Array<{ id?: string }>;
+        search: (params: { args: Record<string, unknown>; config?: unknown }) => Promise<{
+          provider: string;
+          result: Record<string, unknown>;
+        }>;
+      };
+    };
+    config: unknown;
+  },
+  date: Date
+): Promise<{
+  dateKey: string;
+  filePath: string;
+  markdown: string;
+  sources: SourceCollectionResult[];
+  failures: string[];
+}> {
+  const paths = getStatePaths(api);
+  await ensureStorage(paths);
+
+  const [github, linear, web] = await Promise.all([
+    collectGithub(api),
+    collectLinear(api),
+    collectWebSearch(api),
+  ]);
+  const sources = [github, linear, web];
+  const successes = sources.filter(source => source.ok);
+
+  if (successes.length === 0) {
+    throw new Error(
+      'No usable briefing sources are available. Configure at least one of GitHub, Linear, or web search.'
+    );
+  }
+
+  const failures = sources
+    .filter(source => !source.ok)
+    .map(source => `${source.source}: ${source.summary}`);
+  const markdown = buildBriefingMarkdown({
+    date,
+    generatedAt: new Date(),
+    statuses: sources.map(source => ({
+      source: source.source,
+      configured: source.configured,
+      ok: source.ok,
+      summary: source.summary,
+    })),
+    sections: [
+      { title: 'GitHub', lines: github.sectionLines },
+      { title: 'Linear', lines: linear.sectionLines },
+      { title: 'Web Search', lines: web.sectionLines },
+    ],
+    failures,
+  });
+
+  const filePath = resolveBriefingPath(paths.briefingsDir, date);
+  await fs.writeFile(filePath, markdown, 'utf8');
+
+  const dateKey = formatDateKey(date);
+  await writeJsonFile(paths.statusPath, {
+    ...(await readStoredStatus(paths)),
+    lastGeneratedDate: dateKey,
+    lastGeneratedAt: new Date().toISOString(),
+    lastPath: filePath,
+    sourceSummary: sources.map(source => ({
+      source: source.source,
+      configured: source.configured,
+      ok: source.ok,
+      summary: source.summary,
+    })),
+    failures,
+  } satisfies StoredStatus);
+
+  return {
+    dateKey,
+    filePath,
+    markdown,
+    sources,
+    failures,
+  };
+}
+
+async function readBriefingByDate(
+  api: { runtime: { state: { resolveStateDir: () => string } } },
+  date: Date
+): Promise<{ dateKey: string; filePath: string; exists: boolean; markdown: string | null }> {
+  const paths = getStatePaths(api);
+  await ensureStorage(paths);
+  const filePath = resolveBriefingPath(paths.briefingsDir, date);
+  try {
+    const markdown = await fs.readFile(filePath, 'utf8');
+    return {
+      dateKey: formatDateKey(date),
+      filePath,
+      exists: true,
+      markdown,
+    };
+  } catch {
+    return {
+      dateKey: formatDateKey(date),
+      filePath,
+      exists: false,
+      markdown: null,
+    };
+  }
+}
+
+async function getStatusSnapshot(api: {
+  runtime: {
+    state: { resolveStateDir: () => string };
+    system: {
+      runCommandWithTimeout: (
+        argv: string[],
+        options: { timeoutMs: number; cwd?: string }
+      ) => Promise<{ stdout: string; stderr: string; code: number | null }>;
+    };
+    webSearch: {
+      listProviders: (params?: { config?: unknown }) => Array<{ id?: string }>;
+    };
+  };
+  config: {
+    agents?: {
+      defaults?: {
+        userTimezone?: string;
+      };
+    };
+  };
+  pluginConfig?: Record<string, unknown>;
+}): Promise<{
+  enabled: boolean;
+  cron: string;
+  timezone: string;
+  cronJobId: string | null;
+  lastGeneratedDate: string | null;
+  lastGeneratedAt: string | null;
+  sourceReadiness: {
+    github: { configured: boolean; summary: string };
+    linear: { configured: boolean; summary: string };
+    web: { configured: boolean; summary: string };
+  };
+  reconcileState: 'idle' | 'in_progress' | 'succeeded' | 'failed';
+  lastReconcileAt: string | null;
+  lastReconcileError: string | null;
+  lastReconcileAction: 'enable' | 'disable' | null;
+  desiredEnabled: boolean;
+  observedEnabled: boolean | null;
+}> {
+  const paths = getStatePaths(api);
+  await ensureStorage(paths);
+  const config = await readStoredConfig(api, paths);
+  const status = await readStoredStatus(paths);
+  const [github, web] = await Promise.all([resolveGithubReady(api), resolveWebSearchReady(api)]);
+  const linear = resolveLinearReady();
+  const enabled = status.observedEnabled ?? config.enabled;
+
+  return {
+    enabled,
+    cron: config.cron,
+    timezone: config.timezone,
+    cronJobId: config.cronJobId,
+    lastGeneratedDate: status.lastGeneratedDate,
+    lastGeneratedAt: status.lastGeneratedAt,
+    sourceReadiness: {
+      github,
+      linear,
+      web,
+    },
+    reconcileState: status.reconcileState,
+    lastReconcileAt: status.lastReconcileAt,
+    lastReconcileError: status.lastReconcileError,
+    lastReconcileAction: status.lastReconcileAction,
+    desiredEnabled: config.enabled,
+    observedEnabled: status.observedEnabled,
+  };
+}
+
+export default definePluginEntry({
+  id: PLUGIN_ID,
+  name: 'KiloClawMorningBriefing',
+  description: 'Morning briefing plugin for KiloClaw-hosted OpenClaw instances',
+  register(api) {
+    let reconcileInFlight: Promise<void> | null = null;
+    let queuedReconcileAction: 'enable' | 'disable' | null = null;
+
+    const reconcileDesiredState = async (
+      action: 'enable' | 'disable'
+    ): Promise<'succeeded' | 'failed'> => {
+      const paths = getStatePaths(api);
+      await ensureStorage(paths);
+      const startedAt = Date.now();
+
+      await patchStoredStatus(paths, {
+        reconcileState: 'in_progress',
+        lastReconcileError: null,
+        lastReconcileAction: action,
+      });
+
+      try {
+        const config = await readStoredConfig(api, paths);
+
+        if (config.enabled) {
+          const ensured = await ensureCronJob(api, config);
+          const finalConfig: StoredConfig = {
+            ...config,
+            cronJobId: ensured.cronJobId,
+            updatedAt: new Date().toISOString(),
+          };
+          await writeJsonFile(paths.configPath, finalConfig);
+          await patchStoredStatus(paths, {
+            observedEnabled: true,
+            reconcileState: 'succeeded',
+            lastReconcileAt: new Date().toISOString(),
+            lastReconcileError: null,
+            lastReconcileDurationMs: Date.now() - startedAt,
+            lastReconcileAction: action,
+          });
+          return 'succeeded';
+        }
+
+        const jobs = await listBriefingCronJobs(api);
+        const disableErrors: string[] = [];
+        for (const job of jobs) {
+          try {
+            await runCronCommand(api, ['disable', job.id]);
+          } catch (error) {
+            disableErrors.push(
+              `Failed to disable cron ${job.id}: ${error instanceof Error ? error.message : String(error)}`
+            );
+          }
+        }
+        const remainingEnabledJobs = filterEnabledBriefingJobs(await listBriefingCronJobs(api));
+        if (disableErrors.length > 0 || remainingEnabledJobs.length > 0) {
+          const issues: string[] = [];
+          issues.push(...disableErrors);
+          if (remainingEnabledJobs.length > 0) {
+            issues.push(
+              `Cron jobs still enabled after disable: ${remainingEnabledJobs.map(job => job.id).join(', ')}`
+            );
+          }
+          throw new Error(issues.join(' | '));
+        }
+
+        const finalConfig: StoredConfig = {
+          ...config,
+          enabled: false,
+          cronJobId: null,
+          updatedAt: new Date().toISOString(),
+        };
+        await writeJsonFile(paths.configPath, finalConfig);
+        await patchStoredStatus(paths, {
+          observedEnabled: false,
+          reconcileState: 'succeeded',
+          lastReconcileAt: new Date().toISOString(),
+          lastReconcileError: null,
+          lastReconcileDurationMs: Date.now() - startedAt,
+          lastReconcileAction: action,
+        });
+        return 'succeeded';
+      } catch (error) {
+        await patchStoredStatus(paths, {
+          reconcileState: 'failed',
+          lastReconcileAt: new Date().toISOString(),
+          lastReconcileError: error instanceof Error ? error.message : String(error),
+          lastReconcileDurationMs: Date.now() - startedAt,
+          lastReconcileAction: action,
+        });
+        return 'failed';
+      }
+    };
+
+    const triggerReconcile = (action: 'enable' | 'disable') => {
+      if (reconcileInFlight) {
+        queuedReconcileAction = action;
+        return;
+      }
+      const runReconcileLoop = async (initialAction: 'enable' | 'disable') => {
+        let nextAction: 'enable' | 'disable' | null = initialAction;
+
+        while (nextAction) {
+          const reconcileResult = await reconcileDesiredState(nextAction);
+
+          const queuedAction = queuedReconcileAction;
+          queuedReconcileAction = null;
+
+          const paths = getStatePaths(api);
+          await ensureStorage(paths);
+          const [config, status] = await Promise.all([
+            readStoredConfig(api, paths),
+            readStoredStatus(paths),
+          ]);
+
+          nextAction =
+            reconcileResult === 'failed'
+              ? queuedAction
+              : resolveNextReconcileAction({
+                  queuedAction,
+                  desiredEnabled: config.enabled,
+                  observedEnabled: status.observedEnabled,
+                });
+        }
+      };
+
+      reconcileInFlight = runReconcileLoop(action).finally(() => {
+        reconcileInFlight = null;
+      });
+      void reconcileInFlight.catch(error => {
+        api.logger.warn?.(`Morning briefing reconcile failed: ${String(error)}`);
+      });
+    };
+
+    const enableFromInput = async (input: EnableInput) => {
+      const paths = getStatePaths(api);
+      await ensureStorage(paths);
+
+      const current = await readStoredConfig(api, paths);
+      const nextConfig: StoredConfig = {
+        ...current,
+        enabled: true,
+        cron: input.cron?.trim() || current.cron,
+        timezone: input.timezone?.trim() || current.timezone,
+        updatedAt: new Date().toISOString(),
+      };
+
+      await writeJsonFile(paths.configPath, nextConfig);
+      await patchStoredStatus(paths, {
+        reconcileState: 'in_progress',
+        lastReconcileError: null,
+        lastReconcileAction: 'enable',
+      });
+      triggerReconcile('enable');
+      return nextConfig;
+    };
+
+    const enableFromCommand = async (args: string | undefined) => {
+      return enableFromInput(parseEnableArgs(args));
+    };
+
+    const disableFromCommand = async () => {
+      const paths = getStatePaths(api);
+      await ensureStorage(paths);
+      const current = await readStoredConfig(api, paths);
+      const nextConfig: StoredConfig = {
+        ...current,
+        enabled: false,
+        updatedAt: new Date().toISOString(),
+      };
+      await writeJsonFile(paths.configPath, nextConfig);
+      await patchStoredStatus(paths, {
+        reconcileState: 'in_progress',
+        lastReconcileError: null,
+        lastReconcileAction: 'disable',
+      });
+      triggerReconcile('disable');
+      return nextConfig;
+    };
+
+    void (async () => {
+      const paths = getStatePaths(api);
+      await ensureStorage(paths);
+      const [config, status] = await Promise.all([
+        readStoredConfig(api, paths),
+        readStoredStatus(paths),
+      ]);
+      const shouldReconcile =
+        status.reconcileState === 'in_progress' ||
+        config.enabled ||
+        (status.observedEnabled !== null && status.observedEnabled !== config.enabled);
+      if (shouldReconcile) {
+        triggerReconcile(config.enabled ? 'enable' : 'disable');
+      }
+    })();
+
+    const runBriefingCommand = async (argsText: string) => {
+      const args = argsText.trim();
+      const [subcommand = 'status'] = args.split(/\s+/).filter(Boolean);
+
+      if (subcommand === 'enable') {
+        const trailing = args.replace(/^enable\s*/, '');
+        const config = await enableFromCommand(trailing);
+        const status = await readStoredStatus(getStatePaths(api));
+        return [
+          'Morning Briefing enable requested.',
+          `- schedule: ${config.cron}`,
+          `- timezone: ${config.timezone}`,
+          `- apply state: ${status.reconcileState}`,
+        ].join('\n');
+      }
+
+      if (subcommand === 'disable') {
+        const config = await disableFromCommand();
+        const status = await readStoredStatus(getStatePaths(api));
+        return [
+          'Morning Briefing disable requested.',
+          `- schedule retained: ${config.cron} (${config.timezone})`,
+          `- apply state: ${status.reconcileState}`,
+        ].join('\n');
+      }
+
+      if (subcommand === 'run') {
+        const result = await generateBriefing(api, new Date());
+        return [
+          `Generated briefing for ${result.dateKey}.`,
+          `- file: ${result.filePath}`,
+          ...result.failures.map(failure => `- note: ${failure}`),
+        ].join('\n');
+      }
+
+      if (subcommand === 'today' || subcommand === 'yesterday') {
+        const targetDate = offsetDays(new Date(), subcommand === 'today' ? 0 : -1);
+        const briefing = await readBriefingByDate(api, targetDate);
+        if (!briefing.exists || !briefing.markdown) {
+          return `No saved briefing for ${briefing.dateKey}.`;
+        }
+        return briefing.markdown;
+      }
+
+      const status = await getStatusSnapshot(api);
+      return [
+        'Morning Briefing status:',
+        `- enabled: ${status.enabled ? 'yes' : 'no'}`,
+        `- schedule: ${status.cron} (${status.timezone})`,
+        `- cron job id: ${status.cronJobId ?? '(none)'}`,
+        `- desired enabled: ${status.desiredEnabled ? 'yes' : 'no'}`,
+        `- reconcile state: ${status.reconcileState}`,
+        `- last generated: ${status.lastGeneratedDate ?? '(none)'}`,
+        `- github: ${status.sourceReadiness.github.configured ? 'ready' : 'not ready'} (${status.sourceReadiness.github.summary})`,
+        `- linear: ${status.sourceReadiness.linear.configured ? 'configured' : 'not configured'} (${status.sourceReadiness.linear.summary})`,
+        `- web search: ${status.sourceReadiness.web.configured ? 'ready' : 'not ready'} (${status.sourceReadiness.web.summary})`,
+      ].join('\n');
+    };
+
+    api.registerCommand({
+      name: 'briefing',
+      description: 'Manage and run KiloClaw Morning Briefings',
+      acceptsArgs: true,
+      handler: async ctx => {
+        return {
+          text: await runBriefingCommand(ctx.args ?? ''),
+        };
+      },
+    });
+
+    api.registerTool({
+      name: 'morning_briefing_handle_command',
+      description:
+        'Deterministically handles /briefing commands from raw inbound text when slash routing fails.',
+      parameters: Type.Object(
+        {
+          message: Type.String({
+            description:
+              'Raw inbound user text that may include wrapper metadata and a /briefing command.',
+            minLength: 1,
+          }),
+        },
+        { additionalProperties: false }
+      ),
+      async execute(_toolCallId, params) {
+        const commandArgs = extractBriefingArgsFromText(params.message);
+        if (commandArgs === null) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'No /briefing command found in the provided message.',
+              },
+            ],
+          };
+        }
+
+        const resultText = await runBriefingCommand(commandArgs);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: resultText,
+            },
+          ],
+        };
+      },
+    });
+
+    api.registerTool({
+      name: 'morning_briefing_generate',
+      description:
+        "Generate today's morning briefing from configured sources and persist it as Markdown.",
+      parameters: Type.Object(
+        {
+          date: Type.Optional(
+            Type.String({
+              description: 'Optional local date key in YYYY-MM-DD format',
+              pattern: '^\\d{4}-\\d{2}-\\d{2}$',
+            })
+          ),
+        },
+        { additionalProperties: false }
+      ),
+      async execute(_toolCallId, params) {
+        const dateValue = typeof params.date === 'string' ? params.date : undefined;
+        const targetDate = dateValue ? new Date(`${dateValue}T08:00:00`) : new Date();
+        const result = await generateBriefing(api, targetDate);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: [
+                `Morning briefing generated for ${result.dateKey}.`,
+                `Saved to ${result.filePath}.`,
+                ...result.failures.map(failure => `Note: ${failure}`),
+              ].join('\n'),
+            },
+          ],
+        };
+      },
+    });
+
+    api.registerTool({
+      name: 'morning_briefing_read',
+      description: 'Read a saved morning briefing Markdown file for a specific date.',
+      parameters: Type.Object(
+        {
+          day: Type.Optional(
+            Type.Union([
+              Type.Literal('today'),
+              Type.Literal('yesterday'),
+              Type.String({ pattern: '^\\d{4}-\\d{2}-\\d{2}$' }),
+            ])
+          ),
+        },
+        { additionalProperties: false }
+      ),
+      async execute(_toolCallId, params) {
+        const rawDay = typeof params.day === 'string' ? params.day : 'today';
+        const date =
+          rawDay === 'yesterday'
+            ? offsetDays(new Date(), -1)
+            : rawDay === 'today'
+              ? new Date()
+              : new Date(`${rawDay}T08:00:00`);
+        const briefing = await readBriefingByDate(api, date);
+        if (!briefing.exists || !briefing.markdown) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `No briefing exists for ${briefing.dateKey}.`,
+              },
+            ],
+          };
+        }
+        return {
+          content: [
+            {
+              type: 'text',
+              text: briefing.markdown,
+            },
+          ],
+        };
+      },
+    });
+
+    api.registerHttpRoute({
+      path: '/api/plugins/kiloclaw-morning-briefing/status',
+      auth: 'gateway',
+      match: 'exact',
+      handler: async (_req, res) => {
+        try {
+          const snapshot = await getStatusSnapshot(api);
+          sendJson(res, 200, {
+            ok: true,
+            ...snapshot,
+          });
+        } catch (error) {
+          sendJson(res, 500, {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+    });
+
+    api.registerHttpRoute({
+      path: '/api/plugins/kiloclaw-morning-briefing/enable',
+      auth: 'gateway',
+      match: 'exact',
+      handler: async (req, res) => {
+        try {
+          const body = asObject(await readRequestBody(req));
+          const cron = typeof body.cron === 'string' ? body.cron.trim() : undefined;
+          const timezone = typeof body.timezone === 'string' ? body.timezone.trim() : undefined;
+          const result = await enableFromInput({ cron, timezone });
+          const status = await readStoredStatus(getStatePaths(api));
+          sendJson(res, 200, {
+            ok: true,
+            enabled: result.enabled,
+            cron: result.cron,
+            timezone: result.timezone,
+            cronJobId: result.cronJobId,
+            reconcileState: status.reconcileState,
+            message: 'Enable requested. Reconciliation is running in background.',
+          });
+        } catch (error) {
+          sendJson(res, 500, {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+    });
+
+    api.registerHttpRoute({
+      path: '/api/plugins/kiloclaw-morning-briefing/disable',
+      auth: 'gateway',
+      match: 'exact',
+      handler: async (_req, res) => {
+        try {
+          const result = await disableFromCommand();
+          const status = await readStoredStatus(getStatePaths(api));
+          sendJson(res, 200, {
+            ok: true,
+            enabled: result.enabled,
+            cron: result.cron,
+            timezone: result.timezone,
+            reconcileState: status.reconcileState,
+            message: 'Disable requested. Reconciliation is running in background.',
+          });
+        } catch (error) {
+          sendJson(res, 500, {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+    });
+
+    api.registerHttpRoute({
+      path: '/api/plugins/kiloclaw-morning-briefing/run',
+      auth: 'gateway',
+      match: 'exact',
+      handler: async (_req, res) => {
+        try {
+          const result = await generateBriefing(api, new Date());
+          sendJson(res, 200, {
+            ok: true,
+            date: result.dateKey,
+            filePath: result.filePath,
+            failures: result.failures,
+          });
+        } catch (error) {
+          sendJson(res, 500, {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+    });
+
+    api.registerHttpRoute({
+      path: '/api/plugins/kiloclaw-morning-briefing/read/today',
+      auth: 'gateway',
+      match: 'exact',
+      handler: async (_req, res) => {
+        try {
+          const result = await readBriefingByDate(api, new Date());
+          sendJson(res, 200, {
+            ok: true,
+            ...result,
+          });
+        } catch (error) {
+          sendJson(res, 500, {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+    });
+
+    api.registerHttpRoute({
+      path: '/api/plugins/kiloclaw-morning-briefing/read/yesterday',
+      auth: 'gateway',
+      match: 'exact',
+      handler: async (_req, res) => {
+        try {
+          const result = await readBriefingByDate(api, offsetDays(new Date(), -1));
+          sendJson(res, 200, {
+            ok: true,
+            ...result,
+          });
+        } catch (error) {
+          sendJson(res, 500, {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+    });
+
+    api.on('before_prompt_build', () => ({
+      appendSystemContext: [
+        'Morning Briefing plugin is installed.',
+        'Use /briefing enable|status|run|today|yesterday|disable for command-driven control.',
+        'If inbound text contains /briefing but command routing did not execute, call morning_briefing_handle_command exactly once with the full raw inbound message.',
+        'Never emulate /briefing by manually calling generic cron/file tools.',
+      ].join('\n'),
+    }));
+  },
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -2,12 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Type } from '@sinclair/typebox';
 import { definePluginEntry } from 'openclaw/plugin-sdk/plugin-entry';
-import {
-  buildBriefingMarkdown,
-  formatDateKey,
-  offsetDays,
-  resolveBriefingPath,
-} from './briefing-utils';
+import { buildBriefingMarkdown, offsetDateKey, resolveBriefingPath } from './briefing-utils';
 import {
   filterEnabledBriefingJobs,
   pickCanonicalCronJobId,
@@ -25,6 +20,7 @@ const CRON_PROMPT =
   'Call the tool morning_briefing_generate exactly once with no arguments. Do not call any other tool.';
 const DEFAULT_CRON = '0 7 * * *';
 const DEFAULT_TIMEZONE = 'UTC';
+const statusWriteQueueByPath = new Map<string, Promise<unknown>>();
 
 type BriefingPluginConfig = {
   defaultCron?: string;
@@ -360,17 +356,32 @@ async function readStoredStatus(paths: { statusPath: string }): Promise<StoredSt
   };
 }
 
+async function queueStatusWrite<T>(statusPath: string, work: () => Promise<T>): Promise<T> {
+  const previous = statusWriteQueueByPath.get(statusPath) ?? Promise.resolve();
+  const next = previous.catch(() => undefined).then(work);
+  statusWriteQueueByPath.set(statusPath, next);
+  try {
+    return await next;
+  } finally {
+    if (statusWriteQueueByPath.get(statusPath) === next) {
+      statusWriteQueueByPath.delete(statusPath);
+    }
+  }
+}
+
 async function patchStoredStatus(
   paths: { statusPath: string },
   patch: Partial<StoredStatus>
 ): Promise<StoredStatus> {
-  const current = await readStoredStatus(paths);
-  const next: StoredStatus = {
-    ...current,
-    ...patch,
-  };
-  await writeJsonFile(paths.statusPath, next);
-  return next;
+  return queueStatusWrite(paths.statusPath, async () => {
+    const current = await readStoredStatus(paths);
+    const next: StoredStatus = {
+      ...current,
+      ...patch,
+    };
+    await writeJsonFile(paths.statusPath, next);
+    return next;
+  });
 }
 
 async function ensureCronJob(
@@ -768,7 +779,7 @@ async function generateBriefing(
     };
     config: unknown;
   },
-  date: Date
+  dateKey: string
 ): Promise<{
   dateKey: string;
   filePath: string;
@@ -797,7 +808,7 @@ async function generateBriefing(
     .filter(source => !source.ok)
     .map(source => `${source.source}: ${source.summary}`);
   const markdown = buildBriefingMarkdown({
-    date,
+    dateKey,
     generatedAt: new Date(),
     statuses: sources.map(source => ({
       source: source.source,
@@ -813,12 +824,10 @@ async function generateBriefing(
     failures,
   });
 
-  const filePath = resolveBriefingPath(paths.briefingsDir, date);
+  const filePath = resolveBriefingPath(paths.briefingsDir, dateKey);
   await fs.writeFile(filePath, markdown, 'utf8');
 
-  const dateKey = formatDateKey(date);
-  await writeJsonFile(paths.statusPath, {
-    ...(await readStoredStatus(paths)),
+  await patchStoredStatus(paths, {
     lastGeneratedDate: dateKey,
     lastGeneratedAt: new Date().toISOString(),
     lastPath: filePath,
@@ -829,7 +838,7 @@ async function generateBriefing(
       summary: source.summary,
     })),
     failures,
-  } satisfies StoredStatus);
+  });
 
   return {
     dateKey,
@@ -840,29 +849,49 @@ async function generateBriefing(
   };
 }
 
-async function readBriefingByDate(
+async function readBriefingByDateKey(
   api: { runtime: { state: { resolveStateDir: () => string } } },
-  date: Date
+  dateKey: string
 ): Promise<{ dateKey: string; filePath: string; exists: boolean; markdown: string | null }> {
   const paths = getStatePaths(api);
   await ensureStorage(paths);
-  const filePath = resolveBriefingPath(paths.briefingsDir, date);
+  const filePath = resolveBriefingPath(paths.briefingsDir, dateKey);
   try {
     const markdown = await fs.readFile(filePath, 'utf8');
     return {
-      dateKey: formatDateKey(date),
+      dateKey,
       filePath,
       exists: true,
       markdown,
     };
   } catch {
     return {
-      dateKey: formatDateKey(date),
+      dateKey,
       filePath,
       exists: false,
       markdown: null,
     };
   }
+}
+
+async function resolveDateKeyForOffset(
+  api: {
+    runtime: { state: { resolveStateDir: () => string } };
+    config: {
+      agents?: {
+        defaults?: {
+          userTimezone?: string;
+        };
+      };
+    };
+    pluginConfig?: Record<string, unknown>;
+  },
+  offset: number
+): Promise<string> {
+  const paths = getStatePaths(api);
+  await ensureStorage(paths);
+  const config = await readStoredConfig(api, paths);
+  return offsetDateKey(new Date(), offset, config.timezone);
 }
 
 async function getStatusSnapshot(api: {
@@ -1157,7 +1186,8 @@ export default definePluginEntry({
       }
 
       if (subcommand === 'run') {
-        const result = await generateBriefing(api, new Date());
+        const dateKey = await resolveDateKeyForOffset(api, 0);
+        const result = await generateBriefing(api, dateKey);
         return [
           `Generated briefing for ${result.dateKey}.`,
           `- file: ${result.filePath}`,
@@ -1166,8 +1196,8 @@ export default definePluginEntry({
       }
 
       if (subcommand === 'today' || subcommand === 'yesterday') {
-        const targetDate = offsetDays(new Date(), subcommand === 'today' ? 0 : -1);
-        const briefing = await readBriefingByDate(api, targetDate);
+        const targetDateKey = await resolveDateKeyForOffset(api, subcommand === 'today' ? 0 : -1);
+        const briefing = await readBriefingByDateKey(api, targetDateKey);
         if (!briefing.exists || !briefing.markdown) {
           return `No saved briefing for ${briefing.dateKey}.`;
         }
@@ -1256,8 +1286,8 @@ export default definePluginEntry({
       ),
       async execute(_toolCallId, params) {
         const dateValue = typeof params.date === 'string' ? params.date : undefined;
-        const targetDate = dateValue ? new Date(`${dateValue}T08:00:00`) : new Date();
-        const result = await generateBriefing(api, targetDate);
+        const targetDateKey = dateValue ?? (await resolveDateKeyForOffset(api, 0));
+        const result = await generateBriefing(api, targetDateKey);
         return {
           content: [
             {
@@ -1290,13 +1320,13 @@ export default definePluginEntry({
       ),
       async execute(_toolCallId, params) {
         const rawDay = typeof params.day === 'string' ? params.day : 'today';
-        const date =
+        const dateKey =
           rawDay === 'yesterday'
-            ? offsetDays(new Date(), -1)
+            ? await resolveDateKeyForOffset(api, -1)
             : rawDay === 'today'
-              ? new Date()
-              : new Date(`${rawDay}T08:00:00`);
-        const briefing = await readBriefingByDate(api, date);
+              ? await resolveDateKeyForOffset(api, 0)
+              : rawDay;
+        const briefing = await readBriefingByDateKey(api, dateKey);
         if (!briefing.exists || !briefing.markdown) {
           return {
             content: [
@@ -1398,7 +1428,8 @@ export default definePluginEntry({
       match: 'exact',
       handler: async (_req, res) => {
         try {
-          const result = await generateBriefing(api, new Date());
+          const dateKey = await resolveDateKeyForOffset(api, 0);
+          const result = await generateBriefing(api, dateKey);
           sendJson(res, 200, {
             ok: true,
             date: result.dateKey,
@@ -1420,7 +1451,8 @@ export default definePluginEntry({
       match: 'exact',
       handler: async (_req, res) => {
         try {
-          const result = await readBriefingByDate(api, new Date());
+          const dateKey = await resolveDateKeyForOffset(api, 0);
+          const result = await readBriefingByDateKey(api, dateKey);
           sendJson(res, 200, {
             ok: true,
             ...result,
@@ -1440,7 +1472,8 @@ export default definePluginEntry({
       match: 'exact',
       handler: async (_req, res) => {
         try {
-          const result = await readBriefingByDate(api, offsetDays(new Date(), -1));
+          const dateKey = await resolveDateKeyForOffset(api, -1);
+          const result = await readBriefingByDateKey(api, dateKey);
           sendJson(res, 200, {
             ok: true,
             ...result,

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -267,6 +267,20 @@ function resolveDefaults(api: {
   };
 }
 
+function resolveEffectiveTimezone(
+  api: { logger: { warn?: (message: string) => void } },
+  timezone: string,
+  context: 'enable' | 'schedule' | 'date'
+): string {
+  if (isValidTimezone(timezone)) {
+    return timezone;
+  }
+  api.logger.warn?.(
+    `Morning briefing: invalid configured timezone "${timezone}" during ${context}; falling back to ${DEFAULT_TIMEZONE}`
+  );
+  return DEFAULT_TIMEZONE;
+}
+
 async function readStoredConfig(
   api: {
     runtime: { state: { resolveStateDir: () => string } };
@@ -398,6 +412,7 @@ async function ensureCronJob(
   },
   config: StoredConfig
 ): Promise<{ cronJobId: string; cron: string; timezone: string }> {
+  const timezone = resolveEffectiveTimezone(api, config.timezone, 'schedule');
   const existingJobs = await listBriefingCronJobs(api);
   let cronJobId = pickCanonicalCronJobId(existingJobs, config.cronJobId);
 
@@ -413,13 +428,13 @@ async function ensureCronJob(
         '--cron',
         config.cron,
         '--tz',
-        config.timezone,
+        timezone,
         '--tools',
         'morning_briefing_generate',
         '--no-deliver',
       ]);
       await removeDuplicateBriefingCronJobs(api, cronJobId);
-      return { cronJobId, cron: config.cron, timezone: config.timezone };
+      return { cronJobId, cron: config.cron, timezone };
     } catch (error) {
       api.logger.warn?.(
         `Morning briefing: existing cron edit failed (${String(error)}), recreating.`
@@ -439,7 +454,7 @@ async function ensureCronJob(
     '--cron',
     config.cron,
     '--tz',
-    config.timezone,
+    timezone,
     '--tools',
     'morning_briefing_generate',
     '--no-deliver',
@@ -458,7 +473,7 @@ async function ensureCronJob(
   return {
     cronJobId: resolvedId,
     cron: config.cron,
-    timezone: config.timezone,
+    timezone,
   };
 }
 
@@ -892,13 +907,8 @@ async function resolveDateKeyForOffset(
   const paths = getStatePaths(api);
   await ensureStorage(paths);
   const config = await readStoredConfig(api, paths);
-  if (!isValidTimezone(config.timezone)) {
-    api.logger.warn?.(
-      `Morning briefing: invalid configured timezone \"${config.timezone}\", falling back to ${DEFAULT_TIMEZONE}`
-    );
-    return offsetDateKey(new Date(), offset, DEFAULT_TIMEZONE);
-  }
-  return offsetDateKey(new Date(), offset, config.timezone);
+  const timezone = resolveEffectiveTimezone(api, config.timezone, 'date');
+  return offsetDateKey(new Date(), offset, timezone);
 }
 
 async function getStatusSnapshot(api: {
@@ -999,6 +1009,8 @@ export default definePluginEntry({
           const finalConfig: StoredConfig = {
             ...config,
             cronJobId: ensured.cronJobId,
+            cron: ensured.cron,
+            timezone: ensured.timezone,
             updatedAt: new Date().toISOString(),
           };
           await writeJsonFile(paths.configPath, finalConfig);
@@ -1113,11 +1125,14 @@ export default definePluginEntry({
       if (requestedTimezone && !isValidTimezone(requestedTimezone)) {
         throw new Error(`Invalid timezone: ${requestedTimezone}`);
       }
+      const timezone = requestedTimezone
+        ? requestedTimezone
+        : resolveEffectiveTimezone(api, current.timezone, 'enable');
       const nextConfig: StoredConfig = {
         ...current,
         enabled: true,
         cron: input.cron?.trim() || current.cron,
-        timezone: requestedTimezone || current.timezone,
+        timezone,
         updatedAt: new Date().toISOString(),
       };
 

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -9,7 +9,7 @@ import {
   selectMorningBriefingJobs,
 } from './cron-utils';
 import { extractBriefingArgsFromText } from './command-fallback-utils';
-import { type EnableInput, parseEnableArgs } from './enable-input-utils';
+import { type EnableInput, isValidTimezone, parseEnableArgs } from './enable-input-utils';
 import { normalizeLinearIssues, summarizeLinearCallFailure } from './linear-utils';
 import { resolveNextReconcileAction } from './reconcile-queue-utils';
 import { normalizeWebResults } from './web-utils';
@@ -885,12 +885,19 @@ async function resolveDateKeyForOffset(
       };
     };
     pluginConfig?: Record<string, unknown>;
+    logger: { warn?: (message: string) => void };
   },
   offset: number
 ): Promise<string> {
   const paths = getStatePaths(api);
   await ensureStorage(paths);
   const config = await readStoredConfig(api, paths);
+  if (!isValidTimezone(config.timezone)) {
+    api.logger.warn?.(
+      `Morning briefing: invalid configured timezone \"${config.timezone}\", falling back to ${DEFAULT_TIMEZONE}`
+    );
+    return offsetDateKey(new Date(), offset, DEFAULT_TIMEZONE);
+  }
   return offsetDateKey(new Date(), offset, config.timezone);
 }
 
@@ -1102,11 +1109,15 @@ export default definePluginEntry({
       await ensureStorage(paths);
 
       const current = await readStoredConfig(api, paths);
+      const requestedTimezone = input.timezone?.trim();
+      if (requestedTimezone && !isValidTimezone(requestedTimezone)) {
+        throw new Error(`Invalid timezone: ${requestedTimezone}`);
+      }
       const nextConfig: StoredConfig = {
         ...current,
         enabled: true,
         cron: input.cron?.trim() || current.cron,
-        timezone: input.timezone?.trim() || current.timezone,
+        timezone: requestedTimezone || current.timezone,
         updatedAt: new Date().toISOString(),
       };
 

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/index.ts
@@ -1415,6 +1415,13 @@ export default definePluginEntry({
             message: 'Enable requested. Reconciliation is running in background.',
           });
         } catch (error) {
+          if (error instanceof Error && error.message.startsWith('Invalid timezone:')) {
+            sendJson(res, 400, {
+              ok: false,
+              error: error.message,
+            });
+            return;
+          }
           sendJson(res, 500, {
             ok: false,
             error: error instanceof Error ? error.message : String(error),

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeLinearIssues, summarizeLinearCallFailure } from './linear-utils';
+
+describe('linear-utils', () => {
+  it('normalizes list_issues payload into concise issue summaries', () => {
+    const issues = normalizeLinearIssues({
+      issues: [
+        {
+          id: 'TES-1',
+          title: 'Get familiar with Linear',
+          status: 'Todo',
+          url: 'https://linear.app/example/issue/TES-1',
+          updatedAt: '2026-04-23T22:28:59.657Z',
+        },
+      ],
+    });
+
+    expect(issues).toEqual([
+      {
+        id: 'TES-1',
+        title: 'Get familiar with Linear',
+        status: 'Todo',
+        url: 'https://linear.app/example/issue/TES-1',
+        updatedAt: '2026-04-23T22:28:59.657Z',
+      },
+    ]);
+  });
+
+  it('summarizes auth errors from mcporter JSON payloads', () => {
+    const summary = summarizeLinearCallFailure(
+      JSON.stringify({
+        server: 'linear',
+        tool: 'list_issues',
+        error: 'SSE error: Non-200 status code (401)',
+        issue: { kind: 'auth', statusCode: 401 },
+      }),
+      ''
+    );
+
+    expect(summary).toBe('Linear authentication failed (check LINEAR_API_KEY and redeploy)');
+  });
+
+  it('falls back to combined stderr/stdout for non-JSON errors', () => {
+    const summary = summarizeLinearCallFailure('', 'mcporter: Unknown tool list_issues_typo');
+    expect(summary).toContain('Unknown tool');
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/linear-utils.ts
@@ -1,0 +1,65 @@
+export type LinearIssueSummary = {
+  id: string;
+  title: string;
+  status: string;
+  url: string;
+  updatedAt?: string;
+};
+
+function asObject(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export function normalizeLinearIssues(payload: unknown): LinearIssueSummary[] {
+  const root = asObject(payload);
+  const issues = Array.isArray(root.issues) ? root.issues : [];
+  return issues
+    .map(raw => asObject(raw))
+    .map(issue => ({
+      id: typeof issue.id === 'string' ? issue.id : '',
+      title: typeof issue.title === 'string' ? issue.title : '(untitled)',
+      status: typeof issue.status === 'string' ? issue.status : 'Unknown',
+      url: typeof issue.url === 'string' ? issue.url : '',
+      updatedAt: typeof issue.updatedAt === 'string' ? issue.updatedAt : undefined,
+    }))
+    .filter(issue => issue.id.length > 0);
+}
+
+export function summarizeLinearCallFailure(stdout: string, stderr: string): string {
+  const parsed = tryParseJson(stdout);
+  if (parsed) {
+    const issue = asObject(parsed.issue);
+    const kind = typeof issue.kind === 'string' ? issue.kind : null;
+    const statusCode = typeof issue.statusCode === 'number' ? issue.statusCode : null;
+    if (kind === 'auth' || statusCode === 401) {
+      return 'Linear authentication failed (check LINEAR_API_KEY and redeploy)';
+    }
+    if (kind === 'offline') {
+      return 'Linear MCP server is unavailable or timed out';
+    }
+    if (typeof parsed.error === 'string' && parsed.error.trim().length > 0) {
+      return parsed.error.trim();
+    }
+  }
+
+  const combined = [stderr.trim(), stdout.trim()].filter(Boolean).join(' | ').trim();
+  if (!combined) {
+    return 'Linear query failed';
+  }
+  return combined.length > 220 ? `${combined.slice(0, 217)}...` : combined;
+}
+
+function tryParseJson(raw: string): Record<string, unknown> | null {
+  const text = raw.trim();
+  if (!text) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(text);
+    return asObject(parsed);
+  } catch {
+    return null;
+  }
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/reconcile-queue-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/reconcile-queue-utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { resolveNextReconcileAction } from './reconcile-queue-utils';
+
+describe('reconcile-queue-utils', () => {
+  it('prefers queued action while a reconcile loop is active', () => {
+    expect(
+      resolveNextReconcileAction({
+        queuedAction: 'disable',
+        desiredEnabled: true,
+        observedEnabled: true,
+      })
+    ).toBe('disable');
+  });
+
+  it('requests follow-up reconcile when observed diverges from desired', () => {
+    expect(
+      resolveNextReconcileAction({
+        queuedAction: null,
+        desiredEnabled: false,
+        observedEnabled: true,
+      })
+    ).toBe('disable');
+  });
+
+  it('returns null when state is already converged', () => {
+    expect(
+      resolveNextReconcileAction({
+        queuedAction: null,
+        desiredEnabled: true,
+        observedEnabled: true,
+      })
+    ).toBeNull();
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/reconcile-queue-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/reconcile-queue-utils.ts
@@ -1,0 +1,21 @@
+export type ReconcileAction = 'enable' | 'disable';
+
+export function resolveNextReconcileAction(params: {
+  queuedAction: ReconcileAction | null;
+  desiredEnabled: boolean;
+  observedEnabled: boolean | null;
+}): ReconcileAction | null {
+  if (params.queuedAction) {
+    return params.queuedAction;
+  }
+
+  if (params.observedEnabled === null) {
+    return null;
+  }
+
+  if (params.observedEnabled !== params.desiredEnabled) {
+    return params.desiredEnabled ? 'enable' : 'disable';
+  }
+
+  return null;
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/web-utils.test.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/web-utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeWebResults } from './web-utils';
+
+describe('web-utils', () => {
+  it('strips external wrapper markers and truncates noisy summaries', () => {
+    const results = normalizeWebResults({
+      results: [
+        {
+          title:
+            '<<<EXTERNAL_UNTRUSTED_CONTENT id="x">>>\nSource: Web Search\n---\nVercel Flags is now generally available\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id="x">>>',
+          url: 'https://vercel.com/changelog/vercel-flags-ga',
+          description:
+            '<<<EXTERNAL_UNTRUSTED_CONTENT id="y">>>\nSource: Web Search\n---\n# Vercel Flags is now generally available\n[...]\nPublished: April 16, 2026\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id="y">>>',
+        },
+      ],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe('Vercel Flags is now generally available');
+    expect(results[0].summary.includes('EXTERNAL_UNTRUSTED_CONTENT')).toBe(false);
+  });
+
+  it('falls back to hostname when title is empty', () => {
+    const results = normalizeWebResults({
+      results: [
+        {
+          url: 'https://example.com/news',
+          summary: 'Simple summary',
+        },
+      ],
+    });
+
+    expect(results[0].title).toBe('example.com');
+  });
+});

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/web-utils.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/src/web-utils.ts
@@ -1,0 +1,66 @@
+export type WebResultSummary = {
+  title: string;
+  url: string;
+  summary: string;
+};
+
+function asObject(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stripUntrustedWrappers(text: string): string {
+  return text
+    .replace(/<<<EXTERNAL_UNTRUSTED_CONTENT[^>]*>>>/g, ' ')
+    .replace(/<<<END_EXTERNAL_UNTRUSTED_CONTENT[^>]*>>>/g, ' ')
+    .replace(/Source:\s*Web Search/gi, ' ')
+    .replace(/\[\.\.\.\]/g, ' ')
+    .replace(/---/g, ' ');
+}
+
+function normalizeText(text: string): string {
+  return stripUntrustedWrappers(text).replace(/\s+/g, ' ').trim();
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max - 3).trimEnd()}...`;
+}
+
+function hostnameFromUrl(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return 'result';
+  }
+}
+
+export function normalizeWebResults(payload: unknown): WebResultSummary[] {
+  const root = asObject(payload);
+  const results = Array.isArray(root.results) ? root.results : [];
+  return results
+    .map(raw => asObject(raw))
+    .map(item => {
+      const url = typeof item.url === 'string' ? item.url : '';
+      const rawTitle = typeof item.title === 'string' ? item.title : '';
+      const rawSummary =
+        typeof item.summary === 'string'
+          ? item.summary
+          : typeof item.description === 'string'
+            ? item.description
+            : '';
+      const normalizedTitle = normalizeText(rawTitle);
+      const normalizedSummary = normalizeText(rawSummary);
+      const title = truncate(normalizedTitle || hostnameFromUrl(url) || '(untitled)', 140);
+      const summary = truncate(normalizedSummary, 280);
+      return {
+        title,
+        url,
+        summary,
+      };
+    })
+    .filter(item => item.url.length > 0);
+}

--- a/services/kiloclaw/plugins/kiloclaw-morning-briefing/vitest.config.ts
+++ b/services/kiloclaw/plugins/kiloclaw-morning-briefing/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -268,6 +268,8 @@ function fetchInputUrl(input: Parameters<typeof fetch>[0]): string {
   return input.url;
 }
 
+const backgroundWaitUntilPromises: Promise<unknown>[] = [];
+
 function createInstance(
   storage = createFakeStorage(),
   env = createFakeEnv()
@@ -281,6 +283,7 @@ function createInstance(
     storage,
     waitUntil: (p: Promise<unknown>) => {
       waitUntilPromises.push(p);
+      backgroundWaitUntilPromises.push(p);
     },
   } as unknown;
   const instance = new KiloClawInstance(
@@ -428,7 +431,9 @@ beforeEach(() => {
   );
 });
 
-afterEach(() => {
+afterEach(async () => {
+  await Promise.allSettled(backgroundWaitUntilPromises.splice(0));
+  vi.unstubAllGlobals();
   vi.useRealTimers();
 });
 
@@ -8524,9 +8529,10 @@ describe('updateBotIdentity', () => {
         }),
       })
     );
-    expect(calls).toEqual(['put:true', 'fetch', 'put:false']);
+    expect(calls[0]).toBe('put:true');
+    expect(calls[calls.length - 1]).toBe('put:false');
+    expect(calls.filter(call => call === 'fetch').length).toBeGreaterThanOrEqual(1);
     expect(storage._store.get('botIdentityApplyPending')).toBe(false);
-    vi.unstubAllGlobals();
   });
 
   it('sets botIdentityApplyPending while status=starting and does not call the gateway', async () => {


### PR DESCRIPTION
## Summary
- Add a new bundled OpenClaw plugin package at `services/kiloclaw/plugins/kiloclaw-morning-briefing` with Morning Briefing command/tool lifecycle, persisted markdown output, and source collection logic.
- Wire the plugin into KiloClaw image build/runtime paths by updating Dockerfiles, controller route registration, config writer defaults, and deployment hash inputs.
- Ensure Morning Briefing runtime endpoints are available inside newly provisioned instances from this image line.

## Verification
- Built and validated plugin/runtime behavior locally in the KiloClaw service environment while iterating on real hosted instances.
- Manually verified command flow inside provisioned instances (`/briefing enable|status|run|today|disable`) after deploying this image line.

## Visual Changes
- N/A

## Reviewer Notes
- This PR is intentionally image/runtime focused so production image rollout can happen independently before dashboard gating and UX follow-up work.
- Follow-up stacked PR (`feat/kiloclaw-morning-briefing-app`) contains dashboard/worker integration and UX-state refinements and should merge after this one.