### PR TITLE
feat(kiloclaw): add Morning Briefing dashboard integration

### DIFF
--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -712,7 +712,7 @@ function MorningBriefingCard({
         </div>
       </div>
 
-      {!actionsReady && (
+      {isWarmupState && (
         <p className="text-muted-foreground mt-2 text-xs">
           Instance is still warming up. Morning Briefing controls will become available once the
           gateway is fully ready.

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -26,7 +26,14 @@ import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombob
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { calverAtLeast, cleanVersion } from '@/lib/kiloclaw/version';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
-import { useClawConfig, useClawMyPin, useClawGoogleSetupCommand } from '../hooks/useClawHooks';
+import {
+  useClawConfig,
+  useClawMyPin,
+  useClawGoogleSetupCommand,
+  useClawGatewayReady,
+  useClawMorningBriefingStatus,
+  useClawReadMorningBriefing,
+} from '../hooks/useClawHooks';
 import { useClawUpdateAvailable } from '../hooks/useClawUpdateAvailable';
 import { useClawContext } from './ClawContext';
 
@@ -77,6 +84,44 @@ type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 const EXA_SEARCH_UI_MIN_CONTROLLER_VERSION = '2026.4.14';
 const MEMORY_MIN_OPENCLAW_VERSION = '2026.4.5';
 const OPENCLAW_IMPORT_UI_MIN_CONTROLLER_VERSION = '2026.4.22';
+
+function formatMorningBriefingSchedule(cron: string, timezone: string): string {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    return `Schedule: ${cron} (${timezone})`;
+  }
+
+  const [minuteRaw, hourRaw, dayOfMonth, month, dayOfWeek] = parts;
+  const minute = Number.parseInt(minuteRaw, 10);
+  const hour24 = Number.parseInt(hourRaw, 10);
+
+  const isDaily = dayOfMonth === '*' && month === '*' && dayOfWeek === '*';
+  const isValidTime =
+    Number.isInteger(minute) &&
+    Number.isInteger(hour24) &&
+    minute >= 0 &&
+    minute <= 59 &&
+    hour24 >= 0 &&
+    hour24 <= 23;
+
+  if (!isDaily || !isValidTime) {
+    return `Schedule: ${cron} (${timezone})`;
+  }
+
+  const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+  const meridiem = hour24 >= 12 ? 'PM' : 'AM';
+  const timeLabel = `${hour12}:${String(minute).padStart(2, '0')} ${meridiem}`;
+  const timezoneLabel = timezone === 'America/Chicago' ? 'CT' : timezone;
+
+  return `Automatically runs daily at ${timeLabel} ${timezoneLabel}`;
+}
+
+function joinFriendlyList(items: string[]): string {
+  if (items.length === 0) return '';
+  if (items.length === 1) return items[0];
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
+}
 
 // ---------------------------------------------------------------------------
 // 1Password setup guide dialog
@@ -444,6 +489,260 @@ function GoogleAccountCard({
         }}
       />
     </>
+  );
+}
+
+function MorningBriefingCard({
+  mutations,
+  briefingStatus,
+  fallbackReadiness,
+  isRunning,
+  actionsReady,
+}: {
+  mutations: ClawMutations;
+  briefingStatus:
+    | {
+        enabled?: boolean;
+        desiredEnabled?: boolean;
+        observedEnabled?: boolean | null;
+        reconcileState?: 'idle' | 'in_progress' | 'succeeded' | 'failed';
+        lastReconcileAction?: 'enable' | 'disable' | null;
+        code?: string;
+        cron?: string;
+        timezone?: string;
+        lastGeneratedDate?: string | null;
+        sourceReadiness?: {
+          github: { configured: boolean; summary: string };
+          linear: { configured: boolean; summary: string };
+          web: { configured: boolean; summary: string };
+        };
+      }
+    | undefined;
+  fallbackReadiness: {
+    githubConfigured: boolean;
+    linearConfigured: boolean;
+    webConfigured: boolean;
+  };
+  isRunning: boolean;
+  actionsReady: boolean;
+}) {
+  const [requestedDay, setRequestedDay] = useState<'today' | 'yesterday' | null>(null);
+  const { data: readData, isFetching: isReading } = useClawReadMorningBriefing(requestedDay, true);
+
+  const sourceReadiness =
+    briefingStatus?.sourceReadiness ??
+    ({
+      github: {
+        configured: fallbackReadiness.githubConfigured,
+        summary: fallbackReadiness.githubConfigured
+          ? 'Configured in Developer Tools'
+          : 'Not configured',
+      },
+      linear: {
+        configured: fallbackReadiness.linearConfigured,
+        summary: fallbackReadiness.linearConfigured
+          ? 'Configured in Developer Tools'
+          : 'Not configured',
+      },
+      web: {
+        configured: fallbackReadiness.webConfigured,
+        summary: fallbackReadiness.webConfigured
+          ? 'Configured in Search settings'
+          : 'Not configured',
+      },
+    } as const);
+
+  const hasSchedule = Boolean(briefingStatus?.cron && briefingStatus?.timezone);
+  const desiredEnabled = briefingStatus?.desiredEnabled ?? briefingStatus?.enabled ?? false;
+  const observedEnabled = briefingStatus?.observedEnabled ?? briefingStatus?.enabled ?? false;
+  const reconcileState = briefingStatus?.reconcileState ?? 'idle';
+  const lastReconcileAction = briefingStatus?.lastReconcileAction ?? null;
+  const isWarmupState = isRunning && actionsReady === false;
+  const isTransitioning =
+    reconcileState === 'in_progress' ||
+    mutations.enableMorningBriefing.isPending ||
+    mutations.disableMorningBriefing.isPending;
+
+  const statusLabel = (() => {
+    if (isWarmupState) {
+      return 'Instance Warming Up';
+    }
+
+    if (!isRunning) {
+      return 'Instance Stopped';
+    }
+
+    if (mutations.enableMorningBriefing.isPending) {
+      return 'Enabling';
+    }
+    if (mutations.disableMorningBriefing.isPending) {
+      return 'Disabling';
+    }
+
+    if (reconcileState === 'in_progress') {
+      if (lastReconcileAction === 'enable') {
+        return observedEnabled === true ? 'Enabled' : 'Enabling';
+      }
+      if (lastReconcileAction === 'disable') {
+        return observedEnabled === false ? 'Disabled' : 'Disabling';
+      }
+      if (desiredEnabled && observedEnabled !== true) {
+        return 'Enabling';
+      }
+      if (!desiredEnabled && observedEnabled === true) {
+        return 'Disabling';
+      }
+    }
+
+    return observedEnabled ? 'Enabled' : 'Disabled';
+  })();
+  const statusVariant =
+    statusLabel === 'Instance Stopped'
+      ? 'secondary'
+      : observedEnabled || (isTransitioning && desiredEnabled)
+        ? 'default'
+        : 'secondary';
+
+  const readySources = [
+    sourceReadiness.github.configured ? 'GitHub' : null,
+    sourceReadiness.linear.configured ? 'Linear' : null,
+    sourceReadiness.web.configured ? 'Web Search' : null,
+  ].filter((value): value is string => value !== null);
+  const missingSources = [
+    sourceReadiness.github.configured ? null : 'GitHub',
+    sourceReadiness.linear.configured ? null : 'Linear',
+    sourceReadiness.web.configured ? null : 'Web Search',
+  ].filter((value): value is string => value !== null);
+
+  const sourceSummaryText =
+    readySources.length === 3
+      ? 'All sources are connected: GitHub, Linear, and Web Search.'
+      : readySources.length === 0
+        ? 'No sources are connected yet. Configure GitHub, Linear, or Web Search to generate richer briefings.'
+        : `Connected sources: ${joinFriendlyList(readySources)}. Disconnected sources: ${joinFriendlyList(missingSources)}.`;
+  const showScheduleDetails = !isWarmupState && hasSchedule && desiredEnabled;
+  const controlsEnabled = actionsReady && !isWarmupState;
+  const canUseBriefingControls = controlsEnabled && desiredEnabled;
+
+  return (
+    <div className="rounded-lg border px-4 py-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <p className="text-sm font-medium">Morning Briefing</p>
+            <Badge variant={statusVariant}>{statusLabel}</Badge>
+          </div>
+          {showScheduleDetails && briefingStatus?.cron && briefingStatus?.timezone && (
+            <p className="text-muted-foreground text-xs">
+              {formatMorningBriefingSchedule(briefingStatus.cron, briefingStatus.timezone)}
+            </p>
+          )}
+          {showScheduleDetails && (
+            <p className="text-muted-foreground text-xs">
+              Last generated: {briefingStatus?.lastGeneratedDate ?? '(none)'}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={
+              !controlsEnabled || desiredEnabled || mutations.enableMorningBriefing.isPending
+            }
+            onClick={() => {
+              mutations.enableMorningBriefing.mutate(
+                {},
+                {
+                  onSuccess: () => toast.success('Morning Briefing enabled'),
+                  onError: err => toast.error(`Failed to enable Morning Briefing: ${err.message}`),
+                }
+              );
+            }}
+          >
+            {mutations.enableMorningBriefing.isPending ? 'Enabling...' : 'Enable'}
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={
+              !controlsEnabled || !desiredEnabled || mutations.disableMorningBriefing.isPending
+            }
+            onClick={() => {
+              mutations.disableMorningBriefing.mutate(undefined, {
+                onSuccess: () => toast.success('Morning Briefing disabled'),
+                onError: err => toast.error(`Failed to disable Morning Briefing: ${err.message}`),
+              });
+            }}
+          >
+            {mutations.disableMorningBriefing.isPending ? 'Disabling...' : 'Disable'}
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!canUseBriefingControls || mutations.runMorningBriefing.isPending}
+            onClick={() => {
+              mutations.runMorningBriefing.mutate(undefined, {
+                onSuccess: data => {
+                  const date = data.date ? ` for ${data.date}` : '';
+                  toast.success(`Morning Briefing generated${date}`);
+                },
+                onError: err => toast.error(`Failed to run Morning Briefing: ${err.message}`),
+              });
+            }}
+          >
+            {mutations.runMorningBriefing.isPending ? 'Running...' : 'Run Now'}
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!canUseBriefingControls}
+            onClick={() => setRequestedDay('today')}
+          >
+            View Today
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!canUseBriefingControls}
+            onClick={() => setRequestedDay('yesterday')}
+          >
+            View Yesterday
+          </Button>
+        </div>
+      </div>
+
+      {!actionsReady && (
+        <p className="text-muted-foreground mt-2 text-xs">
+          Instance is still warming up. Morning Briefing controls will become available once the
+          gateway is fully ready.
+        </p>
+      )}
+
+      {!desiredEnabled && controlsEnabled && (
+        <p className="text-muted-foreground mt-2 text-xs">
+          Enable Morning Briefing to get a personalized briefing everyday.
+        </p>
+      )}
+
+      <p className="text-muted-foreground mt-3 text-xs">{sourceSummaryText}</p>
+
+      {requestedDay && (
+        <div className="mt-3">
+          {isReading ? (
+            <p className="text-muted-foreground text-xs">Loading saved briefing...</p>
+          ) : readData?.markdown ? (
+            <pre className="bg-muted max-h-56 overflow-auto rounded p-3 text-xs whitespace-pre-wrap">
+              {readData.markdown}
+            </pre>
+          ) : (
+            <p className="text-muted-foreground text-xs">
+              No saved briefing for {requestedDay === 'today' ? 'today' : 'yesterday'}.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -1015,6 +1314,8 @@ export function SettingsTab({
     isControllerVersionError,
   } = useClawUpdateAvailable(status);
   const { data: myPin } = useClawMyPin();
+  const { data: morningBriefingStatus } = useClawMorningBriefingStatus(true);
+  const { data: gatewayReady } = useClawGatewayReady(isRunning);
   const [confirmDestroy, setConfirmDestroy] = useState(false);
   const [confirmRestore, setConfirmRestore] = useState(false);
   const hasModelSelectionError = isRunning && isControllerVersionError;
@@ -1105,6 +1406,7 @@ export function SettingsTab({
       : '/api/integrations/google/disconnect';
   }, [organizationId]);
   const canSeeGoogleCalendar = !!user?.is_admin;
+  const canSeeMorningBriefing = !!user?.is_admin;
 
   function handleCycleInboundEmailAddress() {
     mutations.cycleInboundEmailAddress.mutate(undefined, {
@@ -1560,6 +1862,21 @@ export function SettingsTab({
             mutations={mutations}
             onRedeploy={onRedeploy}
           />
+          {canSeeMorningBriefing && (
+            <MorningBriefingCard
+              mutations={mutations}
+              briefingStatus={morningBriefingStatus}
+              isRunning={isRunning}
+              actionsReady={
+                isRunning && gatewayReady?.ready === true && gatewayReady?.settled === true
+              }
+              fallbackReadiness={{
+                githubConfigured: configuredSecrets.github ?? false,
+                linearConfigured: configuredSecrets.linear ?? false,
+                webConfigured: braveSearchConfigured || exaSearchConfigured,
+              }}
+            />
+          )}
         </div>
       </div>
 

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -84,6 +84,7 @@ type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 const EXA_SEARCH_UI_MIN_CONTROLLER_VERSION = '2026.4.14';
 const MEMORY_MIN_OPENCLAW_VERSION = '2026.4.5';
 const OPENCLAW_IMPORT_UI_MIN_CONTROLLER_VERSION = '2026.4.22';
+const MORNING_BRIEFING_MIN_IMAGE_CALVER = '2026.4.24';
 
 function formatMorningBriefingSchedule(cron: string, timezone: string): string {
   const parts = cron.trim().split(/\s+/);
@@ -1406,7 +1407,9 @@ export function SettingsTab({
       : '/api/integrations/google/disconnect';
   }, [organizationId]);
   const canSeeGoogleCalendar = !!user?.is_admin;
-  const canSeeMorningBriefing = !!user?.is_admin;
+  const canSeeMorningBriefing =
+    !!user?.is_admin &&
+    calverAtLeast(cleanVersion(status.trackedImageTag), MORNING_BRIEFING_MIN_IMAGE_CALVER);
 
   function handleCycleInboundEmailAddress() {
     mutations.cycleInboundEmailAddress.mutate(undefined, {

--- a/apps/web/src/app/(app)/claw/components/changelog-data.ts
+++ b/apps/web/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,13 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-04-23',
+    description:
+      'Added Morning Briefing for KiloClaw-hosted OpenClaw instances. The new bundled plugin can schedule daily briefings, run on demand, and save/read today and yesterday briefing Markdown files from persistent instance storage. Dashboard settings now include Morning Briefing status, source readiness, and controls.',
+    category: 'feature',
+    deployHint: 'redeploy_required',
+  },
+  {
     date: '2026-04-20',
     description:
       'Added support for Vector Search, Embedding Models, and Dreaming in Memory configuration. Vector Search lets your agent find relevant context across its memory files using semantic embeddings instead of plain keyword matches. Pick the Embedding Model that generates those vectors to trade off quality, speed, and cost. Dreaming runs in the background and promotes strong short-term signals into durable long-term memory, so the agent remembers what matters across sessions.',

--- a/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
+++ b/apps/web/src/app/(app)/claw/hooks/useClawHooks.ts
@@ -93,6 +93,65 @@ export function useClawControllerVersion(enabled: boolean) {
   return organizationId ? org : personal;
 }
 
+export function useClawMorningBriefingStatus(enabled: boolean) {
+  const trpc = useTRPC();
+  const { organizationId } = useClawContext();
+
+  const getRefetchInterval = (data: unknown): number => {
+    const maybeCode =
+      typeof data === 'object' && data !== null && 'code' in data
+        ? (data as { code?: unknown }).code
+        : undefined;
+    return maybeCode === 'gateway_warming_up' ? 10_000 : 30_000;
+  };
+
+  const personal = useQuery({
+    ...trpc.kiloclaw.getMorningBriefingStatus.queryOptions(undefined, {
+      refetchInterval: query => (enabled ? getRefetchInterval(query.state.data) : false),
+      retry: false,
+    }),
+    enabled: enabled && !organizationId,
+  });
+
+  const org = useQuery({
+    ...trpc.organizations.kiloclaw.getMorningBriefingStatus.queryOptions(
+      { organizationId: organizationId ?? '' },
+      {
+        refetchInterval: query => (enabled ? getRefetchInterval(query.state.data) : false),
+        retry: false,
+      }
+    ),
+    enabled: enabled && !!organizationId,
+  });
+
+  return organizationId ? org : personal;
+}
+
+export function useClawReadMorningBriefing(day: 'today' | 'yesterday' | null, enabled: boolean) {
+  const trpc = useTRPC();
+  const { organizationId } = useClawContext();
+
+  const personal = useQuery({
+    ...trpc.kiloclaw.readMorningBriefing.queryOptions(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by enabled
+      { day: day! },
+      { refetchOnWindowFocus: false }
+    ),
+    enabled: enabled && day !== null && !organizationId,
+  });
+
+  const org = useQuery({
+    ...trpc.organizations.kiloclaw.readMorningBriefing.queryOptions(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by enabled
+      { organizationId: organizationId ?? '', day: day! },
+      { refetchOnWindowFocus: false }
+    ),
+    enabled: enabled && day !== null && !!organizationId,
+  });
+
+  return organizationId ? org : personal;
+}
+
 // Pairing
 
 export function useClawPairing(enabled = true) {

--- a/apps/web/src/hooks/useKiloClaw.ts
+++ b/apps/web/src/hooks/useKiloClaw.ts
@@ -101,6 +101,16 @@ export function useControllerVersion(enabled: boolean) {
   );
 }
 
+export function useMorningBriefingStatus(enabled: boolean) {
+  const trpc = useTRPC();
+  return useQuery(
+    trpc.kiloclaw.getMorningBriefingStatus.queryOptions(undefined, {
+      enabled,
+      refetchInterval: enabled ? 30_000 : false,
+    })
+  );
+}
+
 export function useKiloCliRunStatus(runId: string | null) {
   const trpc = useTRPC();
   return useQuery(
@@ -346,6 +356,36 @@ export function useKiloClawMutations() {
     ),
     setGmailNotifications: useMutation(
       trpc.kiloclaw.setGmailNotifications.mutationOptions({ onSuccess: invalidateStatus })
+    ),
+    enableMorningBriefing: useMutation(
+      trpc.kiloclaw.enableMorningBriefing.mutationOptions({
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.getMorningBriefingStatus.queryKey(),
+          });
+        },
+      })
+    ),
+    disableMorningBriefing: useMutation(
+      trpc.kiloclaw.disableMorningBriefing.mutationOptions({
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.getMorningBriefingStatus.queryKey(),
+          });
+        },
+      })
+    ),
+    runMorningBriefing: useMutation(
+      trpc.kiloclaw.runMorningBriefing.mutationOptions({
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.getMorningBriefingStatus.queryKey(),
+          });
+          await queryClient.invalidateQueries({
+            queryKey: trpc.kiloclaw.readMorningBriefing.queryKey({ day: 'today' }),
+          });
+        },
+      })
     ),
     rename: useMutation(
       trpc.kiloclaw.renameInstance.mutationOptions({ onSuccess: invalidateStatus })

--- a/apps/web/src/hooks/useOrgKiloClaw.ts
+++ b/apps/web/src/hooks/useOrgKiloClaw.ts
@@ -106,6 +106,16 @@ export function useOrgControllerVersion(organizationId: string, enabled: boolean
   );
 }
 
+export function useOrgMorningBriefingStatus(organizationId: string, enabled: boolean) {
+  const trpc = useTRPC();
+  return useQuery(
+    trpc.organizations.kiloclaw.getMorningBriefingStatus.queryOptions(
+      { organizationId },
+      { enabled, refetchInterval: enabled ? 30_000 : false }
+    )
+  );
+}
+
 export function useOrgKiloClawServiceDegraded(organizationId: string) {
   const trpc = useTRPC();
   return useQuery(
@@ -423,6 +433,45 @@ export function useOrgKiloClawMutations(
   const rawCancelKiloCliRun = useMutation(
     trpc.organizations.kiloclaw.cancelKiloCliRun.mutationOptions({ onSuccess: invalidateStatus })
   );
+  const rawEnableMorningBriefing = useMutation(
+    trpc.organizations.kiloclaw.enableMorningBriefing.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: trpc.organizations.kiloclaw.getMorningBriefingStatus.queryKey({
+            organizationId,
+          }),
+        });
+      },
+    })
+  );
+  const rawDisableMorningBriefing = useMutation(
+    trpc.organizations.kiloclaw.disableMorningBriefing.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: trpc.organizations.kiloclaw.getMorningBriefingStatus.queryKey({
+            organizationId,
+          }),
+        });
+      },
+    })
+  );
+  const rawRunMorningBriefing = useMutation(
+    trpc.organizations.kiloclaw.runMorningBriefing.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: trpc.organizations.kiloclaw.getMorningBriefingStatus.queryKey({
+            organizationId,
+          }),
+        });
+        await queryClient.invalidateQueries({
+          queryKey: trpc.organizations.kiloclaw.readMorningBriefing.queryKey({
+            organizationId,
+            day: 'today',
+          }),
+        });
+      },
+    })
+  );
 
   const mutations = {
     start: bindVoid(rawStart),
@@ -451,6 +500,9 @@ export function useOrgKiloClawMutations(
     patchOpenclawConfig: bind(rawPatchOpenclawConfig),
     disconnectGoogle: bindVoid(rawDisconnectGoogle),
     setGmailNotifications: bind(rawSetGmailNotifications),
+    enableMorningBriefing: bind(rawEnableMorningBriefing),
+    disableMorningBriefing: bindVoid(rawDisableMorningBriefing),
+    runMorningBriefing: bindVoid(rawRunMorningBriefing),
     startKiloCliRun: bind(rawStartKiloCliRun),
     cancelKiloCliRun: bind(rawCancelKiloCliRun),
     rename: bind(rawRename),

--- a/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -37,6 +37,9 @@ import type {
   GatewayReadyResponse,
   ControllerVersionResponse,
   OpenclawConfigResponse,
+  MorningBriefingStatusResponse,
+  MorningBriefingActionResponse,
+  MorningBriefingReadResponse,
   GoogleCredentialsInput,
   GoogleCredentialsResponse,
   GoogleOAuthConnectionInput,
@@ -270,6 +273,77 @@ export class KiloClawInternalClient {
         method: 'POST',
         body: JSON.stringify({ userId, message, instanceId }),
       },
+      { userId }
+    );
+  }
+
+  async getMorningBriefingStatus(
+    userId: string,
+    instanceId?: string
+  ): Promise<MorningBriefingStatusResponse> {
+    const params = new URLSearchParams({ userId });
+    if (instanceId) params.set('instanceId', instanceId);
+    return this.request(`/api/platform/morning-briefing/status?${params.toString()}`, undefined, {
+      userId,
+    });
+  }
+
+  async enableMorningBriefing(
+    userId: string,
+    input?: { cron?: string; timezone?: string },
+    instanceId?: string
+  ): Promise<MorningBriefingActionResponse> {
+    const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
+    return this.request(
+      `/api/platform/morning-briefing/enable${params}`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ userId, ...input }),
+      },
+      { userId }
+    );
+  }
+
+  async disableMorningBriefing(
+    userId: string,
+    instanceId?: string
+  ): Promise<MorningBriefingActionResponse> {
+    const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
+    return this.request(
+      `/api/platform/morning-briefing/disable${params}`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ userId }),
+      },
+      { userId }
+    );
+  }
+
+  async runMorningBriefing(
+    userId: string,
+    instanceId?: string
+  ): Promise<MorningBriefingActionResponse> {
+    const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
+    return this.request(
+      `/api/platform/morning-briefing/run${params}`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ userId }),
+      },
+      { userId }
+    );
+  }
+
+  async readMorningBriefing(
+    userId: string,
+    day: 'today' | 'yesterday',
+    instanceId?: string
+  ): Promise<MorningBriefingReadResponse> {
+    const params = new URLSearchParams({ userId });
+    if (instanceId) params.set('instanceId', instanceId);
+    return this.request(
+      `/api/platform/morning-briefing/read/${day}?${params.toString()}`,
+      undefined,
       { userId }
     );
   }

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -403,6 +403,58 @@ export type OpenclawConfigResponse = {
   etag: string;
 };
 
+export type MorningBriefingSourceReadiness = {
+  configured: boolean;
+  summary: string;
+};
+
+export type MorningBriefingStatusResponse = {
+  ok: boolean;
+  enabled?: boolean;
+  cron?: string;
+  timezone?: string;
+  cronJobId?: string | null;
+  lastGeneratedDate?: string | null;
+  lastGeneratedAt?: string | null;
+  reconcileState?: 'idle' | 'in_progress' | 'succeeded' | 'failed';
+  lastReconcileAction?: 'enable' | 'disable' | null;
+  desiredEnabled?: boolean;
+  observedEnabled?: boolean | null;
+  lastReconcileAt?: string | null;
+  lastReconcileError?: string | null;
+  sourceReadiness?: {
+    github: MorningBriefingSourceReadiness;
+    linear: MorningBriefingSourceReadiness;
+    web: MorningBriefingSourceReadiness;
+  };
+  code?: string;
+  retryAfterSec?: number;
+  error?: string;
+};
+
+export type MorningBriefingActionResponse = {
+  ok: boolean;
+  enabled?: boolean;
+  cron?: string;
+  timezone?: string;
+  cronJobId?: string | null;
+  date?: string;
+  filePath?: string;
+  failures?: string[];
+  code?: string;
+  retryAfterSec?: number;
+  error?: string;
+};
+
+export type MorningBriefingReadResponse = {
+  ok: boolean;
+  dateKey?: string;
+  filePath?: string;
+  exists?: boolean;
+  markdown?: string | null;
+  error?: string;
+};
+
 /** Input to POST /api/platform/google-credentials */
 export type GoogleCredentialsInput = {
   googleCredentials: {

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2463,6 +2463,45 @@ export const kiloclawRouter = createTRPCRouter({
       }
     }),
 
+  getMorningBriefingStatus: clawAccessProcedure.query(async ({ ctx }) => {
+    const instance = await getActiveInstance(ctx.user.id);
+    const client = new KiloClawInternalClient();
+    return client.getMorningBriefingStatus(ctx.user.id, workerInstanceId(instance));
+  }),
+
+  enableMorningBriefing: clawAccessProcedure
+    .input(
+      z.object({
+        cron: z.string().min(1).optional(),
+        timezone: z.string().min(1).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const instance = await getActiveInstance(ctx.user.id);
+      const client = new KiloClawInternalClient();
+      return client.enableMorningBriefing(ctx.user.id, input, workerInstanceId(instance));
+    }),
+
+  disableMorningBriefing: clawAccessProcedure.mutation(async ({ ctx }) => {
+    const instance = await getActiveInstance(ctx.user.id);
+    const client = new KiloClawInternalClient();
+    return client.disableMorningBriefing(ctx.user.id, workerInstanceId(instance));
+  }),
+
+  runMorningBriefing: clawAccessProcedure.mutation(async ({ ctx }) => {
+    const instance = await getActiveInstance(ctx.user.id);
+    const client = new KiloClawInternalClient();
+    return client.runMorningBriefing(ctx.user.id, workerInstanceId(instance));
+  }),
+
+  readMorningBriefing: clawAccessProcedure
+    .input(z.object({ day: z.enum(['today', 'yesterday']) }))
+    .query(async ({ ctx, input }) => {
+      const instance = await getActiveInstance(ctx.user.id);
+      const client = new KiloClawInternalClient();
+      return client.readMorningBriefing(ctx.user.id, input.day, workerInstanceId(instance));
+    }),
+
   // Instance lifecycle
   start: clawAccessProcedure.mutation(async ({ ctx }) => {
     const instance = await getActiveInstance(ctx.user.id);

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -1154,6 +1154,57 @@ export const organizationKiloclawRouter = createTRPCRouter({
       }
     }),
 
+  getMorningBriefingStatus: organizationMemberProcedure.query(async ({ ctx, input }) => {
+    const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
+    const client = new KiloClawInternalClient();
+    return client.getMorningBriefingStatus(ctx.user.id, workerInstanceId(instance));
+  }),
+
+  enableMorningBriefing: organizationMemberMutationProcedure
+    .input(
+      z.object({
+        organizationId: z.uuid(),
+        cron: z.string().min(1).optional(),
+        timezone: z.string().min(1).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
+      const client = new KiloClawInternalClient();
+      return client.enableMorningBriefing(
+        ctx.user.id,
+        {
+          cron: input.cron,
+          timezone: input.timezone,
+        },
+        workerInstanceId(instance)
+      );
+    }),
+
+  disableMorningBriefing: organizationMemberMutationProcedure
+    .input(z.object({ organizationId: z.uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
+      const client = new KiloClawInternalClient();
+      return client.disableMorningBriefing(ctx.user.id, workerInstanceId(instance));
+    }),
+
+  runMorningBriefing: organizationMemberMutationProcedure
+    .input(z.object({ organizationId: z.uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
+      const client = new KiloClawInternalClient();
+      return client.runMorningBriefing(ctx.user.id, workerInstanceId(instance));
+    }),
+
+  readMorningBriefing: organizationMemberProcedure
+    .input(z.object({ organizationId: z.uuid(), day: z.enum(['today', 'yesterday']) }))
+    .query(async ({ ctx, input }) => {
+      const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
+      const client = new KiloClawInternalClient();
+      return client.readMorningBriefing(ctx.user.id, input.day, workerInstanceId(instance));
+    }),
+
   // ── Google integration ────────────────────────────────────────
 
   getGoogleSetupCommand: organizationMemberProcedure.query(async ({ ctx, input }) => {

--- a/services/kiloclaw/src/durable-objects/gateway-controller-types.ts
+++ b/services/kiloclaw/src/durable-objects/gateway-controller-types.ts
@@ -99,6 +99,60 @@ export const OpenclawWorkspaceImportResponseSchema = z.object({
   failures: z.array(OpenclawWorkspaceImportFailureSchema),
 });
 
+const MorningBriefingSourceReadinessSchema = z.object({
+  configured: z.boolean(),
+  summary: z.string(),
+});
+
+export const MorningBriefingStatusResponseSchema = z.object({
+  ok: z.boolean(),
+  enabled: z.boolean().optional(),
+  cron: z.string().optional(),
+  timezone: z.string().optional(),
+  cronJobId: z.string().nullable().optional(),
+  lastGeneratedDate: z.string().nullable().optional(),
+  lastGeneratedAt: z.string().nullable().optional(),
+  reconcileState: z.enum(['idle', 'in_progress', 'succeeded', 'failed']).optional(),
+  lastReconcileAction: z.enum(['enable', 'disable']).nullable().optional(),
+  desiredEnabled: z.boolean().optional(),
+  observedEnabled: z.boolean().nullable().optional(),
+  lastReconcileAt: z.string().nullable().optional(),
+  lastReconcileError: z.string().nullable().optional(),
+  sourceReadiness: z
+    .object({
+      github: MorningBriefingSourceReadinessSchema,
+      linear: MorningBriefingSourceReadinessSchema,
+      web: MorningBriefingSourceReadinessSchema,
+    })
+    .optional(),
+  code: z.string().optional(),
+  retryAfterSec: z.number().int().positive().optional(),
+  error: z.string().optional(),
+});
+
+export const MorningBriefingActionResponseSchema = z.object({
+  ok: z.boolean(),
+  enabled: z.boolean().optional(),
+  cron: z.string().optional(),
+  timezone: z.string().optional(),
+  cronJobId: z.string().nullable().optional(),
+  date: z.string().optional(),
+  filePath: z.string().optional(),
+  failures: z.array(z.string()).optional(),
+  code: z.string().optional(),
+  retryAfterSec: z.number().int().positive().optional(),
+  error: z.string().optional(),
+});
+
+export const MorningBriefingReadResponseSchema = z.object({
+  ok: z.boolean(),
+  dateKey: z.string().optional(),
+  filePath: z.string().optional(),
+  exists: z.boolean().optional(),
+  markdown: z.string().nullable().optional(),
+  error: z.string().optional(),
+});
+
 export class GatewayControllerError extends Error {
   readonly status: number;
   readonly code: string | null;

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { deriveGatewayToken } from '../../auth/gateway-token';
 import { createMutableState } from './state';
-import { getGatewayProcessStatus, waitForHealthy } from './gateway';
+import { getGatewayProcessStatus, getMorningBriefingStatus, waitForHealthy } from './gateway';
 
 type FetchMock = ReturnType<
   typeof vi.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>
@@ -110,6 +110,36 @@ describe('gateway controller routing', () => {
     expect(rootUrl).toBe('https://test-app.fly.dev/');
     expect(rootInit?.headers).toMatchObject({
       'fly-force-instance-id': 'machine-1',
+    });
+  });
+
+  it('returns warm-up payload for morning-briefing status when gateway is warming up', async () => {
+    const state = createMutableState();
+    state.provider = 'fly';
+    state.sandboxId = 'sandbox-1';
+    state.flyAppName = 'test-app';
+    state.flyMachineId = 'machine-1';
+
+    const fetchMock: FetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Gateway not running' }), {
+        status: 503,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await getMorningBriefingStatus(state, {
+      GATEWAY_TOKEN_SECRET: 'gateway-secret',
+      FLY_APP_NAME: 'fallback-app',
+    } as never);
+
+    expect(result).toEqual({
+      ok: true,
+      enabled: false,
+      reconcileState: 'in_progress',
+      error: 'Gateway warming up, retrying shortly.',
+      code: 'gateway_warming_up',
+      retryAfterSec: 2,
     });
   });
 });

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { deriveGatewayToken } from '../../auth/gateway-token';
 import { createMutableState } from './state';
 import { getGatewayProcessStatus, getMorningBriefingStatus, waitForHealthy } from './gateway';
+import { GatewayControllerError } from '../gateway-controller-types';
 
 type FetchMock = ReturnType<
   typeof vi.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>
@@ -141,5 +142,28 @@ describe('gateway controller routing', () => {
       code: 'gateway_warming_up',
       retryAfterSec: 2,
     });
+  });
+
+  it('does not mask 401 auth failures as warm-up for morning-briefing status', async () => {
+    const state = createMutableState();
+    state.provider = 'fly';
+    state.sandboxId = 'sandbox-1';
+    state.flyAppName = 'test-app';
+    state.flyMachineId = 'machine-1';
+
+    const fetchMock: FetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getMorningBriefingStatus(state, {
+        GATEWAY_TOKEN_SECRET: 'gateway-secret',
+        FLY_APP_NAME: 'fallback-app',
+      } as never)
+    ).rejects.toBeInstanceOf(GatewayControllerError);
   });
 });

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -13,6 +13,9 @@ import {
   EnvPatchResponseSchema,
   ToolsMdSectionSyncResponseSchema,
   OpenclawConfigResponseSchema,
+  MorningBriefingStatusResponseSchema,
+  MorningBriefingActionResponseSchema,
+  MorningBriefingReadResponseSchema,
   OpenclawWorkspaceImportResponseSchema,
   GatewayControllerError,
 } from '../gateway-controller-types';
@@ -66,7 +69,8 @@ export async function callGatewayController<T>(
   path: string,
   method: 'GET' | 'POST',
   responseSchema: ZodType<T>,
-  jsonBody?: unknown
+  jsonBody?: unknown,
+  options?: { timeoutMs?: number }
 ): Promise<T> {
   const { routingTarget, sandboxId } = await requireGatewayControllerContext(state, env);
 
@@ -87,11 +91,14 @@ export async function callGatewayController<T>(
   }
 
   let response: Response;
+  const timeoutMs = options?.timeoutMs ?? 30_000;
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
   try {
     response = await fetch(url, {
       method,
       headers,
       body: jsonBody !== undefined ? JSON.stringify(jsonBody) : undefined,
+      signal: timeoutSignal,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -262,6 +269,22 @@ export function isErrorUnknownRoute(error: unknown): boolean {
   return (
     error instanceof GatewayControllerError &&
     (error.code === 'controller_route_unavailable' || (error.status === 404 && !error.code))
+  );
+}
+
+function isMorningBriefingWarmupControllerError(error: unknown): boolean {
+  if (!(error instanceof GatewayControllerError)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  return (
+    message.includes('instance has no machine id') ||
+    message.includes('instance not provisioned') ||
+    message.includes('gateway not running') ||
+    message.includes('failed to reach gateway') ||
+    message.includes('operation was aborted due to timeout') ||
+    message.includes('gateway controller request failed (401)')
   );
 }
 
@@ -461,6 +484,115 @@ export async function importOpenclawWorkspace(
       'POST',
       OpenclawWorkspaceImportResponseSchema,
       { files }
+    );
+  } catch (error) {
+    if (isErrorUnknownRoute(error)) return null;
+    throw error;
+  }
+}
+
+export async function getMorningBriefingStatus(
+  state: InstanceMutableState,
+  env: KiloClawEnv
+): Promise<z.infer<typeof MorningBriefingStatusResponseSchema> | null> {
+  try {
+    return await callGatewayController(
+      state,
+      env,
+      '/_kilo/morning-briefing/status',
+      'GET',
+      MorningBriefingStatusResponseSchema,
+      undefined,
+      { timeoutMs: 5_000 }
+    );
+  } catch (error) {
+    if (isErrorUnknownRoute(error)) return null;
+    if (isMorningBriefingWarmupControllerError(error)) {
+      return {
+        ok: true,
+        enabled: false,
+        reconcileState: 'in_progress',
+        error: 'Gateway warming up, retrying shortly.',
+        code: 'gateway_warming_up',
+        retryAfterSec: 2,
+      };
+    }
+    throw error;
+  }
+}
+
+export async function enableMorningBriefing(
+  state: InstanceMutableState,
+  env: KiloClawEnv,
+  input: { cron?: string; timezone?: string }
+): Promise<z.infer<typeof MorningBriefingActionResponseSchema> | null> {
+  try {
+    return await callGatewayController(
+      state,
+      env,
+      '/_kilo/morning-briefing/enable',
+      'POST',
+      MorningBriefingActionResponseSchema,
+      input,
+      { timeoutMs: 8_000 }
+    );
+  } catch (error) {
+    if (isErrorUnknownRoute(error)) return null;
+    throw error;
+  }
+}
+
+export async function disableMorningBriefing(
+  state: InstanceMutableState,
+  env: KiloClawEnv
+): Promise<z.infer<typeof MorningBriefingActionResponseSchema> | null> {
+  try {
+    return await callGatewayController(
+      state,
+      env,
+      '/_kilo/morning-briefing/disable',
+      'POST',
+      MorningBriefingActionResponseSchema,
+      {},
+      { timeoutMs: 8_000 }
+    );
+  } catch (error) {
+    if (isErrorUnknownRoute(error)) return null;
+    throw error;
+  }
+}
+
+export async function runMorningBriefing(
+  state: InstanceMutableState,
+  env: KiloClawEnv
+): Promise<z.infer<typeof MorningBriefingActionResponseSchema> | null> {
+  try {
+    return await callGatewayController(
+      state,
+      env,
+      '/_kilo/morning-briefing/run',
+      'POST',
+      MorningBriefingActionResponseSchema,
+      {}
+    );
+  } catch (error) {
+    if (isErrorUnknownRoute(error)) return null;
+    throw error;
+  }
+}
+
+export async function readMorningBriefing(
+  state: InstanceMutableState,
+  env: KiloClawEnv,
+  day: 'today' | 'yesterday'
+): Promise<z.infer<typeof MorningBriefingReadResponseSchema> | null> {
+  try {
+    return await callGatewayController(
+      state,
+      env,
+      `/_kilo/morning-briefing/read/${day}`,
+      'GET',
+      MorningBriefingReadResponseSchema
     );
   } catch (error) {
     if (isErrorUnknownRoute(error)) return null;

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -283,8 +283,7 @@ function isMorningBriefingWarmupControllerError(error: unknown): boolean {
     message.includes('instance not provisioned') ||
     message.includes('gateway not running') ||
     message.includes('failed to reach gateway') ||
-    message.includes('operation was aborted due to timeout') ||
-    message.includes('gateway controller request failed (401)')
+    message.includes('operation was aborted due to timeout')
   );
 }
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -3079,6 +3079,31 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     return gateway.importOpenclawWorkspace(this.s, this.env, files);
   }
 
+  async getMorningBriefingStatus() {
+    await this.loadState();
+    return gateway.getMorningBriefingStatus(this.s, this.env);
+  }
+
+  async enableMorningBriefing(input: { cron?: string; timezone?: string }) {
+    await this.loadState();
+    return gateway.enableMorningBriefing(this.s, this.env, input);
+  }
+
+  async disableMorningBriefing() {
+    await this.loadState();
+    return gateway.disableMorningBriefing(this.s, this.env);
+  }
+
+  async runMorningBriefing() {
+    await this.loadState();
+    return gateway.runMorningBriefing(this.s, this.env);
+  }
+
+  async readMorningBriefing(day: 'today' | 'yesterday') {
+    await this.loadState();
+    return gateway.readMorningBriefing(this.s, this.env, day);
+  }
+
   // ── Restart machine (user-facing) ──────────────────────────────────
 
   async restartMachine(options?: {

--- a/services/kiloclaw/src/routes/platform-morning-briefing.test.ts
+++ b/services/kiloclaw/src/routes/platform-morning-briefing.test.ts
@@ -101,4 +101,24 @@ describe('platform morning-briefing warm-up handling', () => {
       reconcileState: 'in_progress',
     });
   });
+
+  it('does not treat 401 as warm-up for enable retries', async () => {
+    const enableMorningBriefing = vi
+      .fn<() => Promise<{ ok: boolean; enabled: boolean }>>()
+      .mockRejectedValue(new Error('Gateway controller request failed (401)'));
+    const env = baseEnv({ enableMorningBriefing });
+
+    const response = await platform.request(
+      '/morning-briefing/enable',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: 'user-1' }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(500);
+    expect(enableMorningBriefing).toHaveBeenCalledTimes(1);
+  });
 });

--- a/services/kiloclaw/src/routes/platform-morning-briefing.test.ts
+++ b/services/kiloclaw/src/routes/platform-morning-briefing.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { platform } from './platform';
+
+vi.mock('cloudflare:workers', () => ({
+  DurableObject: class {},
+  waitUntil: (promise: Promise<unknown>) => promise,
+}));
+
+function baseEnv(stub: Record<string, unknown>) {
+  return {
+    KILOCLAW_INSTANCE: {
+      idFromName: (id: string) => id,
+      get: () => stub,
+    },
+    KILOCLAW_AE: { writeDataPoint: vi.fn() },
+    KV_CLAW_CACHE: {
+      get: vi.fn().mockResolvedValue(null),
+      put: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockResolvedValue({ keys: [], list_complete: true }),
+      getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null }),
+    },
+  } as never;
+}
+
+describe('platform morning-briefing warm-up handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('retries enable when gateway is warming up and then succeeds', async () => {
+    const enableMorningBriefing = vi
+      .fn<() => Promise<{ ok: boolean; enabled: boolean }>>()
+      .mockRejectedValueOnce(new Error('Gateway not running'))
+      .mockResolvedValueOnce({ ok: true, enabled: true });
+    const env = baseEnv({ enableMorningBriefing });
+
+    const requestPromise = platform.request(
+      '/morning-briefing/enable',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: 'user-1' }),
+      },
+      env
+    );
+
+    await vi.runAllTimersAsync();
+    const response = await requestPromise;
+
+    expect(response.status).toBe(200);
+    expect(enableMorningBriefing).toHaveBeenCalledTimes(2);
+    expect(await response.json()).toMatchObject({ ok: true, enabled: true });
+  });
+
+  it('retries disable when gateway is warming up and then succeeds', async () => {
+    const disableMorningBriefing = vi
+      .fn<() => Promise<{ ok: boolean; enabled: boolean }>>()
+      .mockRejectedValueOnce(new Error('Failed to reach gateway'))
+      .mockResolvedValueOnce({ ok: true, enabled: false });
+    const env = baseEnv({ disableMorningBriefing });
+
+    const requestPromise = platform.request(
+      '/morning-briefing/disable',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: 'user-1' }),
+      },
+      env
+    );
+
+    await vi.runAllTimersAsync();
+    const response = await requestPromise;
+
+    expect(response.status).toBe(200);
+    expect(disableMorningBriefing).toHaveBeenCalledTimes(2);
+    expect(await response.json()).toMatchObject({ ok: true, enabled: false });
+  });
+
+  it('returns warm-up payload for status timeout instead of 500', async () => {
+    const getMorningBriefingStatus = vi
+      .fn<() => Promise<unknown>>()
+      .mockRejectedValue(
+        new Error('Gateway controller request failed: The operation was aborted due to timeout')
+      );
+    const env = baseEnv({ getMorningBriefingStatus });
+
+    const response = await platform.request('/morning-briefing/status?userId=user-1', {}, env);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      code: 'gateway_warming_up',
+      retryAfterSec: 2,
+      reconcileState: 'in_progress',
+    });
+  });
+});

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -1911,6 +1911,235 @@ platform.patch('/openclaw-config', async c => {
   }
 });
 
+const MorningBriefingSetupSchema = z.object({
+  userId: z.string().min(1),
+  cron: z.string().min(1).optional(),
+  timezone: z.string().min(1).optional(),
+});
+
+function isMorningBriefingWarmupError(err: unknown): boolean {
+  const raw = err instanceof Error ? err.message : String(err);
+  const normalized = raw.replace(/^(?:[A-Za-z]+Error:\s*)+/, '');
+  return (
+    normalized.includes('Gateway not running') ||
+    normalized.includes('Failed to reach gateway') ||
+    normalized.includes('operation was aborted due to timeout') ||
+    normalized.includes('Gateway controller request failed (401)')
+  );
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function withMorningBriefingWarmupRetry<T>(operation: () => Promise<T>): Promise<T> {
+  const delaysMs = [0, 750, 1500];
+  let lastError: unknown = null;
+
+  for (const delayMs of delaysMs) {
+    if (delayMs > 0) {
+      await sleep(delayMs);
+    }
+
+    try {
+      return await operation();
+    } catch (err) {
+      lastError = err;
+      if (!isMorningBriefingWarmupError(err)) {
+        throw err;
+      }
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error('Gateway warming up');
+}
+
+// GET /api/platform/morning-briefing/status?userId=...
+platform.get('/morning-briefing/status', async c => {
+  const userId = setValidatedQueryUserId(c);
+  if (!userId) {
+    return c.json({ error: 'userId query parameter is required' }, 400);
+  }
+
+  const iidResult = parseInstanceIdQuery(c);
+  if ('error' in iidResult) return iidResult.error;
+
+  try {
+    const result = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
+      stub => stub.getMorningBriefingStatus(),
+      'getMorningBriefingStatus'
+    );
+    if (!result) {
+      return jsonError(
+        'Morning Briefing unavailable (controller too old)',
+        404,
+        'controller_route_unavailable'
+      );
+    }
+    return c.json(result, 200);
+  } catch (err) {
+    if (isMorningBriefingWarmupError(err)) {
+      return c.json(
+        {
+          ok: true,
+          enabled: false,
+          reconcileState: 'in_progress',
+          error: 'Gateway warming up, retrying shortly.',
+          code: 'gateway_warming_up',
+          retryAfterSec: 2,
+        },
+        200
+      );
+    }
+    const { message, status, code } = sanitizeOpenclawConfigError(err, 'morning-briefing/status');
+    return jsonError(message, status, code);
+  }
+});
+
+// POST /api/platform/morning-briefing/enable
+platform.post('/morning-briefing/enable', async c => {
+  const result = await parseBody(c, MorningBriefingSetupSchema);
+  if ('error' in result) return result.error;
+
+  const iidResult = parseInstanceIdQuery(c);
+  if ('error' in iidResult) return iidResult.error;
+
+  const { userId, cron, timezone } = result.data;
+  try {
+    const response = await withMorningBriefingWarmupRetry(() =>
+      withResolvedDORetry(
+        c.env,
+        userId,
+        iidResult.instanceId,
+        stub => stub.enableMorningBriefing({ cron, timezone }),
+        'enableMorningBriefing'
+      )
+    );
+    if (!response) {
+      return jsonError(
+        'Morning Briefing unavailable (controller too old)',
+        404,
+        'controller_route_unavailable'
+      );
+    }
+    return c.json(response, 200);
+  } catch (err) {
+    if (isMorningBriefingWarmupError(err)) {
+      return jsonError('Gateway warming up, retrying shortly.', 503, 'gateway_warming_up');
+    }
+    const { message, status, code } = sanitizeOpenclawConfigError(err, 'morning-briefing/enable');
+    return jsonError(message, status, code);
+  }
+});
+
+// POST /api/platform/morning-briefing/disable
+platform.post('/morning-briefing/disable', async c => {
+  const result = await parseBody(c, UserIdRequestSchema);
+  if ('error' in result) return result.error;
+
+  const iidResult = parseInstanceIdQuery(c);
+  if ('error' in iidResult) return iidResult.error;
+
+  try {
+    const response = await withMorningBriefingWarmupRetry(() =>
+      withResolvedDORetry(
+        c.env,
+        result.data.userId,
+        iidResult.instanceId,
+        stub => stub.disableMorningBriefing(),
+        'disableMorningBriefing'
+      )
+    );
+    if (!response) {
+      return jsonError(
+        'Morning Briefing unavailable (controller too old)',
+        404,
+        'controller_route_unavailable'
+      );
+    }
+    return c.json(response, 200);
+  } catch (err) {
+    if (isMorningBriefingWarmupError(err)) {
+      return jsonError('Gateway warming up, retrying shortly.', 503, 'gateway_warming_up');
+    }
+    const { message, status, code } = sanitizeOpenclawConfigError(err, 'morning-briefing/disable');
+    return jsonError(message, status, code);
+  }
+});
+
+// POST /api/platform/morning-briefing/run
+platform.post('/morning-briefing/run', async c => {
+  const result = await parseBody(c, UserIdRequestSchema);
+  if ('error' in result) return result.error;
+
+  const iidResult = parseInstanceIdQuery(c);
+  if ('error' in iidResult) return iidResult.error;
+
+  try {
+    const response = await withResolvedDORetry(
+      c.env,
+      result.data.userId,
+      iidResult.instanceId,
+      stub => stub.runMorningBriefing(),
+      'runMorningBriefing'
+    );
+    if (!response) {
+      return jsonError(
+        'Morning Briefing unavailable (controller too old)',
+        404,
+        'controller_route_unavailable'
+      );
+    }
+    return c.json(response, 200);
+  } catch (err) {
+    const { message, status, code } = sanitizeOpenclawConfigError(err, 'morning-briefing/run');
+    return jsonError(message, status, code);
+  }
+});
+
+// GET /api/platform/morning-briefing/read/{today|yesterday}?userId=...
+platform.get('/morning-briefing/read/:day', async c => {
+  const userId = setValidatedQueryUserId(c);
+  if (!userId) {
+    return c.json({ error: 'userId query parameter is required' }, 400);
+  }
+
+  const day = c.req.param('day');
+  if (day !== 'today' && day !== 'yesterday') {
+    return c.json({ error: 'day must be today or yesterday' }, 400);
+  }
+
+  const iidResult = parseInstanceIdQuery(c);
+  if ('error' in iidResult) return iidResult.error;
+
+  try {
+    const response = await withResolvedDORetry(
+      c.env,
+      userId,
+      iidResult.instanceId,
+      stub => stub.readMorningBriefing(day),
+      'readMorningBriefing'
+    );
+    if (!response) {
+      return jsonError(
+        'Morning Briefing unavailable (controller too old)',
+        404,
+        'controller_route_unavailable'
+      );
+    }
+    return c.json(response, 200);
+  } catch (err) {
+    const { message, status, code } = sanitizeOpenclawConfigError(
+      err,
+      `morning-briefing/read/${day}`
+    );
+    return jsonError(message, status, code);
+  }
+});
+
 // GET /api/platform/files/tree?userId=...
 platform.get('/files/tree', async c => {
   const userId = setValidatedQueryUserId(c);

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -1923,8 +1923,7 @@ function isMorningBriefingWarmupError(err: unknown): boolean {
   return (
     normalized.includes('Gateway not running') ||
     normalized.includes('Failed to reach gateway') ||
-    normalized.includes('operation was aborted due to timeout') ||
-    normalized.includes('Gateway controller request failed (401)')
+    normalized.includes('operation was aborted due to timeout')
   );
 }
 


### PR DESCRIPTION
## Summary
- Add Morning Briefing platform/DO/router/client wiring and dashboard controls in Settings, including enable/disable/run/read interactions and readiness-driven UI state handling.
- Improve warm-up and lifecycle resilience for hosted instances by handling transient startup conditions, reconcile-state transitions, stale-read invalidation, and admin-only visibility control for the card.
- Add targeted tests for platform warm-up behavior, controller proxy auth forwarding, gateway warm-up fallback, and Morning Briefing lifecycle semantics.

## Verification
- Provisioned and exercised fresh KiloClaw instances in local-dev/fly workflows, including startup/redeploy race conditions, to confirm Morning Briefing control behavior and state transitions.
- Manually validated dashboard control paths and chat command outcomes (`enable`, `run`, `today`, `disable`) against the stacked image branch.

## Visual Changes
<img width="1115" height="127" alt="1" src="https://github.com/user-attachments/assets/1ad9d571-b73b-4c3b-9e49-e732e2ebd06b" />
<img width="1115" height="129" alt="2" src="https://github.com/user-attachments/assets/2c51a97e-d431-47a3-9f29-5fb99c3dc11f" />
<img width="1110" height="120" alt="3" src="https://github.com/user-attachments/assets/33607d92-27f4-467e-b5b7-d96d5fe38592" />
<img width="1120" height="364" alt="4" src="https://github.com/user-attachments/assets/d103df0d-f0a6-4541-8ffa-17da8c16e2bf" />
<img width="928" height="1094" alt="5" src="https://github.com/user-attachments/assets/d925caf3-7281-40b1-aa04-f770b7f666f6" />

## Reviewer Notes
- This PR is intentionally stacked on `feat/kiloclaw-morning-briefing-image` so it can adopt the new runtime image first.
- A final image-tag feature gate change will be applied after PR1 merges and production image tag is known.