### PR TITLE
feat(bot): select cloud agent models

### DIFF
--- a/apps/web/src/lib/bot/agent-runner.ts
+++ b/apps/web/src/lib/bot/agent-runner.ts
@@ -16,6 +16,11 @@ import {
   updateBotRequest,
 } from '@/lib/bot/request-logging';
 import { getNextBotCallbackStep, getRemainingBotIterations } from '@/lib/bot/step-budget';
+import {
+  buildCloudAgentModelSelectionPrompt,
+  modelSelectionSchema,
+  resolveCloudAgentModel,
+} from '@/lib/bot/tools/cloud-agent-model-selection';
 import spawnCloudAgentSession, {
   spawnCloudAgentInputSchema,
 } from '@/lib/bot/tools/spawn-cloud-agent-session';
@@ -37,7 +42,7 @@ import { captureException } from '@sentry/nextjs';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import type { PlatformIntegration, User } from '@kilocode/db';
 import type { BotRequestStep } from '@kilocode/db/schema';
-import { ToolLoopAgent, generateText, stepCountIs, tool } from 'ai';
+import { ToolLoopAgent, generateObject, generateText, stepCountIs, tool } from 'ai';
 import type { StepResult, ToolSet } from 'ai';
 import { Actions, Card, CardText, LinkButton, Section } from 'chat';
 import { ThreadImpl } from 'chat';
@@ -123,6 +128,14 @@ ${formatGitHubRepositoriesForPrompt(githubContext)}
 ${formatGitLabRepositoriesForPrompt(gitlabContext)}
 
 Treat this context as authoritative. Prefer selecting a repo from the provided repository list. If the user requests work on a repo that isn't in the list, ask them to confirm the exact owner/repo (or group/project for GitLab) and ensure it's accessible to the integration. Never invent repository names.
+
+## Cloud Agent model requests
+- You can select a Cloud Agent model by setting spawnCloudAgentSession.modelRequest.
+- If the user says to use a model, such as "use minimax", "use opus", or "use the cheap fast model", call spawnCloudAgentSession with modelRequest set to that exact user wording.
+- Do not say the tool cannot select a model. The spawn tool resolves natural-language model requests server-side.
+- Do not invent exact model IDs. Pass the user's model wording unless they provided an exact provider/model ID.
+- Remove model-selection-only wording from the Cloud Agent prompt when modelRequest captures it.
+- If spawnCloudAgentSession returns a model-selection ambiguity or unavailable-model error, ask the user to clarify instead of spawning with the default model.
 
 ## Accuracy & safety
 - Don't claim you ran tools, changed code, or created a PR/MR unless the tool results confirm it.
@@ -262,7 +275,11 @@ export async function runBotAgent(params: RunBotAgentParams): Promise<BotAgentCo
       spawnCloudAgentSession: tool({
         description: `Spawn a Cloud Agent session to perform coding tasks on a GitHub repository or GitLab project. The agent can make code changes, fix bugs, implement features, review/analyze code, run tests, or open PRs/MRs. Do NOT use it for questions you can answer directly.
 
-This tool returns an acknowledgement immediately. The final Cloud Agent result will be posted later in the same thread after the async session completes.`,
+This tool accepts modelRequest for user-requested Cloud Agent model selection. For example, if the user says "use minimax", set modelRequest to "minimax" and keep the task itself in prompt.
+
+This tool returns an acknowledgement immediately. The final Cloud Agent result will be posted later in the same thread after the async session completes.
+
+If the user explicitly requested a Cloud Agent model, pass their wording in modelRequest and do not invent exact model IDs.`,
         inputSchema: spawnCloudAgentInputSchema,
         execute: async args => {
           let resolvedCloudAgentSessionId: string | undefined;
@@ -298,6 +315,19 @@ This tool returns an acknowledgement immediately. The final Cloud Agent result w
               prSignature,
               chatPlatform,
               currentStep,
+              resolveModel: async input =>
+                resolveCloudAgentModel({
+                  ...input,
+                  selectModel: async selectionInput => {
+                    const result = await generateObject({
+                      model: provider.chatModel(modelSlug),
+                      schema: modelSelectionSchema,
+                      prompt: buildCloudAgentModelSelectionPrompt(selectionInput),
+                      temperature: 0,
+                    });
+                    return result.object;
+                  },
+                }),
             }
           );
 

--- a/apps/web/src/lib/bot/tools/cloud-agent-model-selection.test.ts
+++ b/apps/web/src/lib/bot/tools/cloud-agent-model-selection.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from '@jest/globals';
+import type { Owner } from '@/lib/integrations/core/types';
+import {
+  buildSelectableCloudAgentModelCatalog,
+  resolveCloudAgentModel,
+  type CloudAgentModelCatalogDeps,
+  type SelectCloudAgentModel,
+} from './cloud-agent-model-selection';
+
+const userOwner: Owner = { type: 'user', id: 'user-1' };
+const orgOwner: Owner = { type: 'org', id: 'org-1' };
+
+const baseSonnetModel = {
+  id: 'anthropic/claude-sonnet-4.5',
+  name: 'Claude Sonnet 4.5',
+  preferredIndex: 0,
+};
+
+const baseOpusModel = {
+  id: 'anthropic/claude-opus-4.7',
+  name: 'Claude Opus 4.7',
+  preferredIndex: 1,
+};
+
+type TestModel = { id: string; name: string; created?: number; preferredIndex?: number };
+
+function createDeps(params: {
+  baseModels?: TestModel[];
+  organizationByokModels?: TestModel[];
+  userByokModels?: TestModel[];
+  organizationCustomModels?: TestModel[];
+  deniedModels?: string[];
+}): CloudAgentModelCatalogDeps {
+  const deniedModels = new Set(params.deniedModels ?? []);
+  return {
+    getBaseModels: async () => params.baseModels ?? [],
+    getOrganizationByokModels: async () => params.organizationByokModels ?? [],
+    getUserByokModels: async () => params.userByokModels ?? [],
+    getOrganizationCustomModels: async () => params.organizationCustomModels ?? [],
+    getOrganizationModelPolicy: async () => ({
+      isAllowed: async modelId => !deniedModels.has(modelId),
+    }),
+  };
+}
+
+describe('resolveCloudAgentModel', () => {
+  test('missing modelRequest returns the default model without loading catalog', async () => {
+    let loadedCatalog = false;
+    let calledSelector = false;
+    const selectModel: SelectCloudAgentModel = async () => {
+      calledSelector = true;
+      return { selectedModelId: null, confidence: 'low', reason: 'not called', alternatives: [] };
+    };
+
+    const result = await resolveCloudAgentModel({
+      modelRequest: undefined,
+      defaultModel: 'anthropic/default-model',
+      prompt: 'Fix the bug',
+      owner: userOwner,
+      selectModel,
+      catalogDeps: {
+        getBaseModels: async () => {
+          loadedCatalog = true;
+          return [baseSonnetModel];
+        },
+      },
+    });
+
+    expect(result).toEqual({ ok: true, model: 'anthropic/default-model' });
+    expect(loadedCatalog).toBe(false);
+    expect(calledSelector).toBe(false);
+  });
+
+  test('exact available model ID is used without calling selector', async () => {
+    let calledSelector = false;
+    const selectModel: SelectCloudAgentModel = async () => {
+      calledSelector = true;
+      return {
+        selectedModelId: baseSonnetModel.id,
+        confidence: 'high',
+        reason: 'not called',
+        alternatives: [],
+      };
+    };
+
+    const result = await resolveCloudAgentModel({
+      modelRequest: baseOpusModel.id,
+      defaultModel: baseSonnetModel.id,
+      prompt: 'Fix the bug',
+      owner: userOwner,
+      selectModel,
+      catalogDeps: createDeps({ baseModels: [baseSonnetModel, baseOpusModel] }),
+    });
+
+    expect(result).toEqual({ ok: true, model: baseOpusModel.id });
+    expect(calledSelector).toBe(false);
+  });
+
+  test.each(['opus', 'latest version of opus'])(
+    'simple family request %s selects the latest matching model without calling selector',
+    async modelRequest => {
+      let calledSelector = false;
+      const opus3Model = {
+        id: 'anthropic/claude-3-opus',
+        name: 'Claude 3 Opus',
+      };
+      const opus4Model = {
+        id: 'anthropic/claude-opus-4',
+        name: 'Claude Opus 4',
+      };
+      const selectModel: SelectCloudAgentModel = async () => {
+        calledSelector = true;
+        return {
+          selectedModelId: opus3Model.id,
+          confidence: 'low',
+          reason: 'not called',
+          alternatives: [],
+        };
+      };
+
+      const result = await resolveCloudAgentModel({
+        modelRequest,
+        defaultModel: baseSonnetModel.id,
+        prompt: 'Fix the bug',
+        owner: userOwner,
+        selectModel,
+        catalogDeps: createDeps({ baseModels: [opus3Model, opus4Model, baseOpusModel] }),
+      });
+
+      expect(result).toEqual({ ok: true, model: baseOpusModel.id });
+      expect(calledSelector).toBe(false);
+    }
+  );
+
+  test('rejects an LLM-selected model that is not in the catalog', async () => {
+    const result = await resolveCloudAgentModel({
+      modelRequest: 'best coding model',
+      defaultModel: baseSonnetModel.id,
+      prompt: 'Implement a feature',
+      owner: userOwner,
+      selectModel: async () => ({
+        selectedModelId: 'anthropic/nonexistent-model',
+        confidence: 'high',
+        reason: 'bad selection',
+        alternatives: [baseSonnetModel.id],
+      }),
+      catalogDeps: createDeps({ baseModels: [baseSonnetModel] }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response).toContain('selector chose unavailable model');
+      expect(result.response).toContain(baseSonnetModel.id);
+    }
+  });
+
+  test('returns a clarification error for low-confidence or no-match selections', async () => {
+    const result = await resolveCloudAgentModel({
+      modelRequest: 'the meadow model',
+      defaultModel: baseSonnetModel.id,
+      prompt: 'Explain the code',
+      owner: userOwner,
+      selectModel: async () => ({
+        selectedModelId: null,
+        confidence: 'low',
+        reason: 'ambiguous',
+        alternatives: [baseOpusModel.id],
+      }),
+      catalogDeps: createDeps({ baseModels: [baseSonnetModel, baseOpusModel] }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response).toContain('could not confidently match');
+      expect(result.response).toContain(baseOpusModel.id);
+    }
+  });
+
+  test('rejects org-denied models even if the selector chooses them', async () => {
+    const result = await resolveCloudAgentModel({
+      modelRequest: 'opus',
+      defaultModel: baseSonnetModel.id,
+      prompt: 'Fix a complex bug',
+      owner: orgOwner,
+      selectModel: async () => ({
+        selectedModelId: baseOpusModel.id,
+        confidence: 'high',
+        reason: 'requested opus',
+        alternatives: [baseSonnetModel.id],
+      }),
+      catalogDeps: createDeps({
+        baseModels: [baseSonnetModel, baseOpusModel],
+        deniedModels: [baseOpusModel.id],
+      }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response).toContain('selector chose unavailable model');
+      expect(result.response).toContain(baseSonnetModel.id);
+    }
+  });
+});
+
+describe('buildSelectableCloudAgentModelCatalog', () => {
+  test('includes organization BYOK and custom LLM models for org-owned integrations', async () => {
+    const catalog = await buildSelectableCloudAgentModelCatalog(
+      orgOwner,
+      createDeps({
+        baseModels: [baseSonnetModel],
+        organizationByokModels: [{ id: 'openai/gpt-5', name: 'OpenAI: GPT-5' }],
+        userByokModels: [{ id: 'mistral/codestral', name: 'Mistral: Codestral' }],
+        organizationCustomModels: [{ id: 'custom/org-model', name: 'Org Custom Model' }],
+      })
+    );
+
+    expect(catalog.map(model => model.id)).toEqual([
+      baseSonnetModel.id,
+      'openai/gpt-5',
+      'custom/org-model',
+    ]);
+  });
+
+  test('includes user BYOK models for user-owned integrations', async () => {
+    const catalog = await buildSelectableCloudAgentModelCatalog(
+      userOwner,
+      createDeps({
+        baseModels: [baseSonnetModel],
+        organizationByokModels: [{ id: 'openai/gpt-5', name: 'OpenAI: GPT-5' }],
+        userByokModels: [{ id: 'mistral/codestral', name: 'Mistral: Codestral' }],
+        organizationCustomModels: [{ id: 'custom/org-model', name: 'Org Custom Model' }],
+      })
+    );
+
+    expect(catalog.map(model => model.id)).toEqual([baseSonnetModel.id, 'mistral/codestral']);
+  });
+});

--- a/apps/web/src/lib/bot/tools/cloud-agent-model-selection.test.ts
+++ b/apps/web/src/lib/bot/tools/cloud-agent-model-selection.test.ts
@@ -96,41 +96,115 @@ describe('resolveCloudAgentModel', () => {
     expect(calledSelector).toBe(false);
   });
 
-  test.each(['opus', 'latest version of opus'])(
-    'simple family request %s selects the latest matching model without calling selector',
-    async modelRequest => {
-      let calledSelector = false;
-      const opus3Model = {
-        id: 'anthropic/claude-3-opus',
-        name: 'Claude 3 Opus',
-      };
-      const opus4Model = {
-        id: 'anthropic/claude-opus-4',
-        name: 'Claude Opus 4',
-      };
-      const selectModel: SelectCloudAgentModel = async () => {
+  test('natural-language family request delegates to selector for multilingual matching', async () => {
+    let calledSelector = false;
+    const result = await resolveCloudAgentModel({
+      modelRequest: 'usa el modelo opus mas reciente',
+      defaultModel: baseSonnetModel.id,
+      prompt: 'Fix the bug',
+      owner: userOwner,
+      selectModel: async () => {
         calledSelector = true;
         return {
-          selectedModelId: opus3Model.id,
-          confidence: 'low',
-          reason: 'not called',
+          selectedModelId: baseOpusModel.id,
+          confidence: 'high',
+          reason: 'latest opus requested in Spanish',
           alternatives: [],
         };
-      };
+      },
+      catalogDeps: createDeps({ baseModels: [baseSonnetModel, baseOpusModel] }),
+    });
 
-      const result = await resolveCloudAgentModel({
-        modelRequest,
-        defaultModel: baseSonnetModel.id,
-        prompt: 'Fix the bug',
-        owner: userOwner,
-        selectModel,
-        catalogDeps: createDeps({ baseModels: [opus3Model, opus4Model, baseOpusModel] }),
-      });
+    expect(result).toEqual({ ok: true, model: baseOpusModel.id });
+    expect(calledSelector).toBe(true);
+  });
 
-      expect(result).toEqual({ ok: true, model: baseOpusModel.id });
-      expect(calledSelector).toBe(false);
-    }
-  );
+  test('falls back to direct catalog matching when selector is low confidence', async () => {
+    let calledSelector = false;
+    const opus3Model = {
+      id: 'anthropic/claude-3-opus',
+      name: 'Claude 3 Opus',
+    };
+    const opus4Model = {
+      id: 'anthropic/claude-opus-4',
+      name: 'Claude Opus 4',
+    };
+
+    const result = await resolveCloudAgentModel({
+      modelRequest: 'latest version of opus',
+      defaultModel: baseSonnetModel.id,
+      prompt: 'Fix the bug',
+      owner: userOwner,
+      selectModel: async () => {
+        calledSelector = true;
+        return {
+          selectedModelId: null,
+          confidence: 'low',
+          reason: 'fallback test',
+          alternatives: [],
+        };
+      },
+      catalogDeps: createDeps({ baseModels: [opus3Model, opus4Model, baseOpusModel] }),
+    });
+
+    expect(result).toEqual({ ok: true, model: baseOpusModel.id });
+    expect(calledSelector).toBe(true);
+  });
+
+  test('falls back to exact version-like catalog matching when selector is low confidence', async () => {
+    const minimaxM25Model = {
+      id: 'minimax/minimax-m2.5',
+      name: 'MiniMax M2.5',
+    };
+    const minimaxM27Model = {
+      id: 'minimax/minimax-m2.7',
+      name: 'MiniMax M2.7',
+    };
+
+    const result = await resolveCloudAgentModel({
+      modelRequest: 'minimax m2.5',
+      defaultModel: baseSonnetModel.id,
+      prompt: 'Fix the bug',
+      owner: userOwner,
+      selectModel: async () => ({
+        selectedModelId: null,
+        confidence: 'low',
+        reason: 'fallback test',
+        alternatives: [],
+      }),
+      catalogDeps: createDeps({ baseModels: [minimaxM27Model, minimaxM25Model] }),
+    });
+
+    expect(result).toEqual({ ok: true, model: minimaxM25Model.id });
+  });
+
+  test('falls back to current family model when requested version is unavailable', async () => {
+    const minimaxM27Model = {
+      id: 'minimax/minimax-m2.7',
+      name: 'MiniMax M2.7',
+      preferredIndex: 0,
+    };
+    const minimaxM1Model = {
+      id: 'minimax/minimax-m1',
+      name: 'MiniMax M1',
+    };
+
+    const result = await resolveCloudAgentModel({
+      modelRequest: 'minimax m2.5',
+      defaultModel: baseSonnetModel.id,
+      prompt: 'Fix the bug',
+      owner: userOwner,
+      selectModel: async () => ({
+        selectedModelId: null,
+        confidence: 'low',
+        reason: 'fallback test',
+        alternatives: [],
+      }),
+      catalogDeps: createDeps({ baseModels: [minimaxM1Model, minimaxM27Model] }),
+    });
+
+    expect(result).toEqual({ ok: true, model: minimaxM27Model.id });
+  });
 
   test('rejects an LLM-selected model that is not in the catalog', async () => {
     const result = await resolveCloudAgentModel({

--- a/apps/web/src/lib/bot/tools/cloud-agent-model-selection.ts
+++ b/apps/web/src/lib/bot/tools/cloud-agent-model-selection.ts
@@ -1,0 +1,390 @@
+import { listAvailableCustomLlms } from '@/lib/ai-gateway/custom-llm/listAvailableCustomLlms';
+import { isFreeModel } from '@/lib/ai-gateway/models';
+import {
+  getDirectByokModelsForOrganization,
+  getDirectByokModelsForUser,
+} from '@/lib/ai-gateway/providers/direct-byok';
+import { getEnhancedOpenRouterModels } from '@/lib/ai-gateway/providers/openrouter';
+import type { Owner } from '@/lib/integrations/core/types';
+import {
+  createAllowPredicateFromDenyList,
+  type ProviderAwareAllowPredicate,
+} from '@/lib/model-allow.server';
+import { getEffectiveModelRestrictions } from '@/lib/organizations/model-restrictions';
+import { getOrganizationById } from '@/lib/organizations/organizations';
+import z from 'zod';
+
+export type SelectableCloudAgentModel = {
+  id: string;
+  name: string;
+  provider?: string;
+  created?: number;
+  isFree?: boolean;
+  preferredIndex?: number;
+  contextLength?: number;
+};
+
+type CatalogSourceModel = {
+  id: string;
+  name: string;
+  created?: number;
+  isFree?: boolean;
+  preferredIndex?: number;
+  context_length?: number | null;
+  top_provider?: {
+    context_length?: number | null;
+  };
+};
+
+export const modelSelectionSchema = z.object({
+  selectedModelId: z.string().nullable(),
+  confidence: z.enum(['high', 'medium', 'low']),
+  reason: z.string().max(500),
+  alternatives: z.array(z.string()).max(5).default([]),
+});
+
+export type CloudAgentModelSelection = z.infer<typeof modelSelectionSchema>;
+
+export type SelectCloudAgentModel = (input: {
+  modelRequest: string;
+  prompt: string;
+  catalog: SelectableCloudAgentModel[];
+}) => Promise<CloudAgentModelSelection>;
+
+type ModelPolicy = {
+  isAllowed: ProviderAwareAllowPredicate;
+};
+
+export type CloudAgentModelCatalogDeps = {
+  getBaseModels?: () => Promise<CatalogSourceModel[]>;
+  getOrganizationByokModels?: (organizationId: string) => Promise<CatalogSourceModel[]>;
+  getUserByokModels?: (userId: string) => Promise<CatalogSourceModel[]>;
+  getOrganizationCustomModels?: (organizationId: string) => Promise<CatalogSourceModel[]>;
+  getOrganizationModelPolicy?: (organizationId: string) => Promise<ModelPolicy | undefined>;
+};
+
+export type ResolveCloudAgentModelInput = {
+  modelRequest: string | undefined;
+  defaultModel: string;
+  prompt: string;
+  owner: Owner;
+};
+
+export type ResolveCloudAgentModelResult =
+  | { ok: true; model: string }
+  | { ok: false; response: string };
+
+const alwaysAllowed: ProviderAwareAllowPredicate = async () => true;
+
+async function getDefaultBaseModels(): Promise<CatalogSourceModel[]> {
+  const response = await getEnhancedOpenRouterModels();
+  return response.data;
+}
+
+async function getDefaultOrganizationModelPolicy(
+  organizationId: string
+): Promise<ModelPolicy | undefined> {
+  const organization = await getOrganizationById(organizationId);
+  if (!organization) {
+    return undefined;
+  }
+
+  const { modelDenyList, providerDenyList } = getEffectiveModelRestrictions(organization);
+  if (modelDenyList.length === 0 && providerDenyList.length === 0) {
+    return undefined;
+  }
+
+  return { isAllowed: createAllowPredicateFromDenyList(modelDenyList, providerDenyList) };
+}
+
+function getProviderFromModelId(modelId: string): string | undefined {
+  const separatorIndex = modelId.indexOf('/');
+  if (separatorIndex <= 0) {
+    return undefined;
+  }
+  return modelId.slice(0, separatorIndex);
+}
+
+function toSelectableModel(model: CatalogSourceModel): SelectableCloudAgentModel | null {
+  if (!model.id || !model.name) {
+    return null;
+  }
+
+  const contextLength = model.context_length ?? model.top_provider?.context_length ?? undefined;
+  return {
+    id: model.id,
+    name: model.name,
+    provider: getProviderFromModelId(model.id),
+    created: model.created,
+    isFree: model.isFree ?? isFreeModel(model.id),
+    preferredIndex: model.preferredIndex,
+    contextLength: contextLength ?? undefined,
+  };
+}
+
+async function filterAllowedModels(
+  models: SelectableCloudAgentModel[],
+  isAllowed: ProviderAwareAllowPredicate
+): Promise<SelectableCloudAgentModel[]> {
+  const allowedModels: SelectableCloudAgentModel[] = [];
+  for (const model of models) {
+    if (await isAllowed(model.id)) {
+      allowedModels.push(model);
+    }
+  }
+  return allowedModels;
+}
+
+function dedupeModels(models: SelectableCloudAgentModel[]): SelectableCloudAgentModel[] {
+  const byId = new Map<string, SelectableCloudAgentModel>();
+  for (const model of models) {
+    if (!byId.has(model.id)) {
+      byId.set(model.id, model);
+    }
+  }
+  return [...byId.values()];
+}
+
+export async function buildSelectableCloudAgentModelCatalog(
+  owner: Owner,
+  deps: CloudAgentModelCatalogDeps = {}
+): Promise<SelectableCloudAgentModel[]> {
+  const getBaseModels = deps.getBaseModels ?? getDefaultBaseModels;
+  const getOrganizationByokModels =
+    deps.getOrganizationByokModels ?? getDirectByokModelsForOrganization;
+  const getUserByokModels = deps.getUserByokModels ?? getDirectByokModelsForUser;
+  const getOrganizationCustomModels = deps.getOrganizationCustomModels ?? listAvailableCustomLlms;
+  const getOrganizationModelPolicy =
+    deps.getOrganizationModelPolicy ?? getDefaultOrganizationModelPolicy;
+
+  const baseModels = await getBaseModels();
+  const ownerModels =
+    owner.type === 'org'
+      ? [
+          ...(await getOrganizationByokModels(owner.id)),
+          ...(await getOrganizationCustomModels(owner.id)),
+        ]
+      : await getUserByokModels(owner.id);
+
+  const selectableModels = dedupeModels(
+    [...baseModels, ...ownerModels].map(toSelectableModel).filter(model => model !== null)
+  );
+
+  const policy = owner.type === 'org' ? await getOrganizationModelPolicy(owner.id) : undefined;
+  return filterAllowedModels(selectableModels, policy?.isAllowed ?? alwaysAllowed);
+}
+
+function formatModelList(modelIds: string[]): string {
+  if (modelIds.length === 0) {
+    return 'No close alternatives were found.';
+  }
+  return `Available alternatives: ${modelIds.map(id => `\`${id}\``).join(', ')}.`;
+}
+
+function scoreModelForRequest(model: SelectableCloudAgentModel, request: string): number {
+  const searchable = `${model.id} ${model.name}`.toLowerCase();
+  const normalizedRequest = request.toLowerCase();
+  const tokens = normalizedRequest.split(/[^a-z0-9.-]+/).filter(token => token.length >= 2);
+
+  let score = 0;
+  if (searchable.includes(normalizedRequest)) {
+    score += 10;
+  }
+
+  for (const token of tokens) {
+    if (searchable.includes(token)) {
+      score += 1;
+    }
+  }
+
+  if (model.preferredIndex !== undefined) {
+    score += Math.max(0, 5 - model.preferredIndex / 10);
+  }
+
+  return score;
+}
+
+const catalogMatchStopWords = new Set([
+  'a',
+  'an',
+  'and',
+  'best',
+  'for',
+  'latest',
+  'model',
+  'newest',
+  'of',
+  'the',
+  'to',
+  'use',
+  'using',
+  'version',
+  'with',
+]);
+
+function getCatalogMatchTerms(request: string): string[] {
+  return request
+    .toLowerCase()
+    .split(/[^a-z0-9.-]+/)
+    .filter(token => token.length >= 2 && !catalogMatchStopWords.has(token));
+}
+
+function getVersionParts(model: SelectableCloudAgentModel): number[] {
+  const matches = `${model.id} ${model.name}`.match(/\d+(?:\.\d+)*/g) ?? [];
+  return (
+    matches
+      .map(match => match.split('.').map(part => Number(part)))
+      .sort(compareVersionParts)
+      .at(-1) ?? []
+  );
+}
+
+function compareVersionParts(a: number[], b: number[]): number {
+  const maxLength = Math.max(a.length, b.length);
+  for (let index = 0; index < maxLength; index++) {
+    const diff = (a[index] ?? 0) - (b[index] ?? 0);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
+function compareCatalogMatches(a: SelectableCloudAgentModel, b: SelectableCloudAgentModel): number {
+  if (a.preferredIndex !== undefined && b.preferredIndex !== undefined) {
+    return a.preferredIndex - b.preferredIndex;
+  }
+  if (a.preferredIndex !== undefined) {
+    return -1;
+  }
+  if (b.preferredIndex !== undefined) {
+    return 1;
+  }
+
+  const createdDiff = (b.created ?? 0) - (a.created ?? 0);
+  if (createdDiff !== 0) {
+    return createdDiff;
+  }
+
+  return compareVersionParts(getVersionParts(b), getVersionParts(a));
+}
+
+function findDirectCatalogMatch(
+  request: string,
+  catalog: SelectableCloudAgentModel[]
+): SelectableCloudAgentModel | undefined {
+  const terms = getCatalogMatchTerms(request);
+  if (terms.length === 0 || terms.length > 3) {
+    return undefined;
+  }
+
+  const matches = catalog.filter(model => {
+    const searchable = `${model.id} ${model.name}`.toLowerCase();
+    return terms.every(term => searchable.includes(term));
+  });
+
+  if (matches.length === 0) {
+    return undefined;
+  }
+
+  return [...matches].sort(compareCatalogMatches)[0];
+}
+
+function findModelSuggestions(
+  request: string,
+  catalog: SelectableCloudAgentModel[],
+  alternatives: string[] = []
+): string[] {
+  const catalogIds = new Set(catalog.map(model => model.id));
+  const validAlternatives = alternatives.filter(id => catalogIds.has(id));
+  const scored = catalog
+    .map(model => ({ model, score: scoreModelForRequest(model, request) }))
+    .filter(entry => entry.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map(entry => entry.model.id);
+
+  return [...new Set([...validAlternatives, ...scored, ...catalog.map(model => model.id)])].slice(
+    0,
+    5
+  );
+}
+
+export function buildCloudAgentModelSelectionPrompt(input: {
+  modelRequest: string;
+  prompt: string;
+  catalog: SelectableCloudAgentModel[];
+}): string {
+  const catalogJson = JSON.stringify(input.catalog);
+  return `Choose the best exact Cloud Agent model ID for the user's request.
+
+Rules:
+- Return selectedModelId as one exact id from the catalog, or null if there is no good match.
+- Do not invent model ids or aliases.
+- Prefer current, high-quality coding models when the request asks for quality or coding ability.
+- Prefer free or low-cost models only when the request explicitly asks for cheap, low-cost, or free.
+- Prefer faster/smaller models only when the request asks for fast, quick, small, or lightweight.
+- Use high confidence only when the request clearly maps to one catalog entry.
+- Use medium confidence when there are several reasonable matches but one is clearly best.
+- Use low confidence with selectedModelId null when the request is ambiguous or unavailable.
+
+Model request: ${input.modelRequest}
+
+User task for context:
+${input.prompt}
+
+Catalog JSON:
+${catalogJson}`;
+}
+
+export async function resolveCloudAgentModel(
+  input: ResolveCloudAgentModelInput & {
+    selectModel: SelectCloudAgentModel;
+    catalogDeps?: CloudAgentModelCatalogDeps;
+  }
+): Promise<ResolveCloudAgentModelResult> {
+  const modelRequest = input.modelRequest?.trim();
+  if (!modelRequest) {
+    return { ok: true, model: input.defaultModel };
+  }
+
+  const catalog = await buildSelectableCloudAgentModelCatalog(input.owner, input.catalogDeps);
+  const catalogIds = new Set(catalog.map(model => model.id));
+
+  if (catalogIds.has(modelRequest)) {
+    return { ok: true, model: modelRequest };
+  }
+
+  const directCatalogMatch = findDirectCatalogMatch(modelRequest, catalog);
+  if (directCatalogMatch) {
+    return { ok: true, model: directCatalogMatch.id };
+  }
+
+  if (modelRequest.includes('/')) {
+    return {
+      ok: false,
+      response: `Error selecting Cloud Agent model: requested model \`${modelRequest}\` is not available for this integration. ${formatModelList(findModelSuggestions(modelRequest, catalog))}`,
+    };
+  }
+
+  const selection = await input.selectModel({
+    modelRequest,
+    prompt: input.prompt,
+    catalog,
+  });
+
+  if (!selection.selectedModelId || selection.confidence === 'low') {
+    return {
+      ok: false,
+      response: `Error selecting Cloud Agent model: I could not confidently match \`${modelRequest}\` to an available model. ${formatModelList(findModelSuggestions(modelRequest, catalog, selection.alternatives))}`,
+    };
+  }
+
+  if (!catalogIds.has(selection.selectedModelId)) {
+    return {
+      ok: false,
+      response: `Error selecting Cloud Agent model: the selector chose unavailable model \`${selection.selectedModelId}\`. ${formatModelList(findModelSuggestions(modelRequest, catalog, selection.alternatives))}`,
+    };
+  }
+
+  return { ok: true, model: selection.selectedModelId };
+}

--- a/apps/web/src/lib/bot/tools/cloud-agent-model-selection.ts
+++ b/apps/web/src/lib/bot/tools/cloud-agent-model-selection.ts
@@ -269,11 +269,10 @@ function compareCatalogMatches(a: SelectableCloudAgentModel, b: SelectableCloudA
   return compareVersionParts(getVersionParts(b), getVersionParts(a));
 }
 
-function findDirectCatalogMatch(
-  request: string,
+function findBestCatalogMatchForTerms(
+  terms: string[],
   catalog: SelectableCloudAgentModel[]
 ): SelectableCloudAgentModel | undefined {
-  const terms = getCatalogMatchTerms(request);
   if (terms.length === 0 || terms.length > 3) {
     return undefined;
   }
@@ -288,6 +287,28 @@ function findDirectCatalogMatch(
   }
 
   return [...matches].sort(compareCatalogMatches)[0];
+}
+
+function isVersionLikeTerm(term: string): boolean {
+  return /^(?:v?\d+(?:\.\d+)*|[a-z]\d+(?:\.\d+)*)$/.test(term);
+}
+
+function findCatalogFallbackMatch(
+  request: string,
+  catalog: SelectableCloudAgentModel[]
+): SelectableCloudAgentModel | undefined {
+  const terms = getCatalogMatchTerms(request);
+  const directMatch = findBestCatalogMatchForTerms(terms, catalog);
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const familyTerms = terms.filter(term => !isVersionLikeTerm(term));
+  if (familyTerms.length === terms.length) {
+    return undefined;
+  }
+
+  return findBestCatalogMatchForTerms(familyTerms, catalog);
 }
 
 function findModelSuggestions(
@@ -318,14 +339,20 @@ export function buildCloudAgentModelSelectionPrompt(input: {
   return `Choose the best exact Cloud Agent model ID for the user's request.
 
 Rules:
+- Understand the model request in any language.
 - Return selectedModelId as one exact id from the catalog, or null if there is no good match.
 - Do not invent model ids or aliases.
+- If the request names a model family, provider, or nickname, choose the latest/current matching catalog entry by default.
+- For example, "opus" should choose the latest Claude Opus model, and "minimax" should choose the latest MiniMax model.
+- If the user gives a model family with a version-like label, such as "minimax m2.5", choose the matching exact catalog entry when available.
+- If that exact version is unavailable but the same family has a newer current catalog entry, choose the newer current entry instead of asking the user to choose.
+- Do not ask the user to choose between current and legacy versions unless they explicitly requested a legacy version that is available.
 - Prefer current, high-quality coding models when the request asks for quality or coding ability.
 - Prefer free or low-cost models only when the request explicitly asks for cheap, low-cost, or free.
 - Prefer faster/smaller models only when the request asks for fast, quick, small, or lightweight.
-- Use high confidence only when the request clearly maps to one catalog entry.
+- Use high confidence when a family/provider/name request has one best current match.
 - Use medium confidence when there are several reasonable matches but one is clearly best.
-- Use low confidence with selectedModelId null when the request is ambiguous or unavailable.
+- Use low confidence with selectedModelId null only when there is no relevant catalog match or the request is genuinely impossible to disambiguate.
 
 Model request: ${input.modelRequest}
 
@@ -354,11 +381,6 @@ export async function resolveCloudAgentModel(
     return { ok: true, model: modelRequest };
   }
 
-  const directCatalogMatch = findDirectCatalogMatch(modelRequest, catalog);
-  if (directCatalogMatch) {
-    return { ok: true, model: directCatalogMatch.id };
-  }
-
   if (modelRequest.includes('/')) {
     return {
       ok: false,
@@ -372,6 +394,17 @@ export async function resolveCloudAgentModel(
     catalog,
   });
 
+  if (selection.selectedModelId && selection.confidence !== 'low') {
+    if (catalogIds.has(selection.selectedModelId)) {
+      return { ok: true, model: selection.selectedModelId };
+    }
+  }
+
+  const catalogFallbackMatch = findCatalogFallbackMatch(modelRequest, catalog);
+  if (catalogFallbackMatch) {
+    return { ok: true, model: catalogFallbackMatch.id };
+  }
+
   if (!selection.selectedModelId || selection.confidence === 'low') {
     return {
       ok: false,
@@ -379,12 +412,8 @@ export async function resolveCloudAgentModel(
     };
   }
 
-  if (!catalogIds.has(selection.selectedModelId)) {
-    return {
-      ok: false,
-      response: `Error selecting Cloud Agent model: the selector chose unavailable model \`${selection.selectedModelId}\`. ${formatModelList(findModelSuggestions(modelRequest, catalog, selection.alternatives))}`,
-    };
-  }
-
-  return { ok: true, model: selection.selectedModelId };
+  return {
+    ok: false,
+    response: `Error selecting Cloud Agent model: the selector chose unavailable model \`${selection.selectedModelId}\`. ${formatModelList(findModelSuggestions(modelRequest, catalog, selection.alternatives))}`,
+  };
 }

--- a/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.ts
+++ b/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.ts
@@ -18,6 +18,10 @@ import {
 import { APP_URL } from '@/lib/constants';
 import { INTERNAL_API_SECRET } from '@/lib/config.server';
 import { parseBotCallbackStep } from '@/lib/bot/step-budget';
+import type {
+  ResolveCloudAgentModelInput,
+  ResolveCloudAgentModelResult,
+} from '@/lib/bot/tools/cloud-agent-model-selection';
 import { resolveBotSessionProfile } from '@/lib/bot/tools/resolve-bot-session-profile';
 import { ownerFromIntegration } from '@/lib/integrations/core/owner';
 import type { Owner } from '@/lib/integrations/core/types';
@@ -72,6 +76,12 @@ export const spawnCloudAgentInputSchema = z.object({
     .describe(
       'The task description for the Cloud Agent. Be specific about what changes or analysis you want.'
     ),
+  modelRequest: z
+    .string()
+    .describe(
+      'Optional natural-language model preference for the Cloud Agent session. This is how you select a user-requested Cloud Agent model: pass phrases like "minimax", "opus", "latest Claude", "cheap fast model", or an exact provider/model ID. Only set this when the user explicitly asks for a model.'
+    )
+    .optional(),
   mode: z
     .enum(['code', 'ask'])
     .describe(
@@ -81,6 +91,13 @@ export const spawnCloudAgentInputSchema = z.object({
 
 type SpawnCloudAgentInput = z.infer<typeof spawnCloudAgentInputSchema>;
 
+type SpawnCloudAgentSessionOptions = {
+  prSignature?: string;
+  chatPlatform?: string;
+  currentStep?: number;
+  resolveModel?: (input: ResolveCloudAgentModelInput) => Promise<ResolveCloudAgentModelResult>;
+};
+
 /**
  * Spawn a Cloud Agent session and collect the results.
  * Supports both GitHub (githubRepo) and GitLab (gitlabProject) repositories.
@@ -88,13 +105,13 @@ type SpawnCloudAgentInput = z.infer<typeof spawnCloudAgentInputSchema>;
  */
 export default async function spawnCloudAgentSession(
   args: SpawnCloudAgentInput,
-  model: string,
+  defaultModel: string,
   platformIntegration: PlatformIntegration,
   authToken: string,
   ticketUserId: string,
   botRequestId: string | undefined,
   onSessionReady?: RunSessionInput['onSessionReady'],
-  options?: { prSignature?: string; chatPlatform?: string; currentStep?: number }
+  options?: SpawnCloudAgentSessionOptions
 ): Promise<SpawnCloudAgentResult> {
   console.log('[KiloBot] spawnCloudAgentSession called with args:', JSON.stringify(args, null, 2));
 
@@ -123,6 +140,25 @@ export default async function spawnCloudAgentSession(
   }
 
   const owner: Owner = ownerFromIntegration(platformIntegration);
+  let cloudAgentModel = defaultModel;
+  if (options?.resolveModel) {
+    try {
+      const modelResolution = await options.resolveModel({
+        modelRequest: args.modelRequest,
+        defaultModel,
+        prompt: args.prompt,
+        owner,
+      });
+      if (!modelResolution.ok) {
+        return { response: modelResolution.response };
+      }
+      cloudAgentModel = modelResolution.model;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { response: `Error selecting Cloud Agent model: ${message}` };
+    }
+  }
+
   let profileConfig: MergeProfileConfigurationResult;
   try {
     profileConfig = await resolveBotSessionProfile(owner, ticketUserId, args);
@@ -165,7 +201,7 @@ export default async function spawnCloudAgentSession(
     prepareInput = {
       prompt,
       mode,
-      model,
+      model: cloudAgentModel,
       gitUrl,
       gitToken: gitlabToken,
       platform: 'gitlab',
@@ -195,7 +231,7 @@ export default async function spawnCloudAgentSession(
       githubRepo: args.githubRepo,
       prompt,
       mode,
-      model,
+      model: cloudAgentModel,
       githubToken,
       kilocodeOrganizationId,
       createdOnPlatform: chatPlatform,


### PR DESCRIPTION
## Summary
- Add `modelRequest` support to Cloud Agent bot spawns so users can request models in natural language or by exact model ID.
- Resolve Cloud Agent models server-side against the current catalog, including OpenRouter, BYOK, custom LLMs, and org model restrictions.
- Use an internal LLM selector with catalog fallback handling for multilingual, family, and versioned model requests such as Opus and MiniMax.

## Verification
Manual end-to-end bot verification not performed locally.

## Visual Changes
N/A

## Reviewer Notes
- The Cloud Agent summary prompt still uses the bot model, not the selected Cloud Agent model.
- Current fallback matching is intentionally secondary to the LLM selector so non-English requests can be understood by the selector first.