### PR TITLE
fix(kiloclaw): prevent funded subscription demotion on destroy

### DIFF
--- a/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
+++ b/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import {
   collapseOrphanPersonalSubscriptionsOnDestroy,
+  FundedRowDemotionRefusedError,
   markInstanceDestroyedWithPersonalSubscriptionCollapse,
   PersonalSubscriptionDestroyConflictError,
 } from '@kilocode/db';
@@ -19,6 +20,28 @@ const TEST_ACTOR = {
   actorType: 'system',
   actorId: 'personal-subscription-destroy-collapse-test',
 } as const;
+
+const DESTROY_REASON = 'destroy_path_inline_collapse';
+const CANCEL_SINGLE_REASON = 'destroy_path_cancel_single_current_access_row';
+
+type PersonalPlan = 'standard' | 'trial' | 'commit';
+type PersonalStatus = 'active' | 'canceled' | 'trialing' | 'past_due';
+
+type ExpectedChangeLogEntry = {
+  subscriptionId: string;
+  action: 'reassigned' | 'canceled';
+  reason: string;
+  beforeTransferredTo: string | null;
+  afterTransferredTo: string | null;
+  beforePlan: PersonalPlan;
+  afterPlan?: PersonalPlan;
+  beforeStatus: PersonalStatus;
+  afterStatus?: PersonalStatus;
+  beforeStripeSubscriptionId?: string | null;
+  afterStripeSubscriptionId?: string | null;
+  beforeStripeScheduleId?: string | null;
+  afterStripeScheduleId?: string | null;
+};
 
 async function insertPersonalInstance(params: {
   createdAt: string;
@@ -39,11 +62,15 @@ async function insertPersonalSubscription(params: {
   createdAt: string;
   id: string;
   instanceId: string;
-  plan: 'standard' | 'trial';
+  plan: PersonalPlan;
   paymentSource?: 'credits' | 'stripe' | null;
-  status: 'active' | 'canceled';
+  status: PersonalStatus;
+  stripeScheduleId?: string | null;
   stripeSubscriptionId?: string | null;
+  suspendedAt?: string | null;
   transferredToSubscriptionId?: string | null;
+  trialEndsAt?: string | null;
+  trialStartedAt?: string | null;
   userId: string;
 }) {
   await db.insert(kiloclaw_subscriptions).values({
@@ -52,13 +79,149 @@ async function insertPersonalSubscription(params: {
     instance_id: params.instanceId,
     plan: params.plan,
     status: params.status,
-    payment_source: params.paymentSource ?? 'credits',
+    payment_source: params.paymentSource ?? (params.plan === 'trial' ? null : 'credits'),
     stripe_subscription_id: params.stripeSubscriptionId ?? null,
+    stripe_schedule_id: params.stripeScheduleId ?? null,
+    suspended_at: params.suspendedAt ?? null,
+    trial_started_at: params.trialStartedAt ?? null,
+    trial_ends_at: params.trialEndsAt ?? null,
     cancel_at_period_end: false,
     transferred_to_subscription_id: params.transferredToSubscriptionId ?? null,
     created_at: params.createdAt,
     updated_at: params.createdAt,
   });
+}
+
+async function listUserSubscriptions(userId: string) {
+  return await db
+    .select()
+    .from(kiloclaw_subscriptions)
+    .where(eq(kiloclaw_subscriptions.user_id, userId))
+    .orderBy(kiloclaw_subscriptions.created_at, kiloclaw_subscriptions.id);
+}
+
+async function listChangeLogsForSubscriptions(subscriptionIds: string[]) {
+  if (subscriptionIds.length === 0) {
+    return [];
+  }
+
+  return await db
+    .select()
+    .from(kiloclaw_subscription_change_log)
+    .where(inArray(kiloclaw_subscription_change_log.subscription_id, subscriptionIds))
+    .orderBy(
+      kiloclaw_subscription_change_log.created_at,
+      kiloclaw_subscription_change_log.subscription_id
+    );
+}
+
+function expectTransferredToTargets(
+  subscriptions: Awaited<ReturnType<typeof listUserSubscriptions>>,
+  expectedTargets: Record<string, string | null>
+) {
+  expect(
+    Object.fromEntries(
+      subscriptions.map(subscription => [
+        subscription.id,
+        subscription.transferred_to_subscription_id,
+      ])
+    )
+  ).toEqual(expectedTargets);
+}
+
+async function expectCurrentHead(params: { subscriptionId: string; userId: string }) {
+  const currentRows = await listCurrentPersonalSubscriptionRows({ userId: params.userId });
+  expect(currentRows).toHaveLength(1);
+  expect(currentRows[0]?.subscription.id).toBe(params.subscriptionId);
+}
+
+async function expectNoChangeLogsForSubscriptions(subscriptionIds: string[]) {
+  const logs = await listChangeLogsForSubscriptions(subscriptionIds);
+  expect(logs).toHaveLength(0);
+}
+
+async function expectChangeLogsForSubscriptions(expectedEntries: ExpectedChangeLogEntry[]) {
+  const logs = await listChangeLogsForSubscriptions(
+    expectedEntries.map(entry => entry.subscriptionId)
+  );
+
+  expect(logs).toHaveLength(expectedEntries.length);
+
+  for (const entry of expectedEntries) {
+    const log = logs.find(
+      candidate =>
+        candidate.subscription_id === entry.subscriptionId &&
+        candidate.action === entry.action &&
+        candidate.reason === entry.reason
+    );
+
+    expect(log).toBeDefined();
+    if (!log) {
+      continue;
+    }
+
+    expect(log).toEqual(
+      expect.objectContaining({
+        actor_type: TEST_ACTOR.actorType,
+        actor_id: TEST_ACTOR.actorId,
+        action: entry.action,
+        reason: entry.reason,
+      })
+    );
+
+    const expectedBeforeState = {
+      id: entry.subscriptionId,
+      transferred_to_subscription_id: entry.beforeTransferredTo,
+      plan: entry.beforePlan,
+      status: entry.beforeStatus,
+      ...(entry.beforeStripeSubscriptionId !== undefined
+        ? { stripe_subscription_id: entry.beforeStripeSubscriptionId }
+        : {}),
+      ...(entry.beforeStripeScheduleId !== undefined
+        ? { stripe_schedule_id: entry.beforeStripeScheduleId }
+        : {}),
+    };
+
+    const expectedAfterState = {
+      id: entry.subscriptionId,
+      transferred_to_subscription_id: entry.afterTransferredTo,
+      plan: entry.afterPlan ?? entry.beforePlan,
+      status: entry.afterStatus ?? entry.beforeStatus,
+      ...(entry.afterStripeSubscriptionId !== undefined ||
+      entry.beforeStripeSubscriptionId !== undefined
+        ? {
+            stripe_subscription_id:
+              entry.afterStripeSubscriptionId ?? entry.beforeStripeSubscriptionId ?? null,
+          }
+        : {}),
+      ...(entry.afterStripeScheduleId !== undefined || entry.beforeStripeScheduleId !== undefined
+        ? {
+            stripe_schedule_id: entry.afterStripeScheduleId ?? entry.beforeStripeScheduleId ?? null,
+          }
+        : {}),
+    };
+
+    expect(log.before_state).toEqual(expect.objectContaining(expectedBeforeState));
+    expect(log.after_state).toEqual(expect.objectContaining(expectedAfterState));
+  }
+}
+
+function expectCollapseStructuredLog(params: {
+  destroyedInstanceId: string;
+  headPlan: PersonalPlan;
+  headStatus: PersonalStatus;
+  headStripeSubscriptionId: string | null;
+  headSubscriptionId: string;
+  rowCountAlive: number;
+  rowCountTotal: number;
+  updateCount: number;
+  userId: string;
+}) {
+  expect(console.log).toHaveBeenCalledTimes(1);
+  expect(console.log).toHaveBeenCalledWith(
+    'personal_subscription_destroy_collapse_applied',
+    expect.objectContaining(params)
+  );
 }
 
 describe('personal subscription destroy collapse', () => {
@@ -132,38 +295,370 @@ describe('personal subscription destroy collapse', () => {
         actor: TEST_ACTOR,
         executor: tx,
         instanceId: instanceC,
-        reason: 'destroy_path_inline_collapse',
+        reason: DESTROY_REASON,
         userId: user.id,
       });
     });
 
-    const currentRows = await listCurrentPersonalSubscriptionRows({ userId: user.id });
-    expect(currentRows).toHaveLength(1);
-    expect(currentRows[0]?.subscription.id).toBe(subscriptionC);
+    await expectCurrentHead({ subscriptionId: subscriptionC, userId: user.id });
 
-    const subscriptions = await db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.user_id, user.id))
-      .orderBy(kiloclaw_subscriptions.created_at);
+    const subscriptions = await listUserSubscriptions(user.id);
+    expectTransferredToTargets(subscriptions, {
+      [subscriptionA]: subscriptionB,
+      [subscriptionB]: subscriptionC,
+      [subscriptionC]: null,
+    });
 
-    expect(subscriptions.map(subscription => subscription.transferred_to_subscription_id)).toEqual([
-      subscriptionB,
-      subscriptionC,
-      null,
+    await expectChangeLogsForSubscriptions([
+      {
+        subscriptionId: subscriptionA,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: subscriptionB,
+        beforePlan: 'trial',
+        beforeStatus: 'canceled',
+      },
+      {
+        subscriptionId: subscriptionB,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: subscriptionC,
+        beforePlan: 'standard',
+        beforeStatus: 'canceled',
+      },
     ]);
 
-    const changeLogs = await db
-      .select()
-      .from(kiloclaw_subscription_change_log)
-      .where(eq(kiloclaw_subscription_change_log.actor_id, TEST_ACTOR.actorId))
-      .orderBy(kiloclaw_subscription_change_log.created_at);
+    expectCollapseStructuredLog({
+      userId: user.id,
+      destroyedInstanceId: instanceC,
+      rowCountTotal: 3,
+      rowCountAlive: 0,
+      headSubscriptionId: subscriptionC,
+      headPlan: 'standard',
+      headStatus: 'active',
+      headStripeSubscriptionId: null,
+      updateCount: 2,
+    });
+  });
 
-    expect(changeLogs).toHaveLength(2);
-    expect(changeLogs.every(log => log.reason === 'destroy_path_inline_collapse')).toBe(true);
-    expect(changeLogs.map(log => log.subscription_id).sort()).toEqual(
-      [subscriptionA, subscriptionB].sort()
+  it('keeps an older funded commit row at the head above destroyed trials', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-collapse-commit-head@example.com',
+    });
+
+    const commitInstanceId = crypto.randomUUID();
+    const commitSubscriptionId = crypto.randomUUID();
+    const trialSubscriptions: Array<{ instanceId: string; subscriptionId: string }> = [];
+
+    await insertPersonalInstance({
+      id: commitInstanceId,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    });
+    await insertPersonalSubscription({
+      id: commitSubscriptionId,
+      userId: user.id,
+      instanceId: commitInstanceId,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'commit',
+      status: 'active',
+    });
+
+    for (let index = 0; index < 9; index += 1) {
+      const instanceId = crypto.randomUUID();
+      const subscriptionId = crypto.randomUUID();
+      trialSubscriptions.push({ instanceId, subscriptionId });
+      const createdAt = `2026-04-01T00:0${index + 1}:00.000Z`;
+
+      await insertPersonalInstance({
+        id: instanceId,
+        userId: user.id,
+        createdAt,
+        destroyedAt: `2026-04-02T00:0${index + 1}:00.000Z`,
+      });
+      await insertPersonalSubscription({
+        id: subscriptionId,
+        userId: user.id,
+        instanceId,
+        createdAt,
+        plan: 'trial',
+        status: 'canceled',
+      });
+    }
+
+    await db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId: commitInstanceId,
+        reason: DESTROY_REASON,
+        userId: user.id,
+      });
+    });
+
+    await expectCurrentHead({ subscriptionId: commitSubscriptionId, userId: user.id });
+
+    const subscriptions = await listUserSubscriptions(user.id);
+    const expectedTargets: Record<string, string | null> = {
+      [commitSubscriptionId]: null,
+    };
+    for (const [index, trial] of trialSubscriptions.entries()) {
+      expectedTargets[trial.subscriptionId] =
+        trialSubscriptions[index + 1]?.subscriptionId ?? commitSubscriptionId;
+    }
+    expectTransferredToTargets(subscriptions, expectedTargets);
+
+    await expectChangeLogsForSubscriptions(
+      trialSubscriptions.map((trial, index) => ({
+        subscriptionId: trial.subscriptionId,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: trialSubscriptions[index + 1]?.subscriptionId ?? commitSubscriptionId,
+        beforePlan: 'trial',
+        beforeStatus: 'canceled',
+      }))
     );
+
+    expectCollapseStructuredLog({
+      userId: user.id,
+      destroyedInstanceId: commitInstanceId,
+      rowCountTotal: 10,
+      rowCountAlive: 0,
+      headSubscriptionId: commitSubscriptionId,
+      headPlan: 'commit',
+      headStatus: 'active',
+      headStripeSubscriptionId: null,
+      updateCount: 9,
+    });
+  });
+
+  it('keeps an older Stripe-funded standard row at the head above destroyed trials', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-collapse-stripe-head@example.com',
+    });
+
+    const standardInstanceId = crypto.randomUUID();
+    const standardSubscriptionId = crypto.randomUUID();
+    const trialInstanceA = crypto.randomUUID();
+    const trialInstanceB = crypto.randomUUID();
+    const trialSubscriptionA = crypto.randomUUID();
+    const trialSubscriptionB = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: standardInstanceId,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: trialInstanceA,
+      userId: user.id,
+      createdAt: '2026-04-01T00:01:00.000Z',
+      destroyedAt: '2026-04-02T00:01:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: trialInstanceB,
+      userId: user.id,
+      createdAt: '2026-04-01T00:02:00.000Z',
+      destroyedAt: '2026-04-02T00:02:00.000Z',
+    });
+
+    await insertPersonalSubscription({
+      id: standardSubscriptionId,
+      userId: user.id,
+      instanceId: standardInstanceId,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'standard',
+      status: 'active',
+      paymentSource: 'credits',
+      stripeSubscriptionId: 'sub_destroy_collapse_standard',
+    });
+    await insertPersonalSubscription({
+      id: trialSubscriptionA,
+      userId: user.id,
+      instanceId: trialInstanceA,
+      createdAt: '2026-04-01T00:01:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+    await insertPersonalSubscription({
+      id: trialSubscriptionB,
+      userId: user.id,
+      instanceId: trialInstanceB,
+      createdAt: '2026-04-01T00:02:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+
+    await db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId: standardInstanceId,
+        reason: DESTROY_REASON,
+        userId: user.id,
+      });
+    });
+
+    await expectCurrentHead({ subscriptionId: standardSubscriptionId, userId: user.id });
+
+    const subscriptions = await listUserSubscriptions(user.id);
+    expectTransferredToTargets(subscriptions, {
+      [standardSubscriptionId]: null,
+      [trialSubscriptionA]: trialSubscriptionB,
+      [trialSubscriptionB]: standardSubscriptionId,
+    });
+
+    await expectChangeLogsForSubscriptions([
+      {
+        subscriptionId: trialSubscriptionA,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: trialSubscriptionB,
+        beforePlan: 'trial',
+        beforeStatus: 'canceled',
+      },
+      {
+        subscriptionId: trialSubscriptionB,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: standardSubscriptionId,
+        beforePlan: 'trial',
+        beforeStatus: 'canceled',
+      },
+    ]);
+
+    expectCollapseStructuredLog({
+      userId: user.id,
+      destroyedInstanceId: standardInstanceId,
+      rowCountTotal: 3,
+      rowCountAlive: 0,
+      headSubscriptionId: standardSubscriptionId,
+      headPlan: 'standard',
+      headStatus: 'active',
+      headStripeSubscriptionId: 'sub_destroy_collapse_standard',
+      updateCount: 2,
+    });
+  });
+
+  it('keeps a Stripe-funded row with a schedule at the head above destroyed trials', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-collapse-stripe-schedule-head@example.com',
+    });
+
+    const standardInstanceId = crypto.randomUUID();
+    const standardSubscriptionId = crypto.randomUUID();
+    const trialInstanceA = crypto.randomUUID();
+    const trialInstanceB = crypto.randomUUID();
+    const trialSubscriptionA = crypto.randomUUID();
+    const trialSubscriptionB = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: standardInstanceId,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: trialInstanceA,
+      userId: user.id,
+      createdAt: '2026-04-01T00:01:00.000Z',
+      destroyedAt: '2026-04-02T00:01:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: trialInstanceB,
+      userId: user.id,
+      createdAt: '2026-04-01T00:02:00.000Z',
+      destroyedAt: '2026-04-02T00:02:00.000Z',
+    });
+
+    await insertPersonalSubscription({
+      id: standardSubscriptionId,
+      userId: user.id,
+      instanceId: standardInstanceId,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'standard',
+      status: 'active',
+      paymentSource: 'credits',
+      stripeSubscriptionId: 'sub_destroy_collapse_scheduled',
+      stripeScheduleId: 'sub_sched_destroy_collapse_scheduled',
+    });
+    await insertPersonalSubscription({
+      id: trialSubscriptionA,
+      userId: user.id,
+      instanceId: trialInstanceA,
+      createdAt: '2026-04-01T00:01:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+    await insertPersonalSubscription({
+      id: trialSubscriptionB,
+      userId: user.id,
+      instanceId: trialInstanceB,
+      createdAt: '2026-04-01T00:02:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+
+    await db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId: standardInstanceId,
+        reason: DESTROY_REASON,
+        userId: user.id,
+      });
+    });
+
+    await expectCurrentHead({ subscriptionId: standardSubscriptionId, userId: user.id });
+
+    const currentRows = await listCurrentPersonalSubscriptionRows({ userId: user.id });
+    expect(currentRows[0]?.subscription.stripe_schedule_id).toBe(
+      'sub_sched_destroy_collapse_scheduled'
+    );
+
+    const subscriptions = await listUserSubscriptions(user.id);
+    expectTransferredToTargets(subscriptions, {
+      [standardSubscriptionId]: null,
+      [trialSubscriptionA]: trialSubscriptionB,
+      [trialSubscriptionB]: standardSubscriptionId,
+    });
+
+    await expectChangeLogsForSubscriptions([
+      {
+        subscriptionId: trialSubscriptionA,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: trialSubscriptionB,
+        beforePlan: 'trial',
+        beforeStatus: 'canceled',
+      },
+      {
+        subscriptionId: trialSubscriptionB,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: standardSubscriptionId,
+        beforePlan: 'trial',
+        beforeStatus: 'canceled',
+      },
+    ]);
+
+    expectCollapseStructuredLog({
+      userId: user.id,
+      destroyedInstanceId: standardInstanceId,
+      rowCountTotal: 3,
+      rowCountAlive: 0,
+      headSubscriptionId: standardSubscriptionId,
+      headPlan: 'standard',
+      headStatus: 'active',
+      headStripeSubscriptionId: 'sub_destroy_collapse_scheduled',
+      updateCount: 2,
+    });
   });
 
   it('splices existing chain around orphan and is idempotent on rerun', async () => {
@@ -227,41 +722,50 @@ describe('personal subscription destroy collapse', () => {
         actor: TEST_ACTOR,
         executor: tx,
         instanceId: instanceC,
-        reason: 'destroy_path_inline_collapse',
+        reason: DESTROY_REASON,
         userId: user.id,
       });
     });
 
-    const afterFirstRun = await db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.user_id, user.id))
-      .orderBy(kiloclaw_subscriptions.created_at);
-
-    expect(afterFirstRun.map(subscription => subscription.transferred_to_subscription_id)).toEqual([
-      subscriptionB,
-      subscriptionC,
-      null,
-    ]);
+    const afterFirstRun = await listUserSubscriptions(user.id);
+    expectTransferredToTargets(afterFirstRun, {
+      [subscriptionA]: subscriptionB,
+      [subscriptionB]: subscriptionC,
+      [subscriptionC]: null,
+    });
 
     const result = await db.transaction(async tx => {
       return await collapseOrphanPersonalSubscriptionsOnDestroy({
         actor: TEST_ACTOR,
         destroyedInstanceId: instanceC,
         executor: tx,
-        reason: 'destroy_path_inline_collapse',
+        reason: DESTROY_REASON,
         userId: user.id,
       });
     });
 
     expect(result.updatedSubscriptionIds).toHaveLength(0);
 
-    const logs = await db
-      .select()
-      .from(kiloclaw_subscription_change_log)
-      .where(eq(kiloclaw_subscription_change_log.actor_id, TEST_ACTOR.actorId));
-
-    expect(logs).toHaveLength(2);
+    await expectChangeLogsForSubscriptions([
+      {
+        subscriptionId: subscriptionA,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: subscriptionC,
+        afterTransferredTo: subscriptionB,
+        beforePlan: 'trial',
+        beforeStatus: 'canceled',
+      },
+      {
+        subscriptionId: subscriptionB,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: subscriptionC,
+        beforePlan: 'standard',
+        beforeStatus: 'canceled',
+      },
+    ]);
   });
 
   it('logs and continues when collapse change log write fails outside transaction', async () => {
@@ -348,7 +852,7 @@ describe('personal subscription destroy collapse', () => {
       executor,
       instanceId: instanceC,
       onChangeLogFailure,
-      reason: 'destroy_path_inline_collapse',
+      reason: DESTROY_REASON,
       userId: user.id,
     });
 
@@ -358,7 +862,7 @@ describe('personal subscription destroy collapse', () => {
       1,
       expect.objectContaining({
         error: changeLogFailure,
-        reason: 'destroy_path_inline_collapse',
+        reason: DESTROY_REASON,
         subscriptionId: subscriptionA,
         userId: user.id,
       })
@@ -367,30 +871,20 @@ describe('personal subscription destroy collapse', () => {
       2,
       expect.objectContaining({
         error: changeLogFailure,
-        reason: 'destroy_path_inline_collapse',
+        reason: DESTROY_REASON,
         subscriptionId: subscriptionB,
         userId: user.id,
       })
     );
 
-    const subscriptions = await db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.user_id, user.id))
-      .orderBy(kiloclaw_subscriptions.created_at);
+    const subscriptions = await listUserSubscriptions(user.id);
+    expectTransferredToTargets(subscriptions, {
+      [subscriptionA]: subscriptionB,
+      [subscriptionB]: subscriptionC,
+      [subscriptionC]: null,
+    });
 
-    expect(subscriptions.map(subscription => subscription.transferred_to_subscription_id)).toEqual([
-      subscriptionB,
-      subscriptionC,
-      null,
-    ]);
-
-    const logs = await db
-      .select()
-      .from(kiloclaw_subscription_change_log)
-      .where(eq(kiloclaw_subscription_change_log.actor_id, TEST_ACTOR.actorId));
-
-    expect(logs).toHaveLength(0);
+    await expectNoChangeLogsForSubscriptions([subscriptionA, subscriptionB, subscriptionC]);
   });
 
   it('rolls back single-row cancellation when change-log insert fails in transaction', async () => {
@@ -433,7 +927,7 @@ describe('personal subscription destroy collapse', () => {
           actor: TEST_ACTOR,
           executor,
           instanceId,
-          reason: 'destroy_path_inline_collapse',
+          reason: DESTROY_REASON,
           userId: user.id,
         });
       })
@@ -450,6 +944,7 @@ describe('personal subscription destroy collapse', () => {
 
     expect(subscription?.status).toBe('active');
     expect(instance?.destroyed_at).toBeNull();
+    await expectNoChangeLogsForSubscriptions([subscriptionId]);
   });
 
   it('does not auto-cancel single destroyed Stripe or hybrid current row on destroy path', async () => {
@@ -500,14 +995,14 @@ describe('personal subscription destroy collapse', () => {
         actor: TEST_ACTOR,
         executor: tx,
         instanceId: stripeInstanceId,
-        reason: 'destroy_path_inline_collapse',
+        reason: DESTROY_REASON,
         userId: stripeUser.id,
       });
       await markInstanceDestroyedWithPersonalSubscriptionCollapse({
         actor: TEST_ACTOR,
         executor: tx,
         instanceId: hybridInstanceId,
-        reason: 'destroy_path_inline_collapse',
+        reason: DESTROY_REASON,
         userId: hybridUser.id,
       });
     });
@@ -516,15 +1011,6 @@ describe('personal subscription destroy collapse', () => {
       .select()
       .from(kiloclaw_subscriptions)
       .where(inArray(kiloclaw_subscriptions.id, [stripeSubscriptionId, hybridSubscriptionId]));
-    const logs = await db
-      .select()
-      .from(kiloclaw_subscription_change_log)
-      .where(
-        inArray(kiloclaw_subscription_change_log.subscription_id, [
-          stripeSubscriptionId,
-          hybridSubscriptionId,
-        ])
-      );
 
     expect(subscriptions).toEqual(
       expect.arrayContaining([
@@ -532,10 +1018,11 @@ describe('personal subscription destroy collapse', () => {
         expect.objectContaining({ id: hybridSubscriptionId, status: 'active' }),
       ])
     );
-    expect(logs).toHaveLength(0);
+    await expectNoChangeLogsForSubscriptions([stripeSubscriptionId, hybridSubscriptionId]);
+    expect(console.log).not.toHaveBeenCalled();
   });
 
-  it('cancels single destroyed current access row on destroy path', async () => {
+  it('cancels a single destroyed current access row without entering the chain-build path', async () => {
     const user = await insertTestUser({
       google_user_email: 'destroy-cancel-single-current@example.com',
     });
@@ -561,7 +1048,7 @@ describe('personal subscription destroy collapse', () => {
         actor: TEST_ACTOR,
         executor: tx,
         instanceId,
-        reason: 'destroy_path_inline_collapse',
+        reason: DESTROY_REASON,
         userId: user.id,
       });
     });
@@ -570,23 +1057,27 @@ describe('personal subscription destroy collapse', () => {
       .select()
       .from(kiloclaw_subscriptions)
       .where(eq(kiloclaw_subscriptions.id, subscriptionId));
-    const logs = await db
-      .select()
-      .from(kiloclaw_subscription_change_log)
-      .where(eq(kiloclaw_subscription_change_log.subscription_id, subscriptionId));
 
     expect(subscription?.status).toBe('canceled');
-    expect(logs).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          action: 'canceled',
-          reason: 'destroy_path_cancel_single_current_access_row',
-        }),
-      ])
-    );
+    expect(subscription?.transferred_to_subscription_id).toBeNull();
+
+    await expectChangeLogsForSubscriptions([
+      {
+        subscriptionId,
+        action: 'canceled',
+        reason: CANCEL_SINGLE_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: null,
+        beforePlan: 'standard',
+        beforeStatus: 'active',
+        afterStatus: 'canceled',
+      },
+    ]);
+
+    expect(console.log).not.toHaveBeenCalled();
   });
 
-  it('refuses collapse when multiple alive current personal rows exist', async () => {
+  it('refuses collapse when multiple alive current funded personal rows exist', async () => {
     const user = await insertTestUser({
       google_user_email: 'destroy-refuse-multi-alive@example.com',
     });
@@ -630,7 +1121,7 @@ describe('personal subscription destroy collapse', () => {
           actor: TEST_ACTOR,
           executor: tx,
           instanceId: instanceB,
-          reason: 'destroy_path_inline_collapse',
+          reason: DESTROY_REASON,
           userId: user.id,
         });
       })
@@ -644,14 +1135,236 @@ describe('personal subscription destroy collapse', () => {
 
     expect(instances.every(instance => instance.destroyed_at === null)).toBe(true);
 
-    const subscriptions = await db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.user_id, user.id))
-      .orderBy(kiloclaw_subscriptions.created_at);
+    const subscriptions = await listUserSubscriptions(user.id);
+    expectTransferredToTargets(subscriptions, {
+      [subscriptionA]: null,
+      [subscriptionB]: null,
+    });
 
-    expect(
-      subscriptions.every(subscription => subscription.transferred_to_subscription_id === null)
-    ).toBe(true);
+    await expectNoChangeLogsForSubscriptions([subscriptionA, subscriptionB]);
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('keeps the newest canceled trial at the head when all rows are destroyed trials', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-collapse-all-trials@example.com',
+    });
+
+    const instanceA = crypto.randomUUID();
+    const instanceB = crypto.randomUUID();
+    const instanceC = crypto.randomUUID();
+    const instanceD = crypto.randomUUID();
+    const subscriptionA = crypto.randomUUID();
+    const subscriptionB = crypto.randomUUID();
+    const subscriptionC = crypto.randomUUID();
+    const subscriptionD = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: instanceA,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      destroyedAt: '2026-04-02T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: instanceB,
+      userId: user.id,
+      createdAt: '2026-04-01T00:01:00.000Z',
+      destroyedAt: '2026-04-02T00:01:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: instanceC,
+      userId: user.id,
+      createdAt: '2026-04-01T00:02:00.000Z',
+      destroyedAt: '2026-04-02T00:02:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: instanceD,
+      userId: user.id,
+      createdAt: '2026-04-01T00:03:00.000Z',
+    });
+
+    await insertPersonalSubscription({
+      id: subscriptionA,
+      userId: user.id,
+      instanceId: instanceA,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionB,
+      userId: user.id,
+      instanceId: instanceB,
+      createdAt: '2026-04-01T00:01:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionC,
+      userId: user.id,
+      instanceId: instanceC,
+      createdAt: '2026-04-01T00:02:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionD,
+      userId: user.id,
+      instanceId: instanceD,
+      createdAt: '2026-04-01T00:03:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+
+    await db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId: instanceD,
+        reason: DESTROY_REASON,
+        userId: user.id,
+      });
+    });
+
+    await expectCurrentHead({ subscriptionId: subscriptionD, userId: user.id });
+
+    const subscriptions = await listUserSubscriptions(user.id);
+    expectTransferredToTargets(subscriptions, {
+      [subscriptionA]: subscriptionB,
+      [subscriptionB]: subscriptionC,
+      [subscriptionC]: subscriptionD,
+      [subscriptionD]: null,
+    });
+
+    await expectChangeLogsForSubscriptions([
+      {
+        subscriptionId: subscriptionA,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: subscriptionB,
+        beforePlan: 'trial',
+        beforeStatus: 'canceled',
+      },
+      {
+        subscriptionId: subscriptionB,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: subscriptionC,
+        beforePlan: 'trial',
+        beforeStatus: 'canceled',
+      },
+      {
+        subscriptionId: subscriptionC,
+        action: 'reassigned',
+        reason: DESTROY_REASON,
+        beforeTransferredTo: null,
+        afterTransferredTo: subscriptionD,
+        beforePlan: 'trial',
+        beforeStatus: 'canceled',
+      },
+    ]);
+
+    expectCollapseStructuredLog({
+      userId: user.id,
+      destroyedInstanceId: instanceD,
+      rowCountTotal: 4,
+      rowCountAlive: 0,
+      headSubscriptionId: subscriptionD,
+      headPlan: 'trial',
+      headStatus: 'canceled',
+      headStripeSubscriptionId: null,
+      updateCount: 3,
+    });
+  });
+
+  it('refuses to demote a funded row when a bad transfer plan is injected', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-collapse-refuse-funded-demotion@example.com',
+    });
+
+    const fundedInstanceId = crypto.randomUUID();
+    const trialInstanceId = crypto.randomUUID();
+    const fundedSubscriptionId = crypto.randomUUID();
+    const trialSubscriptionId = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: fundedInstanceId,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: trialInstanceId,
+      userId: user.id,
+      createdAt: '2026-04-01T00:01:00.000Z',
+      destroyedAt: '2026-04-02T00:01:00.000Z',
+    });
+
+    await insertPersonalSubscription({
+      id: fundedSubscriptionId,
+      userId: user.id,
+      instanceId: fundedInstanceId,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'commit',
+      status: 'active',
+    });
+    await insertPersonalSubscription({
+      id: trialSubscriptionId,
+      userId: user.id,
+      instanceId: trialInstanceId,
+      createdAt: '2026-04-01T00:01:00.000Z',
+      plan: 'trial',
+      status: 'canceled',
+    });
+
+    const destroyPromise = db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        buildTransferUpdatesOverride: ({ rows }) => {
+          const fundedRow = rows.find(row => row.subscription.id === fundedSubscriptionId);
+          const trialRow = rows.find(row => row.subscription.id === trialSubscriptionId);
+
+          expect(fundedRow).toBeDefined();
+          expect(trialRow).toBeDefined();
+          if (!fundedRow || !trialRow) {
+            return [];
+          }
+
+          return [
+            {
+              before: fundedRow.subscription,
+              transferredToSubscriptionId: trialRow.subscription.id,
+            },
+          ];
+        },
+        executor: tx,
+        instanceId: fundedInstanceId,
+        reason: DESTROY_REASON,
+        userId: user.id,
+      });
+    });
+
+    await expect(destroyPromise).rejects.toBeInstanceOf(FundedRowDemotionRefusedError);
+    await expect(destroyPromise).rejects.toMatchObject({
+      userId: user.id,
+      destroyedInstanceId: fundedInstanceId,
+      demotionCandidateSubscriptionId: fundedSubscriptionId,
+    });
+
+    const [instance] = await db
+      .select()
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.id, fundedInstanceId));
+    expect(instance?.destroyed_at).toBeNull();
+
+    const subscriptions = await listUserSubscriptions(user.id);
+    expectTransferredToTargets(subscriptions, {
+      [fundedSubscriptionId]: null,
+      [trialSubscriptionId]: null,
+    });
+
+    await expectNoChangeLogsForSubscriptions([fundedSubscriptionId, trialSubscriptionId]);
+    expect(console.log).not.toHaveBeenCalled();
   });
 });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -15,6 +15,7 @@ export {
 } from './kiloclaw-subscription-change-log';
 export {
   collapseOrphanPersonalSubscriptionsOnDestroy,
+  FundedRowDemotionRefusedError,
   markInstanceDestroyedWithPersonalSubscriptionCollapse,
   PersonalSubscriptionDestroyConflictError,
   type DestroyedInstanceRow,

--- a/packages/db/src/kiloclaw-personal-subscription-collapse.ts
+++ b/packages/db/src/kiloclaw-personal-subscription-collapse.ts
@@ -17,6 +17,36 @@ type PersonalSubscriptionRow = {
   };
 };
 
+type TransferUpdate = {
+  before: KiloClawSubscription;
+  transferredToSubscriptionId: string | null;
+};
+
+type TransferPlan = {
+  headRow: PersonalSubscriptionRow;
+  updates: TransferUpdate[];
+};
+
+type ChangeLogFailurePolicy = 'fail' | 'log';
+
+type ChangeLogFailureContext = {
+  error: unknown;
+  reason: string;
+  subscriptionId: string;
+  userId: string;
+};
+
+type CollapseOptions = {
+  changeLogFailurePolicy?: ChangeLogFailurePolicy;
+  cancelSingleCurrentAccessRow?: boolean;
+  onChangeLogFailure?: (context: ChangeLogFailureContext) => Promise<void> | void;
+};
+
+type BuildTransferUpdatesOverride = (params: {
+  rows: PersonalSubscriptionRow[];
+  now: Date;
+}) => TransferUpdate[];
+
 export type DestroyedInstanceRow = {
   id: string;
   userId: string;
@@ -42,11 +72,41 @@ export class PersonalSubscriptionDestroyConflictError extends Error {
   }
 }
 
-function byCreatedAtAndId(left: PersonalSubscriptionRow, right: PersonalSubscriptionRow): number {
+export class FundedRowDemotionRefusedError extends Error {
+  readonly userId: string;
+  readonly destroyedInstanceId: string;
+  readonly demotionCandidateSubscriptionId: string;
+
+  constructor(params: {
+    userId: string;
+    destroyedInstanceId: string;
+    demotionCandidateSubscriptionId: string;
+  }) {
+    super(
+      `Refusing to demote funded or access-granting personal subscription ${params.demotionCandidateSubscriptionId} for user ${params.userId} while destroying instance ${params.destroyedInstanceId}`
+    );
+    this.name = 'FundedRowDemotionRefusedError';
+    this.userId = params.userId;
+    this.destroyedInstanceId = params.destroyedInstanceId;
+    this.demotionCandidateSubscriptionId = params.demotionCandidateSubscriptionId;
+  }
+}
+
+function compareRowsByCreatedAtAndIdAscending(
+  left: PersonalSubscriptionRow,
+  right: PersonalSubscriptionRow
+): number {
   if (left.subscription.created_at === right.subscription.created_at) {
     return left.subscription.id.localeCompare(right.subscription.id);
   }
   return left.subscription.created_at.localeCompare(right.subscription.created_at);
+}
+
+function compareRowsByCreatedAtAndIdDescending(
+  left: PersonalSubscriptionRow,
+  right: PersonalSubscriptionRow
+): number {
+  return compareRowsByCreatedAtAndIdAscending(right, left);
 }
 
 async function listPersonalSubscriptionRows(
@@ -108,32 +168,70 @@ function shouldCancelSingleDestroyedCurrentAccessRow(row: KiloClawSubscription):
   );
 }
 
-type TransferUpdate = {
-  before: KiloClawSubscription;
-  transferredToSubscriptionId: string | null;
-};
+function getHeadSelectionPriority(
+  row: Pick<
+    KiloClawSubscription,
+    'plan' | 'status' | 'stripe_subscription_id' | 'suspended_at' | 'trial_ends_at'
+  >,
+  now: Date
+): number {
+  if (row.stripe_subscription_id !== null) {
+    return 4;
+  }
+  if (row.plan === 'commit' && row.status === 'active') {
+    return 3;
+  }
+  if (row.plan === 'standard' && row.status === 'active') {
+    return 2;
+  }
+  if (
+    (row.status === 'trialing' && row.suspended_at === null && row.trial_ends_at === null) ||
+    (row.status !== 'active' && isAccessGrantingSubscription(row, now))
+  ) {
+    return 1;
+  }
+  return 0;
+}
 
-type ChangeLogFailurePolicy = 'fail' | 'log';
+function compareRowsByHeadSelectionPriority(
+  left: PersonalSubscriptionRow,
+  right: PersonalSubscriptionRow,
+  now: Date
+): number {
+  const priorityDifference =
+    getHeadSelectionPriority(right.subscription, now) -
+    getHeadSelectionPriority(left.subscription, now);
+  if (priorityDifference !== 0) {
+    return priorityDifference;
+  }
+  return compareRowsByCreatedAtAndIdDescending(left, right);
+}
 
-type ChangeLogFailureContext = {
-  error: unknown;
-  reason: string;
-  subscriptionId: string;
-  userId: string;
-};
+function selectTransferHeadRow(
+  rows: PersonalSubscriptionRow[],
+  now: Date
+): PersonalSubscriptionRow {
+  const [headRow] = [...rows].sort((left, right) =>
+    compareRowsByHeadSelectionPriority(left, right, now)
+  );
+  if (!headRow) {
+    throw new Error('Cannot select a personal subscription collapse head from an empty row set');
+  }
+  return headRow;
+}
 
-type CollapseOptions = {
-  changeLogFailurePolicy?: ChangeLogFailurePolicy;
-  cancelSingleCurrentAccessRow?: boolean;
-  onChangeLogFailure?: (context: ChangeLogFailureContext) => Promise<void> | void;
-};
+function buildDesiredTransferUpdates(rows: PersonalSubscriptionRow[], now: Date): TransferPlan {
+  const headRow = selectTransferHeadRow(rows, now);
+  const nonHeadRowsDescending = rows
+    .filter(row => row.subscription.id !== headRow.subscription.id)
+    .sort(compareRowsByCreatedAtAndIdDescending);
+  const desiredChainTailToHead = [...nonHeadRowsDescending].reverse();
+  desiredChainTailToHead.push(headRow);
 
-function buildTransferUpdates(rows: PersonalSubscriptionRow[]): TransferUpdate[] {
-  const orderedRows = [...rows].sort(byCreatedAtAndId);
   const updates: TransferUpdate[] = [];
 
-  for (const [index, row] of orderedRows.entries()) {
-    const nextRow = orderedRows[index + 1];
+  for (const [index, row] of desiredChainTailToHead.entries()) {
+    const nextRow = desiredChainTailToHead[index + 1];
     const desiredTransferredTo = nextRow?.subscription.id ?? null;
     if (row.subscription.transferred_to_subscription_id === desiredTransferredTo) {
       continue;
@@ -144,7 +242,86 @@ function buildTransferUpdates(rows: PersonalSubscriptionRow[]): TransferUpdate[]
     });
   }
 
-  return updates;
+  return { headRow, updates };
+}
+
+function orderTransferUpdatesForUniqueIndex(
+  rows: PersonalSubscriptionRow[],
+  updates: TransferUpdate[]
+): TransferUpdate[] {
+  if (updates.length <= 1) {
+    return updates;
+  }
+
+  const remainingUpdates = new Map(updates.map(update => [update.before.id, update]));
+  const currentOccupantByTarget = new Map<string, string>();
+
+  for (const row of rows) {
+    if (row.subscription.transferred_to_subscription_id !== null) {
+      currentOccupantByTarget.set(
+        row.subscription.transferred_to_subscription_id,
+        row.subscription.id
+      );
+    }
+  }
+
+  const orderedUpdates: TransferUpdate[] = [];
+
+  while (remainingUpdates.size > 0) {
+    let appliedAtLeastOneUpdate = false;
+
+    for (const update of updates) {
+      if (!remainingUpdates.has(update.before.id)) {
+        continue;
+      }
+
+      const targetId = update.transferredToSubscriptionId;
+      const targetOccupantId = targetId ? currentOccupantByTarget.get(targetId) : undefined;
+      const targetIsBlockedByPendingUpdate =
+        targetId !== null &&
+        targetOccupantId !== undefined &&
+        targetOccupantId !== update.before.id &&
+        remainingUpdates.has(targetOccupantId);
+
+      if (targetIsBlockedByPendingUpdate) {
+        continue;
+      }
+
+      orderedUpdates.push(update);
+      remainingUpdates.delete(update.before.id);
+      appliedAtLeastOneUpdate = true;
+
+      if (
+        update.before.transferred_to_subscription_id !== null &&
+        currentOccupantByTarget.get(update.before.transferred_to_subscription_id) ===
+          update.before.id
+      ) {
+        currentOccupantByTarget.delete(update.before.transferred_to_subscription_id);
+      }
+
+      if (targetId !== null) {
+        currentOccupantByTarget.set(targetId, update.before.id);
+      }
+    }
+
+    if (appliedAtLeastOneUpdate) {
+      continue;
+    }
+
+    throw new Error(
+      'Unable to order personal subscription collapse updates without violating UQ_kiloclaw_subscriptions_transferred_to'
+    );
+  }
+
+  return orderedUpdates;
+}
+
+function buildTransferPlan(rows: PersonalSubscriptionRow[], now: Date): TransferPlan {
+  const desiredPlan = buildDesiredTransferUpdates(rows, now);
+  return {
+    headRow: desiredPlan.headRow,
+    updates: orderTransferUpdatesForUniqueIndex(rows, desiredPlan.updates),
+  };
 }
 
 async function cancelSingleDestroyedCurrentAccessRow(params: {
@@ -253,6 +430,7 @@ async function applyTransferUpdates(
 
 export async function collapseOrphanPersonalSubscriptionsOnDestroy(params: {
   actor: KiloClawSubscriptionChangeActor;
+  buildTransferUpdatesOverride?: BuildTransferUpdatesOverride;
   changeLogFailurePolicy?: ChangeLogFailurePolicy;
   destroyedInstanceId: string;
   executor: PersonalSubscriptionCollapseWriter;
@@ -300,27 +478,60 @@ export async function collapseOrphanPersonalSubscriptionsOnDestroy(params: {
     return { updatedSubscriptionIds: canceledSubscriptionId ? [canceledSubscriptionId] : [] };
   }
 
-  const updates = buildTransferUpdates(personalRows);
+  const now = new Date();
+  const transferPlan = buildTransferPlan(personalRows, now);
+  const updates =
+    params.buildTransferUpdatesOverride?.({ rows: personalRows, now }) ?? transferPlan.updates;
+
+  const demotionCandidate = updates.find(
+    update =>
+      update.transferredToSubscriptionId !== null &&
+      getHeadSelectionPriority(update.before, now) > 0
+  );
+
+  if (demotionCandidate) {
+    throw new FundedRowDemotionRefusedError({
+      userId: params.userId,
+      destroyedInstanceId: params.destroyedInstanceId,
+      demotionCandidateSubscriptionId: demotionCandidate.before.id,
+    });
+  }
+
   if (updates.length === 0) {
     return { updatedSubscriptionIds: [] };
   }
 
+  const updatedSubscriptionIds = await applyTransferUpdates(
+    params.executor,
+    updates,
+    params.actor,
+    params.reason,
+    {
+      changeLogFailurePolicy: params.changeLogFailurePolicy,
+      onChangeLogFailure: params.onChangeLogFailure,
+    }
+  );
+
+  console.log('personal_subscription_destroy_collapse_applied', {
+    userId: params.userId,
+    destroyedInstanceId: params.destroyedInstanceId,
+    rowCountTotal: personalRows.length,
+    rowCountAlive: personalRows.filter(row => row.instance.destroyedAt === null).length,
+    headSubscriptionId: transferPlan.headRow.subscription.id,
+    headPlan: transferPlan.headRow.subscription.plan,
+    headStatus: transferPlan.headRow.subscription.status,
+    headStripeSubscriptionId: transferPlan.headRow.subscription.stripe_subscription_id,
+    updateCount: updatedSubscriptionIds.length,
+  });
+
   return {
-    updatedSubscriptionIds: await applyTransferUpdates(
-      params.executor,
-      updates,
-      params.actor,
-      params.reason,
-      {
-        changeLogFailurePolicy: params.changeLogFailurePolicy,
-        onChangeLogFailure: params.onChangeLogFailure,
-      }
-    ),
+    updatedSubscriptionIds,
   };
 }
 
 export async function markInstanceDestroyedWithPersonalSubscriptionCollapse(params: {
   actor: KiloClawSubscriptionChangeActor;
+  buildTransferUpdatesOverride?: BuildTransferUpdatesOverride;
   changeLogFailurePolicy?: ChangeLogFailurePolicy;
   destroyedAt?: string;
   executor: PersonalSubscriptionCollapseWriter;
@@ -391,6 +602,7 @@ export async function markInstanceDestroyedWithPersonalSubscriptionCollapse(para
   if (destroyedInstance.organizationId === null) {
     await collapseOrphanPersonalSubscriptionsOnDestroy({
       actor: params.actor,
+      buildTransferUpdatesOverride: params.buildTransferUpdatesOverride,
       changeLogFailurePolicy: params.changeLogFailurePolicy,
       destroyedInstanceId: destroyedInstance.id,
       executor: params.executor,


### PR DESCRIPTION
## Summary
Prevents personal subscription collapse on instance destroy from selecting canceled trial rows ahead of funded or access-granting rows.

### Why this change is needed
The destroy-path collapse helper rebuilt personal subscription chains by `created_at` alone. When a funded row was older than destroyed trial rows, the helper could move the funded row behind those trials and leave a canceled trial as the current head. That hid the user's real subscription even though the underlying paid row still existed.

### How this is addressed
- Select the chain head by access strength instead of raw creation order, preferring Stripe-backed rows first, then active commit, then active standard, then other still-access-granting rows, with `created_at DESC, id DESC` as the final tiebreaker.
- Keep non-head rows chained below the selected head in `created_at DESC, id DESC` order so destroy-path rewrites stay deterministic and idempotent.
- Refuse to write if a planned rewrite would transfer out a funded or access-granting row, and emit a structured log when a chain rewrite succeeds.
- Extend destroy-collapse coverage to the funded-row regression shapes, the single-row cancel path, the multi-funded conflict path, the all-destroyed trials path, and the demotion-refusal guard.

## Verification
- Investigated reported issue and remediated the regression in the production database. The fix here simply implements the same logic in the destroy-path helper.

## Visual Changes
N/A

## Reviewer Notes
### Human Reviewer
- No notable items for human review beyond what the summary covers.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- The shared destroy-collapse helper now computes the intended head from a compound rank: `stripe_subscription_id` present, then `commit/active`, then `standard/active`, then other access-granting rows, then `created_at DESC, id DESC`.
- The demotion guard reuses the same access-granting notion as the single-row cancel path and throws `FundedRowDemotionRefusedError` before any writes if an access-granting row would be transferred out.
- Update application is dependency-ordered to avoid transient collisions on `UQ_kiloclaw_subscriptions_transferred_to` without falling back to a null-first rewrite.
- Added change-log assertions for the final chain shapes and before/after snapshots in the destroy-collapse test harness, including Stripe schedule pass-through coverage.
</details>
