### PR TITLE
fix(o11y): use local dev bindings

### DIFF
--- a/apps/web/.env.development.local.example
+++ b/apps/web/.env.development.local.example
@@ -31,6 +31,13 @@ USER_DEPLOYMENTS_DISPATCHER_URL=http://localhost:8799
 # @url cloudflare-webhook-agent-ingest
 WEBHOOK_AGENT_URL=http://localhost:8793
 
+# @url cloudflare-o11y
+O11Y_SERVICE_URL=http://localhost:8801
+
+# Shared admin token used by the web app to call o11y admin endpoints.
+# @from O11Y_KILO_GATEWAY_CLIENT_SECRET
+O11Y_KILO_GATEWAY_CLIENT_SECRET=
+
 # @url cloud-agent-next
 NEXT_PUBLIC_CLOUD_AGENT_WS_URL=ws://localhost:8794
 

--- a/dev/local/env-sync/output.ts
+++ b/dev/local/env-sync/output.ts
@@ -209,7 +209,11 @@ function upsertEnvValue(filePath: string, key: string, value: string): void {
 
   const regex = new RegExp(`^${escapeRegex(key)}=.*$`, 'm');
   if (regex.test(content)) {
-    fs.writeFileSync(filePath, content.replace(regex, line), 'utf-8');
+    fs.writeFileSync(
+      filePath,
+      content.replace(regex, () => line),
+      'utf-8'
+    );
     return;
   }
 
@@ -323,7 +327,8 @@ function applyPlan(plan: EnvSyncPlan, repoRoot: string): void {
       for (const kc of change.keyChanges) {
         const regex = new RegExp(`^${escapeRegex(kc.key)}=.*$`, 'm');
         if (regex.test(content)) {
-          content = content.replace(regex, `${kc.key}=${formatValue(kc.newValue)}`);
+          const line = `${kc.key}=${formatValue(kc.newValue)}`;
+          content = content.replace(regex, () => line);
         } else {
           appendLines.push(`${kc.key}=${formatValue(kc.newValue)}`);
         }
@@ -351,15 +356,16 @@ function applyPlan(plan: EnvSyncPlan, repoRoot: string): void {
       let content = existingContent;
       for (const change of plan.envDevLocalChanges) {
         const regex = new RegExp(`^${escapeRegex(change.key)}=.*$`, 'm');
+        const line = `${change.key}=${formatValue(change.newValue)}`;
         if (regex.test(content)) {
-          content = content.replace(regex, `${change.key}=${change.newValue}`);
+          content = content.replace(regex, () => line);
         } else {
-          content = content.trimEnd() + `\n${change.key}=${change.newValue}\n`;
+          content = content.trimEnd() + `\n${line}\n`;
         }
       }
       fs.writeFileSync(envDevLocalPath, content, 'utf-8');
     } else {
-      const lines = plan.envDevLocalChanges.map(c => `${c.key}=${c.newValue}`);
+      const lines = plan.envDevLocalChanges.map(c => `${c.key}=${formatValue(c.newValue)}`);
       fs.writeFileSync(envDevLocalPath, lines.join('\n') + '\n', 'utf-8');
     }
   }

--- a/services/o11y/.dev.vars.example
+++ b/services/o11y/.dev.vars.example
@@ -1,0 +1,3 @@
+# Local backend URL used by o11y when it needs to call the Kilo API.
+# @url nextjs
+O11Y_API_BASE_URL=http://localhost:3000

--- a/services/o11y/package.json
+++ b/services/o11y/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",
-    "dev": "wrangler dev",
-    "start": "wrangler dev",
+    "dev": "wrangler dev --local",
+    "start": "wrangler dev --local",
     "test": "vitest",
     "cf-typegen": "wrangler types",
     "typecheck": "tsgo --noEmit",


### PR DESCRIPTION
## Summary
- Force the o11y Worker dev/start scripts into local Wrangler mode so dev startup does not trigger Cloudflare OAuth.
- Add o11y env-sync templates for the Worker and web app so `pnpm dev:env` wires local o11y URLs and the shared admin token.
- Fix env-sync replacement/formatting so values with replacement tokens or escaped newlines are written literally and stay stable across checks.

## Verification
- Started the o11y Worker dev server locally and confirmed all bindings were reported in local mode without an OAuth login attempt.
- Ran `pnpm dev:env cloudflare-o11y nextjs -y`, then confirmed the generated env files were stable with `pnpm dev:env cloudflare-o11y nextjs --check` except for expected missing local Secrets Store warnings for alert-only secrets.

## Visual Changes
N/A

## Reviewer Notes
- `pnpm dev:env cloudflare-o11y nextjs --check` still warns when local Secrets Store entries for the Analytics Engine token and Slack webhooks are absent; those are not generated from `.env.local` and are only needed for local alert querying/Slack notification paths.