### PR TITLE
chore(kiloclaw): upgrade openclaw 2026.4.9 → 2026.4.15

### DIFF
--- a/services/kiloclaw/.dev.vars.example
+++ b/services/kiloclaw/.dev.vars.example
@@ -98,7 +98,7 @@ FLY_IMAGE_DIGEST=
 # Used by the worker to self-register the version → image tag mapping in KV,
 # enabling per-user version tracking. Without this, version tracking fields
 # will be null and instances fall back to FLY_IMAGE_TAG directly.
-OPENCLAW_VERSION=2026.4.5
+OPENCLAW_VERSION=2026.4.15
 
 # Legacy fallback for existing instances without per-user apps.
 # New instances get per-user apps (acct-{hash}) created automatically.

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -55,7 +55,7 @@ RUN npm install -g pnpm
 # Patch: bump model discovery timeout from 5s to 60s — shared-cpu machines
 # under boot load routinely need 27-35s for the first TLS+fetch to complete.
 # Remove this sed patch once openclaw exposes a configurable timeout.
-RUN npm install -g openclaw@2026.4.9 \
+RUN npm install -g openclaw@2026.4.15 \
     && OC_DIST=/usr/local/lib/node_modules/openclaw/dist \
     && FOUND_FILES=$(find "$OC_DIST" -name 'provider-models-*.js' | wc -l | tr -d ' ') \
     && if [ "$FOUND_FILES" -eq 0 ]; then echo "ERROR: provider-models-*.js not found in openclaw dist" >&2; exit 1; fi \
@@ -190,8 +190,8 @@ RUN mkdir -p /root/.openclaw \
     && mkdir -p /root/clawd/skills
 
 # Copy helper scripts (used at runtime by the controller/gateway)
-# Build cache bust: 2026-03-17-v65-remove-startup-script
-RUN echo "11"
+# Build cache bust: 2026-04-24-v66-openclaw-2026.4.15
+RUN echo "12"
 COPY openclaw-pairing-list.js /usr/local/bin/openclaw-pairing-list.js
 COPY openclaw-device-pairing-list.js /usr/local/bin/openclaw-device-pairing-list.js
 

--- a/services/kiloclaw/e2e/docker-image-testing.md
+++ b/services/kiloclaw/e2e/docker-image-testing.md
@@ -141,7 +141,7 @@ docker rm kiloclaw-gateway
 ```bash
 # Check versions
 docker run --rm kiloclaw:test node --version        # v24.14.1
-docker run --rm kiloclaw:test openclaw --version    # 2026.4.5
+docker run --rm kiloclaw:test openclaw --version    # 2026.4.15
 
 # Check directories
 docker run --rm kiloclaw:test ls -la /root/.openclaw


### PR DESCRIPTION
## Summary
- Bump OpenClaw version pin from `2026.4.9` to `2026.4.15` (5 releases, v2026.4.13 never published)
- 374 changelog entries analyzed — zero code-level impact on KiloClaw (all CLI flags, config keys, env vars, plugin interfaces unchanged)
- Increment Dockerfile build cache bust (v66)
- Clean up stale `2026.4.5` version references in `.dev.vars.example` and `e2e/docker-image-testing.md`

## Notable upstream changes (no KiloClaw action needed)
- Codex provider bundled
- Active Memory plugin
- Plugin loading narrowed to manifest-declared needs
- Default Anthropic model bumped to Opus 4.7 (overridden by our explicit model setting)
- Dreaming storage mode default `inline` → `separate` (we don't set this field)
- Unknown-tool stream guard enabled by default (beneficial)
- 51 security fixes

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (1563 tests)
- [x] `pnpm lint` passes
- [ ] Docker build succeeds (sed patch for `DISCOVERY_TIMEOUT_MS` self-validates)
- [ ] Push to dev via `push-dev.sh kiloclaw-machines-dev`
- [ ] Fresh instance boots and completes bootstrap
- [ ] Existing instance restarts cleanly
- [ ] Plugins load (kiloclaw-customizer, Stream Chat)
- [ ] WebSocket proxy works end-to-end