### PR TITLE
chore(kiloclaw): update Kilo CLI install timing

### DIFF
--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -100,7 +100,7 @@ RUN npm install -g github:Kilo-Org/openclaw-channel-streamchat#fix/plugin-name-r
 RUN npm install -g @steipete/summarize@0.12.0
 
 # Install Kilo CLI (agentic coding assistant for the terminal)
-RUN npm install -g @kilocode/cli@7.1.13
+RUN npm install -g @kilocode/cli@7.2.22
 
 # Install Go (available at runtime for users to `go install` additional tools)
 ENV GO_VERSION=1.26.0

--- a/services/kiloclaw/Dockerfile.local
+++ b/services/kiloclaw/Dockerfile.local
@@ -59,7 +59,7 @@ RUN npm install -g github:Kilo-Org/openclaw-channel-streamchat#fix/plugin-name-r
 RUN npm install -g @steipete/summarize@0.12.0
 
 # Install Kilo CLI (agentic coding assistant for the terminal)
-RUN npm install -g @kilocode/cli@7.1.13
+RUN npm install -g @kilocode/cli@7.2.22
 
 # Install Go (available at runtime for users to `go install` additional tools)
 ENV GO_VERSION=1.26.0

--- a/services/kiloclaw/controller/src/index.ts
+++ b/services/kiloclaw/controller/src/index.ts
@@ -531,7 +531,7 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
     // request. Once the gateway is warm and CPU has settled, the upgrade
     // runs safely in the background.
     if (env.KILOCLAW_KILO_CLI === 'true') {
-      const KILO_CLI_UPGRADE_DELAY_MS = 5 * 60 * 1000; // 5 minutes
+      const KILO_CLI_UPGRADE_DELAY_MS = 3 * 60 * 60 * 1000; // 3 hours
       setTimeout(() => {
         // Strip NPM_CONFIG_PREFIX so the install overwrites the system-wide
         // binary in /usr/local/bin instead of writing to the per-user prefix.


### PR DESCRIPTION
## Summary

- Bump the baked Kilo CLI version in the KiloClaw runtime and local Docker images from `7.1.13` to `7.2.22`.
- Delay the controller's background `@kilocode/cli@latest` upgrade from 5 minutes to 3 hours after startup so it is less likely to compete with early gateway warmup or first user activity.
- No architectural changes; this preserves the existing baked-version-plus-background-upgrade model and only changes the pinned version and upgrade timing.

## Verification

- No manual verification was performed; this only changes Docker install pins and controller upgrade timing, and no KiloClaw machine image was built or booted in this session.
- [ ] Add any additional manual verification details before merge.

## Visual Changes

N/A

## Reviewer Notes

- The baked CLI remains available immediately on boot; the delayed background upgrade only affects when the image attempts to move from the baked version to npm `latest`.
- The delayed upgrade still only runs when `KILOCLAW_KILO_CLI === 'true'`.