### PR TITLE
fix(kiloclaw): preserve org gateway model discovery

### DIFF
--- a/.specs/kiloclaw-controller.md
+++ b/.specs/kiloclaw-controller.md
@@ -337,20 +337,25 @@ patches to `openclaw.json`. The patches MUST include:
 5. Stale kilocode provider migration (remove entries with old base
    URLs).
 6. KiloCode API base URL override from `KILOCODE_API_BASE_URL`.
-7. Default model from `KILOCODE_DEFAULT_MODEL`.
-8. Agent default user timezone from `KILOCLAW_USER_TIMEZONE`.
-9. Remove `agents.defaults.models` allowlist (KiloClaw users see all
-   models).
-10. `tools.profile`: MUST be set to `full` on fresh install or config
+7. Org-scoped KiloCode provider configuration from
+   `KILOCODE_ORGANIZATION_ID`: MUST set the
+   `X-KiloCode-OrganizationId` header and MUST set the provider's
+   `models` array to `[]` so OpenClaw uses live gateway model discovery
+   rather than a stale static catalog.
+8. Default model from `KILOCODE_DEFAULT_MODEL`.
+9. Agent default user timezone from `KILOCLAW_USER_TIMEZONE`.
+10. Remove `agents.defaults.models` allowlist (KiloClaw users see all
+    models).
+11. `tools.profile`: MUST be set to `full` on fresh install or config
     restore. MUST be preserved on subsequent boots.
-11. Exec policy: host `gateway`, security `allowlist`, ask `on-miss`.
-12. Browser: enabled, headless, noSandbox.
-13. KiloClaw customizer plugin: load path and entry MUST be present;
+12. Exec policy: host `gateway`, security `allowlist`, ask `on-miss`.
+13. Browser: enabled, headless, noSandbox.
+14. KiloClaw customizer plugin: load path and entry MUST be present;
     when `plugins.allow` exists, it MUST include `kiloclaw-customizer`.
-14. Channel configuration from `TELEGRAM_BOT_TOKEN`,
+15. Channel configuration from `TELEGRAM_BOT_TOKEN`,
     `DISCORD_BOT_TOKEN`, `SLACK_BOT_TOKEN`/`SLACK_APP_TOKEN`, with
     corresponding plugin enablement.
-15. Hooks configuration from `KILOCLAW_HOOKS_TOKEN`: enabled,
+16. Hooks configuration from `KILOCLAW_HOOKS_TOKEN`: enabled,
     token, inbound email mapping. When Gmail credentials are present, the
     gmail preset MUST also be enabled.
 

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -347,14 +347,14 @@ describe('generateBaseConfig', () => {
     expect(config.models).toBeUndefined();
   });
 
-  it('skips gateway-URL stale migration for org-scoped instances', () => {
+  it('keeps gateway provider for org-scoped instances but clears static models', () => {
     const existing = JSON.stringify({
       models: {
         providers: {
           kilocode: {
             baseUrl: 'https://api.kilo.ai/api/gateway/',
             headers: { 'X-Custom': 'user-managed' },
-            models: [{ id: 'kept/model', name: 'Kept' }],
+            models: [{ id: 'kilo/auto', name: 'Kilo Auto' }],
           },
         },
       },
@@ -363,13 +363,12 @@ describe('generateBaseConfig', () => {
     const env = { ...minimalEnv(), KILOCODE_ORGANIZATION_ID: 'org_abc123' };
     const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
 
-    // Provider not nuked — user-managed settings preserved
     expect(config.models.providers.kilocode.headers['X-Custom']).toBe('user-managed');
     expect(config.models.providers.kilocode.headers['X-KiloCode-OrganizationId']).toBe(
       'org_abc123'
     );
     expect(config.models.providers.kilocode.baseUrl).toBe('https://api.kilo.ai/api/gateway/');
-    expect(config.models.providers.kilocode.models).toEqual([{ id: 'kept/model', name: 'Kept' }]);
+    expect(config.models.providers.kilocode.models).toEqual([]);
   });
 
   it('still removes openrouter stale provider for org-scoped instances', () => {
@@ -469,7 +468,7 @@ describe('generateBaseConfig', () => {
     expect(config.models).toBeUndefined();
   });
 
-  it('preserves existing kilocode config when adding org header', () => {
+  it('preserves existing kilocode baseUrl and headers when adding org header', () => {
     const existing = JSON.stringify({
       models: {
         providers: {
@@ -490,7 +489,7 @@ describe('generateBaseConfig', () => {
     );
     expect(config.models.providers.kilocode.headers['X-Custom']).toBe('value');
     expect(config.models.providers.kilocode.baseUrl).toBe('https://tunnel.example.com/');
-    expect(config.models.providers.kilocode.models).toEqual([{ id: 'kept/model', name: 'Kept' }]);
+    expect(config.models.providers.kilocode.models).toEqual([]);
   });
 
   it('removes stale org header when KILOCODE_ORGANIZATION_ID is no longer set', () => {

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -228,8 +228,9 @@ export function generateBaseConfig(
   // /api/openrouter/ URL or the production /api/gateway/ URL conflict with it.
   // For the production /api/gateway/ URL, skip removal when KILOCODE_ORGANIZATION_ID
   // is set: org-scoped instances need an explicit provider entry (with the production
-  // baseUrl) to carry the org header. The /api/openrouter/ cleanup always runs since
-  // that URL is unconditionally broken.
+  // baseUrl) to carry the org header. Its model list is cleared below so live gateway
+  // discovery still controls the catalog. The /api/openrouter/ cleanup always runs
+  // since that URL is unconditionally broken.
   if (config.models?.providers?.kilocode) {
     const staleBaseUrl: string = config.models.providers.kilocode.baseUrl || '';
     const isOpenrouterUrl = staleBaseUrl.includes('/api/openrouter/');
@@ -276,7 +277,9 @@ export function generateBaseConfig(
     config.models.providers.kilocode.headers = config.models.providers.kilocode.headers ?? {};
     config.models.providers.kilocode.headers['X-KiloCode-OrganizationId'] =
       env.KILOCODE_ORGANIZATION_ID;
-    config.models.providers.kilocode.models = config.models.providers.kilocode.models ?? [];
+    // Empty array keeps the provider schema-valid while allowing OpenClaw to
+    // populate the full Kilo Gateway catalog through live model discovery.
+    config.models.providers.kilocode.models = [];
     console.log('Configured KiloCode organization header from KILOCODE_ORGANIZATION_ID');
   } else {
     // Remove stale org header from previous boots (e.g., instance was transferred


### PR DESCRIPTION
## Summary

- Keep org-scoped KiloClaw instances configured with the `X-KiloCode-OrganizationId` Kilo Gateway provider header while setting the explicit `kilocode` provider model list to `[]`. 
- This lets OpenClaw merge live Kilo Gateway model discovery instead of just limiting org instances to the static/default catalog row as org instances get today.

## Verification

- No manual verification performed; this change affects generated OpenClaw config behavior and was validated through focused controller config coverage.
- [ ] Add any additional manual verification details.

## Visual Changes

Before:
<img width="739" height="370" alt="Screenshot 2026-04-24 at 3 59 25 PM" src="https://github.com/user-attachments/assets/8aeb2cb4-30ea-4f87-9790-9a0aad083e6b" />


After:
<img width="849" height="863" alt="Screenshot 2026-04-24 at 4 00 26 PM" src="https://github.com/user-attachments/assets/df21c9e2-79f0-4e6e-b06d-d23fb22e01a7" />


## Reviewer Notes

- Main review focus: `models.providers.kilocode.models = []` is intentional for org instances; OpenClaw treats non-empty explicit model arrays as overriding the discovered provider catalog.
- OpenClaw source was checked to confirm empty explicit models still allow implicit gateway-discovered models to merge while preserving configured provider headers at runtime.