### PR TITLE
fix(kiloclaw): show Morning Briefing for all admin instances

### DIFF
--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -84,7 +84,6 @@ type ClawMutations = ReturnType<typeof useKiloClawMutations>;
 const EXA_SEARCH_UI_MIN_CONTROLLER_VERSION = '2026.4.14';
 const MEMORY_MIN_OPENCLAW_VERSION = '2026.4.5';
 const OPENCLAW_IMPORT_UI_MIN_CONTROLLER_VERSION = '2026.4.22';
-const MORNING_BRIEFING_MIN_IMAGE_CALVER = '2026.4.24';
 
 function formatMorningBriefingSchedule(cron: string, timezone: string): string {
   const parts = cron.trim().split(/\s+/);
@@ -1407,9 +1406,7 @@ export function SettingsTab({
       : '/api/integrations/google/disconnect';
   }, [organizationId]);
   const canSeeGoogleCalendar = !!user?.is_admin;
-  const canSeeMorningBriefing =
-    !!user?.is_admin &&
-    calverAtLeast(cleanVersion(status.trackedImageTag), MORNING_BRIEFING_MIN_IMAGE_CALVER);
+  const canSeeMorningBriefing = !!user?.is_admin;
 
   function handleCycleInboundEmailAddress() {
     mutations.cycleInboundEmailAddress.mutate(undefined, {


### PR DESCRIPTION
## Summary
- Remove the image calver visibility gate from the Morning Briefing card in Claw Settings.
- Keep the admin-only visibility gate so Morning Briefing is shown for admins regardless of tracked image tag format.
- This fixes local/dev cases where non-calver image tags (for example `dev-*`) incorrectly hid the feature.

## Verification
- [x] In local Claw Settings, confirmed Morning Briefing now appears for admin users even when tracked image tag is not a calver.

## Visual Changes
N/A

## Reviewer Notes
N/A