### PR TITLE
fix(ai-gateway): exclude DeepSeek models from Vercel routing

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from '@jest/globals';
-import { getAnthropicProviderOptionsForVercel } from '@/lib/ai-gateway/providers/vercel';
+import {
+  getAnthropicProviderOptionsForVercel,
+  shouldRouteToVercel,
+} from '@/lib/ai-gateway/providers/vercel';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 
 describe('getAnthropicProviderOptionsForVercel', () => {
@@ -60,5 +63,19 @@ describe('getAnthropicProviderOptionsForVercel', () => {
     expect(getAnthropicProviderOptionsForVercel('anthropic/claude-sonnet-4.5', request)).toBe(
       undefined
     );
+  });
+});
+
+describe('shouldRouteToVercel', () => {
+  it('excludes DeepSeek models (Vercel does not provide reasoning_content passthrough)', async () => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'deepseek/deepseek-v4-pro',
+        messages: [{ role: 'user', content: 'hello' }],
+      },
+    };
+
+    expect(await shouldRouteToVercel('deepseek/deepseek-v4-pro', request, 'seed')).toBe(false);
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -58,6 +58,14 @@ export async function shouldRouteToVercel(
     return false;
   }
 
+  // DeepSeek models excluded — Vercel AI Gateway routes directly to DeepSeek which rejects
+  // requests where assistant messages omit `reasoning_content` in thinking mode. OpenRouter
+  // handles that translation from `providerOptions.openrouter.reasoning_details`; Vercel does not.
+  if (requestedModel.startsWith('deepseek/')) {
+    console.debug(`[shouldRouteToVercel] DeepSeek models excluded (reasoning_content passthrough)`);
+    return false;
+  }
+
   console.debug('[shouldRouteToVercel] randomizing user to either OpenRouter or Vercel');
   const passedRandomization =
     getRandomNumber('vercel_routing_' + randomSeed, 100) < (await getVercelRoutingPercentage());


### PR DESCRIPTION
## Summary

DeepSeek in thinking mode requires assistant messages to round-trip \`reasoning_content\` back to the API. OpenRouter translates from \`providerOptions.openrouter.reasoning_details\` automatically; Vercel AI Gateway routes directly to DeepSeek without that translation, producing 400s on multi-turn reasoning conversations.

This adds a DeepSeek exclusion to \`shouldRouteToVercel\` so the default OpenRouter path is always used. Matches the existing exclusion pattern used for other incompatible models in earlier revisions of the gateway.

## Reported error

\`\`\`
[DeepSeek] The \`reasoning_content\` in the thinking mode must be passed back to the API.
providerMetadata.gateway.routing.resolvedProvider = "deepseek"
\`\`\`

## Related

Companion to [Kilo-Org/kilocode#9526](https://github.com/Kilo-Org/kilocode/pull/9526), which cherry-picks the upstream client-side fix for the OpenRouter path. That PR covers direct OpenRouter and \`@kilocode/kilo-gateway\` → OpenRouter. This PR covers the remaining \`@kilocode/kilo-gateway\` → Vercel → DeepSeek path.