### PR TITLE
fix(kiloclaw): bump pairing approve timeouts to unblock openclaw 2026.4.15

### DIFF
--- a/services/kiloclaw/controller/src/pairing-cache.ts
+++ b/services/kiloclaw/controller/src/pairing-cache.ts
@@ -63,7 +63,11 @@ export const DEBOUNCE_DELAY_MS = 2_000;
 
 export const FAILURE_RETRY_BASE_MS = 30_000;
 export const FAILURE_RETRY_MAX_MS = 300_000;
-export const APPROVE_TIMEOUT_MS = 45_000;
+// TEMPORARY: bumped from 45_000 to 180_000 because openclaw 2026.4.15 CLI
+// startup takes ~65s (CPU profile shows ~55% in jiti normalizeAliases/createJiti
+// from per-plugin loader churn). Revert to 45_000 once openclaw upstream
+// reduces startup time. Tracking: <openclaw issue link TBD>.
+export const APPROVE_TIMEOUT_MS = 180_000;
 export const CONFIG_PATH = '/root/.openclaw/openclaw.json';
 
 // TTL constants — exact matches to openclaw source

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/pairing.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/pairing.ts
@@ -171,7 +171,10 @@ export async function approvePairingRequest(
       '/_kilo/pairing/channels/approve',
       'POST',
       ControllerPairingApproveResponseSchema,
-      { channel, code }
+      { channel, code },
+      // TEMPORARY: 180s timeout — openclaw 2026.4.15 CLI startup is ~65s
+      // (jiti loader churn). Revert to default 30s once openclaw startup is fixed.
+      { timeoutMs: 180_000 }
     );
   } catch (error) {
     if (error instanceof GatewayControllerError && error.status === 400) {
@@ -354,7 +357,10 @@ export async function approveDevicePairingRequest(
       '/_kilo/pairing/devices/approve',
       'POST',
       ControllerPairingApproveResponseSchema,
-      { requestId }
+      { requestId },
+      // TEMPORARY: 180s timeout — openclaw 2026.4.15 CLI startup is ~65s
+      // (jiti loader churn). Revert to default 30s once openclaw startup is fixed.
+      { timeoutMs: 180_000 }
     );
   } catch (error) {
     if (error instanceof GatewayControllerError && error.status === 400) {


### PR DESCRIPTION
## Summary
- Channel pairing approves have been failing 100% since 2026-04-24 17:00 UTC, immediately after PR #2801 (openclaw 2026.4.9 → 2026.4.15) merged. 490/491 attempts in the last 24h have returned `KiloClaw API error (500)`. Same root cause hits device pairing approves.
- Root cause is openclaw 2026.4.15 CLI **startup**, not the approve action: a fresh `openclaw pairing list telegram --json` on a controller machine takes **~65s wall / ~76s CPU**. The controller's 45s exec timeout (and the worker's 30s fetch timeout) fire before openclaw can respond, producing a SIGTERM with empty stdout/stderr.
- CPU profile from a controller machine: **~42% `normalizeAliases` + ~13% `createJiti`** in `jiti`, called per bundled plugin via `getCachedPluginJitiLoader`. The 4.12 changelog entry "Plugins/loading: narrow CLI, provider, and channel activation to manifest-declared needs" reworked plugin activation in a way that creates a fresh jiti loader per plugin, defeating the loader cache.

This PR is the short-term unblock. It bumps three timeouts to **180s** with `TEMPORARY` comments so they're easy to find and revert once openclaw upstream fixes startup time.

## Changes
- `services/kiloclaw/controller/src/pairing-cache.ts`: `APPROVE_TIMEOUT_MS` 45_000 → 180_000 (covers both channel and device approve, which both spawn openclaw)
- `services/kiloclaw/src/durable-objects/kiloclaw-instance/pairing.ts`: pass `{ timeoutMs: 180_000 }` at the two `callGatewayController` callsites for `/_kilo/pairing/channels/approve` and `/_kilo/pairing/devices/approve`. Default (30s) is unchanged for every other gateway-controller call.

## Follow-ups (not this PR)
- File an upstream openclaw issue with the CPU profile attached — fix is to share one root jiti loader across bundled plugins, or to drop `modulePath` from the cache key in `src/plugins/jiti-loader-cache.ts` when the alias map is identical.
- Consider trimming bundled extensions in the kiloclaw Dockerfile (every removed extension is one less jiti instance during startup) once we know which channels are actually in use.
- Revert these timeout bumps once openclaw startup is back under 30s.

## Test plan
- [x] `pnpm typecheck` (kiloclaw) clean
- [x] `pnpm lint` (kiloclaw) clean — 0 warnings, 0 errors
- [x] `pnpm test` (kiloclaw) — 1571/1571 passing
- [ ] After deploy: retry "Approve" on a pending Telegram pairing request; expect ~60-70s spinner then success
- [ ] Verify normal operations (status, start, list, etc.) are unaffected (other gateway-controller calls keep the 30s default)