### PR TITLE
fix(gastown): reduce TownContainer sleepAfter from 30m to 10m

### DIFF
--- a/services/gastown/src/dos/TownContainer.do.ts
+++ b/services/gastown/src/dos/TownContainer.do.ts
@@ -20,7 +20,7 @@ const TC_LOG = '[TownContainer.do]';
  */
 export class TownContainerDO extends Container<Env> {
   defaultPort = 8080;
-  sleepAfter = '30m';
+  sleepAfter = '10m';
 
   // Container env vars. Includes infra URLs and any tokens stored via setEnvVar().
   // The Container base class reads this when booting the container.


### PR DESCRIPTION
## Summary

Reduce `sleepAfter` on `TownContainerDO` from `'30m'` to `'10m'` to cut idle container cost ~3x while larger cost-reduction fixes land. Cold start is ~10-30s so users won't notice; real work continues to wake the container via `ensureContainerReady` as before.

## Verification

- Inspected `services/gastown/src/dos/TownContainer.do.ts:23` — now reads `sleepAfter = '10m';`.

## Visual Changes

N/A

## Reviewer Notes

- Single-line config change, zero-risk quick win.
- Targets `gastown-staging` feature branch per bead instructions.