### PR TITLE
fix(gastown): drop alarm cadence for long-stalled agents; auto-idle after 2h30m

### DIFF
--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -2205,6 +2205,14 @@ export function reconcileGUPP(sql: SqlStorage, opts?: { draining?: boolean }): A
     const elapsed = Date.now() - new Date(activityTimestamp).getTime();
     if (Number.isNaN(elapsed) || elapsed < 0) continue;
 
+    // Stalled agents past the auto-idle threshold are owned by
+    // reconcileAgents (stalled → idle + unhook). Skip them here so the
+    // later GUPP force-stop action (stalled → stalled) doesn't overwrite
+    // the earlier auto-idle transition in the same reconcile pass.
+    // applyAction('transition_agent') ignores `from`, so action order
+    // decides the final state.
+    if (agent.status === 'stalled' && elapsed > STALLED_AUTO_IDLE_MS) continue;
+
     if (elapsed > GUPP_FORCE_STOP_MS) {
       actions.push({
         type: 'transition_agent',

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -117,6 +117,13 @@ const ORPHANED_PR_REVIEW_TIMEOUT_MS = 30 * 60_000; // 30 min
  * to avoid racing with the idle-timer → agentCompleted → reconciler flow. */
 const STALE_IN_PROGRESS_TIMEOUT_MS = 5 * 60_000; // 5 min
 
+/** Time in 'stalled' before auto-transitioning to idle.
+ * Today, stalled agents are only cleared via container_status: exited|not_found
+ * events. If the container crashed hard or /status keeps returning
+ * running/unknown, the stalled row persists indefinitely. This time-based
+ * cleanup closes the loop. */
+const STALLED_AUTO_IDLE_MS = 2.5 * 60 * 60_000; // 2h 30min
+
 // ── Helper: staleness check ─────────────────────────────────────────
 
 function staleMs(timestamp: string | null, thresholdMs: number): boolean {
@@ -721,6 +728,52 @@ export function reconcileAgents(sql: SqlStorage, opts?: { draining?: boolean }):
         to: 'idle',
         reason: 'working agent has no hook (gt_done already completed)',
       });
+    }
+  }
+
+  // Stalled agents that have been stuck past STALLED_AUTO_IDLE_MS —
+  // transition to idle and unhook. Without this, a stalled row persists
+  // indefinitely if its container crashed hard or its /status keeps
+  // returning running/unknown (so the container_status → exited|not_found
+  // cleanup path never fires). Skip during drain to match working-agent
+  // handling above.
+  if (!opts?.draining) {
+    const longStalledAgents = AgentRow.array().parse([
+      ...query(
+        sql,
+        /* sql */ `
+          SELECT ${agent_metadata.bead_id}, ${agent_metadata.role},
+                 ${agent_metadata.status}, ${agent_metadata.current_hook_bead_id},
+                 ${agent_metadata.dispatch_attempts},
+                 ${agent_metadata.last_activity_at},
+                 b.${beads.columns.rig_id}
+          FROM ${agent_metadata}
+          LEFT JOIN ${beads} b ON b.${beads.columns.bead_id} = ${agent_metadata.bead_id}
+          WHERE ${agent_metadata.status} = 'stalled'
+        `,
+        []
+      ),
+    ]);
+
+    for (const agent of longStalledAgents) {
+      if (!agent.last_activity_at) continue;
+      const stalledMs = Date.now() - new Date(agent.last_activity_at).getTime();
+      if (stalledMs <= STALLED_AUTO_IDLE_MS) continue;
+
+      actions.push({
+        type: 'transition_agent',
+        agent_id: agent.bead_id,
+        from: 'stalled',
+        to: 'idle',
+        reason: 'stalled_timeout (exceeded 2h 30min)',
+      });
+      if (agent.current_hook_bead_id) {
+        actions.push({
+          type: 'unhook_agent',
+          agent_id: agent.bead_id,
+          reason: 'stalled_timeout (exceeded 2h 30min)',
+        });
+      }
     }
   }
 

--- a/services/gastown/src/dos/town/scheduling.ts
+++ b/services/gastown/src/dos/town/scheduling.ts
@@ -266,10 +266,18 @@ export function dispatchUnblockedBeads(ctx: SchedulingContext, closedBeadId: str
  * interval. Used to decide between active and idle alarm cadence.
  */
 export function hasActiveWork(sql: SqlStorage): boolean {
+  // Stalled agents older than 30min no longer count as active work: they
+  // typically represent stuck rows (container crashed hard, /status keeps
+  // returning running/unknown). Keeping them in the active set would pin
+  // the alarm at its 5s fast cadence indefinitely. The stalled->idle
+  // auto-transition in reconcileAgents cleans them up after 2h 30min.
   const activeAgentRows = [
     ...query(
       sql,
-      /* sql */ `SELECT COUNT(*) as cnt FROM ${agent_metadata} WHERE ${agent_metadata.status} IN ('working', 'stalled')`,
+      /* sql */ `SELECT COUNT(*) as cnt FROM ${agent_metadata}
+        WHERE ${agent_metadata.status} = 'working'
+           OR (${agent_metadata.status} = 'stalled'
+               AND ${agent_metadata.last_activity_at} > strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 minutes'))`,
       []
     ),
   ];


### PR DESCRIPTION
## Summary

Fixes two cost issues caused by agents stuck in 'stalled':

- `hasActiveWork()` (scheduling.ts) no longer counts stalled agents older than 30 minutes as active work, so towns with only stuck stalled rows drop from the 5s fast alarm cadence to the 5m idle cadence — a 60x reduction in per-agent `/status` ping rate.
- `reconcileAgents()` (reconciler.ts) now auto-transitions stalled agents whose `last_activity_at` is older than 2h 30min to `idle` and unhooks the bead, closing the cleanup loop when the `container_status: exited|not_found` event never fires (hard crash, `/status` stuck returning running/unknown).

## Verification

Verified by code inspection against the acceptance criteria in the bead:
- `hasActiveWork()` returns false for towns whose only active agents are stalled >30min (SQL now requires `last_activity_at > now - 30min` for a stalled row to count).
- Alarm cadence drops from 5s to 5m for such towns; per-agent `/status` pings (Town.do.ts `_alarm`) stop when `hasActiveWork()` flips.
- Agents stalled >2h 30min emit `transition_agent` (to=idle) plus `unhook_agent`.
- Working agents unaffected (loop is gated on `status = 'stalled'`).
- Skipped during drain, symmetric to existing working-agent heartbeat check.

## Visual Changes

N/A

## Reviewer Notes

- 30min cutoff in `hasActiveWork()` is coarser than a heartbeat-lost check but matches the bead spec and is the same threshold used elsewhere for stale dispatch-attempt resets.
- `STALLED_AUTO_IDLE_MS = 2.5 * 60 * 60_000` is the bead's prescribed threshold. Stalled agents with NULL `last_activity_at` are skipped (defensive — they should not exist in practice because `stalled` is only set after heartbeats arrived).
- The `transition_agent` action handler in `actions.ts` only updates status; I emit a paired `unhook_agent` action when a hook is present, matching the pattern used for idle agents hooked to terminal beads.