### PR TITLE
fix(gastown): reduce Cloudflare container usage

### DIFF
--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -2549,6 +2549,25 @@ export class TownDO extends DurableObject<Env> {
     let sessionStatus: 'idle' | 'active' | 'starting';
 
     if (isAlive) {
+      // Refresh the container-scoped JWT before sending. The mayor makes GT
+      // tool calls using GASTOWN_CONTAINER_TOKEN, and sendMessageToAgent does
+      // not otherwise call ensureContainerToken. Without this, a mayor that
+      // has been waiting longer than the 8h token expiry would 401 on its
+      // first GT tool call for the new prompt.
+      //
+      // Best-effort: ensureContainerToken throws on non-2xx /refresh-token
+      // responses. We don't want a transient refresh failure (404/500) to
+      // drop the user's prompt — the stored envVar fallback and the next
+      // alarm tick will recover. Log and proceed to sendMessageToAgent.
+      try {
+        const townConfig = await this.getTownConfig();
+        const userId = townConfig.owner_user_id ?? townId;
+        await dispatch.ensureContainerToken(this.env, townId, userId);
+      } catch (err) {
+        logger.warn('sendMayorMessage: ensureContainerToken failed, proceeding with send', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
       const sent = await dispatch.sendMessageToAgent(this.env, townId, mayor.id, combinedMessage);
       if (sent) {
         // Transition waiting → working so the alarm runs at the active cadence
@@ -4106,17 +4125,16 @@ export class TownDO extends DurableObject<Env> {
    * requests that reset the container's sleepAfter timer (#1409).
    */
   private async refreshContainerToken(): Promise<void> {
-    // Skip if no active work AND no alive mayor — the container is sleeping
-    // and doesn't need a fresh token. The token will be refreshed when work
-    // is next dispatched (ensureContainerToken is called in
-    // startAgentInContainer at container-dispatch.ts:329).
-    // However, a waiting mayor IS alive in the container and needs a valid
-    // token for GT tool calls when the user sends the next message
-    // (sendMayorMessage → sendMessageToAgent does NOT call ensureContainerToken).
+    // Skip if no active work AND no actively-running mayor — the container is
+    // sleeping (or about to) and doesn't need a fresh token. The token will be
+    // refreshed when work is next dispatched (ensureContainerToken is called in
+    // startAgentInContainer at container-dispatch.ts) and on the warm-send path
+    // in _sendMayorMessage before sendMessageToAgent. 'waiting' is intentionally
+    // excluded: a user may leave a mayor in waiting indefinitely, and counting
+    // it as alive here would keep the container awake forever via hourly
+    // /refresh-token pings that reset sleepAfter (#1409).
     const mayor = agents.listAgents(this.sql, { role: 'mayor' })[0] ?? null;
-    const mayorAlive =
-      mayor &&
-      (mayor.status === 'working' || mayor.status === 'stalled' || mayor.status === 'waiting');
+    const mayorAlive = mayor && (mayor.status === 'working' || mayor.status === 'stalled');
     if (!this.hasActiveWork() && !mayorAlive) return;
 
     const TOKEN_REFRESH_INTERVAL_MS = 60 * 60_000; // 1 hour

--- a/services/gastown/src/dos/TownContainer.do.ts
+++ b/services/gastown/src/dos/TownContainer.do.ts
@@ -20,7 +20,7 @@ const TC_LOG = '[TownContainer.do]';
  */
 export class TownContainerDO extends Container<Env> {
   defaultPort = 8080;
-  sleepAfter = '30m';
+  sleepAfter = '10m';
 
   // Container env vars. Includes infra URLs and any tokens stored via setEnvVar().
   // The Container base class reads this when booting the container.

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -117,6 +117,13 @@ const ORPHANED_PR_REVIEW_TIMEOUT_MS = 30 * 60_000; // 30 min
  * to avoid racing with the idle-timer → agentCompleted → reconciler flow. */
 const STALE_IN_PROGRESS_TIMEOUT_MS = 5 * 60_000; // 5 min
 
+/** Time in 'stalled' before auto-transitioning to idle.
+ * Today, stalled agents are only cleared via container_status: exited|not_found
+ * events. If the container crashed hard or /status keeps returning
+ * running/unknown, the stalled row persists indefinitely. This time-based
+ * cleanup closes the loop. */
+const STALLED_AUTO_IDLE_MS = 2.5 * 60 * 60_000; // 2h 30min
+
 // ── Helper: staleness check ─────────────────────────────────────────
 
 function staleMs(timestamp: string | null, thresholdMs: number): boolean {
@@ -721,6 +728,52 @@ export function reconcileAgents(sql: SqlStorage, opts?: { draining?: boolean }):
         to: 'idle',
         reason: 'working agent has no hook (gt_done already completed)',
       });
+    }
+  }
+
+  // Stalled agents that have been stuck past STALLED_AUTO_IDLE_MS —
+  // transition to idle and unhook. Without this, a stalled row persists
+  // indefinitely if its container crashed hard or its /status keeps
+  // returning running/unknown (so the container_status → exited|not_found
+  // cleanup path never fires). Skip during drain to match working-agent
+  // handling above.
+  if (!opts?.draining) {
+    const longStalledAgents = AgentRow.array().parse([
+      ...query(
+        sql,
+        /* sql */ `
+          SELECT ${agent_metadata.bead_id}, ${agent_metadata.role},
+                 ${agent_metadata.status}, ${agent_metadata.current_hook_bead_id},
+                 ${agent_metadata.dispatch_attempts},
+                 ${agent_metadata.last_activity_at},
+                 b.${beads.columns.rig_id}
+          FROM ${agent_metadata}
+          LEFT JOIN ${beads} b ON b.${beads.columns.bead_id} = ${agent_metadata.bead_id}
+          WHERE ${agent_metadata.status} = 'stalled'
+        `,
+        []
+      ),
+    ]);
+
+    for (const agent of longStalledAgents) {
+      if (!agent.last_activity_at) continue;
+      const stalledMs = Date.now() - new Date(agent.last_activity_at).getTime();
+      if (stalledMs <= STALLED_AUTO_IDLE_MS) continue;
+
+      actions.push({
+        type: 'transition_agent',
+        agent_id: agent.bead_id,
+        from: 'stalled',
+        to: 'idle',
+        reason: 'stalled_timeout (exceeded 2h 30min)',
+      });
+      if (agent.current_hook_bead_id) {
+        actions.push({
+          type: 'unhook_agent',
+          agent_id: agent.bead_id,
+          reason: 'stalled_timeout (exceeded 2h 30min)',
+        });
+      }
     }
   }
 
@@ -2151,6 +2204,14 @@ export function reconcileGUPP(sql: SqlStorage, opts?: { draining?: boolean }): A
 
     const elapsed = Date.now() - new Date(activityTimestamp).getTime();
     if (Number.isNaN(elapsed) || elapsed < 0) continue;
+
+    // Stalled agents past the auto-idle threshold are owned by
+    // reconcileAgents (stalled → idle + unhook). Skip them here so the
+    // later GUPP force-stop action (stalled → stalled) doesn't overwrite
+    // the earlier auto-idle transition in the same reconcile pass.
+    // applyAction('transition_agent') ignores `from`, so action order
+    // decides the final state.
+    if (agent.status === 'stalled' && elapsed > STALLED_AUTO_IDLE_MS) continue;
 
     if (elapsed > GUPP_FORCE_STOP_MS) {
       actions.push({

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -2211,7 +2211,19 @@ export function reconcileGUPP(sql: SqlStorage, opts?: { draining?: boolean }): A
     // the earlier auto-idle transition in the same reconcile pass.
     // applyAction('transition_agent') ignores `from`, so action order
     // decides the final state.
-    if (agent.status === 'stalled' && elapsed > STALLED_AUTO_IDLE_MS) continue;
+    //
+    // Mirror reconcileAgents' auto-idle eligibility check against
+    // last_activity_at. If last_event_at is stale but heartbeats keep
+    // refreshing last_activity_at, reconcileAgents won't idle the row yet —
+    // skipping GUPP handling in that case would leave the row stuck stalled
+    // while the alarm keeps firing.
+    if (
+      agent.status === 'stalled' &&
+      agent.last_activity_at &&
+      Date.now() - new Date(agent.last_activity_at).getTime() > STALLED_AUTO_IDLE_MS
+    ) {
+      continue;
+    }
 
     if (elapsed > GUPP_FORCE_STOP_MS) {
       actions.push({

--- a/services/gastown/src/dos/town/scheduling.ts
+++ b/services/gastown/src/dos/town/scheduling.ts
@@ -266,10 +266,18 @@ export function dispatchUnblockedBeads(ctx: SchedulingContext, closedBeadId: str
  * interval. Used to decide between active and idle alarm cadence.
  */
 export function hasActiveWork(sql: SqlStorage): boolean {
+  // Stalled agents older than 30min no longer count as active work: they
+  // typically represent stuck rows (container crashed hard, /status keeps
+  // returning running/unknown). Keeping them in the active set would pin
+  // the alarm at its 5s fast cadence indefinitely. The stalled->idle
+  // auto-transition in reconcileAgents cleans them up after 2h 30min.
   const activeAgentRows = [
     ...query(
       sql,
-      /* sql */ `SELECT COUNT(*) as cnt FROM ${agent_metadata} WHERE ${agent_metadata.status} IN ('working', 'stalled')`,
+      /* sql */ `SELECT COUNT(*) as cnt FROM ${agent_metadata}
+        WHERE ${agent_metadata.status} = 'working'
+           OR (${agent_metadata.status} = 'stalled'
+               AND ${agent_metadata.last_activity_at} > strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 minutes'))`,
       []
     ),
   ];


### PR DESCRIPTION
## Summary

Reduces Cloudflare container runtime by combining three fixes that prevent the container from being kept awake unnecessarily and by cleaning up stalled agent rows that previously pinned the alarm cadence:

- `TownContainerDO.sleepAfter` reduced from `30m` → `10m` (#2828).
- Stop keeping the container awake for `waiting` mayors: `refreshContainerToken` now only treats `working`/`stalled` mayors as alive. The warm-send path (`sendMayorMessage`) calls `ensureContainerToken` before dispatching so a post-wait user prompt still gets a fresh JWT (#2829).
- Long-stalled agents now auto-transition `stalled → idle` after 2h 30min via `reconcileAgents`, and `hasActiveWork` excludes stalled agents older than 30min so the alarm does not stay on its fast cadence indefinitely. `reconcileGUPP` skips these agents to avoid clobbering the auto-idle transition in the same pass (#2830).

## Verification

Manually reviewed the three already-merged sub-PRs (#2828, #2829, #2830) that make up this convoy branch.

## Visual Changes

N/A

## Reviewer Notes

- Action ordering is load-bearing in `reconciler.ts`: the new stalled-timeout `transition_agent` must run before `reconcileGUPP`'s force-stop action in the same reconcile pass. `reconcileGUPP` now explicitly skips agents past `STALLED_AUTO_IDLE_MS`.
- `ensureContainerToken` throws on non-2xx `/refresh-token`. `_sendMayorMessage` wraps it in try/catch so a transient refresh failure does not drop the user prompt; the stored envVar fallback and the next alarm tick recover.
- Shortening `sleepAfter` to 10m may slightly increase cold-start frequency for idle towns; the warm-send token refresh keeps the first post-wake GT tool call healthy.