### PR TITLE
fix(web): include gastown URL in dev env sync template

### DIFF
--- a/apps/web/.env.development.local.example
+++ b/apps/web/.env.development.local.example
@@ -38,7 +38,7 @@ NEXT_PUBLIC_CLOUD_AGENT_WS_URL=ws://localhost:8794
 NEXT_PUBLIC_CLOUD_AGENT_NEXT_WS_URL=ws://localhost:8794
 
 # @url cloudflare-gastown
-NEXT_PUBLIC_GASTOWN_URL=http://localhost:8810
+NEXT_PUBLIC_GASTOWN_URL=http://localhost:8803
 
 # @url kilo-chat
 NEXT_PUBLIC_KILO_CHAT_URL=http://localhost:8808

--- a/apps/web/.env.development.local.example
+++ b/apps/web/.env.development.local.example
@@ -37,6 +37,9 @@ NEXT_PUBLIC_CLOUD_AGENT_WS_URL=ws://localhost:8794
 # @url cloud-agent-next
 NEXT_PUBLIC_CLOUD_AGENT_NEXT_WS_URL=ws://localhost:8794
 
+# @url cloudflare-gastown
+NEXT_PUBLIC_GASTOWN_URL=http://localhost:8810
+
 # @url kilo-chat
 NEXT_PUBLIC_KILO_CHAT_URL=http://localhost:8808
 


### PR DESCRIPTION
## Summary
- Add `NEXT_PUBLIC_GASTOWN_URL` to `apps/web/.env.development.local.example` so `pnpm dev:env` writes the required public Gastown URL into `apps/web/.env.development.local`.
- This aligns local dev env sync with recent web startup requirements and prevents `dev:start` from failing when `GASTOWN_URL` is required at Next.js startup.

## Verification
- [x] Ran `pnpm dev:env -y` and confirmed `.env.development.local` receives `NEXT_PUBLIC_GASTOWN_URL`.
- [x] Verified the generated value is present in `apps/web/.env.development.local` after sync.

## Visual Changes
N/A

## Reviewer Notes
- This is a narrow dev-env template fix only; no runtime/business logic changes.