### PR TITLE
fix(kiloclaw): split upgrade confirmation flow

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawInstanceOverview.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawInstanceOverview.tsx
@@ -11,7 +11,15 @@ import { InstanceControls } from './InstanceControls';
 import { InstanceTab } from './InstanceTab';
 import { useClawContext } from './ClawContext';
 
-export function ClawInstanceOverview({ status }: { status: KiloClawDashboardStatus }) {
+export function ClawInstanceOverview({
+  status,
+  onRedeploySuccess,
+  onRequestUpgrade,
+}: {
+  status: KiloClawDashboardStatus;
+  onRedeploySuccess?: () => void;
+  onRequestUpgrade?: () => void;
+}) {
   const { organizationId } = useClawContext();
 
   const personalMutations = useKiloClawMutations();
@@ -60,6 +68,8 @@ export function ClawInstanceOverview({ status }: { status: KiloClawDashboardStat
           <InstanceControls
             status={status}
             mutations={mutations}
+            onRedeploySuccess={onRedeploySuccess}
+            onRequestUpgrade={onRequestUpgrade}
             gatewayReady={gatewayStatus?.state === 'running'}
           />
         </CardContent>

--- a/apps/web/src/app/(app)/claw/components/ClawSettingsPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawSettingsPage.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { Settings } from 'lucide-react';
 import { useRouter } from 'next/navigation';
+import { usePostHog } from 'posthog-js/react';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { useKiloClawStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { useOrgKiloClawStatus, useOrgKiloClawMutations } from '@/hooks/useOrgKiloClaw';
@@ -11,6 +12,7 @@ import { ClawContextProvider, useClawContext } from './ClawContext';
 import { ClawConfigServiceBanner } from './ClawConfigServiceBanner';
 import { ClawInstanceOverview } from './ClawInstanceOverview';
 import { SettingsTab } from './SettingsTab';
+import { UpgradeKiloClawDialog } from './UpgradeKiloClawDialog';
 import { BillingWrapper } from './billing/BillingWrapper';
 import { SetPageTitle } from '@/components/SetPageTitle';
 import { Card, CardContent } from '@/components/ui/card';
@@ -27,12 +29,14 @@ function ClawSettingsInner({
   organizationName?: string;
 }) {
   const { organizationId } = useClawContext();
+  const posthog = usePostHog();
 
   const personalMutations = useKiloClawMutations();
   const orgMutations = useOrgKiloClawMutations(organizationId ?? '');
   const mutations = organizationId ? orgMutations : personalMutations;
 
   const [dirtySecrets, setDirtySecrets] = useState<Set<string>>(new Set());
+  const [confirmUpgrade, setConfirmUpgrade] = useState(false);
   const onSecretsChanged = useCallback((entryId: string) => {
     setDirtySecrets(prev => new Set([...prev, entryId]));
   }, []);
@@ -53,12 +57,21 @@ function ClawSettingsInner({
     });
   }, [mutations.restartMachine, onRedeploySuccess]);
 
-  const onUpgrade = useCallback(() => {
+  const onRequestUpgrade = useCallback(() => {
+    setConfirmUpgrade(true);
+  }, []);
+
+  const onConfirmUpgrade = useCallback(() => {
+    posthog?.capture('claw_redeploy_clicked', {
+      instance_status: status.status,
+      redeploy_mode: 'upgrade',
+    });
     mutations.restartMachine.mutate(
       { imageTag: 'latest' },
       {
         onSuccess: () => {
-          toast.success('Upgrading to latest image');
+          toast.success('Upgrading KiloClaw');
+          setConfirmUpgrade(false);
           onRedeploySuccess();
         },
         onError: err => {
@@ -66,23 +79,35 @@ function ClawSettingsInner({
         },
       }
     );
-  }, [mutations.restartMachine, onRedeploySuccess]);
-
-  const onRequestUpgrade = useCallback(() => {
-    onUpgrade();
-  }, [onUpgrade]);
+  }, [mutations.restartMachine, onRedeploySuccess, posthog, status.status]);
 
   return (
-    <SettingsTab
-      status={status}
-      mutations={mutations}
-      onSecretsChanged={onSecretsChanged}
-      dirtySecrets={dirtySecrets}
-      onRedeploy={onRedeploy}
-      onUpgrade={onUpgrade}
-      onRequestUpgrade={onRequestUpgrade}
-      organizationName={organizationName}
-    />
+    <>
+      <ClawInstanceOverview
+        status={status}
+        onRedeploySuccess={onRedeploySuccess}
+        onRequestUpgrade={onRequestUpgrade}
+      />
+      <SettingsTab
+        status={status}
+        mutations={mutations}
+        onSecretsChanged={onSecretsChanged}
+        dirtySecrets={dirtySecrets}
+        onRedeploy={onRedeploy}
+        onRequestUpgrade={onRequestUpgrade}
+        organizationName={organizationName}
+      />
+      <UpgradeKiloClawDialog
+        open={confirmUpgrade}
+        onOpenChange={open => {
+          if (mutations.restartMachine.isPending) return;
+          if (!open) posthog?.capture('claw_redeploy_cancelled');
+          setConfirmUpgrade(open);
+        }}
+        isPending={mutations.restartMachine.isPending}
+        onConfirm={onConfirmUpgrade}
+      />
+    </>
   );
 }
 
@@ -139,7 +164,6 @@ function ClawSettingsWithStatus({
   const settingsContent = (
     <div className="flex flex-col gap-6">
       <ClawConfigServiceBanner status={status} />
-      <ClawInstanceOverview status={status} />
       <ClawSettingsInner status={status} organizationName={organizationName} />
     </div>
   );

--- a/apps/web/src/app/(app)/claw/components/ClawSettingsPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawSettingsPage.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { Settings } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { usePostHog } from 'posthog-js/react';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { useKiloClawStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { useOrgKiloClawStatus, useOrgKiloClawMutations } from '@/hooks/useOrgKiloClaw';
@@ -29,7 +28,6 @@ function ClawSettingsInner({
   organizationName?: string;
 }) {
   const { organizationId } = useClawContext();
-  const posthog = usePostHog();
 
   const personalMutations = useKiloClawMutations();
   const orgMutations = useOrgKiloClawMutations(organizationId ?? '');
@@ -62,10 +60,6 @@ function ClawSettingsInner({
   }, []);
 
   const onConfirmUpgrade = useCallback(() => {
-    posthog?.capture('claw_redeploy_clicked', {
-      instance_status: status.status,
-      redeploy_mode: 'upgrade',
-    });
     mutations.restartMachine.mutate(
       { imageTag: 'latest' },
       {
@@ -79,7 +73,7 @@ function ClawSettingsInner({
         },
       }
     );
-  }, [mutations.restartMachine, onRedeploySuccess, posthog, status.status]);
+  }, [mutations.restartMachine, onRedeploySuccess]);
 
   return (
     <>
@@ -101,7 +95,6 @@ function ClawSettingsInner({
         open={confirmUpgrade}
         onOpenChange={open => {
           if (mutations.restartMachine.isPending) return;
-          if (!open) posthog?.capture('claw_redeploy_cancelled');
           setConfirmUpgrade(open);
         }}
         isPending={mutations.restartMachine.isPending}

--- a/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
@@ -38,6 +38,7 @@ import { StartKiloCliRunDialog } from './StartKiloCliRunDialog';
 import { AnimatedDots } from './AnimatedDots';
 import { OpenClawButton } from './OpenClawButton';
 import { KiloClawUpdateAvailableBanner } from './KiloClawUpdateAvailableBanner';
+import { UpgradeKiloClawDialog } from './UpgradeKiloClawDialog';
 
 const VOLUME_SIZE_GB = 10;
 // Default machine spec fallback (matches kiloclaw DEFAULT_MACHINE_GUEST)
@@ -54,15 +55,13 @@ export function InstanceControls({
   status,
   mutations,
   onRedeploySuccess,
-  upgradeRequested,
-  onUpgradeHandled,
+  onRequestUpgrade,
   gatewayReady,
 }: {
   status: KiloClawDashboardStatus;
   mutations: ClawMutations;
   onRedeploySuccess?: () => void;
-  upgradeRequested?: boolean;
-  onUpgradeHandled?: () => void;
+  onRequestUpgrade?: () => void;
   gatewayReady?: boolean;
 }) {
   const posthog = usePostHog();
@@ -84,6 +83,7 @@ export function InstanceControls({
   const [kiloRunOpen, setKiloRunOpen] = useState(false);
   const [confirmRestart, setConfirmRestart] = useState(false);
   const [confirmRedeploy, setConfirmRedeploy] = useState(false);
+  const [confirmUpgrade, setConfirmUpgrade] = useState(false);
   const [redeployMode, setRedeployMode] = useState<'redeploy' | 'upgrade'>('redeploy');
 
   const { updateAvailable, catalogNewerThanImage, latestAvailableVersion, latestVersion } =
@@ -113,6 +113,33 @@ export function InstanceControls({
     setManuallyDismissed(true);
   }, [dismissKey]);
 
+  const openUpgradeConfirmation = useCallback(() => {
+    if (onRequestUpgrade) {
+      onRequestUpgrade();
+      return;
+    }
+
+    setConfirmUpgrade(true);
+  }, [onRequestUpgrade]);
+
+  const handleUpgradeConfirm = useCallback(() => {
+    posthog?.capture('claw_redeploy_clicked', {
+      instance_status: status.status,
+      redeploy_mode: 'upgrade',
+    });
+    mutations.restartMachine.mutate(
+      { imageTag: 'latest' },
+      {
+        onSuccess: () => {
+          toast.success('Upgrading KiloClaw');
+          setConfirmUpgrade(false);
+          onRedeploySuccess?.();
+        },
+        onError: err => toast.error(err.message, { duration: 10000 }),
+      }
+    );
+  }, [mutations.restartMachine, onRedeploySuccess, posthog, status.status]);
+
   const showUpgradeBanner =
     isFlyProvider && updateAvailable && !isDismissedInStorage && !manuallyDismissed;
 
@@ -131,18 +158,6 @@ export function InstanceControls({
       }
     );
   };
-
-  // Toggle-flag pattern: parent sets upgradeRequested=true, we open the dialog
-  // with "upgrade" preselected, then immediately reset via onUpgradeHandled.
-  // Safe for single-click flows; won't re-fire if already true (no state change).
-  useEffect(() => {
-    if (!upgradeRequested) return;
-    if (isFlyProvider) {
-      setRedeployMode('upgrade');
-      setConfirmRedeploy(true);
-    }
-    onUpgradeHandled?.();
-  }, [upgradeRequested, isFlyProvider, onUpgradeHandled]);
 
   return (
     <div>
@@ -216,10 +231,7 @@ export function InstanceControls({
         <KiloClawUpdateAvailableBanner
           className="mb-4"
           catalogNewerThanImage={catalogNewerThanImage}
-          onUpgrade={() => {
-            setRedeployMode('upgrade');
-            setConfirmRedeploy(true);
-          }}
+          onUpgrade={openUpgradeConfirmation}
           onDismiss={dismissBanner}
         />
       )}
@@ -458,6 +470,16 @@ export function InstanceControls({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+      <UpgradeKiloClawDialog
+        open={confirmUpgrade}
+        onOpenChange={open => {
+          if (mutations.restartMachine.isPending) return;
+          if (!open) posthog?.capture('claw_redeploy_cancelled');
+          setConfirmUpgrade(open);
+        }}
+        isPending={mutations.restartMachine.isPending}
+        onConfirm={handleUpgradeConfirm}
+      />
       <RunDoctorDialog
         open={doctorOpen}
         onOpenChange={setDoctorOpen}

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -1277,7 +1277,6 @@ export function SettingsTab({
   onSecretsChanged,
   dirtySecrets,
   onRedeploy,
-  onUpgrade,
   onRequestUpgrade,
   organizationName,
 }: {
@@ -1286,9 +1285,7 @@ export function SettingsTab({
   onSecretsChanged?: (entryId: string) => void;
   dirtySecrets: Set<string>;
   onRedeploy?: () => void;
-  /** Callback that triggers an image upgrade (pull latest) instead of a plain restart. */
-  onUpgrade?: () => void;
-  /** Callback that requests an upgrade via the InstanceControls dialog. */
+  /** Callback that opens the focused upgrade confirmation flow. */
   onRequestUpgrade?: () => void;
   /** Present in organization context; required in the destroy confirmation phrase. */
   organizationName?: string;
@@ -1821,7 +1818,7 @@ export function SettingsTab({
                   mutations={mutations}
                   onSecretsChanged={onSecretsChanged}
                   isDirty={dirtySecrets.has(entry.id)}
-                  onRedeploy={onUpgrade ?? onRedeploy}
+                  onRedeploy={onRequestUpgrade ?? onRedeploy}
                   redeployLabel="Upgrade"
                   actionRowExtra={<AgentCardSetupGuide />}
                 />

--- a/apps/web/src/app/(app)/claw/components/UpgradeKiloClawDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/UpgradeKiloClawDialog.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { ArrowUpCircle, RotateCw } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { AnimatedDots } from './AnimatedDots';
+
+const upgradeButtonClassName =
+  'border-amber-500/30 bg-amber-500/10 text-amber-400 hover:bg-amber-500/20 hover:text-amber-300';
+
+export function UpgradeKiloClawDialog({
+  open,
+  onOpenChange,
+  isPending,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  isPending: boolean;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={isPending ? undefined : onOpenChange}>
+      <DialogContent className="max-w-md gap-5">
+        <DialogHeader className="gap-3 space-y-0 pr-6">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full border border-amber-500/30 bg-amber-500/10 text-amber-300">
+            <ArrowUpCircle className="h-5 w-5" />
+          </div>
+          <div className="space-y-2">
+            <DialogTitle>Upgrade KiloClaw</DialogTitle>
+            <DialogDescription className="leading-6">
+              Upgrade this instance to the latest supported KiloClaw version. This also redeploys
+              the runtime, so it may be briefly offline.
+            </DialogDescription>
+          </div>
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button className={upgradeButtonClassName} onClick={onConfirm} disabled={isPending}>
+            {isPending ? (
+              <>
+                Upgrading
+                <AnimatedDots />
+              </>
+            ) : (
+              <>
+                <RotateCw className="h-4 w-4" />
+                Upgrade & Redeploy
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a focused KiloClaw upgrade confirmation modal for Upgrade Now and settings upgrade entry points.
- Keep the existing Redeploy or Upgrade flow intact for manual redeploys, including its two-choice Fly instance modal.
- Remove temporary local debug testing hooks and stale transitional upgrade props before PR.

## Verification

- Manually verified via local dev using a temporary `debugClawUpgradeModal=1` trigger during implementation that the focused upgrade modal opened with only Cancel and Upgrade & Redeploy, then removed the temporary trigger before PR.
- Manually verified the existing Redeploy or Upgrade button still opens the two-choice redeploy modal.

## Visual Changes

| Before | After |
| --- | --- |
| <img width="1490" height="1024" alt="Screenshot 2026-04-27 at 12 57 37@2x" src="https://github.com/user-attachments/assets/42fa6389-a944-4e3e-b600-6e5da426764f" /> | <img width="1146" height="698" alt="Screenshot 2026-04-27 at 12 40 25@2x" src="https://github.com/user-attachments/assets/ef347262-8893-49f8-a2f0-073f89578292" /> |

## Reviewer Notes

- Upgrade and redeploy still use the existing `restartMachine` mutation; upgrade passes `{ imageTag: 'latest' }`, redeploy passes no payload.
- Unrelated local working-tree changes were left out of this branch commit.