### PR TITLE
fix(kiloclaw): only seed IDENTITY.md on first boot

### DIFF
--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -597,6 +597,25 @@ describe('writeBotIdentityFile', () => {
       ['/root/.openclaw/workspace/BOOTSTRAP.md'],
     ]);
   });
+
+  it('does not overwrite an existing workspace/IDENTITY.md', () => {
+    const harness = fakeDeps();
+    (harness.deps.existsSync as ReturnType<typeof vi.fn>).mockImplementation(
+      (p: string) => p === '/root/.openclaw/workspace/IDENTITY.md'
+    );
+
+    writeBotIdentityFile(
+      { KILOCLAW_BOT_NAME: 'Milo', KILOCLAW_BOT_NATURE: 'Operator' },
+      harness.deps
+    );
+
+    expect(harness.writeCalls.some(call => call.path.endsWith('/workspace/IDENTITY.md'))).toBe(
+      false
+    );
+    expect(
+      harness.renameCalls.some(call => call.to === '/root/.openclaw/workspace/IDENTITY.md')
+    ).toBe(false);
+  });
 });
 
 // ---- user profile file ----
@@ -871,9 +890,11 @@ describe('runOnboardOrDoctor', () => {
 
   it('runs doctor when config exists', () => {
     const harness = fakeDeps();
-    // Make config exist
+    // Make config and IDENTITY.md exist — simulates a reboot of a provisioned
+    // instance. IDENTITY.md must not be clobbered on the doctor path.
     (harness.deps.existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
       if (p.endsWith('openclaw.json')) return true;
+      if (p.endsWith('/workspace/IDENTITY.md')) return true;
       return false;
     });
     (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
@@ -895,7 +916,9 @@ describe('runOnboardOrDoctor', () => {
     expect(doctorCall?.args).toContain('--fix');
     expect(doctorCall?.args).toContain('--non-interactive');
     expect(env.KILOCLAW_FRESH_INSTALL).toBe('false');
-    expect(harness.renameCalls.some(call => call.to.endsWith('/workspace/IDENTITY.md'))).toBe(true);
+    expect(harness.renameCalls.some(call => call.to.endsWith('/workspace/IDENTITY.md'))).toBe(
+      false
+    );
   });
 
   it('migrates legacy plaintext kilocode key in auth-profiles.json to a keyRef', () => {

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -289,11 +289,18 @@ export function writeBotIdentityFile(
   > = defaultDeps
 ): void {
   deps.mkdirSync(path.dirname(IDENTITY_MD_DEST), { recursive: true });
-  atomicWrite(IDENTITY_MD_DEST, formatBotIdentityMarkdown(env), {
-    writeFileSync: deps.writeFileSync,
-    renameSync: deps.renameSync,
-    unlinkSync: deps.unlinkSync,
-  });
+
+  // Only seed IDENTITY.md on the initial boot. After that it's agent/user-owned
+  // content — we must not clobber edits on subsequent reboots. Bot-identity env
+  // var changes (KILOCLAW_BOT_NAME etc.) therefore only take effect on a fresh
+  // instance; existing instances keep whatever IDENTITY.md currently contains.
+  if (!deps.existsSync(IDENTITY_MD_DEST)) {
+    atomicWrite(IDENTITY_MD_DEST, formatBotIdentityMarkdown(env), {
+      writeFileSync: deps.writeFileSync,
+      renameSync: deps.renameSync,
+      unlinkSync: deps.unlinkSync,
+    });
+  }
 
   for (const legacyPath of LEGACY_BOT_IDENTITY_DESTS) {
     if (!deps.existsSync(legacyPath)) continue;


### PR DESCRIPTION
## Summary

The controller's bootstrap was atomically rewriting `/root/.openclaw/workspace/IDENTITY.md` from the `KILOCLAW_BOT_*` env vars on every machine start, silently clobbering any agent- or user-authored edits every time the instance restarted. This gates `writeBotIdentityFile` on an `existsSync(IDENTITY_MD_DEST)` check so the file is only seeded when absent; subsequent boots leave it untouched.

No architectural change — the runtime update path is unchanged. Structured identity changes still flow through the existing hot-patch pipeline (`patchBotIdentity` tRPC mutation → `PATCH /api/platform/bot-identity` → DO `updateBotIdentity` → `POST /_kilo/bot-identity` → `atomicWrite(IDENTITY.md)`), which uses the same `formatBotIdentityMarkdown` renderer as the bootstrap seed.


## Verification

## Visual Changes

N/A

## Reviewer Notes

- Fresh-provision / machine-rebuild / snapshot-restore paths all still do the right thing: empty volume seeds from env, existing volumes (including restored snapshots) keep whatever `IDENTITY.md` is present.
