### PR TITLE
feat(kilo-chat): client-driven bot status polling

### DIFF
--- a/apps/web/src/app/(app)/claw/kilo-chat/hooks/useBotStatus.ts
+++ b/apps/web/src/app/(app)/claw/kilo-chat/hooks/useBotStatus.ts
@@ -7,6 +7,11 @@ import { useKiloChatContext } from '../components/kiloChatContext';
 
 const botKey = (sandboxId: string) => ['kilo-chat', 'bot-status', sandboxId] as const;
 
+// Matches the bot's old heartbeat cadence so UI staleness thresholds keep
+// working unchanged. Server-side dedupe absorbs multi-tab / multi-device
+// polling so this stays at ~1 webhook per sandbox per interval.
+const POLL_INTERVAL_MS = 15_000;
+
 export function useBotStatus(): BotStatusRecord | null {
   const { kiloChatClient, sandboxId } = useKiloChatContext();
   const queryClient = useQueryClient();
@@ -20,6 +25,27 @@ export function useBotStatus(): BotStatusRecord | null {
       );
     });
   }, [kiloChatClient, sandboxId, queryClient]);
+
+  // Active presence signal: while the hook is mounted (user is on a chat
+  // surface), nudge the bot to publish a fresh status. The server dedupes
+  // and an idle sandbox with no observers stops generating traffic.
+  useEffect(() => {
+    if (!sandboxId) return;
+    let cancelled = false;
+    const tick = () => {
+      if (cancelled) return;
+      void kiloChatClient.requestBotStatus(sandboxId).catch(() => {
+        // Best-effort; the visible status comes from event-service pushes,
+        // so a failed nudge just means the next tick retries.
+      });
+    };
+    tick();
+    const timer = setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [kiloChatClient, sandboxId]);
 
   const { data } = useQuery({
     queryKey: botKey(sandboxId ?? ''),

--- a/packages/kilo-chat/src/client.ts
+++ b/packages/kilo-chat/src/client.ts
@@ -229,6 +229,16 @@ export class KiloChatClient {
     });
   }
 
+  // Fire-and-forget: nudges the bot to push a fresh `bot.status` event over
+  // event-service. Server dedupes per sandbox; subscribed clients call this
+  // every ~15s while the user is on a chat surface.
+  async requestBotStatus(sandboxId: string): Promise<void> {
+    await this.httpRequest(`/v1/sandboxes/${sandboxId}/request-bot-status`, {
+      method: 'POST',
+      schema: voidSchema,
+    });
+  }
+
   async getConversationStatus(conversationId: string): Promise<GetConversationStatusResponse> {
     return this.httpRequest(`/v1/conversations/${conversationId}/conversation-status`, {
       schema: getConversationStatusResponseSchema,

--- a/packages/kilo-chat/src/webhook-schemas.ts
+++ b/packages/kilo-chat/src/webhook-schemas.ts
@@ -26,12 +26,21 @@ export const actionExecutedWebhookSchema = z.object({
   executedAt: z.string().min(1),
 });
 
+// Sent when a subscribed client polls for bot status. The plugin replies by
+// POSTing the current heartbeat back via `sendBotStatus`. No payload fields —
+// `sandboxId` is carried by the rpc-level `targetBotId`.
+export const botStatusRequestWebhookSchema = z.object({
+  type: z.literal('bot.status_request'),
+});
+
 export const chatWebhookSchema = z.discriminatedUnion('type', [
   messageCreatedWebhookSchema,
   actionExecutedWebhookSchema,
+  botStatusRequestWebhookSchema,
 ]);
 
 export const chatWebhookRpcSchema = z.discriminatedUnion('type', [
   messageCreatedWebhookSchema.extend({ targetBotId: z.string().min(1) }),
   actionExecutedWebhookSchema.extend({ targetBotId: z.string().min(1) }),
+  botStatusRequestWebhookSchema.extend({ targetBotId: z.string().min(1) }),
 ]);

--- a/services/kilo-chat/src/__tests__/bot-status-request.test.ts
+++ b/services/kilo-chat/src/__tests__/bot-status-request.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { isDefiniteUnreachable } from '../services/bot-status-request';
+
+describe('isDefiniteUnreachable', () => {
+  it('classifies missing-routing errors as definitive', () => {
+    expect(isDefiniteUnreachable(new Error('No routing target for sandbox-foo'))).toBe(true);
+    expect(isDefiniteUnreachable(new Error('Instance for sandbox-foo has no sandboxId'))).toBe(
+      true
+    );
+  });
+
+  it('classifies upstream 4xx as definitive', () => {
+    expect(isDefiniteUnreachable(new Error('Webhook forward failed: 401 Unauthorized'))).toBe(true);
+    expect(isDefiniteUnreachable(new Error('Webhook forward failed: 404 Not Found'))).toBe(true);
+    expect(isDefiniteUnreachable(new Error('Webhook forward failed: 410 Gone'))).toBe(true);
+  });
+
+  it('classifies upstream 5xx as transient', () => {
+    expect(isDefiniteUnreachable(new Error('Webhook forward failed: 500 Internal'))).toBe(false);
+    expect(isDefiniteUnreachable(new Error('Webhook forward failed: 502 Bad Gateway'))).toBe(false);
+    expect(isDefiniteUnreachable(new Error('Webhook forward failed: 504 Gateway Timeout'))).toBe(
+      false
+    );
+  });
+
+  it('classifies network/abort errors as transient', () => {
+    expect(isDefiniteUnreachable(new Error('fetch failed'))).toBe(false);
+    expect(isDefiniteUnreachable(new Error('Aborted'))).toBe(false);
+    expect(isDefiniteUnreachable(new TypeError('network error'))).toBe(false);
+  });
+
+  it('classifies unknown error shapes as transient', () => {
+    expect(isDefiniteUnreachable('plain string')).toBe(false);
+    expect(isDefiniteUnreachable(undefined)).toBe(false);
+    expect(isDefiniteUnreachable(null)).toBe(false);
+  });
+});

--- a/services/kilo-chat/src/__tests__/sandbox-read-routes.test.ts
+++ b/services/kilo-chat/src/__tests__/sandbox-read-routes.test.ts
@@ -140,6 +140,82 @@ describe('GET /v1/sandboxes/:sandboxId/bot-status', () => {
   });
 });
 
+describe('POST /v1/sandboxes/:sandboxId/request-bot-status', () => {
+  type RecordingKiloclaw = typeof env.KILOCLAW & {
+    __recordedWebhookCalls(): Promise<Array<Record<string, unknown>>>;
+    __clearWebhookCalls(): Promise<void>;
+  };
+  const recordingKiloclaw = env.KILOCLAW as RecordingKiloclaw;
+
+  it('401 when unauthenticated', async () => {
+    const app = makeReadApp();
+    const res = await app.request(
+      '/v1/sandboxes/sandbox-req-noauth/request-bot-status',
+      { method: 'POST' },
+      makeEnv()
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('403 when caller does not own the sandbox', async () => {
+    grantSandbox('user-req-owner', 'sandbox-req-owned');
+    const app = makeReadAppAs('user-req-other');
+    const res = await app.request(
+      '/v1/sandboxes/sandbox-req-owned/request-bot-status',
+      { method: 'POST' },
+      makeEnv()
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('fires the bot.status_request webhook when no fresh cache exists', async () => {
+    grantSandbox('user-req-fresh', 'sandbox-req-fresh');
+    await recordingKiloclaw.__clearWebhookCalls();
+
+    const app = makeReadAppAs('user-req-fresh');
+    const res = await app.request(
+      '/v1/sandboxes/sandbox-req-fresh/request-bot-status',
+      { method: 'POST' },
+      makeEnv()
+    );
+    expect(res.status).toBe(200);
+
+    const calls = await recordingKiloclaw.__recordedWebhookCalls();
+    const myCalls = calls.filter(c => c.targetBotId === 'bot:kiloclaw:sandbox-req-fresh');
+    expect(myCalls).toHaveLength(1);
+    expect(myCalls[0]).toMatchObject({
+      type: 'bot.status_request',
+      targetBotId: 'bot:kiloclaw:sandbox-req-fresh',
+    });
+  });
+
+  it('skips the webhook when cached status is fresh (dedupe)', async () => {
+    grantSandbox('user-req-dedupe', 'sandbox-req-dedupe');
+    const testEnv = makeEnv();
+    const stub = testEnv.SANDBOX_STATUS_DO.get(
+      testEnv.SANDBOX_STATUS_DO.idFromName('sandbox-req-dedupe')
+    );
+    // putBotStatus stamps `updatedAt = Date.now()`, which by definition is
+    // within the FRESH_STATUS_TTL_MS window when the request below runs.
+    await stub.putBotStatus({ online: true, at: Date.now() });
+    await recordingKiloclaw.__clearWebhookCalls();
+
+    const app = makeReadAppAs('user-req-dedupe');
+    const res = await app.request(
+      '/v1/sandboxes/sandbox-req-dedupe/request-bot-status',
+      { method: 'POST' },
+      testEnv
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{ ok: boolean; dedupe?: string }>();
+    expect(body.dedupe).toBe('fresh');
+
+    const calls = await recordingKiloclaw.__recordedWebhookCalls();
+    const myCalls = calls.filter(c => c.targetBotId === 'bot:kiloclaw:sandbox-req-dedupe');
+    expect(myCalls).toHaveLength(0);
+  });
+});
+
 describe('GET /v1/conversations/:conversationId/conversation-status', () => {
   it('401 when unauthenticated', async () => {
     const app = makeReadApp();

--- a/services/kilo-chat/src/__tests__/sandbox-read-routes.test.ts
+++ b/services/kilo-chat/src/__tests__/sandbox-read-routes.test.ts
@@ -99,10 +99,10 @@ describe('GET /v1/sandboxes/:sandboxId/bot-status', () => {
     expect(res.status).toBe(401);
   });
 
-  it('404 when sandbox does not exist (no owner mapping)', async () => {
+  it('403 when sandbox does not exist (no owner mapping)', async () => {
     const app = makeReadAppAs('user-missing');
     const res = await app.request('/v1/sandboxes/sandbox-missing/bot-status', {}, makeEnv());
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(403);
   });
 
   it('403 when caller is not the sandbox owner', async () => {

--- a/services/kilo-chat/src/routes/sandbox-reads.ts
+++ b/services/kilo-chat/src/routes/sandbox-reads.ts
@@ -2,7 +2,7 @@ import type { Context, Hono } from 'hono';
 import type { AuthContext } from '../auth';
 import { sandboxIdSchema, ulidSchema } from '@kilocode/kilo-chat';
 import { withDORetry } from '@kilocode/worker-utils';
-import { lookupSandboxOwnerUserId } from '../services/sandbox-ownership';
+import { userOwnsSandbox } from '../services/sandbox-ownership';
 import { extractSandboxId } from '../services/event-push';
 import { handleRequestBotStatus } from '../services/bot-status-request';
 
@@ -14,9 +14,8 @@ async function handleGetBotStatus(c: HonoCtx): Promise<Response> {
   const sandboxId = parsed.data;
 
   const userId = c.get('callerId');
-  const owner = await lookupSandboxOwnerUserId(c.env, sandboxId);
-  if (!owner) return c.json({ error: 'sandbox_not_found' }, 404);
-  if (owner !== userId) return c.json({ error: 'forbidden' }, 403);
+  const owns = await userOwnsSandbox(c.env, userId, sandboxId);
+  if (!owns) return c.json({ error: 'forbidden' }, 403);
 
   const status = await withDORetry(
     () => c.env.SANDBOX_STATUS_DO.get(c.env.SANDBOX_STATUS_DO.idFromName(sandboxId)),

--- a/services/kilo-chat/src/routes/sandbox-reads.ts
+++ b/services/kilo-chat/src/routes/sandbox-reads.ts
@@ -4,6 +4,7 @@ import { sandboxIdSchema, ulidSchema } from '@kilocode/kilo-chat';
 import { withDORetry } from '@kilocode/worker-utils';
 import { lookupSandboxOwnerUserId } from '../services/sandbox-ownership';
 import { extractSandboxId } from '../services/event-push';
+import { handleRequestBotStatus } from '../services/bot-status-request';
 
 type HonoCtx = Context<{ Bindings: Env; Variables: AuthContext }>;
 
@@ -55,5 +56,6 @@ export function registerSandboxReadRoutes(
   app: Hono<{ Bindings: Env; Variables: AuthContext }>
 ): void {
   app.get('/v1/sandboxes/:sandboxId/bot-status', handleGetBotStatus);
+  app.post('/v1/sandboxes/:sandboxId/request-bot-status', handleRequestBotStatus);
   app.get('/v1/conversations/:conversationId/conversation-status', handleGetConversationStatus);
 }

--- a/services/kilo-chat/src/services/bot-status-request.ts
+++ b/services/kilo-chat/src/services/bot-status-request.ts
@@ -1,0 +1,107 @@
+import type { Context } from 'hono';
+import type { AuthContext } from '../auth';
+import { sandboxIdSchema } from '@kilocode/kilo-chat';
+import { formatError, withDORetry } from '@kilocode/worker-utils';
+import { logger } from '../util/logger';
+import { userOwnsSandbox } from './sandbox-ownership';
+import { pushBotStatus } from './event-push';
+
+type HonoCtx = Context<{ Bindings: Env; Variables: AuthContext }>;
+
+// Skip the upstream webhook if the cached status is fresher than this — keeps
+// per-sandbox QPS bounded when multiple clients (tabs, devices) poll in
+// parallel. Slightly less than the 15s client poll interval so a single
+// client's individual ticks always reach the bot.
+const FRESH_STATUS_TTL_MS = 10_000;
+
+/**
+ * Client-driven bot-status nudge. The web/mobile client POSTs this every ~15s
+ * while subscribed to a chat surface. Server side:
+ *   1. authz: caller must own the sandbox,
+ *   2. dedupe: skip if `SandboxStatusDO` has a fresh entry,
+ *   3. fan out: tell the bot to push a fresh `bot.status` via the existing
+ *      `KILOCLAW.deliverChatWebhook` rpc,
+ *   4. failure escalation: on definitive bot-unreachable signals (no routing
+ *      target, 4xx), publish `online: false` immediately so the UI flips
+ *      without waiting for staleness inference.
+ */
+export async function handleRequestBotStatus(c: HonoCtx): Promise<Response> {
+  const parsed = sandboxIdSchema.safeParse(c.req.param('sandboxId'));
+  if (!parsed.success) return c.json({ error: 'Invalid sandboxId' }, 400);
+  const sandboxId = parsed.data;
+
+  const userId = c.get('callerId');
+  const owns = await userOwnsSandbox(c.env, userId, sandboxId);
+  if (!owns) return c.json({ error: 'forbidden' }, 403);
+
+  const cached = await withDORetry(
+    () => c.env.SANDBOX_STATUS_DO.get(c.env.SANDBOX_STATUS_DO.idFromName(sandboxId)),
+    stub => stub.getBotStatus(),
+    'SandboxStatusDO.getBotStatus'
+  );
+  const now = Date.now();
+  if (cached && now - cached.updatedAt < FRESH_STATUS_TTL_MS) {
+    // Cached status is fresh enough — another tab/device just nudged the bot.
+    // The fan-out already pushed the event to all of this user's connections;
+    // skipping here keeps webhook QPS at ~1 per 15s per sandbox regardless of
+    // how many clients are subscribed.
+    return c.json({ ok: true, dedupe: 'fresh' });
+  }
+
+  c.executionCtx.waitUntil(triggerBotStatusWebhook(c.env, sandboxId));
+  return c.json({ ok: true });
+}
+
+/**
+ * Sends a `bot.status_request` webhook to the kiloclaw plugin. On
+ * definitively-bad responses, persists `online: false` so the UI flips
+ * without waiting for the cache to age out.
+ */
+async function triggerBotStatusWebhook(env: Env, sandboxId: string): Promise<void> {
+  try {
+    await env.KILOCLAW.deliverChatWebhook({
+      type: 'bot.status_request',
+      targetBotId: `bot:kiloclaw:${sandboxId}`,
+    });
+  } catch (err) {
+    if (isDefiniteUnreachable(err)) {
+      logger.warn('bot.status_request: bot unreachable, publishing offline', {
+        sandboxId,
+        ...formatError(err),
+      });
+      try {
+        await pushBotStatus(env, sandboxId, { online: false, at: Date.now() });
+      } catch (pushErr) {
+        logger.error('bot.status_request: pushBotStatus(offline) failed', {
+          sandboxId,
+          ...formatError(pushErr),
+        });
+      }
+      return;
+    }
+    // Transient error (timeout, 5xx, network blip): leave the cached status
+    // alone and let the next poll retry. Staleness will eventually surface
+    // offline state on its own if the machine is genuinely dead.
+    logger.warn('bot.status_request: transient delivery failure', {
+      sandboxId,
+      ...formatError(err),
+    });
+  }
+}
+
+// Definitive vs transient classification for the upstream RPC error. Strings
+// come from `deliverChatWebhook` in services/kiloclaw/src/index.ts; treat
+// "no routing target" / "no sandboxId" as definitive (the bot is gone), and
+// any 4xx upstream as definitive (the controller actively rejected). Network
+// errors and 5xx/timeouts stay transient.
+export function isDefiniteUnreachable(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (msg.includes('No routing target')) return true;
+  if (msg.includes('has no sandboxId')) return true;
+  const m = msg.match(/Webhook forward failed: (\d{3})/);
+  if (m) {
+    const code = Number(m[1]);
+    return code >= 400 && code < 500;
+  }
+  return false;
+}

--- a/services/kiloclaw/plugins/kilo-chat/src/channel.ts
+++ b/services/kiloclaw/plugins/kilo-chat/src/channel.ts
@@ -109,19 +109,19 @@ export const kiloChatPlugin = createChatChannelPlugin<ResolvedKiloChatAccount>({
 
         // Bot-status is driven by client polling (kilo-chat sends a
         // `bot.status_request` webhook on demand and the plugin replies).
-        // We still emit a single startup heartbeat so the server cache
-        // reflects "online" before the first poll, and a shutdown heartbeat
-        // so a graceful abort flips the UI to offline immediately rather
-        // than waiting for cache staleness.
+        // We still emit one startup ping so the server cache reflects
+        // "online" before the first poll, and one shutdown ping so a
+        // graceful abort flips the UI to offline immediately rather than
+        // waiting for cache staleness.
         const client = makeClient();
-        const sendHeartbeat = (online: boolean) => {
+        const sendPresence = (online: boolean) => {
           void client.sendBotStatus({ online, at: Date.now() });
         };
-        sendHeartbeat(true);
+        sendPresence(true);
         abortSignal.addEventListener(
           'abort',
           () => {
-            sendHeartbeat(false);
+            sendPresence(false);
           },
           { once: true }
         );

--- a/services/kiloclaw/plugins/kilo-chat/src/channel.ts
+++ b/services/kiloclaw/plugins/kilo-chat/src/channel.ts
@@ -88,7 +88,6 @@ const pluginBase = createChannelPluginBase({
 // Webhook-based channel — no long-running monitor needed. A minimal
 // gateway.startAccount ensures the approval handler bootstrap runs and
 // the native runtime can deliver rich approval messages.
-const HEARTBEAT_MS = 15_000;
 
 export const kiloChatPlugin = createChatChannelPlugin<ResolvedKiloChatAccount>({
   base: {
@@ -108,18 +107,20 @@ export const kiloChatPlugin = createChatChannelPlugin<ResolvedKiloChatAccount>({
           });
         }
 
-        // Heartbeat loop: the browser uses this to render a real "Online" dot
-        // (driven by plugin liveness, not the Fly machine lifecycle).
+        // Bot-status is driven by client polling (kilo-chat sends a
+        // `bot.status_request` webhook on demand and the plugin replies).
+        // We still emit a single startup heartbeat so the server cache
+        // reflects "online" before the first poll, and a shutdown heartbeat
+        // so a graceful abort flips the UI to offline immediately rather
+        // than waiting for cache staleness.
         const client = makeClient();
         const sendHeartbeat = (online: boolean) => {
           void client.sendBotStatus({ online, at: Date.now() });
         };
         sendHeartbeat(true);
-        const timer = setInterval(() => sendHeartbeat(true), HEARTBEAT_MS);
         abortSignal.addEventListener(
           'abort',
           () => {
-            clearInterval(timer);
             sendHeartbeat(false);
           },
           { once: true }

--- a/services/kiloclaw/plugins/kilo-chat/src/synced/webhook-schemas.ts
+++ b/services/kiloclaw/plugins/kilo-chat/src/synced/webhook-schemas.ts
@@ -26,12 +26,21 @@ export const actionExecutedWebhookSchema = z.object({
   executedAt: z.string().min(1),
 });
 
+// Sent when a subscribed client polls for bot status. The plugin replies by
+// POSTing the current heartbeat back via `sendBotStatus`. No payload fields —
+// `sandboxId` is carried by the rpc-level `targetBotId`.
+export const botStatusRequestWebhookSchema = z.object({
+  type: z.literal('bot.status_request'),
+});
+
 export const chatWebhookSchema = z.discriminatedUnion('type', [
   messageCreatedWebhookSchema,
   actionExecutedWebhookSchema,
+  botStatusRequestWebhookSchema,
 ]);
 
 export const chatWebhookRpcSchema = z.discriminatedUnion('type', [
   messageCreatedWebhookSchema.extend({ targetBotId: z.string().min(1) }),
   actionExecutedWebhookSchema.extend({ targetBotId: z.string().min(1) }),
+  botStatusRequestWebhookSchema.extend({ targetBotId: z.string().min(1) }),
 ]);

--- a/services/kiloclaw/plugins/kilo-chat/src/webhook.test.ts
+++ b/services/kiloclaw/plugins/kilo-chat/src/webhook.test.ts
@@ -8,6 +8,7 @@ import {
   parseActionExecutedPayload,
   parseInboundPayload,
 } from './webhook/index.js';
+import { handleBotStatusRequest } from './webhook/dispatch.js';
 import type { KiloChatClient } from './client.js';
 
 describe('parseInboundPayload', () => {
@@ -252,6 +253,21 @@ describe('createKiloChatWebhookHandler', () => {
     const { res, getStatus } = makeRes();
     await handler(makeReq(body), res);
     expect(getStatus()).toBe(202);
+  });
+
+  it('handleBotStatusRequest pushes online:true with a current timestamp', async () => {
+    const sendBotStatus = vi.fn().mockResolvedValue(undefined);
+    const fakeClient = { sendBotStatus } as unknown as KiloChatClient;
+
+    const before = Date.now();
+    await handleBotStatusRequest(fakeClient);
+    const after = Date.now();
+
+    expect(sendBotStatus).toHaveBeenCalledTimes(1);
+    const arg = sendBotStatus.mock.calls[0]?.[0] as { online: boolean; at: number };
+    expect(arg.online).toBe(true);
+    expect(arg.at).toBeGreaterThanOrEqual(before);
+    expect(arg.at).toBeLessThanOrEqual(after);
   });
 
   it('accepts message.created type explicitly', async () => {

--- a/services/kiloclaw/plugins/kilo-chat/src/webhook.test.ts
+++ b/services/kiloclaw/plugins/kilo-chat/src/webhook.test.ts
@@ -246,6 +246,14 @@ describe('createKiloChatWebhookHandler', () => {
     expect(getBody()).toContain('Invalid action payload');
   });
 
+  it('acks bot.status_request with 202 (handled in background)', async () => {
+    const body = JSON.stringify({ type: 'bot.status_request' });
+    const handler = createKiloChatWebhookHandler({ api: {} as never });
+    const { res, getStatus } = makeRes();
+    await handler(makeReq(body), res);
+    expect(getStatus()).toBe(202);
+  });
+
   it('accepts message.created type explicitly', async () => {
     // message.created with missing required message fields should 400 with
     // "Invalid payload" (not "Unknown webhook type").

--- a/services/kiloclaw/plugins/kilo-chat/src/webhook/dispatch.ts
+++ b/services/kiloclaw/plugins/kilo-chat/src/webhook/dispatch.ts
@@ -30,6 +30,18 @@ export async function handleActionExecuted(
   });
 }
 
+// Replies to kilo-chat's `bot.status_request` webhook. Reaching this handler
+// at all means the plugin is alive and reachable, so we publish `online: true`
+// with the current timestamp. Definitive offline signals (machine gone) are
+// detected upstream when the webhook fails to deliver.
+export async function handleBotStatusRequest(): Promise<void> {
+  const client = createKiloChatClient({
+    controllerBaseUrl: resolveControllerUrl(),
+    gatewayToken: resolveGatewayToken(),
+  });
+  await client.sendBotStatus({ online: true, at: Date.now() });
+}
+
 function readSessionStore(cfg: unknown): string | undefined {
   if (typeof cfg !== 'object' || cfg === null) return undefined;
   if (!('session' in cfg)) return undefined;

--- a/services/kiloclaw/plugins/kilo-chat/src/webhook/dispatch.ts
+++ b/services/kiloclaw/plugins/kilo-chat/src/webhook/dispatch.ts
@@ -8,7 +8,7 @@ import type { OpenClawPluginApi } from 'openclaw/plugin-sdk/plugin-entry';
 import { createNormalizedOutboundDeliverer } from 'openclaw/plugin-sdk/reply-payload';
 import { resolveApprovalOverGateway } from 'openclaw/plugin-sdk/approval-gateway-runtime';
 
-import { createKiloChatClient } from '../client.js';
+import { createKiloChatClient, type KiloChatClient } from '../client.js';
 import { resolveControllerUrl, resolveGatewayToken } from '../env.js';
 import { DEFAULT_ACCOUNT_ID } from '../channel.js';
 import { readSessionUsage, toContextPayload } from '../bot-status.js';
@@ -33,13 +33,16 @@ export async function handleActionExecuted(
 // Replies to kilo-chat's `bot.status_request` webhook. Reaching this handler
 // at all means the plugin is alive and reachable, so we publish `online: true`
 // with the current timestamp. Definitive offline signals (machine gone) are
-// detected upstream when the webhook fails to deliver.
-export async function handleBotStatusRequest(): Promise<void> {
-  const client = createKiloChatClient({
-    controllerBaseUrl: resolveControllerUrl(),
-    gatewayToken: resolveGatewayToken(),
-  });
-  await client.sendBotStatus({ online: true, at: Date.now() });
+// detected upstream when the webhook fails to deliver. The `client` arg is
+// injectable for tests; production callers omit it.
+export async function handleBotStatusRequest(client?: KiloChatClient): Promise<void> {
+  const c =
+    client ??
+    createKiloChatClient({
+      controllerBaseUrl: resolveControllerUrl(),
+      gatewayToken: resolveGatewayToken(),
+    });
+  await c.sendBotStatus({ online: true, at: Date.now() });
 }
 
 function readSessionStore(cfg: unknown): string | undefined {

--- a/services/kiloclaw/plugins/kilo-chat/src/webhook/index.ts
+++ b/services/kiloclaw/plugins/kilo-chat/src/webhook/index.ts
@@ -17,7 +17,7 @@ import {
   parseActionExecutedPayload,
   parseInboundPayload,
 } from './schemas.js';
-import { dispatchInbound, handleActionExecuted } from './dispatch.js';
+import { dispatchInbound, handleActionExecuted, handleBotStatusRequest } from './dispatch.js';
 
 export type KiloChatWebhookDeps = {
   api: OpenClawPluginApi;
@@ -55,6 +55,14 @@ export function createKiloChatWebhookHandler(deps: KiloChatWebhookDeps) {
     // resolution can easily exceed that on a cold machine. If we awaited
     // completion before responding, the client would mark the message
     // "delivery failed" even when the bot actually processed it.
+    if (type === 'bot.status_request') {
+      ackAccepted(res);
+      void handleBotStatusRequest().catch(err => {
+        console.error('[kilo-chat] bot.status_request failed:', err);
+      });
+      return true;
+    }
+
     if (type === 'action.executed') {
       const actionPayload = parseActionExecutedPayload(parsed);
       if (!actionPayload) {

--- a/services/kiloclaw/src/index.ts
+++ b/services/kiloclaw/src/index.ts
@@ -1234,6 +1234,15 @@ export default class extends WorkerEntrypoint<KiloClawEnv> {
    * based on the targetBotId (bot:kiloclaw:{sandboxId}).
    *
    * See resolveChatWebhookDoKey for the two supported sandboxId formats.
+   *
+   * Load-bearing error strings: the messages thrown below ("has no sandboxId",
+   * "No routing target", "Webhook forward failed: <status>") are pattern-matched
+   * by `isDefiniteUnreachable` in services/kilo-chat/src/services/bot-status-request.ts
+   * to decide whether to flip a bot to offline immediately. Typed errors don't
+   * survive the Workers RPC boundary, so kilo-chat does substring matching on
+   * `err.message`. If you reword these, update the classifier in lock-step —
+   * otherwise the worst case is degrading to "always transient" (UI shows
+   * stale-online until staleness inference catches up, ~poll interval).
    */
   async deliverChatWebhook(payload: ChatWebhookPayload): Promise<void> {
     const parsed = chatWebhookRpcSchema.parse(payload);


### PR DESCRIPTION
## Summary

Replaces the kiloclaw plugin's unconditional 15s heartbeat with a client-driven request/response flow so an idle sandbox with no observers generates no bot-status traffic.

- **Web client** (`useBotStatus`) POSTs `/v1/sandboxes/:sandboxId/request-bot-status` every 15s while subscribed.
- **kilo-chat worker** dedupes via `SandboxStatusDO` (skips the upstream when cached `updatedAt` is <10s old) and fans a new `bot.status_request` webhook through the existing `KILOCLAW.deliverChatWebhook` RPC.
- **Plugin** registers a `bot.status_request` webhook branch that replies with the same `sendBotStatus({online:true, at})` payload as the old timer; the 15s `setInterval` is gone, but a single startup + shutdown heartbeat is still emitted so the cache is warm before the first poll and graceful aborts flip the UI to offline immediately.
- **Definitive offline signal**: when `deliverChatWebhook` returns "no routing target" / upstream 4xx, kilo-chat persists `online: false` and pushes the event right away (instead of waiting for staleness inference). Transient errors (timeout, 5xx, network blips) leave the cache alone for the next poll to retry.

Architectural note: this changes who drives presence. Today it's the bot; with this change kilo-chat owns liveness — the bot is "online" iff a webhook round-trip succeeds while at least one client is subscribed.

## Verification

- [ ] Manual: open the chat UI on an active sandbox, confirm the green dot stays on and the network panel shows one `request-bot-status` POST per 15s.
- [ ] Manual: with two tabs open on the same sandbox, confirm webhook QPS to kiloclaw stays at ~1/15s (server dedupe).
- [ ] Manual: stop the Fly machine; confirm the dot flips to offline within ~15s of the next poll (definitive 4xx / no routing target path).
- [ ] Manual: close the chat tab; confirm bot-status webhook traffic stops.

## Visual Changes

N/A — server/protocol change; UI presentation unchanged.

## Reviewer Notes

- New error-classifier `isDefiniteUnreachable` in `services/kilo-chat/src/services/bot-status-request.ts` matches strings produced by `deliverChatWebhook` in `services/kiloclaw/src/index.ts`. If those messages get reworded the classifier degrades gracefully (everything becomes transient), but worth keeping in sync.
- `FRESH_STATUS_TTL_MS = 10_000` is intentionally less than the 15s client poll so a single client's individual ticks always reach the bot; only multi-tab/multi-device polls dedupe.
- Plugin tarball: schemas live in `packages/kilo-chat/src/webhook-schemas.ts` and are mirrored into `services/kiloclaw/plugins/kilo-chat/src/synced/` via `scripts/sync-plugin-shared.sh` (CI checks this).
- Mobile app has no bot-status integration today, so no client change needed there.