### PR TITLE
fix(kiloclaw): bind migrate-legacy arrays as text[]

### DIFF
--- a/services/kiloclaw/src/routes/controller.test.ts
+++ b/services/kiloclaw/src/routes/controller.test.ts
@@ -1384,6 +1384,68 @@ describe('POST /google/migrate-legacy', () => {
     );
   });
 
+  it('handles empty scopes and capabilities when inserting a new legacy row', async () => {
+    const encryptionKey = Buffer.alloc(32, 7).toString('base64');
+    const execute = vi.fn().mockResolvedValue(undefined);
+    mockGetWorkerDb.mockReturnValue({ execute });
+    const env = makeEnv({
+      hyperdriveConnectionString: 'postgres://example',
+      googleWorkspaceRefreshTokenEncryptionKey: encryptionKey,
+    });
+    const headers = await makeAuthHeaders();
+
+    mockGetInstanceBySandboxId.mockResolvedValue({ id: 'instance-1' });
+    mockGetGoogleOAuthConnectionByInstanceId.mockResolvedValueOnce(null).mockResolvedValueOnce(
+      makeGoogleConnection(encryptionKey, {
+        credential_profile: 'legacy',
+        account_email: 'legacy@example.com',
+        account_subject: 'legacy-subject',
+        oauth_client_id: 'legacy-client-id',
+        oauth_client_secret_encrypted: encryptWithSymmetricKey(
+          'legacy-client-secret',
+          encryptionKey
+        ),
+        refresh_token_encrypted: encryptWithSymmetricKey('legacy-refresh-token', encryptionKey),
+        grants_by_source: {},
+        capabilities: [],
+        scopes: [],
+        status: 'active',
+      })
+    );
+
+    const response = await controller.request(
+      '/google/migrate-legacy',
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          sandboxId,
+          accountEmail: 'legacy@example.com',
+          accountSubject: 'legacy-subject',
+          oauthClientId: 'legacy-client-id',
+          oauthClientSecret: 'legacy-client-secret',
+          refreshToken: 'legacy-refresh-token',
+          scopes: [],
+          capabilities: [],
+        }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ migrated: true, profile: 'legacy' });
+    expect(execute).toHaveBeenCalledTimes(1);
+
+    const instanceStub = getInstanceStub(env);
+    expect(instanceStub.updateGoogleOAuthConnection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'active',
+        scopes: [],
+        capabilities: [],
+      })
+    );
+  });
+
   it('does not clobber concurrent kilo_owned row when migration insert conflicts', async () => {
     const encryptionKey = Buffer.alloc(32, 7).toString('base64');
     const execute = vi.fn().mockResolvedValue(undefined);

--- a/services/kiloclaw/src/routes/controller.ts
+++ b/services/kiloclaw/src/routes/controller.ts
@@ -107,6 +107,17 @@ type GoogleGrantsBySource = {
   oauth?: string[];
 };
 
+function sqlTextArray(values: readonly string[]) {
+  if (values.length === 0) {
+    return sql`ARRAY[]::text[]`;
+  }
+
+  return sql`ARRAY[${sql.join(
+    values.map(value => sql`${value}`),
+    sql`, `
+  )}]::text[]`;
+}
+
 function normalizeCapabilities(capabilities: readonly string[]): string[] {
   return [...new Set(capabilities.map(capability => capability.trim()).filter(Boolean))].sort();
 }
@@ -689,7 +700,7 @@ controller.post('/google/migrate-legacy', async (c: Context<AppEnv>) => {
       UPDATE kiloclaw_google_oauth_connections
       SET
         grants_by_source = ${JSON.stringify(grantsBySource)}::jsonb,
-        capabilities = ${capabilities},
+        capabilities = ${sqlTextArray(capabilities)},
         updated_at = ${now}
       WHERE instance_id = ${instance.id}
     `);
@@ -714,7 +725,7 @@ controller.post('/google/migrate-legacy', async (c: Context<AppEnv>) => {
         account_email = ${parsed.data.accountEmail},
         account_subject = ${parsed.data.accountSubject},
         grants_by_source = ${JSON.stringify(grantsBySource)}::jsonb,
-        capabilities = ${capabilities},
+        capabilities = ${sqlTextArray(capabilities)},
         connected_at = ${now},
         updated_at = ${now}
       WHERE instance_id = ${instance.id}
@@ -749,9 +760,9 @@ controller.post('/google/migrate-legacy', async (c: Context<AppEnv>) => {
         ${encryptWithSymmetricKey(parsed.data.oauthClientSecret, encryptionKey)},
         'legacy',
         ${encryptWithSymmetricKey(parsed.data.refreshToken, encryptionKey)},
-        ${scopes},
+        ${sqlTextArray(scopes)},
         ${JSON.stringify(grantsBySource)}::jsonb,
-        ${capabilities},
+        ${sqlTextArray(capabilities)},
         'active',
         ${now},
         ${now},
@@ -813,7 +824,7 @@ controller.post('/google/migrate-legacy', async (c: Context<AppEnv>) => {
       UPDATE kiloclaw_google_oauth_connections
       SET
         grants_by_source = ${JSON.stringify(mergedGrantsBySource)}::jsonb,
-        capabilities = ${resolvedCapabilities},
+        capabilities = ${sqlTextArray(resolvedCapabilities)},
         updated_at = ${now}
       WHERE instance_id = ${instance.id}
     `);


### PR DESCRIPTION
## Summary
- Fix `/api/controller/google/migrate-legacy` writes to bind `scopes` and `capabilities` as explicit `text[]` SQL expressions instead of relying on raw array interpolation in `sql` templates.
- Reuse the same safe array binding for all legacy migration update paths so `capabilities` updates cannot emit tuple-shaped SQL.
- Add a regression test covering migration insert with empty `scopes` and empty `capabilities` to prevent 500 regressions on edge payloads.

## Verification
- Reviewed generated SQL construction in `services/kiloclaw/src/routes/controller.ts` and confirmed array writes now use explicit `ARRAY[]::text[]` / `ARRAY[...]::text[]` binding.
- Reviewed all writes to `kiloclaw_google_oauth_connections` in this path to ensure array fields in migrate-legacy are handled consistently.

## Visual Changes
- N/A

## Reviewer Notes
- Risk is isolated to broker migration write paths in the KiloClaw worker.
- This change targets the production failure mode where malformed array SQL caused `migration_endpoint_failed` due to server-side 500s.