### PR TITLE
fix(slack): sign OAuth state

### DIFF
--- a/apps/web/src/app/api/integrations/slack/callback/route.ts
+++ b/apps/web/src/app/api/integrations/slack/callback/route.ts
@@ -5,16 +5,20 @@ import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import type { Owner } from '@/lib/integrations/core/types';
 import { captureException, captureMessage } from '@sentry/nextjs';
 import { upsertSlackInstallation } from '@/lib/integrations/slack-service';
+import { verifyOAuthState } from '@/lib/integrations/oauth-state';
 import { APP_URL } from '@/lib/constants';
 import { bot } from '@/lib/bot';
 
 const SLACK_REDIRECT_URI = `${APP_URL}/api/integrations/slack/callback`;
 
 const buildSlackRedirectPath = (state: string | null, queryParam: string): string => {
-  if (state?.startsWith('org_')) {
-    return `/organizations/${state.replace('org_', '')}/integrations/slack?${queryParam}`;
+  const verified = state ? verifyOAuthState(state) : null;
+  const owner = verified?.owner;
+
+  if (owner?.startsWith('org_')) {
+    return `/organizations/${owner.replace('org_', '')}/integrations/slack?${queryParam}`;
   }
-  if (state?.startsWith('user_')) {
+  if (owner?.startsWith('user_')) {
     return `/integrations/slack?${queryParam}`;
   }
   return `/integrations?${queryParam}`;
@@ -65,18 +69,10 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // 3. Parse owner from state
-    let owner: Owner;
-    let ownerId: string;
-
-    if (state?.startsWith('org_')) {
-      ownerId = state.replace('org_', '');
-      owner = { type: 'org', id: ownerId };
-    } else if (state?.startsWith('user_')) {
-      ownerId = state.replace('user_', '');
-      owner = { type: 'user', id: ownerId };
-    } else {
-      captureMessage('Slack callback missing or invalid owner in state', {
+    // 3. Verify signed state (CSRF protection)
+    const verified = verifyOAuthState(state);
+    if (!verified) {
+      captureMessage('Slack callback invalid or tampered state signature', {
         level: 'warning',
         tags: { endpoint: 'slack/callback', source: 'slack_oauth' },
         extra: { code: '***', state, allParams: Object.fromEntries(searchParams.entries()) },
@@ -84,7 +80,36 @@ export async function GET(request: NextRequest) {
       return NextResponse.redirect(new URL('/integrations?error=invalid_state', APP_URL));
     }
 
-    // 4. Verify user has access to the owner
+    // 4. Verify the user completing the flow is the same user who initiated it
+    if (verified.userId !== user.id) {
+      captureMessage('Slack callback user mismatch (possible CSRF)', {
+        level: 'warning',
+        tags: { endpoint: 'slack/callback', source: 'slack_oauth' },
+        extra: { stateUserId: verified.userId, sessionUserId: user.id },
+      });
+      return NextResponse.redirect(new URL('/integrations?error=unauthorized', APP_URL));
+    }
+
+    // 5. Parse owner from verified state payload
+    let owner: Owner;
+    const ownerStr = verified.owner;
+
+    if (ownerStr.startsWith('org_')) {
+      const ownerId = ownerStr.replace('org_', '');
+      owner = { type: 'org', id: ownerId };
+    } else if (ownerStr.startsWith('user_')) {
+      const ownerId = ownerStr.replace('user_', '');
+      owner = { type: 'user', id: ownerId };
+    } else {
+      captureMessage('Slack callback missing or invalid owner in state', {
+        level: 'warning',
+        tags: { endpoint: 'slack/callback', source: 'slack_oauth' },
+        extra: { code: '***', owner: ownerStr },
+      });
+      return NextResponse.redirect(new URL('/integrations?error=invalid_state', APP_URL));
+    }
+
+    // 6. Verify user has access to the owner
     if (owner.type === 'org') {
       await ensureOrganizationAccess({ user }, owner.id);
     } else {
@@ -94,7 +119,7 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // 5. Let the Chat SDK exchange the code and seed its installation state
+    // 7. Let the Chat SDK exchange the code and seed its installation state
     await bot.initialize();
     const slackAdapter = bot.getAdapter('slack');
     const url = new URL(request.url);
@@ -102,10 +127,10 @@ export async function GET(request: NextRequest) {
     const patchedRequest = new Request(url, request);
     const { teamId, installation } = await slackAdapter.handleOAuthCallback(patchedRequest);
 
-    // 6. Store installation in database
+    // 8. Store installation in database
     await upsertSlackInstallation({ owner, teamId, installation });
 
-    // 7. Redirect to success page
+    // 9. Redirect to success page
     const successPath =
       owner.type === 'org'
         ? `/organizations/${owner.id}/integrations/slack?success=installed`

--- a/apps/web/src/app/get-started/slack/_components/SlackConnectStep.tsx
+++ b/apps/web/src/app/get-started/slack/_components/SlackConnectStep.tsx
@@ -16,16 +16,18 @@ type SlackConnectStepProps = {
 export function SlackConnectStep({ workspace, onBack }: SlackConnectStepProps) {
   const trpc = useTRPC();
 
-  // Get OAuth URL based on workspace type
-  const { data: oauthUrlData, isLoading: isLoadingOAuthUrl } = useQuery(
+  // Get OAuth URL only when the user clicks Connect so the signed state is fresh.
+  const { refetch: refetchOAuthUrl, isFetching: isFetchingOAuthUrl } = useQuery(
     trpc.slack.getOAuthUrl.queryOptions(
-      workspace.type === 'org' ? { organizationId: workspace.id } : undefined
+      workspace.type === 'org' ? { organizationId: workspace.id } : undefined,
+      { enabled: false }
     )
   );
 
-  const handleConnectSlack = () => {
-    if (oauthUrlData?.url) {
-      window.location.href = oauthUrlData.url;
+  const handleConnectSlack = async () => {
+    const result = await refetchOAuthUrl();
+    if (result.data?.url) {
+      window.location.href = result.data.url;
     }
   };
 
@@ -104,10 +106,10 @@ export function SlackConnectStep({ workspace, onBack }: SlackConnectStepProps) {
             onClick={handleConnectSlack}
             size="lg"
             className="w-full bg-[#4A154B] text-white hover:bg-[#3a1039]"
-            disabled={isLoadingOAuthUrl || !oauthUrlData?.url}
+            disabled={isFetchingOAuthUrl}
           >
             <MessageSquare className="mr-2 h-5 w-5" />
-            {isLoadingOAuthUrl ? 'Loading...' : 'Connect Slack'}
+            {isFetchingOAuthUrl ? 'Loading...' : 'Connect Slack'}
           </Button>
 
           <p className="text-muted-foreground text-center text-xs">

--- a/apps/web/src/app/get-started/slack/_components/SlackConnectStep.tsx
+++ b/apps/web/src/app/get-started/slack/_components/SlackConnectStep.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { ArrowLeft, MessageSquare, CheckCircle2, Building2, User } from 'lucide-react';
 import type { WorkspaceSelection } from './types';
+import { useState } from 'react';
 
 type SlackConnectStepProps = {
   workspace: WorkspaceSelection;
@@ -15,6 +16,7 @@ type SlackConnectStepProps = {
 
 export function SlackConnectStep({ workspace, onBack }: SlackConnectStepProps) {
   const trpc = useTRPC();
+  const [isStartingSlackConnection, setIsStartingSlackConnection] = useState(false);
 
   // Get OAuth URL only when the user clicks Connect so the signed state is fresh.
   const { refetch: refetchOAuthUrl, isFetching: isFetchingOAuthUrl } = useQuery(
@@ -25,9 +27,12 @@ export function SlackConnectStep({ workspace, onBack }: SlackConnectStepProps) {
   );
 
   const handleConnectSlack = async () => {
+    setIsStartingSlackConnection(true);
     const result = await refetchOAuthUrl();
     if (result.data?.url) {
       window.location.href = result.data.url;
+    } else {
+      setIsStartingSlackConnection(false);
     }
   };
 
@@ -106,10 +111,10 @@ export function SlackConnectStep({ workspace, onBack }: SlackConnectStepProps) {
             onClick={handleConnectSlack}
             size="lg"
             className="w-full bg-[#4A154B] text-white hover:bg-[#3a1039]"
-            disabled={isFetchingOAuthUrl}
+            disabled={isStartingSlackConnection || isFetchingOAuthUrl}
           >
             <MessageSquare className="mr-2 h-5 w-5" />
-            {isFetchingOAuthUrl ? 'Loading...' : 'Connect Slack'}
+            {isStartingSlackConnection || isFetchingOAuthUrl ? 'Loading...' : 'Connect Slack'}
           </Button>
 
           <p className="text-muted-foreground text-center text-xs">

--- a/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
@@ -58,6 +58,7 @@ export function SlackIntegrationDetails({
 
   // Track selected model
   const [selectedModel, setSelectedModel] = useState<string>('');
+  const [isStartingSlackConnection, setIsStartingSlackConnection] = useState(false);
 
   // Initialize selected model from installation data
   useEffect(() => {
@@ -111,13 +112,17 @@ export function SlackIntegrationDetails({
   }, [success, error]);
 
   const handleInstall = async () => {
+    setIsStartingSlackConnection(true);
     const result = await refetchOAuthUrl();
     if (result.data?.url) {
       window.location.href = result.data.url;
     } else if (result.error) {
+      setIsStartingSlackConnection(false);
       toast.error('Failed to start Slack connection', {
         description: result.error.message,
       });
+    } else {
+      setIsStartingSlackConnection(false);
     }
   };
 
@@ -374,10 +379,10 @@ export function SlackIntegrationDetails({
                 onClick={handleInstall}
                 size="lg"
                 className="w-full"
-                disabled={isFetchingOAuthUrl}
+                disabled={isStartingSlackConnection || isFetchingOAuthUrl}
               >
                 <MessageSquare className="mr-2 h-4 w-4" />
-                {isFetchingOAuthUrl ? 'Loading...' : 'Connect Slack'}
+                {isStartingSlackConnection || isFetchingOAuthUrl ? 'Loading...' : 'Connect Slack'}
               </Button>
             </>
           )}

--- a/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
@@ -43,8 +43,10 @@ export function SlackIntegrationDetails({
     refetch,
   } = useQuery(trpc.slack.getInstallation.queryOptions(input));
 
-  // Get OAuth URL for installation
-  const { data: oauthUrlData } = useQuery(trpc.slack.getOAuthUrl.queryOptions(input));
+  // Get OAuth URL only when the user clicks Connect so the signed state is fresh.
+  const { refetch: refetchOAuthUrl, isFetching: isFetchingOAuthUrl } = useQuery(
+    trpc.slack.getOAuthUrl.queryOptions(input, { enabled: false })
+  );
 
   // Fetch models for the model selector
   const { data: openRouterModels, isLoading: isLoadingModels } =
@@ -108,9 +110,14 @@ export function SlackIntegrationDetails({
     }
   }, [success, error]);
 
-  const handleInstall = () => {
-    if (oauthUrlData?.url) {
-      window.location.href = oauthUrlData.url;
+  const handleInstall = async () => {
+    const result = await refetchOAuthUrl();
+    if (result.data?.url) {
+      window.location.href = result.data.url;
+    } else if (result.error) {
+      toast.error('Failed to start Slack connection', {
+        description: result.error.message,
+      });
     }
   };
 
@@ -363,9 +370,14 @@ export function SlackIntegrationDetails({
                 </ul>
               </div>
 
-              <Button onClick={handleInstall} size="lg" className="w-full">
+              <Button
+                onClick={handleInstall}
+                size="lg"
+                className="w-full"
+                disabled={isFetchingOAuthUrl}
+              >
                 <MessageSquare className="mr-2 h-4 w-4" />
-                Connect Slack
+                {isFetchingOAuthUrl ? 'Loading...' : 'Connect Slack'}
               </Button>
             </>
           )}

--- a/apps/web/src/routers/slack-router.ts
+++ b/apps/web/src/routers/slack-router.ts
@@ -2,6 +2,7 @@ import 'server-only';
 import { z } from 'zod';
 import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import * as slackService from '@/lib/integrations/slack-service';
+import { createOAuthState } from '@/lib/integrations/oauth-state';
 import { TRPCError } from '@trpc/server';
 import {
   resolveOwner,
@@ -65,7 +66,10 @@ export const slackRouter = createTRPCRouter({
     if (input?.organizationId) {
       await ensureOrganizationAccess(ctx, input.organizationId);
     }
-    const state = input?.organizationId ? `org_${input.organizationId}` : `user_${ctx.user.id}`;
+    const statePrefix = input?.organizationId
+      ? `org_${input.organizationId}`
+      : `user_${ctx.user.id}`;
+    const state = createOAuthState(statePrefix, ctx.user.id);
     return {
       url: slackService.getSlackOAuthUrl(state),
     };


### PR DESCRIPTION
## Summary

- Generate Slack OAuth state values with the existing signed, nonce-backed OAuth state helper so each authorization request gets a non-guessable dynamic value.
- Verify Slack callback state before trusting the embedded owner and reject tampered, missing, or mismatched-user callback states.

## Verification

- Manually tested the Slack OAuth flow and confirmed it works.

## Visual Changes

N/A

## Reviewer Notes

- This mirrors the Discord OAuth state handling and addresses Slack Marketplace feedback around non-guessable dynamic state parameters.