### PR TITLE
chore(kiloclaw): add trial inactivity stop dashboard panels

### DIFF
--- a/dev/grafana/dashboards/kiloclaw-events.json
+++ b/dev/grafana/dashboards/kiloclaw-events.json
@@ -1231,7 +1231,7 @@
         "x": 0,
         "y": 50
       },
-      "description": "Count of instance.stopped DO events with label trial_inactivity over a fixed 7-day lookback.",
+      "description": "Sample-corrected count of instance.stopped DO events with label trial_inactivity in the selected dashboard time range.",
       "id": 16,
       "options": {
         "colorMode": "value",
@@ -1263,8 +1263,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity'",
-          "rawSql": "SELECT count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity'",
+          "query": "SELECT SUM(_sample_interval) AS stops FROM kiloclaw_events WHERE $timeFilter AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity'",
+          "rawSql": "SELECT SUM(_sample_interval) AS stops FROM kiloclaw_events WHERE $timeFilter AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity'",
           "refId": "A",
           "round": "0s",
           "showFormattedSQL": false,
@@ -1274,7 +1274,7 @@
           "useWindowFuncForMacros": true
         }
       ],
-      "title": "Trial Inactivity Stops (7d)",
+      "title": "Trial Inactivity Stops",
       "type": "stat"
     },
     {
@@ -1335,7 +1335,7 @@
         "x": 0,
         "y": 54
       },
-      "description": "Trial inactivity stops bucketed by Grafana's automatic interval over the same fixed 7-day lookback.",
+      "description": "Sample-corrected trial inactivity stops bucketed by Grafana's automatic interval in the selected dashboard time range.",
       "id": 18,
       "options": {
         "legend": {
@@ -1365,8 +1365,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT $timeSeries AS t, 'stops' AS label, count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' GROUP BY t ORDER BY t",
-          "rawSql": "SELECT $timeSeries AS t, 'stops' AS label, count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' GROUP BY t ORDER BY t",
+          "query": "SELECT $timeSeries AS t, 'stops' AS label, SUM(_sample_interval) AS stops FROM kiloclaw_events WHERE $timeFilter AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'stops' AS label, SUM(_sample_interval) AS stops FROM kiloclaw_events WHERE $timeFilter AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' GROUP BY t ORDER BY t",
           "refId": "A",
           "round": "0s",
           "showFormattedSQL": false,
@@ -1413,7 +1413,7 @@
         "x": 6,
         "y": 50
       },
-      "description": "Recent instance.stopped DO events with label trial_inactivity over a fixed 7-day lookback. double2 is machine uptime before stop.",
+      "description": "Recent instance.stopped DO events with label trial_inactivity in the selected dashboard time range. double2 is machine uptime before stop. Limited to 100 rows.",
       "id": 17,
       "options": {
         "cellHeight": "sm",
@@ -1439,8 +1439,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT timestamp, blob2 AS user_id, blob15 AS instance_id, blob6 AS fly_app_name, blob7 AS fly_machine_id, blob8 AS sandbox_id, blob9 AS status, blob13 AS stop_reason, double2 AS machine_uptime_ms FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' ORDER BY timestamp DESC",
-          "rawSql": "SELECT timestamp, blob2 AS user_id, blob15 AS instance_id, blob6 AS fly_app_name, blob7 AS fly_machine_id, blob8 AS sandbox_id, blob9 AS status, blob13 AS stop_reason, double2 AS machine_uptime_ms FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' ORDER BY timestamp DESC",
+          "query": "SELECT timestamp, blob2 AS user_id, blob15 AS instance_id, blob6 AS fly_app_name, blob7 AS fly_machine_id, blob8 AS sandbox_id, blob9 AS status, blob13 AS stop_reason, double2 AS machine_uptime_ms FROM kiloclaw_events WHERE $timeFilter AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' ORDER BY timestamp DESC LIMIT 100",
+          "rawSql": "SELECT timestamp, blob2 AS user_id, blob15 AS instance_id, blob6 AS fly_app_name, blob7 AS fly_machine_id, blob8 AS sandbox_id, blob9 AS status, blob13 AS stop_reason, double2 AS machine_uptime_ms FROM kiloclaw_events WHERE $timeFilter AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' ORDER BY timestamp DESC LIMIT 100",
           "refId": "A",
           "round": "0s",
           "showFormattedSQL": false,
@@ -1450,7 +1450,7 @@
           "useWindowFuncForMacros": true
         }
       ],
-      "title": "Recent Trial Inactivity Stops (7d)",
+      "title": "Recent Trial Inactivity Stops",
       "type": "table"
     },
     {

--- a/dev/grafana/dashboards/kiloclaw-events.json
+++ b/dev/grafana/dashboards/kiloclaw-events.json
@@ -1208,12 +1208,258 @@
       "type": "table"
     },
     {
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "${DS_KILOCLAW}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 50
+      },
+      "description": "Count of instance.stopped DO events with label trial_inactivity over a fixed 7-day lookback.",
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": false,
+          "format": "table",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity'",
+          "rawSql": "SELECT count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity'",
+          "refId": "A",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "kiloclaw_events",
+          "useWindowFuncForMacros": true
+        }
+      ],
+      "title": "Trial Inactivity Stops (7d)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "${DS_KILOCLAW}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 35,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 54
+      },
+      "description": "Trial inactivity stops bucketed by Grafana's automatic interval over the same fixed 7-day lookback.",
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": false,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, 'stops' AS label, count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'stops' AS label, count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' GROUP BY t ORDER BY t",
+          "refId": "A",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "kiloclaw_events",
+          "useWindowFuncForMacros": true
+        }
+      ],
+      "title": "Trial Stops by Interval",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "${DS_KILOCLAW}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "instance_id" },
+            "properties": [{ "id": "custom.width", "value": 280 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "fly_machine_id" },
+            "properties": [{ "id": "custom.width", "value": 220 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "machine_uptime_ms" },
+            "properties": [{ "id": "unit", "value": "ms" }]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 18,
+        "x": 6,
+        "y": 50
+      },
+      "description": "Recent instance.stopped DO events with label trial_inactivity over a fixed 7-day lookback. double2 is machine uptime before stop.",
+      "id": 17,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": false,
+          "format": "table",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT timestamp, blob2 AS user_id, blob15 AS instance_id, blob6 AS fly_app_name, blob7 AS fly_machine_id, blob8 AS sandbox_id, blob9 AS status, blob13 AS stop_reason, double2 AS machine_uptime_ms FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' ORDER BY timestamp DESC",
+          "rawSql": "SELECT timestamp, blob2 AS user_id, blob15 AS instance_id, blob6 AS fly_app_name, blob7 AS fly_machine_id, blob8 AS sandbox_id, blob9 AS status, blob13 AS stop_reason, double2 AS machine_uptime_ms FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' ORDER BY timestamp DESC",
+          "refId": "A",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "kiloclaw_events",
+          "useWindowFuncForMacros": true
+        }
+      ],
+      "title": "Recent Trial Inactivity Stops (7d)",
+      "type": "table"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 60
       },
       "id": 104,
       "panels": [],
@@ -1278,7 +1524,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 61
       },
       "id": 14,
       "options": {

--- a/services/kilo-ops/container/provisioning/dashboards/kiloclaw-events.json
+++ b/services/kilo-ops/container/provisioning/dashboards/kiloclaw-events.json
@@ -1263,8 +1263,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity'",
-          "rawSql": "SELECT count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity'",
+          "query": "SELECT SUM(_sample_interval) AS stops FROM kiloclaw_events WHERE $timeFilter AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity'",
+          "rawSql": "SELECT SUM(_sample_interval) AS stops FROM kiloclaw_events WHERE $timeFilter AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity'",
           "refId": "A",
           "round": "0s",
           "showFormattedSQL": false,
@@ -1274,7 +1274,7 @@
           "useWindowFuncForMacros": true
         }
       ],
-      "title": "Trial Inactivity Stops (7d)",
+      "title": "Trial Inactivity Stops",
       "type": "stat"
     },
     {
@@ -1335,7 +1335,7 @@
         "x": 0,
         "y": 54
       },
-      "description": "Trial inactivity stops bucketed by Grafana's automatic interval over the same fixed 7-day lookback.",
+      "description": "Sample-corrected trial inactivity stops bucketed by Grafana's automatic interval in the selected dashboard time range.",
       "id": 18,
       "options": {
         "legend": {
@@ -1365,8 +1365,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT $timeSeries AS t, 'stops' AS label, count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' GROUP BY t ORDER BY t",
-          "rawSql": "SELECT $timeSeries AS t, 'stops' AS label, count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' GROUP BY t ORDER BY t",
+          "query": "SELECT $timeSeries AS t, 'stops' AS label, SUM(_sample_interval) AS stops FROM kiloclaw_events WHERE $timeFilter AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'stops' AS label, SUM(_sample_interval) AS stops FROM kiloclaw_events WHERE $timeFilter AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' GROUP BY t ORDER BY t",
           "refId": "A",
           "round": "0s",
           "showFormattedSQL": false,
@@ -1413,7 +1413,7 @@
         "x": 6,
         "y": 50
       },
-      "description": "Recent instance.stopped DO events with label trial_inactivity over a fixed 7-day lookback. double2 is machine uptime before stop.",
+      "description": "Recent instance.stopped DO events with label trial_inactivity in the selected dashboard time range. double2 is machine uptime before stop. Limited to 100 rows.",
       "id": 17,
       "options": {
         "cellHeight": "sm",
@@ -1439,8 +1439,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT timestamp, blob2 AS user_id, blob15 AS instance_id, blob6 AS fly_app_name, blob7 AS fly_machine_id, blob8 AS sandbox_id, blob9 AS status, blob13 AS stop_reason, double2 AS machine_uptime_ms FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' ORDER BY timestamp DESC",
-          "rawSql": "SELECT timestamp, blob2 AS user_id, blob15 AS instance_id, blob6 AS fly_app_name, blob7 AS fly_machine_id, blob8 AS sandbox_id, blob9 AS status, blob13 AS stop_reason, double2 AS machine_uptime_ms FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' ORDER BY timestamp DESC",
+          "query": "SELECT timestamp, blob2 AS user_id, blob15 AS instance_id, blob6 AS fly_app_name, blob7 AS fly_machine_id, blob8 AS sandbox_id, blob9 AS status, blob13 AS stop_reason, double2 AS machine_uptime_ms FROM kiloclaw_events WHERE $timeFilter AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' ORDER BY timestamp DESC LIMIT 100",
+          "rawSql": "SELECT timestamp, blob2 AS user_id, blob15 AS instance_id, blob6 AS fly_app_name, blob7 AS fly_machine_id, blob8 AS sandbox_id, blob9 AS status, blob13 AS stop_reason, double2 AS machine_uptime_ms FROM kiloclaw_events WHERE $timeFilter AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' ORDER BY timestamp DESC LIMIT 100",
           "refId": "A",
           "round": "0s",
           "showFormattedSQL": false,
@@ -1450,7 +1450,7 @@
           "useWindowFuncForMacros": true
         }
       ],
-      "title": "Recent Trial Inactivity Stops (7d)",
+      "title": "Recent Trial Inactivity Stops",
       "type": "table"
     },
     {

--- a/services/kilo-ops/container/provisioning/dashboards/kiloclaw-events.json
+++ b/services/kilo-ops/container/provisioning/dashboards/kiloclaw-events.json
@@ -1208,12 +1208,258 @@
       "type": "table"
     },
     {
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "${DS_KILOCLAW}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 50
+      },
+      "description": "Count of instance.stopped DO events with label trial_inactivity over a fixed 7-day lookback.",
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": false,
+          "format": "table",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity'",
+          "rawSql": "SELECT count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity'",
+          "refId": "A",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "kiloclaw_events",
+          "useWindowFuncForMacros": true
+        }
+      ],
+      "title": "Trial Inactivity Stops (7d)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "${DS_KILOCLAW}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 35,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 54
+      },
+      "description": "Trial inactivity stops bucketed by Grafana's automatic interval over the same fixed 7-day lookback.",
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": false,
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT $timeSeries AS t, 'stops' AS label, count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'stops' AS label, count() AS stops FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' GROUP BY t ORDER BY t",
+          "refId": "A",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "kiloclaw_events",
+          "useWindowFuncForMacros": true
+        }
+      ],
+      "title": "Trial Stops by Interval",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "vertamedia-clickhouse-datasource",
+        "uid": "${DS_KILOCLAW}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "instance_id" },
+            "properties": [{ "id": "custom.width", "value": 280 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "fly_machine_id" },
+            "properties": [{ "id": "custom.width", "value": 220 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "machine_uptime_ms" },
+            "properties": [{ "id": "unit", "value": "ms" }]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 18,
+        "x": 6,
+        "y": 50
+      },
+      "description": "Recent instance.stopped DO events with label trial_inactivity over a fixed 7-day lookback. double2 is machine uptime before stop.",
+      "id": 17,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "adHocFilters": [],
+          "adHocValuesQuery": "",
+          "add_metadata": true,
+          "contextWindowSize": "10",
+          "dateTimeColDataType": "timestamp",
+          "dateTimeType": "DATETIME",
+          "editorMode": "sql",
+          "extrapolate": false,
+          "format": "table",
+          "interval": "",
+          "intervalFactor": 1,
+          "nullifySparse": false,
+          "query": "SELECT timestamp, blob2 AS user_id, blob15 AS instance_id, blob6 AS fly_app_name, blob7 AS fly_machine_id, blob8 AS sandbox_id, blob9 AS status, blob13 AS stop_reason, double2 AS machine_uptime_ms FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' ORDER BY timestamp DESC",
+          "rawSql": "SELECT timestamp, blob2 AS user_id, blob15 AS instance_id, blob6 AS fly_app_name, blob7 AS fly_machine_id, blob8 AS sandbox_id, blob9 AS status, blob13 AS stop_reason, double2 AS machine_uptime_ms FROM kiloclaw_events WHERE timestamp >= now() - interval '7' day AND index1 = 'instance.stopped' AND blob3 = 'do' AND blob13 = 'trial_inactivity' ORDER BY timestamp DESC",
+          "refId": "A",
+          "round": "0s",
+          "showFormattedSQL": false,
+          "showHelp": false,
+          "skip_comments": true,
+          "table": "kiloclaw_events",
+          "useWindowFuncForMacros": true
+        }
+      ],
+      "title": "Recent Trial Inactivity Stops (7d)",
+      "type": "table"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 60
       },
       "id": 104,
       "panels": [],
@@ -1278,7 +1524,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 61
       },
       "id": 14,
       "options": {


### PR DESCRIPTION
## Summary

- Add KiloClaw Grafana panels for trial inactivity stops so operators can confirm the idle trial auto-stop behavior from Analytics Engine data.
- Add a sample-corrected stop count stat, an interval-bucketed trend chart, and a recent stop events detail table filtered to `instance.stopped` DO events with `blob13 = 'trial_inactivity'`.
- Have all new panels respect the selected dashboard time range and cap the recent stop table to 100 rows.
- Keep the provisioned `kilo-ops` dashboard and the local dev Grafana dashboard in sync.
- Architectural changes: N/A; this only updates dashboard JSON panels and queries.

## Verification

- [x] Confirmed in Grafana that the `Trial Inactivity Stops` stat rendered results after matching the working Analytics Engine interval syntax.
- [x] Confirmed in Grafana that the recent trial inactivity stop table rendered matching stop events.
- [ ] Confirm the new `Trial Stops by Interval` chart renders as expected after the dashboard refreshes.
- [ ] Add any extra manual verification details before merge.

## Visual Changes

| Before | After |
| ------ | ----- |
| KiloClaw Events dashboard did not have dedicated trial inactivity stop observability panels. | KiloClaw Events dashboard includes a stop count, interval trend chart, and recent stop events table that respect the selected time range. |

## Reviewer Notes

- Stop totals use `SUM(_sample_interval)` to stay consistent with the dashboard's other Analytics Engine volume panels.
- The recent stop table is intentionally limited to 100 rows to avoid large dashboard loads during spikes.
- Review both dashboard copies together; they should remain identical.