### PR TITLE
ci(kiloclaw): allow package writes in production deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -173,5 +173,8 @@ jobs:
   deploy-kiloclaw:
     needs: [check-kiloclaw-changes]
     if: needs.check-kiloclaw-changes.outputs.changed == 'true'
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/deploy-kiloclaw.yml
     secrets: inherit


### PR DESCRIPTION
## Summary
- Grant the production KiloClaw reusable workflow call `packages: write` so GHCR image publishing permissions satisfy GitHub Actions validation.
- Keep the caller permissions scoped to `contents: read` and `packages: write`, matching the called deploy workflow requirements.

## Verification
- Inspected the production workflow permission envelope against the reusable KiloClaw deploy workflow.

## Visual Changes
N/A

## Reviewer Notes
This should unblock the production deploy workflow validation failure 