### PR TITLE
feat(mobile): show per-instance unread badges on dashboard

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -75,7 +75,8 @@
     "stream-chat": "catalog:",
     "stream-chat-expo": "^8.13.7",
     "tailwind-merge": "^3.5.0",
-    "tailwindcss": "^4.2.2"
+    "tailwindcss": "^4.2.2",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@sentry/cli": "catalog:",

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -25,6 +25,7 @@ import {
   setupNotificationResponseHandler,
 } from '@/lib/notifications';
 import { useForceUpdate } from '@/lib/hooks/use-force-update';
+import { useUnreadCountsInvalidation } from '@/lib/hooks/use-unread-counts-invalidation';
 import { queryClient } from '@/lib/query-client';
 import { trpcClient, TRPCProvider } from '@/lib/trpc';
 
@@ -69,6 +70,8 @@ function RootLayoutNav() {
   const { updateRequired, isChecking: updateChecking } = useForceUpdate();
   const segments = useSegments();
   const router = useRouter();
+
+  useUnreadCountsInvalidation();
 
   const isLoading = authLoading || updateChecking;
   const inAuthGroup = segments[0] === '(auth)';

--- a/apps/mobile/src/components/home/home-screen.tsx
+++ b/apps/mobile/src/components/home/home-screen.tsx
@@ -15,6 +15,7 @@ import { ScreenHeader } from '@/components/screen-header';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAgentSessions } from '@/lib/hooks/use-agent-sessions';
 import { useAllKiloClawInstances } from '@/lib/hooks/use-instance-context';
+import { useUnreadCounts } from '@/lib/hooks/use-unread-counts';
 import { useOrganization } from '@/lib/organization-context';
 
 type ClawInstance = NonNullable<ReturnType<typeof useAllKiloClawInstances>['data']>[number];
@@ -29,6 +30,7 @@ export function HomeScreen() {
     isPending: instancesPending,
     isError: instancesError,
   } = useAllKiloClawInstances();
+  const { byInstance: unreadByInstance } = useUnreadCounts();
   const {
     storedSessions,
     activeSessions,
@@ -74,7 +76,11 @@ export function HomeScreen() {
           </Animated.View>
         ) : (
           <Animated.View entering={FadeIn.duration(200)} className="gap-6">
-            {renderKiloClawSlot({ instances: instances ?? [], instancesError })}
+            {renderKiloClawSlot({
+              instances: instances ?? [],
+              instancesError,
+              unreadByInstance,
+            })}
 
             {renderSessionsOrPromo({
               hasAnySession,
@@ -90,14 +96,22 @@ export function HomeScreen() {
   );
 }
 
-function renderKiloClawSlot(params: { instances: ClawInstance[]; instancesError: boolean }) {
+function renderKiloClawSlot(params: {
+  instances: ClawInstance[];
+  instancesError: boolean;
+  unreadByInstance: Map<string, number>;
+}) {
   if (params.instances.length > 0) {
     return (
       <View className="gap-2">
         <SectionHeader label="KiloClaw" />
         <View className="gap-3">
           {params.instances.map(instance => (
-            <KiloClawCard key={instance.sandboxId} instance={instance} />
+            <KiloClawCard
+              key={instance.sandboxId}
+              instance={instance}
+              unreadCount={params.unreadByInstance.get(instance.sandboxId) ?? 0}
+            />
           ))}
         </View>
       </View>

--- a/apps/mobile/src/components/home/home-screen.tsx
+++ b/apps/mobile/src/components/home/home-screen.tsx
@@ -30,7 +30,7 @@ export function HomeScreen() {
     isPending: instancesPending,
     isError: instancesError,
   } = useAllKiloClawInstances();
-  const { byInstance: unreadByInstance } = useUnreadCounts();
+  const { byChannel: unreadByChannel } = useUnreadCounts();
   const {
     storedSessions,
     activeSessions,
@@ -79,7 +79,7 @@ export function HomeScreen() {
             {renderKiloClawSlot({
               instances: instances ?? [],
               instancesError,
-              unreadByInstance,
+              unreadByChannel,
             })}
 
             {renderSessionsOrPromo({
@@ -99,7 +99,7 @@ export function HomeScreen() {
 function renderKiloClawSlot(params: {
   instances: ClawInstance[];
   instancesError: boolean;
-  unreadByInstance: Map<string, number>;
+  unreadByChannel: Map<string, number>;
 }) {
   if (params.instances.length > 0) {
     return (
@@ -110,7 +110,7 @@ function renderKiloClawSlot(params: {
             <KiloClawCard
               key={instance.sandboxId}
               instance={instance}
-              unreadCount={params.unreadByInstance.get(instance.sandboxId) ?? 0}
+              unreadCount={params.unreadByChannel.get(instance.sandboxId) ?? 0}
             />
           ))}
         </View>

--- a/apps/mobile/src/components/home/kiloclaw-card.tsx
+++ b/apps/mobile/src/components/home/kiloclaw-card.tsx
@@ -15,14 +15,19 @@ type KiloClawCardProps = {
     organizationName: string | null;
     status: string | null;
   };
+  unreadCount?: number;
 };
+
+function formatUnreadCount(count: number): string {
+  return count > 99 ? '99+' : String(count);
+}
 
 function formatMessagePreview(message: { text: string; senderName: string }): string {
   const text = message.text.length > 0 ? message.text : 'New message';
   return message.senderName.length > 0 ? `${message.senderName}: ${text}` : text;
 }
 
-export function KiloClawCard({ instance }: Readonly<KiloClawCardProps>) {
+export function KiloClawCard({ instance, unreadCount = 0 }: Readonly<KiloClawCardProps>) {
   const router = useRouter();
   const colors = useThemeColors();
 
@@ -38,6 +43,11 @@ export function KiloClawCard({ instance }: Readonly<KiloClawCardProps>) {
     ? `${statusLabel} · ${instance.organizationName}`
     : statusLabel;
 
+  const hasUnread = unreadCount > 0;
+  const accessibilityLabel = hasUnread
+    ? `Open ${displayName}, ${unreadCount} unread ${unreadCount === 1 ? 'message' : 'messages'}`
+    : `Open ${displayName}`;
+
   const handlePress = () => {
     router.push(`/(app)/chat/${instance.sandboxId}` as Href);
   };
@@ -46,7 +56,7 @@ export function KiloClawCard({ instance }: Readonly<KiloClawCardProps>) {
     <Pressable
       onPress={handlePress}
       className="mx-4 rounded-xl border border-border bg-card p-4 active:opacity-80"
-      accessibilityLabel={`Open ${displayName}`}
+      accessibilityLabel={accessibilityLabel}
     >
       <View className="flex-row items-center gap-3">
         <View className="h-10 w-10 items-center justify-center rounded-full bg-muted">
@@ -73,6 +83,13 @@ export function KiloClawCard({ instance }: Readonly<KiloClawCardProps>) {
             </Text>
           </View>
         </View>
+        {hasUnread ? (
+          <View className="min-w-5 items-center justify-center rounded-full bg-red-500 px-1.5 py-0.5">
+            <Text className="text-xs font-semibold leading-none text-white">
+              {formatUnreadCount(unreadCount)}
+            </Text>
+          </View>
+        ) : null}
         <ChevronRight size={18} color={colors.mutedForeground} />
       </View>
 

--- a/apps/mobile/src/components/kiloclaw/chat.tsx
+++ b/apps/mobile/src/components/kiloclaw/chat.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -18,7 +18,7 @@ import { useStreamChatTheme } from '@/components/kiloclaw/chat-theme';
 import { useAppLifecycle } from '@/lib/hooks/use-app-lifecycle';
 import { useStreamChatCredentials } from '@/lib/hooks/use-kiloclaw-queries';
 import { setLastActiveInstance } from '@/lib/last-active-instance';
-import { type NotificationData, setActiveChatInstance } from '@/lib/notifications';
+import { parseNotificationData, setActiveChatInstance } from '@/lib/notifications';
 import { useTRPC } from '@/lib/trpc';
 
 type KiloClawChatProps = {
@@ -27,6 +27,8 @@ type KiloClawChatProps = {
   enabled: boolean;
   organizationId?: string | null;
 };
+
+type UnreadCountsData = { instanceId: string; badgeCount: number }[];
 
 export function KiloClawChat({
   instanceId,
@@ -39,13 +41,30 @@ export function KiloClawChat({
   const { isActive } = useAppLifecycle();
   const isFocusedRef = useRef(false);
 
+  const queryClient = useQueryClient();
+  const unreadCountsKey = useMemo(() => trpc.user.getUnreadCounts.queryOptions().queryKey, [trpc]);
+
   const { mutate: markChatRead } = useMutation(
     trpc.user.markChatRead.mutationOptions({
+      onMutate: async ({ channelId }) => {
+        await queryClient.cancelQueries({ queryKey: unreadCountsKey });
+        const previous = queryClient.getQueryData<UnreadCountsData>(unreadCountsKey);
+        queryClient.setQueryData<UnreadCountsData>(unreadCountsKey, old =>
+          (old ?? []).filter(row => row.instanceId !== channelId)
+        );
+        return { previous };
+      },
       onSuccess: ({ badgeCount }) => {
         void Notifications.setBadgeCountAsync(badgeCount);
       },
-      onError: (err: { message: string }) => {
+      onError: (err: { message: string }, _input, context) => {
+        if (context?.previous) {
+          queryClient.setQueryData<UnreadCountsData>(unreadCountsKey, context.previous);
+        }
         toast.error(err.message || 'Failed to update badge count');
+      },
+      onSettled: () => {
+        void queryClient.invalidateQueries({ queryKey: unreadCountsKey });
       },
     })
   );
@@ -61,7 +80,7 @@ export function KiloClawChat({
       // visually suppressed, but the DO still incremented the server-side count. Clear
       // it immediately so the badge never drifts above 0 while the user is reading.
       const subscription = Notifications.addNotificationReceivedListener(notification => {
-        const data = notification.request.content.data as NotificationData | undefined;
+        const data = parseNotificationData(notification.request.content.data);
         if (data?.type === 'chat' && data.instanceId === instanceId) {
           markChatRead({ channelId: instanceId });
         }

--- a/apps/mobile/src/components/kiloclaw/chat.tsx
+++ b/apps/mobile/src/components/kiloclaw/chat.tsx
@@ -28,7 +28,7 @@ type KiloClawChatProps = {
   organizationId?: string | null;
 };
 
-type UnreadCountsData = { instanceId: string; badgeCount: number }[];
+type UnreadCountsData = { channelId: string; badgeCount: number }[];
 
 export function KiloClawChat({
   instanceId,
@@ -50,7 +50,7 @@ export function KiloClawChat({
         await queryClient.cancelQueries({ queryKey: unreadCountsKey });
         const previous = queryClient.getQueryData<UnreadCountsData>(unreadCountsKey);
         queryClient.setQueryData<UnreadCountsData>(unreadCountsKey, old =>
-          (old ?? []).filter(row => row.instanceId !== channelId)
+          (old ?? []).filter(row => row.channelId !== channelId)
         );
         return { previous };
       },

--- a/apps/mobile/src/lib/hooks/use-unread-counts-invalidation.ts
+++ b/apps/mobile/src/lib/hooks/use-unread-counts-invalidation.ts
@@ -1,0 +1,52 @@
+import { useQueryClient } from '@tanstack/react-query';
+import * as Notifications from 'expo-notifications';
+import { useEffect } from 'react';
+import { AppState } from 'react-native';
+
+import { parseNotificationData } from '@/lib/notifications';
+import { useTRPC } from '@/lib/trpc';
+
+/**
+ * Keeps the `user.getUnreadCounts` cache in sync with real-time notification
+ * traffic so per-instance badges on the dashboard reflect pushes received while
+ * the app is open or resumed from background.
+ *
+ * - Foreground chat push → invalidate (server already incremented the count).
+ * - App returns to active state → invalidate (pushes received while
+ *   backgrounded don't fire the received-listener).
+ *
+ * Mounted once inside `RootLayoutNav` so it covers every screen, including
+ * when the dashboard is not rendered yet.
+ */
+export function useUnreadCountsInvalidation() {
+  const queryClient = useQueryClient();
+  const trpc = useTRPC();
+
+  useEffect(() => {
+    // `trpc` is stable (memoized inside TRPCProvider) but `queryKey()` returns
+    // a fresh array on each call, so we resolve it inside each invalidation.
+    const invalidate = () => {
+      void queryClient.invalidateQueries({
+        queryKey: trpc.user.getUnreadCounts.queryKey(),
+      });
+    };
+
+    const received = Notifications.addNotificationReceivedListener(notification => {
+      const data = parseNotificationData(notification.request.content.data);
+      if (data?.type === 'chat') {
+        invalidate();
+      }
+    });
+
+    const appStateSubscription = AppState.addEventListener('change', state => {
+      if (state === 'active') {
+        invalidate();
+      }
+    });
+
+    return () => {
+      received.remove();
+      appStateSubscription.remove();
+    };
+  }, [queryClient, trpc]);
+}

--- a/apps/mobile/src/lib/hooks/use-unread-counts.ts
+++ b/apps/mobile/src/lib/hooks/use-unread-counts.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { useTRPC } from '@/lib/trpc';
+
+/**
+ * Fetches per-instance unread message counts for the current user and returns
+ * a Map keyed by instanceId for O(1) lookup from dashboard cards.
+ *
+ * Freshness is driven by invalidations, not polling:
+ *   - Foreground chat push → invalidate (see `use-unread-counts-invalidation`).
+ *   - App returns to active → invalidate.
+ *   - `markChatRead` optimistically clears the relevant row.
+ */
+export function useUnreadCounts() {
+  const trpc = useTRPC();
+  const query = useQuery(
+    trpc.user.getUnreadCounts.queryOptions(undefined, {
+      staleTime: 30_000,
+    })
+  );
+
+  const byInstance = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const row of query.data ?? []) {
+      map.set(row.instanceId, row.badgeCount);
+    }
+    return map;
+  }, [query.data]);
+
+  return { byInstance, query };
+}

--- a/apps/mobile/src/lib/hooks/use-unread-counts.ts
+++ b/apps/mobile/src/lib/hooks/use-unread-counts.ts
@@ -4,8 +4,9 @@ import { useMemo } from 'react';
 import { useTRPC } from '@/lib/trpc';
 
 /**
- * Fetches per-instance unread message counts for the current user and returns
- * a Map keyed by instanceId for O(1) lookup from dashboard cards.
+ * Fetches per-channel unread message counts for the current user and returns
+ * a Map keyed by channelId for O(1) lookup from dashboard cards. For kiloclaw
+ * chats, `channelId` equals the instance's `sandboxId`.
  *
  * Freshness is driven by invalidations, not polling:
  *   - Foreground chat push → invalidate (see `use-unread-counts-invalidation`).
@@ -20,13 +21,13 @@ export function useUnreadCounts() {
     })
   );
 
-  const byInstance = useMemo(() => {
+  const byChannel = useMemo(() => {
     const map = new Map<string, number>();
     for (const row of query.data ?? []) {
-      map.set(row.instanceId, row.badgeCount);
+      map.set(row.channelId, row.badgeCount);
     }
     return map;
   }, [query.data]);
 
-  return { byInstance, query };
+  return { byChannel, query };
 }

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -2,6 +2,7 @@ import expoConstants from 'expo-constants';
 import * as Notifications from 'expo-notifications';
 import { type Href, router } from 'expo-router';
 import { Platform } from 'react-native';
+import { z } from 'zod';
 
 function getProjectId(): string {
   const eas = expoConstants.expoConfig?.extra?.eas as { projectId?: string } | undefined;
@@ -24,21 +25,20 @@ export function setActiveChatInstance(instanceId: string | null) {
 }
 
 // Keep in sync with data field in services/notifications/src/dos/NotificationChannelDO.ts
-export type NotificationData = { type: 'chat'; instanceId: string };
+const notificationDataSchema = z.object({
+  type: z.literal('chat'),
+  instanceId: z.string().min(1),
+});
+
+export type NotificationData = z.infer<typeof notificationDataSchema>;
 
 // Runtime-validates that an arbitrary notification `data` payload matches the
 // shape we care about. Use this instead of `as NotificationData` when reading
 // from the OS-provided notification content, since push producers can evolve
 // independently of the app.
 export function parseNotificationData(data: unknown): NotificationData | null {
-  if (typeof data !== 'object' || data === null) {
-    return null;
-  }
-  const { type, instanceId } = data as { type?: unknown; instanceId?: unknown };
-  if (type === 'chat' && typeof instanceId === 'string' && instanceId.length > 0) {
-    return { type: 'chat', instanceId };
-  }
-  return null;
+  const parsed = notificationDataSchema.safeParse(data);
+  return parsed.success ? parsed.data : null;
 }
 
 const shown = {

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -26,6 +26,21 @@ export function setActiveChatInstance(instanceId: string | null) {
 // Keep in sync with data field in services/notifications/src/dos/NotificationChannelDO.ts
 export type NotificationData = { type: 'chat'; instanceId: string };
 
+// Runtime-validates that an arbitrary notification `data` payload matches the
+// shape we care about. Use this instead of `as NotificationData` when reading
+// from the OS-provided notification content, since push producers can evolve
+// independently of the app.
+export function parseNotificationData(data: unknown): NotificationData | null {
+  if (typeof data !== 'object' || data === null) {
+    return null;
+  }
+  const { type, instanceId } = data as { type?: unknown; instanceId?: unknown };
+  if (type === 'chat' && typeof instanceId === 'string' && instanceId.length > 0) {
+    return { type: 'chat', instanceId };
+  }
+  return null;
+}
+
 const shown = {
   shouldShowAlert: true,
   shouldPlaySound: true,

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -30,12 +30,11 @@ const notificationDataSchema = z.object({
   instanceId: z.string().min(1),
 });
 
-export type NotificationData = z.infer<typeof notificationDataSchema>;
+type NotificationData = z.infer<typeof notificationDataSchema>;
 
 // Runtime-validates that an arbitrary notification `data` payload matches the
-// shape we care about. Use this instead of `as NotificationData` when reading
-// from the OS-provided notification content, since push producers can evolve
-// independently of the app.
+// shape we care about. Push producers can evolve independently of the app, so
+// always parse before reading fields from the OS-provided notification content.
 export function parseNotificationData(data: unknown): NotificationData | null {
   const parsed = notificationDataSchema.safeParse(data);
   return parsed.success ? parsed.data : null;
@@ -61,10 +60,10 @@ export function setupNotificationHandler() {
   Notifications.setNotificationHandler({
     // eslint-disable-next-line require-await -- expo-notifications requires async callback type but logic is synchronous
     handleNotification: async notification => {
-      const data = notification.request.content.data as NotificationData | undefined;
+      const data = parseNotificationData(notification.request.content.data);
 
       // Suppress only if the user is already viewing this exact chat
-      if (data?.type === 'chat' && data.instanceId === activeChatInstanceId) {
+      if (data && data.instanceId === activeChatInstanceId) {
         return suppressed;
       }
 
@@ -85,9 +84,9 @@ export function getPendingNotificationLink(): string | null {
 
 export function setupNotificationResponseHandler() {
   const subscription = Notifications.addNotificationResponseReceivedListener(response => {
-    const data = response.notification.request.content.data as NotificationData | undefined;
+    const data = parseNotificationData(response.notification.request.content.data);
 
-    if (data?.type === 'chat') {
+    if (data) {
       const path = `/(app)/chat/${data.instanceId}`;
       // If the router is ready (has segments), navigate immediately.
       // Otherwise store as pending for consumption after auth completes.
@@ -108,8 +107,8 @@ export function checkInitialNotification(): void {
   if (!response) {
     return;
   }
-  const data = response.notification.request.content.data as NotificationData | undefined;
-  if (data?.type === 'chat') {
+  const data = parseNotificationData(response.notification.request.content.data);
+  if (data) {
     pendingNotificationLink = `/(app)/chat/${data.instanceId}`;
   }
 }

--- a/apps/web/src/routers/user-router.test.ts
+++ b/apps/web/src/routers/user-router.test.ts
@@ -1,7 +1,7 @@
 import { createCallerForUser } from '@/routers/test-utils';
 import { db } from '@/lib/drizzle';
 import { channel_badge_counts, kilocode_users } from '@kilocode/db/schema';
-import { and, eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import type { User } from '@kilocode/db/schema';
 
@@ -418,52 +418,6 @@ describe('session and API token reset mutations', () => {
 });
 
 describe('user router - getUnreadCounts', () => {
-  async function seedBadge(userId: string, channelId: string, count: number) {
-    await db
-      .insert(channel_badge_counts)
-      .values({ user_id: userId, channel_id: channelId, badge_count: count });
-  }
-
-  async function cleanupBadges(userId: string) {
-    await db.delete(channel_badge_counts).where(eq(channel_badge_counts.user_id, userId));
-  }
-
-  it('returns per-channel unread counts for the current user', async () => {
-    const user = await insertTestUser({
-      google_user_email: `unread-counts-basic-${crypto.randomUUID()}@example.com`,
-    });
-    await seedBadge(user.id, 'sandbox-alpha', 3);
-    await seedBadge(user.id, 'sandbox-beta', 7);
-
-    const caller = await createCallerForUser(user.id);
-    const result = await caller.user.getUnreadCounts();
-
-    expect(result).toHaveLength(2);
-    expect(result).toEqual(
-      expect.arrayContaining([
-        { channelId: 'sandbox-alpha', badgeCount: 3 },
-        { channelId: 'sandbox-beta', badgeCount: 7 },
-      ])
-    );
-
-    await cleanupBadges(user.id);
-  });
-
-  it('omits channels with a zero badge count', async () => {
-    const user = await insertTestUser({
-      google_user_email: `unread-counts-zero-${crypto.randomUUID()}@example.com`,
-    });
-    await seedBadge(user.id, 'sandbox-has-unread', 2);
-    await seedBadge(user.id, 'sandbox-no-unread', 0);
-
-    const caller = await createCallerForUser(user.id);
-    const result = await caller.user.getUnreadCounts();
-
-    expect(result).toEqual([{ channelId: 'sandbox-has-unread', badgeCount: 2 }]);
-
-    await cleanupBadges(user.id);
-  });
-
   it('does not return counts from other users', async () => {
     const user = await insertTestUser({
       google_user_email: `unread-counts-me-${crypto.randomUUID()}@example.com`,
@@ -471,44 +425,18 @@ describe('user router - getUnreadCounts', () => {
     const other = await insertTestUser({
       google_user_email: `unread-counts-other-${crypto.randomUUID()}@example.com`,
     });
-    await seedBadge(user.id, 'sandbox-mine', 4);
-    await seedBadge(other.id, 'sandbox-theirs', 9);
+    await db.insert(channel_badge_counts).values([
+      { user_id: user.id, channel_id: 'sandbox-mine', badge_count: 4 },
+      { user_id: other.id, channel_id: 'sandbox-theirs', badge_count: 9 },
+    ]);
 
     const caller = await createCallerForUser(user.id);
     const result = await caller.user.getUnreadCounts();
 
     expect(result).toEqual([{ channelId: 'sandbox-mine', badgeCount: 4 }]);
 
-    await cleanupBadges(user.id);
-    await cleanupBadges(other.id);
-  });
-
-  it('reflects a count that was reset via markChatRead', async () => {
-    const user = await insertTestUser({
-      google_user_email: `unread-counts-after-read-${crypto.randomUUID()}@example.com`,
-    });
-    await seedBadge(user.id, 'sandbox-read', 5);
-    await seedBadge(user.id, 'sandbox-still-unread', 1);
-
-    const caller = await createCallerForUser(user.id);
-    await caller.user.markChatRead({ channelId: 'sandbox-read' });
-
-    const result = await caller.user.getUnreadCounts();
-
-    expect(result).toEqual([{ channelId: 'sandbox-still-unread', badgeCount: 1 }]);
-
-    // Defensive: confirm the row was zeroed, not deleted.
-    const zeroed = await db
-      .select({ count: channel_badge_counts.badge_count })
-      .from(channel_badge_counts)
-      .where(
-        and(
-          eq(channel_badge_counts.user_id, user.id),
-          eq(channel_badge_counts.channel_id, 'sandbox-read')
-        )
-      );
-    expect(zeroed).toEqual([{ count: 0 }]);
-
-    await cleanupBadges(user.id);
+    await db
+      .delete(channel_badge_counts)
+      .where(inArray(channel_badge_counts.user_id, [user.id, other.id]));
   });
 });

--- a/apps/web/src/routers/user-router.test.ts
+++ b/apps/web/src/routers/user-router.test.ts
@@ -441,8 +441,8 @@ describe('user router - getUnreadCounts', () => {
     expect(result).toHaveLength(2);
     expect(result).toEqual(
       expect.arrayContaining([
-        { instanceId: 'sandbox-alpha', badgeCount: 3 },
-        { instanceId: 'sandbox-beta', badgeCount: 7 },
+        { channelId: 'sandbox-alpha', badgeCount: 3 },
+        { channelId: 'sandbox-beta', badgeCount: 7 },
       ])
     );
 
@@ -459,7 +459,7 @@ describe('user router - getUnreadCounts', () => {
     const caller = await createCallerForUser(user.id);
     const result = await caller.user.getUnreadCounts();
 
-    expect(result).toEqual([{ instanceId: 'sandbox-has-unread', badgeCount: 2 }]);
+    expect(result).toEqual([{ channelId: 'sandbox-has-unread', badgeCount: 2 }]);
 
     await cleanupBadges(user.id);
   });
@@ -477,7 +477,7 @@ describe('user router - getUnreadCounts', () => {
     const caller = await createCallerForUser(user.id);
     const result = await caller.user.getUnreadCounts();
 
-    expect(result).toEqual([{ instanceId: 'sandbox-mine', badgeCount: 4 }]);
+    expect(result).toEqual([{ channelId: 'sandbox-mine', badgeCount: 4 }]);
 
     await cleanupBadges(user.id);
     await cleanupBadges(other.id);
@@ -495,7 +495,7 @@ describe('user router - getUnreadCounts', () => {
 
     const result = await caller.user.getUnreadCounts();
 
-    expect(result).toEqual([{ instanceId: 'sandbox-still-unread', badgeCount: 1 }]);
+    expect(result).toEqual([{ channelId: 'sandbox-still-unread', badgeCount: 1 }]);
 
     // Defensive: confirm the row was zeroed, not deleted.
     const zeroed = await db

--- a/apps/web/src/routers/user-router.test.ts
+++ b/apps/web/src/routers/user-router.test.ts
@@ -1,7 +1,7 @@
 import { createCallerForUser } from '@/routers/test-utils';
 import { db } from '@/lib/drizzle';
-import { kilocode_users } from '@kilocode/db/schema';
-import { eq } from 'drizzle-orm';
+import { channel_badge_counts, kilocode_users } from '@kilocode/db/schema';
+import { and, eq } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import type { User } from '@kilocode/db/schema';
 
@@ -414,5 +414,101 @@ describe('session and API token reset mutations', () => {
     expect(updated.web_session_pepper).toEqual(expect.any(String));
     expect(updated.web_session_pepper).not.toBe('web-session-pepper-before');
     expect(updated.api_token_pepper).toBe('api-pepper-before');
+  });
+});
+
+describe('user router - getUnreadCounts', () => {
+  async function seedBadge(userId: string, channelId: string, count: number) {
+    await db
+      .insert(channel_badge_counts)
+      .values({ user_id: userId, channel_id: channelId, badge_count: count });
+  }
+
+  async function cleanupBadges(userId: string) {
+    await db.delete(channel_badge_counts).where(eq(channel_badge_counts.user_id, userId));
+  }
+
+  it('returns per-channel unread counts for the current user', async () => {
+    const user = await insertTestUser({
+      google_user_email: `unread-counts-basic-${crypto.randomUUID()}@example.com`,
+    });
+    await seedBadge(user.id, 'sandbox-alpha', 3);
+    await seedBadge(user.id, 'sandbox-beta', 7);
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.user.getUnreadCounts();
+
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { instanceId: 'sandbox-alpha', badgeCount: 3 },
+        { instanceId: 'sandbox-beta', badgeCount: 7 },
+      ])
+    );
+
+    await cleanupBadges(user.id);
+  });
+
+  it('omits channels with a zero badge count', async () => {
+    const user = await insertTestUser({
+      google_user_email: `unread-counts-zero-${crypto.randomUUID()}@example.com`,
+    });
+    await seedBadge(user.id, 'sandbox-has-unread', 2);
+    await seedBadge(user.id, 'sandbox-no-unread', 0);
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.user.getUnreadCounts();
+
+    expect(result).toEqual([{ instanceId: 'sandbox-has-unread', badgeCount: 2 }]);
+
+    await cleanupBadges(user.id);
+  });
+
+  it('does not return counts from other users', async () => {
+    const user = await insertTestUser({
+      google_user_email: `unread-counts-me-${crypto.randomUUID()}@example.com`,
+    });
+    const other = await insertTestUser({
+      google_user_email: `unread-counts-other-${crypto.randomUUID()}@example.com`,
+    });
+    await seedBadge(user.id, 'sandbox-mine', 4);
+    await seedBadge(other.id, 'sandbox-theirs', 9);
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.user.getUnreadCounts();
+
+    expect(result).toEqual([{ instanceId: 'sandbox-mine', badgeCount: 4 }]);
+
+    await cleanupBadges(user.id);
+    await cleanupBadges(other.id);
+  });
+
+  it('reflects a count that was reset via markChatRead', async () => {
+    const user = await insertTestUser({
+      google_user_email: `unread-counts-after-read-${crypto.randomUUID()}@example.com`,
+    });
+    await seedBadge(user.id, 'sandbox-read', 5);
+    await seedBadge(user.id, 'sandbox-still-unread', 1);
+
+    const caller = await createCallerForUser(user.id);
+    await caller.user.markChatRead({ channelId: 'sandbox-read' });
+
+    const result = await caller.user.getUnreadCounts();
+
+    expect(result).toEqual([{ instanceId: 'sandbox-still-unread', badgeCount: 1 }]);
+
+    // Defensive: confirm the row was zeroed, not deleted.
+    const zeroed = await db
+      .select({ count: channel_badge_counts.badge_count })
+      .from(channel_badge_counts)
+      .where(
+        and(
+          eq(channel_badge_counts.user_id, user.id),
+          eq(channel_badge_counts.channel_id, 'sandbox-read')
+        )
+      );
+    expect(zeroed).toEqual([{ count: 0 }]);
+
+    await cleanupBadges(user.id);
   });
 });

--- a/apps/web/src/routers/user-router.ts
+++ b/apps/web/src/routers/user-router.ts
@@ -749,14 +749,13 @@ export const userRouter = createTRPCRouter({
       return { badgeCount: Number(totals?.total ?? 0) };
     }),
 
-  // Per-instance unread counts for showing badges on the mobile dashboard.
-  // channel_id is the sandbox_id of a kiloclaw instance (see NotificationChannelDO);
-  // returned as `instanceId` since that's how the mobile client identifies instances.
+  // Per-channel unread counts for showing badges on the mobile dashboard. For
+  // kiloclaw chats, `channelId` equals `sandbox_id` (see NotificationChannelDO).
   // Destroyed instances are filtered implicitly on the client — the dashboard only
   // renders cards for instances returned by `listAllInstances`, which already
   // excludes destroyed ones.
   getUnreadCounts: baseProcedure.query(async ({ ctx }) => {
-    const rows = await readDb
+    return readDb
       .select({
         channelId: channel_badge_counts.channel_id,
         badgeCount: channel_badge_counts.badge_count,
@@ -765,10 +764,5 @@ export const userRouter = createTRPCRouter({
       .where(
         and(eq(channel_badge_counts.user_id, ctx.user.id), gt(channel_badge_counts.badge_count, 0))
       );
-
-    return rows.map(row => ({
-      instanceId: row.channelId,
-      badgeCount: row.badgeCount,
-    }));
   }),
 });

--- a/apps/web/src/routers/user-router.ts
+++ b/apps/web/src/routers/user-router.ts
@@ -22,7 +22,7 @@ import {
   user_push_tokens,
   channel_badge_counts,
 } from '@kilocode/db/schema';
-import { eq, and, isNull, inArray, sql, gte, sum } from 'drizzle-orm';
+import { eq, and, isNull, inArray, sql, gt, gte, sum } from 'drizzle-orm';
 import crypto from 'crypto';
 import { checkDiscordGuildMembership } from '@/lib/integrations/discord-guild-membership';
 import { AuthProviderIdSchema } from '@/lib/auth/provider-metadata';
@@ -748,4 +748,27 @@ export const userRouter = createTRPCRouter({
 
       return { badgeCount: Number(totals?.total ?? 0) };
     }),
+
+  // Per-instance unread counts for showing badges on the mobile dashboard.
+  // channel_id is the sandbox_id of a kiloclaw instance (see NotificationChannelDO);
+  // returned as `instanceId` since that's how the mobile client identifies instances.
+  // Destroyed instances are filtered implicitly on the client — the dashboard only
+  // renders cards for instances returned by `listAllInstances`, which already
+  // excludes destroyed ones.
+  getUnreadCounts: baseProcedure.query(async ({ ctx }) => {
+    const rows = await readDb
+      .select({
+        channelId: channel_badge_counts.channel_id,
+        badgeCount: channel_badge_counts.badge_count,
+      })
+      .from(channel_badge_counts)
+      .where(
+        and(eq(channel_badge_counts.user_id, ctx.user.id), gt(channel_badge_counts.badge_count, 0))
+      );
+
+    return rows.map(row => ({
+      instanceId: row.channelId,
+      badgeCount: row.badgeCount,
+    }));
+  }),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,6 +311,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
     devDependencies:
       '@sentry/cli':
         specifier: ^3.3.4


### PR DESCRIPTION
## Summary

Adds per-instance unread badges to the KiloClaw cards on the mobile dashboard, so users can see at a glance which instances have unread chat messages.

<img width="568" height="1084" alt="Screenshot 2026-04-28 at 22 09 34" src="https://github.com/user-attachments/assets/a6e0820a-1890-4ba1-97ba-ac0d8ee73cf0" />
