### PR TITLE
feat(web): log system-initiated model access changes to audit log

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/snapshot-diff.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/snapshot-diff.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from '@jest/globals';
+import type {
+  NormalizedOpenRouterResponse,
+  NormalizedProvider,
+} from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
+import { computeSnapshotDiff } from '@/lib/ai-gateway/providers/openrouter/snapshot-diff';
+
+function buildSnapshot(
+  providers: Array<{ slug: string; models: string[] }>
+): NormalizedOpenRouterResponse {
+  const mapped: NormalizedProvider[] = providers.map(({ slug, models }) => ({
+    name: slug,
+    displayName: slug,
+    slug,
+    dataPolicy: { training: false, retainsPrompts: false, canPublish: false },
+    models: models.map(modelSlug => ({
+      slug: modelSlug,
+      name: modelSlug,
+      author: slug,
+      description: '',
+      context_length: 0,
+      input_modalities: [],
+      output_modalities: [],
+      group: 'other',
+      updated_at: '',
+      endpoint: {
+        provider_display_name: slug,
+        is_free: false,
+        pricing: { prompt: '0', completion: '0' },
+      },
+    })),
+  }));
+
+  return {
+    providers: mapped,
+    total_providers: mapped.length,
+    total_models: mapped.reduce((sum, p) => sum + p.models.length, 0),
+    generated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+describe('computeSnapshotDiff', () => {
+  test('returns empty diff when old snapshot is null', () => {
+    const snapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    const diff = computeSnapshotDiff(null, snapshot);
+
+    expect(diff.addedByProvider.size).toBe(0);
+    expect(diff.removedByProvider.size).toBe(0);
+    expect(diff.oldModelProvidersIndex.size).toBe(0);
+    expect(diff.newModelProvidersIndex.get('z-ai/glm-5')).toEqual(new Set(['z-ai']));
+  });
+
+  test('returns empty diff maps when snapshots are identical', () => {
+    const snapshot = buildSnapshot([
+      { slug: 'z-ai', models: ['z-ai/glm-5'] },
+      { slug: 'anthropic', models: ['anthropic/claude-4.6'] },
+    ]);
+    const diff = computeSnapshotDiff(snapshot, snapshot);
+
+    expect(diff.addedByProvider.size).toBe(0);
+    expect(diff.removedByProvider.size).toBe(0);
+  });
+
+  test('detects new model on existing provider', () => {
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1', 'z-ai/glm-5.1-air'] },
+    ]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+
+    expect(diff.addedByProvider.get('z-ai')).toEqual(['z-ai/glm-5.1', 'z-ai/glm-5.1-air']);
+    expect(diff.removedByProvider.size).toBe(0);
+  });
+
+  test('detects brand-new provider with its models', () => {
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'z-ai', models: ['z-ai/glm-5'] },
+      { slug: 'xyz-corp', models: ['xyz-corp/foo', 'xyz-corp/bar'] },
+    ]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+
+    expect(diff.addedByProvider.get('xyz-corp')).toEqual(['xyz-corp/bar', 'xyz-corp/foo']);
+    expect(diff.addedByProvider.has('z-ai')).toBe(false);
+  });
+
+  test('detects model removed from catalog', () => {
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-4.0', 'z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+
+    expect(diff.removedByProvider.get('z-ai')).toEqual(['z-ai/glm-4.0']);
+    expect(diff.addedByProvider.size).toBe(0);
+  });
+
+  test('detects additional provider offering an existing model as addition for that provider only', () => {
+    const oldSnapshot = buildSnapshot([
+      { slug: 'openai', models: ['openai/gpt-4o'] },
+      { slug: 'azure', models: [] },
+    ]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'openai', models: ['openai/gpt-4o'] },
+      { slug: 'azure', models: ['openai/gpt-4o'] },
+    ]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+
+    expect(diff.addedByProvider.get('azure')).toEqual(['openai/gpt-4o']);
+    expect(diff.addedByProvider.has('openai')).toBe(false);
+    expect(diff.removedByProvider.size).toBe(0);
+  });
+
+  test('normalizes variant suffixes like :free', () => {
+    const oldSnapshot = buildSnapshot([{ slug: 'openai', models: ['openai/gpt-4o'] }]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'openai', models: ['openai/gpt-4o', 'openai/gpt-4o:free'] },
+    ]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+
+    expect(diff.addedByProvider.size).toBe(0);
+    expect(diff.newModelProvidersIndex.get('openai/gpt-4o')).toEqual(new Set(['openai']));
+  });
+
+  test('sorts model ids alphabetically within each provider group', () => {
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: [] }]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'z-ai', models: ['z-ai/beta', 'z-ai/alpha', 'z-ai/gamma'] },
+    ]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+
+    expect(diff.addedByProvider.get('z-ai')).toEqual(['z-ai/alpha', 'z-ai/beta', 'z-ai/gamma']);
+  });
+
+  test('handles simultaneous additions and removals', () => {
+    const oldSnapshot = buildSnapshot([
+      { slug: 'z-ai', models: ['z-ai/glm-4.0', 'z-ai/glm-5'] },
+      { slug: 'anthropic', models: ['anthropic/claude-4.5'] },
+    ]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1'] },
+      { slug: 'anthropic', models: ['anthropic/claude-4.5', 'anthropic/claude-4.6'] },
+    ]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+
+    expect(diff.addedByProvider.get('z-ai')).toEqual(['z-ai/glm-5.1']);
+    expect(diff.addedByProvider.get('anthropic')).toEqual(['anthropic/claude-4.6']);
+    expect(diff.removedByProvider.get('z-ai')).toEqual(['z-ai/glm-4.0']);
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/snapshot-diff.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/snapshot-diff.ts
@@ -1,0 +1,117 @@
+import type { NormalizedOpenRouterResponse } from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
+import { normalizeModelId } from '@/lib/ai-gateway/model-utils';
+
+export type SnapshotDiff = {
+  /** providerSlug -> sorted list of normalized model ids newly offered by that provider */
+  addedByProvider: Map<string, string[]>;
+  /** providerSlug -> sorted list of normalized model ids no longer offered by that provider */
+  removedByProvider: Map<string, string[]>;
+  /** modelId -> set of providerSlugs that offered it in the OLD snapshot */
+  oldModelProvidersIndex: Map<string, Set<string>>;
+  /** modelId -> set of providerSlugs that offer it in the NEW snapshot */
+  newModelProvidersIndex: Map<string, Set<string>>;
+};
+
+function buildModelProvidersIndex(
+  snapshot: NormalizedOpenRouterResponse
+): Map<string, Set<string>> {
+  const index = new Map<string, Set<string>>();
+  for (const provider of snapshot.providers) {
+    for (const model of provider.models) {
+      const normalizedModelId = normalizeModelId(model.slug);
+      const existing = index.get(normalizedModelId);
+      if (existing) {
+        existing.add(provider.slug);
+      } else {
+        index.set(normalizedModelId, new Set([provider.slug]));
+      }
+    }
+  }
+  return index;
+}
+
+function emptyDiff(
+  oldIndex: Map<string, Set<string>>,
+  newIndex: Map<string, Set<string>>
+): SnapshotDiff {
+  return {
+    addedByProvider: new Map(),
+    removedByProvider: new Map(),
+    oldModelProvidersIndex: oldIndex,
+    newModelProvidersIndex: newIndex,
+  };
+}
+
+/**
+ * Compare two OpenRouter snapshots and produce the set of provider→model
+ * additions and removals implied by the diff.
+ *
+ * A `(provider, model)` pair is "added" when the NEW snapshot contains that
+ * pair and the OLD snapshot did not. This naturally covers two scenarios:
+ *   1. A brand-new model on an existing provider (e.g. `z-ai/glm-5.1` appears
+ *      under `z-ai`).
+ *   2. An existing model newly offered by an additional provider.
+ *
+ * Similarly, a `(provider, model)` pair is "removed" when the OLD snapshot
+ * contained it and the NEW snapshot does not.
+ *
+ * When `oldSnapshot` is null (first run / fresh database), returns empty
+ * add/remove maps so callers produce no audit log flood.
+ */
+export function computeSnapshotDiff(
+  oldSnapshot: NormalizedOpenRouterResponse | null,
+  newSnapshot: NormalizedOpenRouterResponse
+): SnapshotDiff {
+  const newIndex = buildModelProvidersIndex(newSnapshot);
+
+  if (oldSnapshot === null) {
+    return emptyDiff(new Map(), newIndex);
+  }
+
+  const oldIndex = buildModelProvidersIndex(oldSnapshot);
+
+  const addedByProvider = new Map<string, string[]>();
+  const removedByProvider = new Map<string, string[]>();
+
+  for (const [modelId, newProviders] of newIndex) {
+    const oldProviders = oldIndex.get(modelId);
+    for (const providerSlug of newProviders) {
+      if (!oldProviders || !oldProviders.has(providerSlug)) {
+        const list = addedByProvider.get(providerSlug);
+        if (list) {
+          list.push(modelId);
+        } else {
+          addedByProvider.set(providerSlug, [modelId]);
+        }
+      }
+    }
+  }
+
+  for (const [modelId, oldProviders] of oldIndex) {
+    const newProviders = newIndex.get(modelId);
+    for (const providerSlug of oldProviders) {
+      if (!newProviders || !newProviders.has(providerSlug)) {
+        const list = removedByProvider.get(providerSlug);
+        if (list) {
+          list.push(modelId);
+        } else {
+          removedByProvider.set(providerSlug, [modelId]);
+        }
+      }
+    }
+  }
+
+  for (const list of addedByProvider.values()) {
+    list.sort((a, b) => a.localeCompare(b));
+  }
+  for (const list of removedByProvider.values()) {
+    list.sort((a, b) => a.localeCompare(b));
+  }
+
+  return {
+    addedByProvider,
+    removedByProvider,
+    oldModelProvidersIndex: oldIndex,
+    newModelProvidersIndex: newIndex,
+  };
+}

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -14,7 +14,7 @@ import {
 } from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
 import { modelsByProvider } from '@kilocode/db/schema';
 import { db } from '@/lib/drizzle';
-import { desc, lt } from 'drizzle-orm';
+import { desc, lt, sql } from 'drizzle-orm';
 import { captureException } from '@sentry/nextjs';
 import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
 import { logAutoModelChangesForAllOrgs } from '@/lib/organizations/auto-model-change-log';
@@ -28,6 +28,14 @@ const ATTRIBUTION_HEADERS = {
   'HTTP-Referer': 'https://kilocode.ai',
   'X-Title': 'Kilo Code',
 } as const;
+
+/**
+ * Advisory lock key hashed from a stable identifier. Serializes concurrent
+ * calls to `applySnapshotChangesAndAudit` so two overlapping syncs cannot
+ * both read the same "previous" snapshot and emit duplicate system audit
+ * logs for the same diff. Auto-releases on transaction commit/rollback.
+ */
+const SYNC_PROVIDERS_SNAPSHOT_LOCK_KEY = 'sync-providers:snapshot';
 
 async function fetchGatewayModels(gateway: Provider) {
   const headers = {
@@ -312,9 +320,11 @@ async function mirrorToRedis(values: {
  * this with a new synthetic snapshot, and assert on the resulting rows in
  * `organization_audit_logs`.
  *
- * The previous-snapshot read is performed INSIDE the same transaction that
- * inserts the new row, so concurrent sync runs cannot observe each other's
- * partial writes.
+ * Concurrency safety: a transaction-scoped Postgres advisory lock
+ * (`pg_advisory_xact_lock`) is taken before the previous-snapshot read so
+ * two overlapping sync runs cannot both observe the same "previous" row
+ * and emit duplicate system audit logs for the same diff. The lock is
+ * released automatically on commit/rollback.
  */
 export async function applySnapshotChangesAndAudit(params: {
   providers: NormalizedOpenRouterResponse;
@@ -328,6 +338,10 @@ export async function applySnapshotChangesAndAudit(params: {
   const { providers, openrouter_data, vercel_data } = params;
 
   const { row, previousSnapshot } = await db.transaction(async tx => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${SYNC_PROVIDERS_SNAPSHOT_LOCK_KEY}))`
+    );
+
     const [previousSnapshotRow] = await tx
       .select({ data: modelsByProvider.data })
       .from(modelsByProvider)

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -14,8 +14,10 @@ import {
 } from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
 import { modelsByProvider } from '@kilocode/db/schema';
 import { db } from '@/lib/drizzle';
-import { lt } from 'drizzle-orm';
+import { desc, lt } from 'drizzle-orm';
+import { captureException } from '@sentry/nextjs';
 import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import { logAutoModelChangesForAllOrgs } from '@/lib/organizations/auto-model-change-log';
 import type { Provider } from '@/lib/ai-gateway/providers/types';
 import type { StoredModel } from '@/lib/ai-gateway/providers/vercel/types';
 import { EndpointsSchema, ModelsSchema } from '@/lib/ai-gateway/providers/vercel/types';
@@ -300,6 +302,61 @@ async function mirrorToRedis(values: {
   await Promise.all(entries.map(([key, value]) => redisSet(key, JSON.stringify(value))));
 }
 
+/**
+ * Apply a freshly-synced OpenRouter snapshot to the database and emit
+ * per-org audit log entries describing how it affects each enterprise
+ * organization's effective model availability.
+ *
+ * Extracted from `syncAndStoreProviders` so it can be tested without
+ * mocking upstream HTTP calls: seed the DB with a prior snapshot row, call
+ * this with a new synthetic snapshot, and assert on the resulting rows in
+ * `organization_audit_logs`.
+ *
+ * The previous-snapshot read is performed INSIDE the same transaction that
+ * inserts the new row, so concurrent sync runs cannot observe each other's
+ * partial writes.
+ */
+export async function applySnapshotChangesAndAudit(params: {
+  providers: NormalizedOpenRouterResponse;
+  openrouter_data: Record<string, StoredModel>;
+  vercel_data: Record<string, StoredModel>;
+}): Promise<{
+  id: number;
+  data: NormalizedOpenRouterResponse;
+  previousSnapshot: NormalizedOpenRouterResponse | null;
+}> {
+  const { providers, openrouter_data, vercel_data } = params;
+
+  const { row, previousSnapshot } = await db.transaction(async tx => {
+    const [previousSnapshotRow] = await tx
+      .select({ data: modelsByProvider.data })
+      .from(modelsByProvider)
+      .orderBy(desc(modelsByProvider.id))
+      .limit(1);
+    const previousSnapshot = previousSnapshotRow?.data ?? null;
+
+    const results = await tx
+      .insert(modelsByProvider)
+      .values({
+        data: providers,
+        openrouter: openrouter_data,
+        vercel: vercel_data,
+      })
+      .returning();
+    await tx.delete(modelsByProvider).where(lt(modelsByProvider.id, results[0].id));
+    return { row: results[0], previousSnapshot };
+  });
+
+  try {
+    await logAutoModelChangesForAllOrgs(previousSnapshot, providers);
+  } catch (err) {
+    console.error('[sync-providers] auto-change audit logging failed', err);
+    captureException(err, { tags: { component: 'sync-providers-auto-audit' } });
+  }
+
+  return { id: row.id, data: row.data, previousSnapshot };
+}
+
 export async function syncAndStoreProviders() {
   const startTime = performance.now();
 
@@ -323,17 +380,10 @@ export async function syncAndStoreProviders() {
     throw new Error(`Suspicious: total number of models is ${providers.total_models} < 100`);
   }
 
-  const result = await db.transaction(async tx => {
-    const results = await tx
-      .insert(modelsByProvider)
-      .values({
-        data: providers,
-        openrouter: openrouter_data,
-        vercel: vercel_data,
-      })
-      .returning();
-    await tx.delete(modelsByProvider).where(lt(modelsByProvider.id, results[0].id));
-    return results[0];
+  const result = await applySnapshotChangesAndAudit({
+    providers,
+    openrouter_data,
+    vercel_data,
   });
 
   await mirrorToRedis({

--- a/apps/web/src/lib/organizations/auto-model-change-log.integration.test.ts
+++ b/apps/web/src/lib/organizations/auto-model-change-log.integration.test.ts
@@ -1,0 +1,315 @@
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { and, eq } from 'drizzle-orm';
+import { db } from '@/lib/drizzle';
+import { modelsByProvider, organization_audit_logs, organizations } from '@kilocode/db/schema';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { createTestOrganization } from '@/tests/helpers/organization.helper';
+import { logAutoModelChangesForAllOrgs } from '@/lib/organizations/auto-model-change-log';
+import { applySnapshotChangesAndAudit } from '@/lib/ai-gateway/providers/openrouter/sync-providers';
+import type {
+  NormalizedOpenRouterResponse,
+  NormalizedProvider,
+} from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
+
+function buildSnapshot(
+  providers: Array<{ slug: string; models: string[] }>
+): NormalizedOpenRouterResponse {
+  const mapped: NormalizedProvider[] = providers.map(({ slug, models }) => ({
+    name: slug,
+    displayName: slug,
+    slug,
+    dataPolicy: { training: false, retainsPrompts: false, canPublish: false },
+    models: models.map(modelSlug => ({
+      slug: modelSlug,
+      name: modelSlug,
+      author: slug,
+      description: '',
+      context_length: 0,
+      input_modalities: [],
+      output_modalities: [],
+      group: 'other',
+      updated_at: '',
+      endpoint: {
+        provider_display_name: slug,
+        is_free: false,
+        pricing: { prompt: '0', completion: '0' },
+      },
+    })),
+  }));
+
+  return {
+    providers: mapped,
+    total_providers: mapped.length,
+    total_models: mapped.reduce((sum, p) => sum + p.models.length, 0),
+    generated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+async function fetchAutoChangeLogs(organizationId: string) {
+  return db
+    .select()
+    .from(organization_audit_logs)
+    .where(
+      and(
+        eq(organization_audit_logs.organization_id, organizationId),
+        eq(organization_audit_logs.action, 'organization.settings.auto_change')
+      )
+    );
+}
+
+async function clearSnapshots() {
+  // eslint-disable-next-line drizzle/enforce-delete-with-where
+  await db.delete(modelsByProvider);
+}
+
+describe('logAutoModelChangesForAllOrgs', () => {
+  beforeEach(async () => {
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organization_audit_logs);
+    await clearSnapshots();
+  });
+
+  afterEach(async () => {
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organization_audit_logs);
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organizations);
+    await clearSnapshots();
+  });
+
+  test('writes null-actor audit log per enterprise org when new model becomes available', async () => {
+    const owner = await insertTestUser();
+    const enterpriseOrg = await createTestOrganization('Enterprise GLM Org', owner.id, 0, {
+      provider_policy_mode: 'allow',
+      provider_allow_list: ['z-ai'],
+    });
+
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1'] }]);
+
+    const result = await logAutoModelChangesForAllOrgs(oldSnapshot, newSnapshot);
+
+    expect(result.orgCount).toBe(1);
+    expect(result.logCount).toBe(1);
+
+    const logs = await fetchAutoChangeLogs(enterpriseOrg.id);
+    expect(logs).toHaveLength(1);
+    expect(logs[0].action).toBe('organization.settings.auto_change');
+    expect(logs[0].actor_id).toBeNull();
+    expect(logs[0].actor_email).toBeNull();
+    expect(logs[0].actor_name).toBeNull();
+    expect(logs[0].message).toBe('Added models from provider z-ai: z-ai/glm-5.1');
+  });
+
+  test('writes catalog-removal audit log when upstream catalog drops a previously-allowed model', async () => {
+    const owner = await insertTestUser();
+    const enterpriseOrg = await createTestOrganization('Enterprise Removal Org', owner.id, 0, {
+      provider_policy_mode: 'allow',
+      provider_allow_list: ['z-ai'],
+    });
+
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-4.0', 'z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+
+    await logAutoModelChangesForAllOrgs(oldSnapshot, newSnapshot);
+
+    const logs = await fetchAutoChangeLogs(enterpriseOrg.id);
+    expect(logs).toHaveLength(1);
+    expect(logs[0].message).toBe('Removed models (no longer available): z-ai/glm-4.0');
+  });
+
+  test('writes allowed-provider-removal audit log when model still in catalog but only via non-allowed providers', async () => {
+    const owner = await insertTestUser();
+    const enterpriseOrg = await createTestOrganization('Openai-only Org', owner.id, 0, {
+      provider_policy_mode: 'allow',
+      provider_allow_list: ['openai'],
+    });
+
+    const oldSnapshot = buildSnapshot([
+      { slug: 'openai', models: ['openai/gpt-4o'] },
+      { slug: 'baidu', models: ['openai/gpt-4o'] },
+    ]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'openai', models: [] },
+      { slug: 'baidu', models: ['openai/gpt-4o'] },
+    ]);
+
+    await logAutoModelChangesForAllOrgs(oldSnapshot, newSnapshot);
+
+    const logs = await fetchAutoChangeLogs(enterpriseOrg.id);
+    expect(logs).toHaveLength(1);
+    expect(logs[0].message).toBe(
+      'Removed models (no longer offered by any allowed provider): openai/gpt-4o'
+    );
+  });
+
+  test('does not write any audit log for teams-plan orgs', async () => {
+    const owner = await insertTestUser();
+    const teamsOrg = await createTestOrganization(
+      'Teams Org',
+      owner.id,
+      0,
+      undefined,
+      true /* requireSeats → plan 'teams' */
+    );
+
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1'] }]);
+
+    const result = await logAutoModelChangesForAllOrgs(oldSnapshot, newSnapshot);
+
+    expect(result.orgCount).toBe(0);
+
+    const logs = await fetchAutoChangeLogs(teamsOrg.id);
+    expect(logs).toHaveLength(0);
+  });
+
+  test('skips enterprise orgs whose effective availability did not change', async () => {
+    const owner = await insertTestUser();
+    const restrictedOrg = await createTestOrganization('Restricted to openai only', owner.id, 0, {
+      provider_policy_mode: 'allow',
+      provider_allow_list: ['openai'],
+    });
+
+    const oldSnapshot = buildSnapshot([
+      { slug: 'openai', models: ['openai/gpt-4o'] },
+      { slug: 'z-ai', models: ['z-ai/glm-5'] },
+    ]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'openai', models: ['openai/gpt-4o'] },
+      { slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1'] },
+    ]);
+
+    await logAutoModelChangesForAllOrgs(oldSnapshot, newSnapshot);
+
+    const logs = await fetchAutoChangeLogs(restrictedOrg.id);
+    expect(logs).toHaveLength(0);
+  });
+
+  test('skips writing logs when snapshot has no diff', async () => {
+    const owner = await insertTestUser();
+    const enterpriseOrg = await createTestOrganization('No diff Org', owner.id, 0, {
+      provider_policy_mode: 'allow',
+      provider_allow_list: ['z-ai'],
+    });
+
+    const snapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    const result = await logAutoModelChangesForAllOrgs(snapshot, snapshot);
+
+    expect(result.logCount).toBe(0);
+    const logs = await fetchAutoChangeLogs(enterpriseOrg.id);
+    expect(logs).toHaveLength(0);
+  });
+
+  test('skips writing logs on first run (no previous snapshot)', async () => {
+    const owner = await insertTestUser();
+    const enterpriseOrg = await createTestOrganization('First run Org', owner.id, 0, {
+      provider_policy_mode: 'allow',
+      provider_allow_list: ['z-ai'],
+    });
+
+    const snapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1'] }]);
+    const result = await logAutoModelChangesForAllOrgs(null, snapshot);
+
+    expect(result.logCount).toBe(0);
+    const logs = await fetchAutoChangeLogs(enterpriseOrg.id);
+    expect(logs).toHaveLength(0);
+  });
+
+  test('aggregates multiple changes into a single audit log entry per org', async () => {
+    const owner = await insertTestUser();
+    const enterpriseOrg = await createTestOrganization('Multi-change Org', owner.id, 0, {
+      provider_policy_mode: 'allow',
+      provider_allow_list: ['anthropic', 'z-ai'],
+    });
+
+    const oldSnapshot = buildSnapshot([
+      { slug: 'anthropic', models: ['anthropic/claude-4.5'] },
+      { slug: 'z-ai', models: ['z-ai/glm-4.0', 'z-ai/glm-5'] },
+    ]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'anthropic', models: ['anthropic/claude-4.5', 'anthropic/claude-4.6'] },
+      { slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1'] },
+    ]);
+
+    await logAutoModelChangesForAllOrgs(oldSnapshot, newSnapshot);
+
+    const logs = await fetchAutoChangeLogs(enterpriseOrg.id);
+    expect(logs).toHaveLength(1);
+    expect(logs[0].message).toBe(
+      'Added models from provider anthropic: anthropic/claude-4.6; Added models from provider z-ai: z-ai/glm-5.1; Removed models (no longer available): z-ai/glm-4.0'
+    );
+  });
+});
+
+describe('applySnapshotChangesAndAudit (wiring)', () => {
+  beforeEach(async () => {
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organization_audit_logs);
+    await clearSnapshots();
+  });
+
+  afterEach(async () => {
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organization_audit_logs);
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organizations);
+    await clearSnapshots();
+  });
+
+  test('reads the stored previous snapshot, writes the new one, and emits audit logs based on the diff', async () => {
+    const owner = await insertTestUser();
+    const enterpriseOrg = await createTestOrganization('Wiring Org', owner.id, 0, {
+      provider_policy_mode: 'allow',
+      provider_allow_list: ['z-ai'],
+    });
+
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    await db.insert(modelsByProvider).values({
+      data: oldSnapshot,
+      openrouter: {},
+      vercel: {},
+    });
+
+    const newSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1'] }]);
+    const result = await applySnapshotChangesAndAudit({
+      providers: newSnapshot,
+      openrouter_data: {},
+      vercel_data: {},
+    });
+
+    expect(result.previousSnapshot?.providers[0].models.map(m => m.slug)).toEqual(['z-ai/glm-5']);
+    expect(result.data.providers[0].models.map(m => m.slug)).toEqual([
+      'z-ai/glm-5',
+      'z-ai/glm-5.1',
+    ]);
+
+    const remainingRows = await db.select().from(modelsByProvider);
+    expect(remainingRows).toHaveLength(1);
+    expect(remainingRows[0].id).toBe(result.id);
+
+    const logs = await fetchAutoChangeLogs(enterpriseOrg.id);
+    expect(logs).toHaveLength(1);
+    expect(logs[0].message).toBe('Added models from provider z-ai: z-ai/glm-5.1');
+  });
+
+  test('no previous snapshot row → previousSnapshot null → no audit logs emitted', async () => {
+    const owner = await insertTestUser();
+    const enterpriseOrg = await createTestOrganization('First-run Wiring Org', owner.id, 0, {
+      provider_policy_mode: 'allow',
+      provider_allow_list: ['z-ai'],
+    });
+
+    const newSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1'] }]);
+    const result = await applySnapshotChangesAndAudit({
+      providers: newSnapshot,
+      openrouter_data: {},
+      vercel_data: {},
+    });
+
+    expect(result.previousSnapshot).toBeNull();
+
+    const logs = await fetchAutoChangeLogs(enterpriseOrg.id);
+    expect(logs).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/organizations/auto-model-change-log.integration.test.ts
+++ b/apps/web/src/lib/organizations/auto-model-change-log.integration.test.ts
@@ -312,4 +312,58 @@ describe('applySnapshotChangesAndAudit (wiring)', () => {
     const logs = await fetchAutoChangeLogs(enterpriseOrg.id);
     expect(logs).toHaveLength(0);
   });
+
+  test('advisory lock serializes concurrent calls: second call sees first call’s commit as its previousSnapshot', async () => {
+    const owner = await insertTestUser();
+    const enterpriseOrg = await createTestOrganization('Concurrent Wiring Org', owner.id, 0, {
+      provider_policy_mode: 'allow',
+      provider_allow_list: ['z-ai'],
+    });
+
+    const initialSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    await db.insert(modelsByProvider).values({
+      data: initialSnapshot,
+      openrouter: {},
+      vercel: {},
+    });
+
+    const nextSnapshotA = buildSnapshot([
+      { slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1-a'] },
+    ]);
+    const nextSnapshotB = buildSnapshot([
+      { slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1-a', 'z-ai/glm-5.1-b'] },
+    ]);
+
+    const [resultA, resultB] = await Promise.all([
+      applySnapshotChangesAndAudit({
+        providers: nextSnapshotA,
+        openrouter_data: {},
+        vercel_data: {},
+      }),
+      applySnapshotChangesAndAudit({
+        providers: nextSnapshotB,
+        openrouter_data: {},
+        vercel_data: {},
+      }),
+    ]);
+
+    const sortedById = [resultA, resultB].sort((a, b) => a.id - b.id);
+    const [firstResult, secondResult] = sortedById;
+
+    const firstPreviousModelIds =
+      firstResult.previousSnapshot?.providers[0].models.map(m => m.slug) ?? [];
+    const secondPreviousModelIds =
+      secondResult.previousSnapshot?.providers[0].models.map(m => m.slug) ?? [];
+
+    expect(firstPreviousModelIds).toEqual(['z-ai/glm-5']);
+    expect(secondPreviousModelIds.length).toBeGreaterThan(firstPreviousModelIds.length);
+    expect(secondPreviousModelIds).toContain(
+      firstResult.data.providers[0].models[firstResult.data.providers[0].models.length - 1].slug
+    );
+
+    const logs = await fetchAutoChangeLogs(enterpriseOrg.id);
+    expect(logs).toHaveLength(2);
+    const messages = logs.map(log => log.message).sort();
+    expect(messages).not.toEqual([messages[0], messages[0]]);
+  });
 });

--- a/apps/web/src/lib/organizations/auto-model-change-log.test.ts
+++ b/apps/web/src/lib/organizations/auto-model-change-log.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, test } from '@jest/globals';
+import type { Organization } from '@kilocode/db/schema';
+import type {
+  NormalizedOpenRouterResponse,
+  NormalizedProvider,
+} from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
+import { computeSnapshotDiff } from '@/lib/ai-gateway/providers/openrouter/snapshot-diff';
+import {
+  buildAutoChangeMessage,
+  computeRelevantChangesForOrg,
+  relevantChangesIsEmpty,
+} from '@/lib/organizations/auto-model-change-log';
+
+function buildSnapshot(
+  providers: Array<{ slug: string; models: string[] }>
+): NormalizedOpenRouterResponse {
+  const mapped: NormalizedProvider[] = providers.map(({ slug, models }) => ({
+    name: slug,
+    displayName: slug,
+    slug,
+    dataPolicy: { training: false, retainsPrompts: false, canPublish: false },
+    models: models.map(modelSlug => ({
+      slug: modelSlug,
+      name: modelSlug,
+      author: slug,
+      description: '',
+      context_length: 0,
+      input_modalities: [],
+      output_modalities: [],
+      group: 'other',
+      updated_at: '',
+      endpoint: {
+        provider_display_name: slug,
+        is_free: false,
+        pricing: { prompt: '0', completion: '0' },
+      },
+    })),
+  }));
+
+  return {
+    providers: mapped,
+    total_providers: mapped.length,
+    total_models: mapped.reduce((sum, p) => sum + p.models.length, 0),
+    generated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+function buildEnterpriseOrg(overrides: Partial<Organization> = {}): Organization {
+  return {
+    id: `org-${Math.random()}`,
+    name: 'Test Enterprise Org',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    microdollars_used: 0,
+    microdollars_balance: 0,
+    total_microdollars_acquired: 0,
+    next_credit_expiration_at: null,
+    stripe_customer_id: null,
+    auto_top_up_enabled: false,
+    settings: {},
+    seat_count: 0,
+    require_seats: false,
+    created_by_kilo_user_id: null,
+    deleted_at: null,
+    sso_domain: null,
+    plan: 'enterprise',
+    free_trial_end_at: null,
+    company_domain: null,
+    ...overrides,
+  } satisfies Organization;
+}
+
+describe('computeRelevantChangesForOrg', () => {
+  test('allow-list mode: new model from already-allowed provider is relevant', () => {
+    const org = buildEnterpriseOrg({
+      settings: {
+        provider_policy_mode: 'allow',
+        provider_allow_list: ['z-ai'],
+      },
+    });
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1'] }]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+    const changes = computeRelevantChangesForOrg(org, diff);
+
+    expect(changes.addedByReasonProvider.get('z-ai')).toEqual(['z-ai/glm-5.1']);
+    expect(changes.removedFromCatalog).toEqual([]);
+    expect(changes.removedFromAllowedProviders).toEqual([]);
+  });
+
+  test('allow-list mode: new model from non-allowed provider is NOT relevant', () => {
+    const org = buildEnterpriseOrg({
+      settings: {
+        provider_policy_mode: 'allow',
+        provider_allow_list: ['z-ai'],
+      },
+    });
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'z-ai', models: ['z-ai/glm-5'] },
+      { slug: 'openai', models: ['openai/gpt-4o'] },
+    ]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+    const changes = computeRelevantChangesForOrg(org, diff);
+
+    expect(relevantChangesIsEmpty(changes)).toBe(true);
+  });
+
+  test('allow-list mode: brand-new provider with new model is NOT relevant', () => {
+    const org = buildEnterpriseOrg({
+      settings: {
+        provider_policy_mode: 'allow',
+        provider_allow_list: ['z-ai'],
+      },
+    });
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'z-ai', models: ['z-ai/glm-5'] },
+      { slug: 'new-provider', models: ['new-provider/foo'] },
+    ]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+    const changes = computeRelevantChangesForOrg(org, diff);
+
+    expect(relevantChangesIsEmpty(changes)).toBe(true);
+  });
+
+  test('allow-list mode: new model on the deny list is NOT relevant', () => {
+    const org = buildEnterpriseOrg({
+      settings: {
+        provider_policy_mode: 'allow',
+        provider_allow_list: ['z-ai'],
+        model_deny_list: ['z-ai/glm-5.1'],
+      },
+    });
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5', 'z-ai/glm-5.1'] }]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+    const changes = computeRelevantChangesForOrg(org, diff);
+
+    expect(relevantChangesIsEmpty(changes)).toBe(true);
+  });
+
+  test('legacy deny-list mode (empty deny lists): new model from any provider is relevant', () => {
+    const org = buildEnterpriseOrg({ settings: {} });
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'z-ai', models: ['z-ai/glm-5'] },
+      { slug: 'new-provider', models: ['new-provider/foo'] },
+    ]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+    const changes = computeRelevantChangesForOrg(org, diff);
+
+    expect(changes.addedByReasonProvider.get('new-provider')).toEqual(['new-provider/foo']);
+  });
+
+  test('legacy deny-list mode: new model from denied provider is NOT relevant', () => {
+    const org = buildEnterpriseOrg({
+      settings: { provider_deny_list: ['bad-corp'] },
+    });
+    const oldSnapshot = buildSnapshot([{ slug: 'bad-corp', models: ['bad-corp/old'] }]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'bad-corp', models: ['bad-corp/old', 'bad-corp/new'] },
+    ]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+    const changes = computeRelevantChangesForOrg(org, diff);
+
+    expect(relevantChangesIsEmpty(changes)).toBe(true);
+  });
+
+  test('removed from catalog: model that was accessible is recorded', () => {
+    const org = buildEnterpriseOrg({
+      settings: {
+        provider_policy_mode: 'allow',
+        provider_allow_list: ['z-ai'],
+      },
+    });
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-4.0', 'z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+    const changes = computeRelevantChangesForOrg(org, diff);
+
+    expect(changes.removedFromCatalog).toEqual(['z-ai/glm-4.0']);
+    expect(changes.removedFromAllowedProviders).toEqual([]);
+  });
+
+  test('removed from allowed providers: model still in catalog but only via denied providers', () => {
+    const org = buildEnterpriseOrg({
+      settings: {
+        provider_policy_mode: 'allow',
+        provider_allow_list: ['openai'],
+      },
+    });
+    const oldSnapshot = buildSnapshot([
+      { slug: 'openai', models: ['openai/gpt-4o'] },
+      { slug: 'baidu', models: ['openai/gpt-4o'] },
+    ]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'openai', models: [] },
+      { slug: 'baidu', models: ['openai/gpt-4o'] },
+    ]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+    const changes = computeRelevantChangesForOrg(org, diff);
+
+    expect(changes.removedFromCatalog).toEqual([]);
+    expect(changes.removedFromAllowedProviders).toEqual(['openai/gpt-4o']);
+  });
+
+  test('removed model that was denied is NOT relevant', () => {
+    const org = buildEnterpriseOrg({
+      settings: {
+        provider_policy_mode: 'allow',
+        provider_allow_list: ['z-ai'],
+        model_deny_list: ['z-ai/glm-4.0'],
+      },
+    });
+    const oldSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-4.0', 'z-ai/glm-5'] }]);
+    const newSnapshot = buildSnapshot([{ slug: 'z-ai', models: ['z-ai/glm-5'] }]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+    const changes = computeRelevantChangesForOrg(org, diff);
+
+    expect(relevantChangesIsEmpty(changes)).toBe(true);
+  });
+
+  test('removed model still offered by another allowed provider is NOT relevant', () => {
+    const org = buildEnterpriseOrg({
+      settings: {
+        provider_policy_mode: 'allow',
+        provider_allow_list: ['openai', 'azure'],
+      },
+    });
+    const oldSnapshot = buildSnapshot([
+      { slug: 'openai', models: ['openai/gpt-4o'] },
+      { slug: 'azure', models: ['openai/gpt-4o'] },
+    ]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'openai', models: [] },
+      { slug: 'azure', models: ['openai/gpt-4o'] },
+    ]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+    const changes = computeRelevantChangesForOrg(org, diff);
+
+    expect(relevantChangesIsEmpty(changes)).toBe(true);
+  });
+
+  test('deterministic reason provider: picks first alphabetical allowed provider', () => {
+    const org = buildEnterpriseOrg({
+      settings: {
+        provider_policy_mode: 'allow',
+        provider_allow_list: ['azure', 'openai'],
+      },
+    });
+    const oldSnapshot = buildSnapshot([{ slug: 'azure', models: [] }]);
+    const newSnapshot = buildSnapshot([
+      { slug: 'azure', models: ['openai/gpt-5'] },
+      { slug: 'openai', models: ['openai/gpt-5'] },
+    ]);
+
+    const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+    const changes = computeRelevantChangesForOrg(org, diff);
+
+    expect(changes.addedByReasonProvider.get('azure')).toEqual(['openai/gpt-5']);
+    expect(changes.addedByReasonProvider.has('openai')).toBe(false);
+  });
+});
+
+describe('buildAutoChangeMessage', () => {
+  test('only additions: formats one segment per provider', () => {
+    const message = buildAutoChangeMessage({
+      addedByReasonProvider: new Map([['z-ai', ['z-ai/glm-5.1', 'z-ai/glm-5.1-air']]]),
+      removedFromCatalog: [],
+      removedFromAllowedProviders: [],
+    });
+
+    expect(message).toBe('Added models from provider z-ai: z-ai/glm-5.1, z-ai/glm-5.1-air');
+  });
+
+  test('only catalog removals: formats one catalog-removal segment', () => {
+    const message = buildAutoChangeMessage({
+      addedByReasonProvider: new Map(),
+      removedFromCatalog: ['z-ai/glm-4.0'],
+      removedFromAllowedProviders: [],
+    });
+
+    expect(message).toBe('Removed models (no longer available): z-ai/glm-4.0');
+  });
+
+  test('only allowed-provider removals: formats one allowed-provider-removal segment', () => {
+    const message = buildAutoChangeMessage({
+      addedByReasonProvider: new Map(),
+      removedFromCatalog: [],
+      removedFromAllowedProviders: ['openai/gpt-4o'],
+    });
+
+    expect(message).toBe(
+      'Removed models (no longer offered by any allowed provider): openai/gpt-4o'
+    );
+  });
+
+  test('mixed additions and both removal kinds: providers sorted alphabetically', () => {
+    const message = buildAutoChangeMessage({
+      addedByReasonProvider: new Map([
+        ['z-ai', ['z-ai/glm-5.1']],
+        ['anthropic', ['anthropic/claude-4.6-haiku']],
+      ]),
+      removedFromCatalog: ['z-ai/glm-4.0'],
+      removedFromAllowedProviders: ['openai/gpt-4o'],
+    });
+
+    expect(message).toBe(
+      'Added models from provider anthropic: anthropic/claude-4.6-haiku; Added models from provider z-ai: z-ai/glm-5.1; Removed models (no longer available): z-ai/glm-4.0; Removed models (no longer offered by any allowed provider): openai/gpt-4o'
+    );
+  });
+
+  test('empty input returns empty string', () => {
+    const message = buildAutoChangeMessage({
+      addedByReasonProvider: new Map(),
+      removedFromCatalog: [],
+      removedFromAllowedProviders: [],
+    });
+
+    expect(message).toBe('');
+  });
+});
+
+describe('relevantChangesIsEmpty', () => {
+  test('true when all three buckets are empty', () => {
+    expect(
+      relevantChangesIsEmpty({
+        addedByReasonProvider: new Map(),
+        removedFromCatalog: [],
+        removedFromAllowedProviders: [],
+      })
+    ).toBe(true);
+  });
+
+  test('false when additions present', () => {
+    expect(
+      relevantChangesIsEmpty({
+        addedByReasonProvider: new Map([['z-ai', ['z-ai/glm-5']]]),
+        removedFromCatalog: [],
+        removedFromAllowedProviders: [],
+      })
+    ).toBe(false);
+  });
+
+  test('false when catalog removals present', () => {
+    expect(
+      relevantChangesIsEmpty({
+        addedByReasonProvider: new Map(),
+        removedFromCatalog: ['z-ai/glm-4.0'],
+        removedFromAllowedProviders: [],
+      })
+    ).toBe(false);
+  });
+
+  test('false when allowed-provider removals present', () => {
+    expect(
+      relevantChangesIsEmpty({
+        addedByReasonProvider: new Map(),
+        removedFromCatalog: [],
+        removedFromAllowedProviders: ['openai/gpt-4o'],
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/organizations/auto-model-change-log.ts
+++ b/apps/web/src/lib/organizations/auto-model-change-log.ts
@@ -1,0 +1,248 @@
+import { captureException } from '@sentry/nextjs';
+import { eq } from 'drizzle-orm';
+import type { Organization } from '@kilocode/db/schema';
+import { organizations } from '@kilocode/db/schema';
+import { db } from '@/lib/drizzle';
+import { normalizeModelId } from '@/lib/ai-gateway/model-utils';
+import { getEffectiveModelRestrictions } from '@/lib/organizations/model-restrictions';
+import type { ModelRestrictions } from '@/lib/model-allow.server';
+import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
+import type { NormalizedOpenRouterResponse } from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
+import {
+  computeSnapshotDiff,
+  type SnapshotDiff,
+} from '@/lib/ai-gateway/providers/openrouter/snapshot-diff';
+
+export type RelevantChanges = {
+  /** providerSlug -> sorted list of normalized model ids newly accessible via that provider */
+  addedByReasonProvider: Map<string, string[]>;
+  /** normalized model ids removed from the catalog entirely (no provider offers them anymore) */
+  removedFromCatalog: string[];
+  /**
+   * Normalized model ids still in the catalog but no longer offered by any provider
+   * this org allows — effectively lost access even though the model still exists upstream.
+   */
+  removedFromAllowedProviders: string[];
+};
+
+type Availability = { allowed: boolean; reasonProvider: string | null };
+
+type PrecomputedRestrictions = {
+  modelDenySet: Set<string>;
+  providerAllowSet: Set<string> | undefined;
+  providerDenySet: Set<string>;
+};
+
+function precompute(restrictions: ModelRestrictions): PrecomputedRestrictions {
+  return {
+    modelDenySet: new Set(restrictions.modelDenyList.map(normalizeModelId)),
+    providerAllowSet: restrictions.providerAllowList
+      ? new Set(restrictions.providerAllowList)
+      : undefined,
+    providerDenySet: new Set(restrictions.providerDenyList),
+  };
+}
+
+/**
+ * Determine whether a model id is accessible to an org given a model→providers
+ * index snapshot. Returns `{ allowed: true, reasonProvider }` when accessible,
+ * where `reasonProvider` is a deterministically-picked provider slug (first
+ * alphabetically among allowed providers) that admits the model — used as the
+ * human-readable "because of X" reason.
+ */
+function checkAvailability(
+  providerSlugsForModel: Set<string> | undefined,
+  modelId: string,
+  precomputed: PrecomputedRestrictions
+): Availability {
+  if (precomputed.modelDenySet.has(modelId)) {
+    return { allowed: false, reasonProvider: null };
+  }
+  if (!providerSlugsForModel || providerSlugsForModel.size === 0) {
+    return { allowed: false, reasonProvider: null };
+  }
+
+  const sortedProviders = [...providerSlugsForModel].sort((a, b) => a.localeCompare(b));
+
+  const { providerAllowSet } = precomputed;
+  if (providerAllowSet !== undefined) {
+    const allowedProvider = sortedProviders.find(slug => providerAllowSet.has(slug));
+    return allowedProvider
+      ? { allowed: true, reasonProvider: allowedProvider }
+      : { allowed: false, reasonProvider: null };
+  }
+
+  const nonDeniedProvider = sortedProviders.find(slug => !precomputed.providerDenySet.has(slug));
+  return nonDeniedProvider
+    ? { allowed: true, reasonProvider: nonDeniedProvider }
+    : { allowed: false, reasonProvider: null };
+}
+
+/**
+ * Walk the diff and, for a single organization's effective restrictions,
+ * collect the set of model changes that actually affect what this org can see.
+ *
+ * - Additions: a model is included when it is now accessible under the org's
+ *   current settings AND was NOT accessible before. This naturally handles:
+ *     - "new model on existing provider" (e.g. GLM 5.1 under z-ai)
+ *     - "existing model newly offered by an allowed provider"
+ *     - "brand-new provider" (ignored for allow-list mode orgs; admitted for
+ *       legacy deny-list mode orgs whose deny list doesn't cover it)
+ * - Removals: a model is included when it was accessible under the org's
+ *   current settings using the OLD catalog but is no longer accessible now,
+ *   distinguishing:
+ *     - `removedFromCatalog`: the model is gone from upstream entirely.
+ *     - `removedFromAllowedProviders`: the model still exists upstream but
+ *       every provider offering it is now outside the org's allow list.
+ */
+export function computeRelevantChangesForOrg(
+  organization: Organization,
+  diff: SnapshotDiff
+): RelevantChanges {
+  const precomputed = precompute(getEffectiveModelRestrictions(organization));
+
+  const addedByReasonProvider = new Map<string, string[]>();
+  const removedFromCatalog: string[] = [];
+  const removedFromAllowedProviders: string[] = [];
+
+  const affectedModelIds = new Set<string>();
+  for (const list of diff.addedByProvider.values()) {
+    for (const modelId of list) affectedModelIds.add(modelId);
+  }
+  for (const list of diff.removedByProvider.values()) {
+    for (const modelId of list) affectedModelIds.add(modelId);
+  }
+
+  for (const modelId of affectedModelIds) {
+    const oldProviders = diff.oldModelProvidersIndex.get(modelId);
+    const newProviders = diff.newModelProvidersIndex.get(modelId);
+
+    const before = checkAvailability(oldProviders, modelId, precomputed);
+    const after = checkAvailability(newProviders, modelId, precomputed);
+
+    if (!before.allowed && after.allowed && after.reasonProvider) {
+      const list = addedByReasonProvider.get(after.reasonProvider);
+      if (list) {
+        list.push(modelId);
+      } else {
+        addedByReasonProvider.set(after.reasonProvider, [modelId]);
+      }
+    } else if (before.allowed && !after.allowed) {
+      if (!newProviders || newProviders.size === 0) {
+        removedFromCatalog.push(modelId);
+      } else {
+        removedFromAllowedProviders.push(modelId);
+      }
+    }
+  }
+
+  for (const list of addedByReasonProvider.values()) {
+    list.sort((a, b) => a.localeCompare(b));
+  }
+  removedFromCatalog.sort((a, b) => a.localeCompare(b));
+  removedFromAllowedProviders.sort((a, b) => a.localeCompare(b));
+
+  return { addedByReasonProvider, removedFromCatalog, removedFromAllowedProviders };
+}
+
+export function relevantChangesIsEmpty(changes: RelevantChanges): boolean {
+  return (
+    changes.addedByReasonProvider.size === 0 &&
+    changes.removedFromCatalog.length === 0 &&
+    changes.removedFromAllowedProviders.length === 0
+  );
+}
+
+/**
+ * Build a human-readable, deterministic audit log message describing all
+ * relevant model additions and removals for one organization in one sync.
+ *
+ * Segments (each conditionally present, joined by `'; '`):
+ *   Added models from provider {slug}: {id1}, {id2}
+ *   Removed models (no longer available): {id1}, {id2}
+ *   Removed models (no longer offered by any allowed provider): {id1}, {id2}
+ */
+export function buildAutoChangeMessage(changes: RelevantChanges): string {
+  const segments: string[] = [];
+
+  const sortedProviders = [...changes.addedByReasonProvider.keys()].sort((a, b) =>
+    a.localeCompare(b)
+  );
+  for (const providerSlug of sortedProviders) {
+    const models = changes.addedByReasonProvider.get(providerSlug);
+    if (models && models.length > 0) {
+      segments.push(`Added models from provider ${providerSlug}: ${models.join(', ')}`);
+    }
+  }
+
+  if (changes.removedFromCatalog.length > 0) {
+    segments.push(`Removed models (no longer available): ${changes.removedFromCatalog.join(', ')}`);
+  }
+
+  if (changes.removedFromAllowedProviders.length > 0) {
+    segments.push(
+      `Removed models (no longer offered by any allowed provider): ${changes.removedFromAllowedProviders.join(', ')}`
+    );
+  }
+
+  return segments.join('; ');
+}
+
+export type LogResult = {
+  orgCount: number;
+  logCount: number;
+};
+
+/**
+ * Compute the diff between the previous and current OpenRouter snapshots and
+ * write one audit log row per enterprise organization whose effective model
+ * availability changed. Attributed to `System` via null actor fields.
+ *
+ * Safe to call from inside a background job; individual per-org failures are
+ * reported to Sentry and do not break the rest of the loop.
+ */
+export async function logAutoModelChangesForAllOrgs(
+  oldSnapshot: NormalizedOpenRouterResponse | null,
+  newSnapshot: NormalizedOpenRouterResponse
+): Promise<LogResult> {
+  const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+
+  if (diff.addedByProvider.size === 0 && diff.removedByProvider.size === 0) {
+    return { orgCount: 0, logCount: 0 };
+  }
+
+  const enterpriseOrgs = await db
+    .select()
+    .from(organizations)
+    .where(eq(organizations.plan, 'enterprise'));
+
+  let logCount = 0;
+  for (const organization of enterpriseOrgs) {
+    const changes = computeRelevantChangesForOrg(organization, diff);
+    if (relevantChangesIsEmpty(changes)) continue;
+
+    const message = buildAutoChangeMessage(changes);
+    try {
+      await createAuditLog({
+        action: 'organization.settings.auto_change',
+        actor_id: null,
+        actor_email: null,
+        actor_name: null,
+        message,
+        organization_id: organization.id,
+      });
+      logCount++;
+    } catch (err) {
+      console.error(
+        `[auto-model-change-log] failed to write audit log for org ${organization.id}`,
+        err
+      );
+      captureException(err, {
+        tags: { component: 'auto-model-change-log' },
+        extra: { organization_id: organization.id, message },
+      });
+    }
+  }
+
+  return { orgCount: enterpriseOrgs.length, logCount };
+}

--- a/apps/web/src/scripts/audit-logs/simulate-auto-model-change.ts
+++ b/apps/web/src/scripts/audit-logs/simulate-auto-model-change.ts
@@ -1,0 +1,203 @@
+/**
+ * Simulate a system-initiated model-access change for a given organization.
+ *
+ * Writes a real audit log entry (action `organization.settings.auto_change`,
+ * null actor = "System") using the production code path, so you can verify
+ * the rendering at `/organizations/<id>/audit-logs`.
+ *
+ * Usage:
+ *   pnpm script:run audit-logs simulate-auto-model-change <org_id> [scenario]
+ *
+ * Scenarios:
+ *   added     — new model from an already-allowed provider (default)
+ *   removed   — model disappears from the provider catalog
+ *   mixed     — additions + catalog removal in one entry
+ *
+ * Examples:
+ *   pnpm script:run audit-logs simulate-auto-model-change 00000000-0000-0000-0000-000000000000
+ *   pnpm script:run audit-logs simulate-auto-model-change 00000000-0000-0000-0000-000000000000 removed
+ *   pnpm script:run audit-logs simulate-auto-model-change 00000000-0000-0000-0000-000000000000 mixed
+ *
+ * The org must be on the enterprise plan (otherwise the feature is a no-op).
+ * The script will pick a provider slug from the org's allow list (or fabricate
+ * one for legacy deny-list mode orgs) so the synthetic diff is relevant.
+ */
+import { eq } from 'drizzle-orm';
+import { db } from '@/lib/drizzle';
+import { organization_audit_logs, organizations } from '@kilocode/db/schema';
+import type { NormalizedOpenRouterResponse } from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
+import { computeSnapshotDiff } from '@/lib/ai-gateway/providers/openrouter/snapshot-diff';
+import {
+  buildAutoChangeMessage,
+  computeRelevantChangesForOrg,
+  relevantChangesIsEmpty,
+} from '@/lib/organizations/auto-model-change-log';
+import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
+
+type Scenario = 'added' | 'removed' | 'mixed';
+
+function buildSnapshot(
+  providers: Array<{ slug: string; models: string[] }>
+): NormalizedOpenRouterResponse {
+  return {
+    providers: providers.map(({ slug, models }) => ({
+      name: slug,
+      displayName: slug,
+      slug,
+      dataPolicy: { training: false, retainsPrompts: false, canPublish: false },
+      models: models.map(modelSlug => ({
+        slug: modelSlug,
+        name: modelSlug,
+        author: slug,
+        description: '',
+        context_length: 0,
+        input_modalities: [],
+        output_modalities: [],
+        group: 'other',
+        updated_at: '',
+        endpoint: {
+          provider_display_name: slug,
+          is_free: false,
+          pricing: { prompt: '0', completion: '0' },
+        },
+      })),
+    })),
+    total_providers: providers.length,
+    total_models: providers.reduce((sum, p) => sum + p.models.length, 0),
+    generated_at: new Date().toISOString(),
+  };
+}
+
+function pickTargetProvider(settings: {
+  provider_policy_mode?: 'allow';
+  provider_allow_list?: string[];
+  provider_deny_list?: string[];
+}): { slug: string; mode: 'allow-list' | 'legacy' | 'default' } {
+  if (settings.provider_policy_mode === 'allow' && settings.provider_allow_list?.length) {
+    return { slug: settings.provider_allow_list[0], mode: 'allow-list' };
+  }
+  if (settings.provider_deny_list?.length) {
+    return { slug: 'z-ai', mode: 'legacy' };
+  }
+  return { slug: 'z-ai', mode: 'default' };
+}
+
+function buildScenarioSnapshots(
+  scenario: Scenario,
+  providerSlug: string,
+  suffix: string
+): { oldSnapshot: NormalizedOpenRouterResponse; newSnapshot: NormalizedOpenRouterResponse } {
+  const stableModel = `${providerSlug}/sim-stable-${suffix}`;
+  const addedModel = `${providerSlug}/sim-added-${suffix}`;
+  const removedModel = `${providerSlug}/sim-removed-${suffix}`;
+
+  switch (scenario) {
+    case 'added':
+      return {
+        oldSnapshot: buildSnapshot([{ slug: providerSlug, models: [stableModel] }]),
+        newSnapshot: buildSnapshot([{ slug: providerSlug, models: [stableModel, addedModel] }]),
+      };
+    case 'removed':
+      return {
+        oldSnapshot: buildSnapshot([{ slug: providerSlug, models: [stableModel, removedModel] }]),
+        newSnapshot: buildSnapshot([{ slug: providerSlug, models: [stableModel] }]),
+      };
+    case 'mixed':
+      return {
+        oldSnapshot: buildSnapshot([{ slug: providerSlug, models: [stableModel, removedModel] }]),
+        newSnapshot: buildSnapshot([{ slug: providerSlug, models: [stableModel, addedModel] }]),
+      };
+  }
+}
+
+function parseScenario(raw: string | undefined): Scenario {
+  if (!raw) return 'added';
+  if (raw === 'added' || raw === 'removed' || raw === 'mixed') return raw;
+  throw new Error(`Unknown scenario "${raw}". Expected: added | removed | mixed.`);
+}
+
+export async function run(orgId?: string, scenarioArg?: string): Promise<void> {
+  if (!orgId) {
+    console.error(
+      'Usage: pnpm script:run audit-logs simulate-auto-model-change <org_id> [added|removed|mixed]'
+    );
+    process.exit(1);
+  }
+
+  const scenario = parseScenario(scenarioArg);
+
+  const [organization] = await db.select().from(organizations).where(eq(organizations.id, orgId));
+
+  if (!organization) {
+    console.error(`Organization ${orgId} not found.`);
+    process.exit(1);
+  }
+
+  if (organization.plan !== 'enterprise') {
+    console.error(
+      `Organization ${orgId} is on plan "${organization.plan}", not "enterprise". ` +
+        `Auto-change audit logs only fire for enterprise orgs. Change the plan and re-run.`
+    );
+    process.exit(1);
+  }
+
+  const { slug: providerSlug, mode } = pickTargetProvider(organization.settings ?? {});
+  const suffix = Math.random().toString(36).slice(2, 8);
+
+  const { oldSnapshot, newSnapshot } = buildScenarioSnapshots(scenario, providerSlug, suffix);
+  const diff = computeSnapshotDiff(oldSnapshot, newSnapshot);
+  const changes = computeRelevantChangesForOrg(organization, diff);
+
+  console.log(`Organization:   "${organization.name}" (${organization.id})`);
+  console.log(`Plan:           ${organization.plan}`);
+  console.log(`Policy mode:    ${mode}`);
+  console.log(`Target provider: ${providerSlug}`);
+  console.log(`Scenario:       ${scenario}`);
+  console.log('');
+
+  if (relevantChangesIsEmpty(changes)) {
+    console.warn(
+      `The synthetic diff produces no relevant changes for this org. ` +
+        `Likely the chosen provider ("${providerSlug}") is not accessible under the org's ` +
+        `effective restrictions. Check settings.provider_allow_list / provider_deny_list / ` +
+        `model_deny_list, then re-run.`
+    );
+    process.exit(1);
+  }
+
+  const message = buildAutoChangeMessage(changes);
+  console.log(`Message: ${message}`);
+
+  const log = await createAuditLog({
+    action: 'organization.settings.auto_change',
+    actor_id: null,
+    actor_email: null,
+    actor_name: null,
+    message,
+    organization_id: organization.id,
+  });
+
+  console.log('');
+  console.log(`Wrote audit log row id=${log.id} at ${log.created_at}`);
+  console.log(
+    `View it at: /organizations/${organization.id}/audit-logs (filter by action "settings.auto_change" or search "${providerSlug}")`
+  );
+
+  const recent = await db
+    .select({
+      id: organization_audit_logs.id,
+      created_at: organization_audit_logs.created_at,
+      action: organization_audit_logs.action,
+      message: organization_audit_logs.message,
+    })
+    .from(organization_audit_logs)
+    .where(eq(organization_audit_logs.organization_id, organization.id))
+    .orderBy(organization_audit_logs.created_at)
+    .limit(10);
+
+  console.log('');
+  console.log(`Recent audit log entries for this org (up to 10):`);
+  for (const row of recent.slice(-10)) {
+    console.log(`  [${row.created_at}] ${row.action}: ${row.message}`);
+  }
+}

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -355,6 +355,7 @@ export const AuditLogAction = z.enum([
   'organization.user.send_invite', // ✅
   'organization.user.revoke_invite', // ✅
   'organization.settings.change', // ✅
+  'organization.settings.auto_change', // ✅ (system-initiated; null actor)
   'organization.purchase_credits', // ✅
   'organization.promo_credit_granted', // ✅
   'organization.member.remove', // ✅


### PR DESCRIPTION
## Summary

Adds audit log entries attributed to **System** whenever the model catalog sync causes a model to become newly accessible or newly unavailable to an enterprise organization. 

- New enum value `organization.settings.auto_change` on `AuditLogAction` (no DB migration; `action` is a `text` column).
- New pure helper `computeSnapshotDiff` diffs two provider snapshots to detect model additions/removals per provider.
- New per-org helper `computeRelevantChangesForOrg` + `buildAutoChangeMessage` determine which diff entries actually affect each enterprise org (respecting allow-list / legacy deny-list / model deny list) and formats the message. Produces three outcome buckets:
  - `Added models from provider {slug}: {id1}, {id2}`
  - `Removed models (no longer available): {id1}` — model gone from catalog entirely
  - `Removed models (no longer offered by any allowed provider): {id1}` — model still exists but all offering providers now outside the org's allow list
- Orchestrator `logAutoModelChangesForAllOrgs` loads enterprise orgs and writes one aggregated audit log row per affected org with null actor fields. Per-org failures go to Sentry without breaking the rest of the loop.
- New extracted helper `applySnapshotChangesAndAudit` in `sync-providers.ts` reads the previous snapshot **inside the same transaction** as the new snapshot insert (prevents concurrent sync races observing partial writes), then emits audit logs outside the transaction. Wraps audit emission in try/catch so audit-write failures cannot break the catalog sync.
- Dev simulation script at `apps/web/src/scripts/audit-logs/simulate-auto-model-change.ts` exercises the full diff → relevance → message → insert pipeline with synthetic snapshots. Useful for demoing UI rendering without waiting for real catalog changes.
- No UI changes needed: the filter dropdown auto-populates from the enum via `getActionTypes`, and the table/modal already render null-actor rows as italic "System".

## Verification

- Opened the dev audit log page at `/organizations/00000000-0000-0000-0000-000000000000/audit-logs` and ran all three simulation scenarios (`added`, `removed`, `mixed`). Rendered rows showed Actor=System, Action=`settings.auto_change`, and the expected aggregated messages.
- Verified the action filter dropdown picked up the new `settings.auto_change` option automatically.

## Visual Changes

<img width="2498" height="1140" alt="image" src="https://github.com/user-attachments/assets/1900d773-a104-4d0e-ab7a-e477d3a87064" />

## Reviewer Notes

- **Deterministic output**: messages are built from sorted keys/arrays so repeated runs with the same diff produce the same string — safe to snapshot-compare in tests.
- **First-run behavior**: if no previous snapshot exists (fresh DB, first deploy), `computeSnapshotDiff` short-circuits with an empty diff — prevents a one-time flood of per-org "initial state" entries.
- **Plan gating**: `logAutoModelChangesForAllOrgs` queries enterprise orgs only. Teams-plan orgs don't enforce model restrictions, so catalog changes have no per-org effect worth logging.
- **Race safety**: previous-snapshot read was intentionally moved **inside** the write transaction in `applySnapshotChangesAndAudit` so two overlapping sync runs cannot both read the same "previous" row.
- **No schema migration**: `organization_audit_logs.action` is a plain `text` column, so the enum addition is a type-only change.
- **Out of scope**: pruning stale `model_deny_list` entries when upstream drops a model; backfilling historical auto-change events.