### PR TITLE
fix(kiloclaw): recover stale gateway-client pairing

### DIFF
--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -72,7 +72,6 @@ RUN npm install -g openclaw@2026.4.26 \
     && sed -i 's/MESSAGE_ACTION_TARGET_MODE\[action\] !== "none"/\(MESSAGE_ACTION_TARGET_MODE[action] ?? "none"\) !== "none"/' "$CT_FILE" \
     && if grep -q 'MESSAGE_ACTION_TARGET_MODE\[action\] !== "none"' "$CT_FILE"; then echo "ERROR: actionRequiresTarget patch failed" >&2; exit 1; fi \
     && echo "OK: patched actionRequiresTarget in $(basename "$CT_FILE")" \
-    && test "$(openclaw --version)" = "2026.4.26" \
     && openclaw --version
 
 # Bake bundled plugin runtime deps into the image so first boot is pure

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -55,23 +55,24 @@ RUN npm install -g pnpm
 # Patch: bump model discovery timeout from 5s to 60s — shared-cpu machines
 # under boot load routinely need 27-35s for the first TLS+fetch to complete.
 # Remove this sed patch once openclaw exposes a configurable timeout.
-RUN npm install -g openclaw@2026.4.15 \
+RUN npm install -g openclaw@2026.4.26 \
     && OC_DIST=/usr/local/lib/node_modules/openclaw/dist \
-    && FOUND_FILES=$(find "$OC_DIST" -name 'provider-models-*.js' | wc -l | tr -d ' ') \
-    && if [ "$FOUND_FILES" -eq 0 ]; then echo "ERROR: provider-models-*.js not found in openclaw dist" >&2; exit 1; fi \
+    && FOUND_FILES=$(find "$OC_DIST" -name 'provider-models-*.js' -exec grep -l 'DISCOVERY_TIMEOUT_MS = 5e3' {} \; | wc -l | tr -d ' ') \
+    && if [ "$FOUND_FILES" -eq 0 ]; then echo "ERROR: no provider-models-*.js with DISCOVERY_TIMEOUT_MS = 5e3 found in openclaw dist" >&2; exit 1; fi \
     && BEFORE=$(grep -h 'DISCOVERY_TIMEOUT_MS = 5e3' "$OC_DIST"/provider-models-*.js 2>/dev/null | wc -l | tr -d ' ') \
-    && if [ "$BEFORE" -ne 1 ]; then echo "ERROR: expected exactly 1 occurrence of DISCOVERY_TIMEOUT_MS = 5e3, found $BEFORE - openclaw may have changed" >&2; exit 1; fi \
-    && PM_FILE=$(grep -l 'DISCOVERY_TIMEOUT_MS = 5e3' "$OC_DIST"/provider-models-*.js 2>/dev/null | head -1) \
-    && sed -i 's/DISCOVERY_TIMEOUT_MS = 5e3/DISCOVERY_TIMEOUT_MS = 60e3/' "$PM_FILE" \
+    && if [ "$BEFORE" -eq 0 ]; then echo "ERROR: DISCOVERY_TIMEOUT_MS = 5e3 not found - openclaw may have changed" >&2; exit 1; fi \
+    && grep -l 'DISCOVERY_TIMEOUT_MS = 5e3' "$OC_DIST"/provider-models-*.js 2>/dev/null \
+       | xargs sed -i 's/DISCOVERY_TIMEOUT_MS = 5e3/DISCOVERY_TIMEOUT_MS = 60e3/g' \
     && AFTER=$(grep -h 'DISCOVERY_TIMEOUT_MS = 60e3' "$OC_DIST"/provider-models-*.js 2>/dev/null | wc -l | tr -d ' ') \
-    && if [ "$AFTER" -ne 1 ]; then echo "ERROR: sed patch failed - expected 1 occurrence of 60e3, found $AFTER" >&2; exit 1; fi \
+    && if [ "$AFTER" -ne "$BEFORE" ]; then echo "ERROR: sed patch failed - expected $BEFORE occurrence(s) of 60e3, found $AFTER" >&2; exit 1; fi \
     && if grep -q 'DISCOVERY_TIMEOUT_MS = 5e3' "$OC_DIST"/provider-models-*.js 2>/dev/null; then echo "ERROR: old 5e3 value still present after patch" >&2; exit 1; fi \
-    && echo "OK: patched DISCOVERY_TIMEOUT_MS 5e3 -> 60e3 in $(basename "$PM_FILE")" \
+    && echo "OK: patched DISCOVERY_TIMEOUT_MS 5e3 -> 60e3 in $FOUND_FILES provider model file(s)" \
     && CT_FILE=$(find "$OC_DIST" -name 'channel-target-*.js' | head -1) \
     && if [ -z "$CT_FILE" ]; then echo "ERROR: channel-target-*.js not found in openclaw dist" >&2; exit 1; fi \
     && sed -i 's/MESSAGE_ACTION_TARGET_MODE\[action\] !== "none"/\(MESSAGE_ACTION_TARGET_MODE[action] ?? "none"\) !== "none"/' "$CT_FILE" \
     && if grep -q 'MESSAGE_ACTION_TARGET_MODE\[action\] !== "none"' "$CT_FILE"; then echo "ERROR: actionRequiresTarget patch failed" >&2; exit 1; fi \
     && echo "OK: patched actionRequiresTarget in $(basename "$CT_FILE")" \
+    && test "$(openclaw --version)" = "2026.4.26" \
     && openclaw --version
 
 # Bake bundled plugin runtime deps into the image so first boot is pure

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -667,6 +667,7 @@ describe('generateBaseConfig', () => {
     expect(config.channels.telegram.botToken).toBe('tg-token-123');
     expect(config.channels.telegram.enabled).toBe(true);
     expect(config.channels.telegram.dmPolicy).toBe('pairing');
+    expect(config.channels.telegram.groupPolicy).toBe('open');
     expect(config.plugins.entries.telegram.enabled).toBe(true);
   });
 
@@ -690,6 +691,57 @@ describe('generateBaseConfig', () => {
     expect(config.channels.telegram.enabled).toBe(true);
     expect(config.channels.telegram.groupPolicy).toBe('restricted');
     expect(config.channels.telegram.customField).toBe('user-value');
+  });
+
+  it('does not default Telegram group policy when group access is already configured', () => {
+    const existing = JSON.stringify({
+      channels: {
+        telegram: {
+          botToken: 'tg-token-old',
+          enabled: true,
+          dmPolicy: 'pairing',
+          groups: { '-5055658641': {} },
+        },
+      },
+    });
+    const { deps } = fakeDeps(existing);
+    const env = { ...minimalEnv(), TELEGRAM_BOT_TOKEN: 'tg-token-new' };
+    const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
+
+    expect(config.channels.telegram.groupPolicy).toBeUndefined();
+    expect(config.channels.telegram.groups).toEqual({ '-5055658641': {} });
+  });
+
+  it('does not default Telegram group policy when sender access is already configured', () => {
+    const existing = JSON.stringify({
+      channels: {
+        telegram: {
+          botToken: 'tg-token-old',
+          enabled: true,
+          dmPolicy: 'pairing',
+          allowFrom: ['7676134290'],
+        },
+      },
+    });
+    const { deps } = fakeDeps(existing);
+    const env = { ...minimalEnv(), TELEGRAM_BOT_TOKEN: 'tg-token-new' };
+    const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
+
+    expect(config.channels.telegram.groupPolicy).toBeUndefined();
+    expect(config.channels.telegram.allowFrom).toEqual(['7676134290']);
+  });
+
+  it('does not default Telegram group policy when env supplies sender access', () => {
+    const { deps } = fakeDeps();
+    const env = {
+      ...minimalEnv(),
+      TELEGRAM_BOT_TOKEN: 'tg-token-new',
+      TELEGRAM_DM_ALLOW_FROM: '7676134290',
+    };
+    const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
+
+    expect(config.channels.telegram.groupPolicy).toBeUndefined();
+    expect(config.channels.telegram.allowFrom).toEqual(['7676134290']);
   });
 
   it('configures Telegram with open DM policy and allowFrom wildcard', () => {

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -932,6 +932,8 @@ describe('generateBaseConfig', () => {
     expect(config.hooks.enabled).toBe(true);
     expect(config.hooks.token).toBe('test-hooks-token');
     expect(config.hooks.path).toBe('/hooks');
+    expect(config.hooks.allowRequestSessionKey).toBe(true);
+    expect(config.hooks.allowedSessionKeyPrefixes).toEqual(['hook:', 'inbound-email:']);
     expect(config.hooks.presets).toBeUndefined();
     expect(config.hooks.mappings).toContainEqual({
       id: 'cloudflare-email-inbound',
@@ -971,6 +973,8 @@ describe('generateBaseConfig', () => {
     const env = { ...minimalEnv(), KILOCLAW_HOOKS_TOKEN: 'test-hooks-token' };
     const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
 
+    expect(config.hooks.allowRequestSessionKey).toBe(true);
+    expect(config.hooks.allowedSessionKeyPrefixes).toEqual(['hook:', 'inbound-email:']);
     expect(config.hooks.mappings).toContainEqual({
       id: 'cloudflare-email-inbound',
       match: { path: 'email' },

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -541,6 +541,8 @@ export function generateBaseConfig(
     config.hooks.enabled = true;
     config.hooks.token = env.KILOCLAW_HOOKS_TOKEN;
     config.hooks.path = '/hooks';
+    config.hooks.allowRequestSessionKey = true;
+    config.hooks.allowedSessionKeyPrefixes = ['hook:', 'inbound-email:'];
 
     config.hooks.mappings = Array.isArray(config.hooks.mappings)
       ? config.hooks.mappings.map((mapping: ConfigObject) => migrateHookMapping(mapping))

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -9,6 +9,7 @@ import { execFileSync as nodeExecFileSync } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { shouldDefaultTelegramGroupPolicyOpen } from './telegram-group-policy';
 
 const DEFAULT_CONFIG_PATH = '/root/.openclaw/openclaw.json';
 
@@ -436,6 +437,9 @@ export function generateBaseConfig(
       config.channels.telegram.allowFrom = env.TELEGRAM_DM_ALLOW_FROM.split(',');
     } else if (!('allowFrom' in config.channels.telegram)) {
       config.channels.telegram.allowFrom = dmPolicy === 'open' ? ['*'] : [];
+    }
+    if (shouldDefaultTelegramGroupPolicyOpen(config.channels.telegram)) {
+      config.channels.telegram.groupPolicy = 'open';
     }
 
     config.plugins = config.plugins ?? {};

--- a/services/kiloclaw/controller/src/device-pairing-repair.test.ts
+++ b/services/kiloclaw/controller/src/device-pairing-repair.test.ts
@@ -1,0 +1,312 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { repairInternalGatewayClientPairingState } from './device-pairing-repair.js';
+
+const tempDirs: string[] = [];
+
+function makeStateDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kiloclaw-pairing-repair-'));
+  tempDirs.push(dir);
+  fs.mkdirSync(path.join(dir, 'devices'), { recursive: true });
+  return dir;
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readJson(filePath: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+}
+
+function pairedPath(stateDir: string): string {
+  return path.join(stateDir, 'devices', 'paired.json');
+}
+
+function pendingPath(stateDir: string): string {
+  return path.join(stateDir, 'devices', 'pending.json');
+}
+
+function staleGatewayClientDevice(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    deviceId: 'gateway-device',
+    publicKey: 'public-key-redacted',
+    clientId: 'gateway-client',
+    clientMode: 'backend',
+    role: 'operator',
+    roles: ['operator'],
+    scopes: ['operator.read'],
+    approvedScopes: ['operator.read'],
+    tokens: {
+      operator: {
+        token: 'token-redacted',
+        role: 'operator',
+        scopes: ['operator.read'],
+        createdAtMs: 1,
+      },
+    },
+    createdAtMs: 1,
+    approvedAtMs: 2,
+    ...overrides,
+  };
+}
+
+function pendingGatewayClientRequest(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    requestId: 'request-1',
+    deviceId: 'gateway-device',
+    publicKey: 'public-key-redacted',
+    clientId: 'gateway-client',
+    clientMode: 'backend',
+    role: 'operator',
+    roles: ['operator'],
+    scopes: ['operator.approvals'],
+    ts: Date.now(),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('repairInternalGatewayClientPairingState', () => {
+  it('repairs a stale paired gateway-client backend even without a pending request', () => {
+    const stateDir = makeStateDir();
+    writeJson(pairedPath(stateDir), { 'gateway-device': staleGatewayClientDevice() });
+    writeJson(pendingPath(stateDir), {});
+
+    const result = repairInternalGatewayClientPairingState({ stateDir });
+
+    expect(result).toEqual({
+      status: 'repaired',
+      pairedDevicesRepaired: 1,
+      pendingRequestsRemoved: 0,
+      operatorTokenScopesUpdated: true,
+      warnings: [],
+    });
+    const paired = readJson(pairedPath(stateDir));
+    const device = paired['gateway-device'] as Record<string, unknown>;
+    expect(device.scopes).toEqual(['operator.read', 'operator.approvals']);
+    expect(device.approvedScopes).toEqual(['operator.read', 'operator.approvals']);
+    expect((device.tokens as Record<string, Record<string, unknown>>).operator.scopes).toEqual([
+      'operator.read',
+      'operator.approvals',
+    ]);
+    expect((device.tokens as Record<string, Record<string, unknown>>).operator.token).toBe(
+      'token-redacted'
+    );
+  });
+
+  it('removes a matching pending internal gateway-client request after repair', () => {
+    const stateDir = makeStateDir();
+    writeJson(pairedPath(stateDir), { 'gateway-device': staleGatewayClientDevice() });
+    writeJson(pendingPath(stateDir), {
+      'request-1': pendingGatewayClientRequest(),
+    });
+
+    const result = repairInternalGatewayClientPairingState({ stateDir });
+
+    expect(result.status).toBe('repaired');
+    expect(result.pairedDevicesRepaired).toBe(1);
+    expect(result.pendingRequestsRemoved).toBe(1);
+    expect(readJson(pendingPath(stateDir))).toEqual({});
+  });
+
+  it('removes matching pending request when the paired baseline already has operator.approvals', () => {
+    const stateDir = makeStateDir();
+    writeJson(pairedPath(stateDir), {
+      'gateway-device': staleGatewayClientDevice({
+        scopes: ['operator.read', 'operator.approvals'],
+        approvedScopes: ['operator.read', 'operator.approvals'],
+        tokens: {
+          operator: {
+            token: 'token-redacted',
+            role: 'operator',
+            scopes: ['operator.read', 'operator.approvals'],
+            createdAtMs: 1,
+          },
+        },
+      }),
+    });
+    writeJson(pendingPath(stateDir), { 'request-1': pendingGatewayClientRequest() });
+
+    const result = repairInternalGatewayClientPairingState({ stateDir });
+
+    expect(result.status).toBe('repaired');
+    expect(result.pairedDevicesRepaired).toBe(0);
+    expect(result.pendingRequestsRemoved).toBe(1);
+    expect(readJson(pendingPath(stateDir))).toEqual({});
+  });
+
+  it('does not grant admin or write scopes while repairing approvals', () => {
+    const stateDir = makeStateDir();
+    writeJson(pairedPath(stateDir), { 'gateway-device': staleGatewayClientDevice() });
+    writeJson(pendingPath(stateDir), {
+      'request-1': pendingGatewayClientRequest({
+        scopes: ['operator.approvals', 'operator.admin', 'operator.write'],
+      }),
+    });
+
+    const result = repairInternalGatewayClientPairingState({ stateDir });
+
+    const paired = readJson(pairedPath(stateDir));
+    const device = paired['gateway-device'] as Record<string, unknown>;
+    expect(device.scopes).toEqual(['operator.read', 'operator.approvals']);
+    expect(device.approvedScopes).toEqual(['operator.read', 'operator.approvals']);
+    expect((device.tokens as Record<string, Record<string, unknown>>).operator.scopes).toEqual([
+      'operator.read',
+      'operator.approvals',
+    ]);
+    expect(result.pendingRequestsRemoved).toBe(0);
+    expect(Object.keys(readJson(pendingPath(stateDir)))).toEqual(['request-1']);
+  });
+
+  it('does not create token material when the operator token is absent', () => {
+    const stateDir = makeStateDir();
+    writeJson(pairedPath(stateDir), {
+      'gateway-device': staleGatewayClientDevice({ tokens: {} }),
+    });
+    writeJson(pendingPath(stateDir), {});
+
+    const result = repairInternalGatewayClientPairingState({ stateDir });
+
+    expect(result.operatorTokenScopesUpdated).toBe(false);
+    const paired = readJson(pairedPath(stateDir));
+    const device = paired['gateway-device'] as Record<string, unknown>;
+    expect(device.tokens).toEqual({});
+  });
+
+  it('does not modify revoked operator tokens', () => {
+    const stateDir = makeStateDir();
+    writeJson(pairedPath(stateDir), {
+      'gateway-device': staleGatewayClientDevice({
+        tokens: {
+          operator: {
+            token: 'token-redacted',
+            role: 'operator',
+            scopes: ['operator.read'],
+            createdAtMs: 1,
+            revokedAtMs: 2,
+          },
+        },
+      }),
+    });
+    writeJson(pendingPath(stateDir), {});
+
+    const result = repairInternalGatewayClientPairingState({ stateDir });
+
+    expect(result.operatorTokenScopesUpdated).toBe(false);
+    const paired = readJson(pairedPath(stateDir));
+    const device = paired['gateway-device'] as Record<string, unknown>;
+    expect((device.tokens as Record<string, Record<string, unknown>>).operator.scopes).toEqual([
+      'operator.read',
+    ]);
+  });
+
+  it('does not modify non-gateway-client records', () => {
+    const stateDir = makeStateDir();
+    const otherDevice = staleGatewayClientDevice({ clientId: 'mobile-app' });
+    writeJson(pairedPath(stateDir), { 'mobile-device': otherDevice });
+    writeJson(pendingPath(stateDir), {
+      'request-1': pendingGatewayClientRequest({ clientId: 'mobile-app' }),
+    });
+
+    const result = repairInternalGatewayClientPairingState({ stateDir });
+
+    expect(result.status).toBe('noop');
+    expect(readJson(pairedPath(stateDir))).toEqual({ 'mobile-device': otherDevice });
+    expect(Object.keys(readJson(pendingPath(stateDir)))).toEqual(['request-1']);
+  });
+
+  it('does not modify gateway-client records with a non-backend mode', () => {
+    const stateDir = makeStateDir();
+    const uiDevice = staleGatewayClientDevice({ clientMode: 'webchat' });
+    writeJson(pairedPath(stateDir), { 'gateway-device': uiDevice });
+    writeJson(pendingPath(stateDir), {
+      'request-1': pendingGatewayClientRequest({ clientMode: 'webchat' }),
+    });
+
+    const result = repairInternalGatewayClientPairingState({ stateDir });
+
+    expect(result.status).toBe('noop');
+    expect(readJson(pairedPath(stateDir))).toEqual({ 'gateway-device': uiDevice });
+    expect(Object.keys(readJson(pendingPath(stateDir)))).toEqual(['request-1']);
+  });
+
+  it('does not repair paired gateway-client records with missing mode unless a matching pending request exists', () => {
+    const stateDir = makeStateDir();
+    const ambiguousDevice = staleGatewayClientDevice({ clientMode: undefined });
+    writeJson(pairedPath(stateDir), { 'gateway-device': ambiguousDevice });
+    writeJson(pendingPath(stateDir), {});
+
+    const result = repairInternalGatewayClientPairingState({ stateDir });
+
+    expect(result.status).toBe('noop');
+    expect(readJson(pairedPath(stateDir))).toEqual({ 'gateway-device': ambiguousDevice });
+  });
+
+  it('repairs paired gateway-client records with missing mode when a matching internal pending request exists', () => {
+    const stateDir = makeStateDir();
+    writeJson(pairedPath(stateDir), {
+      'gateway-device': staleGatewayClientDevice({ clientMode: undefined }),
+    });
+    writeJson(pendingPath(stateDir), { 'request-1': pendingGatewayClientRequest() });
+
+    const result = repairInternalGatewayClientPairingState({ stateDir });
+
+    expect(result.status).toBe('repaired');
+    expect(result.pairedDevicesRepaired).toBe(1);
+    expect(result.pendingRequestsRemoved).toBe(1);
+    const paired = readJson(pairedPath(stateDir));
+    const device = paired['gateway-device'] as Record<string, unknown>;
+    expect(device.scopes).toEqual(['operator.read', 'operator.approvals']);
+  });
+
+  it('treats missing pairing files as a no-op', () => {
+    const stateDir = makeStateDir();
+    fs.rmSync(pairedPath(stateDir), { force: true });
+    fs.rmSync(pendingPath(stateDir), { force: true });
+
+    expect(repairInternalGatewayClientPairingState({ stateDir })).toEqual({
+      status: 'noop',
+      pairedDevicesRepaired: 0,
+      pendingRequestsRemoved: 0,
+      operatorTokenScopesUpdated: false,
+      warnings: [],
+    });
+  });
+
+  it('returns a warning without writing when pairing JSON is malformed', () => {
+    const stateDir = makeStateDir();
+    fs.writeFileSync(pairedPath(stateDir), '{not-json');
+    writeJson(pendingPath(stateDir), {});
+
+    const result = repairInternalGatewayClientPairingState({ stateDir });
+
+    expect(result.status).toBe('warning');
+    expect(result.pairedDevicesRepaired).toBe(0);
+    expect(result.pendingRequestsRemoved).toBe(0);
+    expect(result.warnings[0]).toContain('could not parse paired.json');
+    expect(fs.readFileSync(pairedPath(stateDir), 'utf8')).toBe('{not-json');
+  });
+
+  it('writes repaired files with owner-only permissions', () => {
+    const stateDir = makeStateDir();
+    writeJson(pairedPath(stateDir), { 'gateway-device': staleGatewayClientDevice() });
+    writeJson(pendingPath(stateDir), { 'request-1': pendingGatewayClientRequest() });
+
+    repairInternalGatewayClientPairingState({ stateDir });
+
+    expect(fs.statSync(pairedPath(stateDir)).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(pendingPath(stateDir)).mode & 0o777).toBe(0o600);
+  });
+});

--- a/services/kiloclaw/controller/src/device-pairing-repair.test.ts
+++ b/services/kiloclaw/controller/src/device-pairing-repair.test.ts
@@ -170,6 +170,36 @@ describe('repairInternalGatewayClientPairingState', () => {
     expect(Object.keys(readJson(pendingPath(stateDir)))).toEqual(['request-1']);
   });
 
+  it('does not propagate unsafe paired scopes between scope fields while repairing', () => {
+    const stateDir = makeStateDir();
+    writeJson(pairedPath(stateDir), {
+      'gateway-device': staleGatewayClientDevice({
+        scopes: ['operator.read', 'operator.write'],
+        approvedScopes: ['operator.read', 'operator.admin'],
+        tokens: {
+          operator: {
+            token: 'token-redacted',
+            role: 'operator',
+            scopes: ['operator.read', 'operator.pairing'],
+            createdAtMs: 1,
+          },
+        },
+      }),
+    });
+    writeJson(pendingPath(stateDir), {});
+
+    repairInternalGatewayClientPairingState({ stateDir });
+
+    const paired = readJson(pairedPath(stateDir));
+    const device = paired['gateway-device'] as Record<string, unknown>;
+    expect(device.scopes).toEqual(['operator.read', 'operator.approvals']);
+    expect(device.approvedScopes).toEqual(['operator.read', 'operator.approvals']);
+    expect((device.tokens as Record<string, Record<string, unknown>>).operator.scopes).toEqual([
+      'operator.read',
+      'operator.approvals',
+    ]);
+  });
+
   it('does not create token material when the operator token is absent', () => {
     const stateDir = makeStateDir();
     writeJson(pairedPath(stateDir), {

--- a/services/kiloclaw/controller/src/device-pairing-repair.ts
+++ b/services/kiloclaw/controller/src/device-pairing-repair.ts
@@ -8,6 +8,13 @@ const BACKEND_CLIENT_MODE = 'backend';
 const OPERATOR_ROLE = 'operator';
 const OPERATOR_APPROVALS_SCOPE = 'operator.approvals';
 
+export const KILOCLAW_PAIRING_REPAIR_TAG = 'KILOCLAW_PAIRING_REPAIR_2026_04_28';
+
+// KILOCLAW_PAIRING_REPAIR_2026_04_28: temporary recovery for persisted
+// OpenClaw <=2026.4.26 internal gateway-client backend device records missing
+// operator.approvals. Remove after fleet volumes have been repaired and
+// OpenClaw no longer routes native approval startup through this stale baseline.
+
 type JsonRecord = Record<string, unknown>;
 
 export type DevicePairingRepairResult = {

--- a/services/kiloclaw/controller/src/device-pairing-repair.ts
+++ b/services/kiloclaw/controller/src/device-pairing-repair.ts
@@ -7,6 +7,7 @@ const GATEWAY_CLIENT_ID = 'gateway-client';
 const BACKEND_CLIENT_MODE = 'backend';
 const OPERATOR_ROLE = 'operator';
 const OPERATOR_APPROVALS_SCOPE = 'operator.approvals';
+const SAFE_REPAIR_SCOPES = new Set(['operator.read', OPERATOR_APPROVALS_SCOPE]);
 
 export const KILOCLAW_PAIRING_REPAIR_TAG = 'KILOCLAW_PAIRING_REPAIR_2026_04_28';
 
@@ -63,6 +64,13 @@ function mergeStrings(...groups: readonly string[][]): string[] {
     }
   }
   return merged;
+}
+
+function safeRepairScopes(...groups: readonly string[][]): string[] {
+  return mergeStrings(
+    ...groups.map(group => group.filter(scope => SAFE_REPAIR_SCOPES.has(scope))),
+    [OPERATOR_APPROVALS_SCOPE]
+  );
 }
 
 function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
@@ -149,10 +157,9 @@ function repairPairedDevice(record: JsonRecord): {
   let changed = false;
   let tokenScopesUpdated = false;
 
-  const desiredScopes = mergeStrings(
+  const desiredScopes = safeRepairScopes(
     getStringArray(record, 'approvedScopes'),
-    getStringArray(record, 'scopes'),
-    [OPERATOR_APPROVALS_SCOPE]
+    getStringArray(record, 'scopes')
   );
   if (!arraysEqual(getStringArray(record, 'approvedScopes'), desiredScopes)) {
     next.approvedScopes = desiredScopes;
@@ -176,9 +183,7 @@ function repairPairedDevice(record: JsonRecord): {
   if (isRecord(record.tokens)) {
     const operatorToken = record.tokens[OPERATOR_ROLE];
     if (isRecord(operatorToken) && operatorToken.revokedAtMs === undefined) {
-      const desiredTokenScopes = mergeStrings(getStringArray(operatorToken, 'scopes'), [
-        OPERATOR_APPROVALS_SCOPE,
-      ]);
+      const desiredTokenScopes = safeRepairScopes(getStringArray(operatorToken, 'scopes'));
       if (!arraysEqual(getStringArray(operatorToken, 'scopes'), desiredTokenScopes)) {
         next.tokens = {
           ...record.tokens,

--- a/services/kiloclaw/controller/src/device-pairing-repair.ts
+++ b/services/kiloclaw/controller/src/device-pairing-repair.ts
@@ -1,0 +1,286 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { atomicWrite } from './atomic-write.js';
+
+const DEFAULT_OPENCLAW_STATE_DIR = '/root/.openclaw';
+const GATEWAY_CLIENT_ID = 'gateway-client';
+const BACKEND_CLIENT_MODE = 'backend';
+const OPERATOR_ROLE = 'operator';
+const OPERATOR_APPROVALS_SCOPE = 'operator.approvals';
+
+type JsonRecord = Record<string, unknown>;
+
+export type DevicePairingRepairResult = {
+  status: 'noop' | 'repaired' | 'warning';
+  pairedDevicesRepaired: number;
+  pendingRequestsRemoved: number;
+  operatorTokenScopesUpdated: boolean;
+  warnings: string[];
+};
+
+type DevicePairingRepairOptions = {
+  stateDir?: string;
+};
+
+type ReadJsonRecordResult =
+  | { ok: true; exists: boolean; value: JsonRecord }
+  | { ok: false; warning: string };
+
+function resolveOpenClawStateDir(stateDir?: string): string {
+  return stateDir?.trim() || process.env.OPENCLAW_STATE_DIR?.trim() || DEFAULT_OPENCLAW_STATE_DIR;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getString(record: JsonRecord, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getStringArray(record: JsonRecord, key: string): string[] {
+  const value = record[key];
+  if (!Array.isArray(value)) return [];
+  return value.filter(item => typeof item === 'string');
+}
+
+function mergeStrings(...groups: readonly string[][]): string[] {
+  const seen = new Set<string>();
+  const merged: string[] = [];
+  for (const group of groups) {
+    for (const item of group) {
+      if (seen.has(item)) continue;
+      seen.add(item);
+      merged.push(item);
+    }
+  }
+  return merged;
+}
+
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((item, index) => item === right[index]);
+}
+
+function isOperatorRecord(record: JsonRecord): boolean {
+  return (
+    getString(record, 'role') === OPERATOR_ROLE ||
+    getStringArray(record, 'roles').includes(OPERATOR_ROLE)
+  );
+}
+
+function isGatewayClientBackendRecord(
+  record: JsonRecord,
+  options: { allowMissingClientMode?: boolean } = {}
+): boolean {
+  const clientMode = getString(record, 'clientMode');
+  return (
+    getString(record, 'clientId') === GATEWAY_CLIENT_ID &&
+    (clientMode === BACKEND_CLIENT_MODE ||
+      (clientMode === undefined && options.allowMissingClientMode === true)) &&
+    isOperatorRecord(record)
+  );
+}
+
+function requestsOnlySafeInternalScopes(record: JsonRecord): boolean {
+  const scopes = getStringArray(record, 'scopes');
+  if (!scopes.includes(OPERATOR_APPROVALS_SCOPE)) return false;
+  return scopes.every(scope => scope === 'operator.read' || scope === OPERATOR_APPROVALS_SCOPE);
+}
+
+function isGatewayClientBackendPendingRequest(record: JsonRecord): boolean {
+  return (
+    isGatewayClientBackendRecord(record, { allowMissingClientMode: true }) &&
+    requestsOnlySafeInternalScopes(record)
+  );
+}
+
+function readJsonRecord(filePath: string): ReadJsonRecordResult {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { ok: true, exists: false, value: {} };
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, warning: `could not read ${path.basename(filePath)}: ${message}` };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, warning: `could not parse ${path.basename(filePath)}: ${message}` };
+  }
+
+  if (!isRecord(parsed)) {
+    return { ok: false, warning: `${path.basename(filePath)} did not contain a JSON object` };
+  }
+  return { ok: true, exists: true, value: parsed };
+}
+
+function writeJsonRecord(filePath: string, value: JsonRecord): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  atomicWrite(filePath, `${JSON.stringify(value, null, 2)}\n`, undefined, { mode: 0o600 });
+}
+
+function hasOperatorApprovals(record: JsonRecord): boolean {
+  return (
+    getStringArray(record, 'approvedScopes').includes(OPERATOR_APPROVALS_SCOPE) &&
+    getStringArray(record, 'scopes').includes(OPERATOR_APPROVALS_SCOPE)
+  );
+}
+
+function repairPairedDevice(record: JsonRecord): {
+  record: JsonRecord;
+  changed: boolean;
+  tokenScopesUpdated: boolean;
+} {
+  const next: JsonRecord = { ...record };
+  let changed = false;
+  let tokenScopesUpdated = false;
+
+  const desiredScopes = mergeStrings(
+    getStringArray(record, 'approvedScopes'),
+    getStringArray(record, 'scopes'),
+    [OPERATOR_APPROVALS_SCOPE]
+  );
+  if (!arraysEqual(getStringArray(record, 'approvedScopes'), desiredScopes)) {
+    next.approvedScopes = desiredScopes;
+    changed = true;
+  }
+  if (!arraysEqual(getStringArray(record, 'scopes'), desiredScopes)) {
+    next.scopes = desiredScopes;
+    changed = true;
+  }
+
+  if (getString(record, 'role') !== OPERATOR_ROLE) {
+    next.role = OPERATOR_ROLE;
+    changed = true;
+  }
+  const desiredRoles = mergeStrings(getStringArray(record, 'roles'), [OPERATOR_ROLE]);
+  if (!arraysEqual(getStringArray(record, 'roles'), desiredRoles)) {
+    next.roles = desiredRoles;
+    changed = true;
+  }
+
+  if (isRecord(record.tokens)) {
+    const operatorToken = record.tokens[OPERATOR_ROLE];
+    if (isRecord(operatorToken) && operatorToken.revokedAtMs === undefined) {
+      const desiredTokenScopes = mergeStrings(getStringArray(operatorToken, 'scopes'), [
+        OPERATOR_APPROVALS_SCOPE,
+      ]);
+      if (!arraysEqual(getStringArray(operatorToken, 'scopes'), desiredTokenScopes)) {
+        next.tokens = {
+          ...record.tokens,
+          [OPERATOR_ROLE]: {
+            ...operatorToken,
+            scopes: desiredTokenScopes,
+          },
+        };
+        changed = true;
+        tokenScopesUpdated = true;
+      }
+    }
+  }
+
+  return { record: next, changed, tokenScopesUpdated };
+}
+
+export function repairInternalGatewayClientPairingState(
+  options: DevicePairingRepairOptions = {}
+): DevicePairingRepairResult {
+  const stateDir = resolveOpenClawStateDir(options.stateDir);
+  const devicesDir = path.join(stateDir, 'devices');
+  const pendingPath = path.join(devicesDir, 'pending.json');
+  const pairedPath = path.join(devicesDir, 'paired.json');
+
+  const pending = readJsonRecord(pendingPath);
+  const paired = readJsonRecord(pairedPath);
+  if (!pending.ok || !paired.ok) {
+    const warnings: string[] = [];
+    if (!pending.ok) warnings.push(pending.warning);
+    if (!paired.ok) warnings.push(paired.warning);
+    return {
+      status: 'warning',
+      pairedDevicesRepaired: 0,
+      pendingRequestsRemoved: 0,
+      operatorTokenScopesUpdated: false,
+      warnings,
+    };
+  }
+
+  let pairedDevicesRepaired = 0;
+  let pendingRequestsRemoved = 0;
+  let operatorTokenScopesUpdated = false;
+  let pairedChanged = false;
+  let pendingChanged = false;
+
+  const pairedByDeviceId: JsonRecord = { ...paired.value };
+  const pendingByRequestId: JsonRecord = { ...pending.value };
+
+  const internalPendingDeviceIds = new Set<string>();
+  for (const request of Object.values(pendingByRequestId)) {
+    if (!isRecord(request)) continue;
+    if (!isGatewayClientBackendPendingRequest(request)) continue;
+    const deviceId = getString(request, 'deviceId');
+    if (deviceId) {
+      internalPendingDeviceIds.add(deviceId);
+    }
+  }
+
+  for (const [deviceId, device] of Object.entries(pairedByDeviceId)) {
+    if (!isRecord(device)) continue;
+    if (
+      !isGatewayClientBackendRecord(device, {
+        allowMissingClientMode: internalPendingDeviceIds.has(deviceId),
+      })
+    )
+      continue;
+    const needsScopeRepair = !hasOperatorApprovals(device);
+    if (!needsScopeRepair && !internalPendingDeviceIds.has(deviceId)) continue;
+
+    const repaired = repairPairedDevice(device);
+    if (repaired.changed) {
+      pairedByDeviceId[deviceId] = repaired.record;
+      pairedChanged = true;
+      pairedDevicesRepaired += 1;
+      operatorTokenScopesUpdated = operatorTokenScopesUpdated || repaired.tokenScopesUpdated;
+    }
+  }
+
+  for (const [requestId, request] of Object.entries(pendingByRequestId)) {
+    if (!isRecord(request)) continue;
+    if (!isGatewayClientBackendPendingRequest(request)) continue;
+    const deviceId = getString(request, 'deviceId');
+    if (!deviceId) continue;
+    const pairedDevice = pairedByDeviceId[deviceId];
+    if (
+      !isRecord(pairedDevice) ||
+      !isGatewayClientBackendRecord(pairedDevice, { allowMissingClientMode: true })
+    )
+      continue;
+
+    delete pendingByRequestId[requestId];
+    pendingChanged = true;
+    pendingRequestsRemoved += 1;
+  }
+
+  if (pairedChanged) {
+    writeJsonRecord(pairedPath, pairedByDeviceId);
+  }
+  if (pendingChanged || (pending.exists && pendingRequestsRemoved > 0)) {
+    writeJsonRecord(pendingPath, pendingByRequestId);
+  }
+
+  const repaired = pairedDevicesRepaired > 0 || pendingRequestsRemoved > 0;
+  return {
+    status: repaired ? 'repaired' : 'noop',
+    pairedDevicesRepaired,
+    pendingRequestsRemoved,
+    operatorTokenScopesUpdated,
+    warnings: [],
+  };
+}

--- a/services/kiloclaw/controller/src/index.ts
+++ b/services/kiloclaw/controller/src/index.ts
@@ -54,7 +54,10 @@ import { getOpenclawVersion } from './openclaw-version';
 import { startCheckin } from './checkin';
 import { collectProductTelemetry } from './product-telemetry';
 import { GoogleOAuthTokenProvider } from './google-oauth-token-provider';
-import { repairInternalGatewayClientPairingState } from './device-pairing-repair.js';
+import {
+  KILOCLAW_PAIRING_REPAIR_TAG,
+  repairInternalGatewayClientPairingState,
+} from './device-pairing-repair.js';
 
 export type RuntimeConfig = {
   port: number;
@@ -545,17 +548,22 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
   }
 
   if (env.AUTO_APPROVE_DEVICES === 'true') {
+    // KILOCLAW_PAIRING_REPAIR_2026_04_28: run before gateway startup so stale
+    // internal gateway-client pairing state cannot recreate the native approval
+    // handler's scope-upgrade loop on boot.
     const repairResult = repairInternalGatewayClientPairingState();
     if (repairResult.status === 'warning') {
       console.warn(
-        `[pairing-repair] internal gateway-client repair warning: ${repairResult.warnings.join('; ')}`
+        `[pairing-repair] ${KILOCLAW_PAIRING_REPAIR_TAG} internal gateway-client repair warning: ${repairResult.warnings.join('; ')}`
       );
     } else if (repairResult.status === 'repaired') {
       console.log(
-        `[pairing-repair] internal gateway-client repair applied paired=${repairResult.pairedDevicesRepaired} pendingRemoved=${repairResult.pendingRequestsRemoved} tokenScopesUpdated=${repairResult.operatorTokenScopesUpdated}`
+        `[pairing-repair] ${KILOCLAW_PAIRING_REPAIR_TAG} internal gateway-client repair applied paired=${repairResult.pairedDevicesRepaired} pendingRemoved=${repairResult.pendingRequestsRemoved} tokenScopesUpdated=${repairResult.operatorTokenScopesUpdated}`
       );
     } else {
-      console.log('[pairing-repair] internal gateway-client repair not needed');
+      console.log(
+        `[pairing-repair] ${KILOCLAW_PAIRING_REPAIR_TAG} internal gateway-client repair not needed`
+      );
     }
   }
 

--- a/services/kiloclaw/controller/src/index.ts
+++ b/services/kiloclaw/controller/src/index.ts
@@ -54,6 +54,7 @@ import { getOpenclawVersion } from './openclaw-version';
 import { startCheckin } from './checkin';
 import { collectProductTelemetry } from './product-telemetry';
 import { GoogleOAuthTokenProvider } from './google-oauth-token-provider';
+import { repairInternalGatewayClientPairingState } from './device-pairing-repair.js';
 
 export type RuntimeConfig = {
   port: number;
@@ -541,6 +542,21 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
     installGogShim();
   } catch (err) {
     console.error('[gog] Failed to install shim:', err);
+  }
+
+  if (env.AUTO_APPROVE_DEVICES === 'true') {
+    const repairResult = repairInternalGatewayClientPairingState();
+    if (repairResult.status === 'warning') {
+      console.warn(
+        `[pairing-repair] internal gateway-client repair warning: ${repairResult.warnings.join('; ')}`
+      );
+    } else if (repairResult.status === 'repaired') {
+      console.log(
+        `[pairing-repair] internal gateway-client repair applied paired=${repairResult.pairedDevicesRepaired} pendingRemoved=${repairResult.pendingRequestsRemoved} tokenScopesUpdated=${repairResult.operatorTokenScopesUpdated}`
+      );
+    } else {
+      console.log('[pairing-repair] internal gateway-client repair not needed');
+    }
   }
 
   // ── Phase 7: Start gateway ──────────────────────────────────────────

--- a/services/kiloclaw/controller/src/index.ts
+++ b/services/kiloclaw/controller/src/index.ts
@@ -551,18 +551,25 @@ export async function startController(env: NodeJS.ProcessEnv = process.env): Pro
     // KILOCLAW_PAIRING_REPAIR_2026_04_28: run before gateway startup so stale
     // internal gateway-client pairing state cannot recreate the native approval
     // handler's scope-upgrade loop on boot.
-    const repairResult = repairInternalGatewayClientPairingState();
-    if (repairResult.status === 'warning') {
-      console.warn(
-        `[pairing-repair] ${KILOCLAW_PAIRING_REPAIR_TAG} internal gateway-client repair warning: ${repairResult.warnings.join('; ')}`
-      );
-    } else if (repairResult.status === 'repaired') {
-      console.log(
-        `[pairing-repair] ${KILOCLAW_PAIRING_REPAIR_TAG} internal gateway-client repair applied paired=${repairResult.pairedDevicesRepaired} pendingRemoved=${repairResult.pendingRequestsRemoved} tokenScopesUpdated=${repairResult.operatorTokenScopesUpdated}`
-      );
-    } else {
-      console.log(
-        `[pairing-repair] ${KILOCLAW_PAIRING_REPAIR_TAG} internal gateway-client repair not needed`
+    try {
+      const repairResult = repairInternalGatewayClientPairingState();
+      if (repairResult.status === 'warning') {
+        console.warn(
+          `[pairing-repair] ${KILOCLAW_PAIRING_REPAIR_TAG} internal gateway-client repair warning: ${repairResult.warnings.join('; ')}`
+        );
+      } else if (repairResult.status === 'repaired') {
+        console.log(
+          `[pairing-repair] ${KILOCLAW_PAIRING_REPAIR_TAG} internal gateway-client repair applied paired=${repairResult.pairedDevicesRepaired} pendingRemoved=${repairResult.pendingRequestsRemoved} tokenScopesUpdated=${repairResult.operatorTokenScopesUpdated}`
+        );
+      } else {
+        console.log(
+          `[pairing-repair] ${KILOCLAW_PAIRING_REPAIR_TAG} internal gateway-client repair not needed`
+        );
+      }
+    } catch (err) {
+      console.error(
+        `[pairing-repair] ${KILOCLAW_PAIRING_REPAIR_TAG} internal gateway-client repair failed:`,
+        err
       );
     }
   }

--- a/services/kiloclaw/controller/src/pairing-cache.test.ts
+++ b/services/kiloclaw/controller/src/pairing-cache.test.ts
@@ -8,6 +8,7 @@ import {
   FAILURE_RETRY_MAX_MS,
   type ReadChannelPairingImpl,
   type ReadDevicePairingImpl,
+  type RepairInternalGatewayClientPairingImpl,
 } from './pairing-cache';
 
 type ExecImpl = (command: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
@@ -22,6 +23,7 @@ function createTestHarness(overrides?: {
   readConfigImpl?: () => unknown;
   readChannelPairingImpl?: ReadChannelPairingImpl;
   readDevicePairingImpl?: ReadDevicePairingImpl;
+  repairInternalGatewayClientPairingImpl?: RepairInternalGatewayClientPairingImpl;
 }) {
   const execImpl = overrides?.execImpl ?? vi.fn<ExecImpl>();
   const readConfigImpl =
@@ -45,6 +47,7 @@ function createTestHarness(overrides?: {
     readConfigImpl,
     readChannelPairingImpl,
     readDevicePairingImpl,
+    repairInternalGatewayClientPairingImpl: overrides?.repairInternalGatewayClientPairingImpl,
     nowImpl,
     nowMsImpl,
   });
@@ -391,6 +394,8 @@ describe('createPairingCache', () => {
           clientId: 'c1',
           ts: RECENT_TS,
           publicKey: 'SHOULD_BE_STRIPPED',
+          clientMode: 'backend',
+          scopes: ['operator.approvals'],
         },
       });
 
@@ -403,8 +408,10 @@ describe('createPairingCache', () => {
         requestId: 'r1',
         deviceId: 'd1',
         role: 'operator',
+        scopes: ['operator.approvals'],
         platform: 'ios',
         clientId: 'c1',
+        clientMode: 'backend',
         ts: RECENT_TS,
       });
       expect(result.lastUpdated).toBe('2026-03-12T00:00:00.000Z');
@@ -540,8 +547,17 @@ describe('createPairingCache', () => {
   });
 
   describe('autoApproveGatewayClient', () => {
-    it('auto-approves pending gateway-client devices on refresh', async () => {
+    it('repairs pending backend gateway-client devices locally on refresh', async () => {
       const execImpl = vi.fn<ExecImpl>().mockResolvedValue({ stdout: '{}', stderr: '' });
+      const repairInternalGatewayClientPairingImpl = vi
+        .fn<RepairInternalGatewayClientPairingImpl>()
+        .mockResolvedValue({
+          status: 'repaired',
+          pairedDevicesRepaired: 1,
+          pendingRequestsRemoved: 1,
+          operatorTokenScopesUpdated: true,
+          warnings: [],
+        });
       const readDevicePairingImpl = vi
         .fn<ReadDevicePairingImpl>()
         .mockResolvedValueOnce({
@@ -549,11 +565,13 @@ describe('createPairingCache', () => {
             requestId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
             deviceId: 'dev1',
             clientId: 'gateway-client',
+            clientMode: 'backend',
             role: 'operator',
+            scopes: ['operator.approvals'],
             ts: RECENT_TS,
           },
         })
-        // After approval, re-read returns empty
+        // After local repair, re-read returns empty.
         .mockResolvedValue({});
 
       const cache = createPairingCache({
@@ -561,6 +579,7 @@ describe('createPairingCache', () => {
         readConfigImpl: () => ({ channels: {} }),
         readChannelPairingImpl: vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] }),
         readDevicePairingImpl,
+        repairInternalGatewayClientPairingImpl,
         nowImpl: () => '2026-03-12T00:00:00.000Z',
         nowMsImpl: () => NOW_MS,
         autoApproveGatewayClient: true,
@@ -568,16 +587,57 @@ describe('createPairingCache', () => {
 
       await cache.refreshDevicePairing();
 
-      expect(execImpl).toHaveBeenCalledWith(OPENCLAW_BIN, [
-        'devices',
-        'approve',
-        'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
-      ]);
+      expect(execImpl).not.toHaveBeenCalled();
+      expect(repairInternalGatewayClientPairingImpl).toHaveBeenCalledOnce();
+      expect(readDevicePairingImpl).toHaveBeenCalledTimes(2);
       expect(cache.getDevicePairing().requests).toEqual([]);
+    });
+
+    it('does not recursively refresh if local gateway-client repair leaves a request pending', async () => {
+      const repairInternalGatewayClientPairingImpl = vi
+        .fn<RepairInternalGatewayClientPairingImpl>()
+        .mockResolvedValue({
+          status: 'noop',
+          pairedDevicesRepaired: 0,
+          pendingRequestsRemoved: 0,
+          operatorTokenScopesUpdated: false,
+          warnings: [],
+        });
+      const request = {
+        requestId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        deviceId: 'dev1',
+        clientId: 'gateway-client',
+        clientMode: 'backend',
+        role: 'operator',
+        scopes: ['operator.approvals'],
+        ts: RECENT_TS,
+      };
+      const readDevicePairingImpl = vi
+        .fn<ReadDevicePairingImpl>()
+        .mockResolvedValue({ 'req-1': request });
+
+      const cache = createPairingCache({
+        execImpl: vi.fn<ExecImpl>(),
+        readConfigImpl: () => ({ channels: {} }),
+        readChannelPairingImpl: vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] }),
+        readDevicePairingImpl,
+        repairInternalGatewayClientPairingImpl,
+        nowImpl: () => '2026-03-12T00:00:00.000Z',
+        nowMsImpl: () => NOW_MS,
+        autoApproveGatewayClient: true,
+      });
+
+      await cache.refreshDevicePairing();
+
+      expect(repairInternalGatewayClientPairingImpl).toHaveBeenCalledOnce();
+      expect(readDevicePairingImpl).toHaveBeenCalledTimes(2);
+      expect(cache.getDevicePairing().requests).toEqual([request]);
     });
 
     it('does not auto-approve non-gateway-client devices', async () => {
       const execImpl = vi.fn<ExecImpl>().mockResolvedValue({ stdout: '{}', stderr: '' });
+      const repairInternalGatewayClientPairingImpl =
+        vi.fn<RepairInternalGatewayClientPairingImpl>();
       const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({
         'req-1': {
           requestId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
@@ -593,6 +653,7 @@ describe('createPairingCache', () => {
         readConfigImpl: () => ({ channels: {} }),
         readChannelPairingImpl: vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] }),
         readDevicePairingImpl,
+        repairInternalGatewayClientPairingImpl,
         nowImpl: () => '2026-03-12T00:00:00.000Z',
         nowMsImpl: () => NOW_MS,
         autoApproveGatewayClient: true,
@@ -601,6 +662,39 @@ describe('createPairingCache', () => {
       await cache.refreshDevicePairing();
 
       expect(execImpl).not.toHaveBeenCalled();
+      expect(repairInternalGatewayClientPairingImpl).not.toHaveBeenCalled();
+      expect(cache.getDevicePairing().requests).toHaveLength(1);
+    });
+
+    it('does not repair gateway-client requests with a non-backend mode', async () => {
+      const repairInternalGatewayClientPairingImpl =
+        vi.fn<RepairInternalGatewayClientPairingImpl>();
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({
+        'req-1': {
+          requestId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+          deviceId: 'dev1',
+          clientId: 'gateway-client',
+          clientMode: 'webchat',
+          role: 'operator',
+          scopes: ['operator.approvals'],
+          ts: RECENT_TS,
+        },
+      });
+
+      const cache = createPairingCache({
+        execImpl: vi.fn<ExecImpl>(),
+        readConfigImpl: () => ({ channels: {} }),
+        readChannelPairingImpl: vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] }),
+        readDevicePairingImpl,
+        repairInternalGatewayClientPairingImpl,
+        nowImpl: () => '2026-03-12T00:00:00.000Z',
+        nowMsImpl: () => NOW_MS,
+        autoApproveGatewayClient: true,
+      });
+
+      await cache.refreshDevicePairing();
+
+      expect(repairInternalGatewayClientPairingImpl).not.toHaveBeenCalled();
       expect(cache.getDevicePairing().requests).toHaveLength(1);
     });
 

--- a/services/kiloclaw/controller/src/pairing-cache.ts
+++ b/services/kiloclaw/controller/src/pairing-cache.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { z } from 'zod';
 import {
+  KILOCLAW_PAIRING_REPAIR_TAG,
   repairInternalGatewayClientPairingState,
   type DevicePairingRepairResult,
 } from './device-pairing-repair.js';
@@ -379,18 +380,21 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
       if (autoApproveGatewayClient && allowAutoRepair) {
         const gatewayRequests = requests.filter(isInternalGatewayClientBackendRequest);
         if (gatewayRequests.length > 0) {
+          // KILOCLAW_PAIRING_REPAIR_2026_04_28: use local file repair for the
+          // internal backend gateway-client so we do not depend on Gateway RPC
+          // while Gateway itself may be blocked by pairing-required state.
           console.log(
-            `[pairing-cache] repairing ${gatewayRequests.length} internal gateway-client device request(s)`
+            `[pairing-cache] ${KILOCLAW_PAIRING_REPAIR_TAG} repairing ${gatewayRequests.length} internal gateway-client device request(s)`
           );
           try {
             const repairResult = await repairInternalGatewayClientPairingImpl();
             if (repairResult.status === 'warning') {
               console.warn(
-                `[pairing-cache] internal gateway-client repair warning: ${repairResult.warnings.join('; ')}`
+                `[pairing-cache] ${KILOCLAW_PAIRING_REPAIR_TAG} internal gateway-client repair warning: ${repairResult.warnings.join('; ')}`
               );
             } else if (repairResult.status === 'repaired') {
               console.log(
-                `[pairing-cache] internal gateway-client repair applied paired=${repairResult.pairedDevicesRepaired} pendingRemoved=${repairResult.pendingRequestsRemoved} tokenScopesUpdated=${repairResult.operatorTokenScopesUpdated}`
+                `[pairing-cache] ${KILOCLAW_PAIRING_REPAIR_TAG} internal gateway-client repair applied paired=${repairResult.pairedDevicesRepaired} pendingRemoved=${repairResult.pendingRequestsRemoved} tokenScopesUpdated=${repairResult.operatorTokenScopesUpdated}`
               );
             }
           } catch (err) {

--- a/services/kiloclaw/controller/src/pairing-cache.ts
+++ b/services/kiloclaw/controller/src/pairing-cache.ts
@@ -3,6 +3,10 @@ import { promisify } from 'node:util';
 import fs from 'node:fs';
 import path from 'node:path';
 import { z } from 'zod';
+import {
+  repairInternalGatewayClientPairingState,
+  type DevicePairingRepairResult,
+} from './device-pairing-repair.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -18,8 +22,10 @@ export type DevicePairingRequest = {
   requestId: string;
   deviceId: string;
   role?: string;
+  scopes?: string[];
   platform?: string;
   clientId?: string;
+  clientMode?: string;
   ts?: number;
 };
 
@@ -48,6 +54,9 @@ type ExecImpl = (command: string, args: string[]) => Promise<{ stdout: string; s
 
 export type ReadChannelPairingImpl = (channel: string) => Promise<unknown>;
 export type ReadDevicePairingImpl = () => Promise<unknown>;
+export type RepairInternalGatewayClientPairingImpl = () =>
+  | DevicePairingRepairResult
+  | Promise<DevicePairingRepairResult>;
 
 type PairingCacheOptions = {
   execImpl?: ExecImpl;
@@ -55,6 +64,7 @@ type PairingCacheOptions = {
   nowImpl?: () => string;
   readChannelPairingImpl?: ReadChannelPairingImpl;
   readDevicePairingImpl?: ReadDevicePairingImpl;
+  repairInternalGatewayClientPairingImpl?: RepairInternalGatewayClientPairingImpl;
   nowMsImpl?: () => number;
   /** Auto-approve pending device pairings from the gateway's own exec client. */
   autoApproveGatewayClient?: boolean;
@@ -156,8 +166,10 @@ const devicePendingEntrySchema = z.object({
   requestId: z.string(),
   deviceId: z.string(),
   role: z.string().optional(),
+  scopes: z.array(z.string()).optional(),
   platform: z.string().optional(),
   clientId: z.string().optional(),
+  clientMode: z.string().optional(),
   ts: z.number().optional(),
 });
 
@@ -184,6 +196,13 @@ function collectValidEntries<T extends z.ZodTypeAny>(
 function isUnexpiredDeviceRequest(req: DevicePairingRequest, nowMs: number): boolean {
   if (req.ts === undefined) return true;
   return nowMs - req.ts <= DEVICE_PAIRING_TTL_MS;
+}
+
+function isInternalGatewayClientBackendRequest(req: DevicePairingRequest): boolean {
+  return (
+    req.clientId === 'gateway-client' &&
+    (req.clientMode === undefined || req.clientMode === 'backend')
+  );
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
@@ -218,6 +237,7 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
       const filePath = resolveDevicePendingPath();
       return JSON.parse(await fs.promises.readFile(filePath, 'utf8')) as unknown;
     },
+    repairInternalGatewayClientPairingImpl = repairInternalGatewayClientPairingState,
     nowMsImpl = () => Date.now(),
     autoApproveGatewayClient = false,
   } = options ?? {};
@@ -292,7 +312,7 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
         allRequests.push(...result.value);
         anySuccess = true;
       } else {
-        const err = result.reason;
+        const err: unknown = result.reason;
         const msg = errorMessage(err);
         const priorRequests = channelCache.requests.filter(r => r.channel === channels[i]);
         if (priorRequests.length > 0) {
@@ -326,7 +346,7 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
     return true;
   };
 
-  const refreshDevicePairingInternal = async (): Promise<boolean> => {
+  const refreshDevicePairingInternal = async (allowAutoRepair = true): Promise<boolean> => {
     if (stopped) return false;
     const gen = ++deviceGeneration;
     try {
@@ -356,19 +376,28 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
       }
       console.log(`[pairing-cache] devices: read ok, ${requests.length} pending`);
 
-      if (autoApproveGatewayClient) {
-        const gatewayRequests = requests.filter(r => r.clientId === 'gateway-client');
-        for (const req of gatewayRequests) {
-          console.log(`[pairing-cache] auto-approving gateway-client device ${req.requestId}`);
-          try {
-            await execImpl(OPENCLAW_BIN, ['devices', 'approve', req.requestId]);
-          } catch (err) {
-            console.error(`[pairing-cache] auto-approve failed for ${req.requestId}:`, err);
-          }
-        }
+      if (autoApproveGatewayClient && allowAutoRepair) {
+        const gatewayRequests = requests.filter(isInternalGatewayClientBackendRequest);
         if (gatewayRequests.length > 0) {
-          // Re-read after approvals so the cache reflects the updated state.
-          await refreshDevicePairingInternal();
+          console.log(
+            `[pairing-cache] repairing ${gatewayRequests.length} internal gateway-client device request(s)`
+          );
+          try {
+            const repairResult = await repairInternalGatewayClientPairingImpl();
+            if (repairResult.status === 'warning') {
+              console.warn(
+                `[pairing-cache] internal gateway-client repair warning: ${repairResult.warnings.join('; ')}`
+              );
+            } else if (repairResult.status === 'repaired') {
+              console.log(
+                `[pairing-cache] internal gateway-client repair applied paired=${repairResult.pairedDevicesRepaired} pendingRemoved=${repairResult.pendingRequestsRemoved} tokenScopesUpdated=${repairResult.operatorTokenScopesUpdated}`
+              );
+            }
+          } catch (err) {
+            console.error('[pairing-cache] internal gateway-client repair failed:', err);
+          }
+          // Re-read once after repair so the cache reflects the updated state without recursion.
+          await refreshDevicePairingInternal(false);
         }
       }
 

--- a/services/kiloclaw/controller/src/routes/config.test.ts
+++ b/services/kiloclaw/controller/src/routes/config.test.ts
@@ -221,6 +221,175 @@ describe('/_kilo/config/patch routes', () => {
     expect(written.gateway.port).toBe(3001);
   });
 
+  it('does not overwrite an existing Telegram groupPolicy with a managed default', async () => {
+    const app = new Hono();
+    registerConfigRoutes(app, createMockSupervisor(), 'test-token');
+
+    readMock.mockReturnValue(
+      JSON.stringify({
+        channels: {
+          telegram: {
+            botToken: 'old-token',
+            enabled: true,
+            dmPolicy: 'pairing',
+            groupPolicy: 'restricted',
+          },
+        },
+      })
+    );
+
+    const resp = await app.request('/_kilo/config/patch', {
+      method: 'POST',
+      body: JSON.stringify({
+        channels: {
+          telegram: {
+            botToken: 'new-token',
+            enabled: true,
+            dmPolicy: 'pairing',
+            groupPolicy: 'open',
+          },
+        },
+      }),
+      headers: authHeaders(),
+    });
+
+    expect(resp.status).toBe(200);
+    expect(atomicWriteMock).toHaveBeenCalledOnce();
+    const written = JSON.parse(atomicWriteMock.mock.calls[0][1] as string);
+    expect(written.channels.telegram).toEqual({
+      botToken: 'new-token',
+      enabled: true,
+      dmPolicy: 'pairing',
+      groupPolicy: 'restricted',
+    });
+  });
+
+  it('does not seed Telegram groupPolicy when group access is already configured', async () => {
+    const app = new Hono();
+    registerConfigRoutes(app, createMockSupervisor(), 'test-token');
+
+    readMock.mockReturnValue(
+      JSON.stringify({
+        channels: {
+          telegram: {
+            botToken: 'old-token',
+            enabled: true,
+            dmPolicy: 'pairing',
+            groups: { '-5055658641': {} },
+          },
+        },
+      })
+    );
+
+    const resp = await app.request('/_kilo/config/patch', {
+      method: 'POST',
+      body: JSON.stringify({
+        channels: {
+          telegram: {
+            botToken: 'new-token',
+            enabled: true,
+            dmPolicy: 'pairing',
+            groupPolicy: 'open',
+          },
+        },
+      }),
+      headers: authHeaders(),
+    });
+
+    expect(resp.status).toBe(200);
+    const written = JSON.parse(atomicWriteMock.mock.calls[0][1] as string);
+    expect(written.channels.telegram).toEqual({
+      botToken: 'new-token',
+      enabled: true,
+      dmPolicy: 'pairing',
+      groups: { '-5055658641': {} },
+    });
+  });
+
+  it('does not seed Telegram groupPolicy when sender access is already configured', async () => {
+    const app = new Hono();
+    registerConfigRoutes(app, createMockSupervisor(), 'test-token');
+
+    readMock.mockReturnValue(
+      JSON.stringify({
+        channels: {
+          telegram: {
+            botToken: 'old-token',
+            enabled: true,
+            dmPolicy: 'pairing',
+            groupAllowFrom: ['7676134290'],
+          },
+        },
+      })
+    );
+
+    const resp = await app.request('/_kilo/config/patch', {
+      method: 'POST',
+      body: JSON.stringify({
+        channels: {
+          telegram: {
+            botToken: 'new-token',
+            enabled: true,
+            dmPolicy: 'pairing',
+            groupPolicy: 'open',
+          },
+        },
+      }),
+      headers: authHeaders(),
+    });
+
+    expect(resp.status).toBe(200);
+    const written = JSON.parse(atomicWriteMock.mock.calls[0][1] as string);
+    expect(written.channels.telegram).toEqual({
+      botToken: 'new-token',
+      enabled: true,
+      dmPolicy: 'pairing',
+      groupAllowFrom: ['7676134290'],
+    });
+  });
+
+  it('seeds Telegram groupPolicy from a managed patch when no setting exists', async () => {
+    const app = new Hono();
+    registerConfigRoutes(app, createMockSupervisor(), 'test-token');
+
+    readMock.mockReturnValue(
+      JSON.stringify({
+        channels: {
+          telegram: {
+            botToken: 'old-token',
+            enabled: true,
+            dmPolicy: 'pairing',
+          },
+        },
+      })
+    );
+
+    const resp = await app.request('/_kilo/config/patch', {
+      method: 'POST',
+      body: JSON.stringify({
+        channels: {
+          telegram: {
+            botToken: 'new-token',
+            enabled: true,
+            dmPolicy: 'pairing',
+            groupPolicy: 'open',
+          },
+        },
+      }),
+      headers: authHeaders(),
+    });
+
+    expect(resp.status).toBe(200);
+    expect(atomicWriteMock).toHaveBeenCalledOnce();
+    const written = JSON.parse(atomicWriteMock.mock.calls[0][1] as string);
+    expect(written.channels.telegram).toEqual({
+      botToken: 'new-token',
+      enabled: true,
+      dmPolicy: 'pairing',
+      groupPolicy: 'open',
+    });
+  });
+
   it('rejects non-object body', async () => {
     const app = new Hono();
     registerConfigRoutes(app, createMockSupervisor(), 'test-token');

--- a/services/kiloclaw/controller/src/routes/config.ts
+++ b/services/kiloclaw/controller/src/routes/config.ts
@@ -7,6 +7,7 @@ import { timingSafeTokenEqual } from '../auth';
 import type { Supervisor } from '../supervisor';
 import { backupConfigFile, writeBaseConfig } from '../config-writer';
 import { GOG_SECTION_CONFIG, seedExecApprovalsDefaults, updateToolsMdSection } from '../bootstrap';
+import { shouldDefaultTelegramGroupPolicyOpen } from '../telegram-group-policy';
 import { getBearerToken } from './gateway';
 
 const ReplaceConfigBodySchema = z.object({
@@ -57,6 +58,23 @@ function deepMerge(target: Record<string, unknown>, patch: Record<string, unknow
       target[key] = value;
     }
   }
+}
+
+function stripManagedTelegramGroupPolicyWhenConfigured(
+  config: Record<string, unknown>,
+  patch: Record<string, unknown>
+): void {
+  const existingChannels = config.channels;
+  const patchChannels = patch.channels;
+  if (!isJsonObject(existingChannels) || !isJsonObject(patchChannels)) return;
+
+  const existingTelegram = existingChannels.telegram;
+  const patchTelegram = patchChannels.telegram;
+  if (!isJsonObject(existingTelegram) || !isJsonObject(patchTelegram)) return;
+  if (!('groupPolicy' in patchTelegram)) return;
+  if (shouldDefaultTelegramGroupPolicyOpen(existingTelegram)) return;
+
+  delete patchTelegram.groupPolicy;
 }
 
 export function registerConfigRoutes(
@@ -195,6 +213,7 @@ export function registerConfigRoutes(
     try {
       const raw = fs.readFileSync(CONFIG_PATH, 'utf8');
       const config = JSON.parse(raw);
+      stripManagedTelegramGroupPolicyWhenConfigured(config, patch as Record<string, unknown>);
       deepMerge(config, patch as Record<string, unknown>);
 
       // Sync exec-approvals.json BEFORE writing openclaw.json so the host

--- a/services/kiloclaw/controller/src/start-controller-degraded.test.ts
+++ b/services/kiloclaw/controller/src/start-controller-degraded.test.ts
@@ -260,6 +260,37 @@ describe('startController degraded behavior', () => {
     expect(callOrder).toEqual(['repair', 'start']);
   });
 
+  it('continues starting the gateway when internal gateway-client repair throws', async () => {
+    const repairInternalGatewayClientPairingState = vi.fn(() => {
+      throw new Error('disk full');
+    });
+    const supervisorStart = vi.fn(async () => undefined);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { startController } = await loadStartControllerWithMocks({
+      bootstrapCritical: async () => undefined,
+      bootstrapNonCritical: async () => ({ ok: true }),
+      supervisorStart,
+      repairInternalGatewayClientPairingState,
+    });
+
+    const env = {
+      OPENCLAW_GATEWAY_TOKEN: 'test-token',
+      KILOCLAW_HOOKS_TOKEN: 'test-hooks-token',
+      KILOCLAW_GATEWAY_ARGS: '["--port","3001"]',
+      AUTO_APPROVE_DEVICES: 'true',
+    } as unknown as NodeJS.ProcessEnv;
+
+    await startController(env);
+
+    expect(repairInternalGatewayClientPairingState).toHaveBeenCalledOnce();
+    expect(supervisorStart).toHaveBeenCalledOnce();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('internal gateway-client repair failed'),
+      expect.any(Error)
+    );
+    errorSpy.mockRestore();
+  });
+
   it('skips internal gateway-client startup repair when auto-approval is disabled', async () => {
     const repairInternalGatewayClientPairingState = vi.fn();
     const supervisorStart = vi.fn(async () => undefined);

--- a/services/kiloclaw/controller/src/start-controller-degraded.test.ts
+++ b/services/kiloclaw/controller/src/start-controller-degraded.test.ts
@@ -116,6 +116,7 @@ async function loadStartControllerWithMocks(options: {
   }));
 
   vi.doMock('./device-pairing-repair.js', () => ({
+    KILOCLAW_PAIRING_REPAIR_TAG: 'KILOCLAW_PAIRING_REPAIR_2026_04_28',
     repairInternalGatewayClientPairingState:
       options.repairInternalGatewayClientPairingState ??
       (() => ({

--- a/services/kiloclaw/controller/src/start-controller-degraded.test.ts
+++ b/services/kiloclaw/controller/src/start-controller-degraded.test.ts
@@ -75,6 +75,8 @@ async function dispatch(
 async function loadStartControllerWithMocks(options: {
   bootstrapCritical: () => Promise<void>;
   bootstrapNonCritical: () => Promise<{ ok: true } | { ok: false; phase: string; error: string }>;
+  supervisorStart?: () => Promise<void>;
+  repairInternalGatewayClientPairingState?: () => unknown;
 }) {
   vi.resetModules();
 
@@ -103,7 +105,7 @@ async function loadStartControllerWithMocks(options: {
   vi.doMock('./supervisor', () => ({
     createSupervisor: () => ({
       getState: () => 'stopped',
-      start: async () => undefined,
+      start: options.supervisorStart ?? (async () => undefined),
       shutdown: async () => undefined,
       getStats: () => ({
         state: 'stopped',
@@ -111,6 +113,18 @@ async function loadStartControllerWithMocks(options: {
       }),
       signalUsr1: () => false,
     }),
+  }));
+
+  vi.doMock('./device-pairing-repair.js', () => ({
+    repairInternalGatewayClientPairingState:
+      options.repairInternalGatewayClientPairingState ??
+      (() => ({
+        status: 'noop',
+        pairedDevicesRepaired: 0,
+        pendingRequestsRemoved: 0,
+        operatorTokenScopesUpdated: false,
+        warnings: [],
+      })),
   }));
 
   vi.doMock('./pairing-cache', () => ({
@@ -207,5 +221,63 @@ describe('startController degraded behavior', () => {
     });
     expect(filesTree.status).toBe(503);
     expect(JSON.parse(filesTree.body)).toEqual({ error: 'Service starting', state: 'degraded' });
+  });
+
+  it('repairs internal gateway-client pairing before starting the gateway when auto-approval is enabled', async () => {
+    const callOrder: string[] = [];
+    const repairInternalGatewayClientPairingState = vi.fn(() => {
+      callOrder.push('repair');
+      return {
+        status: 'repaired',
+        pairedDevicesRepaired: 1,
+        pendingRequestsRemoved: 1,
+        operatorTokenScopesUpdated: true,
+        warnings: [],
+      };
+    });
+    const supervisorStart = vi.fn(async () => {
+      callOrder.push('start');
+    });
+    const { startController } = await loadStartControllerWithMocks({
+      bootstrapCritical: async () => undefined,
+      bootstrapNonCritical: async () => ({ ok: true }),
+      supervisorStart,
+      repairInternalGatewayClientPairingState,
+    });
+
+    const env = {
+      OPENCLAW_GATEWAY_TOKEN: 'test-token',
+      KILOCLAW_HOOKS_TOKEN: 'test-hooks-token',
+      KILOCLAW_GATEWAY_ARGS: '["--port","3001"]',
+      AUTO_APPROVE_DEVICES: 'true',
+    } as unknown as NodeJS.ProcessEnv;
+
+    await startController(env);
+
+    expect(repairInternalGatewayClientPairingState).toHaveBeenCalledOnce();
+    expect(supervisorStart).toHaveBeenCalledOnce();
+    expect(callOrder).toEqual(['repair', 'start']);
+  });
+
+  it('skips internal gateway-client startup repair when auto-approval is disabled', async () => {
+    const repairInternalGatewayClientPairingState = vi.fn();
+    const supervisorStart = vi.fn(async () => undefined);
+    const { startController } = await loadStartControllerWithMocks({
+      bootstrapCritical: async () => undefined,
+      bootstrapNonCritical: async () => ({ ok: true }),
+      supervisorStart,
+      repairInternalGatewayClientPairingState,
+    });
+
+    const env = {
+      OPENCLAW_GATEWAY_TOKEN: 'test-token',
+      KILOCLAW_HOOKS_TOKEN: 'test-hooks-token',
+      KILOCLAW_GATEWAY_ARGS: '["--port","3001"]',
+    } as unknown as NodeJS.ProcessEnv;
+
+    await startController(env);
+
+    expect(repairInternalGatewayClientPairingState).not.toHaveBeenCalled();
+    expect(supervisorStart).toHaveBeenCalledOnce();
   });
 });

--- a/services/kiloclaw/controller/src/telegram-group-policy.test.ts
+++ b/services/kiloclaw/controller/src/telegram-group-policy.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { shouldDefaultTelegramGroupPolicyOpen } from './telegram-group-policy';
+
+describe('shouldDefaultTelegramGroupPolicyOpen', () => {
+  it('defaults token-only Telegram configs', () => {
+    expect(
+      shouldDefaultTelegramGroupPolicyOpen({
+        botToken: 'token',
+        enabled: true,
+        dmPolicy: 'pairing',
+      })
+    ).toBe(true);
+  });
+
+  it('defaults configs with empty or wildcard allowFrom only', () => {
+    expect(shouldDefaultTelegramGroupPolicyOpen({ allowFrom: [] })).toBe(true);
+    expect(shouldDefaultTelegramGroupPolicyOpen({ allowFrom: ['*'] })).toBe(true);
+  });
+
+  it('does not default when an explicit group policy exists', () => {
+    expect(shouldDefaultTelegramGroupPolicyOpen({ groupPolicy: 'restricted' })).toBe(false);
+    expect(shouldDefaultTelegramGroupPolicyOpen({ groupPolicy: 'disabled' })).toBe(false);
+    expect(shouldDefaultTelegramGroupPolicyOpen({ groupPolicy: 'open' })).toBe(false);
+  });
+
+  it('does not default when group access config exists', () => {
+    expect(shouldDefaultTelegramGroupPolicyOpen({ groups: {} })).toBe(false);
+    expect(
+      shouldDefaultTelegramGroupPolicyOpen({ groups: { '*': { requireMention: true } } })
+    ).toBe(false);
+    expect(shouldDefaultTelegramGroupPolicyOpen({ groups: { '-5055658641': {} } })).toBe(false);
+  });
+
+  it('does not default when concrete sender identifiers exist', () => {
+    expect(shouldDefaultTelegramGroupPolicyOpen({ groupAllowFrom: ['7676134290'] })).toBe(false);
+    expect(shouldDefaultTelegramGroupPolicyOpen({ groupAllowFrom: ['*'] })).toBe(false);
+    expect(shouldDefaultTelegramGroupPolicyOpen({ allowFrom: ['7676134290'] })).toBe(false);
+    expect(shouldDefaultTelegramGroupPolicyOpen({ allowFrom: ['telegram:7676134290'] })).toBe(
+      false
+    );
+    expect(shouldDefaultTelegramGroupPolicyOpen({ allowFrom: ['-5055658641'] })).toBe(false);
+  });
+
+  it('does not default advanced multi-account Telegram config', () => {
+    expect(shouldDefaultTelegramGroupPolicyOpen({ accounts: { default: {} } })).toBe(false);
+  });
+});

--- a/services/kiloclaw/controller/src/telegram-group-policy.ts
+++ b/services/kiloclaw/controller/src/telegram-group-policy.ts
@@ -1,0 +1,21 @@
+type TelegramConfig = Record<string, unknown>;
+
+function hasConfiguredEntries(value: unknown): boolean {
+  if (!Array.isArray(value)) return false;
+  return value.some(item => typeof item === 'string' && item.trim() !== '');
+}
+
+function hasConcreteTelegramIdentifiers(value: unknown): boolean {
+  if (!Array.isArray(value)) return false;
+  return value.some(item => typeof item === 'string' && item.trim() !== '' && item.trim() !== '*');
+}
+
+export function shouldDefaultTelegramGroupPolicyOpen(telegram: TelegramConfig): boolean {
+  if ('groupPolicy' in telegram) return false;
+  if ('groups' in telegram) return false;
+  if ('accounts' in telegram) return false;
+  if (hasConfiguredEntries(telegram.groupAllowFrom)) return false;
+  if (hasConcreteTelegramIdentifiers(telegram.allowFrom)) return false;
+
+  return true;
+}

--- a/services/kiloclaw/plugins/kilo-chat/package.json
+++ b/services/kiloclaw/plugins/kilo-chat/package.json
@@ -28,7 +28,7 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "openclaw": "2026.4.15"
+    "openclaw": "2026.4.26"
   },
   "devDependencies": {
     "esbuild": "^0.25.2",

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -2855,6 +2855,7 @@ describe('updateChannels', () => {
           botToken: 'data',
           enabled: true,
           dmPolicy: 'pairing',
+          groupPolicy: 'open',
         },
         discord: {
           token: 'discord-data',
@@ -8887,6 +8888,7 @@ describe('channel config patch builder', () => {
           botToken: 'telegram-token',
           enabled: true,
           dmPolicy: 'pairing',
+          groupPolicy: 'open',
         },
         discord: {
           token: 'discord-token',
@@ -9051,6 +9053,7 @@ describe('flushPendingConfigToGateway: alarm retry for pending identity/exec/cha
           botToken: 'telegram-token',
           enabled: true,
           dmPolicy: 'pairing',
+          groupPolicy: 'open',
         },
       },
       plugins: { entries: { telegram: { enabled: true } } },

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/channel-config.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/channel-config.ts
@@ -8,6 +8,7 @@ export type ChannelConfigPatch = {
       botToken: string;
       enabled: true;
       dmPolicy: string;
+      groupPolicy: 'open';
     };
     discord?: {
       token: string;
@@ -58,6 +59,7 @@ export function buildChannelConfigPatch(
       botToken: channelEnv.TELEGRAM_BOT_TOKEN,
       enabled: true,
       dmPolicy,
+      groupPolicy: 'open',
     };
     patch.plugins.entries.telegram = { enabled: true };
   }


### PR DESCRIPTION
## Summary
- Upgrade the KiloClaw image to OpenClaw 2026.4.26 and harden the existing OpenClaw dist patch for provider-model discovery timeout changes.
- Add a narrowly scoped startup repair for persisted internal backend `gateway-client` pairing records missing `operator.approvals`, plus pairing-cache repair handling that avoids using Gateway RPC while Gateway may be pairing-blocked.
- Add OpenClaw 2026.4.26 hook config compatibility for templated inbound-email session keys by declaring allowed request session key prefixes.

## Verification
- Built and pushed a dev KiloClaw image after removing the overly strict OpenClaw version assertion; the image installed OpenClaw 2026.4.26 and applied both OpenClaw dist patches successfully.
- Upgraded a dev KiloClaw instance and confirmed the controller/gateway reached ready state with OpenClaw 2026.4.26.
- Confirmed the previously observed gateway startup failure for templated hook session keys was addressed by the generated hook config patch.

## Visual Changes
N/A

## Reviewer Notes
- `KILOCLAW_PAIRING_REPAIR_2026_04_28` marks the temporary repair paths so they can be found and removed after affected persisted volumes are repaired and OpenClaw no longer routes native approval startup through stale paired-device state.
- The repair intentionally only targets internal backend `gateway-client` records and only adds `operator.approvals`; it does not grant admin/write scopes or touch user devices.
- Pre-push hook currently fails on existing Northflank lint errors from rebased `origin/main`, outside this PR's changed files. The branch was pushed with explicit approval using `--no-verify`.