### PR TITLE
Kiloclaw user early access

### DIFF
--- a/apps/web/src/app/(app)/claw/components/EarlyAccessCard.tsx
+++ b/apps/web/src/app/(app)/claw/components/EarlyAccessCard.tsx
@@ -32,8 +32,14 @@ export function EarlyAccessCard() {
         void queryClient.invalidateQueries({
           queryKey: trpc.kiloclaw.myEarlyAccess.queryKey(),
         });
+        // Refresh both personal and org latest-version queries — this card
+        // renders on both Settings pages and the toggle affects whichever
+        // instance the user is looking at.
         void queryClient.invalidateQueries({
           queryKey: trpc.kiloclaw.latestVersion.queryKey(),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.organizations.kiloclaw.latestVersion.queryKey(),
         });
       },
       onError: err => {

--- a/apps/web/src/app/(app)/claw/components/EarlyAccessCard.tsx
+++ b/apps/web/src/app/(app)/claw/components/EarlyAccessCard.tsx
@@ -19,7 +19,11 @@ export function EarlyAccessCard() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
-  const { data: enabled, isLoading } = useQuery(trpc.kiloclaw.myEarlyAccess.queryOptions());
+  const {
+    data: enabled,
+    isLoading,
+    isError,
+  } = useQuery(trpc.kiloclaw.myEarlyAccess.queryOptions());
 
   const { mutateAsync, isPending } = useMutation(
     trpc.kiloclaw.setMyEarlyAccess.mutationOptions({
@@ -65,14 +69,16 @@ export function EarlyAccessCard() {
         <div className="flex items-center gap-3 pt-0.5">
           <Switch
             checked={!!enabled}
-            disabled={isLoading || isPending}
+            disabled={isLoading || isPending || isError}
             onCheckedChange={next => {
               void mutateAsync({ value: next });
             }}
             aria-label="Early Access"
           />
           <span className="text-sm">
-            {isLoading || isPending ? (
+            {isError ? (
+              <span className="text-destructive">Failed to load</span>
+            ) : isLoading || isPending ? (
               <span className="text-muted-foreground">…</span>
             ) : enabled ? (
               <span className="font-medium text-green-500">Enabled</span>

--- a/apps/web/src/app/(app)/claw/components/EarlyAccessCard.tsx
+++ b/apps/web/src/app/(app)/claw/components/EarlyAccessCard.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { Rocket, Info } from 'lucide-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Switch } from '@/components/ui/switch';
+
+/**
+ * User self serve toggle for the per user `kiloclaw_early_access` flag.
+ * When on, the rollout selector force includes the user's instances in any
+ * in flight candidate, regardless of bucket. Per instance pins still win,
+ * so the toggle is purely additive: it never overrides a pin.
+ *
+ * Sits inside the "Manage Version" expandable on the consumer settings page,
+ * alongside VersionPinCard.
+ */
+export function EarlyAccessCard() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const { data: enabled, isLoading } = useQuery(trpc.kiloclaw.myEarlyAccess.queryOptions());
+
+  const { mutateAsync, isPending } = useMutation(
+    trpc.kiloclaw.setMyEarlyAccess.mutationOptions({
+      onSuccess: result => {
+        toast.success(result.earlyAccess ? 'Early Access enabled' : 'Early Access disabled');
+        void queryClient.invalidateQueries({
+          queryKey: trpc.kiloclaw.myEarlyAccess.queryKey(),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.kiloclaw.latestVersion.queryKey(),
+        });
+      },
+      onError: err => {
+        toast.error(`Failed to update Early Access: ${err.message}`);
+      },
+    })
+  );
+
+  return (
+    <div>
+      <h3 className="text-foreground mb-1 flex items-center gap-2 text-sm font-medium">
+        <Rocket className="size-4" />
+        Early Access
+      </h3>
+      <div className="grid grid-cols-1 items-start gap-6 sm:grid-cols-2">
+        {/* Left: description */}
+        <div className="space-y-2">
+          <p className="text-muted-foreground text-sm">
+            Get new versions before everyone else. When a release is rolling out, your instances see
+            it right away instead of waiting for full availability.
+          </p>
+          <div className="text-muted-foreground flex items-start gap-1 text-xs">
+            <Info className="mt-0.5 h-3 w-3 shrink-0" />
+            <span>
+              Applies to all of your instances, personal and org. A version pin always wins per
+              instance, so a pinned instance ignores Early Access until you unpin.
+            </span>
+          </div>
+        </div>
+
+        {/* Right: toggle + inline status label. Vertically centers in the
+            column so it lines up against the start of the description. */}
+        <div className="flex items-center gap-3 pt-0.5">
+          <Switch
+            checked={!!enabled}
+            disabled={isLoading || isPending}
+            onCheckedChange={next => {
+              void mutateAsync({ value: next });
+            }}
+            aria-label="Early Access"
+          />
+          <span className="text-sm">
+            {isLoading || isPending ? (
+              <span className="text-muted-foreground">…</span>
+            ) : enabled ? (
+              <span className="font-medium text-green-500">Enabled</span>
+            ) : (
+              <span className="text-muted-foreground">Disabled</span>
+            )}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/claw/components/EarlyAccessCard.tsx
+++ b/apps/web/src/app/(app)/claw/components/EarlyAccessCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Rocket, Info } from 'lucide-react';
+import { Rocket, Info, AlertTriangle } from 'lucide-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useTRPC } from '@/lib/trpc/utils';
@@ -61,6 +61,14 @@ export function EarlyAccessCard() {
             Get new versions before everyone else. When a release is rolling out, your instances see
             it right away instead of waiting for full availability.
           </p>
+          <div className="flex items-start gap-1 text-xs text-amber-500">
+            <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+            <span>
+              Heads up: early versions are still being tested. They may have bugs or rough edges
+              that the general release won&apos;t. Leave this off if you want the most stable
+              experience.
+            </span>
+          </div>
           <div className="text-muted-foreground flex items-start gap-1 text-xs">
             <Info className="mt-0.5 h-3 w-3 shrink-0" />
             <span>

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -76,6 +76,7 @@ import { AnimatedDots } from './AnimatedDots';
 import { ConfirmActionDialog } from './ConfirmActionDialog';
 import { PairingSection } from './PairingSection';
 import { VersionPinCard } from './VersionPinCard';
+import { EarlyAccessCard } from './EarlyAccessCard';
 import { WorkspaceFileEditor } from './WorkspaceFileEditor';
 import { PermissionPresetCards } from './PermissionPresetCards';
 import { CustomSecretsSection } from './CustomSecretsSection';
@@ -1611,14 +1612,15 @@ export function SettingsTab({
           </Button>
         </div>
 
-        {/* Expandable version pinning */}
+        {/* Expandable Manage Version section: pinning + Early Access opt in. */}
         {manageVersionOpen && (
-          <div className="mt-4 border-t pt-4">
+          <div className="mt-4 space-y-6 border-t pt-4">
             <VersionPinCard
               trackedImageTag={status.trackedImageTag}
               latestImageTag={variantsMatch ? (latestVersion?.imageTag ?? null) : null}
               mutations={mutations}
             />
+            <EarlyAccessCard />
           </div>
         )}
       </div>

--- a/apps/web/src/app/(app)/claw/components/VersionPinCard.tsx
+++ b/apps/web/src/app/(app)/claw/components/VersionPinCard.tsx
@@ -96,29 +96,20 @@ export function VersionPinCard({
     <div>
       <h3 className="text-foreground mb-1 flex items-center gap-2 text-sm font-medium">
         <Pin className="size-4" />
-        Version Pinning
+        Pin a version
       </h3>
       <div className="grid grid-cols-1 items-start gap-6 sm:grid-cols-2">
-        {/* Left: Description + Pinning Controls */}
+        {/* Left: description + controls (or pinned status) */}
         <div className="space-y-3">
-          <div className="space-y-2">
-            <p className="text-muted-foreground text-sm">
-              Pin your instance to a specific OpenClaw version or follow the latest
-            </p>
-            <div className="text-muted-foreground flex items-start gap-1 text-xs">
-              <Info className="mt-0.5 h-3 w-3 shrink-0" />
-              <span>
-                Pinning locks your instance to a specific version. You won&apos;t receive automatic
-                updates until you unpin.
-              </span>
-            </div>
-          </div>
+          <p className="text-muted-foreground text-sm">
+            Lock your instance to a specific OpenClaw version. No automatic updates until you unpin.
+          </p>
 
           {!isPinned ? (
             <div className="space-y-3">
               <div className="space-y-2">
                 <Label htmlFor="version-select" className="text-sm">
-                  Select Version
+                  Select version
                 </Label>
                 <div className="flex items-center gap-2">
                   <Select value={selectedImageTag} onValueChange={setSelectedImageTag}>
@@ -167,24 +158,12 @@ export function VersionPinCard({
                 />
               </div>
             </div>
-          ) : null}
-        </div>
-
-        {/* Right: Current Status */}
-        <div>
-          <h3 className="text-muted-foreground mb-2 text-sm font-medium">Current Status</h3>
-          {isPinned ? (
+          ) : (
             <div className="space-y-1.5 text-sm">
               <div>
                 <span className="text-muted-foreground">Pinned to: </span>
                 <code className="bg-muted rounded px-1.5 py-0.5 text-xs">
                   {myPin.openclaw_version ?? 'Unknown'} / {myPin.variant ?? 'Unknown'}
-                </code>
-              </div>
-              <div>
-                <span className="text-muted-foreground">Image tag: </span>
-                <code className="bg-muted rounded px-1.5 py-0.5 text-xs" title={myPin.image_tag}>
-                  {truncateTag(myPin.image_tag)}
                 </code>
               </div>
               {myPin.reason && (
@@ -197,7 +176,7 @@ export function VersionPinCard({
                 <span className="text-muted-foreground">Pinned by: </span>
                 <span>{pinnedByLabel}</span>
               </div>
-              <div className="space-y-1.5 pt-2">
+              <div className="pt-2">
                 {pinnedBySelf ? (
                   <>
                     <Button
@@ -209,7 +188,7 @@ export function VersionPinCard({
                       <PinOff className="mr-2 size-4" />
                       {isUnpinning ? 'Unpinning...' : 'Unpin'}
                     </Button>
-                    <p className="text-muted-foreground flex items-start gap-1 text-xs">
+                    <p className="text-muted-foreground mt-1.5 flex items-start gap-1 text-xs">
                       <Info className="mt-0.5 h-3 w-3 shrink-0" />
                       <span>
                         Unpinning returns to following latest. Use the Upgrade button to upgrade
@@ -227,50 +206,59 @@ export function VersionPinCard({
                 )}
               </div>
             </div>
-          ) : (
-            <div className="space-y-3">
-              <div className="flex items-center gap-2">
-                <span className="rounded-full bg-green-100 px-3 py-0.5 text-center text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-100">
-                  Following latest
-                </span>
-                <span className="text-muted-foreground text-xs">
-                  Automatically uses newest version
-                </span>
-              </div>
-              {(trackedImageTag || latestImageTag) && (
-                <table className="text-sm">
-                  <tbody>
-                    {trackedImageTag && (
-                      <tr>
-                        <td className="text-muted-foreground pr-3 align-top">Current image</td>
-                        <td>
-                          <code
-                            className="bg-muted rounded px-1.5 py-0.5 text-xs"
-                            title={trackedImageTag}
-                          >
-                            {truncateTag(trackedImageTag)}
-                          </code>
-                        </td>
-                      </tr>
-                    )}
-                    {latestImageTag && (
-                      <tr>
-                        <td className="text-muted-foreground pr-3 pt-1 align-top">Latest image</td>
-                        <td className="pt-1">
-                          <code
-                            className="bg-muted rounded px-1.5 py-0.5 text-xs"
-                            title={latestImageTag}
-                          >
-                            {truncateTag(latestImageTag)}
-                          </code>
-                        </td>
-                      </tr>
-                    )}
-                  </tbody>
-                </table>
-              )}
-            </div>
           )}
+        </div>
+
+        {/* Right: compact image hash list. No redundant heading and no
+            "Following latest" pill — those live in the OpenClaw Instance row
+            above. */}
+        <div className="text-sm">
+          <table>
+            <tbody>
+              {isPinned ? (
+                <tr>
+                  <td className="text-muted-foreground pr-3 align-top">Pinned image</td>
+                  <td>
+                    <code
+                      className="bg-muted rounded px-1.5 py-0.5 text-xs"
+                      title={myPin.image_tag}
+                    >
+                      {truncateTag(myPin.image_tag)}
+                    </code>
+                  </td>
+                </tr>
+              ) : (
+                <>
+                  {trackedImageTag && (
+                    <tr>
+                      <td className="text-muted-foreground pr-3 align-top">Current image</td>
+                      <td>
+                        <code
+                          className="bg-muted rounded px-1.5 py-0.5 text-xs"
+                          title={trackedImageTag}
+                        >
+                          {truncateTag(trackedImageTag)}
+                        </code>
+                      </td>
+                    </tr>
+                  )}
+                  {latestImageTag && (
+                    <tr>
+                      <td className="text-muted-foreground pr-3 pt-1 align-top">Latest image</td>
+                      <td className="pt-1">
+                        <code
+                          className="bg-muted rounded px-1.5 py-0.5 text-xs"
+                          title={latestImageTag}
+                        >
+                          {truncateTag(latestImageTag)}
+                        </code>
+                      </td>
+                    </tr>
+                  )}
+                </>
+              )}
+            </tbody>
+          </table>
         </div>
       </div>
     </div>

--- a/apps/web/src/app/(app)/claw/components/changelog-data.ts
+++ b/apps/web/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,13 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-04-28',
+    description:
+      'Added an Early Access opt-in under Settings → Manage Version. Turn it on to receive new KiloClaw versions while they are still rolling out, instead of waiting for full availability. Applies to all of your instances, personal and org. A version pin always wins per instance, so a pinned instance ignores Early Access until you unpin.',
+    category: 'feature',
+    deployHint: null,
+  },
+  {
     date: '2026-04-23',
     description:
       'Added Morning Briefing for KiloClaw-hosted OpenClaw instances. The new bundled plugin can schedule daily briefings, run on demand, and save/read today and yesterday briefing Markdown files from persistent instance storage. Dashboard settings now include Morning Briefing status, source readiness, and controls.',

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -33,7 +33,6 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
-import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import {
   User,
@@ -193,45 +192,14 @@ function CopySshCommandButton({
 
 function EarlyAccessSection({
   userId,
-  initialValue,
+  value,
   isPinned,
 }: {
   userId: string;
-  initialValue: boolean;
+  value: boolean;
   /** When true, the user's pin takes precedence and Early Access has no effect for this instance. */
   isPinned: boolean;
 }) {
-  const trpc = useTRPC();
-  const queryClient = useQueryClient();
-  const [optimistic, setOptimistic] = useState(initialValue);
-
-  // Keep the toggle in sync if the parent's data refreshes out-of-band (e.g.,
-  // another admin toggles the same flag, or React Query cache invalidates).
-  // useState's initializer only runs on mount; without this we'd render stale
-  // state after a refetch.
-  useEffect(() => {
-    setOptimistic(initialValue);
-  }, [initialValue]);
-
-  const { mutateAsync, isPending } = useMutation(
-    trpc.admin.kiloclawInstances.setEarlyAccess.mutationOptions({
-      onSuccess: result => {
-        toast.success(
-          result.earlyAccess
-            ? 'Early Access enabled for this user'
-            : 'Early Access disabled for this user'
-        );
-        void queryClient.invalidateQueries({
-          queryKey: trpc.admin.kiloclawInstances.get.queryKey(),
-        });
-      },
-      onError: err => {
-        setOptimistic(initialValue);
-        toast.error(`Failed to update Early Access: ${err.message}`);
-      },
-    })
-  );
-
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-2">
@@ -240,30 +208,28 @@ function EarlyAccessSection({
       </div>
       <p className="text-muted-foreground text-sm">
         Offers this user the newest available image (including any in-flight rollout candidate)
-        across all of their instances — personal and org. Used for staff dogfooding and designated
-        beta testers. Per instance pins still take precedence.
+        across all of their instances — personal and org. Per instance pins still take precedence.
       </p>
-      <div className="flex items-center gap-3">
-        <Switch
-          checked={optimistic}
-          disabled={isPending}
-          onCheckedChange={next => {
-            setOptimistic(next);
-            void mutateAsync({ userId, value: next });
-          }}
-          aria-label="Early Access"
-        />
-        <span className="text-sm">
-          {isPending ? (
-            <span className="text-muted-foreground">Saving…</span>
-          ) : optimistic ? (
-            <span className="font-medium text-green-500">Enabled</span>
-          ) : (
-            <span className="text-muted-foreground">Disabled</span>
-          )}
-        </span>
+      <div className="flex flex-wrap items-center gap-3 text-sm">
+        <span className="text-muted-foreground">Status:</span>
+        {value ? (
+          <span className="font-medium text-green-500">Enabled</span>
+        ) : (
+          <span className="text-muted-foreground">Disabled</span>
+        )}
+        <Link
+          href={`/admin/users/${encodeURIComponent(userId)}?tab=kiloclaw`}
+          className="group ml-auto inline-flex items-center gap-1 text-xs text-blue-400 hover:underline"
+        >
+          Edit on user page
+          <ExternalLink className="h-3 w-3 opacity-60 group-hover:opacity-100" />
+        </Link>
       </div>
-      {isPinned && optimistic && (
+      <p className="text-muted-foreground text-xs">
+        Early Access is a per-user setting. Edit it on the user admin page; the user can also toggle
+        it themselves under Settings → Manage Version.
+      </p>
+      {isPinned && value && (
         <p className="flex items-start gap-1 text-xs text-amber-500">
           <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
           This instance is pinned, so Early Access has no effect here. Other instances owned by this
@@ -465,11 +431,11 @@ function VersionPinSection({ userId, instanceId }: { userId: string; instanceId:
 function VersionManagementCard({
   userId,
   instanceId,
-  earlyAccessInitial,
+  earlyAccessValue,
 }: {
   userId: string;
   instanceId: string;
-  earlyAccessInitial: boolean;
+  earlyAccessValue: boolean;
 }) {
   const trpc = useTRPC();
   // Same query VersionPinSection uses — React Query dedupes on the key, so
@@ -492,11 +458,7 @@ function VersionManagementCard({
       <CardContent>
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
           <VersionPinSection userId={userId} instanceId={instanceId} />
-          <EarlyAccessSection
-            userId={userId}
-            initialValue={earlyAccessInitial}
-            isPinned={isPinned}
-          />
+          <EarlyAccessSection userId={userId} value={earlyAccessValue} isPinned={isPinned} />
         </div>
       </CardContent>
     </Card>
@@ -3339,7 +3301,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         <VersionManagementCard
           userId={data.user_id}
           instanceId={data.id}
-          earlyAccessInitial={data.user_kiloclaw_early_access}
+          earlyAccessValue={data.user_kiloclaw_early_access}
         />
 
         {/* Workspace File Editor */}

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
@@ -11,6 +11,7 @@ import {
   CreditCard,
   ExternalLink,
   History,
+  Rocket,
   Wallet,
 } from 'lucide-react';
 import type { inferRouterOutputs } from '@trpc/server';
@@ -30,6 +31,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { RadioButtonGroup } from '@/components/ui/RadioGroup';
+import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useTRPC } from '@/lib/trpc/utils';
 import { formatDate, formatRelativeTime } from '@/lib/admin-utils';
@@ -320,6 +322,82 @@ function PaymentSourceLabel({ sub }: { sub: Subscription }) {
     );
   }
   return <span className="text-xs text-muted-foreground">No payment source</span>;
+}
+
+// ---------------------------------------------------------------------------
+// Early Access — canonical per-user toggle. The instance admin page mirrors
+// this read-only and links here, since the underlying flag lives on the user.
+// ---------------------------------------------------------------------------
+
+function EarlyAccessRow({ userId, initialValue }: { userId: string; initialValue: boolean }) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [optimistic, setOptimistic] = useState(initialValue);
+
+  // Reset to server value if the parent's data refreshes (e.g. cache invalidate
+  // from another admin tab). useState's initializer runs only on mount.
+  useEffect(() => {
+    setOptimistic(initialValue);
+  }, [initialValue]);
+
+  const { mutateAsync, isPending } = useMutation(
+    trpc.admin.kiloclawInstances.setEarlyAccess.mutationOptions({
+      onSuccess: result => {
+        toast.success(
+          result.earlyAccess
+            ? 'Early Access enabled for this user'
+            : 'Early Access disabled for this user'
+        );
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.users.getKiloClawState.queryKey({ userId }),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.kiloclawInstances.get.queryKey(),
+        });
+      },
+      onError: err => {
+        setOptimistic(initialValue);
+        toast.error(`Failed to update Early Access: ${err.message}`);
+      },
+    })
+  );
+
+  return (
+    <div className="rounded-lg border bg-card/40 px-4 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex min-w-0 items-start gap-2">
+          <Rocket className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
+          <div className="min-w-0">
+            <h4 className="text-sm font-medium">Early Access</h4>
+            <p className="text-muted-foreground text-xs">
+              Offers this user the newest available image (including any in-flight rollout
+              candidate) across all of their instances. Per-instance pins still take precedence.
+            </p>
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Switch
+            checked={optimistic}
+            disabled={isPending}
+            onCheckedChange={next => {
+              setOptimistic(next);
+              void mutateAsync({ userId, value: next });
+            }}
+            aria-label="Early Access"
+          />
+          <span className="text-sm">
+            {isPending ? (
+              <span className="text-muted-foreground">Saving…</span>
+            ) : optimistic ? (
+              <span className="font-medium text-green-500">Enabled</span>
+            ) : (
+              <span className="text-muted-foreground">Disabled</span>
+            )}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -1275,6 +1353,8 @@ export function UserAdminKiloClaw({ userId }: { userId: string }) {
           ) : null}
 
           {subscriptions.length > 0 ? <SummaryStrip state={data} effective={effective} /> : null}
+
+          <EarlyAccessRow userId={userId} initialValue={data.kiloclawEarlyAccess} />
 
           {effective?.status === 'past_due' ? <PastDueBanner sub={effective} /> : null}
 

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminKiloClaw.tsx
@@ -351,9 +351,6 @@ function EarlyAccessRow({ userId, initialValue }: { userId: string; initialValue
         void queryClient.invalidateQueries({
           queryKey: trpc.admin.users.getKiloClawState.queryKey({ userId }),
         });
-        void queryClient.invalidateQueries({
-          queryKey: trpc.admin.kiloclawInstances.get.queryKey(),
-        });
       },
       onError: err => {
         setOptimistic(initialValue);

--- a/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-user-router.test.ts
@@ -79,6 +79,7 @@ describe('admin.users.getKiloClawState', () => {
       accessReason: null,
       earlybird: null,
       activeInstanceId: null,
+      kiloclawEarlyAccess: false,
       billingStateError: null,
       needsSupportReview: false,
     });

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -673,7 +673,7 @@ export const adminRouter = createTRPCRouter({
 
     getKiloClawState: adminProcedure.input(GetKiloClawStateSchema).query(async ({ input }) => {
       const user = await db.query.kilocode_users.findFirst({
-        columns: { id: true },
+        columns: { id: true, kiloclaw_early_access: true },
         where: eq(kilocode_users.id, input.userId),
       });
 
@@ -776,6 +776,7 @@ export const adminRouter = createTRPCRouter({
             }
           : null,
         activeInstanceId: activeInstance?.id ?? null,
+        kiloclawEarlyAccess: user.kiloclaw_early_access ?? false,
         billingStateError,
         needsSupportReview: billingStateError !== null,
       };

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -3321,12 +3321,17 @@ export const kiloclawRouter = createTRPCRouter({
    * Toggle the signed in user's own `kiloclaw_early_access` flag.
    * Self serve counterpart of admin.kiloclawInstances.setEarlyAccess.
    *
+   * Uses baseProcedure (not clawAccessProcedure) because the Settings page is
+   * shared between personal and org contexts. An org-only user — who has
+   * KiloClaw access via their org but no personal subscription/trial — must
+   * still be able to toggle this user-level preference for their org instance.
+   *
    * Routes through the KiloClaw platform service (same path as the admin
    * endpoint) so writes to this flag have a single choke-point — if that
    * route ever gains side-effects (cache bust, audit log, DO notification),
    * both admin and self-serve paths pick them up automatically.
    */
-  setMyEarlyAccess: clawAccessProcedure
+  setMyEarlyAccess: baseProcedure
     .input(z.object({ value: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
       const client = new KiloClawInternalClient();

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -3320,19 +3320,25 @@ export const kiloclawRouter = createTRPCRouter({
   /**
    * Toggle the signed in user's own `kiloclaw_early_access` flag.
    * Self serve counterpart of admin.kiloclawInstances.setEarlyAccess.
+   *
+   * Routes through the KiloClaw platform service (same path as the admin
+   * endpoint) so writes to this flag have a single choke-point — if that
+   * route ever gains side-effects (cache bust, audit log, DO notification),
+   * both admin and self-serve paths pick them up automatically.
    */
   setMyEarlyAccess: clawAccessProcedure
     .input(z.object({ value: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
-      const result = await db
-        .update(kilocode_users)
-        .set({ kiloclaw_early_access: input.value })
-        .where(eq(kilocode_users.id, ctx.user.id))
-        .returning({ id: kilocode_users.id });
-      if (result.length === 0) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+      const client = new KiloClawInternalClient();
+      try {
+        const result = await client.setUserKiloclawEarlyAccess(ctx.user.id, input.value);
+        return { earlyAccess: result.earlyAccess };
+      } catch (err) {
+        if (err instanceof KiloClawApiError && err.statusCode === 404) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+        }
+        throw err;
       }
-      return { earlyAccess: input.value };
     }),
 
   getMyPin: baseProcedure.query(async ({ ctx }) => {

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -27,6 +27,7 @@ import {
   kiloclaw_instances,
   kiloclaw_email_log,
   kiloclaw_cli_runs,
+  kilocode_users,
   cloud_agent_webhook_triggers,
   credit_transactions,
   organizations,
@@ -3300,6 +3301,38 @@ export const kiloclawRouter = createTRPCRouter({
           totalPages: Math.ceil(totalCount / limit),
         },
       };
+    }),
+
+  /**
+   * Read the signed in user's `kiloclaw_early_access` flag. When true, the
+   * rollout selector force includes the user's instances in any in flight
+   * candidate, regardless of bucket. Pin overrides still win per instance.
+   */
+  myEarlyAccess: baseProcedure.query(async ({ ctx }) => {
+    const [row] = await db
+      .select({ early_access: kilocode_users.kiloclaw_early_access })
+      .from(kilocode_users)
+      .where(eq(kilocode_users.id, ctx.user.id))
+      .limit(1);
+    return row?.early_access ?? false;
+  }),
+
+  /**
+   * Toggle the signed in user's own `kiloclaw_early_access` flag.
+   * Self serve counterpart of admin.kiloclawInstances.setEarlyAccess.
+   */
+  setMyEarlyAccess: clawAccessProcedure
+    .input(z.object({ value: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      const result = await db
+        .update(kilocode_users)
+        .set({ kiloclaw_early_access: input.value })
+        .where(eq(kilocode_users.id, ctx.user.id))
+        .returning({ id: kilocode_users.id });
+      if (result.length === 0) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+      }
+      return { earlyAccess: input.value };
     }),
 
   getMyPin: baseProcedure.query(async ({ ctx }) => {


### PR DESCRIPTION
## Summary

Adds a self serve Early Access opt in for KiloClaw users and reorganizes the admin surface so the per user `kiloclaw_early_access` flag is edited where the data lives.

* New `EarlyAccessCard` under Settings > Manage Version, alongside `VersionPinCard`. Toggle reads `kiloclaw.myEarlyAccess` and writes through `kiloclaw.setMyEarlyAccess`. Surfaces a "Failed to load" state when the read query errors so the toggle never silently shows the wrong status.
* `setMyEarlyAccess` routes through the KiloClaw platform service (same path as the admin endpoint) so writes have a single choke point. It uses `baseProcedure` rather than `clawAccessProcedure` so org only users (KiloClaw access via org, no personal subscription) can still toggle this user level preference.
* `UserAdminKiloClaw` is now the canonical admin edit point for the flag. A new `EarlyAccessRow` near the top of the user KiloClaw card lets admins flip it without hunting for an instance and works for users who have zero instances.
* `KiloclawInstanceDetail` keeps an Early Access section but it is read only; it shows the current state and links to `/admin/users/{id}?tab=kiloclaw`.
* `admin.users.getKiloClawState` now returns `kiloclawEarlyAccess` so the user admin card can render without an extra fetch.
* On a successful toggle, both `kiloclaw.latestVersion` and `organizations.kiloclaw.latestVersion` query caches are invalidated so the "Update available" badge refreshes whichever Settings page the user is on.
* `VersionPinCard` reorganized for the new two card layout: heading reads "Pin a version", the redundant "Following latest" pill is removed (the OpenClaw Instance row above already shows it), and the right column is now a clean image hash table.
* Added a What's New changelog entry dated 2026-04-28 describing the user facing toggle.

## Verification

* Manually toggled Early Access on the consumer Settings page as a personal user and confirmed the flag persists, the toast fires, and the latest version badge refreshes.
* Manually toggled Early Access on the user admin page and confirmed it propagates back to the consumer Settings page.
* Visited the instance admin page and confirmed Early Access is read only with a working "Edit on user page" link.
* Ran `pnpm run format:check`, `pnpm run lint`, and `pnpm --filter web typecheck` locally; all pass.

## Visual Changes

<img width="1122" height="528" alt="Screenshot 2026-04-28 at 4 19 38 PM" src="https://github.com/user-attachments/assets/d32b4a6a-34e1-4382-9bfc-5469edfad1cb" />


## Reviewer Notes

* Shape mirrors `VersionPinCard` so the two cards stack cleanly inside the Manage Version expandable.
* The instance admin page intentionally shows the flag read only rather than dropping it. Reason: admins debugging a specific instance still want to see whether Early Access is in effect without leaving the page, even if they have to navigate to the user page to change it.
* The admin instance procedure `admin.kiloclawInstances.setEarlyAccess` is unchanged; the user admin row reuses it (it already takes a `userId`, not an `instanceId`).
