### PR TITLE
feat(kiloclaw): route *.kiloclaw.ai and inject per-instance origins

### DIFF
--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -607,6 +607,29 @@ describe('generateBaseConfig', () => {
     ]);
   });
 
+  it('passes allowed origins entries through as literal strings', () => {
+    // The config-writer does not interpret entries — whatever openclaw's
+    // origin check understands (exact matches and bare `*`) is what matters.
+    // Per-instance virtual hosting is implemented by the worker appending a
+    // specific `https://<instanceId>.kiloclaw.ai` entry to the list before it
+    // reaches the controller (see services/kiloclaw/src/gateway/env.ts), not
+    // by using a wildcard host pattern here. A wildcard entry would be kept
+    // in the config but would never match a real Origin header.
+    const { deps } = fakeDeps();
+    const env = {
+      ...minimalEnv(),
+      OPENCLAW_ALLOWED_ORIGINS:
+        'https://claw.kilosessions.ai, https://abc.kiloclaw.ai, https://kilo.ai',
+    };
+    const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
+
+    expect(config.gateway.controlUi.allowedOrigins).toEqual([
+      'https://claw.kilosessions.ai',
+      'https://abc.kiloclaw.ai',
+      'https://kilo.ai',
+    ]);
+  });
+
   it('always configures the KiloClaw customizer plugin', () => {
     const { deps } = fakeDeps();
     const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);

--- a/services/kiloclaw/src/auth/hostname-label.test.ts
+++ b/services/kiloclaw/src/auth/hostname-label.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { sandboxIdFromUserId } from './sandbox-id';
+import { sandboxIdFromInstanceId } from '@kilocode/worker-utils/instance-id';
+import {
+  hostnameLabelFromSandboxId,
+  sandboxIdFromHostnameLabel,
+  MAX_HOSTNAME_LABEL_LENGTH,
+} from './hostname-label';
+
+describe('hostnameLabelFromSandboxId', () => {
+  it('maps an instance-keyed sandboxId to `i-{32hex}`', () => {
+    const sandboxId = sandboxIdFromInstanceId('550e8400-e29b-41d4-a716-446655440000');
+    expect(sandboxId).toBe('ki_550e8400e29b41d4a716446655440000');
+
+    expect(hostnameLabelFromSandboxId(sandboxId)).toBe('i-550e8400e29b41d4a716446655440000');
+  });
+
+  it('maps a legacy UUID userId sandboxId to `u-{base64url}`', () => {
+    const sandboxId = sandboxIdFromUserId('550e8400-e29b-41d4-a716-446655440000');
+    const label = hostnameLabelFromSandboxId(sandboxId);
+
+    expect(label).not.toBeNull();
+    expect(label?.startsWith('u-')).toBe(true);
+    expect(label).toMatch(/^u-[A-Za-z0-9]+$/);
+  });
+
+  it('maps a legacy oauth-provider userId sandboxId to a safe label', () => {
+    const sandboxId = sandboxIdFromUserId('oauth/google:118234567890');
+    const label = hostnameLabelFromSandboxId(sandboxId);
+
+    expect(label).not.toBeNull();
+    expect(label).toMatch(/^u-[A-Za-z0-9]+$/);
+  });
+
+  it('maps a legacy email-shaped userId sandboxId to a safe label', () => {
+    const sandboxId = sandboxIdFromUserId('user+tag@example.com');
+    const label = hostnameLabelFromSandboxId(sandboxId);
+
+    expect(label).not.toBeNull();
+    expect(label).toMatch(/^u-[A-Za-z0-9]+$/);
+  });
+
+  it('returns null when the legacy sandboxId contains base64url `-` or `_`', () => {
+    // `>` (0x3E) at byte position 2 / 5 / … in a userId produces a `-` in the
+    // base64url encoding (group-3 value = 62). `?` (0x3F) at the same
+    // positions produces a `_`. Neither appears in production userIds but
+    // we must not emit them in a hostname label (would violate strict RFC 1035
+    // and trip some TLS/DNS stacks). Caller should skip origin injection.
+    const sandboxIdWithDash = sandboxIdFromUserId('ab>');
+    expect(sandboxIdWithDash).toMatch(/-/);
+    expect(hostnameLabelFromSandboxId(sandboxIdWithDash)).toBeNull();
+
+    const sandboxIdWithUnderscore = sandboxIdFromUserId('ab?');
+    expect(sandboxIdWithUnderscore).toMatch(/_/);
+    expect(hostnameLabelFromSandboxId(sandboxIdWithUnderscore)).toBeNull();
+  });
+
+  it('returns null when the label would exceed the DNS label length', () => {
+    // 62-char alnum sandboxId + `u-` = 64, over the 63-char limit.
+    const overlongSandboxId = 'a'.repeat(62);
+    expect(hostnameLabelFromSandboxId(overlongSandboxId)).toBeNull();
+
+    const atLimitSandboxId = 'a'.repeat(61);
+    const label = hostnameLabelFromSandboxId(atLimitSandboxId);
+    expect(label).toBe(`u-${atLimitSandboxId}`);
+    expect(label?.length).toBe(MAX_HOSTNAME_LABEL_LENGTH);
+  });
+});
+
+describe('sandboxIdFromHostnameLabel', () => {
+  it('roundtrips an instance-keyed label', () => {
+    const sandboxId = sandboxIdFromInstanceId('550e8400-e29b-41d4-a716-446655440000');
+    const label = hostnameLabelFromSandboxId(sandboxId);
+
+    expect(label).not.toBeNull();
+    expect(sandboxIdFromHostnameLabel(label ?? '')).toBe(sandboxId);
+  });
+
+  it('roundtrips legacy userId shapes', () => {
+    const inputs = [
+      '550e8400-e29b-41d4-a716-446655440000',
+      'oauth/google:118234567890',
+      'user+tag@example.com',
+      'user_abc123',
+      '118234567890',
+    ];
+
+    for (const userId of inputs) {
+      const sandboxId = sandboxIdFromUserId(userId);
+      const label = hostnameLabelFromSandboxId(sandboxId);
+      expect(label, `userId=${userId}`).not.toBeNull();
+      expect(sandboxIdFromHostnameLabel(label ?? ''), `userId=${userId}`).toBe(sandboxId);
+    }
+  });
+
+  it('rejects labels without a recognised prefix', () => {
+    expect(sandboxIdFromHostnameLabel('abc123')).toBeNull();
+    expect(sandboxIdFromHostnameLabel('x-deadbeef')).toBeNull();
+    expect(sandboxIdFromHostnameLabel('')).toBeNull();
+  });
+
+  it('rejects instance labels with non-hex bodies', () => {
+    expect(sandboxIdFromHostnameLabel('i-NOTHEX')).toBeNull();
+    expect(sandboxIdFromHostnameLabel('i-550e8400e29b41d4a716446655440000extra')).toBeNull();
+    expect(sandboxIdFromHostnameLabel('i-')).toBeNull();
+  });
+
+  it('rejects user labels with unsafe characters', () => {
+    expect(sandboxIdFromHostnameLabel('u-foo_bar')).toBeNull();
+    expect(sandboxIdFromHostnameLabel('u-foo.bar')).toBeNull();
+    expect(sandboxIdFromHostnameLabel('u-')).toBeNull();
+  });
+});

--- a/services/kiloclaw/src/auth/hostname-label.test.ts
+++ b/services/kiloclaw/src/auth/hostname-label.test.ts
@@ -15,13 +15,14 @@ describe('hostnameLabelFromSandboxId', () => {
     expect(hostnameLabelFromSandboxId(sandboxId)).toBe('i-550e8400e29b41d4a716446655440000');
   });
 
-  it('maps a legacy UUID userId sandboxId to `u-{base64url}`', () => {
+  it('maps a legacy UUID userId sandboxId to lowercase `u-{base32hex(userId)}`', () => {
     const sandboxId = sandboxIdFromUserId('550e8400-e29b-41d4-a716-446655440000');
     const label = hostnameLabelFromSandboxId(sandboxId);
 
     expect(label).not.toBeNull();
     expect(label?.startsWith('u-')).toBe(true);
-    expect(label).toMatch(/^u-[A-Za-z0-9]+$/);
+    expect(label).toMatch(/^u-[0-9a-v]+$/);
+    expect(label).toBe(label?.toLowerCase());
   });
 
   it('maps a legacy oauth-provider userId sandboxId to a safe label', () => {
@@ -29,7 +30,8 @@ describe('hostnameLabelFromSandboxId', () => {
     const label = hostnameLabelFromSandboxId(sandboxId);
 
     expect(label).not.toBeNull();
-    expect(label).toMatch(/^u-[A-Za-z0-9]+$/);
+    expect(label).toMatch(/^u-[0-9a-v]+$/);
+    expect(label).toBe(label?.toLowerCase());
   });
 
   it('maps a legacy email-shaped userId sandboxId to a safe label', () => {
@@ -37,32 +39,28 @@ describe('hostnameLabelFromSandboxId', () => {
     const label = hostnameLabelFromSandboxId(sandboxId);
 
     expect(label).not.toBeNull();
-    expect(label).toMatch(/^u-[A-Za-z0-9]+$/);
+    expect(label).toMatch(/^u-[0-9a-v]+$/);
+    expect(label).toBe(label?.toLowerCase());
   });
 
-  it('returns null when the legacy sandboxId contains base64url `-` or `_`', () => {
-    // `>` (0x3E) at byte position 2 / 5 / … in a userId produces a `-` in the
-    // base64url encoding (group-3 value = 62). `?` (0x3F) at the same
-    // positions produces a `_`. Neither appears in production userIds but
-    // we must not emit them in a hostname label (would violate strict RFC 1035
-    // and trip some TLS/DNS stacks). Caller should skip origin injection.
+  it('maps legacy sandboxIds containing base64url `-` or `_` to safe labels', () => {
     const sandboxIdWithDash = sandboxIdFromUserId('ab>');
     expect(sandboxIdWithDash).toMatch(/-/);
-    expect(hostnameLabelFromSandboxId(sandboxIdWithDash)).toBeNull();
+    expect(hostnameLabelFromSandboxId(sandboxIdWithDash)).toBe('u-c5h3s');
 
     const sandboxIdWithUnderscore = sandboxIdFromUserId('ab?');
     expect(sandboxIdWithUnderscore).toMatch(/_/);
-    expect(hostnameLabelFromSandboxId(sandboxIdWithUnderscore)).toBeNull();
+    expect(hostnameLabelFromSandboxId(sandboxIdWithUnderscore)).toBe('u-c5h3u');
   });
 
   it('returns null when the label would exceed the DNS label length', () => {
-    // 62-char alnum sandboxId + `u-` = 64, over the 63-char limit.
-    const overlongSandboxId = 'a'.repeat(62);
+    // 39 raw bytes -> 63 base32 chars + `u-` = 65, over the 63-char limit.
+    const overlongSandboxId = sandboxIdFromUserId('a'.repeat(39));
     expect(hostnameLabelFromSandboxId(overlongSandboxId)).toBeNull();
 
-    const atLimitSandboxId = 'a'.repeat(61);
+    // 38 raw bytes -> 61 base32 chars + `u-` = 63, exactly at the limit.
+    const atLimitSandboxId = sandboxIdFromUserId('a'.repeat(38));
     const label = hostnameLabelFromSandboxId(atLimitSandboxId);
-    expect(label).toBe(`u-${atLimitSandboxId}`);
     expect(label?.length).toBe(MAX_HOSTNAME_LABEL_LENGTH);
   });
 });
@@ -93,6 +91,18 @@ describe('sandboxIdFromHostnameLabel', () => {
     }
   });
 
+  it('parses labels case-insensitively', () => {
+    const instanceSandboxId = sandboxIdFromInstanceId('550e8400-e29b-41d4-a716-446655440000');
+    expect(sandboxIdFromHostnameLabel('I-550E8400E29B41D4A716446655440000')).toBe(
+      instanceSandboxId
+    );
+
+    const legacySandboxId = sandboxIdFromUserId('oauth/google:118234567890');
+    const label = hostnameLabelFromSandboxId(legacySandboxId);
+    expect(label).not.toBeNull();
+    expect(sandboxIdFromHostnameLabel(label?.toUpperCase() ?? '')).toBe(legacySandboxId);
+  });
+
   it('rejects labels without a recognised prefix', () => {
     expect(sandboxIdFromHostnameLabel('abc123')).toBeNull();
     expect(sandboxIdFromHostnameLabel('x-deadbeef')).toBeNull();
@@ -108,6 +118,7 @@ describe('sandboxIdFromHostnameLabel', () => {
   it('rejects user labels with unsafe characters', () => {
     expect(sandboxIdFromHostnameLabel('u-foo_bar')).toBeNull();
     expect(sandboxIdFromHostnameLabel('u-foo.bar')).toBeNull();
+    expect(sandboxIdFromHostnameLabel('u-zzzz')).toBeNull();
     expect(sandboxIdFromHostnameLabel('u-')).toBeNull();
   });
 });

--- a/services/kiloclaw/src/auth/hostname-label.ts
+++ b/services/kiloclaw/src/auth/hostname-label.ts
@@ -1,0 +1,84 @@
+/**
+ * Hostname label <-> sandboxId translation for per-instance virtual hosting
+ * on `*.kiloclaw.ai`.
+ *
+ * Two instance shapes map to two label prefixes:
+ *
+ *   instance-keyed sandboxId  "ki_{32hex}"         <->  "i-{32hex}"
+ *   legacy sandboxId          "{base64url-body}"   <->  "u-{body}"
+ *
+ * Prefix disambiguates the two cases without a database lookup.
+ *
+ * DNS (RFC 1035) labels are `[A-Za-z0-9-]` with max length 63. base64url
+ * theoretically uses `_` and `-`, but for realistic (ASCII) userIds the
+ * output is alnum-only because `-` and `_` only appear in base64url when
+ * the input byte stream contains bytes >= 0x3E in specific positions, and
+ * no userId shape in production (UUIDs, `oauth/{provider}:{sub}`, emails,
+ * Google numeric subs) contains those characters. We enforce the alnum
+ * property with SAFE_LABEL_BODY_RE and fall back to "no label" for any
+ * pathological outlier rather than trying to escape.
+ */
+
+import { isInstanceKeyedSandboxId } from '@kilocode/worker-utils/instance-id';
+
+/** RFC 1035 max label length. */
+export const MAX_HOSTNAME_LABEL_LENGTH = 63;
+
+/**
+ * Characters permitted in the label body (after the `i-` or `u-` prefix).
+ * Alnum-only keeps us strictly RFC 1035 compliant without worrying about
+ * adjacent hyphens or leading/trailing hyphens that would break some
+ * resolvers and TLS stacks.
+ */
+const SAFE_LABEL_BODY_RE = /^[A-Za-z0-9]+$/;
+
+const INSTANCE_KEYED_BODY_RE = /^[0-9a-f]{32}$/;
+
+const INSTANCE_LABEL_RE = /^i-([0-9a-f]{32})$/;
+const USER_LABEL_RE = /^u-([A-Za-z0-9]+)$/;
+
+/**
+ * Produce a DNS-safe hostname label for `<label>.kiloclaw.ai` from a
+ * sandboxId, or `null` if the sandboxId can't be represented as a safe
+ * label (e.g. pathological Unicode userId whose base64url encoding
+ * contains non-alnum chars, or a label that would exceed 63 chars).
+ *
+ * Callers should treat `null` as "no per-instance origin available for
+ * this sandbox" and fall back to the shared origin list.
+ */
+export function hostnameLabelFromSandboxId(sandboxId: string): string | null {
+  if (isInstanceKeyedSandboxId(sandboxId)) {
+    const body = sandboxId.slice(3);
+    if (!INSTANCE_KEYED_BODY_RE.test(body)) return null;
+    const label = `i-${body}`;
+    if (label.length > MAX_HOSTNAME_LABEL_LENGTH) return null;
+    return label;
+  }
+
+  if (!SAFE_LABEL_BODY_RE.test(sandboxId)) return null;
+  const label = `u-${sandboxId}`;
+  if (label.length > MAX_HOSTNAME_LABEL_LENGTH) return null;
+  return label;
+}
+
+/**
+ * Reverse of `hostnameLabelFromSandboxId`: parse a hostname label back
+ * into its sandboxId, returning `null` if the label doesn't match either
+ * scheme.
+ *
+ * Used by the host-based router in a follow-up PR to resolve
+ * `<label>.kiloclaw.ai` to the owning Instance DO.
+ */
+export function sandboxIdFromHostnameLabel(label: string): string | null {
+  const instanceMatch = INSTANCE_LABEL_RE.exec(label);
+  if (instanceMatch) return `ki_${instanceMatch[1]}`;
+
+  const userMatch = USER_LABEL_RE.exec(label);
+  if (userMatch) {
+    const body = userMatch[1];
+    if (body.length + 2 > MAX_HOSTNAME_LABEL_LENGTH) return null;
+    return body;
+  }
+
+  return null;
+}

--- a/services/kiloclaw/src/auth/hostname-label.ts
+++ b/services/kiloclaw/src/auth/hostname-label.ts
@@ -4,19 +4,10 @@
  *
  * Two instance shapes map to two label prefixes:
  *
- *   instance-keyed sandboxId  "ki_{32hex}"         <->  "i-{32hex}"
- *   legacy sandboxId          "{base64url-body}"   <->  "u-{body}"
+ *   instance-keyed sandboxId  "ki_{32hex}"       <->  "i-{32hex}"
+ *   legacy sandboxId          base64url(userId)   <->  "u-{base32hex(userId)}"
  *
  * Prefix disambiguates the two cases without a database lookup.
- *
- * DNS (RFC 1035) labels are `[A-Za-z0-9-]` with max length 63. base64url
- * theoretically uses `_` and `-`, but for realistic (ASCII) userIds the
- * output is alnum-only because `-` and `_` only appear in base64url when
- * the input byte stream contains bytes >= 0x3E in specific positions, and
- * no userId shape in production (UUIDs, `oauth/{provider}:{sub}`, emails,
- * Google numeric subs) contains those characters. We enforce the alnum
- * property with SAFE_LABEL_BODY_RE and fall back to "no label" for any
- * pathological outlier rather than trying to escape.
  */
 
 import { isInstanceKeyedSandboxId } from '@kilocode/worker-utils/instance-id';
@@ -24,18 +15,74 @@ import { isInstanceKeyedSandboxId } from '@kilocode/worker-utils/instance-id';
 /** RFC 1035 max label length. */
 export const MAX_HOSTNAME_LABEL_LENGTH = 63;
 
-/**
- * Characters permitted in the label body (after the `i-` or `u-` prefix).
- * Alnum-only keeps us strictly RFC 1035 compliant without worrying about
- * adjacent hyphens or leading/trailing hyphens that would break some
- * resolvers and TLS stacks.
- */
-const SAFE_LABEL_BODY_RE = /^[A-Za-z0-9]+$/;
-
+const BASE32_HEX_ALPHABET = '0123456789abcdefghijklmnopqrstuv';
 const INSTANCE_KEYED_BODY_RE = /^[0-9a-f]{32}$/;
 
 const INSTANCE_LABEL_RE = /^i-([0-9a-f]{32})$/;
-const USER_LABEL_RE = /^u-([A-Za-z0-9]+)$/;
+const USER_LABEL_RE = /^u-([0-9a-v]+)$/;
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  const binString = Array.from(bytes, b => String.fromCodePoint(b)).join('');
+  return btoa(binString).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64urlToBytes(encoded: string): Uint8Array | null {
+  try {
+    let b64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+    while (b64.length % 4 !== 0) {
+      b64 += '=';
+    }
+    const binString = atob(b64);
+    const bytes = Uint8Array.from(binString, c => c.codePointAt(0) ?? 0);
+    return bytesToBase64url(bytes) === encoded ? bytes : null;
+  } catch {
+    return null;
+  }
+}
+
+function bytesToBase32Hex(bytes: Uint8Array): string {
+  let output = '';
+  let buffer = 0;
+  let bits = 0;
+
+  for (const byte of bytes) {
+    buffer = (buffer << 8) | byte;
+    bits += 8;
+
+    while (bits >= 5) {
+      bits -= 5;
+      output += BASE32_HEX_ALPHABET[(buffer >> bits) & 31];
+    }
+  }
+
+  if (bits > 0) {
+    output += BASE32_HEX_ALPHABET[(buffer << (5 - bits)) & 31];
+  }
+
+  return output;
+}
+
+function base32HexToBytes(encoded: string): Uint8Array | null {
+  const bytes: number[] = [];
+  let buffer = 0;
+  let bits = 0;
+
+  for (const char of encoded) {
+    const value = BASE32_HEX_ALPHABET.indexOf(char);
+    if (value === -1) return null;
+
+    buffer = (buffer << 5) | value;
+    bits += 5;
+
+    while (bits >= 8) {
+      bits -= 8;
+      bytes.push((buffer >> bits) & 255);
+    }
+  }
+
+  const decoded = Uint8Array.from(bytes);
+  return bytesToBase32Hex(decoded) === encoded ? decoded : null;
+}
 
 /**
  * Produce a DNS-safe hostname label for `<label>.kiloclaw.ai` from a
@@ -55,8 +102,10 @@ export function hostnameLabelFromSandboxId(sandboxId: string): string | null {
     return label;
   }
 
-  if (!SAFE_LABEL_BODY_RE.test(sandboxId)) return null;
-  const label = `u-${sandboxId}`;
+  const legacyUserIdBytes = base64urlToBytes(sandboxId);
+  if (!legacyUserIdBytes || legacyUserIdBytes.length === 0) return null;
+
+  const label = `u-${bytesToBase32Hex(legacyUserIdBytes)}`;
   if (label.length > MAX_HOSTNAME_LABEL_LENGTH) return null;
   return label;
 }
@@ -70,14 +119,17 @@ export function hostnameLabelFromSandboxId(sandboxId: string): string | null {
  * `<label>.kiloclaw.ai` to the owning Instance DO.
  */
 export function sandboxIdFromHostnameLabel(label: string): string | null {
-  const instanceMatch = INSTANCE_LABEL_RE.exec(label);
+  const normalized = label.toLowerCase();
+  const instanceMatch = INSTANCE_LABEL_RE.exec(normalized);
   if (instanceMatch) return `ki_${instanceMatch[1]}`;
 
-  const userMatch = USER_LABEL_RE.exec(label);
+  const userMatch = USER_LABEL_RE.exec(normalized);
   if (userMatch) {
     const body = userMatch[1];
     if (body.length + 2 > MAX_HOSTNAME_LABEL_LENGTH) return null;
-    return body;
+    const bytes = base32HexToBytes(body);
+    if (!bytes) return null;
+    return bytesToBase64url(bytes);
   }
 
   return null;

--- a/services/kiloclaw/src/config.ts
+++ b/services/kiloclaw/src/config.ts
@@ -18,17 +18,17 @@ export const OPENCLAW_BUILTIN_DEFAULT_MODEL = 'kilocode/anthropic/claude-opus-4.
  * Version marker for what the worker hands to a machine's controller at
  * provision/start/restart time. Bumped when we change the set of env vars,
  * controller config shape, or origin-check rules. Persisted per-instance as
- * `controllerCapabilitiesVersion` so the dashboard can tell whether a given
- * live machine was configured by a current worker (safe to route at a new
- * host, etc.) or is still running on a pre-cutover config and needs a restart.
+ * `controllerCapabilitiesVersion` so callers can tell which controller
+ * configuration contract a running machine was started with.
  *
  * Legacy instances (persisted as null) are treated as version 1.
  *
  * Version history:
  *   1 — implicit; pre-capability-tracking.
- *   2 — controller accepts wildcard entries in OPENCLAW_ALLOWED_ORIGINS
- *       (e.g. `https://*.kiloclaw.ai`). Machines at this version can serve
- *       the Control UI from any *.kiloclaw.ai subdomain.
+ *   2 — controller env contains a per-instance literal origin
+ *       `https://<label>.kiloclaw.ai` appended to OPENCLAW_ALLOWED_ORIGINS.
+ *       Origin checking remains exact string only; wildcard host patterns are
+ *       not supported.
  */
 export const WORKER_CONTROLLER_CAPABILITIES_VERSION = 2;
 

--- a/services/kiloclaw/src/config.ts
+++ b/services/kiloclaw/src/config.ts
@@ -14,6 +14,24 @@ export const OPENCLAW_INTERNAL_PORT = 3001;
  *  Used as fallback when the user clears their model selection. */
 export const OPENCLAW_BUILTIN_DEFAULT_MODEL = 'kilocode/anthropic/claude-opus-4.6';
 
+/**
+ * Version marker for what the worker hands to a machine's controller at
+ * provision/start/restart time. Bumped when we change the set of env vars,
+ * controller config shape, or origin-check rules. Persisted per-instance as
+ * `controllerCapabilitiesVersion` so the dashboard can tell whether a given
+ * live machine was configured by a current worker (safe to route at a new
+ * host, etc.) or is still running on a pre-cutover config and needs a restart.
+ *
+ * Legacy instances (persisted as null) are treated as version 1.
+ *
+ * Version history:
+ *   1 — implicit; pre-capability-tracking.
+ *   2 — controller accepts wildcard entries in OPENCLAW_ALLOWED_ORIGINS
+ *       (e.g. `https://*.kiloclaw.ai`). Machines at this version can serve
+ *       the Control UI from any *.kiloclaw.ai subdomain.
+ */
+export const WORKER_CONTROLLER_CAPABILITIES_VERSION = 2;
+
 /** Maximum time to wait for the machine to reach 'started' state.
  *  Fly's /wait endpoint caps at 60s (spec.json:1538). */
 export const STARTUP_TIMEOUT_SECONDS = 60;

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -1992,11 +1992,11 @@ describe('buildUserEnvVars API key refresh', () => {
   });
 
   it('does NOT persist controllerCapabilitiesVersion during env build', async () => {
-    // The capabilities version must only be bumped after the provider
-    // confirms the new env/config has been applied — persisting here would
-    // let the DO report a version the running machine may not actually have
-    // yet if the subsequent provider update fails. See
-    // markControllerCapabilitiesApplied for the post-success write site.
+    // The capabilities version must only be bumped atomically with the
+    // final `status = running` transition, inside the DO's ownership guard.
+    // Persisting here would let the DO report a version the running machine
+    // may not actually have yet if the subsequent provider update fails or
+    // is raced by a concurrent destroy().
     const { instance, storage } = createInstance();
     await seedProvisioned(storage, {
       kilocodeApiKey: 'stale-key',
@@ -2008,34 +2008,6 @@ describe('buildUserEnvVars API key refresh', () => {
     await callBuildUserEnvVars(instance);
 
     expect(storage._store.get('controllerCapabilitiesVersion')).toBeUndefined();
-  });
-});
-
-describe('markControllerCapabilitiesApplied', () => {
-  it('persists the worker version on first call', async () => {
-    const { markControllerCapabilitiesApplied } = await import('./kiloclaw-instance/config');
-    const storage = createFakeStorage();
-    const ctx = { storage } as unknown as DurableObjectState;
-    const state = { controllerCapabilitiesVersion: null as number | null };
-
-    await markControllerCapabilitiesApplied(ctx, state);
-
-    expect(state.controllerCapabilitiesVersion).toBe(WORKER_CONTROLLER_CAPABILITIES_VERSION);
-    expect(storage._store.get('controllerCapabilitiesVersion')).toBe(
-      WORKER_CONTROLLER_CAPABILITIES_VERSION
-    );
-  });
-
-  it('is idempotent when already at the current version', async () => {
-    const { markControllerCapabilitiesApplied } = await import('./kiloclaw-instance/config');
-    const storage = createFakeStorage();
-    const ctx = { storage } as unknown as DurableObjectState;
-    const state = { controllerCapabilitiesVersion: WORKER_CONTROLLER_CAPABILITIES_VERSION };
-    const putSpy = vi.spyOn(storage, 'put');
-
-    await markControllerCapabilitiesApplied(ctx, state);
-
-    expect(putSpy).not.toHaveBeenCalled();
   });
 });
 
@@ -2192,6 +2164,30 @@ describe('startExistingMachine: transient vs 404 errors', () => {
 
     expect(flyClient.createMachine).toHaveBeenCalled();
     expect(storage._store.get('flyMachineId')).toBe('machine-new');
+  });
+
+  it('persists controllerCapabilitiesVersion atomically with the running transition', async () => {
+    // The version bump must land in the same persist call that flips status
+    // to `running`, inside the post-start ownership guard. This keeps it in
+    // sync with what the running machine actually has, and prevents a stale
+    // write recreating partial DO storage after a concurrent destroy.
+    const { instance, storage } = createInstance();
+    await seedRunning(storage, { status: 'stopped' });
+
+    (flyClient.getMachine as Mock).mockRejectedValue(new FlyApiError('not found', 404, '{}'));
+    (flyClient.createMachine as Mock).mockResolvedValue({
+      id: 'machine-new',
+      region: 'iad',
+    });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-1' });
+
+    await instance.start('user-1');
+
+    expect(storage._store.get('status')).toBe('running');
+    expect(storage._store.get('controllerCapabilitiesVersion')).toBe(
+      WORKER_CONTROLLER_CAPABILITIES_VERSION
+    );
   });
 
   it('destroys stale machine and recreates it when updateMachine reports a missing volume', async () => {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -147,6 +147,7 @@ import {
   RESTARTING_MAX_TIMEOUT_MS,
   RECOVERING_TIMEOUT_MS,
   STALE_PROVISION_THRESHOLD_MS,
+  WORKER_CONTROLLER_CAPABILITIES_VERSION,
 } from '../config';
 
 // ============================================================================
@@ -1988,6 +1989,40 @@ describe('buildUserEnvVars API key refresh', () => {
     );
     expect(db.findPepperByUserId).not.toHaveBeenCalled();
     expect(gatewayEnv.buildEnvVars).not.toHaveBeenCalled();
+  });
+
+  it('persists controllerCapabilitiesVersion matching the worker constant', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, {
+      kilocodeApiKey: 'stale-key',
+      kilocodeApiKeyExpiresAt: '2026-12-01T00:00:00.000Z',
+    });
+
+    expect(storage._store.get('controllerCapabilitiesVersion')).toBeUndefined();
+
+    await callBuildUserEnvVars(instance);
+
+    expect(storage._store.get('controllerCapabilitiesVersion')).toBe(
+      WORKER_CONTROLLER_CAPABILITIES_VERSION
+    );
+  });
+
+  it('skips the capabilities version write when storage already matches', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, {
+      kilocodeApiKey: 'stale-key',
+      kilocodeApiKeyExpiresAt: '2026-12-01T00:00:00.000Z',
+      controllerCapabilitiesVersion: WORKER_CONTROLLER_CAPABILITIES_VERSION,
+    });
+    const putSpy = vi.spyOn(storage, 'put');
+
+    await callBuildUserEnvVars(instance);
+
+    const capabilityWrites = putSpy.mock.calls.filter(call => {
+      const [arg] = call;
+      return typeof arg === 'object' && arg !== null && 'controllerCapabilitiesVersion' in arg;
+    });
+    expect(capabilityWrites).toHaveLength(0);
   });
 });
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -1991,7 +1991,12 @@ describe('buildUserEnvVars API key refresh', () => {
     expect(gatewayEnv.buildEnvVars).not.toHaveBeenCalled();
   });
 
-  it('persists controllerCapabilitiesVersion matching the worker constant', async () => {
+  it('does NOT persist controllerCapabilitiesVersion during env build', async () => {
+    // The capabilities version must only be bumped after the provider
+    // confirms the new env/config has been applied — persisting here would
+    // let the DO report a version the running machine may not actually have
+    // yet if the subsequent provider update fails. See
+    // markControllerCapabilitiesApplied for the post-success write site.
     const { instance, storage } = createInstance();
     await seedProvisioned(storage, {
       kilocodeApiKey: 'stale-key',
@@ -2002,27 +2007,35 @@ describe('buildUserEnvVars API key refresh', () => {
 
     await callBuildUserEnvVars(instance);
 
+    expect(storage._store.get('controllerCapabilitiesVersion')).toBeUndefined();
+  });
+});
+
+describe('markControllerCapabilitiesApplied', () => {
+  it('persists the worker version on first call', async () => {
+    const { markControllerCapabilitiesApplied } = await import('./kiloclaw-instance/config');
+    const storage = createFakeStorage();
+    const ctx = { storage } as unknown as DurableObjectState;
+    const state = { controllerCapabilitiesVersion: null as number | null };
+
+    await markControllerCapabilitiesApplied(ctx, state);
+
+    expect(state.controllerCapabilitiesVersion).toBe(WORKER_CONTROLLER_CAPABILITIES_VERSION);
     expect(storage._store.get('controllerCapabilitiesVersion')).toBe(
       WORKER_CONTROLLER_CAPABILITIES_VERSION
     );
   });
 
-  it('skips the capabilities version write when storage already matches', async () => {
-    const { instance, storage } = createInstance();
-    await seedProvisioned(storage, {
-      kilocodeApiKey: 'stale-key',
-      kilocodeApiKeyExpiresAt: '2026-12-01T00:00:00.000Z',
-      controllerCapabilitiesVersion: WORKER_CONTROLLER_CAPABILITIES_VERSION,
-    });
+  it('is idempotent when already at the current version', async () => {
+    const { markControllerCapabilitiesApplied } = await import('./kiloclaw-instance/config');
+    const storage = createFakeStorage();
+    const ctx = { storage } as unknown as DurableObjectState;
+    const state = { controllerCapabilitiesVersion: WORKER_CONTROLLER_CAPABILITIES_VERSION };
     const putSpy = vi.spyOn(storage, 'put');
 
-    await callBuildUserEnvVars(instance);
+    await markControllerCapabilitiesApplied(ctx, state);
 
-    const capabilityWrites = putSpy.mock.calls.filter(call => {
-      const [arg] = call;
-      return typeof arg === 'object' && arg !== null && 'controllerCapabilitiesVersion' in arg;
-    });
-    expect(capabilityWrites).toHaveLength(0);
+    expect(putSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
@@ -247,18 +247,6 @@ export async function buildUserEnvVars(
     result[`${ENCRYPTED_ENV_PREFIX}${name}`] = encryptEnvValue(envKey, value);
   }
 
-  // Record the controller capabilities version this env set corresponds to.
-  // Only the first successful build per worker-version change needs to write
-  // to storage, but the persist is cheap — skip only when already matching.
-  if (state.controllerCapabilitiesVersion !== WORKER_CONTROLLER_CAPABILITIES_VERSION) {
-    state.controllerCapabilitiesVersion = WORKER_CONTROLLER_CAPABILITIES_VERSION;
-    await ctx.storage.put(
-      storageUpdate({
-        controllerCapabilitiesVersion: WORKER_CONTROLLER_CAPABILITIES_VERSION,
-      })
-    );
-  }
-
   return {
     envVars: result,
     bootstrapEnv: {
@@ -266,4 +254,31 @@ export async function buildUserEnvVars(
     },
     minSecretsVersion: secretsVersion,
   };
+}
+
+/**
+ * Record that the running machine has been successfully configured with the
+ * env set produced by the current worker's `buildUserEnvVars`. Callers must
+ * only invoke this *after* the provider confirms the update was applied
+ * (e.g. after `startRuntime` / `restartRuntime` returns without throwing and
+ * `persistProviderResult` has been called). Persisting earlier would leave
+ * the DO reporting a capability the running machine does not actually have
+ * if the provider update then fails.
+ *
+ * Idempotent: no-ops if the DO is already at the worker's current version,
+ * avoiding redundant storage writes on repeated start/restart cycles.
+ */
+export async function markControllerCapabilitiesApplied(
+  ctx: DurableObjectState,
+  state: Pick<InstanceMutableState, 'controllerCapabilitiesVersion'>
+): Promise<void> {
+  if (state.controllerCapabilitiesVersion === WORKER_CONTROLLER_CAPABILITIES_VERSION) {
+    return;
+  }
+  state.controllerCapabilitiesVersion = WORKER_CONTROLLER_CAPABILITIES_VERSION;
+  await ctx.storage.put(
+    storageUpdate({
+      controllerCapabilitiesVersion: WORKER_CONTROLLER_CAPABILITIES_VERSION,
+    })
+  );
 }

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
@@ -3,10 +3,7 @@ import type { KiloClawEnv } from '../../types';
 import { buildEnvVars } from '../../gateway/env';
 import { ENCRYPTED_ENV_PREFIX, encryptEnvValue } from '../../utils/env-encryption';
 import { findPepperByUserId, getWorkerDb } from '../../db';
-import {
-  KILOCODE_API_KEY_EXPIRY_SECONDS,
-  WORKER_CONTROLLER_CAPABILITIES_VERSION,
-} from '../../config';
+import { KILOCODE_API_KEY_EXPIRY_SECONDS } from '../../config';
 import type { InstanceMutableState } from './types';
 import { getAppKey } from './types';
 import { storageUpdate } from './state';
@@ -254,31 +251,4 @@ export async function buildUserEnvVars(
     },
     minSecretsVersion: secretsVersion,
   };
-}
-
-/**
- * Record that the running machine has been successfully configured with the
- * env set produced by the current worker's `buildUserEnvVars`. Callers must
- * only invoke this *after* the provider confirms the update was applied
- * (e.g. after `startRuntime` / `restartRuntime` returns without throwing and
- * `persistProviderResult` has been called). Persisting earlier would leave
- * the DO reporting a capability the running machine does not actually have
- * if the provider update then fails.
- *
- * Idempotent: no-ops if the DO is already at the worker's current version,
- * avoiding redundant storage writes on repeated start/restart cycles.
- */
-export async function markControllerCapabilitiesApplied(
-  ctx: DurableObjectState,
-  state: Pick<InstanceMutableState, 'controllerCapabilitiesVersion'>
-): Promise<void> {
-  if (state.controllerCapabilitiesVersion === WORKER_CONTROLLER_CAPABILITIES_VERSION) {
-    return;
-  }
-  state.controllerCapabilitiesVersion = WORKER_CONTROLLER_CAPABILITIES_VERSION;
-  await ctx.storage.put(
-    storageUpdate({
-      controllerCapabilitiesVersion: WORKER_CONTROLLER_CAPABILITIES_VERSION,
-    })
-  );
 }

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts
@@ -3,7 +3,10 @@ import type { KiloClawEnv } from '../../types';
 import { buildEnvVars } from '../../gateway/env';
 import { ENCRYPTED_ENV_PREFIX, encryptEnvValue } from '../../utils/env-encryption';
 import { findPepperByUserId, getWorkerDb } from '../../db';
-import { KILOCODE_API_KEY_EXPIRY_SECONDS } from '../../config';
+import {
+  KILOCODE_API_KEY_EXPIRY_SECONDS,
+  WORKER_CONTROLLER_CAPABILITIES_VERSION,
+} from '../../config';
 import type { InstanceMutableState } from './types';
 import { getAppKey } from './types';
 import { storageUpdate } from './state';
@@ -242,6 +245,18 @@ export async function buildUserEnvVars(
   const result: Record<string, string> = { ...plainEnv };
   for (const [name, value] of Object.entries(sensitive)) {
     result[`${ENCRYPTED_ENV_PREFIX}${name}`] = encryptEnvValue(envKey, value);
+  }
+
+  // Record the controller capabilities version this env set corresponds to.
+  // Only the first successful build per worker-version change needs to write
+  // to storage, but the persist is cheap — skip only when already matching.
+  if (state.controllerCapabilitiesVersion !== WORKER_CONTROLLER_CAPABILITIES_VERSION) {
+    state.controllerCapabilitiesVersion = WORKER_CONTROLLER_CAPABILITIES_VERSION;
+    await ctx.storage.put(
+      storageUpdate({
+        controllerCapabilitiesVersion: WORKER_CONTROLLER_CAPABILITIES_VERSION,
+      })
+    );
   }
 
   return {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -2397,6 +2397,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     botNature: string | null;
     botVibe: string | null;
     botEmoji: string | null;
+    controllerCapabilitiesVersion: number | null;
   }> {
     await this.loadState();
 
@@ -2454,6 +2455,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       botNature: this.s.botNature,
       botVibe: this.s.botVibe,
       botEmoji: this.s.botEmoji,
+      controllerCapabilitiesVersion: this.s.controllerCapabilitiesVersion,
     };
   }
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -47,6 +47,7 @@ import {
   OPENCLAW_BUILTIN_DEFAULT_MODEL,
   RESTARTING_TIMEOUT_MS,
   STARTING_TIMEOUT_MS,
+  WORKER_CONTROLLER_CAPABILITIES_VERSION,
 } from '../../config';
 import {
   SECRET_CATALOG,
@@ -76,12 +77,7 @@ import {
 } from './state';
 import { nextAlarmTime, doLog, doError, doWarn, toLoggable, createReconcileContext } from './log';
 import { attemptMetadataRecovery } from './reconcile';
-import {
-  buildUserEnvVars,
-  markControllerCapabilitiesApplied,
-  resolveImageTag,
-  resolveRuntimeImageRef,
-} from './config';
+import { buildUserEnvVars, resolveImageTag, resolveRuntimeImageRef } from './config';
 import * as gateway from './gateway';
 import { buildChannelConfigPatch } from './channel-config';
 import * as pairing from './pairing';
@@ -1943,7 +1939,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       },
     });
     await this.persistProviderResult(startResult);
-    await markControllerCapabilitiesApplied(this.ctx, this.s);
 
     if (getRuntimeId(this.s)) {
       const healthy = await gateway.waitForHealthy(this.s, this.env);
@@ -1979,6 +1974,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     this.s.healthCheckFailCount = 0;
     this.s.lastStartErrorMessage = null;
     this.s.lastStartErrorAt = null;
+    this.s.controllerCapabilitiesVersion = WORKER_CONTROLLER_CAPABILITIES_VERSION;
     await this.persist({
       status: 'running',
       startingAt: null,
@@ -1988,6 +1984,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       flyMachineId: this.s.flyMachineId,
       lastStartErrorMessage: null,
       lastStartErrorAt: null,
+      controllerCapabilitiesVersion: WORKER_CONTROLLER_CAPABILITIES_VERSION,
     });
 
     await this.syncGoogleWorkspaceConfig('instance_started');
@@ -3351,7 +3348,6 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         },
       });
       await this.persistProviderResult(restart);
-      await markControllerCapabilitiesApplied(this.ctx, this.s);
       const healthy = await gateway.waitForHealthy(this.s, this.env);
       if (!healthy) {
         console.warn(

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -76,7 +76,12 @@ import {
 } from './state';
 import { nextAlarmTime, doLog, doError, doWarn, toLoggable, createReconcileContext } from './log';
 import { attemptMetadataRecovery } from './reconcile';
-import { buildUserEnvVars, resolveImageTag, resolveRuntimeImageRef } from './config';
+import {
+  buildUserEnvVars,
+  markControllerCapabilitiesApplied,
+  resolveImageTag,
+  resolveRuntimeImageRef,
+} from './config';
 import * as gateway from './gateway';
 import { buildChannelConfigPatch } from './channel-config';
 import * as pairing from './pairing';
@@ -1938,6 +1943,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       },
     });
     await this.persistProviderResult(startResult);
+    await markControllerCapabilitiesApplied(this.ctx, this.s);
 
     if (getRuntimeId(this.s)) {
       const healthy = await gateway.waitForHealthy(this.s, this.env);
@@ -3345,6 +3351,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         },
       });
       await this.persistProviderResult(restart);
+      await markControllerCapabilitiesApplied(this.ctx, this.s);
       const healthy = await gateway.waitForHealthy(this.s, this.env);
       if (!healthy) {
         console.warn(

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
@@ -878,11 +878,9 @@ export async function syncStatusWithFly(
     if (state.lastStartedAt === null) {
       state.lastStartedAt = Date.now();
     }
-    // Mark the capability version here too: this is the reconcile-driven
-    // success path that covers the case where _startInner / restart's
-    // waitForState timed out (408) but the machine did in fact start with the
-    // new env. Without this mark, a timed-out-but-successful restart would
-    // leave the DO reporting a stale pre-cutover capability version.
+    // Reconcile may be the first path to observe that a machine reached its
+    // running state, so keep the capability marker coupled to the observed
+    // running transition here as well.
     state.controllerCapabilitiesVersion = WORKER_CONTROLLER_CAPABILITIES_VERSION;
     await ctx.storage.put(
       storageUpdate({

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
@@ -10,6 +10,7 @@ import {
   RESTARTING_TIMEOUT_MS,
   RESTARTING_MAX_TIMEOUT_MS,
   RECOVERING_TIMEOUT_MS,
+  WORKER_CONTROLLER_CAPABILITIES_VERSION,
   getProactiveRefreshThresholdMs,
 } from '../../config';
 import { ENCRYPTED_ENV_PREFIX, encryptEnvValue } from '../../utils/env-encryption';
@@ -877,12 +878,19 @@ export async function syncStatusWithFly(
     if (state.lastStartedAt === null) {
       state.lastStartedAt = Date.now();
     }
+    // Mark the capability version here too: this is the reconcile-driven
+    // success path that covers the case where _startInner / restart's
+    // waitForState timed out (408) but the machine did in fact start with the
+    // new env. Without this mark, a timed-out-but-successful restart would
+    // leave the DO reporting a stale pre-cutover capability version.
+    state.controllerCapabilitiesVersion = WORKER_CONTROLLER_CAPABILITIES_VERSION;
     await ctx.storage.put(
       storageUpdate({
         status: 'running',
         startingAt: null,
         healthCheckFailCount: 0,
         lastStartedAt: state.lastStartedAt,
+        controllerCapabilitiesVersion: WORKER_CONTROLLER_CAPABILITIES_VERSION,
       })
     );
     return {};
@@ -1086,6 +1094,7 @@ export async function markRestartSuccessful(
   state.healthCheckFailCount = 0;
   state.lastRestartErrorMessage = null;
   state.lastRestartErrorAt = null;
+  state.controllerCapabilitiesVersion = WORKER_CONTROLLER_CAPABILITIES_VERSION;
   await ctx.storage.put(
     storageUpdate({
       status: 'running',
@@ -1096,6 +1105,7 @@ export async function markRestartSuccessful(
       healthCheckFailCount: 0,
       lastRestartErrorMessage: null,
       lastRestartErrorAt: null,
+      controllerCapabilitiesVersion: WORKER_CONTROLLER_CAPABILITIES_VERSION,
     })
   );
 }

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
@@ -12,7 +12,11 @@ import {
   storageUpdate,
   syncProviderStateForStorage,
 } from './state';
-import { buildUserEnvVars, resolveRuntimeImageRef } from './config';
+import {
+  buildUserEnvVars,
+  markControllerCapabilitiesApplied,
+  resolveRuntimeImageRef,
+} from './config';
 import * as gateway from './gateway';
 import * as flyMachines from './fly-machines';
 import { buildFlyMachineConfig } from './fly-machines';
@@ -446,6 +450,7 @@ export async function runUnexpectedStopRecoveryInBackground(
           })
         )
       );
+      await markControllerCapabilitiesApplied(ctx, state);
     } catch (err) {
       const isStartupTimeout = err instanceof fly.FlyApiError && err.status === 408;
       if (!isStartupTimeout || !state.flyMachineId) {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/recovery.ts
@@ -1,7 +1,7 @@
 import type { PersistedState } from '../../schemas/instance-config';
 import type { KiloClawEnv } from '../../types';
 import * as fly from '../../fly/client';
-import { PREVIOUS_VOLUME_RETENTION_MS } from '../../config';
+import { PREVIOUS_VOLUME_RETENTION_MS, WORKER_CONTROLLER_CAPABILITIES_VERSION } from '../../config';
 import * as regionHelpers from '../regions';
 import { buildRuntimeSpec, guestFromSize, volumeNameFromSandboxId } from '../machine-config';
 import type { InstanceMutableState } from './types';
@@ -12,11 +12,7 @@ import {
   storageUpdate,
   syncProviderStateForStorage,
 } from './state';
-import {
-  buildUserEnvVars,
-  markControllerCapabilitiesApplied,
-  resolveRuntimeImageRef,
-} from './config';
+import { buildUserEnvVars, resolveRuntimeImageRef } from './config';
 import * as gateway from './gateway';
 import * as flyMachines from './fly-machines';
 import { buildFlyMachineConfig } from './fly-machines';
@@ -293,6 +289,7 @@ export async function completeUnexpectedStopRecovery(runtime: RecoveryRuntime): 
   state.lastStartedAt = now;
   state.lastRecoveryErrorMessage = null;
   state.lastRecoveryErrorAt = null;
+  state.controllerCapabilitiesVersion = WORKER_CONTROLLER_CAPABILITIES_VERSION;
   await runtime.persist({
     status: 'running',
     flyMachineId: state.flyMachineId,
@@ -306,6 +303,7 @@ export async function completeUnexpectedStopRecovery(runtime: RecoveryRuntime): 
     lastStartedAt: now,
     lastRecoveryErrorMessage: null,
     lastRecoveryErrorAt: null,
+    controllerCapabilitiesVersion: WORKER_CONTROLLER_CAPABILITIES_VERSION,
   });
 
   runtime.emitEvent({
@@ -450,7 +448,6 @@ export async function runUnexpectedStopRecoveryInBackground(
           })
         )
       );
-      await markControllerCapabilitiesApplied(ctx, state);
     } catch (err) {
       const isStartupTimeout = err instanceof fly.FlyApiError && err.status === 408;
       if (!isStartupTimeout || !state.flyMachineId) {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
@@ -313,6 +313,7 @@ export async function loadState(ctx: DurableObjectState, s: InstanceMutableState
     s.lastRecoveryErrorAt = d.lastRecoveryErrorAt;
     s.lastBoundMachineRecoveryAt = d.lastBoundMachineRecoveryAt;
     s.instanceFeatures = d.instanceFeatures;
+    s.controllerCapabilitiesVersion = d.controllerCapabilitiesVersion;
     s.gmailNotificationsEnabled = d.gmailNotificationsEnabled;
     s.gmailLastHistoryId = d.gmailLastHistoryId;
     s.gmailPushOidcEmail = d.gmailPushOidcEmail;
@@ -415,6 +416,7 @@ export function resetMutableState(s: InstanceMutableState): void {
   s.lastRecoveryErrorAt = null;
   s.lastBoundMachineRecoveryAt = null;
   s.instanceFeatures = [];
+  s.controllerCapabilitiesVersion = null;
   s.gmailNotificationsEnabled = false;
   s.gmailLastHistoryId = null;
   s.gmailPushOidcEmail = null;
@@ -508,6 +510,7 @@ export function createMutableState(): InstanceMutableState {
     lastRecoveryErrorAt: null,
     lastBoundMachineRecoveryAt: null,
     instanceFeatures: [],
+    controllerCapabilitiesVersion: null,
     gmailNotificationsEnabled: false,
     gmailLastHistoryId: null,
     gmailPushOidcEmail: null,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
@@ -113,6 +113,7 @@ export type InstanceMutableState = {
   lastRecoveryErrorAt: number | null;
   lastBoundMachineRecoveryAt: number | null;
   instanceFeatures: string[];
+  controllerCapabilitiesVersion: number | null;
   gmailNotificationsEnabled: boolean;
   gmailLastHistoryId: string | null;
   gmailPushOidcEmail: string | null;

--- a/services/kiloclaw/src/gateway/env.test.ts
+++ b/services/kiloclaw/src/gateway/env.test.ts
@@ -279,11 +279,7 @@ describe('buildEnvVars', () => {
     );
   });
 
-  it('appends `u-{body}.kiloclaw.ai` origin for legacy sandboxes', async () => {
-    // SANDBOX_ID is "test-sandbox-id" which contains `-`. The hostname-label
-    // helper rejects that (hyphen not in alnum body), so for this test we use
-    // a safe alnum sandboxId value representative of a base64url-encoded
-    // ASCII userId.
+  it('appends `u-{base32hex(userId)}.kiloclaw.ai` origin for legacy sandboxes', async () => {
     const legacySandboxId = 'dGVzdHVzZXJhYmMxMjM'; // base64url("testuserabc123")
     const env = createMockEnv({
       OPENCLAW_ALLOWED_ORIGINS: 'https://claw.kilosessions.ai',
@@ -292,16 +288,14 @@ describe('buildEnvVars', () => {
     const result = await buildEnvVars(env, legacySandboxId, SECRET);
 
     expect(result.env.OPENCLAW_ALLOWED_ORIGINS).toBe(
-      `https://claw.kilosessions.ai,https://u-${legacySandboxId}.kiloclaw.ai`
+      'https://claw.kilosessions.ai,https://u-ehin6t3ledin4ob2ccoj4co.kiloclaw.ai'
     );
   });
 
   it('skips per-instance origin when the sandboxId cannot be safely labelled', async () => {
-    // Sandboxes containing `-` or `_` in their base64url body fall through the
-    // label safety check. This is a defensive path — production userIds don't
-    // produce these characters in base64url output — but we must not emit an
-    // RFC-invalid hostname in the allowlist.
-    const unsafeSandboxId = 'test-sandbox-id';
+    // Overlong legacy user IDs cannot fit in one DNS label after base32hex
+    // encoding. Those instances keep using the shared legacy origins.
+    const unsafeSandboxId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'; // base64url("i".repeat(39))
     const env = createMockEnv({
       OPENCLAW_ALLOWED_ORIGINS: 'https://claw.kilosessions.ai',
     });

--- a/services/kiloclaw/src/gateway/env.test.ts
+++ b/services/kiloclaw/src/gateway/env.test.ts
@@ -252,6 +252,42 @@ describe('buildEnvVars', () => {
     expect(result.env.OPENCLAW_ALLOWED_ORIGINS).toBeUndefined();
   });
 
+  it('appends per-instance origin for instance-keyed sandboxes', async () => {
+    // ki_{32 hex} — derived from a UUID with dashes stripped.
+    const instanceSandboxId = 'ki_550e8400e29b41d4a716446655440000';
+    const env = createMockEnv({
+      OPENCLAW_ALLOWED_ORIGINS: 'https://claw.kilosessions.ai,https://kilo.ai',
+    });
+
+    const result = await buildEnvVars(env, instanceSandboxId, SECRET);
+
+    expect(result.env.OPENCLAW_ALLOWED_ORIGINS).toBe(
+      'https://claw.kilosessions.ai,https://kilo.ai,https://550e8400-e29b-41d4-a716-446655440000.kiloclaw.ai'
+    );
+  });
+
+  it('emits per-instance origin as the sole entry when worker env has none', async () => {
+    const instanceSandboxId = 'ki_550e8400e29b41d4a716446655440000';
+    const env = createMockEnv();
+
+    const result = await buildEnvVars(env, instanceSandboxId, SECRET);
+
+    expect(result.env.OPENCLAW_ALLOWED_ORIGINS).toBe(
+      'https://550e8400-e29b-41d4-a716-446655440000.kiloclaw.ai'
+    );
+  });
+
+  it('does not append a per-instance origin for legacy (non-ki_) sandboxes', async () => {
+    const env = createMockEnv({
+      OPENCLAW_ALLOWED_ORIGINS: 'https://claw.kilosessions.ai',
+    });
+
+    const result = await buildEnvVars(env, SANDBOX_ID, SECRET);
+
+    expect(result.env.OPENCLAW_ALLOWED_ORIGINS).toBe('https://claw.kilosessions.ai');
+    expect(result.env.OPENCLAW_ALLOWED_ORIGINS).not.toMatch(/\.kiloclaw\.ai/);
+  });
+
   it('passes REQUIRE_PROXY_TOKEN from worker env when configured', async () => {
     const env = createMockEnv({ REQUIRE_PROXY_TOKEN: 'true' });
     const result = await buildEnvVars(env, SANDBOX_ID, SECRET);

--- a/services/kiloclaw/src/gateway/env.test.ts
+++ b/services/kiloclaw/src/gateway/env.test.ts
@@ -252,8 +252,10 @@ describe('buildEnvVars', () => {
     expect(result.env.OPENCLAW_ALLOWED_ORIGINS).toBeUndefined();
   });
 
-  it('appends per-instance origin for instance-keyed sandboxes', async () => {
-    // ki_{32 hex} — derived from a UUID with dashes stripped.
+  it('appends `i-{hex}.kiloclaw.ai` origin for instance-keyed sandboxes', async () => {
+    // ki_{32 hex} — derived from a UUID with dashes stripped. Hostname label
+    // strips the `ki_` prefix and re-prefixes with `i-` so the body stays
+    // strictly alnum (RFC 1035 compliant).
     const instanceSandboxId = 'ki_550e8400e29b41d4a716446655440000';
     const env = createMockEnv({
       OPENCLAW_ALLOWED_ORIGINS: 'https://claw.kilosessions.ai,https://kilo.ai',
@@ -262,7 +264,7 @@ describe('buildEnvVars', () => {
     const result = await buildEnvVars(env, instanceSandboxId, SECRET);
 
     expect(result.env.OPENCLAW_ALLOWED_ORIGINS).toBe(
-      'https://claw.kilosessions.ai,https://kilo.ai,https://550e8400-e29b-41d4-a716-446655440000.kiloclaw.ai'
+      'https://claw.kilosessions.ai,https://kilo.ai,https://i-550e8400e29b41d4a716446655440000.kiloclaw.ai'
     );
   });
 
@@ -273,16 +275,38 @@ describe('buildEnvVars', () => {
     const result = await buildEnvVars(env, instanceSandboxId, SECRET);
 
     expect(result.env.OPENCLAW_ALLOWED_ORIGINS).toBe(
-      'https://550e8400-e29b-41d4-a716-446655440000.kiloclaw.ai'
+      'https://i-550e8400e29b41d4a716446655440000.kiloclaw.ai'
     );
   });
 
-  it('does not append a per-instance origin for legacy (non-ki_) sandboxes', async () => {
+  it('appends `u-{body}.kiloclaw.ai` origin for legacy sandboxes', async () => {
+    // SANDBOX_ID is "test-sandbox-id" which contains `-`. The hostname-label
+    // helper rejects that (hyphen not in alnum body), so for this test we use
+    // a safe alnum sandboxId value representative of a base64url-encoded
+    // ASCII userId.
+    const legacySandboxId = 'dGVzdHVzZXJhYmMxMjM'; // base64url("testuserabc123")
     const env = createMockEnv({
       OPENCLAW_ALLOWED_ORIGINS: 'https://claw.kilosessions.ai',
     });
 
-    const result = await buildEnvVars(env, SANDBOX_ID, SECRET);
+    const result = await buildEnvVars(env, legacySandboxId, SECRET);
+
+    expect(result.env.OPENCLAW_ALLOWED_ORIGINS).toBe(
+      `https://claw.kilosessions.ai,https://u-${legacySandboxId}.kiloclaw.ai`
+    );
+  });
+
+  it('skips per-instance origin when the sandboxId cannot be safely labelled', async () => {
+    // Sandboxes containing `-` or `_` in their base64url body fall through the
+    // label safety check. This is a defensive path — production userIds don't
+    // produce these characters in base64url output — but we must not emit an
+    // RFC-invalid hostname in the allowlist.
+    const unsafeSandboxId = 'test-sandbox-id';
+    const env = createMockEnv({
+      OPENCLAW_ALLOWED_ORIGINS: 'https://claw.kilosessions.ai',
+    });
+
+    const result = await buildEnvVars(env, unsafeSandboxId, SECRET);
 
     expect(result.env.OPENCLAW_ALLOWED_ORIGINS).toBe('https://claw.kilosessions.ai');
     expect(result.env.OPENCLAW_ALLOWED_ORIGINS).not.toMatch(/\.kiloclaw\.ai/);

--- a/services/kiloclaw/src/gateway/env.ts
+++ b/services/kiloclaw/src/gateway/env.ts
@@ -2,10 +2,6 @@ import {
   ALL_SECRET_ENV_VARS,
   INTERNAL_SENSITIVE_ENV_VARS,
 } from '@kilocode/kiloclaw-secret-catalog';
-import {
-  isInstanceKeyedSandboxId,
-  instanceIdFromSandboxId,
-} from '@kilocode/worker-utils/instance-id';
 import type { KiloClawEnv } from '../types';
 import type {
   EncryptedEnvelope,
@@ -15,6 +11,7 @@ import type {
   KiloExaSearchMode,
 } from '../schemas/instance-config';
 import { deriveGatewayToken } from '../auth/gateway-token';
+import { hostnameLabelFromSandboxId } from '../auth/hostname-label';
 import {
   mergeEnvVarsWithSecrets,
   decryptChannelTokens,
@@ -232,11 +229,14 @@ export async function buildEnvVars(
   if (env.TELEGRAM_DM_POLICY) plainEnv.TELEGRAM_DM_POLICY = env.TELEGRAM_DM_POLICY;
   if (env.DISCORD_DM_POLICY) plainEnv.DISCORD_DM_POLICY = env.DISCORD_DM_POLICY;
 
-  // Control UI allowed origins. Starts from the worker-level shared list, then
-  // appends the per-instance virtual host `https://<instanceId>.kiloclaw.ai`
-  // when this is an instance-keyed sandbox. OpenClaw's origin check does
-  // exact-string matching, so each hostname must be enumerated explicitly.
-  // Legacy (non-`ki_`) sandboxes only get the shared worker-level origins.
+  // Control UI allowed origins. Starts from the worker-level shared list,
+  // then appends a per-instance virtual host `https://<label>.kiloclaw.ai`
+  // derived from the sandboxId. Two label shapes, distinguishable by prefix:
+  //   instance-keyed: `i-{32hex}`   (ki_{32hex} sandboxId)
+  //   legacy:         `u-{body}`    (base64url-encoded userId)
+  // OpenClaw's origin check does exact-string matching, so each hostname
+  // must be enumerated explicitly — this covers both instance-keyed and
+  // legacy sandboxes with a single per-instance origin.
   const originEntries: string[] = [];
   if (env.OPENCLAW_ALLOWED_ORIGINS) {
     for (const raw of env.OPENCLAW_ALLOWED_ORIGINS.split(',')) {
@@ -244,9 +244,9 @@ export async function buildEnvVars(
       if (trimmed) originEntries.push(trimmed);
     }
   }
-  if (isInstanceKeyedSandboxId(sandboxId)) {
-    const instanceId = instanceIdFromSandboxId(sandboxId);
-    const perInstanceOrigin = `https://${instanceId}.kiloclaw.ai`;
+  const perInstanceLabel = hostnameLabelFromSandboxId(sandboxId);
+  if (perInstanceLabel) {
+    const perInstanceOrigin = `https://${perInstanceLabel}.kiloclaw.ai`;
     if (!originEntries.includes(perInstanceOrigin)) {
       originEntries.push(perInstanceOrigin);
     }

--- a/services/kiloclaw/src/gateway/env.ts
+++ b/services/kiloclaw/src/gateway/env.ts
@@ -2,6 +2,10 @@ import {
   ALL_SECRET_ENV_VARS,
   INTERNAL_SENSITIVE_ENV_VARS,
 } from '@kilocode/kiloclaw-secret-catalog';
+import {
+  isInstanceKeyedSandboxId,
+  instanceIdFromSandboxId,
+} from '@kilocode/worker-utils/instance-id';
 import type { KiloClawEnv } from '../types';
 import type {
   EncryptedEnvelope,
@@ -227,8 +231,29 @@ export async function buildEnvVars(
   // Worker-level passthrough (non-sensitive)
   if (env.TELEGRAM_DM_POLICY) plainEnv.TELEGRAM_DM_POLICY = env.TELEGRAM_DM_POLICY;
   if (env.DISCORD_DM_POLICY) plainEnv.DISCORD_DM_POLICY = env.DISCORD_DM_POLICY;
-  if (env.OPENCLAW_ALLOWED_ORIGINS)
-    plainEnv.OPENCLAW_ALLOWED_ORIGINS = env.OPENCLAW_ALLOWED_ORIGINS;
+
+  // Control UI allowed origins. Starts from the worker-level shared list, then
+  // appends the per-instance virtual host `https://<instanceId>.kiloclaw.ai`
+  // when this is an instance-keyed sandbox. OpenClaw's origin check does
+  // exact-string matching, so each hostname must be enumerated explicitly.
+  // Legacy (non-`ki_`) sandboxes only get the shared worker-level origins.
+  const originEntries: string[] = [];
+  if (env.OPENCLAW_ALLOWED_ORIGINS) {
+    for (const raw of env.OPENCLAW_ALLOWED_ORIGINS.split(',')) {
+      const trimmed = raw.trim();
+      if (trimmed) originEntries.push(trimmed);
+    }
+  }
+  if (isInstanceKeyedSandboxId(sandboxId)) {
+    const instanceId = instanceIdFromSandboxId(sandboxId);
+    const perInstanceOrigin = `https://${instanceId}.kiloclaw.ai`;
+    if (!originEntries.includes(perInstanceOrigin)) {
+      originEntries.push(perInstanceOrigin);
+    }
+  }
+  if (originEntries.length > 0) {
+    plainEnv.OPENCLAW_ALLOWED_ORIGINS = originEntries.join(',');
+  }
   if (env.KILOCLAW_CHECKIN_URL) plainEnv.KILOCLAW_CHECKIN_URL = env.KILOCLAW_CHECKIN_URL;
   if (env.KILOCHAT_BASE_URL) plainEnv.KILOCHAT_BASE_URL = env.KILOCHAT_BASE_URL;
   plainEnv.REQUIRE_PROXY_TOKEN = env.REQUIRE_PROXY_TOKEN ?? 'false';

--- a/services/kiloclaw/src/schemas/instance-config.ts
+++ b/services/kiloclaw/src/schemas/instance-config.ts
@@ -362,9 +362,11 @@ export const PersistedStateSchema = z.object({
   // New instances get the current feature set; legacy instances have an empty array.
   instanceFeatures: z.array(z.string()).default([]),
   // Version of the controller config the running machine was last provisioned
-  // with. Written every time the worker builds and applies env vars for a
-  // machine (see buildUserEnvVars). Null means legacy (treat as version 1).
-  // See WORKER_CONTROLLER_CAPABILITIES_VERSION in config.ts for semantics.
+  // with. Written only when the DO observes or completes a transition to a
+  // running machine, so callers can treat it as a property of the running
+  // runtime rather than desired future config. Null means legacy (treat as
+  // version 1). See WORKER_CONTROLLER_CAPABILITIES_VERSION in config.ts for
+  // semantics.
   controllerCapabilitiesVersion: z.number().int().nullable().default(null),
   gmailNotificationsEnabled: z.boolean().default(false),
   gmailLastHistoryId: z.string().nullable().default(null),

--- a/services/kiloclaw/src/schemas/instance-config.ts
+++ b/services/kiloclaw/src/schemas/instance-config.ts
@@ -361,6 +361,11 @@ export const PersistedStateSchema = z.object({
   // Each entry is a feature name (e.g. "npm-global-prefix") that gates runtime behavior.
   // New instances get the current feature set; legacy instances have an empty array.
   instanceFeatures: z.array(z.string()).default([]),
+  // Version of the controller config the running machine was last provisioned
+  // with. Written every time the worker builds and applies env vars for a
+  // machine (see buildUserEnvVars). Null means legacy (treat as version 1).
+  // See WORKER_CONTROLLER_CAPABILITIES_VERSION in config.ts for semantics.
+  controllerCapabilitiesVersion: z.number().int().nullable().default(null),
   gmailNotificationsEnabled: z.boolean().default(false),
   gmailLastHistoryId: z.string().nullable().default(null),
   gmailPushOidcEmail: z.string().nullable().default(null),

--- a/services/kiloclaw/wrangler.jsonc
+++ b/services/kiloclaw/wrangler.jsonc
@@ -19,6 +19,15 @@
       "zone_name": "kilosessions.ai",
       "custom_domain": true,
     },
+    // Wildcard route for per-instance name-based virtual hosting.
+    // Custom Domains do not support wildcard hostnames, so we use a route
+    // pattern instead. Requires a proxied wildcard DNS record on
+    // `*.kiloclaw.ai` and a cert whose SAN covers `*.kiloclaw.ai`.
+    // See .plans/namebasedrouting.md for rollout strategy.
+    {
+      "pattern": "*.kiloclaw.ai/*",
+      "zone_name": "kiloclaw.ai",
+    },
   ],
 
   "durable_objects": {
@@ -121,6 +130,12 @@
     "NF_IMAGE_PATH_TEMPLATE": "ghcr.io/kilo-org/kiloclaw:{tag}",
     "NF_IMAGE_CREDENTIALS_ID": "kiloclaw",
     "BACKEND_API_URL": "https://app.kilo.ai",
+    // Shared, non-per-instance origins. OpenClaw's origin check
+    // (src/gateway/origin-check.ts) does exact string matching only —
+    // wildcard host patterns like `https://*.kiloclaw.ai` would be stored
+    // as literals and never match. For per-instance virtual hosting,
+    // `buildEnvVars` in src/gateway/env.ts appends
+    // `https://<instanceId>.kiloclaw.ai` per-instance at machine build time.
     "OPENCLAW_ALLOWED_ORIGINS": "https://claw.kilosessions.ai,https://kilo.ai,https://www.kilo.ai",
     "KILOCLAW_CHECKIN_URL": "https://claw.kilosessions.ai/api/controller/checkin",
     "KILOCHAT_BASE_URL": "https://chat.kiloapps.io",


### PR DESCRIPTION
## Summary

Lays the groundwork for per-instance name-based virtual hosting on `<label>.kiloclaw.ai`, alongside the existing `claw.kilosessions.ai` custom domain.

This PR makes the worker **reachable** on the new host pattern and teaches it to hand each machine the right `Origin` allowlist, but does not change any user-facing URLs, cookie domains, or redirect targets. That cutover is a follow-up PR.

**What changed**

- **`wrangler.jsonc`** — added a wildcard Workers route `*.kiloclaw.ai/*` on a new `kiloclaw.ai` zone. Cloudflare Custom Domains do not support wildcard hostnames, so this uses a route pattern (non-`custom_domain`). The existing `claw.kilosessions.ai` custom domain entry is untouched. The bare apex `kiloclaw.ai` is **unaffected** by this change — `*.kiloclaw.ai/*` matches one-or-more-labels subdomains only, and no apex DNS record or route is added.
- **Hostname label helper** (`src/auth/hostname-label.ts`). Maps both sandboxId shapes to a DNS-safe hostname label (and back, for the host-based router in the next PR):

  | kind | sandboxId | label |
  | --- | --- | --- |
  | instance-keyed | `ki_{32hex}` | `i-{32hex}` |
  | legacy | `{base64url-body}` | `u-{body}` |

  Prefix (`i-` / `u-`) disambiguates the two cases without a database lookup. For realistic userIds (UUIDs, `oauth/provider:{sub}`, emails, Google numeric subs) the base64url encoder produces alnum-only output, so the label body is strictly RFC 1035 compliant (`[A-Za-z0-9]`). Pathological userIds containing `>`/`~`/`?`/DEL — none of which appear in production data — would yield `-` or `_` in the base64url body; the helper returns `null` for those and the caller skips injection rather than emitting a non-compliant label.

- **`OPENCLAW_ALLOWED_ORIGINS` — per-instance injection for all instances** (`src/gateway/env.ts`). OpenClaw's origin check (`src/gateway/origin-check.ts` upstream) does exact case-insensitive string matching; it does not interpret host wildcards. Rather than widening the allowlist with unsupported patterns or going allow-all, the worker now appends `https://<label>.kiloclaw.ai` to the comma-separated list at env-build time, using the label helper above. **Both legacy and instance-keyed sandboxes get a per-instance origin**, so `*.kiloclaw.ai` routing will work for every instance once the machine restarts.

- **`WORKER_CONTROLLER_CAPABILITIES_VERSION`** (`src/config.ts`) — new constant marking what the worker hands to a machine's controller at env-build time. Starts at 2; legacy pre-tracking instances are treated as 1.

- **`controllerCapabilitiesVersion` on the Instance DO** — new nullable field on `PersistedStateSchema`, hydrated in `loadState`, initialized in `resetMutableState`, and exposed via `getStatus()`. **Persisted only after the provider confirms the machine update was applied**, via a dedicated `markControllerCapabilitiesApplied` helper called at three success sites: after `startRuntime` + `persistProviderResult`, after `restartRuntime` + `persistProviderResult`, and after `createNewMachine` in the recovery path.

**Why capability tracking**

`OPENCLAW_ALLOWED_ORIGINS` is baked into a Fly machine at provision/start/restart time. Running machines don't pick up a new worker-side value until they restart. During the eventual cutover to `<label>.kiloclaw.ai`, the dashboard needs a per-instance signal to decide whether an instance is safe to route to the new host or must keep using `claw.kilosessions.ai` until it's restarted. `controllerCapabilitiesVersion` is that signal, written only once the new env is in place on a live machine.

**Out of scope (follow-up PRs)**

- Host-based instance routing in the catch-all proxy (`Host: <label>.kiloclaw.ai` → Instance DO, parsing via `sandboxIdFromHostnameLabel`).
- Access-gateway cookie semantics on the new host.
- Dashboard "Open instance" link generation.
- `KILOCLAW_CHECKIN_URL` / OAuth redirect URIs.
- Retiring `claw.kilosessions.ai`.

**Cloudflare-side prerequisites (not code)**

- `kiloclaw.ai` active as a zone on the production CF account.
- Proxied wildcard DNS record on `*.kiloclaw.ai` (originless `AAAA * → 100::`). No apex record added — bare `kiloclaw.ai` stays independent of this change.
- TLS cert SAN covers `*.kiloclaw.ai` (Universal handles this on CF nameservers).

## Verification

Planned smoke test after deploy:

- `curl https://claw.kilosessions.ai/health` still works (regression).
- `curl https://kiloclaw.ai/` does **not** hit this worker (apex is unaffected).
- TLS handshake on `https://foo.kiloclaw.ai` presents a cert whose SAN covers `*.kiloclaw.ai`.
- After an **instance-keyed** user restarts their machine, its `config.gateway.controlUi.allowedOrigins` contains `https://i-<32hex>.kiloclaw.ai` and its DO `getStatus()` reports `controllerCapabilitiesVersion: 2`.



## Visual Changes

N/A

## Reviewer Notes

- **No user-visible change in this PR.** The new wildcard route is dormant until `*.kiloclaw.ai` resolves, and no caller constructs URLs on the new host yet.
- **Apex `kiloclaw.ai` is intentionally untouched.** The route pattern `*.kiloclaw.ai/*` does not match the apex; no apex DNS record or route is added.
- **OpenClaw origin check** is exact-match only. Wildcard host patterns like `https://*.kiloclaw.ai` would be stored as literals and never match a real `Origin` header — intentionally avoided.
- **Legacy and instance-keyed are unified.** Both get a per-instance origin (`u-` / `i-` labels respectively) via the shared `hostnameLabelFromSandboxId` helper. There is no "legacy stays on the old host" fallback path.
- **Capability version is only written after provider success.** `buildUserEnvVars` no longer persists it. The three call sites of `markControllerCapabilitiesApplied` all fire after `persistProviderResult` returns; a provider failure aborts before the mark, keeping the DO state consistent with what's actually running.
- **Risk**: the capability version needs to be bumped every time we change what the controller is configured with (env var shape, config structure, etc.). The constant has a version-history docstring to make that expectation explicit.
- **Follow-up `hostnameLabelFromSandboxId` / `sandboxIdFromHostnameLabel`** are the two sides of the label boundary that PR2 (host-based routing) will consume — the inverse function is already implemented and tested here so the next PR stays small.