### PR TITLE
docs(skills): add Kilo design skill

### DIFF
--- a/.agents/skills/kilo-design/NOTICE.md
+++ b/.agents/skills/kilo-design/NOTICE.md
@@ -1,0 +1,46 @@
+# NOTICE
+
+This skill contains content adapted from the Impeccable project.
+
+## Upstream Attribution
+
+- **Project**: [`pbakaus/impeccable`](https://github.com/pbakaus/impeccable)
+- **License**: Apache License, Version 2.0
+- **Copyright**: Copyright 2025 Paul Bakaus
+- **Source commit**: `9a5d0e71a9011def4fbd011d5fca33360880b409` (fetched 2026-04-28)
+
+## Adapted Reference Files
+
+The following files under `reference/` are derivative works based on
+corresponding files in `pbakaus/impeccable` at `source/skills/impeccable/reference/`:
+
+| Local file                        | Upstream source                                                                                          |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `reference/typography.md`         | https://github.com/pbakaus/impeccable/blob/main/source/skills/impeccable/reference/typography.md         |
+| `reference/color-and-contrast.md` | https://github.com/pbakaus/impeccable/blob/main/source/skills/impeccable/reference/color-and-contrast.md |
+| `reference/spatial-design.md`     | https://github.com/pbakaus/impeccable/blob/main/source/skills/impeccable/reference/spatial-design.md     |
+| `reference/motion-design.md`      | https://github.com/pbakaus/impeccable/blob/main/source/skills/impeccable/reference/motion-design.md      |
+| `reference/interaction-design.md` | https://github.com/pbakaus/impeccable/blob/main/source/skills/impeccable/reference/interaction-design.md |
+| `reference/responsive-design.md`  | https://github.com/pbakaus/impeccable/blob/main/source/skills/impeccable/reference/responsive-design.md  |
+| `reference/ux-writing.md`         | https://github.com/pbakaus/impeccable/blob/main/source/skills/impeccable/reference/ux-writing.md         |
+
+Each of these files has been modified to:
+
+- Add a `Kilo application` section at the top that re-grounds the guidance in
+  the Kilo Code brand, product tokens, and component system.
+- Remove or soften instructions that conflict with Kilo's existing product UI
+  conventions (dark-first shadcn surfaces, compact app rhythm, restrained
+  brand accent use).
+- Shorten some passages so the files remain load-friendly for an agent.
+
+`reference/kilo-brand.md` and `SKILL.md` are original Kilo content and are
+not derivative works.
+
+## License Summary
+
+The adapted files continue to be made available under the terms of the
+Apache License, Version 2.0. You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0.
+
+Files modified from the upstream source are marked by the "Kilo application"
+section at the top of each adapted reference.

--- a/.agents/skills/kilo-design/SKILL.md
+++ b/.agents/skills/kilo-design/SKILL.md
@@ -19,10 +19,10 @@ other reference in this skill conflicts with `kilo-brand.md`,
 Load `reference/kilo-brand.md` on every invocation of this skill before
 picking tokens, typography, layout, or motion. It captures:
 
-- Kilo's dark-first theme and existing CSS tokens.
-- Brand accent discipline (electric yellow-green `--brand-primary`,
-  used sparingly).
-- Product CTA blue (`#2B6AD2`) as the established action color.
+- Kilo's dark-first web theme, mobile light/dark token split, and existing
+  CSS tokens.
+- Brand yellow-green `primary` token as the primary CTA color, used once
+  per surface.
 - Typography (Inter / Roboto Mono / JetBrains Mono) and the known
   font-token mismatch.
 - Spacing, radius, component, and motion conventions.
@@ -81,8 +81,9 @@ Follow these on every task:
    solves the problem.
 3. **Do not rename or restructure the shadcn UI layer** unless the user
    explicitly asks for a design-system refactor.
-4. **Do not replace the product CTA blue** (`#2B6AD2`) with
-   `--brand-primary` yellow-green without an explicit design decision.
+4. **Use the `primary` token for primary CTAs.** The product primary is the
+   Kilo brand yellow-green. Blue is reserved for links and legacy drift
+   that should be migrated when touched.
 5. **Do not add new motion libraries.** `motion/react` and
    `tw-animate-css` are already available.
 6. **Respect `prefers-reduced-motion`** on any motion change beyond
@@ -102,8 +103,8 @@ Follow these on every task:
 When producing code:
 
 - Use Tailwind utilities that map to semantic tokens
-  (`bg-background`, `text-foreground`, `border-border`, etc.) before
-  reaching for hex.
+  (`bg-background`, `text-foreground`, `border-border`, `bg-primary`,
+  `text-primary-foreground`, etc.) before reaching for hex.
 - Extend `cva` variants in existing `ui/` primitives rather than cloning.
 - Icons: `lucide-react`, typically `size-4`, inheriting `currentColor`.
 - Add `aria-label` to icon-only buttons.
@@ -148,8 +149,8 @@ This skill is intentionally scoped. It does **not**:
 - Run automated anti-pattern scans.
 - Run or expose Impeccable's "live mode."
 - Generate a root `DESIGN.md`.
-- Rewrite the font-token mismatch or hardcoded CTA blue as semantic
-  tokens. Those are real follow-ups but belong in separate,
+- Rewrite the font-token mismatch or migrate every legacy hardcoded blue
+  CTA. Those are real follow-ups but belong in separate,
   design-system-scoped PRs.
 
 ## Reference map

--- a/.agents/skills/kilo-design/SKILL.md
+++ b/.agents/skills/kilo-design/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: kilo-design
+description: Use when designing, reviewing, polishing, adapting, or implementing Kilo Code frontend UI. Applies Kilo brand rules, shadcn/Radix component conventions, OKLCH tokens, Inter/Roboto Mono/JetBrains Mono typography, compact product rhythm, restrained motion, and Kilo voice guidelines. Triggers on web app screens (apps/web), Storybook components, React Native mobile surfaces (apps/mobile), marketing/landing pages, onboarding, empty states, forms, dialogs, dashboards, billing, sidebar, theming, accessibility, and visual QA. Triggers on terms like "design", "redesign", "polish", "critique", "audit", "typeset", "typography", "fonts", "color", "palette", "brand", "spacing", "layout", "grid", "motion", "animate", "transitions", "interaction", "forms", "focus", "responsive", "mobile", "breakpoints", "UX copy", "microcopy", "error states", "empty states", "on-brand", "Kilo voice". Not for backend-only work.
+license: Apache 2.0 derivative of pbakaus/impeccable, adapted for Kilo Code. See NOTICE.md.
+---
+
+# Kilo Design
+
+Design guidance for the Kilo Code frontend. Use this skill whenever the
+task involves how something looks, how it behaves, how it reads, or how
+it adapts.
+
+## Canonical rule: Kilo brand first
+
+The overlay in `reference/kilo-brand.md` is the source of truth. When any
+other reference in this skill conflicts with `kilo-brand.md`,
+`kilo-brand.md` wins.
+
+Load `reference/kilo-brand.md` on every invocation of this skill before
+picking tokens, typography, layout, or motion. It captures:
+
+- Kilo's dark-first theme and existing CSS tokens.
+- Brand accent discipline (electric yellow-green `--brand-primary`,
+  used sparingly).
+- Product CTA blue (`#2B6AD2`) as the established action color.
+- Typography (Inter / Roboto Mono / JetBrains Mono) and the known
+  font-token mismatch.
+- Spacing, radius, component, and motion conventions.
+- Kilo-specific anti-patterns to reject on sight.
+
+## Register
+
+Identify the register of the surface before designing:
+
+- **Product UI** — web app, dashboards, settings, billing, admin,
+  Storybook components, mobile app screens. Calm, compact,
+  task-oriented. Fixed type scale. Restrained accent use.
+- **Brand / Marketing** — landing pages, docs, pricing, hero surfaces,
+  campaign moments. More visual expression permitted (hero type,
+  animation, committed color, imagery) while still using Kilo tokens.
+
+When unclear, treat the surface as Product UI.
+
+## Routing
+
+Given a user prompt that invokes this skill:
+
+1. Always load `reference/kilo-brand.md`.
+2. Identify the dominant concern from the prompt and load the matching
+   reference(s):
+
+| Prompt signal                                                    | Load                              |
+| ---------------------------------------------------------------- | --------------------------------- |
+| typography, fonts, type scale, hierarchy, readability            | `reference/typography.md`         |
+| color, palette, contrast, accent, theming, gradient, a11y colors | `reference/color-and-contrast.md` |
+| spacing, layout, grid, rhythm, padding, alignment, cards         | `reference/spatial-design.md`     |
+| motion, animation, transitions, easing, micro-interactions       | `reference/motion-design.md`      |
+| forms, focus, hover, states, dialog, dropdown, keyboard nav      | `reference/interaction-design.md` |
+| responsive, mobile, breakpoints, touch, tablet, adapt            | `reference/responsive-design.md`  |
+| copy, microcopy, error messages, labels, empty state copy        | `reference/ux-writing.md`         |
+| audit / critique / polish / general redesign                     | all references above              |
+
+3. If the prompt targets a specific file, component, or route, **read
+   that file first** before proposing or making changes. Do not guess
+   what the current code looks like.
+
+4. When the user asks for implementation, produce code; when the user
+   asks for a review, produce a diff-ready report with file paths,
+   line references, specific token/utility suggestions, and a short
+   rationale per finding.
+
+## Operating rules
+
+Follow these on every task:
+
+1. **Inspect before editing.** Open `apps/web/src/app/globals.css`, the
+   relevant component under `apps/web/src/components/`, and any
+   Storybook story before proposing visual changes.
+2. **Prefer existing tokens, utilities, and components.** Before adding
+   a new color, font, radius, or primitive, confirm no existing one
+   solves the problem.
+3. **Do not rename or restructure the shadcn UI layer** unless the user
+   explicitly asks for a design-system refactor.
+4. **Do not replace the product CTA blue** (`#2B6AD2`) with
+   `--brand-primary` yellow-green without an explicit design decision.
+5. **Do not add new motion libraries.** `motion/react` and
+   `tw-animate-css` are already available.
+6. **Respect `prefers-reduced-motion`** on any motion change beyond
+   trivial opacity/transform hover feedback.
+7. **Design all interactive states:** default, hover, focus-visible,
+   active, disabled, loading, error, success — whichever are relevant.
+8. **Check responsive behavior** for any visual change: mobile (~375px),
+   tablet/laptop (~768–1024px), wide desktop (~1440px+).
+9. **Use Kilo voice** (see `reference/ux-writing.md`) for any copy you
+   add or rewrite.
+10. **Surface conflicts.** If the user's ask conflicts with
+    `kilo-brand.md`, raise the conflict and propose a path forward
+    before silently overriding the brand system.
+
+## Implementing code changes
+
+When producing code:
+
+- Use Tailwind utilities that map to semantic tokens
+  (`bg-background`, `text-foreground`, `border-border`, etc.) before
+  reaching for hex.
+- Extend `cva` variants in existing `ui/` primitives rather than cloning.
+- Icons: `lucide-react`, typically `size-4`, inheriting `currentColor`.
+- Add `aria-label` to icon-only buttons.
+- Use Radix + shadcn wrappers for overlays (dialog, dropdown, popover,
+  tooltip, sheet) — do not hand-roll positioning.
+- Match compact rhythm: `h-8` / `h-9` / `h-10` controls, `h-14` topbar,
+  `p-6` cards.
+- Prefer `gap-*` over ad-hoc margins.
+
+## Running a design review
+
+When producing a review:
+
+- Reference code locations as `file_path:line_number`.
+- Group findings by severity: **Blocker** (accessibility failure, brand
+  violation, broken behavior), **Improvement** (inconsistency,
+  refinement opportunity), **Nit** (optional polish).
+- Propose specific Tailwind utilities, tokens, or components for each
+  fix.
+- Call out responsive, reduced-motion, keyboard, and screen-reader gaps
+  explicitly — they're the most commonly missed.
+
+## Mobile surfaces
+
+`apps/mobile/` uses React Native + NativeWind, with its own shadcn-style
+setup in `apps/mobile/src/global.css` and `apps/mobile/components.json`.
+Web Tailwind patterns do not always translate:
+
+- CSS-variable theme colors do not compose with Tailwind opacity
+  modifiers (`/40`) in NativeWind.
+- `env(safe-area-inset-*)` is web-only; mobile uses react-native safe
+  area tooling.
+- Hover states do not apply. Design the `pressed` state instead.
+
+Consult `apps/mobile/AGENTS.md` (if present) and existing components
+before styling.
+
+## Non-goals
+
+This skill is intentionally scoped. It does **not**:
+
+- Run automated anti-pattern scans.
+- Run or expose Impeccable's "live mode."
+- Generate a root `DESIGN.md`.
+- Rewrite the font-token mismatch or hardcoded CTA blue as semantic
+  tokens. Those are real follow-ups but belong in separate,
+  design-system-scoped PRs.
+
+## Reference map
+
+| File                              | What it covers                                                  |
+| --------------------------------- | --------------------------------------------------------------- |
+| `reference/kilo-brand.md`         | Kilo-specific tokens, components, rules. Load first, always.    |
+| `reference/typography.md`         | Inter/mono usage, hierarchy, tabular nums, OpenType polish.     |
+| `reference/color-and-contrast.md` | OKLCH tokens, brand vs action color, dark-first contrast rules. |
+| `reference/spatial-design.md`     | Spacing, radius scale, grid patterns, optical alignment.        |
+| `reference/motion-design.md`      | Durations, easings, reduced motion, Kilo brand flourishes.      |
+| `reference/interaction-design.md` | Focus, forms, overlays, destructive actions, keyboard nav.      |
+| `reference/responsive-design.md`  | Breakpoints, input-method queries, safe areas, images.          |
+| `reference/ux-writing.md`         | Kilo voice, labels, error copy, empty states, i18n.             |
+
+See `NOTICE.md` for Impeccable attribution and licensing.

--- a/.agents/skills/kilo-design/reference/color-and-contrast.md
+++ b/.agents/skills/kilo-design/reference/color-and-contrast.md
@@ -1,0 +1,201 @@
+# Color & Contrast
+
+> Adapted from Impeccable's `color-and-contrast.md` (Apache 2.0). See
+> `NOTICE.md` for attribution and upstream source.
+
+## Kilo application
+
+Kilo's palette is already expressed in OKLCH CSS variables. Do not
+introduce a parallel palette.
+
+### Use tokens, not hex
+
+Prefer Tailwind utilities that map to Kilo's semantic tokens
+(`bg-background`, `bg-card`, `text-foreground`, `text-muted-foreground`,
+`border-border`, `ring-ring`, `bg-destructive`, `bg-sidebar`, etc.) over
+raw hex. The token layer is in `apps/web/src/app/globals.css`; the
+Tailwind bindings are in the `@theme inline` block.
+
+### Brand accent use
+
+`--brand-primary` / `text-brand-primary` / `bg-brand-primary` (electric
+yellow-green, `oklch(95% 0.15 108)`) is **restrained-strategy** accent
+color. Hold it under 10% of pixel weight on any given surface. Reserve for:
+
+- Logo, wordmark, and logo-adjacent affordances.
+- Focus rings on branded hero controls (see `HeaderLogo.tsx`).
+- Intentional glow moments (see `animate-pulse-once` in `globals.css`).
+- A small number of brand-defining selected / "on" toggles.
+
+Do **not** use yellow-green as:
+
+- Default primary CTA color.
+- Body or link text color.
+- Chart series color (the `chart-*` tokens exist for that).
+- Border color on product surfaces.
+
+### Product action blue
+
+The current primary product CTA is blue:
+
+- Background `#2B6AD2`
+- Hover `#225eb9`
+- Focus ring `#3b7de8`
+
+This color exists in `apps/web/src/components/ui/button.tsx` (`variant: "primary"`)
+and the legacy `Button.tsx`. It is the canonical "click this to proceed"
+color in product and marketing flows. Do not replace it with yellow-green,
+and do not invent a second blue. Elevating this to a semantic token
+(`--color-action` / `--color-action-foreground`) is a reasonable follow-up
+refactor, but out of scope for routine design work.
+
+### Palette structure (how Kilo's tokens map)
+
+| Role     | Purpose                           | Kilo tokens                                                                                                           |
+| -------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Brand    | Rare, load-bearing accent         | `brand-primary`                                                                                                       |
+| Action   | Primary CTAs in product/marketing | `#2B6AD2` (see Button `variant: "primary"`)                                                                           |
+| Neutral  | Text, backgrounds, borders        | `background`, `foreground`, `muted`, `accent`, `secondary`, `card`, `popover`, `border`, `input`, `ring`, `kilo-gray` |
+| Semantic | Destructive, success pills        | `destructive`, badge variants `beta`/`new`                                                                            |
+| Surface  | Sidebar, charts, Kilo gray        | `sidebar-*`, `chart-1`..`chart-5`, `kilo-gray`                                                                        |
+
+### Theming discipline
+
+The web app is dark-first — `:root` sets `color-scheme: dark`. Do not
+"add light mode" to a web surface on a whim. Mobile follows
+`prefers-color-scheme`. If a redesign needs light-mode behavior, verify
+both modes' tokens resolve and that existing components in the affected
+tree actually react to theme changes.
+
+### Absolute rejects in Kilo UI
+
+- Pure `#000` or `#fff` backgrounds/text. Use tokens.
+- Purple / pink / cyan gradient heroes.
+- Gradient text (`background-clip: text` + gradient).
+- Glassmorphism as a default, decorative effect.
+- Rainbow accent palettes introduced just because the screen felt
+  monochromatic.
+- Yellow-green on body copy, sidebar surfaces, or form fields.
+
+---
+
+## Color Spaces: Use OKLCH
+
+OKLCH is perceptually uniform — equal steps in lightness look equal. HSL
+is not. Kilo's tokens are already OKLCH.
+
+`oklch(lightness chroma hue)` where lightness is 0–100%, chroma ~0–0.4,
+hue 0–360. Hold chroma+hue roughly constant and vary lightness to build
+variants, but **reduce chroma as lightness approaches 0 or 100** — high
+chroma at the extremes reads as garish.
+
+## Building Functional Palettes
+
+### Tinted Neutrals
+
+Pure gray is dead. Add a tiny chroma value (0.005–0.015) to neutrals,
+hued toward the brand hue. Kilo already does this: `--color-kilo-gray`
+is `oklch(0.24 0.007 1)`. Tailwind's shadcn neutral tokens carry 0
+chroma; that's acceptable for the dense product shell, but when you
+create a new branded surface, lean on `kilo-gray` rather than a pure gray.
+
+### Palette Structure
+
+A complete system needs:
+
+| Role         | Purpose                       | Example                   |
+| ------------ | ----------------------------- | ------------------------- |
+| **Brand**    | Rare, voice-carrying accent   | 1 color, 1–2 shades       |
+| **Action**   | Primary call-to-action        | 1 color, 3 states         |
+| **Neutral**  | Text, backgrounds, borders    | 9–11 shade scale          |
+| **Semantic** | Success, error, warning, info | 4 colors, 2–3 shades each |
+| **Surface**  | Cards, modals, overlays       | 2–3 elevation levels      |
+
+Skip secondary/tertiary unless you need them. Most apps work fine with
+one accent and one action color.
+
+### The 60-30-10 Rule (Applied Correctly)
+
+This is **visual weight**, not pixel count:
+
+- **60%** — Neutral backgrounds, whitespace, base surfaces
+- **30%** — Secondary colors: text, borders, inactive states
+- **10%** — Accent: CTAs, highlights, focus states
+
+Accent colors work _because_ they are rare. Overuse kills their power.
+In Kilo, "accent" has two constituents: the product blue CTA and the
+brand-primary yellow-green. Combined, they should still stay near 10%.
+
+## Contrast & Accessibility
+
+### WCAG Requirements
+
+| Content type                    | AA minimum | AAA target |
+| ------------------------------- | ---------- | ---------- |
+| Body text                       | 4.5:1      | 7:1        |
+| Large text (18px+ or 14px bold) | 3:1        | 4.5:1      |
+| UI components, icons            | 3:1        | 4.5:1      |
+
+The gotcha: placeholder text still needs 4.5:1. Check Kilo's
+`placeholder:text-muted-foreground` against `bg-input/30` on real screens
+before lowering opacity further.
+
+### Dangerous Color Combinations
+
+- Light gray on white (the #1 accessibility fail)
+- Gray text on colored backgrounds (looks washed out)
+- Red on green, blue on red (vibrates, colorblind hazards)
+- Yellow on white (fails almost always)
+- Thin light text on images (unpredictable contrast)
+
+### Never Use Pure Gray or Pure Black
+
+Pure gray and pure black do not exist in nature. Even a chroma of 0.005
+is enough to feel natural. Kilo already honors this with `kilo-gray`.
+
+### Testing
+
+Don't trust your eyes. Use:
+
+- WebAIM Contrast Checker
+- Browser DevTools → Rendering → Emulate vision deficiencies
+
+## Theming: Light & Dark Mode
+
+### Dark Mode Is Not Inverted Light Mode
+
+Kilo is dark-first for a reason. If you design something for light mode
+first and "flip" it, you'll introduce bad shadows, under-contrast accents,
+and oversaturated hues. Design on the real `background` / `card` /
+`muted` surfaces, not on `#fff`.
+
+| Light mode principle | Dark mode behavior                          |
+| -------------------- | ------------------------------------------- |
+| Shadows for depth    | Lighter surfaces for depth (no shadows)     |
+| Dark text on light   | Light text on dark (reduce font weight)     |
+| Vibrant accents      | Desaturate accents slightly                 |
+| White backgrounds    | Never pure black — dark gray (OKLCH 12–18%) |
+
+Depth in dark mode comes from surface lightness, not shadow. Kilo's scale
+is already: `background` → `card`/`popover` → `muted`/`secondary`/`accent`.
+
+### Token Hierarchy
+
+Use two layers: primitive tokens (`--blue-500`) and semantic tokens
+(`--color-primary: var(--blue-500)`). In Kilo, primitives live inline in
+OKLCH; semantic tokens map through `@theme inline`. Redefine the semantic
+layer for theme changes, never the primitive layer per component.
+
+## Alpha Is A Design Smell
+
+Heavy use of transparency (`rgba`, `hsla`) usually means an incomplete
+palette. Alpha creates unpredictable contrast, performance overhead, and
+inconsistency. Define explicit overlay colors for each context instead.
+Kilo's borders use `oklch(1 0 0 / 10%)` deliberately; that's fine. Don't
+stack five more alpha layers on top of it.
+
+---
+
+**Avoid**: Relying on color alone to convey information. Creating
+palettes without clear roles. Using pure black (`#000`) for large
+surfaces. Skipping color-blindness testing.

--- a/.agents/skills/kilo-design/reference/color-and-contrast.md
+++ b/.agents/skills/kilo-design/reference/color-and-contrast.md
@@ -16,45 +16,45 @@ Prefer Tailwind utilities that map to Kilo's semantic tokens
 raw hex. The token layer is in `apps/web/src/app/globals.css`; the
 Tailwind bindings are in the `@theme inline` block.
 
-### Brand accent use
+### Primary and brand accent use
 
 `--brand-primary` / `text-brand-primary` / `bg-brand-primary` (electric
-yellow-green, `oklch(95% 0.15 108)`) is **restrained-strategy** accent
-color. Hold it under 10% of pixel weight on any given surface. Reserve for:
+yellow-green, `oklch(95% 0.15 108)`) is the same swatch as the semantic
+`primary` token. It is both brand and primary action color. Hold it under
+10% of pixel weight on any given surface. Reserve for:
 
 - Logo, wordmark, and logo-adjacent affordances.
+- The single primary CTA on a surface.
 - Focus rings on branded hero controls (see `HeaderLogo.tsx`).
 - Intentional glow moments (see `animate-pulse-once` in `globals.css`).
 - A small number of brand-defining selected / "on" toggles.
 
 Do **not** use yellow-green as:
 
-- Default primary CTA color.
+- Multiple competing CTAs on the same surface.
 - Body or link text color.
 - Chart series color (the `chart-*` tokens exist for that).
 - Border color on product surfaces.
 
-### Product action blue
+### Primary action token
 
-The current primary product CTA is blue:
+The primary product CTA is the brand yellow-green semantic token:
 
-- Background `#2B6AD2`
-- Hover `#225eb9`
-- Focus ring `#3b7de8`
+- Background `primary` / `--brand-primary` / `oklch(95% 0.15 108)`
+- Foreground `primary-foreground` (near-black)
+- Hover: slightly darker yellow-green
+- Focus ring: semantic `ring` or low-alpha yellow-green
 
-This color exists in `apps/web/src/components/ui/button.tsx` (`variant: "primary"`)
-and the legacy `Button.tsx`. It is the canonical "click this to proceed"
-color in product and marketing flows. Do not replace it with yellow-green,
-and do not invent a second blue. Elevating this to a semantic token
-(`--color-action` / `--color-action-foreground`) is a reasonable follow-up
-refactor, but out of scope for routine design work.
+Hardcoded blue buttons (`#2B6AD2`, Tailwind `blue-*` fills) are legacy drift.
+Migrate them to `primary` when touching the owning component or flow. Blue is
+reserved for inline links and historical references, not action fills.
 
 ### Palette structure (how Kilo's tokens map)
 
 | Role     | Purpose                           | Kilo tokens                                                                                                           |
 | -------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | Brand    | Rare, load-bearing accent         | `brand-primary`                                                                                                       |
-| Action   | Primary CTAs in product/marketing | `#2B6AD2` (see Button `variant: "primary"`)                                                                           |
+| Action   | Primary CTAs in product/marketing | `primary` / `primary-foreground`                                                                                      |
 | Neutral  | Text, backgrounds, borders        | `background`, `foreground`, `muted`, `accent`, `secondary`, `card`, `popover`, `border`, `input`, `ring`, `kilo-gray` |
 | Semantic | Destructive, success pills        | `destructive`, badge variants `beta`/`new`                                                                            |
 | Surface  | Sidebar, charts, Kilo gray        | `sidebar-*`, `chart-1`..`chart-5`, `kilo-gray`                                                                        |
@@ -76,6 +76,7 @@ tree actually react to theme changes.
 - Rainbow accent palettes introduced just because the screen felt
   monochromatic.
 - Yellow-green on body copy, sidebar surfaces, or form fields.
+- Blue button backgrounds for new primary actions.
 
 ---
 
@@ -123,8 +124,8 @@ This is **visual weight**, not pixel count:
 - **10%** — Accent: CTAs, highlights, focus states
 
 Accent colors work _because_ they are rare. Overuse kills their power.
-In Kilo, "accent" has two constituents: the product blue CTA and the
-brand-primary yellow-green. Combined, they should still stay near 10%.
+In Kilo, the primary CTA and brand accent share the same yellow-green swatch.
+That shared role should still stay near 10% visual weight.
 
 ## Contrast & Accessibility
 

--- a/.agents/skills/kilo-design/reference/interaction-design.md
+++ b/.agents/skills/kilo-design/reference/interaction-design.md
@@ -1,0 +1,277 @@
+# Interaction Design
+
+> Adapted from Impeccable's `interaction-design.md` (Apache 2.0). See
+> `NOTICE.md` for attribution and upstream source.
+
+## Kilo application
+
+Kilo is dark-first and relies on **shadcn/ui + Radix**. Before building
+any interactive control from scratch, check these locations first:
+
+- `apps/web/src/components/ui/` — shadcn primitives (button, input,
+  dialog, dropdown-menu, select, tabs, tooltip, sheet, popover,
+  skeleton, table, sidebar, badge).
+- `apps/web/src/components/` — higher-level composed components.
+- `apps/web/components.json` — shadcn config (style `new-york`, neutral
+  base, lucide icons).
+
+### Kilo-specific rules
+
+- **Use Radix + shadcn for overlays.** Dialog, dropdown, popover, tooltip,
+  sheet, and select already handle focus trapping, escape-to-close,
+  outside-click dismissal, ARIA roles, and stacking. Do not hand-roll.
+- **Focus rings.** Use `focus-visible:ring-ring` (semantic) or the
+  explicit brand ring for branded controls (see `HeaderLogo.tsx` which
+  uses `focus:ring-brand-primary focus:ring-3`). Never strip the ring
+  without a replacement.
+- **Button variants are authoritative.** Use `variant="primary"` for
+  blue CTAs, `variant="default"` for shadcn primary, `variant="destructive"`
+  for destructive, `variant="outline"` for secondary, `variant="ghost"`
+  for bare. Don't invent new variants per feature.
+- **Forms use visible labels.** Placeholders are not labels. Pair inputs
+  with `<Label>` (shadcn) and use `aria-describedby` for help/error text.
+- **Validate on blur**, not every keystroke (password strength is an
+  exception).
+- **Destructive actions prefer undo toasts** over confirmation dialogs
+  for reversible operations. Reserve confirm dialogs for truly
+  irreversible actions (account deletion, workspace deletion, bulk
+  destructive ops).
+- **Icon-only buttons need `aria-label`.** Lucide icons inherit color —
+  don't hand-color them unless a variant demands it.
+- **Touch targets:** visual control can be `h-8`/`h-9`, but the tap
+  target should reach 44px on touch surfaces via padding or `::before`
+  (see `spatial-design.md`).
+
+### Absolute rejects in Kilo UI
+
+- Custom focus-ring removal without a replacement.
+- Reimplementing dialog, dropdown, tooltip, select, popover, or sheet
+  positioning instead of using the shadcn wrappers.
+- Placeholder-as-label in forms.
+- Generic "Submit" / "OK" button labels (see `ux-writing.md`).
+- Confirmation dialog for "are you sure you want to save" style prompts.
+- Custom keyboard handlers that override native form submit / Escape /
+  arrow navigation on shadcn components.
+
+---
+
+## The Eight Interactive States
+
+Every interactive element needs these states designed:
+
+| State        | When                          | Visual treatment            |
+| ------------ | ----------------------------- | --------------------------- |
+| **Default**  | At rest                       | Base styling                |
+| **Hover**    | Pointer over (not touch)      | Subtle lift, color shift    |
+| **Focus**    | Keyboard / programmatic focus | Visible ring (see below)    |
+| **Active**   | Being pressed                 | Pressed in, darker          |
+| **Disabled** | Not interactive               | Reduced opacity, no pointer |
+| **Loading**  | Processing                    | Spinner, skeleton           |
+| **Error**    | Invalid state                 | Red border, icon, message   |
+| **Success**  | Completed                     | Green check, confirmation   |
+
+Common miss: designing hover without focus, or vice versa. Keyboard users
+never see hover states.
+
+## Focus Rings: Do Them Right
+
+Never `outline: none` without a replacement. Use `:focus-visible` to show
+focus only for keyboard users:
+
+```css
+/* Hide focus ring for mouse/touch */
+button:focus {
+  outline: none;
+}
+
+/* Show focus ring for keyboard */
+button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+```
+
+In Kilo:
+
+- Default shadcn primitives already do this correctly
+  (`focus-visible:ring-ring/50`, `focus-visible:ring-[3px]`).
+- Branded interactive moments may use `focus:ring-brand-primary`.
+
+Focus ring design:
+
+- High contrast (3:1 minimum against adjacent colors).
+- 2–3px thick.
+- Offset from element (not inside it).
+- Consistent across all interactive elements of the same type.
+
+## Form Design
+
+- **Placeholders aren't labels** — they disappear on input. Always use
+  visible `<Label>`.
+- **Validate on blur**, not on every keystroke (password strength is an
+  exception).
+- **Errors go below the field** with `aria-describedby` connecting them.
+- **Autocomplete is free accessibility.** Set `autocomplete="email"`,
+  `autocomplete="current-password"`, `autocomplete="one-time-code"`,
+  etc. — browsers fill in correctly and screen readers benefit.
+- **Input types matter.** `type="email"`, `type="tel"`, `type="number"`,
+  `type="url"` trigger appropriate mobile keyboards.
+
+## Loading States
+
+- **Optimistic updates.** Show success immediately, rollback on failure.
+  Use for low-stakes actions (toggles, likes, saves in a session). Never
+  for payments or destructive operations.
+- **Skeleton screens > spinners.** They preview content shape and feel
+  faster than generic spinners. Kilo ships a `Skeleton` primitive.
+- **Set expectations.** For long waits, say "This usually takes 30
+  seconds" instead of an unbounded spinner.
+
+## Modals: The Inert Approach
+
+Focus trapping in modals used to require complex JavaScript. Modern
+options:
+
+```html
+<!-- When modal is open, make everything else inert -->
+<main inert>
+  <!-- Content behind modal can't be focused or clicked -->
+</main>
+<dialog open>
+  <h2>Modal Title</h2>
+</dialog>
+```
+
+Or use the native `<dialog>` element:
+
+```ts
+const dialog = document.querySelector('dialog');
+dialog.showModal(); // Opens with focus trap, closes on Escape
+```
+
+In Kilo, **use `Dialog` from `@/components/ui/dialog`** — Radix already
+handles this correctly.
+
+## The Popover API
+
+For tooltips, dropdowns, and non-modal overlays, native popovers work:
+
+```html
+<button popovertarget="menu">Open menu</button>
+<div id="menu" popover>
+  <button>Option 1</button>
+  <button>Option 2</button>
+</div>
+```
+
+**In Kilo**, use `@/components/ui/popover`, `@/components/ui/dropdown-menu`,
+or `@/components/ui/tooltip` — those already provide light-dismiss,
+correct stacking, and accessibility.
+
+## Dropdown & Overlay Positioning
+
+Dropdowns rendered with `position: absolute` inside a container that has
+`overflow: hidden` or `overflow: auto` will be clipped. The single most
+common dropdown bug in generated code.
+
+### CSS Anchor Positioning
+
+Modern solution ties an overlay to its trigger without JavaScript:
+
+```css
+.trigger {
+  anchor-name: --menu-trigger;
+}
+
+.dropdown {
+  position: fixed;
+  position-anchor: --menu-trigger;
+  position-area: block-end span-inline-end;
+  margin-top: 4px;
+}
+
+@position-try --flip-above {
+  position-area: block-start span-inline-end;
+  margin-bottom: 4px;
+}
+```
+
+`position: fixed` escapes overflow clipping. `@position-try` handles
+viewport edges. Browser support: Chrome 125+, Edge 125+ — use a fallback
+for Firefox/Safari.
+
+### Portal / Teleport Pattern
+
+In component frameworks, render the dropdown at the document root and
+position it from the trigger's `getBoundingClientRect()`. Radix and
+shadcn already do this. Do not replace it with `position: absolute`
+inside a scroll container.
+
+### Anti-Patterns
+
+- `position: absolute` inside `overflow: hidden` — the dropdown clips.
+  Use `position: fixed` or the top layer.
+- Arbitrary z-index like `z-index: 9999` — use a semantic z-index scale
+  (dropdown 100 → sticky 200 → modal-backdrop 300 → modal 400 → toast
+  500 → tooltip 600). In Kilo, Radix handles stacking; do not override
+  its layers.
+- Rendering dropdown markup inline without an escape hatch from the
+  parent's stacking context. Use `popover`, a portal, or `position: fixed`.
+
+## Destructive Actions: Undo > Confirm
+
+Undo beats confirmation dialogs for reversible operations — users click
+through confirmations mindlessly. Remove from UI immediately, show undo
+toast, actually delete after the toast expires.
+
+Use confirmation for:
+
+- Truly irreversible actions (account deletion, workspace deletion).
+- High-cost actions (paid plan downgrade).
+- Bulk operations where the blast radius is unclear.
+
+Confirmation labels name the action. `Delete workspace` / `Keep editing`,
+not `Yes` / `No`.
+
+## Keyboard Navigation Patterns
+
+### Roving Tabindex
+
+For component groups (tabs, menu items, radio groups), one item is
+tabbable; arrow keys move within:
+
+```html
+<div role="tablist">
+  <button role="tab" tabindex="0">Tab 1</button>
+  <button role="tab" tabindex="-1">Tab 2</button>
+  <button role="tab" tabindex="-1">Tab 3</button>
+</div>
+```
+
+Arrow keys move `tabindex="0"` between items. Tab moves to the next
+component entirely. In Kilo, `@/components/ui/tabs` already does this.
+
+### Skip Links
+
+Provide `<a href="#main-content">Skip to main content</a>` for keyboard
+users to jump past navigation. Hide off-screen, show on focus.
+
+## Gesture Discoverability
+
+Swipe-to-delete and similar gestures are invisible. Hint at their
+existence:
+
+- **Partially reveal** — show the delete button peeking from the edge.
+- **Onboarding** — coach marks on first use.
+- **Alternative** — always provide a visible fallback (a menu with
+  "Delete").
+
+Don't rely on gestures as the only way to perform actions. In React
+Native (`apps/mobile/`), use accessible gesture patterns from the
+existing component library.
+
+---
+
+**Avoid**: Removing focus indicators without alternatives. Placeholder
+text as labels. Touch targets <44×44px. Generic error messages. Custom
+controls without ARIA / keyboard support. Reimplementing Radix primitives.

--- a/.agents/skills/kilo-design/reference/interaction-design.md
+++ b/.agents/skills/kilo-design/reference/interaction-design.md
@@ -24,10 +24,11 @@ any interactive control from scratch, check these locations first:
   explicit brand ring for branded controls (see `HeaderLogo.tsx` which
   uses `focus:ring-brand-primary focus:ring-3`). Never strip the ring
   without a replacement.
-- **Button variants are authoritative.** Use `variant="primary"` for
-  blue CTAs, `variant="default"` for shadcn primary, `variant="destructive"`
-  for destructive, `variant="outline"` for secondary, `variant="ghost"`
-  for bare. Don't invent new variants per feature.
+- **Button variants are authoritative.** Use the semantic `primary` token /
+  primary variant for the single yellow CTA on a surface,
+  `variant="destructive"` for red destructive actions, `variant="outline"`
+  or `variant="secondary"` for secondary actions, and `variant="ghost"` for
+  bare actions. Don't invent new variants per feature.
 - **Forms use visible labels.** Placeholders are not labels. Pair inputs
   with `<Label>` (shadcn) and use `aria-describedby` for help/error text.
 - **Validate on blur**, not every keystroke (password strength is an

--- a/.agents/skills/kilo-design/reference/kilo-brand.md
+++ b/.agents/skills/kilo-design/reference/kilo-brand.md
@@ -1,0 +1,241 @@
+# Kilo Brand
+
+The canonical overlay for every other reference in this skill. When any of
+the general design references below conflict with this document, **this
+document wins**.
+
+This is not a style guide rewrite. It captures what the Kilo Code codebase
+already does, so design changes stay coherent instead of drifting into
+generic AI-flavored "modern SaaS."
+
+## Sources of Truth
+
+Before changing tokens, colors, type, radius, or animation, consult these
+files directly:
+
+| Concern                  | File                                                       |
+| ------------------------ | ---------------------------------------------------------- |
+| Web tokens & base theme  | `apps/web/src/app/globals.css`                             |
+| Font loading & variables | `apps/web/src/app/layout.tsx`                              |
+| shadcn config            | `apps/web/components.json`                                 |
+| Core UI primitives       | `apps/web/src/components/ui/*.tsx`                         |
+| Brand lockup             | `apps/web/src/components/HeaderLogo.tsx`                   |
+| Storybook canvas         | `apps/storybook/.storybook/preview.ts` and `storybook.css` |
+| Mobile tokens            | `apps/mobile/src/global.css`                               |
+
+If a token or component already exists, **use it**. Do not reintroduce a
+parallel system.
+
+## Register
+
+Kilo has two surfaces with slightly different design rules. Identify which
+one you are designing for before picking colors, type scale, or motion.
+
+| Register              | Scope                                                                                   |
+| --------------------- | --------------------------------------------------------------------------------------- |
+| **Product UI**        | Web app, dashboards, settings, billing, admin, Storybook components, mobile app screens |
+| **Brand / Marketing** | Landing pages, docs, pricing, hero surfaces, on-brand campaign moments                  |
+
+Both use the same tokens and fonts. Brand permits more visual expression
+(hero type, animation, committed color, imagery). Product UI stays calm,
+compact, and task-oriented.
+
+## Theme
+
+Kilo's web app is **dark-first**. `:root` in `apps/web/src/app/globals.css`
+forces `color-scheme: dark`. Mobile's `apps/mobile/src/global.css` follows
+`prefers-color-scheme`. Design with dark as the default.
+
+Do not "add a light mode" speculatively. If asked to work in light, check
+that the surface actually participates in theme switching and that the
+tokens you need are defined for both modes.
+
+## Color Primitives
+
+### Semantic (use these first)
+
+These are declared as CSS variables in `globals.css` and surfaced to
+Tailwind via `@theme inline`. Prefer the Tailwind utility that maps to the
+token (e.g. `bg-background`, `text-foreground`, `border-border`) over hex.
+
+| Token                          | Role                                                       |
+| ------------------------------ | ---------------------------------------------------------- |
+| `background`                   | Page/body surface. Near-black `oklch(0.145 0 0)`.          |
+| `foreground`                   | Default text. Near-white `oklch(0.985 0 0)`.               |
+| `card`, `popover`              | Elevated dark surface `oklch(0.205 0 0)`.                  |
+| `card-foreground`              | Text on card.                                              |
+| `primary`                      | shadcn primary. Light neutral; pairs with dark foreground. |
+| `secondary`, `muted`, `accent` | Mid-dark surfaces `oklch(0.269 0 0)` for chips, hovers.    |
+| `muted-foreground`             | Secondary text `oklch(0.708 0 0)`.                         |
+| `border`, `input`, `ring`      | Hairline borders and focus rings.                          |
+| `destructive`                  | Error/danger state.                                        |
+| `sidebar-*`                    | Sidebar app-shell tokens.                                  |
+| `chart-1`..`chart-5`           | Data viz palette.                                          |
+
+### Kilo-specific primitives
+
+| Token                               | Value                                           | Use                                                   |
+| ----------------------------------- | ----------------------------------------------- | ----------------------------------------------------- |
+| `--brand-primary` / `brand-primary` | `oklch(95% 0.15 108)` (electric yellow-green)   | Brand moments: logo, focus ring, glow, key highlights |
+| `--color-kilo-gray`                 | `oklch(0.24 0.007 1)`                           | Kilo-branded neutral surface                          |
+| `--color-kilo-gray-lighter`         | Derived via `oklch(from ... calc(l + 0.1) c h)` | Paired with `kilo-gray`                               |
+| `--ease-out-strong`                 | `cubic-bezier(0.23, 1, 0.32, 1)`                | Preferred easing for transitions                      |
+
+### Product action color
+
+There is also a product-blue CTA used in `apps/web/src/components/ui/button.tsx`
+variant `primary` and in the legacy `Button` component:
+
+| Role       | Value     |
+| ---------- | --------- |
+| Background | `#2B6AD2` |
+| Hover      | `#225eb9` |
+| Focus ring | `#3b7de8` |
+
+This is not (yet) a semantic token. Treat it as:
+
+- Existing canonical blue for primary product CTAs in marketing and legacy
+  forms.
+- Do not replace it with `--brand-primary` yellow without a design
+  decision — those two colors mean different things.
+- Do not invent new blues. If you need a primary action color, reuse this.
+
+Technical note: elevating `#2B6AD2` to a semantic token
+(e.g. `--color-action` / `--color-action-foreground`) is a reasonable
+follow-up refactor, but out of scope for routine design work.
+
+## Brand Accent Discipline
+
+`--brand-primary` (electric yellow-green) is load-bearing precisely because
+it is rare. Reserve it for:
+
+- The Kilo logo and wordmark.
+- Focus rings on branded / hero controls.
+- Confirmation glow on intentional brand moments (see
+  `animate-pulse-once` / `pulse-glow` in `globals.css`).
+- Selected / "on" state for a small number of brand-critical toggles.
+
+Avoid:
+
+- Using it for every button.
+- Using it as a default text color.
+- Pairing it with long body copy (contrast and reading feel drop fast).
+- Decorative use on dense product UI.
+
+## Typography
+
+Font loading is in `apps/web/src/app/layout.tsx`:
+
+| Family         | CSS variable       | Use                                                        |
+| -------------- | ------------------ | ---------------------------------------------------------- |
+| Inter          | `--font-sans`      | Default UI text                                            |
+| Roboto Mono    | `--font-mono`      | Code, identifiers, metadata                                |
+| JetBrains Mono | `--font-jetbrains` | Terminal-like and code-editor surfaces (`.font-jetbrains`) |
+
+Known issue to be aware of (do not fix casually): `globals.css` currently
+maps Tailwind's font tokens to `--font-geist-sans` / `--font-geist-mono`,
+while `layout.tsx` defines `--font-sans` / `--font-mono`. This means the
+Tailwind `font-sans` / `font-mono` utilities may fall back to the browser
+default unless the element consumes `--font-sans` directly through the
+`<html>` variable. If you are asked to fix this, raise it as a focused
+design-system cleanup PR rather than bundling it into an unrelated change.
+
+Type scale rules for product UI:
+
+- Prefer fewer sizes with stronger hierarchy. Do not stack 14/15/16/17.
+- Common sizes used in the codebase: `text-xs`, `text-sm`, `text-base`,
+  `text-lg`, `text-3xl` (logo wordmark).
+- Use `font-medium` for buttons/controls, `font-bold` for logos and
+  top-level page titles.
+- Use `tabular-nums` for billing, usage counters, metrics, and anything
+  that aligns in columns.
+
+## Shape and Radius
+
+Base radius: `--radius: 0.625rem` in `globals.css`. Derived tokens:
+
+| Token         | Value                       | Typical use                   |
+| ------------- | --------------------------- | ----------------------------- |
+| `--radius-sm` | `calc(var(--radius) - 4px)` | Tight inline chips            |
+| `--radius-md` | `calc(var(--radius) - 2px)` | Buttons, inputs               |
+| `--radius-lg` | `var(--radius)`             | Popovers, medium containers   |
+| `--radius-xl` | `calc(var(--radius) + 4px)` | Cards, dialogs                |
+| (pill)        | `rounded-full`              | Badges, avatars, status pills |
+
+Follow existing shadcn primitives. Buttons/inputs `rounded-md`, cards
+`rounded-xl`, badges full-pill. Do not introduce new radius values.
+
+## Spacing Rhythm
+
+The app-shell rhythm in the current codebase:
+
+- Controls are compact: `h-8` (sm), `h-9` (default), `h-10` (lg).
+- Icons in controls are `size-4`.
+- Topbars are `h-14`.
+- Cards use `p-6` for header/content/footer, `gap-1.5` between title and
+  description.
+- Sidebars have their own token set (`sidebar-*`).
+- Prefer Tailwind's 4pt-aligned scale (`gap-2`, `gap-3`, `gap-4`, `gap-6`,
+  `gap-8`). Avoid one-off spacing.
+
+## Components
+
+The design system is shadcn/ui in the **New York** style, neutral base
+color, CSS variables enabled (`apps/web/components.json`). Icons come from
+`lucide-react`.
+
+Work inside this system:
+
+- Before building a new control, check `apps/web/src/components/ui/` for a
+  primitive. Extend variants before creating new files.
+- Radix primitives back most overlays (dialog, dropdown, popover, select,
+  tabs, tooltip, sheet). Use them — do not hand-roll positioning.
+- Mobile uses a sibling shadcn setup in `apps/mobile/`. React Native does
+  not accept every Tailwind pattern; check `apps/mobile/AGENTS.md` (if
+  present) and the components there before styling across mobile surfaces.
+
+## Motion
+
+Current conventions:
+
+- `--ease-out-strong` is the preferred curve for most transitions.
+- `motion/react` is already in use (see `HeaderLogo.tsx`) for brand
+  interactions. `tw-animate-css` is imported in `globals.css` for small
+  utility animations.
+- Brand moments can use `animate-pulse-once` (see `globals.css`) or the
+  logo hover flourish. Treat these as branded punctuation, not defaults.
+- Respect `prefers-reduced-motion`. Product motion should be short and
+  functional.
+
+## Iconography
+
+- `lucide-react` is the default set.
+- `size-4` inside controls, inheriting `currentColor`.
+- Icon-only buttons need an `aria-label`.
+- Do not mix icon packs without a strong reason.
+
+## Anti-Patterns To Reject On Sight
+
+These hurt Kilo specifically, on top of general anti-slop rules:
+
+- **Yellow everywhere.** If the screen screams yellow, back off to semantic
+  tokens and keep brand-primary for real moments.
+- **Swapping the blue CTA for yellow** without design approval.
+- **Inventing a new primary color** instead of using `primary` or the
+  existing product blue.
+- **Purple gradient heroes, gradient text, glassmorphism defaults.**
+- **Nested cards** (card inside card). Use hierarchy and spacing instead.
+- **New font families** beyond Inter / Roboto Mono / JetBrains Mono.
+- **New radius values** outside the token set above.
+- **Ignoring the sidebar tokens** and hand-coloring sidebar surfaces.
+- **Light-mode-only designs** that ignore Kilo's dark-first app.
+
+## How Agents Should Use This File
+
+- Load `kilo-brand.md` whenever a design change touches Kilo's UI.
+- When producing code, prefer existing tokens, utilities, and components
+  before writing new ones.
+- When producing review/critique output, cite specific tokens, files, and
+  components by path.
+- When a user's request conflicts with these rules, surface the conflict
+  first. Do not quietly override the brand system.

--- a/.agents/skills/kilo-design/reference/kilo-brand.md
+++ b/.agents/skills/kilo-design/reference/kilo-brand.md
@@ -43,8 +43,10 @@ compact, and task-oriented.
 ## Theme
 
 Kilo's web app is **dark-first**. `:root` in `apps/web/src/app/globals.css`
-forces `color-scheme: dark`. Mobile's `apps/mobile/src/global.css` follows
-`prefers-color-scheme`. Design with dark as the default.
+forces `color-scheme: dark`. Mobile's `apps/mobile/src/global.css` defines
+light tokens in `:root` and dark tokens under `prefers-color-scheme`. Design
+web surfaces with dark as the default; check mobile surfaces in both system
+themes.
 
 Do not "add a light mode" speculatively. If asked to work in light, check
 that the surface actually participates in theme switching and that the
@@ -58,58 +60,54 @@ These are declared as CSS variables in `globals.css` and surfaced to
 Tailwind via `@theme inline`. Prefer the Tailwind utility that maps to the
 token (e.g. `bg-background`, `text-foreground`, `border-border`) over hex.
 
-| Token                          | Role                                                       |
-| ------------------------------ | ---------------------------------------------------------- |
-| `background`                   | Page/body surface. Near-black `oklch(0.145 0 0)`.          |
-| `foreground`                   | Default text. Near-white `oklch(0.985 0 0)`.               |
-| `card`, `popover`              | Elevated dark surface `oklch(0.205 0 0)`.                  |
-| `card-foreground`              | Text on card.                                              |
-| `primary`                      | shadcn primary. Light neutral; pairs with dark foreground. |
-| `secondary`, `muted`, `accent` | Mid-dark surfaces `oklch(0.269 0 0)` for chips, hovers.    |
-| `muted-foreground`             | Secondary text `oklch(0.708 0 0)`.                         |
-| `border`, `input`, `ring`      | Hairline borders and focus rings.                          |
-| `destructive`                  | Error/danger state.                                        |
-| `sidebar-*`                    | Sidebar app-shell tokens.                                  |
-| `chart-1`..`chart-5`           | Data viz palette.                                          |
+| Token                          | Role                                                    |
+| ------------------------------ | ------------------------------------------------------- |
+| `background`                   | Page/body surface. Near-black `oklch(0.145 0 0)`.       |
+| `foreground`                   | Default text. Near-white `oklch(0.985 0 0)`.            |
+| `card`, `popover`              | Elevated dark surface `oklch(0.205 0 0)`.               |
+| `card-foreground`              | Text on card.                                           |
+| `primary`                      | Brand yellow-green primary CTA token.                   |
+| `primary-foreground`           | Near-black text on primary yellow-green.                |
+| `secondary`, `muted`, `accent` | Mid-dark surfaces `oklch(0.269 0 0)` for chips, hovers. |
+| `muted-foreground`             | Secondary text `oklch(0.708 0 0)`.                      |
+| `border`, `input`, `ring`      | Hairline borders and focus rings.                       |
+| `destructive`                  | Red error/danger state.                                 |
+| `sidebar-*`                    | Sidebar app-shell tokens.                               |
+| `chart-1`..`chart-5`           | Data viz palette.                                       |
 
 ### Kilo-specific primitives
 
-| Token                               | Value                                           | Use                                                   |
-| ----------------------------------- | ----------------------------------------------- | ----------------------------------------------------- |
-| `--brand-primary` / `brand-primary` | `oklch(95% 0.15 108)` (electric yellow-green)   | Brand moments: logo, focus ring, glow, key highlights |
-| `--color-kilo-gray`                 | `oklch(0.24 0.007 1)`                           | Kilo-branded neutral surface                          |
-| `--color-kilo-gray-lighter`         | Derived via `oklch(from ... calc(l + 0.1) c h)` | Paired with `kilo-gray`                               |
-| `--ease-out-strong`                 | `cubic-bezier(0.23, 1, 0.32, 1)`                | Preferred easing for transitions                      |
+| Token                               | Value                                           | Use                              |
+| ----------------------------------- | ----------------------------------------------- | -------------------------------- |
+| `--brand-primary` / `brand-primary` | `oklch(95% 0.15 108)` (electric yellow-green)   | Alias of primary for brand roles |
+| `--color-kilo-gray`                 | `oklch(0.24 0.007 1)`                           | Kilo-branded neutral surface     |
+| `--color-kilo-gray-lighter`         | Derived via `oklch(from ... calc(l + 0.1) c h)` | Paired with `kilo-gray`          |
+| `--ease-out-strong`                 | `cubic-bezier(0.23, 1, 0.32, 1)`                | Preferred easing for transitions |
 
-### Product action color
+### Primary action color
 
-There is also a product-blue CTA used in `apps/web/src/components/ui/button.tsx`
-variant `primary` and in the legacy `Button` component:
+The product primary CTA is the Kilo brand yellow-green, exposed through the
+semantic `primary` token and `--brand-primary` alias:
 
-| Role       | Value     |
-| ---------- | --------- |
-| Background | `#2B6AD2` |
-| Hover      | `#225eb9` |
-| Focus ring | `#3b7de8` |
+| Role       | Value                                    |
+| ---------- | ---------------------------------------- |
+| Background | `oklch(95% 0.15 108)` (`#EDFF00`-ish)    |
+| Hover      | Slightly darker yellow-green             |
+| Text       | Near-black via `primary-foreground`      |
+| Focus ring | Low-alpha yellow-green / semantic `ring` |
 
-This is not (yet) a semantic token. Treat it as:
-
-- Existing canonical blue for primary product CTAs in marketing and legacy
-  forms.
-- Do not replace it with `--brand-primary` yellow without a design
-  decision — those two colors mean different things.
-- Do not invent new blues. If you need a primary action color, reuse this.
-
-Technical note: elevating `#2B6AD2` to a semantic token
-(e.g. `--color-action` / `--color-action-foreground`) is a reasonable
-follow-up refactor, but out of scope for routine design work.
+Use it for the main action on a surface, exactly once. Blue is no longer a
+primary CTA color; treat hardcoded `#2B6AD2` buttons as legacy drift and
+migrate them to semantic `primary` when the owning surface is updated. Blue
+remains acceptable for inline links and historical references only.
 
 ## Brand Accent Discipline
 
-`--brand-primary` (electric yellow-green) is load-bearing precisely because
-it is rare. Reserve it for:
+The yellow-green primary is load-bearing precisely because it is rare.
+Reserve it for:
 
 - The Kilo logo and wordmark.
+- The primary CTA, once per surface.
 - Focus rings on branded / hero controls.
 - Confirmation glow on intentional brand moments (see
   `animate-pulse-once` / `pulse-glow` in `globals.css`).
@@ -218,11 +216,11 @@ Current conventions:
 
 These hurt Kilo specifically, on top of general anti-slop rules:
 
-- **Yellow everywhere.** If the screen screams yellow, back off to semantic
-  tokens and keep brand-primary for real moments.
-- **Swapping the blue CTA for yellow** without design approval.
-- **Inventing a new primary color** instead of using `primary` or the
-  existing product blue.
+- **Yellow everywhere.** If the screen screams yellow, keep yellow to the
+  single primary action plus real brand moments.
+- **Blue button backgrounds.** Blue is for inline links and legacy drift,
+  not primary action fills.
+- **Inventing a new primary color** instead of using the `primary` token.
 - **Purple gradient heroes, gradient text, glassmorphism defaults.**
 - **Nested cards** (card inside card). Use hierarchy and spacing instead.
 - **New font families** beyond Inter / Roboto Mono / JetBrains Mono.

--- a/.agents/skills/kilo-design/reference/motion-design.md
+++ b/.agents/skills/kilo-design/reference/motion-design.md
@@ -1,0 +1,198 @@
+# Motion Design
+
+> Adapted from Impeccable's `motion-design.md` (Apache 2.0). See
+> `NOTICE.md` for attribution and upstream source.
+
+## Kilo application
+
+Kilo motion is **purposeful and subtle** in product UI, with occasional
+**branded flourishes** at specific hero/logo moments.
+
+### Libraries and tokens
+
+- `motion/react` (formerly `framer-motion`) is already in use.
+  `HeaderLogo.tsx` is the canonical example of a branded interaction.
+- `tw-animate-css` is imported in `apps/web/src/app/globals.css` for
+  small utility animations.
+- Preferred easing: `--ease-out-strong` → `cubic-bezier(0.23, 1, 0.32, 1)`.
+  It is defined as a Tailwind token via `@theme inline`.
+- Named brand keyframes already live in `globals.css`:
+  `pulse-glow` / `animate-pulse-once`, `pulse-opacity`,
+  `pulse-opacity-dim`. Reuse these instead of inventing new glow/pulse
+  effects.
+- Brand accent color for glow: `rgba(237, 255, 0, ...)` mirrors
+  `--brand-primary`.
+
+### Kilo-specific motion rules
+
+- **Product UI should feel calm.** Default to opacity/transform fades
+  (100–200ms) for hover, focus, and state changes. Resist adding motion
+  to every element.
+- **Brand moments are opt-in.** The logo hover rotation, the pulse-glow
+  CTA, Lottie logo swap — these are branded punctuation, not templates
+  to copy elsewhere.
+- **Never animate layout properties casually** (`width`, `height`, `top`,
+  `left`, `margin`). Use `transform`, `opacity`, `filter` or layout
+  libraries (Framer Motion's `layout` prop, FLIP, `grid-template-rows`).
+- **Respect `prefers-reduced-motion`.** For anything more than a small
+  hover transform, provide a reduced fallback. Browsers with
+  reduced-motion preference get functional behavior only.
+- **No bouncy/elastic curves** on product UI. Ease-out exponential
+  (`--ease-out-strong`) and short durations are the house style.
+- **Do not animate modals/dropdowns by hand.** Radix + shadcn already
+  ship well-tuned enter/exit transitions; configure them with
+  Tailwind's `data-[state=open]` utilities.
+
+### Durations
+
+| Duration  | Use                                  | Examples                               |
+| --------- | ------------------------------------ | -------------------------------------- |
+| 100–150ms | Instant feedback                     | Button press, toggle, color shift      |
+| 200–300ms | State changes                        | Menu open, tooltip, hover, focus bloom |
+| 300–500ms | Layout changes                       | Accordion, drawer open, sheet open     |
+| 500–800ms | Entrance animations (brand surfaces) | Hero reveal, first-paint choreography  |
+
+Exit animations are faster than entrances (≈75% of enter duration).
+
+### Absolute rejects in Kilo UI
+
+- Animated gradients on product surfaces.
+- Long (≥ 800ms) transitions in app UIs.
+- `ease` (the CSS default) as the only easing on important motion.
+- Bounce/elastic on buttons.
+- Hover-only affordances on touch-capable surfaces (see
+  `responsive-design.md`).
+- Animating `will-change` globally or preemptively.
+
+---
+
+## Duration: The 100/300/500 Rule
+
+Timing matters more than easing. These durations feel right for most UI:
+
+| Duration  | Use                 | Examples                           |
+| --------- | ------------------- | ---------------------------------- |
+| 100–150ms | Instant feedback    | Button press, toggle, color change |
+| 200–300ms | State changes       | Menu open, tooltip, hover states   |
+| 300–500ms | Layout changes      | Accordion, modal, drawer           |
+| 500–800ms | Entrance animations | Page load, hero reveals            |
+
+Exit animations are faster than entrances — use ~75% of enter duration.
+
+## Easing: Pick the Right Curve
+
+Don't use `ease` — it's a compromise that's rarely optimal. Instead:
+
+| Curve           | Use for                      | CSS                              |
+| --------------- | ---------------------------- | -------------------------------- |
+| **ease-out**    | Elements entering            | `cubic-bezier(0.16, 1, 0.3, 1)`  |
+| **ease-in**     | Elements leaving             | `cubic-bezier(0.7, 0, 0.84, 0)`  |
+| **ease-in-out** | State toggles (there → back) | `cubic-bezier(0.65, 0, 0.35, 1)` |
+
+For micro-interactions, exponential curves feel natural (friction,
+deceleration):
+
+```css
+/* Quart out — smooth, refined (Kilo's --ease-out-strong is close) */
+--ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
+
+/* Quint out — slightly more dramatic */
+--ease-out-quint: cubic-bezier(0.22, 1, 0.36, 1);
+
+/* Expo out — snappy, confident */
+--ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+```
+
+**Avoid bounce and elastic curves.** They feel tacky and amateurish. Real
+objects don't bounce when they stop — they decelerate smoothly.
+
+## Premium Motion Materials
+
+Transform and opacity are reliable defaults, not the whole palette.
+Premium interfaces often need atmospheric properties: blur reveals,
+backdrop-filter panels, saturation or brightness shifts, shadow bloom,
+SVG filters, masks, clip paths, gradient-position movement, and variable
+font or shader-driven effects.
+
+Use the right material for the effect:
+
+- **Transform / opacity** — movement, press feedback, simple reveals,
+  list choreography.
+- **Blur / filter / backdrop-filter** — focus pulls, depth, glass/lens
+  effects, softened entrances, atmospheric transitions.
+- **Clip path / masks** — wipes, reveals, editorial cropping, product-
+  like transitions.
+- **Shadow / glow / color filters** — energy, affordance, focus, warmth,
+  active state.
+- **Grid-template rows or FLIP-style transforms** — expanding and
+  reflowing layout without animating `height` directly.
+
+Avoid animating layout-driving properties casually (`width`, `height`,
+`top`, `left`, margins). Keep expensive effects bounded to small or
+isolated areas, and verify in-browser that the result is smooth on
+target viewports.
+
+## Staggered Animations
+
+Use CSS custom properties for cleaner stagger:
+`animation-delay: calc(var(--i, 0) * 50ms)` with `style="--i: 0"` on each
+item. **Cap total stagger time** — 10 items × 50ms = 500ms total. For
+many items, reduce per-item delay or cap staggered count.
+
+## Reduced Motion
+
+Not optional. Vestibular disorders affect ~35% of adults over 40.
+
+```css
+/* Define animations normally */
+.card {
+  animation: slide-up 500ms ease-out;
+}
+
+/* Provide alternative for reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    animation: fade-in 200ms ease-out;
+  }
+}
+
+/* Or disable entirely */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+Preserve functional animations: progress bars, loading spinners (slowed),
+focus indicators.
+
+## Perceived Performance
+
+Nobody cares how fast your site is — only how fast it feels.
+
+- **80ms threshold.** Anything under ~80ms feels instant. Target this
+  for micro-interactions.
+- **Active vs passive time.** Passive waiting (staring at a spinner)
+  feels longer than active engagement. Preemptive transitions, early
+  completion, and optimistic UI shift the balance.
+- **Easing affects perceived duration.** Ease-in toward a task's end
+  compresses perceived time.
+- **Caution.** Instantaneous responses can decrease perceived value
+  for complex operations — a brief delay can signal "real work."
+
+## Performance
+
+Don't use `will-change` preemptively — only when animation is imminent
+(`:hover`, `.animating`). For scroll-triggered animations, use
+Intersection Observer, and `unobserve()` after animating once. Create
+motion tokens for consistency (Kilo already has `--ease-out-strong`).
+
+---
+
+**Avoid**: Animating everything (animation fatigue is real). >500ms for
+UI feedback. Ignoring `prefers-reduced-motion`. Using animation to hide
+slow loading. Reinventing Radix primitives' transitions.

--- a/.agents/skills/kilo-design/reference/responsive-design.md
+++ b/.agents/skills/kilo-design/reference/responsive-design.md
@@ -1,0 +1,201 @@
+# Responsive Design
+
+> Adapted from Impeccable's `responsive-design.md` (Apache 2.0). See
+> `NOTICE.md` for attribution and upstream source.
+
+## Kilo application
+
+Kilo has two parallel responsive surfaces:
+
+1. **Web** (`apps/web/`) — Next.js + Tailwind v4. Responsive tooling is
+   Tailwind breakpoints + container queries + `env(safe-area-inset-*)`.
+2. **Mobile** (`apps/mobile/`) — React Native + NativeWind. Tailwind
+   breakpoints do **not** map to RN components the same way; use the
+   device conventions already in that app.
+
+### Kilo-specific rules
+
+- **Design mobile-first** for web flows that appear on both marketing
+  and the app shell. Add complexity at `md:` / `lg:` / `xl:` breakpoints,
+  not the other way around.
+- **Do not rely on hover for required functionality.** Hover is
+  supplementary. Touch users can't use it.
+- **Cards and forms should reflow**, not clip. Long labels, long email
+  addresses, long plan names are the norm, not the edge case.
+- **Sidebar rules.** The app shell sidebar has its own mobile behavior
+  via `@/components/ui/sidebar`. Don't reinvent mobile nav — wrap into
+  the existing sidebar state or use `Sheet` from shadcn.
+- **Respect safe areas** on mobile web (iPhone notches, rounded corners).
+  Use `max(…, env(safe-area-inset-*))` on fixed bottom/top bars.
+- **Test at least three widths** for any visual change:
+  - A narrow mobile viewport (~375px).
+  - A tablet or narrow laptop (~768–1024px).
+  - A wide desktop (~1440px+).
+- **React Native + NativeWind caveat:** opacity modifiers (`bg-card/40`)
+  do not work on CSS-variable theme colors. Verify with the component in
+  `apps/mobile/` before assuming a utility composes the same way it does
+  on web.
+
+### Absolute rejects in Kilo UI
+
+- Hover-only required actions.
+- Fixed-pixel widths that break at mobile widths without reflow.
+- Device-user-agent sniffing instead of feature queries.
+- Separate mobile/desktop component trees built from scratch when a
+  shared responsive component would work.
+- Hiding content on mobile (`hidden md:block`) just because the layout
+  is inconvenient. If information matters at desktop, it matters on
+  mobile — reshape it.
+
+---
+
+## Mobile-First: Write It Right
+
+Start with base styles for mobile, use `min-width` queries to layer
+complexity. Desktop-first (`max-width`) means mobile loads unnecessary
+styles first. In Tailwind this is the default behavior: unprefixed
+utilities apply at the smallest viewport, and `md:`, `lg:`, `xl:` add
+complexity upward.
+
+## Breakpoints: Content-Driven
+
+Don't chase device sizes — let content tell you where to break. Start
+narrow, stretch until the design breaks, and add a breakpoint there.
+Three breakpoints usually suffice (the Tailwind `md` 768, `lg` 1024,
+`xl` 1280 defaults work). Use `clamp()` for fluid values without
+breakpoints — but only on marketing/brand pages (see `typography.md`).
+
+## Detect Input Method, Not Just Screen Size
+
+Screen size doesn't tell you input method. A laptop with a touchscreen,
+a tablet with a keyboard — use pointer and hover queries:
+
+```css
+/* Fine pointer (mouse, trackpad) */
+@media (pointer: fine) {
+  .button {
+    padding: 8px 16px;
+  }
+}
+
+/* Coarse pointer (touch, stylus) */
+@media (pointer: coarse) {
+  .button {
+    padding: 12px 20px;
+  } /* Larger touch target */
+}
+
+/* Device supports hover */
+@media (hover: hover) {
+  .card:hover {
+    transform: translateY(-2px);
+  }
+}
+
+/* Device doesn't support hover (touch) */
+@media (hover: none) {
+  /* No hover state — use active instead */
+}
+```
+
+**Critical**: Don't rely on hover for functionality. Touch users can't
+hover. In Tailwind, `hover:` + `@media (hover: hover)` wrapping via the
+`hocus` pattern / `@custom-variant` is fine, but design the no-hover
+path first.
+
+## Safe Areas: Handle the Notch
+
+Modern phones have notches, rounded corners, and home indicators. Use
+`env()`:
+
+```css
+body {
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}
+
+/* With fallback */
+.footer {
+  padding-bottom: max(1rem, env(safe-area-inset-bottom));
+}
+```
+
+Enable `viewport-fit` in your meta tag:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+```
+
+`apps/web/src/app/layout.tsx` sets a Next.js `viewport` object — align
+additions there, not via manual meta tags.
+
+## Responsive Images: Get It Right
+
+### srcset with Width Descriptors
+
+```html
+<img
+  src="hero-800.jpg"
+  srcset="hero-400.jpg 400w, hero-800.jpg 800w, hero-1200.jpg 1200w"
+  sizes="(max-width: 768px) 100vw, 50vw"
+  alt="Hero image"
+/>
+```
+
+How it works:
+
+- `srcset` lists available images with actual widths (`w` descriptors).
+- `sizes` tells the browser how wide the image will display.
+- Browser picks the best file based on viewport width AND device pixel
+  ratio.
+
+In Kilo, prefer Next.js `<Image>` — it produces correct srcset, sizes,
+and lazy loading automatically.
+
+### Picture Element for Art Direction
+
+When you need different crops/compositions (not just resolutions):
+
+```html
+<picture>
+  <source media="(min-width: 768px)" srcset="wide.jpg" />
+  <source media="(max-width: 767px)" srcset="tall.jpg" />
+  <img src="fallback.jpg" alt="..." />
+</picture>
+```
+
+## Layout Adaptation Patterns
+
+- **Navigation.** Three stages — hamburger/sheet on mobile, horizontal
+  compact on tablet, full with labels on desktop. In Kilo, the
+  `Sidebar` primitive + `Sheet` covers this.
+- **Tables.** Transform to cards on mobile using `display: block` and
+  `data-label` attributes. For simple tables, horizontal scroll with a
+  fade mask is acceptable — Kilo already uses this pattern in a few
+  billing/admin views.
+- **Progressive disclosure.** Use `<details>/<summary>` or shadcn's
+  `Accordion` / `Collapsible` for content that can collapse on mobile.
+
+## Testing: Don't Trust DevTools Alone
+
+DevTools device emulation is useful for layout but misses:
+
+- Actual touch interactions.
+- Real CPU/memory constraints.
+- Network latency patterns.
+- Font rendering differences.
+- Browser chrome / keyboard appearances.
+
+Test on at least one real iPhone, one real Android, a tablet if relevant.
+Cheap Android phones reveal performance issues you'll never see on
+simulators. For Kilo's mobile app, test on a real device via Expo Go or
+the dev client before shipping significant UI changes.
+
+---
+
+**Avoid**: Desktop-first design. Device detection instead of feature
+detection. Separate mobile/desktop codebases grown by accident. Ignoring
+tablet and landscape. Assuming all mobile devices are powerful.
+Mobile-hostile `hidden` instead of reshaping content.

--- a/.agents/skills/kilo-design/reference/responsive-design.md
+++ b/.agents/skills/kilo-design/reference/responsive-design.md
@@ -190,8 +190,9 @@ DevTools device emulation is useful for layout but misses:
 
 Test on at least one real iPhone, one real Android, a tablet if relevant.
 Cheap Android phones reveal performance issues you'll never see on
-simulators. For Kilo's mobile app, test on a real device via Expo Go or
-the dev client before shipping significant UI changes.
+simulators. For Kilo's mobile app, use a dev build / dev client on a real
+device before shipping significant UI changes. Do not use Expo Go; the app
+does not support it.
 
 ---
 

--- a/.agents/skills/kilo-design/reference/spatial-design.md
+++ b/.agents/skills/kilo-design/reference/spatial-design.md
@@ -1,0 +1,192 @@
+# Spatial Design
+
+> Adapted from Impeccable's `spatial-design.md` (Apache 2.0). See
+> `NOTICE.md` for attribution and upstream source.
+
+## Kilo application
+
+Kilo's product UI is **compact and task-oriented**. Do not redesign the
+app shell with marketing-scale spacing.
+
+### Spacing
+
+- Use Tailwind's 4pt-aligned scale: `gap-1`, `gap-2`, `gap-3`, `gap-4`,
+  `gap-6`, `gap-8`. Avoid arbitrary `gap-[19px]`.
+- Prefer `gap` over margins. It eliminates margin collapse and is
+  consistent with flex/grid in the codebase.
+- Cards use `p-6` for header/content/footer, `gap-1.5` between card title
+  and description (`apps/web/src/components/ui/card.tsx`).
+- App topbars run at `h-14`; avoid arbitrary topbar heights.
+- Controls stay compact: `h-8` (sm), `h-9` (default), `h-10` (lg). Match
+  this rhythm when adding new interactive elements.
+- Mobile (React Native) has its own safe-area behavior — use the tokens
+  in `apps/mobile/`, not web-only `env(safe-area-inset-*)`.
+
+### Radius
+
+Kilo defines a radius scale:
+
+| Token         | Value                       | Use                           |
+| ------------- | --------------------------- | ----------------------------- |
+| `--radius`    | `0.625rem`                  | Base                          |
+| `--radius-sm` | `calc(var(--radius) - 4px)` | Tight inline chips            |
+| `--radius-md` | `calc(var(--radius) - 2px)` | Buttons, inputs               |
+| `--radius-lg` | `var(--radius)`             | Popovers, medium containers   |
+| `--radius-xl` | `calc(var(--radius) + 4px)` | Cards, dialogs                |
+| (full)        | `rounded-full`              | Badges, avatars, status pills |
+
+Do not introduce new radius values.
+
+### Hierarchy
+
+- **Never nest a Card inside a Card.** If you need sub-grouping, use
+  dividers, spacing, headings, or muted backgrounds — not another card.
+- Use Kilo's sidebar tokens for sidebar-adjacent surfaces; don't hand-paint
+  a second sidebar.
+- Use spacing + typography to build hierarchy before reaching for shadows.
+  Dark-mode depth comes from lighter surfaces, not shadows.
+
+### Absolute rejects in Kilo UI
+
+- Arbitrary spacing values outside Tailwind's scale.
+- Nested cards.
+- Uniform padding everywhere (variety creates rhythm).
+- Hand-drawn z-index values like `z-[9999]`. Use semantic layering
+  (`z-10` for sticky, Radix overlays for modals/menus — Radix handles
+  stacking).
+- Reintroducing one-off popover/tooltip/drawer positioning when Radix
+  primitives already exist in `apps/web/src/components/ui/`.
+
+---
+
+## Spacing Systems
+
+### Use 4pt Base
+
+4pt systems give you 12px between 8 and 16. Tailwind's scale is 4pt-aligned;
+use it. Name tokens semantically (`--space-sm`, `--space-lg`), not by value
+(`--spacing-8`). In Kilo this usually means Tailwind utilities.
+
+## Grid Systems
+
+### The Self-Adjusting Grid
+
+Use `repeat(auto-fit, minmax(280px, 1fr))` for responsive grids without
+breakpoints. Columns are at least 280px, as many as fit per row, leftovers
+stretch.
+
+For complex layouts, use named `grid-template-areas` and redefine at
+breakpoints. Kilo's app shell already uses sidebar + content layouts with
+`sidebar-*` tokens; reuse those structural utilities before building new
+ones.
+
+## Visual Hierarchy
+
+### The Squint Test
+
+Blur your eyes or screenshot + blur. Can you still identify:
+
+- The most important element?
+- The second most important?
+- Clear groupings?
+
+If everything looks the same weight blurred, you have a hierarchy problem.
+
+### Hierarchy Through Multiple Dimensions
+
+Do not rely on size alone. Combine:
+
+| Tool         | Strong hierarchy         | Weak hierarchy    |
+| ------------ | ------------------------ | ----------------- |
+| **Size**     | 3:1 ratio or more        | <2:1 ratio        |
+| **Weight**   | Bold vs Regular          | Medium vs Regular |
+| **Color**    | High contrast            | Similar tones     |
+| **Position** | Top / left (primary)     | Bottom / right    |
+| **Space**    | Surrounded by whitespace | Crowded           |
+
+The best hierarchy uses 2–3 dimensions at once: a heading that's larger,
+bolder, AND has more space above it.
+
+### Cards Are Not Required
+
+Cards are overused. Spacing and alignment create visual grouping naturally.
+Use cards only when:
+
+- Content is truly distinct and actionable.
+- Items need visual comparison in a grid.
+- Content needs clear interaction boundaries.
+
+**Never nest cards inside cards.** Use spacing, typography, and subtle
+dividers for hierarchy within a card.
+
+## Container Queries
+
+Viewport queries are for page layouts. **Container queries are for
+components:**
+
+```css
+.card-container {
+  container-type: inline-size;
+}
+
+.card {
+  display: grid;
+  gap: var(--space-md);
+}
+
+/* Card layout changes based on its container, not the viewport */
+@container (min-width: 400px) {
+  .card {
+    grid-template-columns: 120px 1fr;
+  }
+}
+```
+
+A card in a narrow sidebar stays compact while the same card in a main
+content area expands — automatically, no viewport hacks.
+
+## Optical Adjustments
+
+Text at `margin-left: 0` looks indented due to letterform whitespace; use
+negative margin (`-0.05em`) to optically align. Geometrically centered
+icons often look off-center; play icons shift right, arrows shift toward
+their direction.
+
+### Touch Targets vs Visual Size
+
+Buttons can look small but need large touch targets (44px minimum). Use
+padding or pseudo-elements:
+
+```css
+.icon-button {
+  width: 24px;
+  height: 24px;
+  position: relative;
+}
+
+.icon-button::before {
+  content: '';
+  position: absolute;
+  inset: -10px;
+}
+```
+
+In Kilo, `h-9 w-9` icon buttons (`button.tsx` `size: "icon"`) sit just
+below the 44px touch target. On mobile-facing surfaces, stretch the tap
+area via padding or `::before`, not by enlarging the visual control.
+
+## Depth & Elevation
+
+Create semantic z-index scales (`dropdown → sticky → modal-backdrop →
+modal → toast → tooltip`) rather than arbitrary numbers. In Kilo, Radix
+primitives already manage stacking for overlays — don't fight them with
+`z-[99999]`.
+
+Shadows should be subtle — if you can clearly see them, they're too
+strong. Dark-mode Kilo depth comes from surface elevation, not shadow.
+
+---
+
+**Avoid**: Arbitrary spacing values outside your scale. Making all spacing
+equal (variety creates hierarchy). Creating hierarchy through size alone.
+Nested cards. Rewriting positioning for overlays when Radix already solves it.

--- a/.agents/skills/kilo-design/reference/typography.md
+++ b/.agents/skills/kilo-design/reference/typography.md
@@ -1,0 +1,192 @@
+# Typography
+
+> Adapted from Impeccable's `typography.md` (Apache 2.0). See `NOTICE.md` for
+> attribution and upstream source.
+
+## Kilo application
+
+Kilo's fonts are already chosen and loaded. Do not introduce new families.
+
+| Family         | CSS variable       | Use                                                        |
+| -------------- | ------------------ | ---------------------------------------------------------- |
+| Inter          | `--font-sans`      | Default product UI, buttons, labels, body                  |
+| Roboto Mono    | `--font-mono`      | Code tokens, identifiers, metadata                         |
+| JetBrains Mono | `--font-jetbrains` | Terminal and code-editor surfaces (class `font-jetbrains`) |
+
+Kilo-specific rules:
+
+- **Product UI uses a fixed type scale.** No fluid `clamp()` sizing inside
+  the app shell, dashboards, billing, settings, or Storybook components.
+  App UIs need spatial predictability.
+- **Marketing/brand pages may use `clamp()` for hero headlines** only. Body
+  copy stays fixed.
+- **Use `tabular-nums`** on anything numeric that aligns in columns:
+  billing, usage counters, tables, KPIs, timers.
+- **Disable code ligatures** (`font-variant-ligatures: none;`) only on
+  surfaces where glyph-accurate code matters (terminals, diff views).
+- **Dark-first line-height bump.** Kilo's default theme is dark. Light text
+  on dark reads as lighter weight — prefer the upper end of `line-height`
+  ranges (1.55–1.65 for body).
+- Logo wordmark is `text-3xl font-bold`; topbars/pages derive their scale
+  from there.
+- Known token mismatch: `globals.css` maps Tailwind to `--font-geist-*`
+  variables that no longer exist. `font-sans` / `font-mono` utilities may
+  fall back to system fonts until this is fixed. For now, rely on the font
+  variables Inter/Roboto Mono apply via the `<html>` classList in
+  `layout.tsx`. Do not paper over this mismatch per component; it is a
+  design-system issue.
+
+Absolute rejects in Kilo product UI:
+
+- New font families outside the three listed above.
+- Gradient text.
+- ALL-CAPS body copy (short labels/eyebrows OK with added tracking).
+- Font sizes not on the Tailwind scale.
+- Fluid `clamp()` in product UI.
+
+---
+
+## Classic Typography Principles
+
+### Vertical Rhythm
+
+Your line-height should be the base unit for ALL vertical spacing. If body
+text has `line-height: 1.5` on 16px type (24px), spacing values should be
+multiples of 24px. This creates subconscious harmony between text and space.
+
+### Modular Scale & Hierarchy
+
+The common mistake: too many font sizes that are too close together (14, 15,
+16, 18). Muddy hierarchy.
+
+**Use fewer sizes with more contrast.** A five-size system covers most
+product UI:
+
+| Role | Typical ratio | Kilo Tailwind | Use case                |
+| ---- | ------------- | ------------- | ----------------------- |
+| xs   | 0.75rem       | `text-xs`     | Captions, legal, helper |
+| sm   | 0.875rem      | `text-sm`     | Secondary UI, metadata  |
+| base | 1rem          | `text-base`   | Body text               |
+| lg   | 1.125–1.25rem | `text-lg`     | Subheadings, lead text  |
+| xl+  | 1.5rem and up | `text-xl`+    | Page titles, hero       |
+
+Pick a ratio (1.25 major third, 1.333 perfect fourth, 1.5 perfect fifth)
+and commit. Do not mix multiple scales.
+
+### Readability & Measure
+
+Cap body width in the 45–75ch band (`max-width: 65ch`). Narrow columns need
+tighter leading; wide columns need more.
+
+**Dark mode compensation.** Light text on dark reads lighter than dark on
+light. Bump line-height by 0.05–0.1, add a trace of letter-spacing (0.01em),
+and step body weight up one notch if the text looks thin.
+
+**Paragraph rhythm.** Use either space between paragraphs or first-line
+indent. Never both. Product UI uses space.
+
+## Font Selection & Pairing
+
+Kilo does not select new fonts per project. If a brand surface justifies a
+genuine display face for a hero, treat it as a design decision that needs
+approval, not a reflex.
+
+### Pairing principles
+
+One well-chosen family in multiple weights usually beats two competing
+typefaces. Kilo already runs Inter + Roboto Mono + JetBrains Mono; that is
+enough. If a second typeface appears on a marketing page, it contrasts on
+multiple axes (serif + sans, geometric + humanist, condensed + wide), never
+two similar sans-serifs side by side.
+
+### Web font loading
+
+Fonts are loaded in `apps/web/src/app/layout.tsx` via `next/font/google`,
+which handles `font-display: swap` and preload. Do not reintroduce manual
+`@font-face` declarations or competing loaders.
+
+## Modern Web Typography
+
+### Fluid type — limited in Kilo
+
+`clamp(min, preferred, max)` is allowed on marketing hero headlines and
+long-form content where the type dominates the layout. It is **not** used
+for product UI, dashboards, tools, or tables. Material, Polaris, Primer,
+and Carbon all use fixed scales for the same reason: spatial predictability
+matters more than viewport-scaled type in dense surfaces.
+
+Bound your `clamp()`: `max-size ≤ ~2.5 × min-size`.
+
+### OpenType features
+
+```css
+/* Tabular numbers for data alignment */
+.data-table {
+  font-variant-numeric: tabular-nums;
+}
+
+/* Proper fractions */
+.recipe-amount {
+  font-variant-numeric: diagonal-fractions;
+}
+
+/* Small caps for abbreviations */
+abbr {
+  font-variant-caps: all-small-caps;
+}
+
+/* Disable ligatures in code */
+code,
+.font-jetbrains {
+  font-variant-ligatures: none;
+}
+
+/* Explicit kerning */
+body {
+  font-kerning: normal;
+}
+```
+
+### Rendering polish
+
+```css
+/* Even out heading line lengths */
+h1,
+h2,
+h3 {
+  text-wrap: balance;
+}
+
+/* Reduce orphans and ragged endings in long prose */
+article p {
+  text-wrap: pretty;
+}
+
+/* Pick the right optical-size master automatically */
+body {
+  font-optical-sizing: auto;
+}
+```
+
+ALL-CAPS short labels need 5–12% letter-spacing (`letter-spacing: 0.05em`
+to `0.12em`).
+
+## Typography System Architecture
+
+Name tokens semantically (`--text-body`, `--text-heading`), not by value
+(`--font-size-16`). In Kilo, prefer Tailwind's `text-*` scale and the
+`--font-sans` / `--font-mono` / `--font-jetbrains` variables directly.
+
+## Accessibility
+
+- **Never disable zoom.** `user-scalable=no` breaks accessibility.
+- **Use `rem`/`em` for font sizes.** Never `px` for body text.
+- **Minimum 16px body text.** Smaller than this fails WCAG on mobile.
+- **Adequate touch targets.** Text links need padding or line-height that
+  yields a 44px+ tap target.
+
+---
+
+**Avoid**: More than three font families (Kilo already uses three; no
+fourth). Skipping fallback font definitions. Decorative fonts for body
+text. Fluid type in product UI.

--- a/.agents/skills/kilo-design/reference/ux-writing.md
+++ b/.agents/skills/kilo-design/reference/ux-writing.md
@@ -1,0 +1,253 @@
+# UX Writing
+
+> Adapted from Impeccable's `ux-writing.md` (Apache 2.0). See `NOTICE.md`
+> for attribution and upstream source.
+
+## Kilo application
+
+Kilo voice is **clear, technical, calm, and direct**. Engineering-literate
+audience. No hype, no cutesy error copy, no vague productivity slogans.
+
+### Kilo voice in one paragraph
+
+Kilo talks to developers and team leads. Say what the product does, what
+the user needs to do next, and what will happen if they do it. Skip
+adjectives like "powerful," "seamless," "effortless," and "revolutionary."
+Prefer concrete verbs and specific nouns.
+
+### Terminology to pick and keep
+
+Pick one term per concept and hold it across web, mobile, docs, and UI:
+
+| Use                | Not                                                              |
+| ------------------ | ---------------------------------------------------------------- |
+| Sign in / Sign out | Log in, Log out, Enter, Exit                                     |
+| Delete             | Remove, Trash, Clear (for destructive ops)                       |
+| Settings           | Preferences, Options, Configuration                              |
+| Create             | Add, New (for creating a persistent thing)                       |
+| Workspace          | Team, Account, Org (if "workspace" is what the product calls it) |
+| Kilo Code          | KiloCode, kilo-code (product name)                               |
+
+If this repo has a newer glossary, prefer that. Do not invent synonyms
+to add variety.
+
+### Button labels
+
+Use verb + object. Specific over generic. Kilo-flavored examples:
+
+| Bad        | Good                 |
+| ---------- | -------------------- |
+| OK         | Save changes         |
+| Submit     | Create workspace     |
+| Yes        | Delete project       |
+| Cancel     | Keep editing         |
+| Click here | View billing history |
+
+For destructive actions, name the destruction and the count:
+
+- "Delete 5 invites"
+- "Delete workspace permanently"
+- "Remove member from team"
+
+### Error copy
+
+Every error should answer: (1) what happened, (2) why (if knowable),
+(3) what to try next.
+
+Kilo-flavored patterns:
+
+- `Can't reach Stripe. Check your connection and try again.`
+- `Invalid token. Sign in again to refresh your session.`
+- `Email must include an @ symbol. Example: you@example.com`
+- `You don't have access to this workspace. Ask an admin for an invite.`
+- `Something went wrong on our end. Our team has been notified. Try again in a minute.`
+
+Do **not**:
+
+- Blame the user: "You entered an invalid date" → "Please enter a date as
+  MM/DD/YYYY".
+- Use humor in errors — users are already frustrated.
+- Emit stack traces in user-facing copy.
+- Use `Error: ` prefixes in user-facing messages (the UI treatment already
+  signals an error).
+
+### Empty states
+
+Acknowledge, explain value, provide a clear action. Examples:
+
+- `No workspaces yet. Create one to invite your team and start billing.`
+- `No invoices yet. Your first invoice will appear after your trial ends.`
+- `No API keys. Create one to connect Kilo Code to your IDE.`
+
+### Loading copy
+
+Be specific. `Creating workspace…` beats `Loading…`. For long waits, set
+expectations: `Provisioning machine. This usually takes 30–60 seconds.`
+
+### Confirmation copy
+
+Confirm only for truly irreversible or high-stakes actions. Name the
+action in both buttons:
+
+- `Delete workspace permanently?`  
+  Primary: `Delete workspace` (destructive variant).  
+  Secondary: `Keep workspace`.
+
+### Accessibility copy
+
+- Link text must stand alone: `View pricing plans`, not `Click here`.
+- Alt text describes information, not the image:
+  `Revenue increased 40% in Q4`, not `Chart`.
+- Use `alt=""` for decorative images.
+- Icon-only buttons need `aria-label`.
+
+### Translation / i18n
+
+- German and Finnish can be ~30% longer than English. Plan layout for
+  expansion.
+- Keep full sentences as single strings; word order changes between
+  languages.
+- Avoid abbreviations (`5 minutes ago`, not `5m ago`) unless space is
+  actually constrained.
+- When adding new strings, structure them to allow a translator context.
+
+### Absolute rejects in Kilo copy
+
+- "Submit" / "OK" / "Yes/No" as primary labels.
+- "Oops!" / "Whoops" / "Uh oh" in any user-facing error.
+- Emoji in error messages.
+- Em dashes "—" in UI copy. Use commas, colons, semicolons, or
+  parentheses. Also not `--`.
+- "Powerful," "seamless," "revolutionary," "unlock" as adjectives.
+- Undifferentiated terminology: using `delete` / `remove` / `trash`
+  interchangeably in the same product surface.
+
+---
+
+## The Button Label Problem
+
+Never use `OK`, `Submit`, or `Yes`/`No`. Use specific verb + object:
+
+| Bad        | Good           | Why                           |
+| ---------- | -------------- | ----------------------------- |
+| OK         | Save changes   | Says what will happen         |
+| Submit     | Create account | Outcome-focused               |
+| Yes        | Delete message | Confirms the action           |
+| Cancel     | Keep editing   | Clarifies what "cancel" means |
+| Click here | Download PDF   | Describes the destination     |
+
+For destructive actions, name the destruction:
+
+- `Delete`, not `Remove` (delete is permanent; remove implies
+  recoverable).
+- `Delete 5 items`, not `Delete selected` (show the count).
+
+## Error Messages: The Formula
+
+Every error should answer: (1) what happened, (2) why, (3) how to fix it.
+`Email address isn't valid. Please include an @ symbol.` beats
+`Invalid input`.
+
+### Error message templates
+
+| Situation         | Template                                                        |
+| ----------------- | --------------------------------------------------------------- |
+| Format error      | "[Field] needs to be [format]. Example: [example]"              |
+| Missing required  | "Please enter [what's missing]"                                 |
+| Permission denied | "You don't have access to [thing]. [What to do instead]"        |
+| Network error     | "We couldn't reach [thing]. Check your connection and [action]" |
+| Server error      | "Something went wrong on our end. We're looking into it."       |
+
+### Don't blame the user
+
+Reframe errors: `Please enter a date in MM/DD/YYYY format` not
+`You entered an invalid date`.
+
+## Empty States Are Opportunities
+
+Empty states are onboarding moments:
+
+1. Acknowledge briefly.
+2. Explain the value of filling it.
+3. Provide a clear action.
+
+`No projects yet. Create your first one to get started.` not just
+`No items`.
+
+## Voice vs Tone
+
+**Voice** is your brand's personality — consistent everywhere. **Tone**
+adapts to the moment.
+
+| Moment              | Tone shift                                                   |
+| ------------------- | ------------------------------------------------------------ |
+| Success             | Celebratory, brief: "Done! Your changes are live."           |
+| Error               | Empathetic, helpful: "That didn't work. Here's what to try…" |
+| Loading             | Reassuring: "Saving your work…"                              |
+| Destructive confirm | Serious, clear: "Delete this project? This can't be undone." |
+
+Never use humor for errors.
+
+## Writing for Accessibility
+
+- **Link text** must have standalone meaning — `View pricing plans`, not
+  `Click here`.
+- **Alt text** describes information, not the image — `Revenue increased
+40% in Q4`, not `Chart`.
+- Use `alt=""` for decorative images.
+- **Icon buttons** need `aria-label` for screen reader context.
+
+## Writing for Translation
+
+### Plan for expansion
+
+German text is ~30% longer than English. Allocate space:
+
+| Language | Expansion                      |
+| -------- | ------------------------------ |
+| German   | +30%                           |
+| French   | +20%                           |
+| Finnish  | +30–40%                        |
+| Chinese  | -30% (fewer chars, same width) |
+
+### Translation-friendly patterns
+
+- Keep numbers separate (`New messages: 3`, not `You have 3 new
+messages`).
+- Use full sentences as single strings (word order varies by language).
+- Avoid abbreviations (`5 minutes ago`, not `5 mins ago`).
+- Give translators context about where strings appear.
+
+## Consistency: The Terminology Problem
+
+Pick one term and stick with it. Build a terminology glossary and
+enforce it. Variety creates confusion.
+
+## Avoid Redundant Copy
+
+If the heading explains it, the intro is redundant. If the button is
+clear, don't explain it again. Say it once, say it well.
+
+## Loading States
+
+Be specific: `Saving your draft…`, not `Loading…`. For long waits, set
+expectations (`This usually takes 30 seconds`) or show progress.
+
+## Confirmation Dialogs: Use Sparingly
+
+Most confirmation dialogs are design failures — consider undo instead.
+When you must confirm: name the action, explain consequences, use
+specific button labels (`Delete project` / `Keep project`, not
+`Yes` / `No`).
+
+## Form Instructions
+
+Show format with placeholders, not instructions. For non-obvious fields,
+explain why you're asking.
+
+---
+
+**Avoid**: Jargon without explanation. Blaming users
+(`You made an error` → `This field is required`). Vague errors
+(`Something went wrong`). Varying terminology for variety. Humor for
+errors.

--- a/.kilo/command/kilo-design.md
+++ b/.kilo/command/kilo-design.md
@@ -1,0 +1,16 @@
+---
+description: Apply Kilo-specific design guidance to UI work
+---
+
+Use the `kilo-design` skill for this request.
+
+Apply Kilo Cloud's project-local design guidance from `.agents/skills/kilo-design/`:
+
+1. Load `.agents/skills/kilo-design/SKILL.md`.
+2. Load `.agents/skills/kilo-design/reference/kilo-brand.md` before making design decisions.
+3. If the request focuses on typography, color, spacing, motion, interaction, responsive behavior, or UX writing, load the matching reference file from `.agents/skills/kilo-design/reference/`.
+4. If the request is broad design review, polish, critique, or redesign work, use all focused reference files.
+5. Inspect the relevant app, mobile, or Storybook files before proposing or editing UI.
+6. Prefer existing Kilo tokens, shadcn/Radix primitives, fonts, spacing, and component conventions over new one-off styles.
+
+Use this guidance for: $ARGUMENTS


### PR DESCRIPTION
## Summary

Adds a project-local `kilo-design` agent skill under `.agents/skills/kilo-design/`, plus a `/kilo-design` command under `.kilo/command/kilo-design.md` for explicitly invoking it.

This is a Kilo-specific adaptation of the Impeccable design skillset. Impeccable gives AI coding agents a stronger design vocabulary through focused references for typography, color, spacing, motion, interaction, responsive design, and UX writing.

This fork keeps that structure, but grounds it in Kilo Cloud’s actual product context:

- Kilo’s visual identity and design direction
- The web app’s tokens, fonts, and shadcn/Radix component conventions
- Mobile-specific guidance for the React Native app
- Kilo-specific UI anti-patterns agents should avoid
- Practical rules for designing, reviewing, and implementing frontend changes in this repo

Users can invoke it directly with `/kilo-design <task>`, for example `/kilo-design review the billing page` or `/kilo-design polish this Storybook component`. The command tells the agent to load the skill, read `reference/kilo-brand.md` first, and then use the focused reference files that match the task.

The goal is to make agents less generic when working on Kilo UI. Instead of applying broad “modern SaaS” defaults, they should inspect the existing system and make changes that fit Kilo.

The adapted reference files preserve Apache 2.0 attribution to `pbakaus/impeccable` in `NOTICE.md`.

## Verification

- Reviewed `SKILL.md` routing and operating rules
- Checked that each referenced file exists under `.agents/skills/kilo-design/reference/`
- Checked that `/kilo-design` points agents at the skill and Kilo brand reference
- Checked Kilo-specific guidance against current web and mobile source files
- Confirmed upstream attribution is documented in `NOTICE.md`

## Visual Changes

N/A

## Reviewer Notes

- This is a doc/skill/command-only change. It does not change runtime code.
- This does not install Impeccable commands, live mode, or CLI scanning.
- The `/kilo-design` command is a small repo-local entrypoint for explicitly applying this skill to a design task.