### PR TITLE
feat(auth): allow signup burst while capping sustained per-IP abuse

### DIFF
--- a/apps/web/src/lib/user.test.ts
+++ b/apps/web/src/lib/user.test.ts
@@ -142,10 +142,10 @@ describe('User', () => {
       expect(result.user.signup_ip).toBe('203.0.113.25');
     });
 
-    it('rejects new signups after the per-IP threshold (5)', async () => {
+    it('rejects new signups after the per-IP burst threshold (100/24h)', async () => {
       const signupIp = '203.0.113.50';
-      for (let i = 1; i <= 5; i++) {
-        await insertTestUser({ id: `ip-limit-${i}`, signup_ip: signupIp });
+      for (let i = 1; i <= 100; i++) {
+        await insertTestUser({ id: `ip-burst-${i}`, signup_ip: signupIp });
       }
 
       const result = await createOrUpdateUser(
@@ -165,6 +165,98 @@ describe('User', () => {
       expect(result.success).toBe(false);
       if (result.success) return;
       expect(result.error).toBe('SIGNUP-RATE-LIMITED');
+    });
+
+    it('allows up to 99 signups in 24h from a single IP (burst below threshold)', async () => {
+      const signupIp = '203.0.113.51';
+      for (let i = 1; i <= 99; i++) {
+        await insertTestUser({ id: `ip-burst-ok-${i}`, signup_ip: signupIp });
+      }
+
+      const result = await createOrUpdateUser(
+        {
+          google_user_email: 'burst-ok@example.com',
+          google_user_name: 'Burst OK',
+          google_user_image_url: 'https://example.com/avatar.png',
+          hosted_domain: null,
+          provider: 'google',
+          provider_account_id: 'google-burst-ok',
+        },
+        undefined,
+        false,
+        new Headers({ 'x-forwarded-for': signupIp })
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects new signups after the per-IP sustained threshold (150/30d)', async () => {
+      const signupIp = '203.0.113.52';
+      const now = Date.now();
+      // 99 signups yesterday — under the 24h burst threshold.
+      const yesterday = new Date(now - 2 * 60 * 60 * 1000).toISOString();
+      for (let i = 1; i <= 99; i++) {
+        await insertTestUser({
+          id: `ip-sustained-recent-${i}`,
+          signup_ip: signupIp,
+          created_at: yesterday,
+        });
+      }
+      // 51 more signups 10 days ago — outside the 24h window, inside 30d.
+      const tenDaysAgo = new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString();
+      for (let i = 1; i <= 51; i++) {
+        await insertTestUser({
+          id: `ip-sustained-old-${i}`,
+          signup_ip: signupIp,
+          created_at: tenDaysAgo,
+        });
+      }
+
+      const result = await createOrUpdateUser(
+        {
+          google_user_email: 'sustained-limited@example.com',
+          google_user_name: 'Sustained Limited',
+          google_user_image_url: 'https://example.com/avatar.png',
+          hosted_domain: null,
+          provider: 'google',
+          provider_account_id: 'google-sustained-limited',
+        },
+        undefined,
+        false,
+        new Headers({ 'x-forwarded-for': signupIp })
+      );
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error).toBe('SIGNUP-RATE-LIMITED');
+    });
+
+    it('ignores signups older than 30 days when evaluating the sustained limit', async () => {
+      const signupIp = '203.0.113.53';
+      const longAgo = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString();
+      for (let i = 1; i <= 200; i++) {
+        await insertTestUser({
+          id: `ip-sustained-expired-${i}`,
+          signup_ip: signupIp,
+          created_at: longAgo,
+        });
+      }
+
+      const result = await createOrUpdateUser(
+        {
+          google_user_email: 'sustained-expired@example.com',
+          google_user_name: 'Sustained Expired',
+          google_user_image_url: 'https://example.com/avatar.png',
+          hosted_domain: null,
+          provider: 'google',
+          provider_account_id: 'google-sustained-expired',
+        },
+        undefined,
+        false,
+        new Headers({ 'x-forwarded-for': signupIp })
+      );
+
+      expect(result.success).toBe(true);
     });
 
     it('rejects new signups whose normalized_email is already in use', async () => {

--- a/apps/web/src/lib/user.ts
+++ b/apps/web/src/lib/user.ts
@@ -161,26 +161,21 @@ async function checkSignupIpRateLimit(
   const sustainedWindowStart = new Date(now - SIGNUP_SUSTAINED_WINDOW_MS).toISOString();
 
   const burstCount = await countSignupsFromIpSince(signupIp, burstWindowStart, tx);
-  if (burstCount >= SIGNUP_BURST_MAX) {
-    console.warn('[auth] Signup rejected due to per-IP burst rate limit', {
-      ip_address: signupIp,
-      existing_accounts_24h: burstCount,
-      max_signups_24h: SIGNUP_BURST_MAX,
-    });
-    return failureResult('SIGNUP-RATE-LIMITED');
-  }
-
   const sustainedCount = await countSignupsFromIpSince(signupIp, sustainedWindowStart, tx);
-  if (sustainedCount >= SIGNUP_SUSTAINED_MAX) {
-    console.warn('[auth] Signup rejected due to per-IP sustained rate limit', {
-      ip_address: signupIp,
-      existing_accounts_30d: sustainedCount,
-      max_signups_30d: SIGNUP_SUSTAINED_MAX,
-    });
-    return failureResult('SIGNUP-RATE-LIMITED');
+
+  if (burstCount < SIGNUP_BURST_MAX && sustainedCount < SIGNUP_SUSTAINED_MAX) {
+    return successResult(null);
   }
 
-  return successResult(null);
+  console.warn('[auth] Signup rejected due to per-IP rate limit', {
+    ip_address: signupIp,
+    existing_accounts_24h: burstCount,
+    existing_accounts_30d: sustainedCount,
+    max_signups_24h: SIGNUP_BURST_MAX,
+    max_signups_30d: SIGNUP_SUSTAINED_MAX,
+  });
+
+  return failureResult('SIGNUP-RATE-LIMITED');
 }
 
 async function checkNormalizedEmailUnique(

--- a/apps/web/src/lib/user.ts
+++ b/apps/web/src/lib/user.ts
@@ -120,11 +120,33 @@ if (process.env.NEXT_PUBLIC_POSTHOG_DEBUG) {
   posthogClient.debug();
 }
 
-const SIGNUP_RATE_LIMIT_MAX = 5;
-const SIGNUP_RATE_LIMIT_WINDOW_MS = 24 * 60 * 60 * 1000;
+// Per-IP signup rate limit. Two overlapping windows so an IP can absorb a
+// one-off spike (e.g. meetup where 100 people sign up from the same NAT in a
+// single day) while still bounding sustained abuse. Passing requires both:
+//   - <= 100 signups in the last 24h (burst)
+//   - <= 150 signups in the last 30d  (sustained, averages ~5/day)
+// After a full burst day, only ~50 more signups are allowed over the next
+// 29 days, and the burst day must roll out of the 30d window before the IP
+// can spike again.
+const SIGNUP_BURST_MAX = 100;
+const SIGNUP_BURST_WINDOW_MS = 24 * 60 * 60 * 1000;
+const SIGNUP_SUSTAINED_MAX = 150;
+const SIGNUP_SUSTAINED_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 
 function getSignupIp(requestHeaders?: Headers): string | null {
   return requestHeaders?.get('x-forwarded-for')?.split(',')[0]?.trim() || null;
+}
+
+async function countSignupsFromIpSince(
+  signupIp: string,
+  sinceIso: string,
+  tx: DrizzleTransaction
+): Promise<number> {
+  const [result] = await tx
+    .select({ count: count() })
+    .from(kilocode_users)
+    .where(and(eq(kilocode_users.signup_ip, signupIp), gte(kilocode_users.created_at, sinceIso)));
+  return result?.count ?? 0;
 }
 
 async function checkSignupIpRateLimit(
@@ -134,24 +156,31 @@ async function checkSignupIpRateLimit(
   if (IS_DEVELOPMENT) return successResult(null);
   if (!signupIp) return successResult(null);
 
-  const windowStart = new Date(Date.now() - SIGNUP_RATE_LIMIT_WINDOW_MS).toISOString();
-  const [result] = await tx
-    .select({ count: count() })
-    .from(kilocode_users)
-    .where(
-      and(eq(kilocode_users.signup_ip, signupIp), gte(kilocode_users.created_at, windowStart))
-    );
+  const now = Date.now();
+  const burstWindowStart = new Date(now - SIGNUP_BURST_WINDOW_MS).toISOString();
+  const sustainedWindowStart = new Date(now - SIGNUP_SUSTAINED_WINDOW_MS).toISOString();
 
-  const existingAccounts = result?.count ?? 0;
-  if (existingAccounts < SIGNUP_RATE_LIMIT_MAX) return successResult(null);
+  const burstCount = await countSignupsFromIpSince(signupIp, burstWindowStart, tx);
+  if (burstCount >= SIGNUP_BURST_MAX) {
+    console.warn('[auth] Signup rejected due to per-IP burst rate limit', {
+      ip_address: signupIp,
+      existing_accounts_24h: burstCount,
+      max_signups_24h: SIGNUP_BURST_MAX,
+    });
+    return failureResult('SIGNUP-RATE-LIMITED');
+  }
 
-  console.warn('[auth] Signup rejected due to per-IP rate limit', {
-    ip_address: signupIp,
-    existing_accounts_24h: existingAccounts,
-    max_signups: SIGNUP_RATE_LIMIT_MAX,
-  });
+  const sustainedCount = await countSignupsFromIpSince(signupIp, sustainedWindowStart, tx);
+  if (sustainedCount >= SIGNUP_SUSTAINED_MAX) {
+    console.warn('[auth] Signup rejected due to per-IP sustained rate limit', {
+      ip_address: signupIp,
+      existing_accounts_30d: sustainedCount,
+      max_signups_30d: SIGNUP_SUSTAINED_MAX,
+    });
+    return failureResult('SIGNUP-RATE-LIMITED');
+  }
 
-  return failureResult('SIGNUP-RATE-LIMITED');
+  return successResult(null);
 }
 
 async function checkNormalizedEmailUnique(


### PR DESCRIPTION
## Summary

- Replace the flat `5 signups / 24h` per-IP signup limit with two overlapping windows so an IP can absorb a one-off spike (e.g. a meetup NAT where ~100 people sign up the same day) while still bounding sustained abuse.
- New limits (both must pass): `100 signups / 24h` (burst) and `150 signups / 30d` (sustained, averages ~5/day).
- After a full burst day, only ~50 more signups are allowed from that IP over the next 29 days, and the burst day must roll out of the 30d window before the IP can spike again. No config, no per-event flag — the system absorbs unknown meetups automatically.

## Verification

- Existing per-IP limit test updated from the old `5` threshold to the new `100/24h` burst threshold.
- Added tests: a 99-in-24h burst is allowed; 99-yesterday + 51-at-10-days-ago (150 total in 30d) is rejected; 200 signups 40 days ago are ignored (outside the sustained window).

## Visual Changes

N/A

## Reviewer Notes

- Logic lives in `checkSignupIpRateLimit` in `apps/web/src/lib/user.ts`. Two `count()` queries instead of one; both run only when an IP is present and we're not in dev. Both reuse `kilocode_users.signup_ip` + `created_at` indexes (no schema changes).
- Numbers (100 / 24h, 150 / 30d) are tunable constants; see the comment block above the constants for the rationale.
