### PR TITLE
feat(slack): stateful Test Connection button and remove test message

### DIFF
--- a/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
@@ -4,15 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import {
-  CheckCircle2,
-  XCircle,
-  MessageSquare,
-  Settings,
-  ExternalLink,
-  Send,
-  Trash2,
-} from 'lucide-react';
+import { CheckCircle2, XCircle, MessageSquare, Settings, ExternalLink, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -60,12 +52,25 @@ export function SlackIntegrationDetails({
   const [selectedModel, setSelectedModel] = useState<string>('');
   const [isStartingSlackConnection, setIsStartingSlackConnection] = useState(false);
 
+  type ConnectionCheckState =
+    | { status: 'idle' }
+    | { status: 'success' }
+    | { status: 'error'; message: string };
+  const [connectionCheck, setConnectionCheck] = useState<ConnectionCheckState>({ status: 'idle' });
+
   // Initialize selected model from installation data
   useEffect(() => {
     if (installationData?.installation?.modelSlug) {
       setSelectedModel(installationData.installation.modelSlug);
     }
   }, [installationData?.installation?.modelSlug]);
+
+  // Reset the connection check state when the installation disappears
+  useEffect(() => {
+    if (!installationData?.installed) {
+      setConnectionCheck({ status: 'idle' });
+    }
+  }, [installationData?.installed]);
 
   const uninstallApp = useMutation(
     trpc.slack.uninstallApp.mutationOptions({
@@ -78,8 +83,6 @@ export function SlackIntegrationDetails({
   );
 
   const testConnection = useMutation(trpc.slack.testConnection.mutationOptions());
-
-  const sendTestMessage = useMutation(trpc.slack.sendTestMessage.mutationOptions());
 
   const updateModel = useMutation(
     trpc.slack.updateModel.mutationOptions({
@@ -160,41 +163,41 @@ export function SlackIntegrationDetails({
     }
   };
 
+  // NOTE: These mappings are coupled to the exact error strings returned by
+  // `slackService.testConnection` and the Slack Web API. If the service grows
+  // more failure modes, prefer returning a structured `code` alongside `error`.
+  const mapTestConnectionError = (rawError: string | undefined): string => {
+    if (!rawError) return 'Could not verify Slack right now. Try again later.';
+    if (rawError === 'No Slack installation found') return 'Slack is not connected yet.';
+    if (rawError === 'No access token found')
+      return 'Slack connection data is incomplete. Reconnect Slack.';
+    if (
+      rawError.includes('invalid_auth') ||
+      rawError.includes('account_inactive') ||
+      rawError.includes('token_revoked') ||
+      rawError.includes('token_expired')
+    ) {
+      return 'Slack authorization is no longer valid. Reconnect Slack and try again.';
+    }
+    return 'Could not verify Slack right now. Try again later.';
+  };
+
   const handleTestConnection = () => {
     testConnection.mutate(input, {
       onSuccess: result => {
         if (result.success) {
-          toast.success('Connection test successful!');
+          setConnectionCheck({ status: 'success' });
         } else {
-          toast.error('Connection test failed', {
-            description: result.error,
+          setConnectionCheck({
+            status: 'error',
+            message: mapTestConnectionError(result.error),
           });
         }
       },
       onError: err => {
-        toast.error('Connection test failed', {
-          description: err.message,
-        });
-      },
-    });
-  };
-
-  const handleSendTestMessage = () => {
-    sendTestMessage.mutate(input, {
-      onSuccess: result => {
-        if (result.success) {
-          toast.success('Test message sent!', {
-            description: 'Check your Slack workspace for the message.',
-          });
-        } else {
-          toast.error('Failed to send test message', {
-            description: result.error,
-          });
-        }
-      },
-      onError: err => {
-        toast.error('Failed to send test message', {
-          description: err.message,
+        setConnectionCheck({
+          status: 'error',
+          message: mapTestConnectionError(err.message),
         });
       },
     });
@@ -312,50 +315,58 @@ export function SlackIntegrationDetails({
               </div>
 
               {/* Actions */}
-              <div className="flex flex-wrap gap-3">
-                <Button
-                  variant="outline"
-                  onClick={handleTestConnection}
-                  disabled={testConnection.isPending}
-                >
-                  {testConnection.isPending ? 'Testing...' : 'Test Connection'}
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={handleSendTestMessage}
-                  disabled={sendTestMessage.isPending}
-                >
-                  <Send className="mr-2 h-4 w-4" />
-                  {sendTestMessage.isPending ? 'Sending...' : 'Send Test Message'}
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    window.open('https://slack.com/apps/manage', '_blank');
-                  }}
-                >
-                  <Settings className="mr-2 h-4 w-4" />
-                  Manage in Slack
-                  <ExternalLink className="ml-2 h-3 w-3" />
-                </Button>
-                <Button
-                  variant="destructive"
-                  onClick={handleUninstall}
-                  disabled={uninstallApp.isPending}
-                >
-                  {uninstallApp.isPending ? 'Disconnecting...' : 'Disconnect'}
-                </Button>
-                {IS_DEVELOPMENT && (
+              <div className="space-y-2">
+                <div className="flex flex-wrap gap-3">
+                  <TestConnectionButton
+                    isPending={testConnection.isPending}
+                    state={connectionCheck}
+                    onClick={handleTestConnection}
+                  />
                   <Button
                     variant="outline"
-                    onClick={handleDevRemoveDbRowOnly}
-                    disabled={devRemoveDbRowOnly.isPending}
-                    className="border-yellow-500 text-yellow-500 hover:bg-yellow-500/10"
-                    title="Dev only: Remove DB row without revoking Slack token"
+                    onClick={() => {
+                      window.open('https://slack.com/apps/manage', '_blank');
+                    }}
                   >
-                    <Trash2 className="mr-2 h-4 w-4" />
-                    {devRemoveDbRowOnly.isPending ? 'Removing...' : 'Dev: Remove DB Only'}
+                    <Settings className="mr-2 h-4 w-4" />
+                    Manage in Slack
+                    <ExternalLink className="ml-2 h-3 w-3" />
                   </Button>
+                  <Button
+                    variant="destructive"
+                    onClick={handleUninstall}
+                    disabled={uninstallApp.isPending}
+                  >
+                    {uninstallApp.isPending ? 'Disconnecting...' : 'Disconnect'}
+                  </Button>
+                  {IS_DEVELOPMENT && (
+                    <Button
+                      variant="outline"
+                      onClick={handleDevRemoveDbRowOnly}
+                      disabled={devRemoveDbRowOnly.isPending}
+                      className="border-yellow-500 text-yellow-500 hover:bg-yellow-500/10"
+                      title="Dev only: Remove DB row without revoking Slack token"
+                    >
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      {devRemoveDbRowOnly.isPending ? 'Removing...' : 'Dev: Remove DB Only'}
+                    </Button>
+                  )}
+                </div>
+                <p className="text-muted-foreground text-xs">
+                  This verifies Kilo can authenticate with Slack. To use Kilo in a channel, invite
+                  or mention Kilo in Slack.
+                </p>
+                {connectionCheck.status === 'success' && (
+                  <p className="flex items-center gap-2 text-sm text-green-600 dark:text-green-400">
+                    <CheckCircle2 className="h-4 w-4" />
+                    Slack authorization is valid.
+                  </p>
+                )}
+                {connectionCheck.status === 'error' && (
+                  <p className="text-destructive flex items-center gap-2 text-sm">
+                    <XCircle className="h-4 w-4" />
+                    {connectionCheck.message}
+                  </p>
                 )}
               </div>
             </>
@@ -389,5 +400,53 @@ export function SlackIntegrationDetails({
         </CardContent>
       </Card>
     </div>
+  );
+}
+
+type TestConnectionButtonProps = {
+  isPending: boolean;
+  state: { status: 'idle' | 'success' } | { status: 'error'; message: string };
+  onClick: () => void;
+};
+
+function TestConnectionButton({ isPending, state, onClick }: TestConnectionButtonProps) {
+  if (isPending) {
+    return (
+      <Button variant="outline" disabled>
+        Testing...
+      </Button>
+    );
+  }
+
+  if (state.status === 'success') {
+    return (
+      <Button
+        variant="outline"
+        onClick={onClick}
+        className="border-green-600/50 text-green-600 hover:bg-green-600/10 hover:text-green-600 dark:border-green-400/50 dark:text-green-400 dark:hover:text-green-400"
+      >
+        <CheckCircle2 className="mr-2 h-4 w-4" />
+        Connection OK
+      </Button>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <Button
+        variant="outline"
+        onClick={onClick}
+        className="border-destructive/50 text-destructive hover:bg-destructive/10 hover:text-destructive"
+      >
+        <XCircle className="mr-2 h-4 w-4" />
+        Connection Failed
+      </Button>
+    );
+  }
+
+  return (
+    <Button variant="outline" onClick={onClick}>
+      Test Connection
+    </Button>
   );
 }

--- a/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
@@ -72,6 +72,16 @@ export function SlackIntegrationDetails({
     }
   }, [installationData?.installed]);
 
+  // Auto-reset the success state to idle after 30 seconds so the button
+  // becomes actionable again.
+  useEffect(() => {
+    if (connectionCheck.status !== 'success') return;
+    const timer = setTimeout(() => {
+      setConnectionCheck({ status: 'idle' });
+    }, 30_000);
+    return () => clearTimeout(timer);
+  }, [connectionCheck.status]);
+
   const uninstallApp = useMutation(
     trpc.slack.uninstallApp.mutationOptions({
       onSuccess: () => {
@@ -412,8 +422,8 @@ function TestConnectionButton({ isPending, state, onClick }: TestConnectionButto
     return (
       <Button
         variant="outline"
-        onClick={onClick}
-        className="border-green-600/50 text-green-600 hover:bg-green-600/10 hover:text-green-600 dark:border-green-400/50 dark:text-green-400 dark:hover:text-green-400"
+        disabled
+        className="border-green-600/50 text-green-600 disabled:opacity-100 dark:border-green-400/50 dark:text-green-400"
       >
         <CheckCircle2 className="mr-2 h-4 w-4" />
         Connection OK

--- a/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { CheckCircle2, XCircle, MessageSquare, Settings, ExternalLink, Trash2 } from 'lucide-react';
+import { CheckCircle2, XCircle, MessageSquare, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -322,16 +322,6 @@ export function SlackIntegrationDetails({
                     state={connectionCheck}
                     onClick={handleTestConnection}
                   />
-                  <Button
-                    variant="outline"
-                    onClick={() => {
-                      window.open('https://slack.com/apps/manage', '_blank');
-                    }}
-                  >
-                    <Settings className="mr-2 h-4 w-4" />
-                    Manage in Slack
-                    <ExternalLink className="ml-2 h-3 w-3" />
-                  </Button>
                   <Button
                     variant="destructive"
                     onClick={handleUninstall}

--- a/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/SlackIntegrationDetails.tsx
@@ -173,41 +173,22 @@ export function SlackIntegrationDetails({
     }
   };
 
-  // NOTE: These mappings are coupled to the exact error strings returned by
-  // `slackService.testConnection` and the Slack Web API. If the service grows
-  // more failure modes, prefer returning a structured `code` alongside `error`.
-  const mapTestConnectionError = (rawError: string | undefined): string => {
-    if (!rawError) return 'Could not verify Slack right now. Try again later.';
-    if (rawError === 'No Slack installation found') return 'Slack is not connected yet.';
-    if (rawError === 'No access token found')
-      return 'Slack connection data is incomplete. Reconnect Slack.';
-    if (
-      rawError.includes('invalid_auth') ||
-      rawError.includes('account_inactive') ||
-      rawError.includes('token_revoked') ||
-      rawError.includes('token_expired')
-    ) {
-      return 'Slack authorization is no longer valid. Reconnect Slack and try again.';
-    }
-    return 'Could not verify Slack right now. Try again later.';
-  };
-
   const handleTestConnection = () => {
     testConnection.mutate(input, {
       onSuccess: result => {
         if (result.success) {
           setConnectionCheck({ status: 'success' });
-        } else {
+        } else if ('error' in result && result.error) {
           setConnectionCheck({
             status: 'error',
-            message: mapTestConnectionError(result.error),
+            message: result.error,
           });
         }
       },
       onError: err => {
         setConnectionCheck({
           status: 'error',
-          message: mapTestConnectionError(err.message),
+          message: err.message,
         });
       },
     });

--- a/apps/web/src/lib/integrations/slack-service.test.ts
+++ b/apps/web/src/lib/integrations/slack-service.test.ts
@@ -4,6 +4,7 @@ process.env.TURNSTILE_SECRET_KEY ||= 'test-turnstile-secret';
 const mockLimit = jest.fn();
 const mockDeleteWhere = jest.fn();
 const mockAuthRevoke = jest.fn();
+const mockAuthTest = jest.fn();
 
 jest.mock('@/lib/drizzle', () => ({
   db: {
@@ -24,12 +25,13 @@ jest.mock('@slack/web-api', () => ({
   WebClient: jest.fn(() => ({
     auth: {
       revoke: mockAuthRevoke,
+      test: mockAuthTest,
     },
   })),
 }));
 
 import type { Owner } from '@/lib/integrations/core/types';
-import { uninstallApp } from './slack-service';
+import { testConnection, uninstallApp } from './slack-service';
 
 const owner = { type: 'user', id: 'user-1' } satisfies Owner;
 
@@ -113,5 +115,60 @@ describe('slack-service uninstallApp', () => {
 
     expect(deleteChatSdkInstallation).toHaveBeenCalledWith('T456');
     expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('slack-service testConnection', () => {
+  beforeEach(() => {
+    mockLimit.mockReset();
+    mockAuthTest.mockReset();
+  });
+
+  it('returns success when auth.test succeeds', async () => {
+    mockLimit.mockResolvedValue([buildSlackIntegration()]);
+    mockAuthTest.mockResolvedValue({ ok: true });
+
+    await expect(testConnection(owner)).resolves.toEqual({ success: true });
+    expect(mockAuthTest).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns failure when there is no Slack installation', async () => {
+    mockLimit.mockResolvedValue([]);
+
+    await expect(testConnection(owner)).resolves.toEqual({
+      success: false,
+      error: 'No Slack installation found',
+    });
+    expect(mockAuthTest).not.toHaveBeenCalled();
+  });
+
+  it('returns failure when the access token is missing from metadata', async () => {
+    mockLimit.mockResolvedValue([buildSlackIntegration({ metadata: {} })]);
+
+    await expect(testConnection(owner)).resolves.toEqual({
+      success: false,
+      error: 'No access token found',
+    });
+    expect(mockAuthTest).not.toHaveBeenCalled();
+  });
+
+  it('returns the Slack error when auth.test rejects the token', async () => {
+    mockLimit.mockResolvedValue([buildSlackIntegration()]);
+    mockAuthTest.mockResolvedValue({ ok: false, error: 'invalid_auth' });
+
+    await expect(testConnection(owner)).resolves.toEqual({
+      success: false,
+      error: 'invalid_auth',
+    });
+  });
+
+  it('returns a failure when the Slack client throws', async () => {
+    mockLimit.mockResolvedValue([buildSlackIntegration()]);
+    mockAuthTest.mockRejectedValue(new Error('network down'));
+
+    await expect(testConnection(owner)).resolves.toEqual({
+      success: false,
+      error: 'network down',
+    });
   });
 });

--- a/apps/web/src/lib/integrations/slack-service.ts
+++ b/apps/web/src/lib/integrations/slack-service.ts
@@ -33,7 +33,6 @@ export const SLACK_SCOPES = [
   'groups:read',
   'im:history',
   'im:read',
-  'im:write',
   'mpim:history',
   'mpim:read',
   'reactions:read',
@@ -297,112 +296,6 @@ export async function testConnection(owner: Owner): Promise<{ success: boolean; 
     return { success: true };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    return { success: false, error: errorMessage };
-  }
-}
-
-/**
- * Send a test message to verify the Slack integration is working
- * Uses the incoming webhook channel if available, otherwise tries to find a general channel
- */
-export async function sendTestMessage(
-  owner: Owner
-): Promise<{ success: boolean; error?: string; channel?: string }> {
-  const integration = await getInstallation(owner);
-
-  if (!integration) {
-    return { success: false, error: 'No Slack installation found' };
-  }
-
-  const metadata = integration.metadata as {
-    access_token?: string;
-    model_slug?: string;
-    incoming_webhook?: { channel: string; channelId: string; url: string };
-  } | null;
-
-  if (!metadata?.access_token) {
-    return { success: false, error: 'No access token found' };
-  }
-
-  // Build the test message including the configured model
-  const modelInfo = metadata.model_slug
-    ? `\n📊 Configured model: \`${metadata.model_slug}\``
-    : '\n⚠️ No model configured yet';
-  const testMessage = `🎉 Test message from Kilo Code! Your Slack integration is working correctly.${modelInfo}`;
-
-  // If we have an incoming webhook URL, use it directly (doesn't require channel membership)
-  if (metadata.incoming_webhook?.url) {
-    try {
-      const response = await fetch(metadata.incoming_webhook.url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          text: testMessage,
-        }),
-      });
-
-      if (!response.ok) {
-        const text = await response.text();
-        return { success: false, error: `Webhook failed: ${text}` };
-      }
-
-      return { success: true, channel: metadata.incoming_webhook.channel };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      return { success: false, error: `Webhook error: ${errorMessage}` };
-    }
-  }
-
-  // Fall back to using the API (requires bot to be in channel)
-  try {
-    const client = new WebClient(metadata.access_token);
-
-    // Try to find a general or random channel to post to
-    const channelsResult = await client.conversations.list({
-      types: 'public_channel',
-      limit: 100,
-    });
-
-    const generalChannel = channelsResult.channels?.find(
-      c => c.name === 'general' || c.name === 'random'
-    );
-
-    let channel: string | undefined;
-    if (generalChannel?.id) {
-      channel = generalChannel.id;
-    } else if (channelsResult.channels?.[0]?.id) {
-      channel = channelsResult.channels[0].id;
-    }
-
-    if (!channel) {
-      return { success: false, error: 'No channel found to send test message' };
-    }
-
-    const result = await client.chat.postMessage({
-      channel,
-      text: testMessage,
-    });
-
-    if (!result.ok) {
-      return { success: false, error: result.error || 'Unknown error' };
-    }
-
-    return { success: true, channel: result.channel };
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    // Provide more helpful error messages for common issues
-    if (errorMessage.includes('not_in_channel')) {
-      return {
-        success: false,
-        error: 'Bot is not in the channel. Please invite the Kilo Code bot to a channel first.',
-      };
-    }
-    if (errorMessage.includes('channel_not_found')) {
-      return {
-        success: false,
-        error: 'Channel not found. Please make sure the channel exists and is accessible.',
-      };
-    }
     return { success: false, error: errorMessage };
   }
 }

--- a/apps/web/src/routers/slack-router.ts
+++ b/apps/web/src/routers/slack-router.ts
@@ -111,16 +111,6 @@ export const slackRouter = createTRPCRouter({
     return slackService.testConnection(owner);
   }),
 
-  // Send a test message to Slack
-  sendTestMessage: baseProcedure.input(optionalOrgInput).mutation(async ({ ctx, input }) => {
-    if (input?.organizationId) {
-      await ensureOrganizationAccess(ctx, input.organizationId);
-      await requireActiveSubscriptionOrTrial(input.organizationId);
-    }
-    const owner = resolveOwner(ctx, input?.organizationId);
-    return slackService.sendTestMessage(owner);
-  }),
-
   // Update the model for Slack integration
   updateModel: baseProcedure
     .input(


### PR DESCRIPTION
## Summary

Clean up the Integration page for Slack:
- Test Connection now shows the result in the button (see video)
- Removed test message because it didn't work
- Removed "Manage in Slack" because it was useless

## Visual Changes

| Before | After |
|--------|--------|
| <img width="2236" height="976" alt="CleanShot 2026-04-29 at 13 51 54@2x" src="https://github.com/user-attachments/assets/e1a50a91-9bca-4ed7-a4fa-6a47644d7d09" /> | https://github.com/user-attachments/assets/3d6745cd-02f0-4b78-b5fe-b19ff91fca0a |