### PR TITLE
feat(code-reviews): limit code reviews concurrency for individuals 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ next-env.d.ts
 /dev/fixtures/
 /dev/*/fixtures/
 dev-debug-request-logs/*
+**/dev-debug-request-logs/
 /dev/logs/
 /dev/*/logs/
 

--- a/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.test.ts
+++ b/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.test.ts
@@ -1,9 +1,19 @@
 const mockDispatchReview = jest.fn();
+const mockGetAgentConfigForOwner = jest.fn();
+const mockPrepareReviewPayload = jest.fn();
 
 jest.mock('@/lib/code-reviews/client/code-review-worker-client', () => ({
   codeReviewWorkerClient: {
     dispatchReview: (...args: unknown[]) => mockDispatchReview(...args),
   },
+}));
+
+jest.mock('@/lib/agent-config/db/agent-configs', () => ({
+  getAgentConfigForOwner: (...args: unknown[]) => mockGetAgentConfigForOwner(...args),
+}));
+
+jest.mock('@/lib/code-reviews/triggers/prepare-review-payload', () => ({
+  prepareReviewPayload: (...args: unknown[]) => mockPrepareReviewPayload(...args),
 }));
 
 jest.mock('@sentry/nextjs', () => ({
@@ -12,11 +22,21 @@ jest.mock('@sentry/nextjs', () => ({
 
 import { db } from '@/lib/drizzle';
 import { insertTestUser } from '@/tests/helpers/user.helper';
-import { cloud_agent_code_reviews, kilocode_users, type User } from '@kilocode/db/schema';
+import {
+  cloud_agent_code_reviews,
+  kilocode_users,
+  organizations,
+  type User,
+} from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 import { tryDispatchPendingReviews } from './dispatch-pending-reviews';
 
 const REPO = `test-org/dispatch-pending-${Date.now()}`;
+const FUNDED_BALANCE_MICRODOLLARS = 5_000_001;
+const DEFAULT_TIER_BALANCE_MICRODOLLARS = 5_000_000;
+
+type ReviewStatus = 'pending' | 'queued' | 'running';
+type ReviewOwner = { type: 'user'; id: string } | { type: 'org'; id: string };
 
 function minutesAgo(minutes: number) {
   return new Date(Date.now() - minutes * 60 * 1000).toISOString();
@@ -24,30 +44,59 @@ function minutesAgo(minutes: number) {
 
 describe('tryDispatchPendingReviews', () => {
   let testUser: User;
+  let testOrganizationId: string;
   let reviewSequence = 0;
 
   beforeAll(async () => {
     testUser = await insertTestUser();
+    const [organization] = await db
+      .insert(organizations)
+      .values({ name: `Dispatch Pending Reviews ${Date.now()}` })
+      .returning({ id: organizations.id });
+    testOrganizationId = organization.id;
+  });
+
+  beforeEach(() => {
+    mockDispatchReview.mockResolvedValue(undefined);
+    mockGetAgentConfigForOwner.mockResolvedValue({ id: 'test-agent-config', config: {} });
+    mockPrepareReviewPayload.mockImplementation((params: { reviewId: string }) => ({
+      reviewId: params.reviewId,
+    }));
   });
 
   afterEach(async () => {
     await db
       .delete(cloud_agent_code_reviews)
-      .where(eq(cloud_agent_code_reviews.owned_by_user_id, testUser.id));
-    mockDispatchReview.mockClear();
+      .where(eq(cloud_agent_code_reviews.repo_full_name, REPO));
+    mockDispatchReview.mockReset();
+    mockGetAgentConfigForOwner.mockReset();
+    mockPrepareReviewPayload.mockReset();
   });
 
   afterAll(async () => {
+    await db.delete(organizations).where(eq(organizations.id, testOrganizationId));
     await db.delete(kilocode_users).where(eq(kilocode_users.id, testUser.id));
   });
 
+  async function setTestUserBalance(totalMicrodollarsAcquired: number, microdollarsUsed = 0) {
+    await db
+      .update(kilocode_users)
+      .set({
+        total_microdollars_acquired: totalMicrodollarsAcquired,
+        microdollars_used: microdollarsUsed,
+      })
+      .where(eq(kilocode_users.id, testUser.id));
+  }
+
   function reviewValues({
+    owner,
     status,
     createdAt,
     updatedAt,
     startedAt = null,
   }: {
-    status: 'queued' | 'running';
+    owner: ReviewOwner;
+    status: ReviewStatus;
     createdAt: string;
     updatedAt: string;
     startedAt?: string | null;
@@ -55,7 +104,8 @@ describe('tryDispatchPendingReviews', () => {
     const sequence = reviewSequence++;
 
     return {
-      owned_by_user_id: testUser.id,
+      owned_by_user_id: owner.type === 'user' ? owner.id : null,
+      owned_by_organization_id: owner.type === 'org' ? owner.id : null,
       repo_full_name: REPO,
       pr_number: sequence + 1,
       pr_url: `https://github.com/${REPO}/pull/${sequence + 1}`,
@@ -71,12 +121,221 @@ describe('tryDispatchPendingReviews', () => {
     };
   }
 
+  it('keeps organization concurrency at 20 reviews', async () => {
+    const recentTimestamp = minutesAgo(1);
+    const owner = { type: 'org', id: testOrganizationId } satisfies ReviewOwner;
+
+    await db.insert(cloud_agent_code_reviews).values([
+      ...Array.from({ length: 18 }, () =>
+        reviewValues({
+          owner,
+          status: 'running',
+          createdAt: recentTimestamp,
+          updatedAt: recentTimestamp,
+          startedAt: recentTimestamp,
+        })
+      ),
+      ...Array.from({ length: 5 }, () =>
+        reviewValues({
+          owner,
+          status: 'pending',
+          createdAt: recentTimestamp,
+          updatedAt: recentTimestamp,
+        })
+      ),
+    ]);
+
+    const result = await tryDispatchPendingReviews({
+      type: 'org',
+      id: testOrganizationId,
+      userId: testUser.id,
+    });
+
+    expect(result).toEqual({
+      dispatched: 2,
+      pending: 0,
+      activeCount: 20,
+    });
+    expect(mockDispatchReview).toHaveBeenCalledTimes(2);
+    expect(mockPrepareReviewPayload).toHaveBeenCalledTimes(2);
+  });
+
+  it('dispatches up to 3 personal reviews when the user has more than $5 in credits', async () => {
+    const recentTimestamp = minutesAgo(1);
+    const owner = { type: 'user', id: testUser.id } satisfies ReviewOwner;
+    await setTestUserBalance(FUNDED_BALANCE_MICRODOLLARS);
+
+    await db.insert(cloud_agent_code_reviews).values(
+      Array.from({ length: 5 }, () =>
+        reviewValues({
+          owner,
+          status: 'pending',
+          createdAt: recentTimestamp,
+          updatedAt: recentTimestamp,
+        })
+      )
+    );
+
+    const result = await tryDispatchPendingReviews({
+      type: 'user',
+      id: testUser.id,
+      userId: testUser.id,
+    });
+
+    expect(result).toEqual({
+      dispatched: 3,
+      pending: 0,
+      activeCount: 3,
+    });
+    expect(mockDispatchReview).toHaveBeenCalledTimes(3);
+  });
+
+  it('dispatches one additional funded personal review when two are already active', async () => {
+    const recentTimestamp = minutesAgo(1);
+    const owner = { type: 'user', id: testUser.id } satisfies ReviewOwner;
+    await setTestUserBalance(FUNDED_BALANCE_MICRODOLLARS);
+
+    await db.insert(cloud_agent_code_reviews).values([
+      ...Array.from({ length: 2 }, () =>
+        reviewValues({
+          owner,
+          status: 'running',
+          createdAt: recentTimestamp,
+          updatedAt: recentTimestamp,
+          startedAt: recentTimestamp,
+        })
+      ),
+      ...Array.from({ length: 5 }, () =>
+        reviewValues({
+          owner,
+          status: 'pending',
+          createdAt: recentTimestamp,
+          updatedAt: recentTimestamp,
+        })
+      ),
+    ]);
+
+    const result = await tryDispatchPendingReviews({
+      type: 'user',
+      id: testUser.id,
+      userId: testUser.id,
+    });
+
+    expect(result).toEqual({
+      dispatched: 1,
+      pending: 0,
+      activeCount: 3,
+    });
+    expect(mockDispatchReview).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not dispatch funded personal reviews when three are already active', async () => {
+    const recentTimestamp = minutesAgo(1);
+    const owner = { type: 'user', id: testUser.id } satisfies ReviewOwner;
+    await setTestUserBalance(FUNDED_BALANCE_MICRODOLLARS);
+
+    await db.insert(cloud_agent_code_reviews).values([
+      ...Array.from({ length: 3 }, () =>
+        reviewValues({
+          owner,
+          status: 'running',
+          createdAt: recentTimestamp,
+          updatedAt: recentTimestamp,
+          startedAt: recentTimestamp,
+        })
+      ),
+      ...Array.from({ length: 2 }, () =>
+        reviewValues({
+          owner,
+          status: 'pending',
+          createdAt: recentTimestamp,
+          updatedAt: recentTimestamp,
+        })
+      ),
+    ]);
+
+    const result = await tryDispatchPendingReviews({
+      type: 'user',
+      id: testUser.id,
+      userId: testUser.id,
+    });
+
+    expect(result).toEqual({
+      dispatched: 0,
+      pending: 0,
+      activeCount: 3,
+    });
+    expect(mockDispatchReview).not.toHaveBeenCalled();
+  });
+
+  it('dispatches only 1 personal review when the user has exactly $5 in credits', async () => {
+    const recentTimestamp = minutesAgo(1);
+    const owner = { type: 'user', id: testUser.id } satisfies ReviewOwner;
+    await setTestUserBalance(DEFAULT_TIER_BALANCE_MICRODOLLARS);
+
+    await db.insert(cloud_agent_code_reviews).values(
+      Array.from({ length: 5 }, () =>
+        reviewValues({
+          owner,
+          status: 'pending',
+          createdAt: recentTimestamp,
+          updatedAt: recentTimestamp,
+        })
+      )
+    );
+
+    const result = await tryDispatchPendingReviews({
+      type: 'user',
+      id: testUser.id,
+      userId: testUser.id,
+    });
+
+    expect(result).toEqual({
+      dispatched: 1,
+      pending: 0,
+      activeCount: 1,
+    });
+    expect(mockDispatchReview).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches only 1 personal review when the user has less than $5 in credits', async () => {
+    const recentTimestamp = minutesAgo(1);
+    const owner = { type: 'user', id: testUser.id } satisfies ReviewOwner;
+    await setTestUserBalance(DEFAULT_TIER_BALANCE_MICRODOLLARS - 1);
+
+    await db.insert(cloud_agent_code_reviews).values(
+      Array.from({ length: 5 }, () =>
+        reviewValues({
+          owner,
+          status: 'pending',
+          createdAt: recentTimestamp,
+          updatedAt: recentTimestamp,
+        })
+      )
+    );
+
+    const result = await tryDispatchPendingReviews({
+      type: 'user',
+      id: testUser.id,
+      userId: testUser.id,
+    });
+
+    expect(result).toEqual({
+      dispatched: 1,
+      pending: 0,
+      activeCount: 1,
+    });
+    expect(mockDispatchReview).toHaveBeenCalledTimes(1);
+  });
+
   it('does not count stale running reviews against owner capacity', async () => {
     const recentTimestamp = minutesAgo(1);
     const staleRunningTimestamp = minutesAgo(91);
+    const owner = { type: 'org', id: testOrganizationId } satisfies ReviewOwner;
 
     await db.insert(cloud_agent_code_reviews).values([
       reviewValues({
+        owner,
         status: 'running',
         createdAt: recentTimestamp,
         updatedAt: recentTimestamp,
@@ -84,12 +343,14 @@ describe('tryDispatchPendingReviews', () => {
       }),
       ...Array.from({ length: 19 }, () =>
         reviewValues({
+          owner,
           status: 'queued',
           createdAt: recentTimestamp,
           updatedAt: recentTimestamp,
         })
       ),
       reviewValues({
+        owner,
         status: 'running',
         createdAt: staleRunningTimestamp,
         updatedAt: staleRunningTimestamp,
@@ -98,8 +359,8 @@ describe('tryDispatchPendingReviews', () => {
     ]);
 
     const result = await tryDispatchPendingReviews({
-      type: 'user',
-      id: testUser.id,
+      type: 'org',
+      id: testOrganizationId,
       userId: testUser.id,
     });
 
@@ -114,10 +375,12 @@ describe('tryDispatchPendingReviews', () => {
   it('does not count stale queued reviews against owner capacity', async () => {
     const recentTimestamp = minutesAgo(1);
     const staleQueuedTimestamp = minutesAgo(6);
+    const owner = { type: 'org', id: testOrganizationId } satisfies ReviewOwner;
 
     await db.insert(cloud_agent_code_reviews).values([
       ...Array.from({ length: 20 }, () =>
         reviewValues({
+          owner,
           status: 'running',
           createdAt: recentTimestamp,
           updatedAt: recentTimestamp,
@@ -125,6 +388,7 @@ describe('tryDispatchPendingReviews', () => {
         })
       ),
       reviewValues({
+        owner,
         status: 'queued',
         createdAt: staleQueuedTimestamp,
         updatedAt: staleQueuedTimestamp,
@@ -132,8 +396,8 @@ describe('tryDispatchPendingReviews', () => {
     ]);
 
     const result = await tryDispatchPendingReviews({
-      type: 'user',
-      id: testUser.id,
+      type: 'org',
+      id: testOrganizationId,
       userId: testUser.id,
     });
 

--- a/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.ts
+++ b/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.ts
@@ -10,7 +10,11 @@
  */
 
 import { db } from '@/lib/drizzle';
-import { cloud_agent_code_reviews, type CloudAgentCodeReview } from '@kilocode/db/schema';
+import {
+  cloud_agent_code_reviews,
+  kilocode_users,
+  type CloudAgentCodeReview,
+} from '@kilocode/db/schema';
 import { eq, and, or, count, gte, lt, sql } from 'drizzle-orm';
 import type { Owner } from '../core';
 import { prepareReviewPayload } from '../triggers/prepare-review-payload';
@@ -21,7 +25,10 @@ import { errorExceptInTest, logExceptInTest } from '@/lib/utils.server';
 import { codeReviewWorkerClient } from '../client/code-review-worker-client';
 import type { CodeReviewPlatform } from '../core/schemas';
 
-const MAX_CONCURRENT_REVIEWS_PER_OWNER = 20;
+const MAX_CONCURRENT_REVIEWS_PER_ORG = 20;
+const MAX_CONCURRENT_REVIEWS_PER_FUNDED_USER = 3;
+const MAX_CONCURRENT_REVIEWS_PER_DEFAULT_USER = 1;
+const FUNDED_USER_BALANCE_THRESHOLD_MICRODOLLARS = 5_000_000;
 
 // Reviews claimed (queued) but not picked up by the worker within this
 // window are considered abandoned (e.g. process crashed after claim) and
@@ -29,10 +36,33 @@ const MAX_CONCURRENT_REVIEWS_PER_OWNER = 20;
 const STALE_CLAIM_MINUTES = 5;
 const STALE_RUNNING_MINUTES = 90;
 
-export interface DispatchResult {
+export type DispatchResult = {
   dispatched: number;
   pending: number;
   activeCount: number;
+};
+
+async function getMaxConcurrentReviewsForOwner(owner: Owner): Promise<number> {
+  if (owner.type === 'org') return MAX_CONCURRENT_REVIEWS_PER_ORG;
+
+  const [user] = await db
+    .select({
+      totalMicrodollarsAcquired: kilocode_users.total_microdollars_acquired,
+      microdollarsUsed: kilocode_users.microdollars_used,
+    })
+    .from(kilocode_users)
+    .where(eq(kilocode_users.id, owner.id))
+    .limit(1);
+
+  if (!user) {
+    logExceptInTest('[getMaxConcurrentReviewsForOwner] User owner not found', { owner });
+    return MAX_CONCURRENT_REVIEWS_PER_DEFAULT_USER;
+  }
+
+  const balanceMicrodollars = user.totalMicrodollarsAcquired - user.microdollarsUsed;
+  return balanceMicrodollars > FUNDED_USER_BALANCE_THRESHOLD_MICRODOLLARS
+    ? MAX_CONCURRENT_REVIEWS_PER_FUNDED_USER
+    : MAX_CONCURRENT_REVIEWS_PER_DEFAULT_USER;
 }
 
 /**
@@ -74,11 +104,13 @@ export async function tryDispatchPendingReviews(owner: Owner): Promise<DispatchR
       );
 
     const activeCount = activeCountResult[0]?.count || 0;
-    const availableSlots = MAX_CONCURRENT_REVIEWS_PER_OWNER - activeCount;
+    const maxConcurrentReviews = await getMaxConcurrentReviewsForOwner(owner);
+    const availableSlots = maxConcurrentReviews - activeCount;
 
     logExceptInTest('[tryDispatchPendingReviews] Active count check', {
       owner,
       activeCount,
+      maxConcurrentReviews,
       availableSlots,
     });
 


### PR DESCRIPTION
## Why

Personal code reviews could run too many at once, even when an account had little or no credit. That could use too much capacity and make queues harder to control.

## What changed

Organizations can still run up to 20 cloud code reviews at the same time. Personal accounts now get a smaller limit based on credit balance: 3 at once when they have more than $5, and 1 at once when they have $5 or less. The queue uses the new limit before starting more reviews, while old stuck review handling stays the same. Local debug request logs are also ignored so they do not get added by mistake.

## How to test

1. Run `pnpm --filter web typecheck`.
2. Start the test database with `pnpm test:db` if there is no local Postgres.
3. Run `pnpm test -- dispatch-pending-reviews`.