### PR TITLE
CloudAgentSdk - Surface structured tRPC errors in formatError

### DIFF
--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.test.ts
@@ -1476,6 +1476,48 @@ describe('formatError', () => {
     );
   });
 
+  it('handles SERVICE_UNAVAILABLE code', () => {
+    expect(formatError({ data: { code: 'SERVICE_UNAVAILABLE' } })).toBe(
+      'Service is temporarily unavailable. Please retry in a moment.'
+    );
+  });
+
+  it('handles 503 httpStatus', () => {
+    expect(formatError({ data: { httpStatus: 503 } })).toBe(
+      'Service is temporarily unavailable. Please retry in a moment.'
+    );
+  });
+
+  it('handles TRPCClientError-shaped Error instance with CONFLICT code', () => {
+    const err = Object.assign(new Error('Execution exc_123 is in progress'), {
+      data: { code: 'CONFLICT', httpStatus: 409 },
+    });
+    expect(formatError(err)).toBe('Previous task is still finishing up. Please wait a moment.');
+  });
+
+  it('handles TRPCClientError-shaped Error instance with 402 httpStatus', () => {
+    const err = Object.assign(new Error('Payment required'), {
+      data: { httpStatus: 402 },
+    });
+    expect(formatError(err)).toBe(
+      'Insufficient credits. Please add at least $1 to continue using Cloud Agent.'
+    );
+  });
+
+  it('handles TRPCClientError-shaped Error instance with SERVICE_UNAVAILABLE', () => {
+    const err = Object.assign(new Error('upstream handshake failed'), {
+      data: { code: 'SERVICE_UNAVAILABLE', httpStatus: 503 },
+    });
+    expect(formatError(err)).toBe('Service is temporarily unavailable. Please retry in a moment.');
+  });
+
+  it('handles TRPCClientError-shaped Error instance with unmapped code', () => {
+    const err = Object.assign(new Error('boom'), {
+      data: { code: 'INTERNAL_SERVER_ERROR', httpStatus: 500 },
+    });
+    expect(formatError(err)).toBe('Something went wrong. Please retry in a moment.');
+  });
+
   it('handles unknown errors', () => {
     expect(formatError('just a string')).toBe('Something went wrong. Please retry in a moment.');
     expect(formatError(null)).toBe('Something went wrong. Please retry in a moment.');

--- a/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
+++ b/apps/web/src/lib/cloud-agent-sdk/session-manager.ts
@@ -180,12 +180,9 @@ type SessionManager = {
 // Error formatting
 // ---------------------------------------------------------------------------
 
+const GENERIC_ERROR = 'Something went wrong. Please retry in a moment.';
+
 function formatError(err: unknown): string {
-  if (err instanceof Error) {
-    if (err.message.includes('ECONNREFUSED') || err.message.includes('fetch failed'))
-      return 'Connection lost. Please retry in a moment.';
-    return 'Connection failed. Please retry in a moment.';
-  }
   const r = errorShapeSchema.safeParse(err);
   if (r.success) {
     const code = r.data.data?.code ?? r.data.shape?.code;
@@ -197,9 +194,23 @@ function formatError(err: unknown): string {
     if (code === 'NOT_FOUND') return 'Service is unavailable right now. Please try again.';
     if (code === 'CONFLICT' || http === 409)
       return 'Previous task is still finishing up. Please wait a moment.';
-    return 'Something went wrong. Please retry in a moment.';
+    if (code === 'SERVICE_UNAVAILABLE' || http === 503)
+      return 'Service is temporarily unavailable. Please retry in a moment.';
+    if (code !== undefined || http !== undefined) {
+      return GENERIC_ERROR;
+    }
+    // `errorShapeSchema` uses `.passthrough()`, so `safeParse` succeeds on any
+    // object — including plain `Error` instances whose own properties satisfy
+    // the schema vacuously. Fall through to the transport-level checks below
+    // when neither `code` nor `httpStatus` is present so genuine connection
+    // failures keep their existing wording.
   }
-  return 'Something went wrong. Please retry in a moment.';
+  if (err instanceof Error) {
+    if (err.message.includes('ECONNREFUSED') || err.message.includes('fetch failed'))
+      return 'Connection lost. Please retry in a moment.';
+    return 'Connection failed. Please retry in a moment.';
+  }
+  return GENERIC_ERROR;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `formatError` in `apps/web/src/lib/cloud-agent-sdk/session-manager.ts` was entering the `instanceof Error` branch unconditionally. Because `TRPCClientError` extends `Error`, every tRPC failure from `send`, `switchSession`, and `createAndStart` collapsed to the generic "Connection failed. Please retry in a moment." message, hiding the `PAYMENT_REQUIRED`, `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, and `CONFLICT` copy that already existed.
- Reorder `formatError` so the structured-shape branch (`errorShapeSchema.safeParse`) runs before the `instanceof Error` fallback. Add a `SERVICE_UNAVAILABLE` / `503` mapping — the Worker now returns this for retryable start-execution failures. Add a guard for `.passthrough()` falsely succeeding on plain transport `Error`s (no `code` / `httpStatus`) so genuine connection failures keep their existing "Connection lost." / "Connection failed." wording.
- Hoist the duplicated generic-fallback string to a module-scoped `GENERIC_ERROR` constant.
- Extend `session-manager.test.ts` with cases for `TRPCClientError`-shaped `Error` instances (CONFLICT, 402 httpStatus, SERVICE_UNAVAILABLE, and an unmapped code), plus the POJO variants for `SERVICE_UNAVAILABLE` / `503`.

## Verification

- Reproduce the original bug by triggering two `sendMessage` calls in quick succession; the toast now reads "Previous task is still finishing up. Please wait a moment." instead of the generic "Connection failed." message.

## Visual Changes

N/A — error-toast copy change only; no UI layout changes.

## Reviewer Notes

- The `code !== undefined || http !== undefined` guard is load-bearing: `errorShapeSchema` uses `.passthrough()`, so `safeParse` succeeds on any object (including plain `Error` instances). Without the guard, `new Error('ECONNREFUSED')` would fall into the structured path and return the generic message instead of "Connection lost."
- Behavioral shift: a `TRPCClientError` carrying an unmapped code (e.g. `INTERNAL_SERVER_ERROR`) now returns "Something went wrong…" instead of the previous "Connection failed…". Intentional and covered by the new `unmapped code` test.
- No schema, DB, or wire-format changes. Logic is local to a pure function with dedicated tests; low rollout risk.