### PR TITLE
fix(kiloclaw): preserve subscriptions on destroy

### DIFF
--- a/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
+++ b/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
@@ -9,12 +9,15 @@ import {
   kiloclaw_instances,
   kiloclaw_subscription_change_log,
   kiloclaw_subscriptions,
+  kilocode_users,
 } from '@kilocode/db/schema';
 import { eq, inArray } from 'drizzle-orm';
 
 import { listCurrentPersonalSubscriptionRows } from '@/lib/kiloclaw/current-personal-subscription';
+import { enrollWithCredits as enrollWithCreditsImpl } from '@/lib/kiloclaw/credit-billing';
 import { cleanupDbForTest, db } from '@/lib/drizzle';
 import { insertTestUser } from '@/tests/helpers/user.helper';
+import { bootstrapProvisionSubscriptionWithDb } from '../../../../../services/kiloclaw-billing/src/provision-bootstrap-shared';
 
 const TEST_ACTOR = {
   actorType: 'system',
@@ -22,7 +25,6 @@ const TEST_ACTOR = {
 } as const;
 
 const DESTROY_REASON = 'destroy_path_inline_collapse';
-const CANCEL_SINGLE_REASON = 'destroy_path_cancel_single_current_access_row';
 
 type PersonalPlan = 'standard' | 'trial' | 'commit';
 type PersonalStatus = 'active' | 'canceled' | 'trialing' | 'past_due';
@@ -887,12 +889,13 @@ describe('personal subscription destroy collapse', () => {
     await expectNoChangeLogsForSubscriptions([subscriptionA, subscriptionB, subscriptionC]);
   });
 
-  it('rolls back single-row cancellation when change-log insert fails in transaction', async () => {
+  it('trialing row stays trialing when user destroys their only instance', async () => {
     const user = await insertTestUser({
-      google_user_email: 'destroy-cancel-single-rollback@example.com',
+      google_user_email: 'destroy-preserve-single-trial@example.com',
     });
     const instanceId = crypto.randomUUID();
     const subscriptionId = crypto.randomUUID();
+    const trialEndsAt = '2999-04-08T00:00:00.000Z';
 
     await insertPersonalInstance({
       id: instanceId,
@@ -904,34 +907,22 @@ describe('personal subscription destroy collapse', () => {
       userId: user.id,
       instanceId,
       createdAt: '2026-04-01T00:00:00.000Z',
-      plan: 'standard',
-      status: 'active',
+      plan: 'trial',
+      status: 'trialing',
+      paymentSource: null,
+      trialStartedAt: '2026-04-01T00:00:00.000Z',
+      trialEndsAt,
     });
 
-    await expect(
-      db.transaction(async tx => {
-        const executor = Object.assign(Object.create(tx), {
-          insert: ((table: typeof kiloclaw_subscription_change_log) => {
-            if (table === kiloclaw_subscription_change_log) {
-              return {
-                values: async () => {
-                  throw new Error('change-log insert failed');
-                },
-              };
-            }
-            return tx.insert(table);
-          }) as typeof tx.insert,
-        });
-
-        await markInstanceDestroyedWithPersonalSubscriptionCollapse({
-          actor: TEST_ACTOR,
-          executor,
-          instanceId,
-          reason: DESTROY_REASON,
-          userId: user.id,
-        });
-      })
-    ).rejects.toThrow('change-log insert failed');
+    await db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId,
+        reason: DESTROY_REASON,
+        userId: user.id,
+      });
+    });
 
     const [subscription] = await db
       .select()
@@ -942,89 +933,23 @@ describe('personal subscription destroy collapse', () => {
       .from(kiloclaw_instances)
       .where(eq(kiloclaw_instances.id, instanceId));
 
-    expect(subscription?.status).toBe('active');
-    expect(instance?.destroyed_at).toBeNull();
-    await expectNoChangeLogsForSubscriptions([subscriptionId]);
-  });
-
-  it('does not auto-cancel single destroyed Stripe or hybrid current row on destroy path', async () => {
-    const stripeUser = await insertTestUser({
-      google_user_email: 'destroy-cancel-single-stripe@example.com',
-    });
-    const hybridUser = await insertTestUser({
-      google_user_email: 'destroy-cancel-single-hybrid@example.com',
-    });
-    const stripeInstanceId = crypto.randomUUID();
-    const hybridInstanceId = crypto.randomUUID();
-    const stripeSubscriptionId = crypto.randomUUID();
-    const hybridSubscriptionId = crypto.randomUUID();
-
-    await insertPersonalInstance({
-      id: stripeInstanceId,
-      userId: stripeUser.id,
-      createdAt: '2026-04-01T00:00:00.000Z',
-    });
-    await insertPersonalInstance({
-      id: hybridInstanceId,
-      userId: hybridUser.id,
-      createdAt: '2026-04-01T00:00:00.000Z',
-    });
-    await insertPersonalSubscription({
-      id: stripeSubscriptionId,
-      userId: stripeUser.id,
-      instanceId: stripeInstanceId,
-      createdAt: '2026-04-01T00:00:00.000Z',
-      plan: 'standard',
-      status: 'active',
-      paymentSource: 'stripe',
-      stripeSubscriptionId: 'sub_destroy_path_stripe',
-    });
-    await insertPersonalSubscription({
-      id: hybridSubscriptionId,
-      userId: hybridUser.id,
-      instanceId: hybridInstanceId,
-      createdAt: '2026-04-01T00:00:00.000Z',
-      plan: 'standard',
-      status: 'active',
-      paymentSource: 'credits',
-      stripeSubscriptionId: 'sub_destroy_path_hybrid',
-    });
-
-    await db.transaction(async tx => {
-      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
-        actor: TEST_ACTOR,
-        executor: tx,
-        instanceId: stripeInstanceId,
-        reason: DESTROY_REASON,
-        userId: stripeUser.id,
-      });
-      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
-        actor: TEST_ACTOR,
-        executor: tx,
-        instanceId: hybridInstanceId,
-        reason: DESTROY_REASON,
-        userId: hybridUser.id,
-      });
-    });
-
-    const subscriptions = await db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(inArray(kiloclaw_subscriptions.id, [stripeSubscriptionId, hybridSubscriptionId]));
-
-    expect(subscriptions).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ id: stripeSubscriptionId, status: 'active' }),
-        expect.objectContaining({ id: hybridSubscriptionId, status: 'active' }),
-      ])
+    expect(subscription).toEqual(
+      expect.objectContaining({
+        status: 'trialing',
+        plan: 'trial',
+        trial_ends_at: expect.stringContaining('2999-04-08'),
+        transferred_to_subscription_id: null,
+      })
     );
-    await expectNoChangeLogsForSubscriptions([stripeSubscriptionId, hybridSubscriptionId]);
+    expect(instance?.destroyed_at).not.toBeNull();
+    await expectCurrentHead({ subscriptionId, userId: user.id });
+    await expectNoChangeLogsForSubscriptions([subscriptionId]);
     expect(console.log).not.toHaveBeenCalled();
   });
 
-  it('cancels a single destroyed current access row without entering the chain-build path', async () => {
+  it('credit-funded standard active row stays active when user destroys their only instance', async () => {
     const user = await insertTestUser({
-      google_user_email: 'destroy-cancel-single-current@example.com',
+      google_user_email: 'destroy-preserve-single-standard@example.com',
     });
     const instanceId = crypto.randomUUID();
     const subscriptionId = crypto.randomUUID();
@@ -1041,6 +966,7 @@ describe('personal subscription destroy collapse', () => {
       createdAt: '2026-04-01T00:00:00.000Z',
       plan: 'standard',
       status: 'active',
+      paymentSource: 'credits',
     });
 
     await db.transaction(async tx => {
@@ -1058,23 +984,314 @@ describe('personal subscription destroy collapse', () => {
       .from(kiloclaw_subscriptions)
       .where(eq(kiloclaw_subscriptions.id, subscriptionId));
 
-    expect(subscription?.status).toBe('canceled');
-    expect(subscription?.transferred_to_subscription_id).toBeNull();
-
-    await expectChangeLogsForSubscriptions([
-      {
-        subscriptionId,
-        action: 'canceled',
-        reason: CANCEL_SINGLE_REASON,
-        beforeTransferredTo: null,
-        afterTransferredTo: null,
-        beforePlan: 'standard',
-        beforeStatus: 'active',
-        afterStatus: 'canceled',
-      },
-    ]);
-
+    expect(subscription).toEqual(
+      expect.objectContaining({
+        status: 'active',
+        plan: 'standard',
+        payment_source: 'credits',
+        transferred_to_subscription_id: null,
+      })
+    );
+    await expectCurrentHead({ subscriptionId, userId: user.id });
+    await expectNoChangeLogsForSubscriptions([subscriptionId]);
     expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('credit-funded commit active row stays active when user destroys their only instance', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-preserve-single-commit@example.com',
+    });
+    const instanceId = crypto.randomUUID();
+    const subscriptionId = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: instanceId,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionId,
+      userId: user.id,
+      instanceId,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'commit',
+      status: 'active',
+      paymentSource: 'credits',
+    });
+
+    await db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId,
+        reason: DESTROY_REASON,
+        userId: user.id,
+      });
+    });
+
+    const [subscription] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, subscriptionId));
+
+    expect(subscription).toEqual(
+      expect.objectContaining({
+        status: 'active',
+        plan: 'commit',
+        payment_source: 'credits',
+        transferred_to_subscription_id: null,
+      })
+    );
+    await expectCurrentHead({ subscriptionId, userId: user.id });
+    await expectNoChangeLogsForSubscriptions([subscriptionId]);
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('Stripe-funded standard active row stays active when user destroys their only instance', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-preserve-single-stripe@example.com',
+    });
+    const instanceId = crypto.randomUUID();
+    const subscriptionId = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: instanceId,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionId,
+      userId: user.id,
+      instanceId,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'standard',
+      status: 'active',
+      paymentSource: 'stripe',
+      stripeSubscriptionId: 'sub_destroy_path_stripe',
+    });
+
+    await db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId,
+        reason: DESTROY_REASON,
+        userId: user.id,
+      });
+    });
+
+    const [subscription] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, subscriptionId));
+
+    expect(subscription).toEqual(
+      expect.objectContaining({
+        status: 'active',
+        plan: 'standard',
+        payment_source: 'stripe',
+        stripe_subscription_id: 'sub_destroy_path_stripe',
+        transferred_to_subscription_id: null,
+      })
+    );
+    await expectCurrentHead({ subscriptionId, userId: user.id });
+    await expectNoChangeLogsForSubscriptions([subscriptionId]);
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('user can provision a new instance immediately after destroying the old one, and the resulting instance is linked to the original subscription period (trial_ends_at / current_period_end unchanged)', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-reprovision-preserves-period@example.com',
+    });
+    const oldInstanceId = crypto.randomUUID();
+    const newInstanceId = crypto.randomUUID();
+    const subscriptionId = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: oldInstanceId,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionId,
+      userId: user.id,
+      instanceId: oldInstanceId,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'trial',
+      status: 'trialing',
+      paymentSource: null,
+      trialStartedAt: '2026-04-01T00:00:00.000Z',
+      trialEndsAt: '2999-04-08T00:00:00.000Z',
+    });
+    await db
+      .update(kilocode_users)
+      .set({ total_microdollars_acquired: 50_000_000 })
+      .where(eq(kilocode_users.id, user.id));
+    process.env.STRIPE_KILOCLAW_COMMIT_PRICE_ID ||= 'price_commit';
+    process.env.STRIPE_KILOCLAW_STANDARD_PRICE_ID ||= 'price_standard';
+    process.env.STRIPE_KILOCLAW_STANDARD_INTRO_PRICE_ID ||= 'price_standard_intro';
+
+    await enrollWithCreditsImpl({
+      userId: user.id,
+      instanceId: oldInstanceId,
+      plan: 'standard',
+      hadPaidSubscription: false,
+      actor: TEST_ACTOR,
+    });
+
+    const [paidBefore] = await db
+      .select()
+      .from(kiloclaw_subscriptions)
+      .where(eq(kiloclaw_subscriptions.id, subscriptionId));
+    if (
+      !paidBefore?.current_period_start ||
+      !paidBefore.current_period_end ||
+      !paidBefore.credit_renewal_at
+    ) {
+      throw new Error('Expected credit enrollment to set a paid billing period');
+    }
+
+    await db.transaction(async tx => {
+      await markInstanceDestroyedWithPersonalSubscriptionCollapse({
+        actor: TEST_ACTOR,
+        executor: tx,
+        instanceId: oldInstanceId,
+        reason: DESTROY_REASON,
+        userId: user.id,
+      });
+    });
+    await insertPersonalInstance({
+      id: newInstanceId,
+      userId: user.id,
+      createdAt: '2026-04-02T00:00:00.000Z',
+    });
+
+    const successor = await bootstrapProvisionSubscriptionWithDb({
+      db,
+      input: { userId: user.id, instanceId: newInstanceId, orgId: null },
+      actor: TEST_ACTOR,
+    });
+
+    expect(successor).toEqual(
+      expect.objectContaining({
+        instance_id: newInstanceId,
+        status: 'active',
+        plan: 'standard',
+        payment_source: 'credits',
+        trial_ends_at: paidBefore.trial_ends_at,
+        current_period_start: paidBefore.current_period_start,
+        current_period_end: paidBefore.current_period_end,
+        credit_renewal_at: paidBefore.credit_renewal_at,
+      })
+    );
+
+    const subscriptions = await listUserSubscriptions(user.id);
+    const predecessor = subscriptions.find(subscription => subscription.id === subscriptionId);
+    const successorAfter = subscriptions.find(subscription => subscription.id === successor.id);
+    const [newInstance] = await db
+      .select()
+      .from(kiloclaw_instances)
+      .where(eq(kiloclaw_instances.id, newInstanceId));
+
+    expect(newInstance?.destroyed_at).toBeNull();
+    expect(predecessor).toEqual(
+      expect.objectContaining({
+        instance_id: oldInstanceId,
+        status: 'canceled',
+        transferred_to_subscription_id: successor.id,
+      })
+    );
+    expect(successorAfter).toEqual(
+      expect.objectContaining({
+        instance_id: newInstanceId,
+        status: 'active',
+        transferred_to_subscription_id: null,
+      })
+    );
+    await expectCurrentHead({ subscriptionId: successor.id, userId: user.id });
+  });
+
+  it('expired trial row + destroyed instance still blocks provision', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-expired-trial-blocks-provision@example.com',
+    });
+    const oldInstanceId = crypto.randomUUID();
+    const newInstanceId = crypto.randomUUID();
+    const subscriptionId = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: oldInstanceId,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      destroyedAt: '2026-04-10T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: newInstanceId,
+      userId: user.id,
+      createdAt: '2026-04-11T00:00:00.000Z',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionId,
+      userId: user.id,
+      instanceId: oldInstanceId,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'trial',
+      status: 'trialing',
+      paymentSource: null,
+      trialStartedAt: '2026-04-01T00:00:00.000Z',
+      trialEndsAt: '2026-04-08T00:00:00.000Z',
+    });
+
+    await expect(
+      bootstrapProvisionSubscriptionWithDb({
+        db,
+        input: { userId: user.id, instanceId: newInstanceId, orgId: null },
+        actor: TEST_ACTOR,
+      })
+    ).rejects.toThrow(
+      'Cannot bootstrap personal subscription with existing non-access-granting rows'
+    );
+  });
+
+  it('past-due suspended row still blocks provision', async () => {
+    const user = await insertTestUser({
+      google_user_email: 'destroy-past-due-suspended-blocks-provision@example.com',
+    });
+    const oldInstanceId = crypto.randomUUID();
+    const newInstanceId = crypto.randomUUID();
+    const subscriptionId = crypto.randomUUID();
+
+    await insertPersonalInstance({
+      id: oldInstanceId,
+      userId: user.id,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      destroyedAt: '2026-04-10T00:00:00.000Z',
+    });
+    await insertPersonalInstance({
+      id: newInstanceId,
+      userId: user.id,
+      createdAt: '2026-04-11T00:00:00.000Z',
+    });
+    await insertPersonalSubscription({
+      id: subscriptionId,
+      userId: user.id,
+      instanceId: oldInstanceId,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      plan: 'standard',
+      status: 'past_due',
+      paymentSource: 'credits',
+      suspendedAt: '2026-04-08T00:00:00.000Z',
+    });
+
+    await expect(
+      bootstrapProvisionSubscriptionWithDb({
+        db,
+        input: { userId: user.id, instanceId: newInstanceId, orgId: null },
+        actor: TEST_ACTOR,
+      })
+    ).rejects.toThrow(
+      'Cannot bootstrap personal subscription with existing non-access-granting rows'
+    );
   });
 
   it('refuses collapse when multiple alive current funded personal rows exist', async () => {

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -5101,6 +5101,43 @@ describe('enrollWithCredits', () => {
     );
   });
 
+  it('enrollWithCredits with no instanceId after destroy does NOT produce duplicate_enrollment', async () => {
+    const instance = await createInstance(user.id);
+    await giveUserCredits(user.id, 50_000_000);
+    const now = new Date();
+    const periodKey = now.toISOString().slice(0, 7);
+
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      payment_source: 'credits',
+      plan: 'standard',
+      status: 'active',
+      current_period_start: now.toISOString(),
+      current_period_end: new Date(now.getTime() + 30 * 86_400_000).toISOString(),
+      credit_renewal_at: new Date(now.getTime() + 30 * 86_400_000).toISOString(),
+      cancel_at_period_end: false,
+    });
+    await db.insert(credit_transactions).values({
+      kilo_user_id: user.id,
+      amount_microdollars: -4_000_000,
+      is_free: false,
+      description: 'KiloClaw standard enrollment',
+      credit_category: `kiloclaw-subscription:${instance.id}:${periodKey}`,
+      check_category_uniqueness: true,
+      original_baseline_microdollars_used: 0,
+    });
+    await db
+      .update(kiloclaw_instances)
+      .set({ destroyed_at: new Date(now.getTime() + 60_000).toISOString() })
+      .where(eq(kiloclaw_instances.id, instance.id));
+
+    const caller = await createCallerForUser(user.id);
+    await expect(caller.kiloclaw.enrollWithCredits({ plan: 'standard' })).rejects.toThrow(
+      'active subscription already exists'
+    );
+  });
+
   it('enrolls returning subscriber at full price for standard plan', async () => {
     const instance = await createInstance(user.id);
     await giveUserCredits(user.id, 50_000_000);

--- a/packages/db/src/kiloclaw-personal-subscription-collapse.ts
+++ b/packages/db/src/kiloclaw-personal-subscription-collapse.ts
@@ -38,7 +38,6 @@ type ChangeLogFailureContext = {
 
 type CollapseOptions = {
   changeLogFailurePolicy?: ChangeLogFailurePolicy;
-  cancelSingleCurrentAccessRow?: boolean;
   onChangeLogFailure?: (context: ChangeLogFailureContext) => Promise<void> | void;
 };
 
@@ -152,20 +151,6 @@ function isAccessGrantingSubscription(
     return new Date(row.trial_ends_at).getTime() > now.getTime();
   }
   return false;
-}
-
-function shouldCancelSingleDestroyedCurrentAccessRow(row: KiloClawSubscription): boolean {
-  if (row.stripe_subscription_id !== null) {
-    return false;
-  }
-  if (row.plan === 'trial' && row.status === 'trialing' && row.payment_source === null) {
-    return true;
-  }
-  return (
-    (row.plan === 'standard' || row.plan === 'commit') &&
-    row.status === 'active' &&
-    row.payment_source === 'credits'
-  );
 }
 
 function getHeadSelectionPriority(
@@ -324,53 +309,6 @@ function buildTransferPlan(rows: PersonalSubscriptionRow[], now: Date): Transfer
   };
 }
 
-async function cancelSingleDestroyedCurrentAccessRow(params: {
-  actor: KiloClawSubscriptionChangeActor;
-  executor: PersonalSubscriptionCollapseWriter;
-  reason: string;
-  row: KiloClawSubscription;
-}): Promise<string | null> {
-  if (!isAccessGrantingSubscription(params.row, new Date())) {
-    return null;
-  }
-  if (!shouldCancelSingleDestroyedCurrentAccessRow(params.row)) {
-    return null;
-  }
-
-  const [after] = await params.executor
-    .update(kiloclaw_subscriptions)
-    .set({
-      status: 'canceled',
-      suspended_at: null,
-      destruction_deadline: null,
-      auto_resume_requested_at: null,
-      auto_resume_retry_after: null,
-      auto_resume_attempt_count: 0,
-      auto_top_up_triggered_for_period: null,
-      cancel_at_period_end: false,
-      pending_conversion: false,
-      scheduled_plan: null,
-      scheduled_by: null,
-    })
-    .where(eq(kiloclaw_subscriptions.id, params.row.id))
-    .returning();
-
-  if (!after) {
-    throw new Error(`Failed to cancel destroyed current subscription ${params.row.id}`);
-  }
-
-  await insertKiloClawSubscriptionChangeLog(params.executor, {
-    subscriptionId: after.id,
-    actor: params.actor,
-    action: 'canceled',
-    reason: params.reason,
-    before: params.row,
-    after,
-  });
-
-  return after.id;
-}
-
 async function applyTransferUpdates(
   executor: PersonalSubscriptionCollapseWriter,
   updates: TransferUpdate[],
@@ -428,6 +366,14 @@ async function applyTransferUpdates(
   return updatedSubscriptionIds;
 }
 
+/**
+ * Repairs historical multi-row personal subscription drift after a personal
+ * instance is destroyed. Destroying a user's only current personal instance is
+ * not a billing cancellation: if its current subscription still grants access,
+ * the row remains current and keeps its entitlement. A later reprovision creates
+ * a successor row via the provision-bootstrap transfer path, preserving the
+ * remaining trial or paid billing period without a second charge.
+ */
 export async function collapseOrphanPersonalSubscriptionsOnDestroy(params: {
   actor: KiloClawSubscriptionChangeActor;
   buildTransferUpdatesOverride?: BuildTransferUpdatesOverride;
@@ -435,7 +381,6 @@ export async function collapseOrphanPersonalSubscriptionsOnDestroy(params: {
   destroyedInstanceId: string;
   executor: PersonalSubscriptionCollapseWriter;
   onChangeLogFailure?: (context: ChangeLogFailureContext) => Promise<void> | void;
-  cancelSingleCurrentAccessRow?: boolean;
   reason: string;
   userId: string;
 }): Promise<{ updatedSubscriptionIds: string[] }> {
@@ -459,23 +404,8 @@ export async function collapseOrphanPersonalSubscriptionsOnDestroy(params: {
     return { updatedSubscriptionIds: [] };
   }
 
-  if (currentRows.length === 1) {
-    if (!params.cancelSingleCurrentAccessRow) {
-      return { updatedSubscriptionIds: [] };
-    }
-
-    const [currentRow] = currentRows;
-    if (currentRow?.instance.id !== params.destroyedInstanceId) {
-      return { updatedSubscriptionIds: [] };
-    }
-
-    const canceledSubscriptionId = await cancelSingleDestroyedCurrentAccessRow({
-      actor: params.actor,
-      executor: params.executor,
-      reason: 'destroy_path_cancel_single_current_access_row',
-      row: currentRow.subscription,
-    });
-    return { updatedSubscriptionIds: canceledSubscriptionId ? [canceledSubscriptionId] : [] };
+  if (currentRows.length <= 1) {
+    return { updatedSubscriptionIds: [] };
   }
 
   const now = new Date();
@@ -529,6 +459,12 @@ export async function collapseOrphanPersonalSubscriptionsOnDestroy(params: {
   };
 }
 
+/**
+ * Marks a personal instance destroyed without revoking any still-valid personal
+ * subscription attached to it. Access-granting trial/active/past-due rows remain
+ * current so the user can immediately reprovision and transfer the remaining
+ * entitlement to the new instance.
+ */
 export async function markInstanceDestroyedWithPersonalSubscriptionCollapse(params: {
   actor: KiloClawSubscriptionChangeActor;
   buildTransferUpdatesOverride?: BuildTransferUpdatesOverride;
@@ -606,7 +542,6 @@ export async function markInstanceDestroyedWithPersonalSubscriptionCollapse(para
       changeLogFailurePolicy: params.changeLogFailurePolicy,
       destroyedInstanceId: destroyedInstance.id,
       executor: params.executor,
-      cancelSingleCurrentAccessRow: true,
       onChangeLogFailure: params.onChangeLogFailure,
       reason: params.reason,
       userId: params.userId,


### PR DESCRIPTION
## Summary
Preserves access-granting KiloClaw personal subscriptions when users destroy their instance.

### Why this change is needed
Destroying a KiloClaw instance was treated as a billing cancellation when the user had a single current credit-funded subscription row. That canceled paid Standard/Commit access and forced the user through a second subscription flow to reprovision, even though their billing period was still valid.

The desired invariant is that destroying an instance deletes runtime state, not still-valid billing entitlement. Users with an unexpired trial, active subscription, or unsuspended past-due subscription should be able to reprovision without a second payment, new trial, or admin intervention.

### How this is addressed
- Removed the single-row destroy cancellation path for current access-granting personal subscriptions.
- Preserved the existing multi-row collapse and funded-row demotion guard behavior.
- Kept terminal/canceled subscription paths unchanged.
- Added regression coverage for trial, credit-funded Standard, credit-funded Commit, and Stripe-funded rows remaining current after destroy.
- Added reprovision coverage proving the successor subscription preserves the original billing/trial period.
- Added route-level coverage that credit enrollment after destroy no longer fails as a duplicate enrollment.

Relates to [Pylon #17810](https://app.usepylon.com/support/issues/views/all-issues?issueNumber=17810).

Incident context:
- [2026-04-29: KiloClaw destroy cancels paid Standard subscription](https://github.com/Kilo-Org/on-call/blob/main/incidents/2026-04-29-kiloclaw-destroy-cancels-paid-standard-subscription.md)
- [2026-04-24: destroy path inline collapse funded-row demotion](https://github.com/Kilo-Org/on-call/blob/main/incidents/2026-04-24-kiloclaw-destroy-path-inline-collapse-funded-row-demotion.md)

## Human Verification
<details>
<summary>Manual testing performed</summary>

1. Started the local KiloClaw dev stack with Next.js, Postgres, Redis, KiloClaw, billing, and related services.
2. Logged in through the development fake-login flow.
3. Seeded local Postgres with a destroyed personal KiloClaw instance and a still-active credit-funded Standard subscription.
4. Verified `/claw` routed to `/claw/new` onboarding instead of the subscription/payment screen.
5. Reprovisioned through the browser and confirmed `kiloclaw.provision` returned `200`.
6. Confirmed the successor subscription was active and preserved the original period fields.
7. Destroyed the reprovisioned instance through the Settings danger-zone UI.
8. Confirmed `kiloclaw.destroy` returned `200` and the current subscription stayed `active`.
9. Reprovisioned again through the browser and confirmed the successor chain preserved access and billing period state.

</details>

- _Additional verification (to be completed by author)_

## Visual Changes
N/A

## Reviewer Notes

### Human Reviewer
- Please validate the product invariant: instance destruction should not revoke still-valid personal billing entitlement.
- The intentionally terminal paths are unchanged. The billing worker can still destroy terminal suspended rows.
- The reprovision path relies on the existing successor-transfer behavior instead of moving the original row in place.
- Sentry alerting and historical backfill are intentionally left as follow-up work.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- `collapseOrphanPersonalSubscriptionsOnDestroy` now returns early for zero or one current row. Multi-row repair still uses the existing transfer-plan logic.
- `FundedRowDemotionRefusedError` remains intact for ambiguous funded-row chains.
- `markInstanceDestroyedWithPersonalSubscriptionCollapse` still marks the instance destroyed in the same transaction, then runs collapse repair.
- The removed cancellation reason was `destroy_path_cancel_single_current_access_row`.
- Access granting remains defined by existing `getKiloClawSubscriptionAccessReason` semantics.

</details>
