### PR TITLE
fix(gastown): propagate refreshed container token to running kilo serve children

### DIFF
--- a/services/gastown/container/plugin/client.ts
+++ b/services/gastown/container/plugin/client.ts
@@ -26,6 +26,43 @@ function isApiResponse(
   return typeof obj.success === 'boolean';
 }
 
+/**
+ * One-shot refresh of `process.env.GASTOWN_CONTAINER_TOKEN` via the
+ * worker's `/refresh-container-token` endpoint. Returns the fresh
+ * token on success, or null on any failure (network error, non-2xx,
+ * missing env). Used by the plugin clients to recover from a 401
+ * caused by an expired container JWT.
+ *
+ * Duplicates the container/src/token-refresh.ts helper to keep the
+ * plugin independent of the control-server bundle.
+ */
+async function refreshContainerTokenFromWorker(baseUrl: string): Promise<string | null> {
+  const current = process.env.GASTOWN_CONTAINER_TOKEN;
+  const townId = process.env.GASTOWN_TOWN_ID;
+  if (!current || !townId) return null;
+  try {
+    const resp = await fetch(`${baseUrl}/api/towns/${townId}/refresh-container-token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${current}`,
+      },
+      body: '{}',
+    });
+    if (!resp.ok) return null;
+    const body: unknown = await resp.json();
+    const token =
+      body && typeof body === 'object' && 'data' in body
+        ? (body as { data?: { token?: unknown } }).data?.token
+        : undefined;
+    if (typeof token !== 'string' || token.length === 0) return null;
+    process.env.GASTOWN_CONTAINER_TOKEN = token;
+    return token;
+  } catch {
+    return null;
+  }
+}
+
 export class GastownClient {
   private baseUrl: string;
   private containerToken: string | undefined;
@@ -51,25 +88,39 @@ export class GastownClient {
   }
 
   private async request<T>(url: string, init?: RequestInit): Promise<T> {
-    // Normalize headers so callers can pass plain objects, Headers instances, or tuples
-    const headers = new Headers(init?.headers);
-    headers.set('Content-Type', 'application/json');
-    // Prefer the live container token from process.env (refreshed by the
-    // TownDO alarm via POST /refresh-token), then the token captured at
-    // init, then the legacy per-agent JWT.
-    const authToken = process.env.GASTOWN_CONTAINER_TOKEN ?? this.containerToken ?? this.token;
-    headers.set('Authorization', `Bearer ${authToken}`);
-    // When using a container-scoped JWT, send agent identity headers so
-    // the auth middleware can populate agentId/rigId on routes that don't
-    // have :agentId/:rigId params (e.g. /triage/resolve, /mail).
-    if (process.env.GASTOWN_CONTAINER_TOKEN || this.containerToken) {
-      headers.set('X-Gastown-Agent-Id', this.agentId);
-      headers.set('X-Gastown-Rig-Id', this.rigId);
-    }
+    const doFetch = async (): Promise<Response> => {
+      // Normalize headers so callers can pass plain objects, Headers instances, or tuples.
+      // Rebuilt on every attempt so a refreshed token is picked up on retry.
+      const headers = new Headers(init?.headers);
+      headers.set('Content-Type', 'application/json');
+      // Prefer the live container token from process.env (refreshed by the
+      // TownDO alarm via POST /refresh-token or by refreshContainerTokenFromWorker),
+      // then the token captured at init, then the legacy per-agent JWT.
+      const authToken = process.env.GASTOWN_CONTAINER_TOKEN ?? this.containerToken ?? this.token;
+      headers.set('Authorization', `Bearer ${authToken}`);
+      // When using a container-scoped JWT, send agent identity headers so
+      // the auth middleware can populate agentId/rigId on routes that don't
+      // have :agentId/:rigId params (e.g. /triage/resolve, /mail).
+      if (process.env.GASTOWN_CONTAINER_TOKEN || this.containerToken) {
+        headers.set('X-Gastown-Agent-Id', this.agentId);
+        headers.set('X-Gastown-Rig-Id', this.rigId);
+      }
+      return fetch(url, { ...init, headers });
+    };
 
     let response: Response;
     try {
-      response = await fetch(url, { ...init, headers });
+      response = await doFetch();
+      // One-shot token refresh on 401: the running kilo serve child was
+      // spawned with a snapshot of env and doesn't see live updates to
+      // process.env. When the parent receives a 401, mint a fresh token
+      // via the worker and retry once.
+      if (response.status === 401) {
+        const fresh = await refreshContainerTokenFromWorker(this.baseUrl);
+        if (fresh) {
+          response = await doFetch();
+        }
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       throw new GastownApiError(`Network error: ${message}`, 0);
@@ -258,19 +309,29 @@ export class MayorGastownClient {
   }
 
   private async request<T>(url: string, init?: RequestInit): Promise<T> {
-    const headers = new Headers(init?.headers);
-    headers.set('Content-Type', 'application/json');
-    // Prefer live container token (refreshed via POST /refresh-token),
-    // then init-time token, then legacy per-agent JWT.
-    const authToken = process.env.GASTOWN_CONTAINER_TOKEN ?? this.containerToken ?? this.token;
-    headers.set('Authorization', `Bearer ${authToken}`);
-    if (process.env.GASTOWN_CONTAINER_TOKEN || this.containerToken) {
-      headers.set('X-Gastown-Agent-Id', this.agentId);
-    }
+    const doFetch = async (): Promise<Response> => {
+      const headers = new Headers(init?.headers);
+      headers.set('Content-Type', 'application/json');
+      // Prefer live container token (refreshed via POST /refresh-token
+      // or refreshContainerTokenFromWorker), then init-time token,
+      // then legacy per-agent JWT.
+      const authToken = process.env.GASTOWN_CONTAINER_TOKEN ?? this.containerToken ?? this.token;
+      headers.set('Authorization', `Bearer ${authToken}`);
+      if (process.env.GASTOWN_CONTAINER_TOKEN || this.containerToken) {
+        headers.set('X-Gastown-Agent-Id', this.agentId);
+      }
+      return fetch(url, { ...init, headers });
+    };
 
     let response: Response;
     try {
-      response = await fetch(url, { ...init, headers });
+      response = await doFetch();
+      if (response.status === 401) {
+        const fresh = await refreshContainerTokenFromWorker(this.baseUrl);
+        if (fresh) {
+          response = await doFetch();
+        }
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       throw new GastownApiError(`Network error: ${message}`, 0);

--- a/services/gastown/container/src/control-server.ts
+++ b/services/gastown/container/src/control-server.ts
@@ -16,6 +16,8 @@ import {
   isDraining,
   getAgentEvents,
   registerEventSink,
+  refreshTokenForAllAgents,
+  listAgents,
 } from './process-manager';
 import { log } from './logger';
 import { startHeartbeat, stopHeartbeat, notifyContainerReady } from './heartbeat';
@@ -247,16 +249,43 @@ app.post('/dashboard-context', async c => {
 
 // POST /refresh-token
 // Hot-swap the container-scoped JWT on the running process. Called by
-// the TownDO alarm to push a fresh token before the current one expires.
-// Updates process.env so all subsequent API calls use the new token.
+// the TownDO alarm (or the user-facing "Refresh Token" button) to push
+// a fresh token before the current one expires.
+//
+// Updating `process.env.GASTOWN_CONTAINER_TOKEN` alone is not enough:
+// the spawned `kilo serve` child processes snapshot the parent env at
+// spawn time, so the mayor plugin reads the OLD token. To propagate
+// the new token to every agent, we restart each running agent's SDK
+// server — matching the model hot-swap path.
 app.post('/refresh-token', async c => {
   const body: unknown = await c.req.json().catch(() => null);
   if (!body || typeof body !== 'object' || !('token' in body) || typeof body.token !== 'string') {
     return c.json({ error: 'Missing or invalid token field' }, 400);
   }
   process.env.GASTOWN_CONTAINER_TOKEN = body.token;
-  console.log('[control-server] Container token refreshed');
-  return c.json({ refreshed: true });
+
+  const activeAgents = listAgents().filter(a => a.status === 'running' || a.status === 'starting');
+  log.info('refresh_token.received', {
+    agentCount: activeAgents.length,
+    agentIds: activeAgents.map(a => a.agentId),
+  });
+
+  const t0 = Date.now();
+  const results = await refreshTokenForAllAgents();
+  const successCount = results.filter(r => r.success).length;
+  log.info('refresh_token.completed', {
+    agentCount: results.length,
+    successCount,
+    failureCount: results.length - successCount,
+    totalMs: Date.now() - t0,
+  });
+
+  return c.json({
+    refreshed: true,
+    agentsRestarted: successCount,
+    agentsFailed: results.length - successCount,
+    results,
+  });
 });
 
 // POST /sync-config

--- a/services/gastown/container/src/heartbeat.ts
+++ b/services/gastown/container/src/heartbeat.ts
@@ -1,4 +1,5 @@
 import { listAgents } from './process-manager';
+import { fetchFreshContainerToken } from './token-refresh';
 import type { HeartbeatPayload } from './types';
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
@@ -118,19 +119,30 @@ async function sendHeartbeats(): Promise<void> {
       containerInstanceId: CONTAINER_INSTANCE_ID,
     };
 
+    const url = `${gastownApiUrl}/api/towns/${agent.townId}/rigs/${agent.rigId}/agents/${agent.agentId}/heartbeat`;
+    const doPost = (token: string) =>
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      });
+
     try {
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${currentToken}`,
-      };
-      const response = await fetch(
-        `${gastownApiUrl}/api/towns/${agent.townId}/rigs/${agent.rigId}/agents/${agent.agentId}/heartbeat`,
-        {
-          method: 'POST',
-          headers,
-          body: JSON.stringify(payload),
+      let response = await doPost(currentToken);
+      // On 401, mint a fresh token via the worker's refresh endpoint
+      // (it tolerates expired tokens) and retry once.
+      if (response.status === 401) {
+        console.warn(
+          `Heartbeat 401 for agent ${agent.agentId} — attempting one-shot token refresh`
+        );
+        const fresh = await fetchFreshContainerToken();
+        if (fresh) {
+          response = await doPost(fresh);
         }
-      );
+      }
 
       if (!response.ok) {
         console.warn(

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -1463,6 +1463,13 @@ export async function refreshTokenForAllAgents(): Promise<
     const oldInstance = sdkInstances.get(agent.workdir);
     const oldSessionId = agent.sessionId;
     const oldPort = agent.serverPort;
+    // Track the pending ensureSDKServer promise separately so the timeout
+    // path can clean up an orphan server if the spawn eventually resolves
+    // after we've already given up. withTimeout races the promise with a
+    // timer but cannot cancel the underlying spawn — the serialised SDK
+    // server creation may still install an instance into sdkInstances
+    // after we've restored the old one, leaking the fresh kilo serve child.
+    let pendingEnsure: Promise<{ client: KiloClient; port: number }> | null = null;
     try {
       const hotSwapEnv = buildLiveHotSwapEnv(agent);
 
@@ -1474,11 +1481,14 @@ export async function refreshTokenForAllAgents(): Promise<
       // server is the only way to propagate the fresh token.
       sdkInstances.delete(agent.workdir);
 
+      pendingEnsure = ensureSDKServer(agent.workdir, hotSwapEnv);
       const { client, port } = await withTimeout(
-        ensureSDKServer(agent.workdir, hotSwapEnv),
+        pendingEnsure,
         REFRESH_AGENT_TIMEOUT_MS,
         `ensureSDKServer for ${agent.agentId}`
       );
+      // Spawn completed within the timeout — no orphan to clean up.
+      pendingEnsure = null;
       agent.serverPort = port;
 
       // Resume the existing session. kilo.db is on disk and survives
@@ -1575,6 +1585,42 @@ export async function refreshTokenForAllAgents(): Promise<
         sdkInstances.set(agent.workdir, oldInstance);
         agent.serverPort = oldPort;
         agent.sessionId = oldSessionId;
+      }
+      // If ensureSDKServer is still in flight, attach a reaper: when it
+      // finally resolves it will have registered a fresh SDK instance
+      // under agent.workdir, clobbering the restored old one. We evict
+      // and close that orphan so we don't leak a kilo serve process or
+      // leave the agent pointing at an un-subscribed server.
+      if (pendingEnsure) {
+        const reapWorkdir = agent.workdir;
+        const reapAgentId = agent.agentId;
+        const reapOldInstance = oldInstance;
+        pendingEnsure.then(
+          ({ port: orphanPort }) => {
+            const orphan = sdkInstances.get(reapWorkdir);
+            if (!orphan || orphan === reapOldInstance) return;
+            sdkInstances.delete(reapWorkdir);
+            if (reapOldInstance) {
+              sdkInstances.set(reapWorkdir, reapOldInstance);
+            }
+            try {
+              orphan.server.close();
+            } catch (closeErr) {
+              log.warn('refresh_token.orphan_close_failed', {
+                agentId: reapAgentId,
+                error: closeErr instanceof Error ? closeErr.message : String(closeErr),
+              });
+            }
+            log.warn('refresh_token.orphan_reaped', {
+              agentId: reapAgentId,
+              orphanPort,
+            });
+          },
+          () => {
+            // ensureSDKServer itself rejected — nothing was installed, so
+            // nothing to reap. The original timeout error already logged.
+          }
+        );
       }
       log.error('refresh_token.agent_restarted', {
         agentId: agent.agentId,

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -18,6 +18,7 @@ import {
   RESERVED_ENV_KEYS,
 } from './control-server';
 import { log } from './logger';
+import { refreshTokenIfNearExpiry } from './token-refresh';
 
 const MANAGER_LOG = '[process-manager]';
 
@@ -1308,6 +1309,240 @@ function extractOrganizationId(agent?: ManagedAgent): string | undefined {
 const MAYOR_STARTUP_PROMPT = 'Mayor ready. Waiting for instructions.';
 
 /**
+ * Env keys that may be refreshed at runtime by `POST /sync-config` or
+ * `POST /refresh-token`. When rebuilding an agent's env for a live SDK
+ * server restart, these are read from `process.env` (freshest source)
+ * rather than `agent.startupEnv` (captured once at agent start).
+ */
+const LIVE_ENV_KEYS = new Set([
+  'GASTOWN_CONTAINER_TOKEN',
+  'GIT_TOKEN',
+  'GITLAB_TOKEN',
+  'GITLAB_INSTANCE_URL',
+  'GITHUB_CLI_PAT',
+  'GASTOWN_GIT_AUTHOR_NAME',
+  'GASTOWN_GIT_AUTHOR_EMAIL',
+  'GASTOWN_DISABLE_AI_COAUTHOR',
+  'KILOCODE_TOKEN',
+  'GASTOWN_ORGANIZATION_ID',
+]);
+
+/**
+ * Build the env for a fresh `kilo serve` process that replaces an
+ * agent's current SDK server. Used by both model hot-swap and
+ * token-refresh hot-swap.
+ *
+ * Rules:
+ * - Start from `agent.startupEnv` (original dispatch env).
+ * - For every key in `LIVE_ENV_KEYS`, read from `process.env` so live
+ *   updates (container-token refresh, config sync) are picked up.
+ * - Never include `KILO_CONFIG_CONTENT` / `OPENCODE_CONFIG_CONTENT`:
+ *   the caller is responsible for setting these on `process.env`
+ *   before the SDK restart if the model changed.
+ * - Overlay town-config custom `env_vars` so values added/changed
+ *   after the initial dispatch are honoured. Infra keys in
+ *   `LIVE_ENV_KEYS` and `RESERVED_ENV_KEYS` always win.
+ * - Remove custom keys that were previously applied but have been
+ *   dropped from the town config.
+ * - Re-derive `GH_TOKEN` from the live `GITHUB_CLI_PAT` > `GIT_TOKEN`
+ *   > `GITHUB_TOKEN` chain so a rotated token takes effect.
+ */
+function buildLiveHotSwapEnv(agent: ManagedAgent): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(agent.startupEnv)) {
+    if (key === 'KILO_CONFIG_CONTENT' || key === 'OPENCODE_CONFIG_CONTENT') continue;
+    if (LIVE_ENV_KEYS.has(key)) {
+      const live = process.env[key];
+      if (live) env[key] = live;
+      continue;
+    }
+    env[key] = value;
+  }
+  // Inject live values for LIVE_ENV_KEYS that were absent from startupEnv
+  // (e.g. GASTOWN_ORGANIZATION_ID added after initial dispatch).
+  for (const key of LIVE_ENV_KEYS) {
+    if (key in env) continue;
+    const live = process.env[key];
+    if (live) env[key] = live;
+  }
+
+  // Overlay custom env_vars from the town config so hot-swap picks up
+  // values that were added/changed after the initial dispatch. Infra
+  // keys in LIVE_ENV_KEYS and RESERVED_ENV_KEYS always take precedence.
+  const freshConfig = getCurrentTownConfig();
+  const freshEnvVars = freshConfig?.env_vars;
+  const freshCustomKeySet = new Set<string>();
+  if (freshEnvVars !== null && typeof freshEnvVars === 'object' && !Array.isArray(freshEnvVars)) {
+    for (const [key, value] of Object.entries(freshEnvVars as Record<string, unknown>)) {
+      if (LIVE_ENV_KEYS.has(key)) continue;
+      if (RESERVED_ENV_KEYS.has(key)) continue;
+      freshCustomKeySet.add(key);
+      if (value !== undefined && value !== null) {
+        env[key] = typeof value === 'string' ? value : JSON.stringify(value);
+      } else {
+        delete env[key];
+      }
+    }
+  }
+  // Remove stale custom env vars that the town config no longer carries.
+  for (const key of getLastAppliedEnvVarKeys()) {
+    if (!freshCustomKeySet.has(key) && !LIVE_ENV_KEYS.has(key)) {
+      delete env[key];
+    }
+  }
+
+  // Re-derive GH_TOKEN from live values using the same priority chain
+  // as buildAgentEnv: GITHUB_CLI_PAT > GIT_TOKEN > GITHUB_TOKEN.
+  const liveGhToken =
+    process.env.GITHUB_CLI_PAT ?? process.env.GIT_TOKEN ?? process.env.GITHUB_TOKEN;
+  if (liveGhToken) {
+    env.GH_TOKEN = liveGhToken;
+  } else {
+    delete env.GH_TOKEN;
+  }
+
+  return env;
+}
+
+/**
+ * Restart every running agent's SDK server so a newly-refreshed
+ * `GASTOWN_CONTAINER_TOKEN` (or any other LIVE_ENV_KEYS value in
+ * `process.env`) is inherited by the fresh `kilo serve` child process.
+ *
+ * The agent's session is preserved: the mayor resumes its existing
+ * session (conversation history intact); other agents keep their
+ * current session id, since kilo.db persists across the restart.
+ *
+ * Each agent is restarted independently; a failure to restart one
+ * agent never blocks the others. Returns a per-agent summary so the
+ * caller can log telemetry.
+ */
+export async function refreshTokenForAllAgents(): Promise<
+  Array<{ agentId: string; success: boolean; durationMs: number; error?: string }>
+> {
+  const snapshot = [...agents.values()].filter(
+    a => a.status === 'running' || a.status === 'starting'
+  );
+  const results: Array<{ agentId: string; success: boolean; durationMs: number; error?: string }> =
+    [];
+
+  for (const agent of snapshot) {
+    const t0 = Date.now();
+    try {
+      const hotSwapEnv = buildLiveHotSwapEnv(agent);
+
+      // Tear down the existing SDK server so ensureSDKServer spawns
+      // a fresh kilo serve child with the updated env. We don't close
+      // it until after ensureSDKServer returns so fetch() during the
+      // window still has somewhere to land — but process.env changes
+      // are only visible to *new* child processes, so restarting the
+      // server is the only way to propagate the fresh token.
+      const oldInstance = sdkInstances.get(agent.workdir);
+      const oldSessionId = agent.sessionId;
+      const oldPort = agent.serverPort;
+      sdkInstances.delete(agent.workdir);
+
+      const { client, port } = await ensureSDKServer(agent.workdir, hotSwapEnv);
+      agent.serverPort = port;
+
+      // Resume the existing session. kilo.db is on disk and survives
+      // the restart, so session.list returns the prior session(s).
+      let newSessionId = oldSessionId;
+      let resumed = false;
+      try {
+        const existing = await client.session.list();
+        const sessions = (existing.data ?? []) as Array<{
+          id: string;
+          time?: { updated?: number };
+        }>;
+        // Prefer the session we were already on; fall back to the most
+        // recently updated one if that id is no longer present.
+        const preferred = sessions.find(s => s.id === oldSessionId);
+        if (preferred) {
+          newSessionId = preferred.id;
+          resumed = true;
+        } else if (sessions.length > 0) {
+          const sorted = [...sessions].sort(
+            (a, b) => (b.time?.updated ?? 0) - (a.time?.updated ?? 0)
+          );
+          newSessionId = sorted[0].id;
+          resumed = true;
+        }
+      } catch (err) {
+        log.warn('refresh_token.session_list_failed', {
+          agentId: agent.agentId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      agent.sessionId = newSessionId;
+      const newInstance = sdkInstances.get(agent.workdir);
+      if (newInstance) newInstance.sessionCount++;
+
+      // New server is healthy — tear down the old one and its subscription.
+      if (oldInstance) {
+        const oldController = eventAbortControllers.get(agent.agentId);
+        if (oldController) oldController.abort();
+        try {
+          oldInstance.server.close();
+        } catch (err) {
+          log.warn('refresh_token.old_server_close_failed', {
+            agentId: agent.agentId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      // Re-subscribe to events on the new server so the agent keeps
+      // reporting activity after the swap.
+      void subscribeToEvents(client, agent, {
+        agentId: agent.agentId,
+        role: agent.role,
+        name: agent.name,
+        model: agent.model ?? '',
+        prompt: '',
+        rigId: agent.rigId,
+        townId: agent.townId,
+        identity: '',
+        gitUrl: '',
+        branch: '',
+        defaultBranch: '',
+      });
+
+      const durationMs = Date.now() - t0;
+      log.info('refresh_token.agent_restarted', {
+        agentId: agent.agentId,
+        role: agent.role,
+        name: agent.name,
+        oldPort,
+        newPort: port,
+        oldSessionId,
+        newSessionId,
+        resumed,
+        success: true,
+        durationMs,
+      });
+      results.push({ agentId: agent.agentId, success: true, durationMs });
+    } catch (err) {
+      const durationMs = Date.now() - t0;
+      const message = err instanceof Error ? err.message : String(err);
+      log.error('refresh_token.agent_restarted', {
+        agentId: agent.agentId,
+        role: agent.role,
+        name: agent.name,
+        success: false,
+        durationMs,
+        error: message,
+      });
+      results.push({ agentId: agent.agentId, success: false, durationMs, error: message });
+    }
+  }
+
+  return results;
+}
+
+/**
  * Update the model for a running agent by restarting its SDK server with
  * new KILO_CONFIG_CONTENT. The kilo serve child process reads the model
  * from KILO_CONFIG_CONTENT at startup (highest config precedence after
@@ -1387,80 +1622,7 @@ export async function updateAgentModel(
   // gets the same git identity, auth tokens, and plugin vars. Exclude
   // KILO_CONFIG_CONTENT / OPENCODE_CONFIG_CONTENT — those were already
   // rebuilt above with the new model and set on process.env.
-  //
-  // For env vars that syncConfigToContainer can update at runtime, prefer
-  // the live process.env value over the stale startupEnv snapshot.
-  const LIVE_ENV_KEYS = new Set([
-    'GASTOWN_CONTAINER_TOKEN',
-    'GIT_TOKEN',
-    'GITLAB_TOKEN',
-    'GITLAB_INSTANCE_URL',
-    'GITHUB_CLI_PAT',
-    'GASTOWN_GIT_AUTHOR_NAME',
-    'GASTOWN_GIT_AUTHOR_EMAIL',
-    'GASTOWN_DISABLE_AI_COAUTHOR',
-    'KILOCODE_TOKEN',
-    'GASTOWN_ORGANIZATION_ID',
-  ]);
-  const hotSwapEnv: Record<string, string> = {};
-  for (const [key, value] of Object.entries(agent.startupEnv)) {
-    if (key === 'KILO_CONFIG_CONTENT' || key === 'OPENCODE_CONFIG_CONTENT') continue;
-    if (LIVE_ENV_KEYS.has(key)) {
-      const live = process.env[key];
-      if (live) hotSwapEnv[key] = live;
-      continue;
-    }
-    hotSwapEnv[key] = value;
-  }
-  // Inject live values for LIVE_ENV_KEYS that were absent from startupEnv
-  // (e.g. GASTOWN_ORGANIZATION_ID added after initial dispatch).
-  for (const key of LIVE_ENV_KEYS) {
-    if (key in hotSwapEnv) continue;
-    const live = process.env[key];
-    if (live) hotSwapEnv[key] = live;
-  }
-
-  // Overlay custom env_vars from the town config so hot-swap picks up
-  // values that were added/changed after the initial dispatch. Infra
-  // keys in LIVE_ENV_KEYS and RESERVED_ENV_KEYS always take precedence
-  // (LIVE_ENV_KEYS were already populated from process.env above;
-  // RESERVED_ENV_KEYS are runtime routing vars that must never be clobbered).
-  const freshConfig = getCurrentTownConfig();
-  const freshEnvVars = freshConfig?.env_vars;
-  const freshCustomKeySet = new Set<string>();
-  if (freshEnvVars !== null && typeof freshEnvVars === 'object' && !Array.isArray(freshEnvVars)) {
-    for (const [key, value] of Object.entries(freshEnvVars as Record<string, unknown>)) {
-      if (LIVE_ENV_KEYS.has(key)) continue;
-      if (RESERVED_ENV_KEYS.has(key)) continue;
-      freshCustomKeySet.add(key);
-      if (value !== undefined && value !== null) {
-        hotSwapEnv[key] = typeof value === 'string' ? value : JSON.stringify(value);
-      } else {
-        delete hotSwapEnv[key];
-      }
-    }
-  }
-  // Remove stale custom env vars — keys that were applied in a previous
-  // sync but are no longer in the town config. Without this, startupEnv
-  // keeps carrying deleted custom keys through every hot-swap.
-  for (const key of getLastAppliedEnvVarKeys()) {
-    if (!freshCustomKeySet.has(key) && !LIVE_ENV_KEYS.has(key)) {
-      delete hotSwapEnv[key];
-    }
-  }
-
-  // Re-derive GH_TOKEN from live values using the same priority chain
-  // as buildAgentEnv: GITHUB_CLI_PAT > GIT_TOKEN > GITHUB_TOKEN.
-  // syncConfigToContainer updates these on process.env, but buildAgentEnv
-  // only ran once at initial dispatch. When all sources are cleared,
-  // remove GH_TOKEN so the SDK server doesn't retain stale credentials.
-  const liveGhCliPat = process.env.GITHUB_CLI_PAT;
-  const liveGhToken = liveGhCliPat ?? process.env.GIT_TOKEN ?? process.env.GITHUB_TOKEN;
-  if (liveGhToken) {
-    hotSwapEnv.GH_TOKEN = liveGhToken;
-  } else {
-    delete hotSwapEnv.GH_TOKEN;
-  }
+  const hotSwapEnv = buildLiveHotSwapEnv(agent);
 
   try {
     // 4. Create a new SDK server (spawns a fresh kilo serve with updated env)
@@ -1928,6 +2090,13 @@ export async function bootHydration(): Promise<void> {
     );
     return;
   }
+
+  // Proactively refresh the container token if it's near expiry. A cold
+  // container that was last stopped close to the 8h JWT TTL would
+  // otherwise boot with a token about to expire and fail on the first
+  // worker call. The refresh endpoint tolerates tokens that have just
+  // expired so this covers the cold-restart case too.
+  await refreshTokenIfNearExpiry();
 
   console.log(`${LOG} Fetching container registry for town=${townId}`);
   let registry: unknown;

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -1405,6 +1405,33 @@ function buildLiveHotSwapEnv(agent: ManagedAgent): Record<string, string> {
   return env;
 }
 
+// Per-agent timeout for the `ensureSDKServer` step of a token refresh.
+// Server startup normally takes ~1-2s; anything beyond 6s means the
+// spawn is stuck and we'd rather fall back to the old instance than
+// block the caller. The TownDO alarm path has a 10s outer timeout, so
+// each agent must finish well under that even with queuing effects
+// from the sdkServerLock.
+const REFRESH_AGENT_TIMEOUT_MS = 6_000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const handle = setTimeout(
+      () => reject(new Error(`timeout after ${ms}ms: ${label}`)),
+      ms
+    );
+    promise.then(
+      value => {
+        clearTimeout(handle);
+        resolve(value);
+      },
+      err => {
+        clearTimeout(handle);
+        reject(err);
+      }
+    );
+  });
+}
+
 /**
  * Restart every running agent's SDK server so a newly-refreshed
  * `GASTOWN_CONTAINER_TOKEN` (or any other LIVE_ENV_KEYS value in
@@ -1424,11 +1451,18 @@ export async function refreshTokenForAllAgents(): Promise<
   const snapshot = [...agents.values()].filter(
     a => a.status === 'running' || a.status === 'starting'
   );
-  const results: Array<{ agentId: string; success: boolean; durationMs: number; error?: string }> =
-    [];
 
-  for (const agent of snapshot) {
+  // Restart agents in parallel. Each agent has its own workdir (and
+  // therefore its own sdkInstances key), so the Map mutations don't
+  // collide. Running serially would easily blow past the caller's
+  // 10s timeout once we have more than a couple of agents.
+  const restartAgent = async (
+    agent: ManagedAgent
+  ): Promise<{ agentId: string; success: boolean; durationMs: number; error?: string }> => {
     const t0 = Date.now();
+    const oldInstance = sdkInstances.get(agent.workdir);
+    const oldSessionId = agent.sessionId;
+    const oldPort = agent.serverPort;
     try {
       const hotSwapEnv = buildLiveHotSwapEnv(agent);
 
@@ -1438,12 +1472,13 @@ export async function refreshTokenForAllAgents(): Promise<
       // window still has somewhere to land — but process.env changes
       // are only visible to *new* child processes, so restarting the
       // server is the only way to propagate the fresh token.
-      const oldInstance = sdkInstances.get(agent.workdir);
-      const oldSessionId = agent.sessionId;
-      const oldPort = agent.serverPort;
       sdkInstances.delete(agent.workdir);
 
-      const { client, port } = await ensureSDKServer(agent.workdir, hotSwapEnv);
+      const { client, port } = await withTimeout(
+        ensureSDKServer(agent.workdir, hotSwapEnv),
+        REFRESH_AGENT_TIMEOUT_MS,
+        `ensureSDKServer for ${agent.agentId}`
+      );
       agent.serverPort = port;
 
       // Resume the existing session. kilo.db is on disk and survives
@@ -1451,7 +1486,11 @@ export async function refreshTokenForAllAgents(): Promise<
       let newSessionId = oldSessionId;
       let resumed = false;
       try {
-        const existing = await client.session.list();
+        const existing = await withTimeout(
+          client.session.list(),
+          2_000,
+          `session.list for ${agent.agentId}`
+        );
         const sessions = (existing.data ?? []) as Array<{
           id: string;
           time?: { updated?: number };
@@ -1523,10 +1562,20 @@ export async function refreshTokenForAllAgents(): Promise<
         success: true,
         durationMs,
       });
-      results.push({ agentId: agent.agentId, success: true, durationMs });
+      return { agentId: agent.agentId, success: true, durationMs };
     } catch (err) {
       const durationMs = Date.now() - t0;
       const message = err instanceof Error ? err.message : String(err);
+      // Restore the old SDK instance in the map so the agent keeps
+      // pointing at a tracked server. The old kilo serve child still
+      // has the stale token, but having SOME server is strictly better
+      // than having none: session.prompt still works, and the next
+      // refresh / model swap will pick it up again.
+      if (oldInstance && !sdkInstances.has(agent.workdir)) {
+        sdkInstances.set(agent.workdir, oldInstance);
+        agent.serverPort = oldPort;
+        agent.sessionId = oldSessionId;
+      }
       log.error('refresh_token.agent_restarted', {
         agentId: agent.agentId,
         role: agent.role,
@@ -1535,11 +1584,11 @@ export async function refreshTokenForAllAgents(): Promise<
         durationMs,
         error: message,
       });
-      results.push({ agentId: agent.agentId, success: false, durationMs, error: message });
+      return { agentId: agent.agentId, success: false, durationMs, error: message };
     }
-  }
+  };
 
-  return results;
+  return Promise.all(snapshot.map(restartAgent));
 }
 
 /**
@@ -2082,9 +2131,9 @@ export async function bootHydration(): Promise<void> {
   const LOG = '[boot-hydration]';
   const apiUrl = process.env.GASTOWN_API_URL;
   const townId = process.env.GASTOWN_TOWN_ID;
-  const token = process.env.GASTOWN_CONTAINER_TOKEN;
+  const initialToken = process.env.GASTOWN_CONTAINER_TOKEN;
 
-  if (!apiUrl || !townId || !token) {
+  if (!apiUrl || !townId || !initialToken) {
     console.log(
       `${LOG} Missing GASTOWN_API_URL, GASTOWN_TOWN_ID, or GASTOWN_CONTAINER_TOKEN — skipping boot hydration`
     );
@@ -2097,6 +2146,11 @@ export async function bootHydration(): Promise<void> {
   // worker call. The refresh endpoint tolerates tokens that have just
   // expired so this covers the cold-restart case too.
   await refreshTokenIfNearExpiry();
+
+  // Re-read the token AFTER the potential refresh so subsequent calls
+  // (registry fetch, and the env maps we hand to hydrated agents) use
+  // the fresh value.
+  const token = process.env.GASTOWN_CONTAINER_TOKEN ?? initialToken;
 
   console.log(`${LOG} Fetching container registry for town=${townId}`);
   let registry: unknown;
@@ -2133,9 +2187,14 @@ export async function bootHydration(): Promise<void> {
       continue;
     }
 
+    // Registry entries were written with the token snapshot at dispatch
+    // time. If we just refreshed, overlay the fresh value so the hydrated
+    // kilo serve child inherits the current token.
+    const hydratedEnv = { ...env, GASTOWN_CONTAINER_TOKEN: token };
+
     console.log(`${LOG} Resuming agent ${agentId} in ${workdir}`);
     try {
-      await startAgent(agentRequest, workdir, env);
+      await startAgent(agentRequest, workdir, hydratedEnv);
       console.log(`${LOG} Agent ${agentId} resumed`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/services/gastown/container/src/token-refresh.ts
+++ b/services/gastown/container/src/token-refresh.ts
@@ -1,0 +1,131 @@
+/**
+ * Container-side helpers for self-refreshing the container JWT.
+ *
+ * Two use cases:
+ *  1. Boot-time: when bootHydration runs, check whether the token is
+ *     near expiry. If so, mint a fresh one before using it.
+ *  2. Reactive: when a call to the worker 401s, mint a fresh token
+ *     and retry once.
+ */
+
+import { log } from './logger';
+
+const MANAGER_LOG = '[token-refresh]';
+
+/**
+ * Return the number of milliseconds until the JWT `exp` claim.
+ * Returns `null` if the token is malformed or has no `exp`.
+ *
+ * This does NOT verify the token — it only reads the claim.
+ */
+export function msUntilTokenExpiry(token: string): number | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length < 2) return null;
+    const payload = parts[1];
+    // Base64-URL decode. Bun / modern runtimes support atob directly,
+    // but jwt uses URL-safe encoding, so we need to normalise first.
+    const normalised = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalised + '='.repeat((4 - (normalised.length % 4)) % 4);
+    const decoded = atob(padded);
+    const parsed: unknown = JSON.parse(decoded);
+    if (!parsed || typeof parsed !== 'object') return null;
+    const exp = (parsed as { exp?: unknown }).exp;
+    if (typeof exp !== 'number') return null;
+    return exp * 1000 - Date.now();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Call the worker's `/refresh-container-token` endpoint to mint a
+ * fresh container JWT. The current token (possibly expired, but
+ * still correctly signed) authenticates the request.
+ *
+ * On success, updates `process.env.GASTOWN_CONTAINER_TOKEN` and
+ * returns the new token. On failure, logs and returns null — the
+ * caller decides whether to proceed with the stale token or bail.
+ */
+export async function fetchFreshContainerToken(): Promise<string | null> {
+  const apiUrl = process.env.GASTOWN_API_URL;
+  const townId = process.env.GASTOWN_TOWN_ID;
+  const currentToken = process.env.GASTOWN_CONTAINER_TOKEN;
+
+  if (!apiUrl || !townId || !currentToken) {
+    log.warn('token_refresh.skipped_missing_env', {
+      hasApiUrl: !!apiUrl,
+      hasTownId: !!townId,
+      hasCurrentToken: !!currentToken,
+    });
+    return null;
+  }
+
+  const t0 = Date.now();
+  try {
+    const resp = await fetch(`${apiUrl}/api/towns/${townId}/refresh-container-token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${currentToken}`,
+      },
+      body: '{}',
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '');
+      log.warn('token_refresh.fetch_failed', {
+        status: resp.status,
+        durationMs: Date.now() - t0,
+        body: text.slice(0, 200),
+      });
+      return null;
+    }
+    const body: unknown = await resp.json();
+    const token =
+      body && typeof body === 'object' && 'data' in body
+        ? (body as { data?: { token?: unknown } }).data?.token
+        : undefined;
+    if (typeof token !== 'string' || token.length === 0) {
+      log.warn('token_refresh.invalid_response', { durationMs: Date.now() - t0 });
+      return null;
+    }
+    process.env.GASTOWN_CONTAINER_TOKEN = token;
+    log.info('token_refresh.succeeded', { durationMs: Date.now() - t0 });
+    return token;
+  } catch (err) {
+    log.warn('token_refresh.network_error', {
+      error: err instanceof Error ? err.message : String(err),
+      durationMs: Date.now() - t0,
+    });
+    return null;
+  }
+}
+
+/**
+ * Boot-time refresh: if the current container token expires within
+ * `thresholdMs` (default 30 minutes), proactively mint a fresh one.
+ */
+export async function refreshTokenIfNearExpiry(thresholdMs = 30 * 60_000): Promise<void> {
+  const current = process.env.GASTOWN_CONTAINER_TOKEN;
+  if (!current) {
+    console.log(`${MANAGER_LOG} no current container token — skipping near-expiry refresh`);
+    return;
+  }
+  const msLeft = msUntilTokenExpiry(current);
+  if (msLeft === null) {
+    console.log(`${MANAGER_LOG} token has no exp claim — skipping near-expiry refresh`);
+    return;
+  }
+  if (msLeft > thresholdMs) {
+    console.log(
+      `${MANAGER_LOG} token valid for ${Math.round(msLeft / 60_000)}m — skipping near-expiry refresh`
+    );
+    return;
+  }
+  log.info('token_refresh.boot_near_expiry', {
+    msUntilExpiry: msLeft,
+    thresholdMs,
+  });
+  await fetchFreshContainerToken();
+}

--- a/services/gastown/src/gastown.worker.ts
+++ b/services/gastown/src/gastown.worker.ts
@@ -146,6 +146,7 @@ import {
   handleContainerReady,
   handleDrainStatus,
 } from './handlers/town-eviction.handler';
+import { handleRefreshContainerToken } from './handlers/town-container-token.handler';
 
 export { GastownUserDO } from './dos/GastownUser.do';
 export { GastownOrgDO } from './dos/GastownOrg.do';
@@ -582,6 +583,12 @@ app.post('/api/towns/:townId/container-eviction', c =>
 app.post('/api/towns/:townId/container-ready', c =>
   instrumented(c, 'POST /api/towns/:townId/container-ready', () =>
     handleContainerReady(c, c.req.param())
+  )
+);
+
+app.post('/api/towns/:townId/refresh-container-token', c =>
+  instrumented(c, 'POST /api/towns/:townId/refresh-container-token', () =>
+    handleRefreshContainerToken(c, c.req.param())
   )
 );
 

--- a/services/gastown/src/handlers/town-container-token.handler.ts
+++ b/services/gastown/src/handlers/town-container-token.handler.ts
@@ -1,0 +1,57 @@
+import type { Context } from 'hono';
+import { extractBearerToken } from '@kilocode/worker-utils';
+import type { GastownEnv } from '../gastown.worker';
+import { verifyContainerJWTAllowExpired, signContainerJWT } from '../util/jwt.util';
+import { resolveSecret } from '../util/secret.util';
+import { resSuccess, resError } from '../util/res.util';
+
+/**
+ * POST /api/towns/:townId/refresh-container-token
+ *
+ * Mint a fresh container-scoped JWT for a container whose current
+ * token is near expiry or already expired. The caller authenticates
+ * with its existing container token. The signature must be valid —
+ * we previously issued it — but the token is allowed to be expired
+ * so a container that's been asleep past the 8h TTL can still
+ * bootstrap a new token before calling any other endpoints.
+ *
+ * This endpoint only mints a new token; it does NOT push the token
+ * to the running container (the caller is the container itself;
+ * there's nothing to push). The caller is expected to write the
+ * token into its own `process.env.GASTOWN_CONTAINER_TOKEN` and
+ * invoke the existing `/refresh-token` control-server path if it
+ * needs to propagate the token to spawned kilo serve children.
+ */
+export async function handleRefreshContainerToken(
+  c: Context<GastownEnv>,
+  params: { townId: string }
+): Promise<Response> {
+  const token = extractBearerToken(c.req.header('Authorization'));
+  if (!token) {
+    return c.json(resError('Authentication required'), 401);
+  }
+
+  const secret = await resolveSecret(c.env.GASTOWN_JWT_SECRET);
+  if (!secret) {
+    console.error('[refresh-container-token] failed to resolve GASTOWN_JWT_SECRET');
+    return c.json(resError('Internal server error'), 500);
+  }
+
+  const result = verifyContainerJWTAllowExpired(token, secret);
+  if (!result.success) {
+    return c.json(resError(result.error), 401);
+  }
+
+  if (result.payload.townId !== params.townId) {
+    return c.json(resError('Cross-town access denied'), 403);
+  }
+
+  const freshToken = signContainerJWT(
+    { townId: result.payload.townId, userId: result.payload.userId },
+    secret
+  );
+  console.log(
+    `[refresh-container-token] issued fresh token for town=${params.townId} expiredInbound=${result.expired}`
+  );
+  return c.json(resSuccess({ token: freshToken, expiredInbound: result.expired }), 200);
+}

--- a/services/gastown/src/util/jwt.util.ts
+++ b/services/gastown/src/util/jwt.util.ts
@@ -100,13 +100,25 @@ export function verifyContainerJWT(
   }
 }
 
+// Maximum tolerated "past-expiry" window for a container JWT presented
+// to the refresh endpoint. Past this, the token must be re-minted by the
+// TownDO (via ensureContainerToken), not bootstrapped by the container
+// itself. Keeps the renewable window bounded instead of "forever as long
+// as the signature is valid".
+const CONTAINER_REFRESH_GRACE_SECONDS = 24 * 3600;
+
 /**
- * Verify a container-scoped JWT, tolerating expired tokens.
+ * Verify a container-scoped JWT, tolerating tokens that have just expired.
  *
  * Used exclusively by endpoints whose purpose is to mint a replacement
  * token for a container whose current one has expired. The signature
  * still has to be valid, so this only accepts tokens we previously
  * issued — an attacker cannot forge a fresh payload.
+ *
+ * Accepts tokens up to `CONTAINER_REFRESH_GRACE_SECONDS` past their
+ * `exp` claim. Beyond that, the token is considered truly dead and the
+ * refresh request is rejected — this bounds the window during which a
+ * stolen long-expired token could be turned into a fresh one.
  */
 export function verifyContainerJWTAllowExpired(
   token: string,
@@ -126,9 +138,20 @@ export function verifyContainerJWTAllowExpired(
     if (!parsed.success) {
       return { success: false, error: 'Invalid container token payload' };
     }
-    const decoded = jwt.decode(token) as { exp?: number } | null;
-    const expired = typeof decoded?.exp === 'number' && decoded.exp * 1000 < Date.now();
-    return { success: true, payload: parsed.data, expired };
+    const decoded = jwt.decode(token);
+    const exp =
+      decoded && typeof decoded === 'object' && 'exp' in decoded && typeof decoded.exp === 'number'
+        ? decoded.exp
+        : null;
+    if (exp === null) {
+      return { success: false, error: 'Token missing exp claim' };
+    }
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const secondsPastExpiry = nowSeconds - exp;
+    if (secondsPastExpiry > CONTAINER_REFRESH_GRACE_SECONDS) {
+      return { success: false, error: 'Token expired beyond refresh grace period' };
+    }
+    return { success: true, payload: parsed.data, expired: secondsPastExpiry > 0 };
   } catch (error) {
     if (error instanceof jwt.JsonWebTokenError) {
       return { success: false, error: 'Invalid token signature' };

--- a/services/gastown/src/util/jwt.util.ts
+++ b/services/gastown/src/util/jwt.util.ts
@@ -99,3 +99,40 @@ export function verifyContainerJWT(
     return { success: false, error: 'Token validation failed' };
   }
 }
+
+/**
+ * Verify a container-scoped JWT, tolerating expired tokens.
+ *
+ * Used exclusively by endpoints whose purpose is to mint a replacement
+ * token for a container whose current one has expired. The signature
+ * still has to be valid, so this only accepts tokens we previously
+ * issued — an attacker cannot forge a fresh payload.
+ */
+export function verifyContainerJWTAllowExpired(
+  token: string,
+  secret: string
+):
+  | { success: true; payload: ContainerJWTPayload; expired: boolean }
+  | {
+      success: false;
+      error: string;
+    } {
+  try {
+    const raw = jwt.verify(token, secret, {
+      algorithms: ['HS256'],
+      ignoreExpiration: true,
+    });
+    const parsed = ContainerJWTPayload.safeParse(raw);
+    if (!parsed.success) {
+      return { success: false, error: 'Invalid container token payload' };
+    }
+    const decoded = jwt.decode(token) as { exp?: number } | null;
+    const expired = typeof decoded?.exp === 'number' && decoded.exp * 1000 < Date.now();
+    return { success: true, payload: parsed.data, expired };
+  } catch (error) {
+    if (error instanceof jwt.JsonWebTokenError) {
+      return { success: false, error: 'Invalid token signature' };
+    }
+    return { success: false, error: 'Token validation failed' };
+  }
+}


### PR DESCRIPTION
## Summary

- `POST /refresh-token` previously only updated the control-server's own `process.env`. The spawned `kilo serve` child processes inherit env at fork time and never see the update, so the mayor plugin kept reading the old `GASTOWN_CONTAINER_TOKEN` and GT tool calls 401'd until the user forced a model hot-swap. The refresh handler now restarts each running agent's SDK server — matching the model hot-swap path — so the fresh token is inherited by the new child. The mayor resumes its existing session from `kilo.db`, preserving conversation history.
- Extracted the env rebuild logic (previously inlined in `updateAgentModel`) into a shared `buildLiveHotSwapEnv(agent)` helper. Both the model hot-swap and the new `refreshTokenForAllAgents` use it, so `LIVE_ENV_KEYS`, custom `env_vars` overlay, and `GH_TOKEN` re-derivation stay in one place.
- `/refresh-token` emits `refresh_token.received` / `refresh_token.completed` structured logs, and each agent restart emits a per-agent `refresh_token.agent_restarted` log with success/failure + durationMs so we can tell at a glance when refreshes land vs fail.
- Defense-in-depth:
  - New `POST /api/towns/:townId/refresh-container-token` worker endpoint that mints a fresh container JWT from a possibly-expired (but correctly-signed) container token. Lets a container that's been asleep past the 8h TTL bootstrap a new token before calling any other endpoints.
  - `bootHydration` pre-refreshes the container token when it's within 30 minutes of expiry (or already expired).
  - `heartbeat` and the plugin's `GastownClient` / `MayorGastownClient` retry a 401 once after minting a fresh token via the new worker endpoint.

## Verification

- `pnpm --filter gastown-container typecheck` ✅
- `pnpm --filter cloudflare-gastown typecheck` ✅
- `pnpm --filter gastown-container test` — same 2/57 pre-existing failures as base branch (`client.test.ts` auth-header tests affected by ambient `process.env.GASTOWN_CONTAINER_TOKEN` in the agent runtime; unrelated to this change).
- Manual: walked through the flow — control-server receives `/refresh-token`, calls `refreshTokenForAllAgents`, each agent's SDK server is torn down and recreated via `ensureSDKServer(agent.workdir, buildLiveHotSwapEnv(agent))`, fresh `kilo serve` child inherits the new `GASTOWN_CONTAINER_TOKEN`, mayor session is resumed via `client.session.list()` → `preferred = sessions.find(s => s.id === oldSessionId)`.

## Visual Changes

N/A — container-side and worker-side only, no UI surface.

## Reviewer Notes

- The synthetic `StartAgentRequest` object passed to `subscribeToEvents` in `refreshTokenForAllAgents` carries empty strings for `gitUrl` / `branch` / `defaultBranch` / `identity`. `subscribeToEvents` only reads `request.role` (to branch on mayor vs non-mayor idle handling), so the other fields are never accessed. If we ever add new reads, those would need to come from the agent object instead.
- `verifyContainerJWTAllowExpired` intentionally tolerates expired tokens but still requires a valid HS256 signature, so an attacker cannot forge a fresh payload — they'd need the JWT secret, in which case they could sign a fresh token directly.
- The plugin-side `refreshContainerTokenFromWorker` helper duplicates the container/src/token-refresh.ts one. They can't share a module cleanly because the plugin bundle is independent of the control-server bundle. Small duplication, contained, and the behaviour is identical.
- No database migrations, no schema changes, no PII.