### PR TITLE
fix(kiloclaw): harden gateway-client device approvals

### DIFF
--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -17,6 +17,7 @@ import {
   writeUserProfileFile,
   writeUserProfileTimezoneFile,
   ensureWeatherSkillInstalled,
+  remediateGatewayClientDeviceScopes,
   updateToolsMdSection,
   GOG_SECTION_CONFIG,
   KILO_CLI_SECTION_CONFIG,
@@ -1031,6 +1032,107 @@ describe('runOnboardOrDoctor', () => {
       tools?: { web?: { search?: { provider?: string } } };
     };
     expect(config.tools?.web?.search?.provider).toBeUndefined();
+  });
+});
+
+// ---- gateway-client paired device remediation ----
+
+describe('remediateGatewayClientDeviceScopes', () => {
+  it('updates gateway-client approved baseline and operator token scopes', () => {
+    const harness = fakeDeps();
+    const pairedPath = '/root/.openclaw/devices/paired.json';
+    (harness.deps.existsSync as ReturnType<typeof vi.fn>).mockImplementation(
+      (p: string) => p === pairedPath
+    );
+    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p === pairedPath) {
+        return JSON.stringify({
+          gatewayDevice: {
+            deviceId: 'gatewayDevice',
+            publicKey: 'public-key',
+            clientId: 'gateway-client',
+            scopes: ['operator.read'],
+            approvedScopes: ['operator.read'],
+            tokens: {
+              operator: {
+                token: 'secret-token',
+                role: 'operator',
+                scopes: ['operator.read'],
+                createdAtMs: 1,
+              },
+            },
+          },
+          otherDevice: {
+            deviceId: 'otherDevice',
+            clientId: 'openclaw-ios',
+            scopes: ['operator.read'],
+            approvedScopes: ['operator.read'],
+            tokens: {
+              operator: { token: 'other-token', role: 'operator', scopes: ['operator.read'] },
+            },
+          },
+        });
+      }
+      return '{}';
+    });
+
+    const result = remediateGatewayClientDeviceScopes(harness.deps);
+
+    expect(result).toEqual({ checked: 1, updated: 1 });
+    const rename = harness.renameCalls.find(call => call.to === pairedPath);
+    if (!rename) throw new Error('expected a rename into paired.json');
+    const tempWrite = harness.writeCalls.find(call => call.path === rename.from);
+    if (!tempWrite) throw new Error('expected a paired.json temp write');
+
+    const full = [
+      'operator.read',
+      'operator.admin',
+      'operator.approvals',
+      'operator.pairing',
+      'operator.write',
+    ];
+    const rewritten = JSON.parse(tempWrite.data) as Record<string, Record<string, unknown>>;
+    expect(rewritten.gatewayDevice?.scopes).toEqual(full);
+    expect(rewritten.gatewayDevice?.approvedScopes).toEqual(full);
+    expect(rewritten.gatewayDevice?.tokens).toEqual({
+      operator: {
+        token: 'secret-token',
+        role: 'operator',
+        scopes: full,
+        createdAtMs: 1,
+      },
+    });
+    expect(rewritten.otherDevice?.scopes).toEqual(['operator.read']);
+  });
+
+  it('does not rewrite when gateway-client scope state is already remediated', () => {
+    const harness = fakeDeps();
+    const pairedPath = '/root/.openclaw/devices/paired.json';
+    const full = [
+      'operator.read',
+      'operator.admin',
+      'operator.approvals',
+      'operator.pairing',
+      'operator.write',
+    ];
+    (harness.deps.existsSync as ReturnType<typeof vi.fn>).mockImplementation(
+      (p: string) => p === pairedPath
+    );
+    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+      JSON.stringify({
+        gatewayDevice: {
+          clientId: 'gateway-client',
+          scopes: full,
+          approvedScopes: full,
+          tokens: { operator: { role: 'operator', scopes: full } },
+        },
+      })
+    );
+
+    const result = remediateGatewayClientDeviceScopes(harness.deps);
+
+    expect(result).toEqual({ checked: 1, updated: 0 });
+    expect(harness.renameCalls).toHaveLength(0);
   });
 });
 

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -22,6 +22,7 @@ import type { AuthProfilesMigrationDeps } from './auth-profiles-migration';
 const CONFIG_DIR = '/root/.openclaw';
 const CONFIG_PATH = '/root/.openclaw/openclaw.json';
 const EXEC_APPROVALS_PATH = '/root/.openclaw/exec-approvals.json';
+const DEVICE_PAIRED_PATH = '/root/.openclaw/devices/paired.json';
 const WORKSPACE_DIR = '/root/clawd';
 const COMPILE_CACHE_DIR = '/var/tmp/openclaw-compile-cache';
 const TOOLS_MD_SOURCE = '/usr/local/share/kiloclaw/TOOLS.md';
@@ -35,10 +36,21 @@ const LEGACY_BOT_IDENTITY_DESTS = ['/root/.openclaw/workspace/BOOTSTRAP.md'];
 const ENC_PREFIX = 'KILOCLAW_ENC_';
 const VALUE_PREFIX = 'enc:v1:';
 const VALID_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const GATEWAY_CLIENT_ID = 'gateway-client';
+const OPERATOR_TOKEN_ROLE = 'operator';
+const GATEWAY_CLIENT_OPERATOR_SCOPES = [
+  'operator.read',
+  'operator.admin',
+  'operator.approvals',
+  'operator.pairing',
+  'operator.write',
+];
 
 // ---- Types ----
 
 type EnvLike = Record<string, string | undefined>;
+
+type JsonRecord = Record<string, unknown>;
 
 type ExecOpts = {
   env?: NodeJS.ProcessEnv;
@@ -91,6 +103,21 @@ export type ControllerState =
   | { state: 'degraded'; error: string };
 
 export type ControllerStateRef = { current: ControllerState };
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringArrayEquals(left: unknown, right: readonly string[]): boolean {
+  if (!Array.isArray(left) || left.length !== right.length) return false;
+  return left.every((value, index) => value === right[index]);
+}
+
+function setScopeList(record: JsonRecord, key: 'scopes' | 'approvedScopes'): boolean {
+  if (stringArrayEquals(record[key], GATEWAY_CLIENT_OPERATOR_SCOPES)) return false;
+  record[key] = [...GATEWAY_CLIENT_OPERATOR_SCOPES];
+  return true;
+}
 
 // ---- Step 1: Env decryption ----
 
@@ -702,6 +729,17 @@ export function runOnboardOrDoctor(env: EnvLike, deps: BootstrapDeps = defaultDe
     );
   }
 
+  try {
+    const remediation = remediateGatewayClientDeviceScopes(deps);
+    if (remediation.updated > 0) {
+      console.log(
+        `[controller] gateway-client device scopes remediated: ${remediation.updated}/${remediation.checked} paired device(s)`
+      );
+    }
+  } catch (err) {
+    console.warn('[controller] Failed to remediate gateway-client device scopes:', err);
+  }
+
   writeBotIdentityFile(env, deps);
   writeUserProfileFile(env, deps);
   ensureWeatherSkillInstalled(env, deps);
@@ -741,6 +779,70 @@ export function seedExecApprovalsDefaults(env: EnvLike, deps: BootstrapDeps = de
   } catch (err) {
     console.warn('[controller] Failed to seed exec-approvals.json defaults:', err);
   }
+}
+
+// ---- gateway-client paired device remediation ----
+
+export type GatewayClientDeviceScopeRemediationResult = {
+  checked: number;
+  updated: number;
+};
+
+export function remediateGatewayClientDeviceScopes(
+  deps: Pick<
+    BootstrapDeps,
+    'existsSync' | 'readFileSync' | 'writeFileSync' | 'renameSync' | 'unlinkSync' | 'chmodSync'
+  > = defaultDeps
+): GatewayClientDeviceScopeRemediationResult {
+  if (!deps.existsSync(DEVICE_PAIRED_PATH)) {
+    return { checked: 0, updated: 0 };
+  }
+
+  const pairedFile = JSON.parse(deps.readFileSync(DEVICE_PAIRED_PATH, 'utf8')) as unknown;
+  if (!isJsonRecord(pairedFile)) {
+    console.warn('[controller] Device paired state is not an object, skipping remediation');
+    return { checked: 0, updated: 0 };
+  }
+
+  let checked = 0;
+  let updated = 0;
+
+  for (const value of Object.values(pairedFile)) {
+    if (!isJsonRecord(value) || value.clientId !== GATEWAY_CLIENT_ID) continue;
+    checked += 1;
+
+    let changed = false;
+    changed = setScopeList(value, 'scopes') || changed;
+    changed = setScopeList(value, 'approvedScopes') || changed;
+
+    const tokens = value.tokens;
+    if (isJsonRecord(tokens)) {
+      const operatorToken = tokens[OPERATOR_TOKEN_ROLE];
+      if (isJsonRecord(operatorToken)) {
+        changed = setScopeList(operatorToken, 'scopes') || changed;
+      }
+    }
+
+    if (changed) updated += 1;
+  }
+
+  if (updated === 0) {
+    return { checked, updated };
+  }
+
+  atomicWrite(
+    DEVICE_PAIRED_PATH,
+    JSON.stringify(pairedFile, null, 2) + '\n',
+    {
+      writeFileSync: deps.writeFileSync,
+      renameSync: deps.renameSync,
+      unlinkSync: deps.unlinkSync,
+      chmodSync: deps.chmodSync,
+    },
+    { mode: 0o600 }
+  );
+
+  return { checked, updated };
 }
 
 // ---- TOOLS.md bounded-section helper ----

--- a/services/kiloclaw/controller/src/pairing-cache.test.ts
+++ b/services/kiloclaw/controller/src/pairing-cache.test.ts
@@ -6,11 +6,15 @@ import {
   PERIODIC_INTERVAL_MS,
   FAILURE_RETRY_BASE_MS,
   FAILURE_RETRY_MAX_MS,
+  GATEWAY_CLIENT_OPERATOR_SCOPES,
   type ReadChannelPairingImpl,
   type ReadDevicePairingImpl,
+  widenGatewayClientPendingRequestScopes,
 } from './pairing-cache';
 
 type ExecImpl = (command: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
+type ReadTextFileImpl = (filePath: string) => Promise<string>;
+type WriteTextFileAtomicImpl = (filePath: string, data: string) => Promise<void>;
 
 // Epoch-ms equivalent of the nowImpl ISO string, for TTL comparisons
 const NOW_MS = new Date('2026-03-12T00:00:00.000Z').getTime();
@@ -22,6 +26,8 @@ function createTestHarness(overrides?: {
   readConfigImpl?: () => unknown;
   readChannelPairingImpl?: ReadChannelPairingImpl;
   readDevicePairingImpl?: ReadDevicePairingImpl;
+  readTextFileImpl?: ReadTextFileImpl;
+  writeTextFileAtomicImpl?: WriteTextFileAtomicImpl;
 }) {
   const execImpl = overrides?.execImpl ?? vi.fn<ExecImpl>();
   const readConfigImpl =
@@ -37,6 +43,10 @@ function createTestHarness(overrides?: {
     vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] });
   const readDevicePairingImpl =
     overrides?.readDevicePairingImpl ?? vi.fn<ReadDevicePairingImpl>().mockResolvedValue({});
+  const readTextFileImpl =
+    overrides?.readTextFileImpl ?? vi.fn<ReadTextFileImpl>().mockResolvedValue('{}');
+  const writeTextFileAtomicImpl =
+    overrides?.writeTextFileAtomicImpl ?? vi.fn<WriteTextFileAtomicImpl>().mockResolvedValue();
   const nowImpl = vi.fn(() => '2026-03-12T00:00:00.000Z');
   const nowMsImpl = vi.fn(() => NOW_MS);
 
@@ -45,6 +55,8 @@ function createTestHarness(overrides?: {
     readConfigImpl,
     readChannelPairingImpl,
     readDevicePairingImpl,
+    readTextFileImpl,
+    writeTextFileAtomicImpl,
     nowImpl,
     nowMsImpl,
   });
@@ -55,6 +67,8 @@ function createTestHarness(overrides?: {
     readConfigImpl,
     readChannelPairingImpl,
     readDevicePairingImpl,
+    readTextFileImpl,
+    writeTextFileAtomicImpl,
     nowImpl,
     nowMsImpl,
   };
@@ -71,6 +85,83 @@ afterEach(() => {
 });
 
 describe('createPairingCache', () => {
+  describe('widenGatewayClientPendingRequestScopes', () => {
+    it('widens gateway-client operator pending request scopes before approval', async () => {
+      const readTextFile = vi.fn<ReadTextFileImpl>().mockResolvedValue(
+        JSON.stringify({
+          'req-1': {
+            requestId: 'req-1',
+            deviceId: 'dev1',
+            publicKey: 'public-key',
+            clientId: 'gateway-client',
+            clientMode: 'backend',
+            role: 'operator',
+            roles: ['operator'],
+            scopes: ['operator.read'],
+            ts: RECENT_TS,
+          },
+          'req-2': {
+            requestId: 'req-2',
+            deviceId: 'dev2',
+            publicKey: 'public-key-2',
+            clientId: 'openclaw-ios',
+            role: 'operator',
+            scopes: ['operator.read'],
+            ts: RECENT_TS,
+          },
+        })
+      );
+      const writeTextFileAtomic = vi.fn<WriteTextFileAtomicImpl>().mockResolvedValue();
+
+      const result = await widenGatewayClientPendingRequestScopes({
+        requestId: 'req-1',
+        pendingPath: '/tmp/pending.json',
+        readTextFile,
+        writeTextFileAtomic,
+      });
+
+      expect(result).toEqual({ changed: true, missing: false });
+      expect(writeTextFileAtomic).toHaveBeenCalledTimes(1);
+      const written = JSON.parse(writeTextFileAtomic.mock.calls[0]?.[1] ?? '{}') as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(written['req-1']?.scopes).toEqual(GATEWAY_CLIENT_OPERATOR_SCOPES);
+      expect(written['req-2']?.scopes).toEqual(['operator.read']);
+    });
+
+    it('does not rewrite missing or non-gateway pending requests', async () => {
+      const readTextFile = vi.fn<ReadTextFileImpl>().mockResolvedValue(
+        JSON.stringify({
+          'req-1': {
+            requestId: 'req-1',
+            deviceId: 'dev1',
+            clientId: 'openclaw-ios',
+            role: 'operator',
+            scopes: ['operator.read'],
+          },
+        })
+      );
+      const writeTextFileAtomic = vi.fn<WriteTextFileAtomicImpl>().mockResolvedValue();
+
+      await expect(
+        widenGatewayClientPendingRequestScopes({
+          requestId: 'req-1',
+          readTextFile,
+          writeTextFileAtomic,
+        })
+      ).resolves.toEqual({ changed: false, missing: false });
+      await expect(
+        widenGatewayClientPendingRequestScopes({
+          requestId: 'req-missing',
+          readTextFile,
+          writeTextFileAtomic,
+        })
+      ).resolves.toEqual({ changed: false, missing: true });
+      expect(writeTextFileAtomic).not.toHaveBeenCalled();
+    });
+  });
+
   describe('channel pairing list', () => {
     it('merges requests from multiple channels', async () => {
       const readChannelPairingImpl = vi.fn<ReadChannelPairingImpl>().mockImplementation(channel => {
@@ -542,14 +633,32 @@ describe('createPairingCache', () => {
   describe('autoApproveGatewayClient', () => {
     it('auto-approves pending gateway-client devices on refresh', async () => {
       const execImpl = vi.fn<ExecImpl>().mockResolvedValue({ stdout: '{}', stderr: '' });
+      const readTextFileImpl = vi.fn<ReadTextFileImpl>().mockResolvedValue(
+        JSON.stringify({
+          'a1b2c3d4-e5f6-7890-abcd-ef1234567890': {
+            requestId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+            deviceId: 'dev1',
+            publicKey: 'public-key',
+            clientId: 'gateway-client',
+            clientMode: 'backend',
+            role: 'operator',
+            roles: ['operator'],
+            scopes: ['operator.read'],
+            ts: RECENT_TS,
+          },
+        })
+      );
+      const writeTextFileAtomicImpl = vi.fn<WriteTextFileAtomicImpl>().mockResolvedValue();
       const readDevicePairingImpl = vi
         .fn<ReadDevicePairingImpl>()
         .mockResolvedValueOnce({
-          'req-1': {
+          'a1b2c3d4-e5f6-7890-abcd-ef1234567890': {
             requestId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
             deviceId: 'dev1',
             clientId: 'gateway-client',
+            clientMode: 'backend',
             role: 'operator',
+            roles: ['operator'],
             ts: RECENT_TS,
           },
         })
@@ -561,6 +670,8 @@ describe('createPairingCache', () => {
         readConfigImpl: () => ({ channels: {} }),
         readChannelPairingImpl: vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] }),
         readDevicePairingImpl,
+        readTextFileImpl,
+        writeTextFileAtomicImpl,
         nowImpl: () => '2026-03-12T00:00:00.000Z',
         nowMsImpl: () => NOW_MS,
         autoApproveGatewayClient: true,
@@ -573,11 +684,21 @@ describe('createPairingCache', () => {
         'approve',
         'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
       ]);
+      expect(writeTextFileAtomicImpl).toHaveBeenCalledTimes(1);
+      const written = JSON.parse(writeTextFileAtomicImpl.mock.calls[0]?.[1] ?? '{}') as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(written['a1b2c3d4-e5f6-7890-abcd-ef1234567890']?.scopes).toEqual(
+        GATEWAY_CLIENT_OPERATOR_SCOPES
+      );
       expect(cache.getDevicePairing().requests).toEqual([]);
     });
 
     it('does not auto-approve non-gateway-client devices', async () => {
       const execImpl = vi.fn<ExecImpl>().mockResolvedValue({ stdout: '{}', stderr: '' });
+      const readTextFileImpl = vi.fn<ReadTextFileImpl>().mockResolvedValue('{}');
+      const writeTextFileAtomicImpl = vi.fn<WriteTextFileAtomicImpl>().mockResolvedValue();
       const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({
         'req-1': {
           requestId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
@@ -593,6 +714,8 @@ describe('createPairingCache', () => {
         readConfigImpl: () => ({ channels: {} }),
         readChannelPairingImpl: vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] }),
         readDevicePairingImpl,
+        readTextFileImpl,
+        writeTextFileAtomicImpl,
         nowImpl: () => '2026-03-12T00:00:00.000Z',
         nowMsImpl: () => NOW_MS,
         autoApproveGatewayClient: true,
@@ -601,7 +724,81 @@ describe('createPairingCache', () => {
       await cache.refreshDevicePairing();
 
       expect(execImpl).not.toHaveBeenCalled();
+      expect(readTextFileImpl).not.toHaveBeenCalled();
+      expect(writeTextFileAtomicImpl).not.toHaveBeenCalled();
       expect(cache.getDevicePairing().requests).toHaveLength(1);
+    });
+
+    it('does not auto-approve gateway-client requests without operator role', async () => {
+      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({ stdout: '{}', stderr: '' });
+      const readTextFileImpl = vi.fn<ReadTextFileImpl>().mockResolvedValue('{}');
+      const writeTextFileAtomicImpl = vi.fn<WriteTextFileAtomicImpl>().mockResolvedValue();
+      const readDevicePairingImpl = vi.fn<ReadDevicePairingImpl>().mockResolvedValue({
+        'req-1': {
+          requestId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+          deviceId: 'dev1',
+          clientId: 'gateway-client',
+          role: 'node',
+          roles: ['node'],
+          ts: RECENT_TS,
+        },
+      });
+
+      const cache = createPairingCache({
+        execImpl,
+        readConfigImpl: () => ({ channels: {} }),
+        readChannelPairingImpl: vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] }),
+        readDevicePairingImpl,
+        readTextFileImpl,
+        writeTextFileAtomicImpl,
+        nowImpl: () => '2026-03-12T00:00:00.000Z',
+        nowMsImpl: () => NOW_MS,
+        autoApproveGatewayClient: true,
+      });
+
+      await cache.refreshDevicePairing();
+
+      expect(execImpl).not.toHaveBeenCalled();
+      expect(readTextFileImpl).not.toHaveBeenCalled();
+      expect(writeTextFileAtomicImpl).not.toHaveBeenCalled();
+      expect(cache.getDevicePairing().requests).toHaveLength(1);
+    });
+
+    it('skips auto-approval when pending request disappears before widening', async () => {
+      const execImpl = vi.fn<ExecImpl>().mockResolvedValue({ stdout: '{}', stderr: '' });
+      const readTextFileImpl = vi.fn<ReadTextFileImpl>().mockResolvedValue('{}');
+      const writeTextFileAtomicImpl = vi.fn<WriteTextFileAtomicImpl>().mockResolvedValue();
+      const readDevicePairingImpl = vi
+        .fn<ReadDevicePairingImpl>()
+        .mockResolvedValueOnce({
+          'a1b2c3d4-e5f6-7890-abcd-ef1234567890': {
+            requestId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+            deviceId: 'dev1',
+            clientId: 'gateway-client',
+            role: 'operator',
+            roles: ['operator'],
+            ts: RECENT_TS,
+          },
+        })
+        .mockResolvedValue({});
+
+      const cache = createPairingCache({
+        execImpl,
+        readConfigImpl: () => ({ channels: {} }),
+        readChannelPairingImpl: vi.fn<ReadChannelPairingImpl>().mockResolvedValue({ requests: [] }),
+        readDevicePairingImpl,
+        readTextFileImpl,
+        writeTextFileAtomicImpl,
+        nowImpl: () => '2026-03-12T00:00:00.000Z',
+        nowMsImpl: () => NOW_MS,
+        autoApproveGatewayClient: true,
+      });
+
+      await cache.refreshDevicePairing();
+
+      expect(execImpl).not.toHaveBeenCalled();
+      expect(writeTextFileAtomicImpl).not.toHaveBeenCalled();
+      expect(cache.getDevicePairing().requests).toEqual([]);
     });
 
     it('does not auto-approve when option is disabled', async () => {

--- a/services/kiloclaw/controller/src/pairing-cache.ts
+++ b/services/kiloclaw/controller/src/pairing-cache.ts
@@ -3,6 +3,7 @@ import { promisify } from 'node:util';
 import fs from 'node:fs';
 import path from 'node:path';
 import { z } from 'zod';
+import { atomicWrite } from './atomic-write';
 
 const execFileAsync = promisify(execFile);
 
@@ -18,8 +19,10 @@ export type DevicePairingRequest = {
   requestId: string;
   deviceId: string;
   role?: string;
+  roles?: string[];
   platform?: string;
   clientId?: string;
+  clientMode?: string;
   ts?: number;
 };
 
@@ -45,6 +48,8 @@ export type PairingCache = {
 };
 
 type ExecImpl = (command: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
+type ReadTextFileImpl = (filePath: string) => Promise<string>;
+type WriteTextFileAtomicImpl = (filePath: string, data: string) => Promise<void>;
 
 export type ReadChannelPairingImpl = (channel: string) => Promise<unknown>;
 export type ReadDevicePairingImpl = () => Promise<unknown>;
@@ -55,6 +60,8 @@ type PairingCacheOptions = {
   nowImpl?: () => string;
   readChannelPairingImpl?: ReadChannelPairingImpl;
   readDevicePairingImpl?: ReadDevicePairingImpl;
+  readTextFileImpl?: ReadTextFileImpl;
+  writeTextFileAtomicImpl?: WriteTextFileAtomicImpl;
   nowMsImpl?: () => number;
   /** Auto-approve pending device pairings from the gateway's own exec client. */
   autoApproveGatewayClient?: boolean;
@@ -97,6 +104,15 @@ function approveFail(message: string, statusHint: 400 | 500): ApproveResult {
 }
 
 export const OPENCLAW_BIN = '/usr/local/bin/openclaw';
+export const GATEWAY_CLIENT_ID = 'gateway-client';
+export const OPERATOR_ROLE = 'operator';
+export const GATEWAY_CLIENT_OPERATOR_SCOPES = [
+  'operator.read',
+  'operator.admin',
+  'operator.approvals',
+  'operator.pairing',
+  'operator.write',
+];
 
 // Mirrors resolveStateDir() / resolveOAuthDir() in openclaw/src/config/paths.ts
 // Note: openclaw's full resolveStateDir() also does filesystem-existence checks for
@@ -131,6 +147,15 @@ function defaultReadConfigImpl(): unknown {
   return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
 }
 
+async function defaultWriteTextFileAtomicImpl(filePath: string, data: string): Promise<void> {
+  atomicWrite(filePath, data, {
+    writeFileSync: (p, content) => fs.writeFileSync(p, content),
+    renameSync: (oldPath, newPath) => fs.renameSync(oldPath, newPath),
+    unlinkSync: p => fs.unlinkSync(p),
+    chmodSync: (p, mode) => fs.chmodSync(p, mode),
+  });
+}
+
 // Zod schemas for IO boundary parsing — .passthrough() keeps forward compatibility
 // when openclaw adds fields without breaking the controller.
 const channelPairingRequestSchema = z
@@ -156,8 +181,10 @@ const devicePendingEntrySchema = z.object({
   requestId: z.string(),
   deviceId: z.string(),
   role: z.string().optional(),
+  roles: z.array(z.string()).optional(),
   platform: z.string().optional(),
   clientId: z.string().optional(),
+  clientMode: z.string().optional(),
   ts: z.number().optional(),
 });
 
@@ -190,6 +217,77 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function stringArraySetEquals(left: unknown, right: readonly string[]): boolean {
+  if (!Array.isArray(left) || left.length !== right.length) return false;
+  const rightSet = new Set(right);
+  return left.every(value => typeof value === 'string' && rightSet.has(value));
+}
+
+function normalizeRoleList(req: Pick<DevicePairingRequest, 'role' | 'roles'>): string[] {
+  const roles = new Set<string>();
+  if (Array.isArray(req.roles)) {
+    for (const role of req.roles) {
+      const trimmed = role.trim();
+      if (trimmed) roles.add(trimmed);
+    }
+  }
+  const role = req.role?.trim();
+  if (role) roles.add(role);
+  return [...roles];
+}
+
+export function isGatewayClientOperatorRequest(req: DevicePairingRequest): boolean {
+  if (req.clientId !== GATEWAY_CLIENT_ID) return false;
+  const roles = normalizeRoleList(req);
+  return roles.includes(OPERATOR_ROLE);
+}
+
+function widenGatewayClientPendingRequestScopesInFile(
+  parsed: unknown,
+  requestId: string
+): {
+  changed: boolean;
+  missing: boolean;
+  value: unknown;
+} {
+  if (!isRecord(parsed)) {
+    return { changed: false, missing: true, value: parsed };
+  }
+
+  const entry = parsed[requestId];
+  if (!isRecord(entry)) {
+    return { changed: false, missing: true, value: parsed };
+  }
+
+  const candidate = devicePendingEntrySchema.safeParse(entry);
+  if (!candidate.success || !isGatewayClientOperatorRequest(candidate.data)) {
+    return { changed: false, missing: false, value: parsed };
+  }
+
+  if (stringArraySetEquals(entry.scopes, GATEWAY_CLIENT_OPERATOR_SCOPES)) {
+    return { changed: false, missing: false, value: parsed };
+  }
+
+  entry.scopes = [...GATEWAY_CLIENT_OPERATOR_SCOPES];
+  return { changed: true, missing: false, value: parsed };
+}
+
+export async function widenGatewayClientPendingRequestScopes(params: {
+  requestId: string;
+  readTextFile: ReadTextFileImpl;
+  writeTextFileAtomic: WriteTextFileAtomicImpl;
+  pendingPath?: string;
+}): Promise<{ changed: boolean; missing: boolean }> {
+  const pendingPath = params.pendingPath ?? resolveDevicePendingPath();
+  const raw = await params.readTextFile(pendingPath);
+  const parsed = JSON.parse(raw) as unknown;
+  const result = widenGatewayClientPendingRequestScopesInFile(parsed, params.requestId);
+  if (result.changed) {
+    await params.writeTextFileAtomic(pendingPath, JSON.stringify(result.value, null, 2) + '\n');
+  }
+  return { changed: result.changed, missing: result.missing };
+}
+
 export function detectChannels(config: unknown): string[] {
   if (!isRecord(config)) return [];
   const ch = isRecord(config.channels) ? config.channels : {};
@@ -218,6 +316,8 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
       const filePath = resolveDevicePendingPath();
       return JSON.parse(await fs.promises.readFile(filePath, 'utf8')) as unknown;
     },
+    readTextFileImpl = async (filePath: string) => await fs.promises.readFile(filePath, 'utf8'),
+    writeTextFileAtomicImpl = defaultWriteTextFileAtomicImpl,
     nowMsImpl = () => Date.now(),
     autoApproveGatewayClient = false,
   } = options ?? {};
@@ -357,10 +457,26 @@ export function createPairingCache(options?: PairingCacheOptions): PairingCache 
       console.log(`[pairing-cache] devices: read ok, ${requests.length} pending`);
 
       if (autoApproveGatewayClient) {
-        const gatewayRequests = requests.filter(r => r.clientId === 'gateway-client');
+        const gatewayRequests = requests.filter(isGatewayClientOperatorRequest);
         for (const req of gatewayRequests) {
           console.log(`[pairing-cache] auto-approving gateway-client device ${req.requestId}`);
           try {
+            const widened = await widenGatewayClientPendingRequestScopes({
+              requestId: req.requestId,
+              readTextFile: readTextFileImpl,
+              writeTextFileAtomic: writeTextFileAtomicImpl,
+            });
+            if (widened.missing) {
+              console.log(
+                `[pairing-cache] gateway-client pending request ${req.requestId} disappeared before approval`
+              );
+              continue;
+            }
+            if (widened.changed) {
+              console.log(
+                `[pairing-cache] widened gateway-client device ${req.requestId} approval scopes`
+              );
+            }
             await execImpl(OPENCLAW_BIN, ['devices', 'approve', req.requestId]);
           } catch (err) {
             console.error(`[pairing-cache] auto-approve failed for ${req.requestId}:`, err);


### PR DESCRIPTION
## Summary

- Remediate existing KiloClaw gateway-client paired device records whose approved/operator token scopes were narrower than the backend control-plane envelope.
- Widen pending gateway-client operator pairing requests before auto-approval so openclaw@2026.4.15 persists the correct baseline on first approval.
- Cover remediation, preventative widening, non-gateway requests, non-operator requests, and disappeared pending requests with controller tests.

## Verification

No manual verification performed; this is machine-side controller state-file behavior covered by targeted unit tests.

## Visual Changes

N/A

## Reviewer Notes

The preventative path intentionally mutates only pending `clientId: gateway-client` operator requests before invoking the existing OpenClaw approval command. The boot-time remediation remains in place for already-deployed volumes with stale `paired.json` state.