### PR TITLE
fix(gastown): auto-refresh GitHub tokens for long-running agents

### DIFF
--- a/services/gastown/container/src/git-manager.ts
+++ b/services/gastown/container/src/git-manager.ts
@@ -254,11 +254,17 @@ export async function refreshGitToken(rigId: string): Promise<string | null> {
     // process.env) see the new token via authenticateGitUrl.
     process.env.GIT_TOKEN = freshToken;
 
-    // Rewrite every /tmp/.git-credentials* file that currently stores a
-    // token. The credential helper reads these verbatim, so the agent's
-    // own `git push` (running in a subprocess outside this module) picks
-    // up the new token on the next invocation without restart.
-    await rewriteCredentialStoreFiles(freshToken);
+    // Rewrite the per-rig /tmp/.git-credentials* files that currently
+    // store a token. The credential helper reads these verbatim, so the
+    // agent's own `git push` (running in a subprocess outside this module)
+    // picks up the new token on the next invocation without restart.
+    //
+    // Scoped to the current rig only — both configureGitCredentials and
+    // configureRepoCredentials slugify a path containing the rigId into
+    // the credential filename, so we can select them by substring match.
+    // Rewriting every file would clobber other rigs' tokens (each rig can
+    // have a distinct platformIntegrationId, so tokens are not interchangeable).
+    await rewriteCredentialStoreFiles(rigId, freshToken);
 
     console.log(`[refreshGitToken] refreshed token for rig=${rigId}`);
     return freshToken;
@@ -270,11 +276,17 @@ export async function refreshGitToken(rigId: string): Promise<string | null> {
 
 /**
  * Walk /tmp for credential-store files previously written by
- * configureRepoCredentials / configureGitCredentials and rewrite them
- * to use the new token. Silently skips files for non-GitHub remotes
- * (those use gitlab_token which has a different refresh path).
+ * configureRepoCredentials / configureGitCredentials for the given rig
+ * and rewrite them to use the new token. Files for other rigs are left
+ * alone so this refresh doesn't stomp their (possibly distinct) tokens.
+ *
+ * Files are identified by the slugified rigId appearing in the filename
+ * (both writers embed a path under `/workspace/rigs/<rigId>/...` in the
+ * credential file name, slugified via `replace(/[^a-zA-Z0-9]/g, '-')`).
+ * Only GitHub `x-access-token` lines are rewritten; GitLab `oauth2`
+ * lines are left alone (they use gitlab_token, not an installation token).
  */
-async function rewriteCredentialStoreFiles(freshToken: string): Promise<void> {
+async function rewriteCredentialStoreFiles(rigId: string, freshToken: string): Promise<void> {
   let entries: string[];
   try {
     entries = await readdir('/tmp');
@@ -282,8 +294,11 @@ async function rewriteCredentialStoreFiles(freshToken: string): Promise<void> {
     return;
   }
 
+  const rigSlug = rigId.replace(/[^a-zA-Z0-9]/g, '-');
+
   for (const name of entries) {
     if (!name.startsWith('.git-credentials')) continue;
+    if (!name.includes(rigSlug)) continue;
     const path = `/tmp/${name}`;
     let content: string;
     try {
@@ -323,11 +338,23 @@ async function rewriteCredentialStoreFiles(freshToken: string): Promise<void> {
  *
  * `buildArgs` is called again on retry so callers that embed the token
  * in a URL (e.g. `git clone https://<token>@...`) can regenerate it.
+ *
+ * For operations that talk to `origin` (fetch, pull, push without a URL
+ * arg), pass `gitUrl` so that after refresh we rewrite the `origin`
+ * remote URL with the new token. Git reads the embedded password from
+ * the remote URL before consulting the credential helper, so without
+ * this the retry would re-send the same expired token.
  */
 async function execWithAuthRetry(
   cmd: string,
   buildArgs: () => string[] | Promise<string[]>,
-  opts: { cwd?: string; rigId: string; envVars?: Record<string, string> }
+  opts: {
+    cwd?: string;
+    rigId: string;
+    envVars?: Record<string, string>;
+    /** Git URL to rebuild `origin` with after a token refresh. */
+    gitUrl?: string;
+  }
 ): Promise<string> {
   try {
     const args = await buildArgs();
@@ -335,10 +362,9 @@ async function execWithAuthRetry(
   } catch (err) {
     if (!isAuthFailure(err)) throw err;
 
+    const rawMsg = err instanceof Error ? err.message.split('\n')[0] : String(err);
     console.warn(
-      `[execWithAuthRetry] auth failure for rig=${opts.rigId}, refreshing token and retrying: ${
-        err instanceof Error ? err.message.split('\n')[0] : String(err)
-      }`
+      `[execWithAuthRetry] auth failure for rig=${opts.rigId}, refreshing token and retrying: ${redactGitTokens(rawMsg)}`
     );
 
     const fresh = await refreshGitToken(opts.rigId);
@@ -353,9 +379,38 @@ async function execWithAuthRetry(
       opts.envVars.GIT_TOKEN = fresh;
     }
 
+    // If the operation uses the `origin` remote, its stored URL still
+    // has the old token embedded. Rewrite it before retrying so the
+    // retry sends the fresh token.
+    if (opts.gitUrl && opts.cwd) {
+      try {
+        await exec(
+          'git',
+          ['remote', 'set-url', 'origin', authenticateGitUrl(opts.gitUrl, opts.envVars)],
+          opts.cwd
+        );
+      } catch (setUrlErr) {
+        const m = setUrlErr instanceof Error ? setUrlErr.message.split('\n')[0] : String(setUrlErr);
+        console.warn(
+          `[execWithAuthRetry] failed to rewrite origin URL for rig=${opts.rigId}: ${redactGitTokens(m)}`
+        );
+      }
+    }
+
     const retryArgs = await buildArgs();
     return await exec(cmd, retryArgs, opts.cwd);
   }
+}
+
+/**
+ * Redact tokens from a string that may include authenticated git URLs
+ * (e.g. `https://x-access-token:<token>@github.com/...` or
+ * `https://oauth2:<token>@gitlab.com/...`). Used on every error string
+ * and log line that could contain a command line or git stderr, so an
+ * auth failure never leaks the token.
+ */
+function redactGitTokens(s: string): string {
+  return s.replace(/(https?:\/\/)([^:@/\s]+):([^@/\s]+)(@)/g, '$1$2:***REDACTED***$4');
 }
 
 async function exec(cmd: string, args: string[], cwd?: string): Promise<string> {
@@ -382,7 +437,9 @@ async function exec(cmd: string, args: string[], cwd?: string): Promise<string> 
 
   if (exitCode !== 0) {
     const stderr = await new Response(proc.stderr).text();
-    throw new Error(`${cmd} ${args.join(' ')} failed: ${stderr || `exit code ${exitCode}`}`);
+    const cmdLine = redactGitTokens(`${cmd} ${args.join(' ')}`);
+    const detail = redactGitTokens(stderr || `exit code ${exitCode}`);
+    throw new Error(`${cmdLine} failed: ${detail}`);
   }
 
   return stdout.trim();
@@ -446,6 +503,7 @@ async function cloneRepoInner(
       cwd: dir,
       rigId: options.rigId,
       envVars: options.envVars,
+      gitUrl: options.gitUrl,
     });
     console.log(`Fetched latest for rig ${options.rigId}`);
     return dir;
@@ -499,7 +557,7 @@ async function cloneRepoInner(
     await execWithAuthRetry(
       'git',
       () => ['push', 'origin', `HEAD:${options.defaultBranch}`],
-      { cwd: dir, rigId: options.rigId, envVars: options.envVars }
+      { cwd: dir, rigId: options.rigId, envVars: options.envVars, gitUrl: options.gitUrl }
     );
     // Best-effort: set remote HEAD so future operations know the default branch
     await exec('git', ['remote', 'set-head', 'origin', options.defaultBranch], dir).catch(() => {});
@@ -508,6 +566,7 @@ async function cloneRepoInner(
       cwd: dir,
       rigId: options.rigId,
       envVars: options.envVars,
+      gitUrl: options.gitUrl,
     });
     console.log(`Created initial commit on empty repo for rig ${options.rigId}`);
   }
@@ -740,6 +799,7 @@ export async function mergeBranch(options: {
       cwd: repo,
       rigId: options.rigId,
       envVars: options.envVars,
+      gitUrl: options.gitUrl,
     });
   }
 
@@ -789,7 +849,7 @@ export async function mergeBranch(options: {
     await execWithAuthRetry(
       'git',
       () => ['push', 'origin', `${tmpBranch}:${options.targetBranch}`],
-      { cwd: mergeDir, rigId: options.rigId, envVars: options.envVars }
+      { cwd: mergeDir, rigId: options.rigId, envVars: options.envVars, gitUrl: options.gitUrl }
     );
 
     return { status: 'merged', message: 'Merge successful', commitSha };

--- a/services/gastown/container/src/git-manager.ts
+++ b/services/gastown/container/src/git-manager.ts
@@ -1,8 +1,25 @@
-import { mkdir, realpath, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import type { CloneOptions, WorktreeOptions } from './types';
 
 const WORKSPACE_ROOT = '/workspace/rigs';
+
+// Message fragments that indicate a git authentication failure. git CLI
+// doesn't surface HTTP status codes directly; we match on stderr.
+const AUTH_FAILURE_PATTERNS = [
+  /\b(401|403)\b/,
+  /Authentication failed/i,
+  /could not read Username/i,
+  /terminal prompts disabled/i,
+  /fatal: unable to access.*The requested URL returned error:\s*(401|403)/i,
+  /Invalid username or (password|token)/i,
+  /remote: (Invalid|Bad|Write access to repository not granted)/i,
+];
+
+function isAuthFailure(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return AUTH_FAILURE_PATTERNS.some(re => re.test(msg));
+}
 
 // ── Per-rig mutex ────────────────────────────────────────────────────────
 // Git operations (clone, fetch, worktree add/remove) on the same bare repo
@@ -180,6 +197,167 @@ async function assertInsideWorkspace(targetPath: string): Promise<void> {
   }
 }
 
+/**
+ * Call the worker's refresh-git-token endpoint to obtain a fresh GitHub
+ * App installation token. Updates process.env.GIT_TOKEN and rewrites
+ * per-repo credential-store files so subsequent git operations (including
+ * the agent's own `git push`) pick up the new token.
+ *
+ * Returns the new token on success, or null if the refresh failed (no
+ * integration configured, network error, auth rejected, etc.).
+ *
+ * Callers: retry-on-auth-failure wrapper in git-manager, periodic refresh
+ * timer in process-manager (if added).
+ */
+export async function refreshGitToken(rigId: string): Promise<string | null> {
+  const apiUrl = process.env.GASTOWN_API_URL;
+  const townId = process.env.GASTOWN_TOWN_ID;
+  const token = process.env.GASTOWN_CONTAINER_TOKEN;
+  if (!apiUrl || !townId || !token) {
+    console.warn(
+      `[refreshGitToken] missing env: apiUrl=${!!apiUrl} townId=${!!townId} containerToken=${!!token}`
+    );
+    return null;
+  }
+
+  try {
+    const resp = await fetch(
+      `${apiUrl}/api/towns/${townId}/rigs/${rigId}/refresh-git-token`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '(unreadable)');
+      console.warn(
+        `[refreshGitToken] worker returned ${resp.status} for rig=${rigId}: ${body.slice(0, 200)}`
+      );
+      return null;
+    }
+    const raw: unknown = await resp.json();
+    if (
+      !raw ||
+      typeof raw !== 'object' ||
+      !('data' in raw) ||
+      !raw.data ||
+      typeof raw.data !== 'object' ||
+      !('token' in raw.data) ||
+      typeof (raw.data as { token: unknown }).token !== 'string'
+    ) {
+      console.warn(`[refreshGitToken] unexpected response shape for rig=${rigId}`);
+      return null;
+    }
+    const freshToken = (raw.data as { token: string }).token;
+
+    // Update process.env so subsequent exec() calls (which inherit
+    // process.env) see the new token via authenticateGitUrl.
+    process.env.GIT_TOKEN = freshToken;
+
+    // Rewrite every /tmp/.git-credentials* file that currently stores a
+    // token. The credential helper reads these verbatim, so the agent's
+    // own `git push` (running in a subprocess outside this module) picks
+    // up the new token on the next invocation without restart.
+    await rewriteCredentialStoreFiles(freshToken);
+
+    console.log(`[refreshGitToken] refreshed token for rig=${rigId}`);
+    return freshToken;
+  } catch (err) {
+    console.warn(`[refreshGitToken] failed for rig=${rigId}:`, err);
+    return null;
+  }
+}
+
+/**
+ * Walk /tmp for credential-store files previously written by
+ * configureRepoCredentials / configureGitCredentials and rewrite them
+ * to use the new token. Silently skips files for non-GitHub remotes
+ * (those use gitlab_token which has a different refresh path).
+ */
+async function rewriteCredentialStoreFiles(freshToken: string): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await readdir('/tmp');
+  } catch {
+    return;
+  }
+
+  for (const name of entries) {
+    if (!name.startsWith('.git-credentials')) continue;
+    const path = `/tmp/${name}`;
+    let content: string;
+    try {
+      content = await readFile(path, 'utf8');
+    } catch {
+      continue;
+    }
+
+    // Credential line format: https://x-access-token:<token>@<host>\n
+    // Only rewrite lines using x-access-token (GitHub). Leave oauth2
+    // (GitLab) lines alone so we don't replace gitlab_token with a
+    // GitHub token.
+    const rewritten = content
+      .split('\n')
+      .map(line => {
+        if (!line.startsWith('https://x-access-token:')) return line;
+        const match = line.match(/^(https:\/\/x-access-token:)[^@]+(@.+)$/);
+        if (!match) return line;
+        return `${match[1]}${freshToken}${match[2]}`;
+      })
+      .join('\n');
+
+    if (rewritten !== content) {
+      try {
+        await writeFile(path, rewritten, { mode: 0o600 });
+      } catch (err) {
+        console.warn(`[refreshGitToken] failed to rewrite ${path}:`, err);
+      }
+    }
+  }
+}
+
+/**
+ * Run a git operation that uses GIT_TOKEN. On auth failure (401/403),
+ * refresh the token via the worker endpoint and retry once with the
+ * caller-rebuilt args (so authenticated URLs pick up the new token).
+ *
+ * `buildArgs` is called again on retry so callers that embed the token
+ * in a URL (e.g. `git clone https://<token>@...`) can regenerate it.
+ */
+async function execWithAuthRetry(
+  cmd: string,
+  buildArgs: () => string[] | Promise<string[]>,
+  opts: { cwd?: string; rigId: string; envVars?: Record<string, string> }
+): Promise<string> {
+  try {
+    const args = await buildArgs();
+    return await exec(cmd, args, opts.cwd);
+  } catch (err) {
+    if (!isAuthFailure(err)) throw err;
+
+    console.warn(
+      `[execWithAuthRetry] auth failure for rig=${opts.rigId}, refreshing token and retrying: ${
+        err instanceof Error ? err.message.split('\n')[0] : String(err)
+      }`
+    );
+
+    const fresh = await refreshGitToken(opts.rigId);
+    if (!fresh) {
+      throw err;
+    }
+
+    // Mutate the caller's envVars map in place so subsequent calls in
+    // the same workflow (e.g. mergeBranch → push after fetch) use the
+    // fresh token without another round-trip.
+    if (opts.envVars) {
+      opts.envVars.GIT_TOKEN = fresh;
+    }
+
+    const retryArgs = await buildArgs();
+    return await exec(cmd, retryArgs, opts.cwd);
+  }
+}
+
 async function exec(cmd: string, args: string[], cwd?: string): Promise<string> {
   const proc = Bun.spawn([cmd, ...args], {
     cwd,
@@ -252,15 +430,23 @@ async function cloneRepoInner(
   validateGitUrl(options.gitUrl);
   validateBranchName(options.defaultBranch, 'defaultBranch');
   const dir = await repoDir(options.rigId);
-  const authUrl = authenticateGitUrl(options.gitUrl, options.envVars);
 
   if (await pathExists(join(dir, '.git'))) {
-    // Update the remote URL in case the token changed
-    await exec('git', ['remote', 'set-url', 'origin', authUrl], dir).catch(err => {
+    // Update the remote URL in case the token changed. Re-resolve authUrl
+    // inside the retry wrapper so a refreshed GIT_TOKEN is picked up.
+    await execWithAuthRetry(
+      'git',
+      () => ['remote', 'set-url', 'origin', authenticateGitUrl(options.gitUrl, options.envVars)],
+      { cwd: dir, rigId: options.rigId, envVars: options.envVars }
+    ).catch(err => {
       console.warn(`Failed to update remote URL for rig ${options.rigId}:`, err);
     });
     await configureRepoCredentials(dir, options.gitUrl, options.envVars);
-    await exec('git', ['fetch', '--all', '--prune'], dir);
+    await execWithAuthRetry('git', () => ['fetch', '--all', '--prune'], {
+      cwd: dir,
+      rigId: options.rigId,
+      envVars: options.envVars,
+    });
     console.log(`Fetched latest for rig ${options.rigId}`);
     return dir;
   }
@@ -270,7 +456,7 @@ async function cloneRepoInner(
     await rm(dir, { recursive: true, force: true });
   }
 
-  const hasAuth = authUrl !== options.gitUrl;
+  const hasAuth = authenticateGitUrl(options.gitUrl, options.envVars) !== options.gitUrl;
   console.log(
     `Cloning repo for rig ${options.rigId}: hasAuth=${hasAuth} envKeys=[${Object.keys(options.envVars ?? {}).join(',')}]`
   );
@@ -279,7 +465,11 @@ async function cloneRepoInner(
   // exist yet, so `git clone --branch <branch>` would fail with
   // "Remote branch <branch> not found in upstream origin".
   await mkdir(dir, { recursive: true });
-  await exec('git', ['clone', '--no-checkout', authUrl, dir]);
+  await execWithAuthRetry(
+    'git',
+    () => ['clone', '--no-checkout', authenticateGitUrl(options.gitUrl, options.envVars), dir],
+    { rigId: options.rigId, envVars: options.envVars }
+  );
   await configureRepoCredentials(dir, options.gitUrl, options.envVars);
 
   // Detect empty repo: git rev-parse HEAD fails when there are no commits.
@@ -306,11 +496,19 @@ async function cloneRepoInner(
       ],
       dir
     );
-    await exec('git', ['push', 'origin', `HEAD:${options.defaultBranch}`], dir);
+    await execWithAuthRetry(
+      'git',
+      () => ['push', 'origin', `HEAD:${options.defaultBranch}`],
+      { cwd: dir, rigId: options.rigId, envVars: options.envVars }
+    );
     // Best-effort: set remote HEAD so future operations know the default branch
     await exec('git', ['remote', 'set-head', 'origin', options.defaultBranch], dir).catch(() => {});
     // Fetch so origin/<defaultBranch> ref is available locally
-    await exec('git', ['fetch', 'origin'], dir);
+    await execWithAuthRetry('git', () => ['fetch', 'origin'], {
+      cwd: dir,
+      rigId: options.rigId,
+      envVars: options.envVars,
+    });
     console.log(`Created initial commit on empty repo for rig ${options.rigId}`);
   }
 
@@ -332,7 +530,10 @@ async function createWorktreeInner(options: WorktreeOptions): Promise<string> {
 
   if (await pathExists(dir)) {
     await exec('git', ['checkout', options.branch], dir);
-    await exec('git', ['pull', '--rebase', '--autostash'], dir).catch(() => {
+    await execWithAuthRetry('git', () => ['pull', '--rebase', '--autostash'], {
+      cwd: dir,
+      rigId: options.rigId,
+    }).catch(() => {
       // Pull may fail if remote branch doesn't exist yet; that's fine
     });
     console.log(`Reused existing worktree at ${dir}`);
@@ -436,7 +637,10 @@ async function setupBrowseWorktreeInner(rigId: string, defaultBranch: string): P
     // origin/<defaultBranch>. The worktree lives on the synthetic
     // browse-<rigId> branch, not on <defaultBranch> directly.
     try {
-      await exec('git', ['fetch', 'origin', defaultBranch], browseDir);
+      await execWithAuthRetry('git', () => ['fetch', 'origin', defaultBranch], {
+        cwd: browseDir,
+        rigId,
+      });
       await exec('git', ['reset', '--hard', `origin/${defaultBranch}`], browseDir);
       console.log(`Updated browse worktree for rig ${rigId} at ${browseDir}`);
     } catch (err) {
@@ -514,7 +718,6 @@ export async function mergeBranch(options: {
   validateGitUrl(options.gitUrl);
 
   const repo = await repoDir(options.rigId);
-  const authUrl = authenticateGitUrl(options.gitUrl, options.envVars);
 
   // Ensure repo exists and is up to date
   if (!(await pathExists(join(repo, '.git')))) {
@@ -525,9 +728,19 @@ export async function mergeBranch(options: {
       envVars: options.envVars,
     });
   } else {
-    // Update remote URL for fresh token
-    await exec('git', ['remote', 'set-url', 'origin', authUrl], repo).catch(() => {});
-    await exec('git', ['fetch', '--all', '--prune'], repo);
+    // Update remote URL for fresh token. Re-resolve inside the retry
+    // wrapper so a refreshed token replaces the expired one embedded
+    // in the remote URL.
+    await execWithAuthRetry(
+      'git',
+      () => ['remote', 'set-url', 'origin', authenticateGitUrl(options.gitUrl, options.envVars)],
+      { cwd: repo, rigId: options.rigId, envVars: options.envVars }
+    ).catch(() => {});
+    await execWithAuthRetry('git', () => ['fetch', '--all', '--prune'], {
+      cwd: repo,
+      rigId: options.rigId,
+      envVars: options.envVars,
+    });
   }
 
   // Create a temporary worktree for the merge on the target branch
@@ -573,7 +786,11 @@ export async function mergeBranch(options: {
     const commitSha = await exec('git', ['rev-parse', 'HEAD'], mergeDir);
 
     // Push the merge commit to the target branch on the remote
-    await exec('git', ['push', 'origin', `${tmpBranch}:${options.targetBranch}`], mergeDir);
+    await execWithAuthRetry(
+      'git',
+      () => ['push', 'origin', `${tmpBranch}:${options.targetBranch}`],
+      { cwd: mergeDir, rigId: options.rigId, envVars: options.envVars }
+    );
 
     return { status: 'merged', message: 'Merge successful', commitSha };
   } finally {

--- a/services/gastown/src/gastown.worker.ts
+++ b/services/gastown/src/gastown.worker.ts
@@ -146,6 +146,7 @@ import {
   handleContainerReady,
   handleDrainStatus,
 } from './handlers/town-eviction.handler';
+import { handleRefreshGitToken } from './handlers/refresh-git-token.handler';
 
 export { GastownUserDO } from './dos/GastownUser.do';
 export { GastownOrgDO } from './dos/GastownOrg.do';
@@ -496,6 +497,16 @@ app.post('/api/towns/:townId/rigs/:rigId/agents/:agentId/nudge-delivered', c =>
 
 // Agent-to-agent nudge: any authenticated agent can nudge another agent in the rig
 app.post('/api/towns/:townId/rigs/:rigId/nudge', c => handleNudge(c, c.req.param()));
+
+// ── Refresh Git Token ──────────────────────────────────────────────────
+// Called by the container when a GIT_TOKEN (GitHub App installation token,
+// 1h TTL) expires mid-task. Returns a fresh token resolved via the
+// standard chain. Authenticated with the container-scoped JWT.
+app.post('/api/towns/:townId/rigs/:rigId/refresh-git-token', c =>
+  instrumented(c, 'POST /api/towns/:townId/rigs/:rigId/refresh-git-token', () =>
+    handleRefreshGitToken(c, c.req.param())
+  )
+);
 
 // ── Agent Events ─────────────────────────────────────────────────────────
 

--- a/services/gastown/src/handlers/refresh-git-token.handler.ts
+++ b/services/gastown/src/handlers/refresh-git-token.handler.ts
@@ -1,0 +1,66 @@
+import type { Context } from 'hono';
+import { extractBearerToken } from '@kilocode/worker-utils';
+import type { GastownEnv } from '../gastown.worker';
+import { getTownDOStub } from '../dos/Town.do';
+import { verifyContainerJWT } from '../util/jwt.util';
+import { resolveSecret } from '../util/secret.util';
+import { resSuccess, resError } from '../util/res.util';
+import { resolveGitHubToken } from '../dos/town/town-scm';
+
+/**
+ * POST /api/towns/:townId/rigs/:rigId/refresh-git-token
+ *
+ * Called by the container when a git operation fails with 401/403 —
+ * i.e. the GitHub App installation token embedded in GIT_TOKEN has
+ * expired (1h TTL). Resolves a fresh token via the standard chain
+ * (town config → platform integration) and returns it to the caller.
+ *
+ * Authenticated with the container-scoped JWT (same token used for
+ * all other container→worker calls).
+ */
+export async function handleRefreshGitToken(
+  c: Context<GastownEnv>,
+  params: { townId: string; rigId: string }
+): Promise<Response> {
+  const token = extractBearerToken(c.req.header('Authorization'));
+  if (!token) {
+    return c.json(resError('Authentication required'), 401);
+  }
+
+  const secret = await resolveSecret(c.env.GASTOWN_JWT_SECRET);
+  if (!secret) {
+    console.error('[refresh-git-token] failed to resolve GASTOWN_JWT_SECRET');
+    return c.json(resError('Internal server error'), 500);
+  }
+
+  const verified = verifyContainerJWT(token, secret);
+  if (!verified.success) {
+    return c.json(resError(verified.error), 401);
+  }
+
+  if (verified.payload.townId !== params.townId) {
+    return c.json(resError('Cross-town access denied'), 403);
+  }
+
+  const town = getTownDOStub(c.env, params.townId);
+  const rigConfig = await town.getRigConfig(params.rigId);
+
+  const freshToken = await resolveGitHubToken({
+    env: c.env,
+    townId: params.townId,
+    getTownConfig: () => town.getTownConfig(),
+    platformIntegrationId: rigConfig?.platformIntegrationId,
+  });
+
+  if (!freshToken) {
+    console.warn(
+      `[refresh-git-token] no token available for town=${params.townId} rig=${params.rigId}`
+    );
+    return c.json(resError('No git token available for this rig'), 404);
+  }
+
+  console.log(
+    `[refresh-git-token] refreshed git token for town=${params.townId} rig=${params.rigId}`
+  );
+  return c.json(resSuccess({ token: freshToken }), 200);
+}


### PR DESCRIPTION
## Summary

- Adds `POST /api/towns/:townId/rigs/:rigId/refresh-git-token` endpoint that resolves a fresh GitHub App installation token via the existing `resolveGitHubToken()` chain. Authenticated with the container-scoped JWT.
- Wraps `git-manager.ts` clone/fetch/push/pull operations with a retry-on-auth-failure helper. On 401/403, the container calls the refresh endpoint, updates `process.env.GIT_TOKEN`, rewrites all `/tmp/.git-credentials*` files so the agent's own `git push` (in a separate subprocess via credential-store) also picks up the new token, and retries the git operation once with a rebuilt authenticated URL.

Fixes the failure mode where polecats running longer than 1h hit 401 on final `git push` because the installation token (1h TTL) resolved at dispatch time has expired.

## Verification

- `pnpm --filter cloudflare-gastown typecheck` passes.
- `pnpm --filter gastown-container typecheck` passes.
- Auth-failure detection tested by inspection: matches stderr patterns git CLI surfaces (401/403, "Authentication failed", "could not read Username", "terminal prompts disabled", "Invalid username or token", "remote: Invalid/Bad/Write access not granted").

## Visual Changes

N/A (server-side only).

## Reviewer Notes

- `rewriteCredentialStoreFiles` only rewrites lines with `https://x-access-token:` so GitLab (`oauth2:`) credential files are left alone — GitLab tokens have a separate refresh path.
- `execWithAuthRetry` calls `buildArgs()` again on retry so callers embedding the token in a URL (`git clone https://<token>@...`) pick up the new token.
- The refresh endpoint authenticates via container JWT (same pattern as `/container-eviction`, `/container-ready`, `/drain-status`).
- Change 3 (periodic refresh timer) from the bead was skipped — reactive retry-on-401 covers the failure mode without adding a timer.