### PR TITLE
Kiloclaw pin consent and version change

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawSettingsPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawSettingsPage.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { Settings } from 'lucide-react';
 import { useRouter } from 'next/navigation';
+import { TRPCClientError } from '@trpc/client';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { useKiloClawStatus, useKiloClawMutations, useKiloClawMyPin } from '@/hooks/useKiloClaw';
 import {
@@ -37,11 +38,13 @@ function ClawSettingsInner({
   const orgMutations = useOrgKiloClawMutations(organizationId ?? '');
   const mutations = organizationId ? orgMutations : personalMutations;
 
-  // Pin state for the upgrade-confirmation dialog. The dialog surfaces a
-  // warning when a pin exists; the click then acts as the consent that
-  // removes the pin and proceeds with the upgrade.
-  const personalPin = useKiloClawMyPin();
-  const orgPin = useOrgKiloClawMyPin(organizationId ?? '');
+  // Pin state for the upgrade-confirmation dialog. Only the active
+  // context queries (org vs personal); the inactive hook stays disabled
+  // so we don't fire an org getMyPin with an empty organizationId.
+  const personalPin = useKiloClawMyPin({ enabled: !organizationId });
+  const orgPin = useOrgKiloClawMyPin(organizationId ?? '', {
+    enabled: !!organizationId,
+  });
   const pin = organizationId ? orgPin.data : personalPin.data;
   const pinnedImageTag = pin?.image_tag ?? null;
 
@@ -72,11 +75,12 @@ function ClawSettingsInner({
   }, []);
 
   const onConfirmUpgrade = useCallback(() => {
-    // The dialog click acts as the user's consent. Always send
-    // acknowledgePinRemoval: true so the backend gate clears any existing
-    // pin and proceeds. Backend ignores the flag when no pin exists.
+    // Only ack what was actually rendered to the user. If pinnedImageTag
+    // is null (no warning shown), send false; the backend gate will
+    // catch any pin that appeared between render and click and surface
+    // PIN_EXISTS so the user can retry with fresh data.
     mutations.restartMachine.mutate(
-      { imageTag: 'latest', acknowledgePinRemoval: true },
+      { imageTag: 'latest', acknowledgePinRemoval: !!pinnedImageTag },
       {
         onSuccess: () => {
           toast.success('Upgrading KiloClaw');
@@ -84,11 +88,34 @@ function ClawSettingsInner({
           onRedeploySuccess();
         },
         onError: err => {
+          if (
+            err instanceof TRPCClientError &&
+            err.data?.code === 'PRECONDITION_FAILED' &&
+            err.message === 'PIN_EXISTS'
+          ) {
+            // Pin appeared between render and click. Refetch the active
+            // context's pin query so the dialog re-renders with a warning
+            // on the next click.
+            if (organizationId) void orgPin.refetch();
+            else void personalPin.refetch();
+            toast.error(
+              'A version pin was set on this instance. Review the warning and try again.',
+              { duration: 10000 }
+            );
+            return;
+          }
           toast.error(err.message, { duration: 10000 });
         },
       }
     );
-  }, [mutations.restartMachine, onRedeploySuccess]);
+  }, [
+    mutations.restartMachine,
+    onRedeploySuccess,
+    pinnedImageTag,
+    organizationId,
+    orgPin,
+    personalPin,
+  ]);
 
   return (
     <>

--- a/apps/web/src/app/(app)/claw/components/ClawSettingsPage.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawSettingsPage.tsx
@@ -5,8 +5,12 @@ import { toast } from 'sonner';
 import { Settings } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
-import { useKiloClawStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
-import { useOrgKiloClawStatus, useOrgKiloClawMutations } from '@/hooks/useOrgKiloClaw';
+import { useKiloClawStatus, useKiloClawMutations, useKiloClawMyPin } from '@/hooks/useKiloClaw';
+import {
+  useOrgKiloClawStatus,
+  useOrgKiloClawMutations,
+  useOrgKiloClawMyPin,
+} from '@/hooks/useOrgKiloClaw';
 import { ClawContextProvider, useClawContext } from './ClawContext';
 import { ClawConfigServiceBanner } from './ClawConfigServiceBanner';
 import { ClawInstanceOverview } from './ClawInstanceOverview';
@@ -32,6 +36,14 @@ function ClawSettingsInner({
   const personalMutations = useKiloClawMutations();
   const orgMutations = useOrgKiloClawMutations(organizationId ?? '');
   const mutations = organizationId ? orgMutations : personalMutations;
+
+  // Pin state for the upgrade-confirmation dialog. The dialog surfaces a
+  // warning when a pin exists; the click then acts as the consent that
+  // removes the pin and proceeds with the upgrade.
+  const personalPin = useKiloClawMyPin();
+  const orgPin = useOrgKiloClawMyPin(organizationId ?? '');
+  const pin = organizationId ? orgPin.data : personalPin.data;
+  const pinnedImageTag = pin?.image_tag ?? null;
 
   const [dirtySecrets, setDirtySecrets] = useState<Set<string>>(new Set());
   const [confirmUpgrade, setConfirmUpgrade] = useState(false);
@@ -60,8 +72,11 @@ function ClawSettingsInner({
   }, []);
 
   const onConfirmUpgrade = useCallback(() => {
+    // The dialog click acts as the user's consent. Always send
+    // acknowledgePinRemoval: true so the backend gate clears any existing
+    // pin and proceeds. Backend ignores the flag when no pin exists.
     mutations.restartMachine.mutate(
-      { imageTag: 'latest' },
+      { imageTag: 'latest', acknowledgePinRemoval: true },
       {
         onSuccess: () => {
           toast.success('Upgrading KiloClaw');
@@ -99,6 +114,7 @@ function ClawSettingsInner({
         }}
         isPending={mutations.restartMachine.isPending}
         onConfirm={onConfirmUpgrade}
+        pinnedImageTag={pinnedImageTag}
       />
     </>
   );

--- a/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/components/ui/dialog';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Label } from '@/components/ui/label';
+import { TRPCClientError } from '@trpc/client';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { useKiloClawMyPin } from '@/hooks/useKiloClaw';
 import { useOrgKiloClawMyPin } from '@/hooks/useOrgKiloClaw';
@@ -73,12 +74,13 @@ export function InstanceControls({
   const gatewayUrl = useGatewayUrl(status);
   const { organizationId } = useClawContext();
 
-  // Pin state for the upgrade-confirmation dialogs (inline confirm + the
-  // separate UpgradeKiloClawDialog). The dialog click is the user's
-  // consent — sending acknowledgePinRemoval: true unconditionally on
-  // upgrade lets the backend gate clear any existing pin and proceed.
-  const personalPin = useKiloClawMyPin();
-  const orgPin = useOrgKiloClawMyPin(organizationId ?? '');
+  // Pin state for the upgrade-confirmation dialogs. Only the active
+  // context queries (org vs personal) so we don't fire an org getMyPin
+  // with an empty organizationId.
+  const personalPin = useKiloClawMyPin({ enabled: !organizationId });
+  const orgPin = useOrgKiloClawMyPin(organizationId ?? '', {
+    enabled: !!organizationId,
+  });
   const pin = organizationId ? orgPin.data : personalPin.data;
   const pinnedImageTag = pin?.image_tag ?? null;
   const isRunning = status.status === 'running';
@@ -142,20 +144,46 @@ export function InstanceControls({
       instance_status: status.status,
       redeploy_mode: 'upgrade',
     });
-    // Dialog click is the consent — acknowledgePinRemoval lets backend
-    // clear any existing pin and proceed.
+    // Only ack what was actually rendered to the user. If pinnedImageTag
+    // is null (no warning shown), send false; the backend gate catches
+    // any pin that appeared between render and click and returns
+    // PIN_EXISTS so the user can retry with fresh data.
     mutations.restartMachine.mutate(
-      { imageTag: 'latest', acknowledgePinRemoval: true },
+      { imageTag: 'latest', acknowledgePinRemoval: !!pinnedImageTag },
       {
         onSuccess: () => {
           toast.success('Upgrading KiloClaw');
           setConfirmUpgrade(false);
           onRedeploySuccess?.();
         },
-        onError: err => toast.error(err.message, { duration: 10000 }),
+        onError: err => {
+          if (
+            err instanceof TRPCClientError &&
+            err.data?.code === 'PRECONDITION_FAILED' &&
+            err.message === 'PIN_EXISTS'
+          ) {
+            if (organizationId) void orgPin.refetch();
+            else void personalPin.refetch();
+            toast.error(
+              'A version pin was set on this instance. Review the warning and try again.',
+              { duration: 10000 }
+            );
+            return;
+          }
+          toast.error(err.message, { duration: 10000 });
+        },
       }
     );
-  }, [mutations.restartMachine, onRedeploySuccess, posthog, status.status]);
+  }, [
+    mutations.restartMachine,
+    onRedeploySuccess,
+    pinnedImageTag,
+    posthog,
+    status.status,
+    organizationId,
+    orgPin,
+    personalPin,
+  ]);
 
   const showUpgradeBanner =
     isFlyProvider && updateAvailable && !isDismissedInStorage && !manuallyDismissed;
@@ -463,11 +491,14 @@ export function InstanceControls({
                   instance_status: status.status,
                   redeploy_mode: redeployMode,
                 });
-                // For the upgrade path, the dialog click is the consent —
-                // pass acknowledgePinRemoval so the backend can clear any
-                // existing pin and proceed. Plain redeploy (no imageTag)
-                // never triggers the gate.
-                const input = imageTag ? { imageTag, acknowledgePinRemoval: true } : undefined;
+                // For the upgrade path, only ack what the dialog actually
+                // rendered. If no pin warning was shown (pinnedImageTag
+                // null), send false and let the backend gate catch any
+                // pin that appeared between render and click. Plain
+                // redeploy (no imageTag) never triggers the gate.
+                const input = imageTag
+                  ? { imageTag, acknowledgePinRemoval: !!pinnedImageTag }
+                  : undefined;
                 mutations.restartMachine.mutate(input, {
                   onSuccess: () => {
                     toast.success(
@@ -476,7 +507,22 @@ export function InstanceControls({
                     setConfirmRedeploy(false);
                     onRedeploySuccess?.();
                   },
-                  onError: err => toast.error(err.message, { duration: 10000 }),
+                  onError: err => {
+                    if (
+                      err instanceof TRPCClientError &&
+                      err.data?.code === 'PRECONDITION_FAILED' &&
+                      err.message === 'PIN_EXISTS'
+                    ) {
+                      if (organizationId) void orgPin.refetch();
+                      else void personalPin.refetch();
+                      toast.error(
+                        'A version pin was set on this instance. Review the warning and try again.',
+                        { duration: 10000 }
+                      );
+                      return;
+                    }
+                    toast.error(err.message, { duration: 10000 });
+                  },
                 });
               }}
               disabled={mutations.restartMachine.isPending || isRestarting || isRecovering}

--- a/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
@@ -467,12 +467,7 @@ export function InstanceControls({
                 // pass acknowledgePinRemoval so the backend can clear any
                 // existing pin and proceed. Plain redeploy (no imageTag)
                 // never triggers the gate.
-                const input =
-                  imageTag === 'latest'
-                    ? { imageTag, acknowledgePinRemoval: true }
-                    : imageTag
-                      ? { imageTag }
-                      : undefined;
+                const input = imageTag ? { imageTag, acknowledgePinRemoval: true } : undefined;
                 mutations.restartMachine.mutate(input, {
                   onSuccess: () => {
                     toast.success(

--- a/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
+++ b/apps/web/src/app/(app)/claw/components/InstanceControls.tsx
@@ -6,6 +6,7 @@ import {
   Cpu,
   HardDrive,
   Pencil,
+  Pin,
   Play,
   RefreshCw,
   RotateCw,
@@ -16,6 +17,7 @@ import {
 import { usePostHog } from 'posthog-js/react';
 import { toast } from 'sonner';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -30,6 +32,9 @@ import {
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Label } from '@/components/ui/label';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
+import { useKiloClawMyPin } from '@/hooks/useKiloClaw';
+import { useOrgKiloClawMyPin } from '@/hooks/useOrgKiloClaw';
+import { useClawContext } from './ClawContext';
 import { useClawUpdateAvailable } from '../hooks/useClawUpdateAvailable';
 import { useGatewayUrl } from '../hooks/useGatewayUrl';
 import { ConfirmActionDialog } from './ConfirmActionDialog';
@@ -66,6 +71,16 @@ export function InstanceControls({
 }) {
   const posthog = usePostHog();
   const gatewayUrl = useGatewayUrl(status);
+  const { organizationId } = useClawContext();
+
+  // Pin state for the upgrade-confirmation dialogs (inline confirm + the
+  // separate UpgradeKiloClawDialog). The dialog click is the user's
+  // consent — sending acknowledgePinRemoval: true unconditionally on
+  // upgrade lets the backend gate clear any existing pin and proceed.
+  const personalPin = useKiloClawMyPin();
+  const orgPin = useOrgKiloClawMyPin(organizationId ?? '');
+  const pin = organizationId ? orgPin.data : personalPin.data;
+  const pinnedImageTag = pin?.image_tag ?? null;
   const isRunning = status.status === 'running';
   const isProvisioned = status.status === 'provisioned';
   const isStarting = status.status === 'starting';
@@ -127,8 +142,10 @@ export function InstanceControls({
       instance_status: status.status,
       redeploy_mode: 'upgrade',
     });
+    // Dialog click is the consent — acknowledgePinRemoval lets backend
+    // clear any existing pin and proceed.
     mutations.restartMachine.mutate(
-      { imageTag: 'latest' },
+      { imageTag: 'latest', acknowledgePinRemoval: true },
       {
         onSuccess: () => {
           toast.success('Upgrading KiloClaw');
@@ -421,6 +438,15 @@ export function InstanceControls({
               </div>
             )}
           </RadioGroup>
+          {redeployMode === 'upgrade' && pinnedImageTag && (
+            <Alert className="border-blue-500/50">
+              <Pin className="h-4 w-4 text-blue-500" />
+              <AlertDescription>
+                This instance has a version pin to <code className="text-xs">{pinnedImageTag}</code>
+                {'. Upgrading will remove the pin.'}
+              </AlertDescription>
+            </Alert>
+          )}
           <DialogFooter>
             <Button
               variant="outline"
@@ -437,7 +463,17 @@ export function InstanceControls({
                   instance_status: status.status,
                   redeploy_mode: redeployMode,
                 });
-                mutations.restartMachine.mutate(imageTag ? { imageTag } : undefined, {
+                // For the upgrade path, the dialog click is the consent —
+                // pass acknowledgePinRemoval so the backend can clear any
+                // existing pin and proceed. Plain redeploy (no imageTag)
+                // never triggers the gate.
+                const input =
+                  imageTag === 'latest'
+                    ? { imageTag, acknowledgePinRemoval: true }
+                    : imageTag
+                      ? { imageTag }
+                      : undefined;
+                mutations.restartMachine.mutate(input, {
                   onSuccess: () => {
                     toast.success(
                       redeployMode === 'upgrade' ? 'Upgrading KiloClaw' : 'Redeploying'
@@ -479,6 +515,7 @@ export function InstanceControls({
         }}
         isPending={mutations.restartMachine.isPending}
         onConfirm={handleUpgradeConfirm}
+        pinnedImageTag={pinnedImageTag}
       />
       <RunDoctorDialog
         open={doctorOpen}

--- a/apps/web/src/app/(app)/claw/components/StartKiloCliRunDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/StartKiloCliRunDialog.tsx
@@ -76,8 +76,12 @@ export function StartKiloCliRunDialog({
   };
 
   const handleRedeploy = () => {
+    // The "needs redeploy" prompt the user just clicked is itself the
+    // consent — pass acknowledgePinRemoval so the backend gate clears any
+    // existing pin and proceeds. Backend ignores the flag when no pin
+    // exists. (See kiloclaw.restartMachine consent gate.)
     redeployMutation.mutate(
-      { imageTag: 'latest' },
+      { imageTag: 'latest', acknowledgePinRemoval: true },
       {
         onSuccess: () => {
           startMutation.reset();

--- a/apps/web/src/app/(app)/claw/components/StartKiloCliRunDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/StartKiloCliRunDialog.tsx
@@ -15,6 +15,8 @@ import {
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import type { useKiloClawMutations } from '@/hooks/useKiloClaw';
+import { useKiloClawMyPin } from '@/hooks/useKiloClaw';
+import { useOrgKiloClawMyPin } from '@/hooks/useOrgKiloClaw';
 import type { PlatformStatusResponse } from '@/lib/kiloclaw/types';
 import { useClawContext } from './ClawContext';
 import { AnimatedDots } from './AnimatedDots';
@@ -47,6 +49,13 @@ export function StartKiloCliRunDialog({
   const [prompt, setPrompt] = useState('');
   const startMutation = mutations.startKiloCliRun;
   const redeployMutation = mutations.restartMachine;
+
+  // Pin state — surfaced inline on the redeploy prompt so the user knows
+  // their pin will be cleared when they click Upgrade & Redeploy here.
+  const personalPin = useKiloClawMyPin();
+  const orgPin = useOrgKiloClawMyPin(organizationId ?? '');
+  const pin = organizationId ? orgPin.data : personalPin.data;
+  const pinnedImageTag = pin?.image_tag ?? null;
 
   const needsRedeploy = startMutation.isError && isNeedsRedeployError(startMutation.error);
   const machineReady = machineStatus === 'running';
@@ -124,6 +133,13 @@ export function StartKiloCliRunDialog({
               <p className="text-sm text-amber-200">
                 Your KiloClaw instance is running an older version that doesn&apos;t support the
                 recovery agent. Upgrade to the latest version to use this feature.
+                {pinnedImageTag && (
+                  <>
+                    {' '}
+                    This will also remove your version pin to{' '}
+                    <code className="text-xs">{pinnedImageTag}</code>.
+                  </>
+                )}
               </p>
             </div>
             <DialogFooter>

--- a/apps/web/src/app/(app)/claw/components/StartKiloCliRunDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/StartKiloCliRunDialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { AlertTriangle, Loader2, RotateCw, Terminal } from 'lucide-react';
 import { toast } from 'sonner';
+import { TRPCClientError } from '@trpc/client';
 import {
   Dialog,
   DialogContent,
@@ -50,10 +51,14 @@ export function StartKiloCliRunDialog({
   const startMutation = mutations.startKiloCliRun;
   const redeployMutation = mutations.restartMachine;
 
-  // Pin state — surfaced inline on the redeploy prompt so the user knows
-  // their pin will be cleared when they click Upgrade & Redeploy here.
-  const personalPin = useKiloClawMyPin();
-  const orgPin = useOrgKiloClawMyPin(organizationId ?? '');
+  // Pin state surfaced inline on the redeploy prompt so the user knows
+  // their pin will be cleared. Only the active context queries (org vs
+  // personal) so we don't fire an org getMyPin with an empty
+  // organizationId.
+  const personalPin = useKiloClawMyPin({ enabled: !organizationId });
+  const orgPin = useOrgKiloClawMyPin(organizationId ?? '', {
+    enabled: !!organizationId,
+  });
   const pin = organizationId ? orgPin.data : personalPin.data;
   const pinnedImageTag = pin?.image_tag ?? null;
 
@@ -85,17 +90,32 @@ export function StartKiloCliRunDialog({
   };
 
   const handleRedeploy = () => {
-    // The "needs redeploy" prompt the user just clicked is itself the
-    // consent — pass acknowledgePinRemoval so the backend gate clears any
-    // existing pin and proceeds. Backend ignores the flag when no pin
-    // exists. (See kiloclaw.restartMachine consent gate.)
+    // Only ack what the warning actually rendered. If pinnedImageTag is
+    // null (no pin notice shown in the amber warning), send false; the
+    // backend gate catches any pin that appeared between render and
+    // click and surfaces PIN_EXISTS so the user can retry.
     redeployMutation.mutate(
-      { imageTag: 'latest', acknowledgePinRemoval: true },
+      { imageTag: 'latest', acknowledgePinRemoval: !!pinnedImageTag },
       {
         onSuccess: () => {
           startMutation.reset();
         },
-        onError: err => toast.error(err.message, { duration: 10000 }),
+        onError: err => {
+          if (
+            err instanceof TRPCClientError &&
+            err.data?.code === 'PRECONDITION_FAILED' &&
+            err.message === 'PIN_EXISTS'
+          ) {
+            if (organizationId) void orgPin.refetch();
+            else void personalPin.refetch();
+            toast.error(
+              'A version pin was set on this instance. Review the warning and try again.',
+              { duration: 10000 }
+            );
+            return;
+          }
+          toast.error(err.message, { duration: 10000 });
+        },
       }
     );
   };

--- a/apps/web/src/app/(app)/claw/components/UpgradeKiloClawDialog.tsx
+++ b/apps/web/src/app/(app)/claw/components/UpgradeKiloClawDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowUpCircle, RotateCw } from 'lucide-react';
+import { ArrowUpCircle, Pin, RotateCw } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { AnimatedDots } from './AnimatedDots';
 
@@ -20,11 +21,20 @@ export function UpgradeKiloClawDialog({
   onOpenChange,
   isPending,
   onConfirm,
+  pinnedImageTag,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   isPending: boolean;
   onConfirm: () => void;
+  /**
+   * If the instance has a version pin, surface the override warning so the
+   * user understands clicking Upgrade will clear the pin. Pass `null` /
+   * `undefined` when there is no pin. Pin attribution (user vs admin) is
+   * intentionally not surfaced to end users — the consent action is the
+   * same either way.
+   */
+  pinnedImageTag?: string | null;
 }) {
   return (
     <Dialog open={open} onOpenChange={isPending ? undefined : onOpenChange}>
@@ -41,6 +51,15 @@ export function UpgradeKiloClawDialog({
             </DialogDescription>
           </div>
         </DialogHeader>
+        {pinnedImageTag && (
+          <Alert className="border-blue-500/50">
+            <Pin className="h-4 w-4 text-blue-500" />
+            <AlertDescription>
+              This instance has a version pin to <code className="text-xs">{pinnedImageTag}</code>
+              {'. Upgrading will remove the pin.'}
+            </AlertDescription>
+          </Alert>
+        )}
         <DialogFooter className="gap-2 sm:gap-0">
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
             Cancel

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -22,6 +22,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { TRPCClientError } from '@trpc/client';
 import { useTRPC } from '@/lib/trpc/utils';
 import { calverAtLeast, cleanVersion } from '@/lib/kiloclaw/version';
 import { formatBytes, formatUptime, formatVolumeUsage } from '@/lib/kiloclaw/instance-display';
@@ -1583,8 +1584,11 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         // the click-time pre-flight check and the backend gate. Reroute
         // through the Change Version dialog so the admin sees and consents
         // to the override.
-        const code = (err as { data?: { code?: string } }).data?.code;
-        if (code === 'PRECONDITION_FAILED' && err.message === 'PIN_EXISTS') {
+        if (
+          err instanceof TRPCClientError &&
+          err.data?.code === 'PRECONDITION_FAILED' &&
+          err.message === 'PIN_EXISTS'
+        ) {
           const latestEntry = availableVersions.find(v => v.is_latest);
           if (latestEntry) setChangeVersionSelectedTag(latestEntry.image_tag);
           setChangeVersionDialogOpen(true);

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1619,6 +1619,21 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         });
       },
       onError: err => {
+        // PIN_EXISTS comes back when a pin appeared (or was stale) between
+        // dialog render and click. Refetch so the dialog re-renders with
+        // the current pin warning, and surface a clearer message than the
+        // raw upstream code.
+        if (
+          err instanceof TRPCClientError &&
+          err.data?.code === 'PRECONDITION_FAILED' &&
+          err.message === 'PIN_EXISTS'
+        ) {
+          void queryClient.invalidateQueries({
+            queryKey: trpc.admin.kiloclawVersions.getUserPin.queryKey(),
+          });
+          toast.error('A version pin was set on this instance. Review the warning and try again.');
+          return;
+        }
         toast.error(`Failed to change version: ${err.message}`);
       },
     })
@@ -3183,10 +3198,16 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
               <Button
                 onClick={() => {
                   if (!data || !changeVersionSelectedTag) return;
+                  // Only ack what the dialog actually rendered. If
+                  // changeVersionPinData is null (no warning shown), send
+                  // false; the backend gate catches any pin that appeared
+                  // between render and click and surfaces PIN_EXISTS,
+                  // which the onError handler routes back through this
+                  // dialog with the warning.
                   void machineChangeVersion({
                     instanceId: data.id,
                     imageTag: changeVersionSelectedTag,
-                    acknowledgeOverride: true,
+                    acknowledgeOverride: !!changeVersionPinData,
                   });
                 }}
                 disabled={!changeVersionSelectedTag || isChangingVersion}

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1579,6 +1579,17 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
         setAwaitingRestartCompletion(true);
       },
       onError: err => {
+        // Defensive fallback for the rare race where a pin appears between
+        // the click-time pre-flight check and the backend gate. Reroute
+        // through the Change Version dialog so the admin sees and consents
+        // to the override.
+        const code = (err as { data?: { code?: string } }).data?.code;
+        if (code === 'PRECONDITION_FAILED' && err.message === 'PIN_EXISTS') {
+          const latestEntry = availableVersions.find(v => v.is_latest);
+          if (latestEntry) setChangeVersionSelectedTag(latestEntry.image_tag);
+          setChangeVersionDialogOpen(true);
+          return;
+        }
         toast.error(`Failed to upgrade: ${err.message}`);
       },
     })
@@ -2757,7 +2768,19 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                     size="sm"
                     variant="outline"
                     disabled={machineActionPending || machineRestartBlocked || !hasRuntime}
-                    onClick={() => void machineUpgrade({ instanceId: data.id, imageTag: 'latest' })}
+                    onClick={() => {
+                      // Pre-flight: if a pin exists, route through the
+                      // Change Version dialog so the admin can see and
+                      // consent to the override. Avoids a confusing
+                      // PIN_EXISTS toast on the happy path.
+                      if (changeVersionPinData) {
+                        const latestEntry = availableVersions.find(v => v.is_latest);
+                        if (latestEntry) setChangeVersionSelectedTag(latestEntry.image_tag);
+                        setChangeVersionDialogOpen(true);
+                        return;
+                      }
+                      void machineUpgrade({ instanceId: data.id, imageTag: 'latest' });
+                    }}
                   >
                     {isMachineUpgrading ? (
                       <Loader2 className="mr-1 h-4 w-4 animate-spin" />
@@ -3142,7 +3165,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                     <strong>
                       {changeVersionPinData.pinned_by_email ?? changeVersionPinData.pinned_by}
                     </strong>
-                    . Proceeding will remove the pin.
+                    {'. Proceeding will remove the pin.'}
                   </AlertDescription>
                 </Alert>
               )}

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -55,6 +55,7 @@ import {
   ArrowUpDown,
   RefreshCw,
   Pin,
+  Tag,
   Rocket,
   Stethoscope,
   CheckCircle2,
@@ -1290,6 +1291,8 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
   const [resizeMachineDialogOpen, setResizeMachineDialogOpen] = useState(false);
   const [selectedMachineSize, setSelectedMachineSize] = useState<string>('performance-1x');
   const [resizeConfirmText, setResizeConfirmText] = useState('');
+  const [changeVersionDialogOpen, setChangeVersionDialogOpen] = useState(false);
+  const [changeVersionSelectedTag, setChangeVersionSelectedTag] = useState<string>('');
   const [resizePhase, setResizePhase] = useState<
     'idle' | 'stopping' | 'resizing' | 'starting' | 'waiting' | 'done' | 'error'
   >('idle');
@@ -1316,6 +1319,23 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     }),
     enabled: !!userId,
   });
+
+  // Pin + version catalog data for the Change Version dialog. React Query
+  // dedupes against the same queries used by VersionPinSection, so this is
+  // only one network request total per page.
+  const { data: changeVersionPinData } = useQuery({
+    ...trpc.admin.kiloclawVersions.getUserPin.queryOptions({
+      userId: userId ?? '',
+      instanceId,
+    }),
+    enabled: !!userId,
+  });
+  const { data: changeVersionListData } = useQuery(
+    trpc.admin.kiloclawVersions.listVersions.queryOptions({
+      status: 'available',
+      limit: 100,
+    })
+  );
 
   const sandboxId = data?.sandbox_id;
   const aeDiskUsage = useControllerTelemetryDiskUsage(sandboxId ?? '');
@@ -1560,6 +1580,31 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
       },
       onError: err => {
         toast.error(`Failed to upgrade: ${err.message}`);
+      },
+    })
+  );
+
+  // Change-version flow: lets an admin force the instance onto an arbitrary
+  // available image tag (upgrade or downgrade). Direction-agnostic. The
+  // backend gate at admin.kiloclawInstances.restartMachine deletes any
+  // existing pin when acknowledgeOverride is true, so the dialog UI is
+  // the consent surface.
+  const { mutateAsync: machineChangeVersion, isPending: isChangingVersion } = useMutation(
+    trpc.admin.kiloclawInstances.restartMachine.mutationOptions({
+      onSuccess: () => {
+        toast.success('Version change requested');
+        invalidateMachineQueries();
+        invalidateGatewayQueries();
+        setAwaitingRestartCompletion(true);
+        setChangeVersionDialogOpen(false);
+        setChangeVersionSelectedTag('');
+        // Pin may have been cleared as part of the override — refresh.
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.kiloclawVersions.getUserPin.queryKey(),
+        });
+      },
+      onError: err => {
+        toast.error(`Failed to change version: ${err.message}`);
       },
     })
   );
@@ -1848,8 +1893,40 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     isMachineStopping ||
     isMachineRedeploying ||
     isMachineUpgrading ||
+    isChangingVersion ||
     isRetryingRecovery ||
     isDestroyingFlyMachine;
+
+  // Whether the provider supports the imageTag override path on
+  // restartMachine. Fly redeploys with the new tag for real; docker-local
+  // updates DO state so the upgrade UX can be exercised in dev even
+  // though the actual local container is unchanged. Other providers
+  // (e.g. northflank) reject imageTag at the DO layer, so we hide the
+  // affordances that would just produce errors.
+  const supportsImageTagOverride = isFlyProvider || provider === 'docker-local';
+
+  // Change-version dialog helpers. The catalog `listVersions` is sorted by
+  // published_at desc. The instance's current trackedImageTag may or may
+  // not still be in the available catalog (it could have been disabled
+  // since); when missing, the older-version advisory is suppressed.
+  const currentTrackedImageTag = data?.workerStatus?.trackedImageTag ?? null;
+  const availableVersions = changeVersionListData?.items ?? [];
+  const availableVersionsForChange = availableVersions.filter(
+    v => v.image_tag !== currentTrackedImageTag
+  );
+  const currentVersionEntry = currentTrackedImageTag
+    ? (availableVersions.find(v => v.image_tag === currentTrackedImageTag) ?? null)
+    : null;
+  const selectedVersionEntry = changeVersionSelectedTag
+    ? (availableVersions.find(v => v.image_tag === changeVersionSelectedTag) ?? null)
+    : null;
+  const selectedIsOlder = !!(
+    selectedVersionEntry &&
+    currentVersionEntry &&
+    new Date(selectedVersionEntry.published_at).getTime() <
+      new Date(currentVersionEntry.published_at).getTime()
+  );
+
   const gatewayActionPending =
     isGatewayStarting ||
     isGatewayStopping ||
@@ -2675,7 +2752,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                   )}
                   Redeploy
                 </Button>
-                {isFlyProvider && (
+                {supportsImageTagOverride && (
                   <Button
                     size="sm"
                     variant="outline"
@@ -2688,6 +2765,21 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                       <ArrowUpCircle className="mr-1 h-4 w-4" />
                     )}
                     Upgrade to Latest
+                  </Button>
+                )}
+                {supportsImageTagOverride && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={machineActionPending || machineRestartBlocked || !hasRuntime}
+                    onClick={() => setChangeVersionDialogOpen(true)}
+                  >
+                    {isChangingVersion ? (
+                      <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                    ) : (
+                      <Tag className="mr-1 h-4 w-4" />
+                    )}
+                    Change Version…
                   </Button>
                 )}
                 <Button
@@ -2966,6 +3058,114 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                 onClick={() => void handleResize()}
               >
                 Confirm Resize
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        {/* Change Version Dialog */}
+        <Dialog
+          open={changeVersionDialogOpen}
+          onOpenChange={open => {
+            if (isChangingVersion) return;
+            setChangeVersionDialogOpen(open);
+            if (!open) setChangeVersionSelectedTag('');
+          }}
+        >
+          <DialogContent className="sm:max-w-[520px]">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Tag className="h-5 w-5" />
+                Change Version
+              </DialogTitle>
+              <DialogDescription className="pt-3">
+                Switch this instance to any available image tag. The instance will redeploy on the
+                chosen version. Direction-agnostic — works for upgrades and downgrades.
+                <span className="text-foreground mt-2 block font-medium">
+                  User: {data?.user_email ?? data?.user_id}
+                </span>
+                <span className="mt-2 block text-sm">
+                  Current:{' '}
+                  {currentTrackedImageTag ? (
+                    <code className="text-xs">{currentTrackedImageTag}</code>
+                  ) : (
+                    '—'
+                  )}
+                </span>
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4 py-4">
+              <div>
+                <label className="text-sm font-medium">Target version</label>
+                <Select
+                  value={changeVersionSelectedTag}
+                  onValueChange={setChangeVersionSelectedTag}
+                  disabled={isChangingVersion}
+                >
+                  <SelectTrigger className="mt-1 w-full">
+                    <SelectValue placeholder="Select a version..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableVersionsForChange.length === 0 ? (
+                      <div className="text-muted-foreground px-2 py-1.5 text-sm">
+                        No other available versions in catalog.
+                      </div>
+                    ) : (
+                      availableVersionsForChange.map(v => (
+                        <SelectItem key={v.image_tag} value={v.image_tag}>
+                          {v.image_tag} (OpenClaw {v.openclaw_version})
+                          {v.is_latest ? ' — latest' : ''}
+                        </SelectItem>
+                      ))
+                    )}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {selectedIsOlder && (
+                <Alert className="border-orange-500/50">
+                  <AlertTriangle className="h-4 w-4 text-orange-500" />
+                  <AlertDescription>
+                    The selected version is older than the instance is currently running. Older
+                    versions may be missing features or unable to read data written by newer
+                    versions.
+                  </AlertDescription>
+                </Alert>
+              )}
+
+              {changeVersionPinData && (
+                <Alert className="border-blue-500/50">
+                  <Pin className="h-4 w-4 text-blue-500" />
+                  <AlertDescription>
+                    This instance has a version pin to{' '}
+                    <code className="text-xs">{changeVersionPinData.image_tag}</code> set by{' '}
+                    <strong>
+                      {changeVersionPinData.pinned_by_email ?? changeVersionPinData.pinned_by}
+                    </strong>
+                    . Proceeding will remove the pin.
+                  </AlertDescription>
+                </Alert>
+              )}
+            </div>
+            <DialogFooter className="gap-2 sm:gap-0">
+              <DialogClose asChild>
+                <Button variant="secondary" disabled={isChangingVersion}>
+                  Cancel
+                </Button>
+              </DialogClose>
+              <Button
+                onClick={() => {
+                  if (!data || !changeVersionSelectedTag) return;
+                  void machineChangeVersion({
+                    instanceId: data.id,
+                    imageTag: changeVersionSelectedTag,
+                    acknowledgeOverride: true,
+                  });
+                }}
+                disabled={!changeVersionSelectedTag || isChangingVersion}
+              >
+                {isChangingVersion && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}
+                Apply
               </Button>
             </DialogFooter>
           </DialogContent>

--- a/apps/web/src/hooks/useKiloClaw.ts
+++ b/apps/web/src/hooks/useKiloClaw.ts
@@ -436,11 +436,13 @@ export function useKiloClawAvailableVersions(offset = 0, limit = 25) {
   );
 }
 
-export function useKiloClawMyPin() {
+export function useKiloClawMyPin(opts: { enabled?: boolean } = {}) {
+  const { enabled = true } = opts;
   const trpc = useTRPC();
   return useQuery(
     trpc.kiloclaw.getMyPin.queryOptions(undefined, {
       staleTime: 60_000, // pins don't change frequently
+      enabled,
     })
   );
 }

--- a/apps/web/src/hooks/useOrgKiloClaw.ts
+++ b/apps/web/src/hooks/useOrgKiloClaw.ts
@@ -146,10 +146,14 @@ export function useOrgKiloClawAvailableVersions(organizationId: string, offset =
   );
 }
 
-export function useOrgKiloClawMyPin(organizationId: string) {
+export function useOrgKiloClawMyPin(organizationId: string, opts: { enabled?: boolean } = {}) {
+  const { enabled = true } = opts;
   const trpc = useTRPC();
   return useQuery(
-    trpc.organizations.kiloclaw.getMyPin.queryOptions({ organizationId }, { staleTime: 60_000 })
+    trpc.organizations.kiloclaw.getMyPin.queryOptions(
+      { organizationId },
+      { staleTime: 60_000, enabled }
+    )
   );
 }
 

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -6,10 +6,12 @@ import {
   kilocode_users,
   kiloclaw_admin_audit_logs,
   kiloclaw_cli_runs,
+  kiloclaw_image_catalog,
   kiloclaw_inbound_email_aliases,
   kiloclaw_inbound_email_reserved_aliases,
   kiloclaw_instances,
   kiloclaw_subscriptions,
+  kiloclaw_version_pins,
 } from '@kilocode/db/schema';
 import { and, eq, inArray } from 'drizzle-orm';
 import { TRPCError } from '@trpc/server';
@@ -22,6 +24,7 @@ const mockGetKiloCliRunStatus: jest.Mock<any, any> = jest.fn();
 const mockCancelKiloCliRun: jest.Mock<any, any> = jest.fn();
 const mockStartKiloCliRun: jest.Mock<any, any> = jest.fn();
 const mockStart: jest.Mock<any, any> = jest.fn();
+const mockUserClientRestartMachine: jest.Mock<any, any> = jest.fn();
 const startedResponse = {
   ok: true,
   started: true,
@@ -60,6 +63,12 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => ({
       this.responseBody = responseBody;
     }
   },
+}));
+
+jest.mock('@/lib/kiloclaw/kiloclaw-user-client', () => ({
+  KiloClawUserClient: jest.fn().mockImplementation(() => ({
+    restartMachine: mockUserClientRestartMachine,
+  })),
 }));
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
@@ -145,6 +154,8 @@ beforeEach(async () => {
   mockStartKiloCliRun.mockReset();
   mockStart.mockReset();
   mockStart.mockResolvedValue(startedResponse);
+  mockUserClientRestartMachine.mockReset();
+  mockUserClientRestartMachine.mockResolvedValue({ success: true, message: 'restarting' });
   mockKiloClawInternalClient();
 });
 
@@ -1262,5 +1273,237 @@ describe('admin.kiloclawInstances.cancelKiloCliRun', () => {
       await db.delete(kiloclaw_instances).where(eq(kiloclaw_instances.id, destroyedInstance.id));
       /* eslint-enable drizzle/enforce-delete-with-where */
     }
+  });
+});
+
+describe('admin.kiloclawInstances.restartMachine pin override gate', () => {
+  // The pin row has an FK to kiloclaw_image_catalog.image_tag, so we
+  // need real catalog rows for the pin inserts in these tests. The
+  // restartMachine input regex (^[a-zA-Z0-9][a-zA-Z0-9._-]*$) rejects
+  // slashes and colons, so we use docker-tag-style identifiers here even
+  // though production catalog rows use full registry URLs.
+  const newerTag = 'admin-pin-gate-newer';
+  const olderTag = 'admin-pin-gate-older';
+  let testInstanceId: string;
+
+  beforeEach(async () => {
+    await db.insert(kiloclaw_image_catalog).values([
+      {
+        openclaw_version: '2026.4.10',
+        variant: 'default',
+        image_tag: newerTag,
+        image_digest: 'sha256:newer',
+        status: 'available',
+        published_at: new Date().toISOString(),
+      },
+      {
+        openclaw_version: '2026.3.1',
+        variant: 'default',
+        image_tag: olderTag,
+        image_digest: 'sha256:older',
+        status: 'available',
+        published_at: new Date(Date.now() - 30 * 86_400_000).toISOString(),
+      },
+    ]);
+
+    const [instance] = await db
+      .insert(kiloclaw_instances)
+      .values({
+        id: crypto.randomUUID(),
+        user_id: regularUser.id,
+        sandbox_id: `ki_${crypto.randomUUID().replace(/-/g, '')}`,
+      })
+      .returning({ id: kiloclaw_instances.id });
+    testInstanceId = instance.id;
+  });
+
+  afterEach(async () => {
+    /* eslint-disable drizzle/enforce-delete-with-where */
+    await db
+      .delete(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, testInstanceId));
+    await db.delete(kiloclaw_instances).where(eq(kiloclaw_instances.id, testInstanceId));
+    await db
+      .delete(kiloclaw_image_catalog)
+      .where(inArray(kiloclaw_image_catalog.image_tag, [newerTag, olderTag]));
+    /* eslint-enable drizzle/enforce-delete-with-where */
+  });
+
+  it('throws FORBIDDEN for non-admin callers', async () => {
+    const caller = await createCallerForUser(regularUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.restartMachine({
+        instanceId: testInstanceId,
+        imageTag: newerTag,
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    expect(mockUserClientRestartMachine).not.toHaveBeenCalled();
+  });
+
+  it('plain restart with no imageTag ignores pin state and never triggers the gate', async () => {
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: testInstanceId,
+      image_tag: newerTag,
+      pinned_by: regularUser.id,
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.restartMachine({
+      instanceId: testInstanceId,
+    });
+
+    expect(result).toEqual({ success: true, message: 'restarting' });
+    expect(mockUserClientRestartMachine).toHaveBeenCalledWith(undefined, expect.any(Object));
+
+    // Pin must remain untouched on plain restart.
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, testInstanceId));
+    expect(pins.length).toBe(1);
+  });
+
+  it('version change with no pin succeeds without acknowledgeOverride', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.restartMachine({
+      instanceId: testInstanceId,
+      imageTag: newerTag,
+    });
+
+    expect(result).toEqual({ success: true, message: 'restarting' });
+    expect(mockUserClientRestartMachine).toHaveBeenCalledWith(
+      { imageTag: newerTag },
+      expect.any(Object)
+    );
+  });
+
+  it('version change with user-set pin and no override throws PRECONDITION_FAILED', async () => {
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: testInstanceId,
+      image_tag: olderTag,
+      pinned_by: regularUser.id,
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.restartMachine({
+        instanceId: testInstanceId,
+        imageTag: newerTag,
+      })
+    ).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'PIN_EXISTS',
+    });
+
+    expect(mockUserClientRestartMachine).not.toHaveBeenCalled();
+
+    // Pin remains in place after a blocked attempt.
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, testInstanceId));
+    expect(pins.length).toBe(1);
+    expect(pins[0].pinned_by).toBe(regularUser.id);
+  });
+
+  it('version change with admin-set pin and no override throws PRECONDITION_FAILED', async () => {
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: testInstanceId,
+      image_tag: olderTag,
+      pinned_by: adminUser.id,
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.restartMachine({
+        instanceId: testInstanceId,
+        imageTag: newerTag,
+      })
+    ).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'PIN_EXISTS',
+    });
+
+    expect(mockUserClientRestartMachine).not.toHaveBeenCalled();
+  });
+
+  it('version change with acknowledgeOverride deletes a user-set pin and proceeds', async () => {
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: testInstanceId,
+      image_tag: olderTag,
+      pinned_by: regularUser.id,
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.restartMachine({
+      instanceId: testInstanceId,
+      imageTag: newerTag,
+      acknowledgeOverride: true,
+    });
+
+    expect(result).toEqual({ success: true, message: 'restarting' });
+    expect(mockUserClientRestartMachine).toHaveBeenCalledWith(
+      { imageTag: newerTag },
+      expect.any(Object)
+    );
+
+    // Pin row removed; no replacement admin pin written.
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, testInstanceId));
+    expect(pins.length).toBe(0);
+  });
+
+  it('version change with acknowledgeOverride deletes an admin-set pin and proceeds', async () => {
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: testInstanceId,
+      image_tag: olderTag,
+      pinned_by: adminUser.id,
+    });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.restartMachine({
+      instanceId: testInstanceId,
+      imageTag: newerTag,
+      acknowledgeOverride: true,
+    });
+
+    expect(result).toEqual({ success: true, message: 'restarting' });
+
+    // Pin row removed; the override path strips any pin regardless of pinned_by.
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, testInstanceId));
+    expect(pins.length).toBe(0);
+  });
+
+  it('is direction-agnostic — older imageTag works the same as newer', async () => {
+    // No pin: admin can switch to an older tag without override.
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawInstances.restartMachine({
+      instanceId: testInstanceId,
+      imageTag: olderTag,
+    });
+
+    expect(result).toEqual({ success: true, message: 'restarting' });
+    expect(mockUserClientRestartMachine).toHaveBeenCalledWith(
+      { imageTag: olderTag },
+      expect.any(Object)
+    );
+  });
+
+  it('NOT_FOUND when instance does not exist', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawInstances.restartMachine({
+        instanceId: crypto.randomUUID(),
+        imageTag: newerTag,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    expect(mockUserClientRestartMachine).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -6,6 +6,7 @@ import {
   kiloclaw_subscriptions,
   kiloclaw_email_log,
   kiloclaw_cli_runs,
+  kiloclaw_version_pins,
   kilocode_users,
 } from '@kilocode/db/schema';
 import type { KiloClawSubscriptionStatus } from '@kilocode/db/schema-types';
@@ -15,6 +16,7 @@ import {
 } from '@/lib/kiloclaw/inbound-email-alias';
 import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
 import { KiloClawUserClient } from '@/lib/kiloclaw/kiloclaw-user-client';
+import { pushPinToWorker } from '@/lib/kiloclaw/pin-sync';
 import {
   getActiveInstance,
   getInstanceById,
@@ -1209,6 +1211,12 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
             'Image tag must be alphanumeric with dots, hyphens, or underscores'
           )
           .optional(),
+        // When true, the admin has confirmed they are intentionally
+        // overriding any pin set on the instance (user-set or admin-set).
+        // The override deletes the pin row before redeploying. No
+        // replacement pin is written so the user retains the ability to
+        // re-pin afterward (Decision: encourage adoption of new releases).
+        acknowledgeOverride: z.boolean().default(false),
       })
     )
     .mutation(async ({ input }) => {
@@ -1227,6 +1235,50 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
 
       if (!row) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Instance not found' });
+      }
+
+      // Pin consent gate: an admin redeploy with a specific imageTag
+      // (whether forward-upgrading, downgrading, or switching variants)
+      // overrides whatever pin is currently set on the instance. The DO
+      // does not consult the pin table on restart, so the gate lives at
+      // the web layer where authorization context exists.
+      if (input.imageTag) {
+        const [pin] = await db
+          .select({
+            image_tag: kiloclaw_version_pins.image_tag,
+            pinned_by: kiloclaw_version_pins.pinned_by,
+          })
+          .from(kiloclaw_version_pins)
+          .where(eq(kiloclaw_version_pins.instance_id, input.instanceId))
+          .limit(1);
+
+        if (pin && !input.acknowledgeOverride) {
+          // Frontend uses its existing getUserPin query for pin details
+          // (current tag, set by user vs admin) to render the override
+          // confirmation dialog. Re-call with acknowledgeOverride: true
+          // proceeds.
+          throw new TRPCError({
+            code: 'PRECONDITION_FAILED',
+            message: 'PIN_EXISTS',
+          });
+        }
+
+        if (pin) {
+          // Admin override deletes the existing pin (whether user-set or
+          // admin-set). No replacement pin written — once the consent
+          // gate has been spent, the user is free to re-establish their
+          // own pin if they want to block the next change.
+          await db
+            .delete(kiloclaw_version_pins)
+            .where(eq(kiloclaw_version_pins.instance_id, input.instanceId));
+
+          // Sync the cleared pin into DO state. The follow-up restartMachine
+          // call overwrites trackedImageTag anyway, but pushing the clear
+          // keeps DB and DO state consistent if the restart fails after
+          // this point. Mirrors the removeMyPin / removePin pattern.
+          // Failures are logged inside pushPinToWorker.
+          await pushPinToWorker(row.user.id, input.instanceId, null);
+        }
       }
 
       const token = generateApiToken(row.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes });

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2949,11 +2949,66 @@ export const kiloclawRouter = createTRPCRouter({
               'Image tag must be alphanumeric with dots, hyphens, or underscores'
             )
             .optional(),
+          // When true, the caller has confirmed they understand a redeploy
+          // with imageTag will remove their existing user-set pin. The
+          // frontend Upgrade flow sets this after showing the user a
+          // confirmation dialog. Ignored when no pin exists or imageTag is
+          // omitted (a plain restart never touches pin state).
+          acknowledgePinRemoval: z.boolean().default(false),
         })
         .optional()
     )
     .mutation(async ({ ctx, input }) => {
       const instance = await getActiveInstance(ctx.user.id);
+      if (!instance) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'No active KiloClaw instance found' });
+      }
+
+      // Pin consent gate: when the caller is asking for a specific image
+      // tag (typically `latest`), surface a confirmation gate if a pin
+      // exists. Pins are advisory consent gates, not locks — the user is
+      // informed and consents, then the upgrade proceeds. This applies
+      // whether the pin was set by the user themselves or by an admin;
+      // both kinds are removable via the consent dialog. The DO does not
+      // consult the pin table on restart (push-on-write architecture from
+      // PR #2913), so the gate lives here at the web layer.
+      if (input?.imageTag) {
+        const [pin] = await db
+          .select({ image_tag: kiloclaw_version_pins.image_tag })
+          .from(kiloclaw_version_pins)
+          .where(eq(kiloclaw_version_pins.instance_id, instance.id))
+          .limit(1);
+
+        if (pin && !input.acknowledgePinRemoval) {
+          // Frontend handles this discriminator by surfacing a confirmation
+          // dialog and re-calling with acknowledgePinRemoval: true. Pin
+          // details for the dialog come from the existing getMyPin query;
+          // the dialog copy can differentiate user-set vs admin-set based
+          // on the pinned_by field returned there.
+          throw new TRPCError({
+            code: 'PRECONDITION_FAILED',
+            message: 'PIN_EXISTS',
+          });
+        }
+
+        if (pin) {
+          // Consent has been given — drop the pin row and proceed. Any
+          // pin is removable via this path (user-set or admin-set); the
+          // consent dialog is the protection, not the pinned_by check.
+          await db
+            .delete(kiloclaw_version_pins)
+            .where(eq(kiloclaw_version_pins.instance_id, instance.id));
+
+          // Sync the cleared pin into DO state. The follow-up restartMachine
+          // call below overwrites trackedImageTag anyway, but pushing the
+          // clear keeps DB and DO state consistent if the restart fails
+          // after this point. Mirrors the removeMyPin pattern. Failures are
+          // logged inside pushPinToWorker; we don't surface them here
+          // because the restart call is the operative side effect.
+          await pushPinToWorker(ctx.user.id, instance.id, null);
+        }
+      }
+
       const client = new KiloClawUserClient(
         generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
       );
@@ -3369,21 +3424,12 @@ export const kiloclawRouter = createTRPCRouter({
         });
       }
 
-      // Prevent users from overwriting admin-set pins
-      const [existingPin] = await db
-        .select({ pinned_by: kiloclaw_version_pins.pinned_by })
-        .from(kiloclaw_version_pins)
-        .where(eq(kiloclaw_version_pins.instance_id, instance.id))
-        .limit(1);
-
-      if (existingPin && existingPin.pinned_by !== ctx.user.id) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message:
-            'Your version is pinned by an admin. Contact your Kilo admin to change or remove the pin.',
-        });
-      }
-
+      // Pins are advisory consent metadata. Either the user or an admin
+      // can write/replace/delete the pin at any time — overrides happen
+      // through explicit upgrade/downgrade actions where the consent
+      // dialog enforces awareness, not through this metadata mutation.
+      // The upsert below handles overwriting any existing pin (including
+      // admin-set) with the caller's pin.
       let result: typeof kiloclaw_version_pins.$inferSelect | undefined;
       try {
         [result] = await db
@@ -3430,36 +3476,14 @@ export const kiloclawRouter = createTRPCRouter({
       throw new TRPCError({ code: 'NOT_FOUND', message: 'No active KiloClaw instance found' });
     }
 
-    // Atomically delete only self-set pins — the WHERE clause enforces the admin-pin guard
-    // so there's no TOCTOU race between checking pinned_by and deleting.
+    // Pins are advisory consent metadata — either the user or an admin
+    // can clear it at any time. Idempotent: if no row exists, we still
+    // push the clear to the DO so a previously-failed worker sync can be
+    // retried by simply calling removeMyPin again.
     const [deleted] = await db
       .delete(kiloclaw_version_pins)
-      .where(
-        and(
-          eq(kiloclaw_version_pins.instance_id, instance.id),
-          eq(kiloclaw_version_pins.pinned_by, ctx.user.id)
-        )
-      )
+      .where(eq(kiloclaw_version_pins.instance_id, instance.id))
       .returning();
-
-    if (!deleted) {
-      // No self-set pin was deleted. Either an admin pin exists (forbid),
-      // or no pin exists at all. In the latter case we still push the
-      // clear to the DO so a previously-failed worker sync can be retried
-      // by simply calling removeMyPin again.
-      const [existingPin] = await db
-        .select({ pinned_by: kiloclaw_version_pins.pinned_by })
-        .from(kiloclaw_version_pins)
-        .where(eq(kiloclaw_version_pins.instance_id, instance.id))
-        .limit(1);
-
-      if (existingPin) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message: 'Your version is pinned by an admin. Contact your Kilo admin to remove the pin.',
-        });
-      }
-    }
 
     const workerSync = await pushPinToWorker(ctx.user.id, instance.id, null);
 

--- a/apps/web/src/routers/kiloclaw-user-versions-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-user-versions-router.test.ts
@@ -11,6 +11,16 @@ import {
 } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const mockRestartMachine: jest.Mock<any, any> = jest.fn();
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+jest.mock('@/lib/kiloclaw/kiloclaw-user-client', () => ({
+  KiloClawUserClient: jest.fn().mockImplementation(() => ({
+    restartMachine: mockRestartMachine,
+  })),
+}));
+
 let userA: User;
 let userB: User;
 let adminUser: User;
@@ -311,18 +321,20 @@ describe('Authorization', () => {
     expect(resultB?.instance_id).toBe(userBInstanceId);
   });
 
-  it('removeMyPin only removes the current user pin (self-set)', async () => {
+  it("removeMyPin only touches the caller's own instance", async () => {
     const callerA = await createCallerForUser(userA.id);
     await callerA.kiloclaw.removeMyPin();
 
-    // UserA's pin should be deleted
+    // UserA's pin (on UserA's instance) should be deleted.
     const pinsA = await db
       .select()
       .from(kiloclaw_version_pins)
       .where(eq(kiloclaw_version_pins.instance_id, userAInstanceId));
     expect(pinsA.length).toBe(0);
 
-    // UserB's pin should still exist
+    // UserB's pin (on a different instance) is untouched. Pin removal is
+    // scoped to the caller's active instance, not to who originally set
+    // the pin row.
     const pinsB = await db
       .select()
       .from(kiloclaw_version_pins)
@@ -331,53 +343,64 @@ describe('Authorization', () => {
   });
 });
 
-describe('Admin-pin guard', () => {
+describe('Pin metadata mutations are unrestricted by who set the pin', () => {
+  // Pins are advisory consent metadata — either the user or an admin can
+  // write/replace/delete the pin at any time. Override awareness lives on
+  // the upgrade/downgrade paths via the consent dialog, not on these
+  // metadata mutations.
   afterEach(async () => {
     await db
       .delete(kiloclaw_version_pins)
       .where(eq(kiloclaw_version_pins.instance_id, userAInstanceId));
   });
 
-  it('setMyPin throws FORBIDDEN when an admin has pinned the user', async () => {
-    // Admin pins userA
+  it('setMyPin overwrites an admin-set pin with a user-set pin', async () => {
     await db.insert(kiloclaw_version_pins).values({
       instance_id: userAInstanceId,
       image_tag: availableVersion.image_tag,
       pinned_by: adminUser.id,
-      reason: 'Admin override',
+      reason: 'Admin set this',
     });
 
     const caller = await createCallerForUser(userA.id);
-    await expect(
-      caller.kiloclaw.setMyPin({
-        imageTag: availableVersion.image_tag,
-        reason: 'User trying to override',
-      })
-    ).rejects.toThrow('pinned by an admin');
-  });
-
-  it('removeMyPin throws FORBIDDEN when an admin has pinned the user', async () => {
-    // Admin pins userA
-    await db.insert(kiloclaw_version_pins).values({
-      instance_id: userAInstanceId,
-      image_tag: availableVersion.image_tag,
-      pinned_by: adminUser.id,
+    const result = await caller.kiloclaw.setMyPin({
+      imageTag: availableVersion.image_tag,
+      reason: 'User overrides',
     });
 
-    const caller = await createCallerForUser(userA.id);
-    await expect(caller.kiloclaw.removeMyPin()).rejects.toThrow('pinned by an admin');
+    expect(result.pinned_by).toBe(userA.id);
+    expect(result.reason).toBe('User overrides');
 
-    // Verify pin is still there
+    // The single pin row is now owned by the user.
     const pins = await db
       .select()
       .from(kiloclaw_version_pins)
       .where(eq(kiloclaw_version_pins.instance_id, userAInstanceId));
     expect(pins.length).toBe(1);
-    expect(pins[0].pinned_by).toBe(adminUser.id);
+    expect(pins[0].pinned_by).toBe(userA.id);
+  });
+
+  it('removeMyPin clears an admin-set pin', async () => {
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: userAInstanceId,
+      image_tag: availableVersion.image_tag,
+      pinned_by: adminUser.id,
+    });
+
+    const caller = await createCallerForUser(userA.id);
+    const result = await caller.kiloclaw.removeMyPin();
+
+    expect(result.success).toBe(true);
+    expect(result.deleted).toBe(true);
+
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, userAInstanceId));
+    expect(pins.length).toBe(0);
   });
 
   it('setMyPin succeeds when user has self-set pin', async () => {
-    // User pins themselves first
     await db.insert(kiloclaw_version_pins).values({
       instance_id: userAInstanceId,
       image_tag: availableVersion.image_tag,
@@ -392,5 +415,146 @@ describe('Admin-pin guard', () => {
 
     expect(result.reason).toBe('Updated by user');
     expect(result.pinned_by).toBe(userA.id);
+  });
+});
+
+describe('kiloclaw.restartMachine pin consent gate', () => {
+  beforeEach(() => {
+    mockRestartMachine.mockReset();
+    mockRestartMachine.mockResolvedValue({ success: true, message: 'restarting' });
+  });
+
+  afterEach(async () => {
+    await db
+      .delete(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, userAInstanceId));
+  });
+
+  it('plain restart (no imageTag) ignores pin state and never triggers the gate', async () => {
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: userAInstanceId,
+      image_tag: availableVersion.image_tag,
+      pinned_by: userA.id,
+    });
+
+    const caller = await createCallerForUser(userA.id);
+    const result = await caller.kiloclaw.restartMachine();
+
+    expect(result.success).toBe(true);
+    expect(mockRestartMachine).toHaveBeenCalledWith(undefined, expect.any(Object));
+
+    // Pin must remain untouched on plain restart.
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, userAInstanceId));
+    expect(pins.length).toBe(1);
+  });
+
+  it('upgrade with no pin succeeds without acknowledgePinRemoval', async () => {
+    const caller = await createCallerForUser(userA.id);
+    const result = await caller.kiloclaw.restartMachine({ imageTag: 'latest' });
+
+    expect(result.success).toBe(true);
+    expect(mockRestartMachine).toHaveBeenCalledWith({ imageTag: 'latest' }, expect.any(Object));
+  });
+
+  it('upgrade with user-set pin and no acknowledgement throws PRECONDITION_FAILED with PIN_EXISTS', async () => {
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: userAInstanceId,
+      image_tag: availableVersion.image_tag,
+      pinned_by: userA.id,
+    });
+
+    const caller = await createCallerForUser(userA.id);
+    await expect(caller.kiloclaw.restartMachine({ imageTag: 'latest' })).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'PIN_EXISTS',
+    });
+
+    // Worker must NOT be called when the gate blocks.
+    expect(mockRestartMachine).not.toHaveBeenCalled();
+
+    // Pin must remain in place after a blocked attempt.
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, userAInstanceId));
+    expect(pins.length).toBe(1);
+  });
+
+  it('upgrade with user-set pin and acknowledgePinRemoval=true deletes pin and proceeds', async () => {
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: userAInstanceId,
+      image_tag: availableVersion.image_tag,
+      pinned_by: userA.id,
+    });
+
+    const caller = await createCallerForUser(userA.id);
+    const result = await caller.kiloclaw.restartMachine({
+      imageTag: 'latest',
+      acknowledgePinRemoval: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockRestartMachine).toHaveBeenCalledWith({ imageTag: 'latest' }, expect.any(Object));
+
+    // Pin row removed.
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, userAInstanceId));
+    expect(pins.length).toBe(0);
+  });
+
+  it('upgrade against an admin-set pin without ack throws PRECONDITION_FAILED (consent gate, not lock-in)', async () => {
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: userAInstanceId,
+      image_tag: availableVersion.image_tag,
+      pinned_by: adminUser.id,
+    });
+
+    const caller = await createCallerForUser(userA.id);
+    await expect(caller.kiloclaw.restartMachine({ imageTag: 'latest' })).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'PIN_EXISTS',
+    });
+
+    expect(mockRestartMachine).not.toHaveBeenCalled();
+
+    // Admin pin must remain in place when the user has not yet consented.
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, userAInstanceId));
+    expect(pins.length).toBe(1);
+    expect(pins[0].pinned_by).toBe(adminUser.id);
+  });
+
+  it('upgrade against an admin-set pin with ack=true deletes the pin and proceeds', async () => {
+    // Pins are advisory consent gates; an informed user can override an
+    // admin pin via Upgrade just like their own pin. Either party can
+    // re-pin after if they want to block the next change.
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: userAInstanceId,
+      image_tag: availableVersion.image_tag,
+      pinned_by: adminUser.id,
+    });
+
+    const caller = await createCallerForUser(userA.id);
+    const result = await caller.kiloclaw.restartMachine({
+      imageTag: 'latest',
+      acknowledgePinRemoval: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockRestartMachine).toHaveBeenCalledWith({ imageTag: 'latest' }, expect.any(Object));
+
+    // Admin pin removed.
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, userAInstanceId));
+    expect(pins.length).toBe(0);
   });
 });

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -814,10 +814,41 @@ export const organizationKiloclawRouter = createTRPCRouter({
           .max(128)
           .regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/)
           .optional(),
+        // Mirrors kiloclaw-router.restartMachine: when the redeploy targets a
+        // specific image tag, any existing pin is treated as a consent gate.
+        // The frontend dialog click flips this to true; backend deletes the
+        // pin row and pushes the clear to DO state before redeploying.
+        acknowledgePinRemoval: z.boolean().default(false),
       })
     )
     .mutation(async ({ ctx, input }) => {
       const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
+
+      // Pin consent gate. Symmetric with the personal user path: any pin
+      // (set by org member or admin) requires explicit acknowledgement
+      // before a version-changing redeploy proceeds.
+      if (input.imageTag) {
+        const [pin] = await db
+          .select({ image_tag: kiloclaw_version_pins.image_tag })
+          .from(kiloclaw_version_pins)
+          .where(eq(kiloclaw_version_pins.instance_id, instance.id))
+          .limit(1);
+
+        if (pin && !input.acknowledgePinRemoval) {
+          throw new TRPCError({
+            code: 'PRECONDITION_FAILED',
+            message: 'PIN_EXISTS',
+          });
+        }
+
+        if (pin) {
+          await db
+            .delete(kiloclaw_version_pins)
+            .where(eq(kiloclaw_version_pins.instance_id, instance.id));
+          await pushPinToWorker(ctx.user.id, instance.id, null);
+        }
+      }
+
       const token = generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes });
       const client = new KiloClawUserClient(token);
       return client.restartMachine(input.imageTag ? { imageTag: input.imageTag } : undefined, {

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -1046,20 +1046,12 @@ export const organizationKiloclawRouter = createTRPCRouter({
         });
       }
 
-      const [existingPin] = await db
-        .select({ pinned_by: kiloclaw_version_pins.pinned_by })
-        .from(kiloclaw_version_pins)
-        .where(eq(kiloclaw_version_pins.instance_id, instance.id))
-        .limit(1);
-
-      if (existingPin && existingPin.pinned_by !== ctx.user.id) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message:
-            'Your version is pinned by an admin. Contact your Kilo admin to change or remove the pin.',
-        });
-      }
-
+      // Pins are advisory consent metadata. Either an org member or an
+      // admin can write/replace/delete the pin at any time — overrides
+      // happen through explicit upgrade/downgrade actions where the
+      // consent dialog enforces awareness, not through this metadata
+      // mutation. The upsert below handles overwriting any existing pin
+      // (including admin-set) with the caller's pin.
       let result: typeof kiloclaw_version_pins.$inferSelect | undefined;
       try {
         [result] = await db
@@ -1103,34 +1095,14 @@ export const organizationKiloclawRouter = createTRPCRouter({
   removeMyPin: organizationMemberMutationProcedure.mutation(async ({ ctx, input }) => {
     const instance = await requireOrgInstance(ctx.user.id, input.organizationId);
 
+    // Pins are advisory consent metadata — any org member or admin can
+    // clear it at any time. Idempotent: if no row exists, we still push
+    // the clear to the DO so a previously-failed worker sync can be
+    // retried by simply calling removeMyPin again.
     const [deleted] = await db
       .delete(kiloclaw_version_pins)
-      .where(
-        and(
-          eq(kiloclaw_version_pins.instance_id, instance.id),
-          eq(kiloclaw_version_pins.pinned_by, ctx.user.id)
-        )
-      )
+      .where(eq(kiloclaw_version_pins.instance_id, instance.id))
       .returning();
-
-    if (!deleted) {
-      // No self-set pin was deleted. Either an admin pin exists (forbid),
-      // or no pin exists at all. In the latter case we still push the
-      // clear to the DO so a previously-failed worker sync can be retried
-      // by simply calling removeMyPin again.
-      const [existingPin] = await db
-        .select({ pinned_by: kiloclaw_version_pins.pinned_by })
-        .from(kiloclaw_version_pins)
-        .where(eq(kiloclaw_version_pins.instance_id, instance.id))
-        .limit(1);
-
-      if (existingPin) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message: 'Your version is pinned by an admin. Contact your Kilo admin to remove the pin.',
-        });
-      }
-    }
 
     const workerSync = await pushPinToWorker(ctx.user.id, instance.id, null);
 


### PR DESCRIPTION
## Summary

Two behavior changes to KiloClaw version pins.

1. Pins move from a hard lock to an advisory consent gate. Setting or removing a pin no longer requires special permissions. Either the user or an admin can write or clear the pin on an instance at any time.

2. Any version change action (Upgrade to Latest, the new admin Change Version button, the Kilo CLI recovery redeploy) now consults the pin. If a pin exists, the action requires explicit acknowledgement. After the caller confirms, the pin is cleared and the redeploy proceeds.

## What changed

Backend procedures (kiloclaw.restartMachine, admin.kiloclawInstances.restartMachine, organization.kiloclaw.restartMachine):

- New input flag (acknowledgePinRemoval on user and org, acknowledgeOverride on admin). When imageTag is set and a pin exists, the procedure throws PRECONDITION_FAILED with message PIN_EXISTS unless the flag is true.
- On acknowledgement, the pin row is deleted and the cleared state is pushed to the instance Durable Object via the existing pushPinToWorker helper before the redeploy fires.

Pin write mutations (setMyPin and removeMyPin on user and org routers):

- Removed the FORBIDDEN guards that previously blocked users from overwriting an admin pin. Pins are advisory now, so any caller can update them.

End user UI:

- UpgradeKiloClawDialog shows a warning when a pin is present and lists the pinned image tag.
- The redeploy or upgrade dialog inside InstanceControls shows the same warning when the upgrade radio is selected.
- The Kilo CLI recovery dialog mentions pin clearance on the existing amber warning so the user is not surprised when the pin disappears after recovery.
- All four user facing call paths now send acknowledgePinRemoval true so the dialog click acts as consent.

Admin UI on the instance detail page:

- New Change Version button next to Upgrade to Latest. Opens a dialog with a version selector populated from the available catalog. Surfaces a warning when a pin is set, plus a soft advisory when the chosen version is older than the running version.
- Upgrade to Latest is now pin aware. If a pin exists, clicking it routes to the Change Version dialog so the admin can see what is being overridden and confirm. A defensive PIN_EXISTS error fallback covers the rare race where a pin appears between the click time check and the backend gate.
- Replaced the isFlyProvider gate on the version buttons with a capability flag that also includes docker-local, so local dev exercises the same flow.

## Verification

Manual checks against local dev:

- [x] Change Version dialog opens, version selector lists available catalog tags, instance redeploys on the chosen tag
- [x] Override prompt shown and acknowledged when an admin pin is set
- [x] Override prompt shown and acknowledged when a user pin is set
- [x] Older version advisory shown when the chosen tag was published before the running tag
- [x] Backend test suite passes locally (68 tests across user and admin routers)
- [x] format check, typecheck, and lint all pass

## Visual Changes

N/A