### PR TITLE
fix(gastown): token auto-refresh and mayor session persistence

### DIFF
--- a/services/gastown/container/plugin/client.ts
+++ b/services/gastown/container/plugin/client.ts
@@ -26,6 +26,43 @@ function isApiResponse(
   return typeof obj.success === 'boolean';
 }
 
+/**
+ * One-shot refresh of `process.env.GASTOWN_CONTAINER_TOKEN` via the
+ * worker's `/refresh-container-token` endpoint. Returns the fresh
+ * token on success, or null on any failure (network error, non-2xx,
+ * missing env). Used by the plugin clients to recover from a 401
+ * caused by an expired container JWT.
+ *
+ * Duplicates the container/src/token-refresh.ts helper to keep the
+ * plugin independent of the control-server bundle.
+ */
+async function refreshContainerTokenFromWorker(baseUrl: string): Promise<string | null> {
+  const current = process.env.GASTOWN_CONTAINER_TOKEN;
+  const townId = process.env.GASTOWN_TOWN_ID;
+  if (!current || !townId) return null;
+  try {
+    const resp = await fetch(`${baseUrl}/api/towns/${townId}/refresh-container-token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${current}`,
+      },
+      body: '{}',
+    });
+    if (!resp.ok) return null;
+    const body: unknown = await resp.json();
+    const token =
+      body && typeof body === 'object' && 'data' in body
+        ? (body as { data?: { token?: unknown } }).data?.token
+        : undefined;
+    if (typeof token !== 'string' || token.length === 0) return null;
+    process.env.GASTOWN_CONTAINER_TOKEN = token;
+    return token;
+  } catch {
+    return null;
+  }
+}
+
 export class GastownClient {
   private baseUrl: string;
   private containerToken: string | undefined;
@@ -51,25 +88,39 @@ export class GastownClient {
   }
 
   private async request<T>(url: string, init?: RequestInit): Promise<T> {
-    // Normalize headers so callers can pass plain objects, Headers instances, or tuples
-    const headers = new Headers(init?.headers);
-    headers.set('Content-Type', 'application/json');
-    // Prefer the live container token from process.env (refreshed by the
-    // TownDO alarm via POST /refresh-token), then the token captured at
-    // init, then the legacy per-agent JWT.
-    const authToken = process.env.GASTOWN_CONTAINER_TOKEN ?? this.containerToken ?? this.token;
-    headers.set('Authorization', `Bearer ${authToken}`);
-    // When using a container-scoped JWT, send agent identity headers so
-    // the auth middleware can populate agentId/rigId on routes that don't
-    // have :agentId/:rigId params (e.g. /triage/resolve, /mail).
-    if (process.env.GASTOWN_CONTAINER_TOKEN || this.containerToken) {
-      headers.set('X-Gastown-Agent-Id', this.agentId);
-      headers.set('X-Gastown-Rig-Id', this.rigId);
-    }
+    const doFetch = async (): Promise<Response> => {
+      // Normalize headers so callers can pass plain objects, Headers instances, or tuples.
+      // Rebuilt on every attempt so a refreshed token is picked up on retry.
+      const headers = new Headers(init?.headers);
+      headers.set('Content-Type', 'application/json');
+      // Prefer the live container token from process.env (refreshed by the
+      // TownDO alarm via POST /refresh-token or by refreshContainerTokenFromWorker),
+      // then the token captured at init, then the legacy per-agent JWT.
+      const authToken = process.env.GASTOWN_CONTAINER_TOKEN ?? this.containerToken ?? this.token;
+      headers.set('Authorization', `Bearer ${authToken}`);
+      // When using a container-scoped JWT, send agent identity headers so
+      // the auth middleware can populate agentId/rigId on routes that don't
+      // have :agentId/:rigId params (e.g. /triage/resolve, /mail).
+      if (process.env.GASTOWN_CONTAINER_TOKEN || this.containerToken) {
+        headers.set('X-Gastown-Agent-Id', this.agentId);
+        headers.set('X-Gastown-Rig-Id', this.rigId);
+      }
+      return fetch(url, { ...init, headers });
+    };
 
     let response: Response;
     try {
-      response = await fetch(url, { ...init, headers });
+      response = await doFetch();
+      // One-shot token refresh on 401: the running kilo serve child was
+      // spawned with a snapshot of env and doesn't see live updates to
+      // process.env. When the parent receives a 401, mint a fresh token
+      // via the worker and retry once.
+      if (response.status === 401) {
+        const fresh = await refreshContainerTokenFromWorker(this.baseUrl);
+        if (fresh) {
+          response = await doFetch();
+        }
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       throw new GastownApiError(`Network error: ${message}`, 0);
@@ -258,19 +309,29 @@ export class MayorGastownClient {
   }
 
   private async request<T>(url: string, init?: RequestInit): Promise<T> {
-    const headers = new Headers(init?.headers);
-    headers.set('Content-Type', 'application/json');
-    // Prefer live container token (refreshed via POST /refresh-token),
-    // then init-time token, then legacy per-agent JWT.
-    const authToken = process.env.GASTOWN_CONTAINER_TOKEN ?? this.containerToken ?? this.token;
-    headers.set('Authorization', `Bearer ${authToken}`);
-    if (process.env.GASTOWN_CONTAINER_TOKEN || this.containerToken) {
-      headers.set('X-Gastown-Agent-Id', this.agentId);
-    }
+    const doFetch = async (): Promise<Response> => {
+      const headers = new Headers(init?.headers);
+      headers.set('Content-Type', 'application/json');
+      // Prefer live container token (refreshed via POST /refresh-token
+      // or refreshContainerTokenFromWorker), then init-time token,
+      // then legacy per-agent JWT.
+      const authToken = process.env.GASTOWN_CONTAINER_TOKEN ?? this.containerToken ?? this.token;
+      headers.set('Authorization', `Bearer ${authToken}`);
+      if (process.env.GASTOWN_CONTAINER_TOKEN || this.containerToken) {
+        headers.set('X-Gastown-Agent-Id', this.agentId);
+      }
+      return fetch(url, { ...init, headers });
+    };
 
     let response: Response;
     try {
-      response = await fetch(url, { ...init, headers });
+      response = await doFetch();
+      if (response.status === 401) {
+        const fresh = await refreshContainerTokenFromWorker(this.baseUrl);
+        if (fresh) {
+          response = await doFetch();
+        }
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       throw new GastownApiError(`Network error: ${message}`, 0);

--- a/services/gastown/container/src/agent-runner.ts
+++ b/services/gastown/container/src/agent-runner.ts
@@ -565,6 +565,8 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
       branch: request.branch,
       startPoint: request.startPoint,
       defaultBranch: request.defaultBranch,
+      envVars,
+      gitUrl: request.gitUrl,
     });
 
     // Set up git credentials so the agent can push

--- a/services/gastown/container/src/control-server.ts
+++ b/services/gastown/container/src/control-server.ts
@@ -16,6 +16,8 @@ import {
   isDraining,
   getAgentEvents,
   registerEventSink,
+  refreshTokenForAllAgents,
+  listAgents,
 } from './process-manager';
 import { log } from './logger';
 import { startHeartbeat, stopHeartbeat, notifyContainerReady } from './heartbeat';
@@ -247,16 +249,43 @@ app.post('/dashboard-context', async c => {
 
 // POST /refresh-token
 // Hot-swap the container-scoped JWT on the running process. Called by
-// the TownDO alarm to push a fresh token before the current one expires.
-// Updates process.env so all subsequent API calls use the new token.
+// the TownDO alarm (or the user-facing "Refresh Token" button) to push
+// a fresh token before the current one expires.
+//
+// Updating `process.env.GASTOWN_CONTAINER_TOKEN` alone is not enough:
+// the spawned `kilo serve` child processes snapshot the parent env at
+// spawn time, so the mayor plugin reads the OLD token. To propagate
+// the new token to every agent, we restart each running agent's SDK
+// server — matching the model hot-swap path.
 app.post('/refresh-token', async c => {
   const body: unknown = await c.req.json().catch(() => null);
   if (!body || typeof body !== 'object' || !('token' in body) || typeof body.token !== 'string') {
     return c.json({ error: 'Missing or invalid token field' }, 400);
   }
   process.env.GASTOWN_CONTAINER_TOKEN = body.token;
-  console.log('[control-server] Container token refreshed');
-  return c.json({ refreshed: true });
+
+  const activeAgents = listAgents().filter(a => a.status === 'running' || a.status === 'starting');
+  log.info('refresh_token.received', {
+    agentCount: activeAgents.length,
+    agentIds: activeAgents.map(a => a.agentId),
+  });
+
+  const t0 = Date.now();
+  const results = await refreshTokenForAllAgents();
+  const successCount = results.filter(r => r.success).length;
+  log.info('refresh_token.completed', {
+    agentCount: results.length,
+    successCount,
+    failureCount: results.length - successCount,
+    totalMs: Date.now() - t0,
+  });
+
+  return c.json({
+    refreshed: true,
+    agentsRestarted: successCount,
+    agentsFailed: results.length - successCount,
+    results,
+  });
 });
 
 // POST /sync-config

--- a/services/gastown/container/src/git-manager.ts
+++ b/services/gastown/container/src/git-manager.ts
@@ -1,8 +1,25 @@
-import { mkdir, realpath, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import type { CloneOptions, WorktreeOptions } from './types';
 
 const WORKSPACE_ROOT = '/workspace/rigs';
+
+// Message fragments that indicate a git authentication failure. git CLI
+// doesn't surface HTTP status codes directly; we match on stderr.
+const AUTH_FAILURE_PATTERNS = [
+  /\b(401|403)\b/,
+  /Authentication failed/i,
+  /could not read Username/i,
+  /terminal prompts disabled/i,
+  /fatal: unable to access.*The requested URL returned error:\s*(401|403)/i,
+  /Invalid username or (password|token)/i,
+  /remote: (Invalid|Bad|Write access to repository not granted)/i,
+];
+
+function isAuthFailure(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return AUTH_FAILURE_PATTERNS.some(re => re.test(msg));
+}
 
 // ── Per-rig mutex ────────────────────────────────────────────────────────
 // Git operations (clone, fetch, worktree add/remove) on the same bare repo
@@ -180,6 +197,222 @@ async function assertInsideWorkspace(targetPath: string): Promise<void> {
   }
 }
 
+/**
+ * Call the worker's refresh-git-token endpoint to obtain a fresh GitHub
+ * App installation token. Updates process.env.GIT_TOKEN and rewrites
+ * per-repo credential-store files so subsequent git operations (including
+ * the agent's own `git push`) pick up the new token.
+ *
+ * Returns the new token on success, or null if the refresh failed (no
+ * integration configured, network error, auth rejected, etc.).
+ *
+ * Callers: retry-on-auth-failure wrapper in git-manager, periodic refresh
+ * timer in process-manager (if added).
+ */
+export async function refreshGitToken(rigId: string): Promise<string | null> {
+  const apiUrl = process.env.GASTOWN_API_URL;
+  const townId = process.env.GASTOWN_TOWN_ID;
+  const token = process.env.GASTOWN_CONTAINER_TOKEN;
+  if (!apiUrl || !townId || !token) {
+    console.warn(
+      `[refreshGitToken] missing env: apiUrl=${!!apiUrl} townId=${!!townId} containerToken=${!!token}`
+    );
+    return null;
+  }
+
+  try {
+    const resp = await fetch(
+      `${apiUrl}/api/towns/${townId}/rigs/${rigId}/refresh-git-token`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '(unreadable)');
+      console.warn(
+        `[refreshGitToken] worker returned ${resp.status} for rig=${rigId}: ${body.slice(0, 200)}`
+      );
+      return null;
+    }
+    const raw: unknown = await resp.json();
+    if (
+      !raw ||
+      typeof raw !== 'object' ||
+      !('data' in raw) ||
+      !raw.data ||
+      typeof raw.data !== 'object' ||
+      !('token' in raw.data) ||
+      typeof (raw.data as { token: unknown }).token !== 'string'
+    ) {
+      console.warn(`[refreshGitToken] unexpected response shape for rig=${rigId}`);
+      return null;
+    }
+    const freshToken = (raw.data as { token: string }).token;
+
+    // Update process.env so subsequent exec() calls (which inherit
+    // process.env) see the new token via authenticateGitUrl.
+    process.env.GIT_TOKEN = freshToken;
+
+    // Rewrite the per-rig /tmp/.git-credentials* files that currently
+    // store a token. The credential helper reads these verbatim, so the
+    // agent's own `git push` (running in a subprocess outside this module)
+    // picks up the new token on the next invocation without restart.
+    //
+    // Scoped to the current rig only — both configureGitCredentials and
+    // configureRepoCredentials slugify a path containing the rigId into
+    // the credential filename, so we can select them by substring match.
+    // Rewriting every file would clobber other rigs' tokens (each rig can
+    // have a distinct platformIntegrationId, so tokens are not interchangeable).
+    await rewriteCredentialStoreFiles(rigId, freshToken);
+
+    console.log(`[refreshGitToken] refreshed token for rig=${rigId}`);
+    return freshToken;
+  } catch (err) {
+    console.warn(`[refreshGitToken] failed for rig=${rigId}:`, err);
+    return null;
+  }
+}
+
+/**
+ * Walk /tmp for credential-store files previously written by
+ * configureRepoCredentials / configureGitCredentials for the given rig
+ * and rewrite them to use the new token. Files for other rigs are left
+ * alone so this refresh doesn't stomp their (possibly distinct) tokens.
+ *
+ * Files are identified by the slugified rigId appearing in the filename
+ * (both writers embed a path under `/workspace/rigs/<rigId>/...` in the
+ * credential file name, slugified via `replace(/[^a-zA-Z0-9]/g, '-')`).
+ * Only GitHub `x-access-token` lines are rewritten; GitLab `oauth2`
+ * lines are left alone (they use gitlab_token, not an installation token).
+ */
+async function rewriteCredentialStoreFiles(rigId: string, freshToken: string): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await readdir('/tmp');
+  } catch {
+    return;
+  }
+
+  const rigSlug = rigId.replace(/[^a-zA-Z0-9]/g, '-');
+
+  for (const name of entries) {
+    if (!name.startsWith('.git-credentials')) continue;
+    if (!name.includes(rigSlug)) continue;
+    const path = `/tmp/${name}`;
+    let content: string;
+    try {
+      content = await readFile(path, 'utf8');
+    } catch {
+      continue;
+    }
+
+    // Credential line format: https://x-access-token:<token>@<host>\n
+    // Only rewrite lines using x-access-token (GitHub). Leave oauth2
+    // (GitLab) lines alone so we don't replace gitlab_token with a
+    // GitHub token.
+    const rewritten = content
+      .split('\n')
+      .map(line => {
+        if (!line.startsWith('https://x-access-token:')) return line;
+        const match = line.match(/^(https:\/\/x-access-token:)[^@]+(@.+)$/);
+        if (!match) return line;
+        return `${match[1]}${freshToken}${match[2]}`;
+      })
+      .join('\n');
+
+    if (rewritten !== content) {
+      try {
+        await writeFile(path, rewritten, { mode: 0o600 });
+      } catch (err) {
+        console.warn(`[refreshGitToken] failed to rewrite ${path}:`, err);
+      }
+    }
+  }
+}
+
+/**
+ * Run a git operation that uses GIT_TOKEN. On auth failure (401/403),
+ * refresh the token via the worker endpoint and retry once with the
+ * caller-rebuilt args (so authenticated URLs pick up the new token).
+ *
+ * `buildArgs` is called again on retry so callers that embed the token
+ * in a URL (e.g. `git clone https://<token>@...`) can regenerate it.
+ *
+ * For operations that talk to `origin` (fetch, pull, push without a URL
+ * arg), pass `gitUrl` so that after refresh we rewrite the `origin`
+ * remote URL with the new token. Git reads the embedded password from
+ * the remote URL before consulting the credential helper, so without
+ * this the retry would re-send the same expired token.
+ */
+async function execWithAuthRetry(
+  cmd: string,
+  buildArgs: () => string[] | Promise<string[]>,
+  opts: {
+    cwd?: string;
+    rigId: string;
+    envVars?: Record<string, string>;
+    /** Git URL to rebuild `origin` with after a token refresh. */
+    gitUrl?: string;
+  }
+): Promise<string> {
+  try {
+    const args = await buildArgs();
+    return await exec(cmd, args, opts.cwd);
+  } catch (err) {
+    if (!isAuthFailure(err)) throw err;
+
+    const rawMsg = err instanceof Error ? err.message.split('\n')[0] : String(err);
+    console.warn(
+      `[execWithAuthRetry] auth failure for rig=${opts.rigId}, refreshing token and retrying: ${redactGitTokens(rawMsg)}`
+    );
+
+    const fresh = await refreshGitToken(opts.rigId);
+    if (!fresh) {
+      throw err;
+    }
+
+    // Mutate the caller's envVars map in place so subsequent calls in
+    // the same workflow (e.g. mergeBranch → push after fetch) use the
+    // fresh token without another round-trip.
+    if (opts.envVars) {
+      opts.envVars.GIT_TOKEN = fresh;
+    }
+
+    // If the operation uses the `origin` remote, its stored URL still
+    // has the old token embedded. Rewrite it before retrying so the
+    // retry sends the fresh token.
+    if (opts.gitUrl && opts.cwd) {
+      try {
+        await exec(
+          'git',
+          ['remote', 'set-url', 'origin', authenticateGitUrl(opts.gitUrl, opts.envVars)],
+          opts.cwd
+        );
+      } catch (setUrlErr) {
+        const m = setUrlErr instanceof Error ? setUrlErr.message.split('\n')[0] : String(setUrlErr);
+        console.warn(
+          `[execWithAuthRetry] failed to rewrite origin URL for rig=${opts.rigId}: ${redactGitTokens(m)}`
+        );
+      }
+    }
+
+    const retryArgs = await buildArgs();
+    return await exec(cmd, retryArgs, opts.cwd);
+  }
+}
+
+/**
+ * Redact tokens from a string that may include authenticated git URLs
+ * (e.g. `https://x-access-token:<token>@github.com/...` or
+ * `https://oauth2:<token>@gitlab.com/...`). Used on every error string
+ * and log line that could contain a command line or git stderr, so an
+ * auth failure never leaks the token.
+ */
+function redactGitTokens(s: string): string {
+  return s.replace(/(https?:\/\/)([^:@/\s]+):([^@/\s]+)(@)/g, '$1$2:***REDACTED***$4');
+}
+
 async function exec(cmd: string, args: string[], cwd?: string): Promise<string> {
   const proc = Bun.spawn([cmd, ...args], {
     cwd,
@@ -204,7 +437,9 @@ async function exec(cmd: string, args: string[], cwd?: string): Promise<string> 
 
   if (exitCode !== 0) {
     const stderr = await new Response(proc.stderr).text();
-    throw new Error(`${cmd} ${args.join(' ')} failed: ${stderr || `exit code ${exitCode}`}`);
+    const cmdLine = redactGitTokens(`${cmd} ${args.join(' ')}`);
+    const detail = redactGitTokens(stderr || `exit code ${exitCode}`);
+    throw new Error(`${cmdLine} failed: ${detail}`);
   }
 
   return stdout.trim();
@@ -252,15 +487,24 @@ async function cloneRepoInner(
   validateGitUrl(options.gitUrl);
   validateBranchName(options.defaultBranch, 'defaultBranch');
   const dir = await repoDir(options.rigId);
-  const authUrl = authenticateGitUrl(options.gitUrl, options.envVars);
 
   if (await pathExists(join(dir, '.git'))) {
-    // Update the remote URL in case the token changed
-    await exec('git', ['remote', 'set-url', 'origin', authUrl], dir).catch(err => {
+    // Update the remote URL in case the token changed. Re-resolve authUrl
+    // inside the retry wrapper so a refreshed GIT_TOKEN is picked up.
+    await execWithAuthRetry(
+      'git',
+      () => ['remote', 'set-url', 'origin', authenticateGitUrl(options.gitUrl, options.envVars)],
+      { cwd: dir, rigId: options.rigId, envVars: options.envVars }
+    ).catch(err => {
       console.warn(`Failed to update remote URL for rig ${options.rigId}:`, err);
     });
     await configureRepoCredentials(dir, options.gitUrl, options.envVars);
-    await exec('git', ['fetch', '--all', '--prune'], dir);
+    await execWithAuthRetry('git', () => ['fetch', '--all', '--prune'], {
+      cwd: dir,
+      rigId: options.rigId,
+      envVars: options.envVars,
+      gitUrl: options.gitUrl,
+    });
     console.log(`Fetched latest for rig ${options.rigId}`);
     return dir;
   }
@@ -270,7 +514,7 @@ async function cloneRepoInner(
     await rm(dir, { recursive: true, force: true });
   }
 
-  const hasAuth = authUrl !== options.gitUrl;
+  const hasAuth = authenticateGitUrl(options.gitUrl, options.envVars) !== options.gitUrl;
   console.log(
     `Cloning repo for rig ${options.rigId}: hasAuth=${hasAuth} envKeys=[${Object.keys(options.envVars ?? {}).join(',')}]`
   );
@@ -279,7 +523,11 @@ async function cloneRepoInner(
   // exist yet, so `git clone --branch <branch>` would fail with
   // "Remote branch <branch> not found in upstream origin".
   await mkdir(dir, { recursive: true });
-  await exec('git', ['clone', '--no-checkout', authUrl, dir]);
+  await execWithAuthRetry(
+    'git',
+    () => ['clone', '--no-checkout', authenticateGitUrl(options.gitUrl, options.envVars), dir],
+    { rigId: options.rigId, envVars: options.envVars }
+  );
   await configureRepoCredentials(dir, options.gitUrl, options.envVars);
 
   // Detect empty repo: git rev-parse HEAD fails when there are no commits.
@@ -306,11 +554,20 @@ async function cloneRepoInner(
       ],
       dir
     );
-    await exec('git', ['push', 'origin', `HEAD:${options.defaultBranch}`], dir);
+    await execWithAuthRetry(
+      'git',
+      () => ['push', 'origin', `HEAD:${options.defaultBranch}`],
+      { cwd: dir, rigId: options.rigId, envVars: options.envVars, gitUrl: options.gitUrl }
+    );
     // Best-effort: set remote HEAD so future operations know the default branch
     await exec('git', ['remote', 'set-head', 'origin', options.defaultBranch], dir).catch(() => {});
     // Fetch so origin/<defaultBranch> ref is available locally
-    await exec('git', ['fetch', 'origin'], dir);
+    await execWithAuthRetry('git', () => ['fetch', 'origin'], {
+      cwd: dir,
+      rigId: options.rigId,
+      envVars: options.envVars,
+      gitUrl: options.gitUrl,
+    });
     console.log(`Created initial commit on empty repo for rig ${options.rigId}`);
   }
 
@@ -332,7 +589,10 @@ async function createWorktreeInner(options: WorktreeOptions): Promise<string> {
 
   if (await pathExists(dir)) {
     await exec('git', ['checkout', options.branch], dir);
-    await exec('git', ['pull', '--rebase', '--autostash'], dir).catch(() => {
+    await execWithAuthRetry('git', () => ['pull', '--rebase', '--autostash'], {
+      cwd: dir,
+      rigId: options.rigId,
+    }).catch(() => {
       // Pull may fail if remote branch doesn't exist yet; that's fine
     });
     console.log(`Reused existing worktree at ${dir}`);
@@ -436,7 +696,10 @@ async function setupBrowseWorktreeInner(rigId: string, defaultBranch: string): P
     // origin/<defaultBranch>. The worktree lives on the synthetic
     // browse-<rigId> branch, not on <defaultBranch> directly.
     try {
-      await exec('git', ['fetch', 'origin', defaultBranch], browseDir);
+      await execWithAuthRetry('git', () => ['fetch', 'origin', defaultBranch], {
+        cwd: browseDir,
+        rigId,
+      });
       await exec('git', ['reset', '--hard', `origin/${defaultBranch}`], browseDir);
       console.log(`Updated browse worktree for rig ${rigId} at ${browseDir}`);
     } catch (err) {
@@ -514,7 +777,6 @@ export async function mergeBranch(options: {
   validateGitUrl(options.gitUrl);
 
   const repo = await repoDir(options.rigId);
-  const authUrl = authenticateGitUrl(options.gitUrl, options.envVars);
 
   // Ensure repo exists and is up to date
   if (!(await pathExists(join(repo, '.git')))) {
@@ -525,9 +787,20 @@ export async function mergeBranch(options: {
       envVars: options.envVars,
     });
   } else {
-    // Update remote URL for fresh token
-    await exec('git', ['remote', 'set-url', 'origin', authUrl], repo).catch(() => {});
-    await exec('git', ['fetch', '--all', '--prune'], repo);
+    // Update remote URL for fresh token. Re-resolve inside the retry
+    // wrapper so a refreshed token replaces the expired one embedded
+    // in the remote URL.
+    await execWithAuthRetry(
+      'git',
+      () => ['remote', 'set-url', 'origin', authenticateGitUrl(options.gitUrl, options.envVars)],
+      { cwd: repo, rigId: options.rigId, envVars: options.envVars }
+    ).catch(() => {});
+    await execWithAuthRetry('git', () => ['fetch', '--all', '--prune'], {
+      cwd: repo,
+      rigId: options.rigId,
+      envVars: options.envVars,
+      gitUrl: options.gitUrl,
+    });
   }
 
   // Create a temporary worktree for the merge on the target branch
@@ -573,7 +846,11 @@ export async function mergeBranch(options: {
     const commitSha = await exec('git', ['rev-parse', 'HEAD'], mergeDir);
 
     // Push the merge commit to the target branch on the remote
-    await exec('git', ['push', 'origin', `${tmpBranch}:${options.targetBranch}`], mergeDir);
+    await execWithAuthRetry(
+      'git',
+      () => ['push', 'origin', `${tmpBranch}:${options.targetBranch}`],
+      { cwd: mergeDir, rigId: options.rigId, envVars: options.envVars, gitUrl: options.gitUrl }
+    );
 
     return { status: 'merged', message: 'Merge successful', commitSha };
   } finally {

--- a/services/gastown/container/src/git-manager.ts
+++ b/services/gastown/container/src/git-manager.ts
@@ -592,6 +592,8 @@ async function createWorktreeInner(options: WorktreeOptions): Promise<string> {
     await execWithAuthRetry('git', () => ['pull', '--rebase', '--autostash'], {
       cwd: dir,
       rigId: options.rigId,
+      envVars: options.envVars,
+      gitUrl: options.gitUrl,
     }).catch(() => {
       // Pull may fail if remote branch doesn't exist yet; that's fine
     });

--- a/services/gastown/container/src/heartbeat.ts
+++ b/services/gastown/container/src/heartbeat.ts
@@ -1,4 +1,5 @@
 import { listAgents } from './process-manager';
+import { fetchFreshContainerToken } from './token-refresh';
 import type { HeartbeatPayload } from './types';
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
@@ -118,19 +119,30 @@ async function sendHeartbeats(): Promise<void> {
       containerInstanceId: CONTAINER_INSTANCE_ID,
     };
 
+    const url = `${gastownApiUrl}/api/towns/${agent.townId}/rigs/${agent.rigId}/agents/${agent.agentId}/heartbeat`;
+    const doPost = (token: string) =>
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      });
+
     try {
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${currentToken}`,
-      };
-      const response = await fetch(
-        `${gastownApiUrl}/api/towns/${agent.townId}/rigs/${agent.rigId}/agents/${agent.agentId}/heartbeat`,
-        {
-          method: 'POST',
-          headers,
-          body: JSON.stringify(payload),
+      let response = await doPost(currentToken);
+      // On 401, mint a fresh token via the worker's refresh endpoint
+      // (it tolerates expired tokens) and retry once.
+      if (response.status === 401) {
+        console.warn(
+          `Heartbeat 401 for agent ${agent.agentId} — attempting one-shot token refresh`
+        );
+        const fresh = await fetchFreshContainerToken();
+        if (fresh) {
+          response = await doPost(fresh);
         }
-      );
+      }
 
       if (!response.ok) {
         console.warn(

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -992,7 +992,15 @@ async function subscribeToEvents(
     }
   } finally {
     clearIdleTimer(agent.agentId);
-    eventAbortControllers.delete(agent.agentId);
+    // Only clear the map entry if it still points at *our* controller.
+    // A concurrent refresh/model-swap may have already stored a fresh
+    // controller for a new subscription; an unconditional delete here
+    // would strand that stream with no way to abort it on future
+    // stops or refreshes.
+    const current = eventAbortControllers.get(agent.agentId);
+    if (current === controller) {
+      eventAbortControllers.delete(agent.agentId);
+    }
   }
 }
 
@@ -1370,9 +1378,16 @@ export async function sendMessage(agentId: string, prompt: string): Promise<void
   // accepted so the message survives a container crash mid-response.
   // Polecats/refineries/triage have different session semantics (fresh
   // session per dispatch) and rely on exit/drain snapshots.
+  //
+  // Prefer process.env.GASTOWN_CONTAINER_TOKEN over agent.gastownContainerToken:
+  // /refresh-token updates the env var first (process.env.GASTOWN_CONTAINER_TOKEN
+  // = body.token) and only then restarts agents, so the live env token is
+  // always at least as fresh as the cached field. Using the cached field
+  // first would 401 the snapshot upload after rotation and lose the turn
+  // we are trying to preserve.
   if (agent.role === 'mayor') {
     const apiUrl = agent.gastownApiUrl;
-    const token = agent.gastownContainerToken ?? process.env.GASTOWN_CONTAINER_TOKEN ?? null;
+    const token = process.env.GASTOWN_CONTAINER_TOKEN ?? agent.gastownContainerToken ?? null;
     if (apiUrl && token) {
       void saveDbSnapshot(agentId, apiUrl, token, agent.rigId, agent.townId);
     }
@@ -1442,9 +1457,17 @@ const LIVE_ENV_KEYS = new Set([
  * - Start from `agent.startupEnv` (original dispatch env).
  * - For every key in `LIVE_ENV_KEYS`, read from `process.env` so live
  *   updates (container-token refresh, config sync) are picked up.
- * - Never include `KILO_CONFIG_CONTENT` / `OPENCODE_CONFIG_CONTENT`:
- *   the caller is responsible for setting these on `process.env`
- *   before the SDK restart if the model changed.
+ * - `KILO_CONFIG_CONTENT` / `OPENCODE_CONFIG_CONTENT` handling:
+ *     - Model hot-swap (`updateAgentModel`) rebuilds these for the new
+ *       model and writes them to `agent.startupEnv` before calling this
+ *       helper, so picking them up from `startupEnv` keeps the hot-swap
+ *       agent-specific.
+ *     - Token refresh does not touch the model, so `startupEnv` already
+ *       carries the correct per-agent config. Pulling it in here
+ *       guarantees each agent restart sets its own config on
+ *       `process.env` before `ensureSDKServer` spawns, even when a
+ *       different agent's config was last left in the global env by a
+ *       previous model swap or refresh.
  * - Overlay town-config custom `env_vars` so values added/changed
  *   after the initial dispatch are honoured. Infra keys in
  *   `LIVE_ENV_KEYS` and `RESERVED_ENV_KEYS` always win.
@@ -1457,7 +1480,6 @@ function buildLiveHotSwapEnv(agent: ManagedAgent): Record<string, string> {
   const env: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(agent.startupEnv)) {
-    if (key === 'KILO_CONFIG_CONTENT' || key === 'OPENCODE_CONFIG_CONTENT') continue;
     if (LIVE_ENV_KEYS.has(key)) {
       const live = process.env[key];
       if (live) env[key] = live;
@@ -1554,9 +1576,18 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
 export async function refreshTokenForAllAgents(): Promise<
   Array<{ agentId: string; success: boolean; durationMs: number; error?: string }>
 > {
-  const snapshot = [...agents.values()].filter(
-    a => a.status === 'running' || a.status === 'starting'
-  );
+  // Only restart fully-running agents. A `starting` agent may not yet
+  // have a `sessionId` or an `sdkInstances` entry (still hydrating the
+  // DB or waiting on ensureSDKServer), and racing the startup path
+  // would leave duplicate subscriptions, an over-counted sessionCount,
+  // or an orphan server that never closes. `startAgent()` already
+  // reads `process.env.GASTOWN_CONTAINER_TOKEN` when it spawns the
+  // SDK server, so an agent that is still starting will pick up the
+  // fresh token on its own as part of normal startup — no restart
+  // needed. Agents in any terminal state (`exited`, `failed`, etc.)
+  // are also skipped: restarting them would revive a process that the
+  // completion/exit path already tore down.
+  const snapshot = [...agents.values()].filter(a => a.status === 'running');
 
   // Restart agents in parallel. Each agent has its own workdir (and
   // therefore its own sdkInstances key), so the Map mutations don't
@@ -1776,6 +1807,8 @@ export async function updateAgentModel(
   const oldModel = agent.model;
   const prevConfigContent = process.env.KILO_CONFIG_CONTENT;
   const prevOpenCodeContent = process.env.OPENCODE_CONFIG_CONTENT;
+  const prevStartupConfig = agent.startupEnv.KILO_CONFIG_CONTENT;
+  const prevStartupOpenCode = agent.startupEnv.OPENCODE_CONFIG_CONTENT;
 
   console.log(
     `${MANAGER_LOG} updateAgentModel: restarting SDK server for agent ${agentId} with model=${model}`
@@ -1799,8 +1832,13 @@ export async function updateAgentModel(
     agent.startupEnv = { ...agent.startupEnv, GASTOWN_ORGANIZATION_ID: organizationId };
   }
 
-  // 2. Rebuild KILO_CONFIG_CONTENT with the new model and update process.env
-  //    so the next createKilo() spawns kilo serve with fresh config.
+  // 2. Rebuild KILO_CONFIG_CONTENT with the new model and persist it on
+  //    `agent.startupEnv` so subsequent hot-swaps (including token
+  //    refreshes performed by another code path) pick up the new model
+  //    instead of replaying the stale dispatch-time config. We also set
+  //    process.env as a secondary signal for any callers that read it
+  //    directly, but buildLiveHotSwapEnv is the authoritative source
+  //    now that it pulls KILO_CONFIG_CONTENT from startupEnv.
   const kilocodeToken = process.env.KILOCODE_TOKEN;
   if (kilocodeToken) {
     const configJson = buildKiloConfigContent(
@@ -1811,6 +1849,11 @@ export async function updateAgentModel(
     );
     process.env.KILO_CONFIG_CONTENT = configJson;
     process.env.OPENCODE_CONFIG_CONTENT = configJson;
+    agent.startupEnv = {
+      ...agent.startupEnv,
+      KILO_CONFIG_CONTENT: configJson,
+      OPENCODE_CONFIG_CONTENT: configJson,
+    };
   }
 
   // 3. Remove the old instance from the map so ensureSDKServer creates a
@@ -1820,9 +1863,10 @@ export async function updateAgentModel(
   agent.model = model;
 
   // Replay the full env from the initial dispatch so the new SDK server
-  // gets the same git identity, auth tokens, and plugin vars. Exclude
-  // KILO_CONFIG_CONTENT / OPENCODE_CONFIG_CONTENT — those were already
-  // rebuilt above with the new model and set on process.env.
+  // gets the same git identity, auth tokens, and plugin vars.
+  // KILO_CONFIG_CONTENT is now pulled from startupEnv (which we just
+  // updated above), making this hot-swap agent-specific even when
+  // process.env carries another agent's config.
   const hotSwapEnv = buildLiveHotSwapEnv(agent);
 
   try {
@@ -1922,6 +1966,21 @@ export async function updateAgentModel(
     if (prevConfigContent !== undefined) process.env.KILO_CONFIG_CONTENT = prevConfigContent;
     if (prevOpenCodeContent !== undefined)
       process.env.OPENCODE_CONFIG_CONTENT = prevOpenCodeContent;
+    // Also restore the startupEnv copy; buildLiveHotSwapEnv now reads
+    // from startupEnv, so a stale forward-config could carry over into
+    // the next hot-swap otherwise.
+    const restoredStartup = { ...agent.startupEnv };
+    if (prevStartupConfig === undefined) {
+      delete restoredStartup.KILO_CONFIG_CONTENT;
+    } else {
+      restoredStartup.KILO_CONFIG_CONTENT = prevStartupConfig;
+    }
+    if (prevStartupOpenCode === undefined) {
+      delete restoredStartup.OPENCODE_CONFIG_CONTENT;
+    } else {
+      restoredStartup.OPENCODE_CONFIG_CONTENT = prevStartupOpenCode;
+    }
+    agent.startupEnv = restoredStartup;
     throw err;
   }
 }

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -240,6 +240,68 @@ async function createSessionWithStaleDbFallback(
   return retryParsed.data.id;
 }
 
+/**
+ * Run `PRAGMA wal_checkpoint(TRUNCATE)` against kilo.db and return true
+ * only if the WAL is fully drained into the main db file.
+ *
+ * The pragma returns `(busy, log, checkpointed)` as a row:
+ *   busy=0 AND log == checkpointed  → WAL fully merged into main db
+ *   anything else                    → main db is stale vs the WAL
+ *
+ * Returning true on an incomplete checkpoint would cause the caller to
+ * upload a kilo.db that's missing recent writes (e.g. the just-accepted
+ * mayor turn), overwriting the remote snapshot with stale state.
+ */
+async function runWalCheckpoint(dbPath: string, agentId: string): Promise<boolean> {
+  try {
+    const checkpoint = Bun.spawn(
+      [
+        'bun',
+        '-e',
+        `const db = new (require("bun:sqlite").Database)(process.argv[1]);
+         const row = db.query("PRAGMA wal_checkpoint(TRUNCATE)").get();
+         process.stdout.write(JSON.stringify(row ?? null));`,
+        dbPath,
+      ],
+      { stdout: 'pipe', stderr: 'pipe' }
+    );
+    const exitCode = await checkpoint.exited;
+    const stdout = await new Response(checkpoint.stdout).text();
+    const stderr = await new Response(checkpoint.stderr).text();
+
+    if (exitCode !== 0) {
+      console.warn(`${MANAGER_LOG} WAL checkpoint exited ${exitCode} for ${agentId}: ${stderr}`);
+      return false;
+    }
+
+    // bun:sqlite returns the pragma row as an object. Accept snake_case,
+    // camelCase, or bare positional keys (`0`, `1`, `2`) defensively.
+    const parsed: unknown = stdout.trim() ? JSON.parse(stdout) : null;
+    if (!parsed || typeof parsed !== 'object') {
+      console.warn(`${MANAGER_LOG} WAL checkpoint returned no row for ${agentId}: ${stdout}`);
+      return false;
+    }
+    const row: Record<string, unknown> = { ...parsed };
+    const busy = Number(row.busy ?? row['0'] ?? 0);
+    const logFrames = Number(row.log ?? row['1'] ?? 0);
+    const checkpointed = Number(row.checkpointed ?? row['2'] ?? 0);
+
+    if (busy !== 0 || logFrames !== checkpointed) {
+      console.warn(
+        `${MANAGER_LOG} WAL checkpoint incomplete for ${agentId}: busy=${busy} log=${logFrames} checkpointed=${checkpointed}`
+      );
+      return false;
+    }
+    console.log(
+      `${MANAGER_LOG} WAL checkpoint succeeded for ${agentId} (frames=${checkpointed})`
+    );
+    return true;
+  } catch (err) {
+    console.warn(`${MANAGER_LOG} WAL checkpoint failed for ${agentId}:`, err);
+    return false;
+  }
+}
+
 async function saveDbSnapshot(
   agentId: string,
   apiUrl: string,
@@ -248,6 +310,8 @@ async function saveDbSnapshot(
   townId: string
 ): Promise<void> {
   const MANAGER_LOG = '[process-manager]';
+  const t0 = Date.now();
+  const role = agents.get(agentId)?.role ?? null;
   try {
     const dbDir = `/tmp/agent-home-${agentId}/.local/share/kilo`;
     const dbPath = `${dbDir}/kilo.db`;
@@ -257,25 +321,30 @@ async function saveDbSnapshot(
     // checkpoint the WAL into the main DB file before snapshotting so the
     // snapshot contains all data. Use bun's built-in SQLite to run PRAGMA
     // wal_checkpoint(TRUNCATE) which merges the WAL and truncates it.
-    try {
-      const checkpoint = Bun.spawn(
-        [
-          'bun',
-          '-e',
-          `new (require("bun:sqlite").Database)(process.argv[1]).run("PRAGMA wal_checkpoint(TRUNCATE)")`,
-          dbPath,
-        ],
-        { stdout: 'pipe', stderr: 'pipe' }
+    //
+    // `PRAGMA wal_checkpoint(TRUNCATE)` returns a row `(busy, log, checkpointed)`:
+    //   - busy=1 means another writer is holding the WAL and the checkpoint
+    //     was blocked. The main kilo.db is then stale relative to the WAL.
+    //   - log != checkpointed means the checkpoint only partially drained
+    //     the WAL, so again the main db file is missing recent writes.
+    //
+    // Either case means uploading kilo.db would overwrite the remote
+    // snapshot with a stale copy missing the messages this path is meant
+    // to preserve. Skip the upload in that case.
+    const checkpointOk = await runWalCheckpoint(dbPath, agentId);
+    if (!checkpointOk) {
+      console.warn(
+        `${MANAGER_LOG} Skipping DB snapshot for ${agentId}: WAL not fully checkpointed`
       );
-      const exitCode = await checkpoint.exited;
-      if (exitCode === 0) {
-        console.log(`${MANAGER_LOG} WAL checkpoint succeeded for ${agentId}`);
-      } else {
-        const stderr = await new Response(checkpoint.stderr).text();
-        console.warn(`${MANAGER_LOG} WAL checkpoint exited ${exitCode} for ${agentId}: ${stderr}`);
-      }
-    } catch (err) {
-      console.warn(`${MANAGER_LOG} WAL checkpoint failed for ${agentId}:`, err);
+      log.error('mayor.snapshot_failed', {
+        event: 'mayor.snapshot_failed',
+        agentId,
+        role,
+        durationMs: Date.now() - t0,
+        error: 'wal_checkpoint_incomplete',
+        success: false,
+      });
+      return;
     }
 
     const buffer = await fs.readFile(dbPath);
@@ -292,17 +361,42 @@ async function saveDbSnapshot(
     );
     if (!resp.ok) {
       console.warn(`${MANAGER_LOG} Failed to save DB snapshot for ${agentId}: ${resp.status}`);
+      log.error('mayor.snapshot_failed', {
+        event: 'mayor.snapshot_failed',
+        agentId,
+        role,
+        durationMs: Date.now() - t0,
+        sizeBytes: buffer.byteLength,
+        status: resp.status,
+        success: false,
+      });
       return;
     }
     console.log(
       `${MANAGER_LOG} Saved DB snapshot for agent ${agentId} (${buffer.byteLength} bytes)`
     );
+    log.info('mayor.snapshot_saved', {
+      event: 'mayor.snapshot_saved',
+      agentId,
+      role,
+      durationMs: Date.now() - t0,
+      sizeBytes: buffer.byteLength,
+      success: true,
+    });
   } catch (err) {
     if ((err as { code?: string }).code === 'ENOENT') {
       console.log(`${MANAGER_LOG} No kilo.db found for agent ${agentId}, skipping snapshot save`);
       return;
     }
     console.warn(`${MANAGER_LOG} DB snapshot save failed for agent ${agentId}:`, err);
+    log.error('mayor.snapshot_failed', {
+      event: 'mayor.snapshot_failed',
+      agentId,
+      role,
+      durationMs: Date.now() - t0,
+      error: err instanceof Error ? err.message : String(err),
+      success: false,
+    });
   }
 }
 
@@ -1271,6 +1365,18 @@ export async function sendMessage(agentId: string, prompt: string): Promise<void
 
   agent.messageCount++;
   agent.lastActivityAt = new Date().toISOString();
+
+  // Mayor-only: snapshot kilo.db immediately after the user message is
+  // accepted so the message survives a container crash mid-response.
+  // Polecats/refineries/triage have different session semantics (fresh
+  // session per dispatch) and rely on exit/drain snapshots.
+  if (agent.role === 'mayor') {
+    const apiUrl = agent.gastownApiUrl;
+    const token = agent.gastownContainerToken ?? process.env.GASTOWN_CONTAINER_TOKEN ?? null;
+    if (apiUrl && token) {
+      void saveDbSnapshot(agentId, apiUrl, token, agent.rigId, agent.townId);
+    }
+  }
 }
 
 /**
@@ -2097,11 +2203,28 @@ export async function drainAll(): Promise<void> {
         });
       }
 
-      // 4d: Save DB snapshot
+      // 4d: Save DB snapshot — await with a 10s timeout so a slow KV
+      // write doesn't block container exit, but log loudly if it times out.
+      // withTimeout clears the timer on success so we don't leave a ref'd
+      // setTimeout keeping the process alive after drain finishes.
       const apiUrl = agent.gastownApiUrl;
       const token = agent.gastownContainerToken ?? process.env.GASTOWN_CONTAINER_TOKEN ?? null;
       if (apiUrl && token) {
-        await saveDbSnapshot(agent.agentId, apiUrl, token, agent.rigId, agent.townId);
+        await withTimeout(
+          saveDbSnapshot(agent.agentId, apiUrl, token, agent.rigId, agent.townId),
+          10_000,
+          'drain snapshot'
+        ).catch(err => {
+          console.error(`${DRAIN_LOG} snapshot timeout/failure for ${agent.agentId}:`, err);
+          log.error('mayor.snapshot_failed', {
+            event: 'mayor.snapshot_failed',
+            agentId: agent.agentId,
+            role: agent.role,
+            error: err instanceof Error ? err.message : String(err),
+            phase: 'drain',
+            success: false,
+          });
+        });
       }
 
       // 4e: Report the agent as completed so the TownDO can unhook it
@@ -2151,11 +2274,29 @@ export async function stopAll(): Promise<void> {
       agent.status = 'exited';
       agent.exitReason = 'container shutdown';
 
-      // Save DB snapshot before completing shutdown
+      // Save DB snapshot before completing shutdown. Await with a 10s
+      // timeout so the container can exit promptly on a stuck KV write,
+      // but a loud error is emitted so we can observe snapshot drops.
+      // withTimeout clears the timer on success so stopAll doesn't return
+      // with a still-ref'd setTimeout delaying container exit.
       const apiUrl = agent.gastownApiUrl;
       const token = agent.gastownContainerToken ?? process.env.GASTOWN_CONTAINER_TOKEN ?? null;
       if (apiUrl && token) {
-        void saveDbSnapshot(agent.agentId, apiUrl, token, agent.rigId, agent.townId);
+        await withTimeout(
+          saveDbSnapshot(agent.agentId, apiUrl, token, agent.rigId, agent.townId),
+          10_000,
+          'stopAll snapshot'
+        ).catch(err => {
+          console.error(`[stop-all] snapshot timeout/failure for ${agent.agentId}:`, err);
+          log.error('mayor.snapshot_failed', {
+            event: 'mayor.snapshot_failed',
+            agentId: agent.agentId,
+            role: agent.role,
+            error: err instanceof Error ? err.message : String(err),
+            phase: 'stopAll',
+            success: false,
+          });
+        });
       }
     }
   }

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -18,6 +18,7 @@ import {
   RESERVED_ENV_KEYS,
 } from './control-server';
 import { log } from './logger';
+import { refreshTokenIfNearExpiry } from './token-refresh';
 
 const MANAGER_LOG = '[process-manager]';
 
@@ -1308,6 +1309,335 @@ function extractOrganizationId(agent?: ManagedAgent): string | undefined {
 const MAYOR_STARTUP_PROMPT = 'Mayor ready. Waiting for instructions.';
 
 /**
+ * Env keys that may be refreshed at runtime by `POST /sync-config` or
+ * `POST /refresh-token`. When rebuilding an agent's env for a live SDK
+ * server restart, these are read from `process.env` (freshest source)
+ * rather than `agent.startupEnv` (captured once at agent start).
+ */
+const LIVE_ENV_KEYS = new Set([
+  'GASTOWN_CONTAINER_TOKEN',
+  'GIT_TOKEN',
+  'GITLAB_TOKEN',
+  'GITLAB_INSTANCE_URL',
+  'GITHUB_CLI_PAT',
+  'GASTOWN_GIT_AUTHOR_NAME',
+  'GASTOWN_GIT_AUTHOR_EMAIL',
+  'GASTOWN_DISABLE_AI_COAUTHOR',
+  'KILOCODE_TOKEN',
+  'GASTOWN_ORGANIZATION_ID',
+]);
+
+/**
+ * Build the env for a fresh `kilo serve` process that replaces an
+ * agent's current SDK server. Used by both model hot-swap and
+ * token-refresh hot-swap.
+ *
+ * Rules:
+ * - Start from `agent.startupEnv` (original dispatch env).
+ * - For every key in `LIVE_ENV_KEYS`, read from `process.env` so live
+ *   updates (container-token refresh, config sync) are picked up.
+ * - Never include `KILO_CONFIG_CONTENT` / `OPENCODE_CONFIG_CONTENT`:
+ *   the caller is responsible for setting these on `process.env`
+ *   before the SDK restart if the model changed.
+ * - Overlay town-config custom `env_vars` so values added/changed
+ *   after the initial dispatch are honoured. Infra keys in
+ *   `LIVE_ENV_KEYS` and `RESERVED_ENV_KEYS` always win.
+ * - Remove custom keys that were previously applied but have been
+ *   dropped from the town config.
+ * - Re-derive `GH_TOKEN` from the live `GITHUB_CLI_PAT` > `GIT_TOKEN`
+ *   > `GITHUB_TOKEN` chain so a rotated token takes effect.
+ */
+function buildLiveHotSwapEnv(agent: ManagedAgent): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(agent.startupEnv)) {
+    if (key === 'KILO_CONFIG_CONTENT' || key === 'OPENCODE_CONFIG_CONTENT') continue;
+    if (LIVE_ENV_KEYS.has(key)) {
+      const live = process.env[key];
+      if (live) env[key] = live;
+      continue;
+    }
+    env[key] = value;
+  }
+  // Inject live values for LIVE_ENV_KEYS that were absent from startupEnv
+  // (e.g. GASTOWN_ORGANIZATION_ID added after initial dispatch).
+  for (const key of LIVE_ENV_KEYS) {
+    if (key in env) continue;
+    const live = process.env[key];
+    if (live) env[key] = live;
+  }
+
+  // Overlay custom env_vars from the town config so hot-swap picks up
+  // values that were added/changed after the initial dispatch. Infra
+  // keys in LIVE_ENV_KEYS and RESERVED_ENV_KEYS always take precedence.
+  const freshConfig = getCurrentTownConfig();
+  const freshEnvVars = freshConfig?.env_vars;
+  const freshCustomKeySet = new Set<string>();
+  if (freshEnvVars !== null && typeof freshEnvVars === 'object' && !Array.isArray(freshEnvVars)) {
+    for (const [key, value] of Object.entries(freshEnvVars as Record<string, unknown>)) {
+      if (LIVE_ENV_KEYS.has(key)) continue;
+      if (RESERVED_ENV_KEYS.has(key)) continue;
+      freshCustomKeySet.add(key);
+      if (value !== undefined && value !== null) {
+        env[key] = typeof value === 'string' ? value : JSON.stringify(value);
+      } else {
+        delete env[key];
+      }
+    }
+  }
+  // Remove stale custom env vars that the town config no longer carries.
+  for (const key of getLastAppliedEnvVarKeys()) {
+    if (!freshCustomKeySet.has(key) && !LIVE_ENV_KEYS.has(key)) {
+      delete env[key];
+    }
+  }
+
+  // Re-derive GH_TOKEN from live values using the same priority chain
+  // as buildAgentEnv: GITHUB_CLI_PAT > GIT_TOKEN > GITHUB_TOKEN.
+  const liveGhToken =
+    process.env.GITHUB_CLI_PAT ?? process.env.GIT_TOKEN ?? process.env.GITHUB_TOKEN;
+  if (liveGhToken) {
+    env.GH_TOKEN = liveGhToken;
+  } else {
+    delete env.GH_TOKEN;
+  }
+
+  return env;
+}
+
+// Per-agent timeout for the `ensureSDKServer` step of a token refresh.
+// Server startup normally takes ~1-2s; anything beyond 6s means the
+// spawn is stuck and we'd rather fall back to the old instance than
+// block the caller. The TownDO alarm path has a 10s outer timeout, so
+// each agent must finish well under that even with queuing effects
+// from the sdkServerLock.
+const REFRESH_AGENT_TIMEOUT_MS = 6_000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const handle = setTimeout(
+      () => reject(new Error(`timeout after ${ms}ms: ${label}`)),
+      ms
+    );
+    promise.then(
+      value => {
+        clearTimeout(handle);
+        resolve(value);
+      },
+      err => {
+        clearTimeout(handle);
+        reject(err);
+      }
+    );
+  });
+}
+
+/**
+ * Restart every running agent's SDK server so a newly-refreshed
+ * `GASTOWN_CONTAINER_TOKEN` (or any other LIVE_ENV_KEYS value in
+ * `process.env`) is inherited by the fresh `kilo serve` child process.
+ *
+ * The agent's session is preserved: the mayor resumes its existing
+ * session (conversation history intact); other agents keep their
+ * current session id, since kilo.db persists across the restart.
+ *
+ * Each agent is restarted independently; a failure to restart one
+ * agent never blocks the others. Returns a per-agent summary so the
+ * caller can log telemetry.
+ */
+export async function refreshTokenForAllAgents(): Promise<
+  Array<{ agentId: string; success: boolean; durationMs: number; error?: string }>
+> {
+  const snapshot = [...agents.values()].filter(
+    a => a.status === 'running' || a.status === 'starting'
+  );
+
+  // Restart agents in parallel. Each agent has its own workdir (and
+  // therefore its own sdkInstances key), so the Map mutations don't
+  // collide. Running serially would easily blow past the caller's
+  // 10s timeout once we have more than a couple of agents.
+  const restartAgent = async (
+    agent: ManagedAgent
+  ): Promise<{ agentId: string; success: boolean; durationMs: number; error?: string }> => {
+    const t0 = Date.now();
+    const oldInstance = sdkInstances.get(agent.workdir);
+    const oldSessionId = agent.sessionId;
+    const oldPort = agent.serverPort;
+    // Track the pending ensureSDKServer promise separately so the timeout
+    // path can clean up an orphan server if the spawn eventually resolves
+    // after we've already given up. withTimeout races the promise with a
+    // timer but cannot cancel the underlying spawn — the serialised SDK
+    // server creation may still install an instance into sdkInstances
+    // after we've restored the old one, leaking the fresh kilo serve child.
+    let pendingEnsure: Promise<{ client: KiloClient; port: number }> | null = null;
+    try {
+      const hotSwapEnv = buildLiveHotSwapEnv(agent);
+
+      // Tear down the existing SDK server so ensureSDKServer spawns
+      // a fresh kilo serve child with the updated env. We don't close
+      // it until after ensureSDKServer returns so fetch() during the
+      // window still has somewhere to land — but process.env changes
+      // are only visible to *new* child processes, so restarting the
+      // server is the only way to propagate the fresh token.
+      sdkInstances.delete(agent.workdir);
+
+      pendingEnsure = ensureSDKServer(agent.workdir, hotSwapEnv);
+      const { client, port } = await withTimeout(
+        pendingEnsure,
+        REFRESH_AGENT_TIMEOUT_MS,
+        `ensureSDKServer for ${agent.agentId}`
+      );
+      // Spawn completed within the timeout — no orphan to clean up.
+      pendingEnsure = null;
+      agent.serverPort = port;
+
+      // Resume the existing session. kilo.db is on disk and survives
+      // the restart, so session.list returns the prior session(s).
+      let newSessionId = oldSessionId;
+      let resumed = false;
+      try {
+        const existing = await withTimeout(
+          client.session.list(),
+          2_000,
+          `session.list for ${agent.agentId}`
+        );
+        const sessions = (existing.data ?? []) as Array<{
+          id: string;
+          time?: { updated?: number };
+        }>;
+        // Prefer the session we were already on; fall back to the most
+        // recently updated one if that id is no longer present.
+        const preferred = sessions.find(s => s.id === oldSessionId);
+        if (preferred) {
+          newSessionId = preferred.id;
+          resumed = true;
+        } else if (sessions.length > 0) {
+          const sorted = [...sessions].sort(
+            (a, b) => (b.time?.updated ?? 0) - (a.time?.updated ?? 0)
+          );
+          newSessionId = sorted[0].id;
+          resumed = true;
+        }
+      } catch (err) {
+        log.warn('refresh_token.session_list_failed', {
+          agentId: agent.agentId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      agent.sessionId = newSessionId;
+      const newInstance = sdkInstances.get(agent.workdir);
+      if (newInstance) newInstance.sessionCount++;
+
+      // New server is healthy — tear down the old one and its subscription.
+      if (oldInstance) {
+        const oldController = eventAbortControllers.get(agent.agentId);
+        if (oldController) oldController.abort();
+        try {
+          oldInstance.server.close();
+        } catch (err) {
+          log.warn('refresh_token.old_server_close_failed', {
+            agentId: agent.agentId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      // Re-subscribe to events on the new server so the agent keeps
+      // reporting activity after the swap.
+      void subscribeToEvents(client, agent, {
+        agentId: agent.agentId,
+        role: agent.role,
+        name: agent.name,
+        model: agent.model ?? '',
+        prompt: '',
+        rigId: agent.rigId,
+        townId: agent.townId,
+        identity: '',
+        gitUrl: '',
+        branch: '',
+        defaultBranch: '',
+      });
+
+      const durationMs = Date.now() - t0;
+      log.info('refresh_token.agent_restarted', {
+        agentId: agent.agentId,
+        role: agent.role,
+        name: agent.name,
+        oldPort,
+        newPort: port,
+        oldSessionId,
+        newSessionId,
+        resumed,
+        success: true,
+        durationMs,
+      });
+      return { agentId: agent.agentId, success: true, durationMs };
+    } catch (err) {
+      const durationMs = Date.now() - t0;
+      const message = err instanceof Error ? err.message : String(err);
+      // Restore the old SDK instance in the map so the agent keeps
+      // pointing at a tracked server. The old kilo serve child still
+      // has the stale token, but having SOME server is strictly better
+      // than having none: session.prompt still works, and the next
+      // refresh / model swap will pick it up again.
+      if (oldInstance && !sdkInstances.has(agent.workdir)) {
+        sdkInstances.set(agent.workdir, oldInstance);
+        agent.serverPort = oldPort;
+        agent.sessionId = oldSessionId;
+      }
+      // If ensureSDKServer is still in flight, attach a reaper: when it
+      // finally resolves it will have registered a fresh SDK instance
+      // under agent.workdir, clobbering the restored old one. We evict
+      // and close that orphan so we don't leak a kilo serve process or
+      // leave the agent pointing at an un-subscribed server.
+      if (pendingEnsure) {
+        const reapWorkdir = agent.workdir;
+        const reapAgentId = agent.agentId;
+        const reapOldInstance = oldInstance;
+        pendingEnsure.then(
+          ({ port: orphanPort }) => {
+            const orphan = sdkInstances.get(reapWorkdir);
+            if (!orphan || orphan === reapOldInstance) return;
+            sdkInstances.delete(reapWorkdir);
+            if (reapOldInstance) {
+              sdkInstances.set(reapWorkdir, reapOldInstance);
+            }
+            try {
+              orphan.server.close();
+            } catch (closeErr) {
+              log.warn('refresh_token.orphan_close_failed', {
+                agentId: reapAgentId,
+                error: closeErr instanceof Error ? closeErr.message : String(closeErr),
+              });
+            }
+            log.warn('refresh_token.orphan_reaped', {
+              agentId: reapAgentId,
+              orphanPort,
+            });
+          },
+          () => {
+            // ensureSDKServer itself rejected — nothing was installed, so
+            // nothing to reap. The original timeout error already logged.
+          }
+        );
+      }
+      log.error('refresh_token.agent_restarted', {
+        agentId: agent.agentId,
+        role: agent.role,
+        name: agent.name,
+        success: false,
+        durationMs,
+        error: message,
+      });
+      return { agentId: agent.agentId, success: false, durationMs, error: message };
+    }
+  };
+
+  return Promise.all(snapshot.map(restartAgent));
+}
+
+/**
  * Update the model for a running agent by restarting its SDK server with
  * new KILO_CONFIG_CONTENT. The kilo serve child process reads the model
  * from KILO_CONFIG_CONTENT at startup (highest config precedence after
@@ -1387,80 +1717,7 @@ export async function updateAgentModel(
   // gets the same git identity, auth tokens, and plugin vars. Exclude
   // KILO_CONFIG_CONTENT / OPENCODE_CONFIG_CONTENT — those were already
   // rebuilt above with the new model and set on process.env.
-  //
-  // For env vars that syncConfigToContainer can update at runtime, prefer
-  // the live process.env value over the stale startupEnv snapshot.
-  const LIVE_ENV_KEYS = new Set([
-    'GASTOWN_CONTAINER_TOKEN',
-    'GIT_TOKEN',
-    'GITLAB_TOKEN',
-    'GITLAB_INSTANCE_URL',
-    'GITHUB_CLI_PAT',
-    'GASTOWN_GIT_AUTHOR_NAME',
-    'GASTOWN_GIT_AUTHOR_EMAIL',
-    'GASTOWN_DISABLE_AI_COAUTHOR',
-    'KILOCODE_TOKEN',
-    'GASTOWN_ORGANIZATION_ID',
-  ]);
-  const hotSwapEnv: Record<string, string> = {};
-  for (const [key, value] of Object.entries(agent.startupEnv)) {
-    if (key === 'KILO_CONFIG_CONTENT' || key === 'OPENCODE_CONFIG_CONTENT') continue;
-    if (LIVE_ENV_KEYS.has(key)) {
-      const live = process.env[key];
-      if (live) hotSwapEnv[key] = live;
-      continue;
-    }
-    hotSwapEnv[key] = value;
-  }
-  // Inject live values for LIVE_ENV_KEYS that were absent from startupEnv
-  // (e.g. GASTOWN_ORGANIZATION_ID added after initial dispatch).
-  for (const key of LIVE_ENV_KEYS) {
-    if (key in hotSwapEnv) continue;
-    const live = process.env[key];
-    if (live) hotSwapEnv[key] = live;
-  }
-
-  // Overlay custom env_vars from the town config so hot-swap picks up
-  // values that were added/changed after the initial dispatch. Infra
-  // keys in LIVE_ENV_KEYS and RESERVED_ENV_KEYS always take precedence
-  // (LIVE_ENV_KEYS were already populated from process.env above;
-  // RESERVED_ENV_KEYS are runtime routing vars that must never be clobbered).
-  const freshConfig = getCurrentTownConfig();
-  const freshEnvVars = freshConfig?.env_vars;
-  const freshCustomKeySet = new Set<string>();
-  if (freshEnvVars !== null && typeof freshEnvVars === 'object' && !Array.isArray(freshEnvVars)) {
-    for (const [key, value] of Object.entries(freshEnvVars as Record<string, unknown>)) {
-      if (LIVE_ENV_KEYS.has(key)) continue;
-      if (RESERVED_ENV_KEYS.has(key)) continue;
-      freshCustomKeySet.add(key);
-      if (value !== undefined && value !== null) {
-        hotSwapEnv[key] = typeof value === 'string' ? value : JSON.stringify(value);
-      } else {
-        delete hotSwapEnv[key];
-      }
-    }
-  }
-  // Remove stale custom env vars — keys that were applied in a previous
-  // sync but are no longer in the town config. Without this, startupEnv
-  // keeps carrying deleted custom keys through every hot-swap.
-  for (const key of getLastAppliedEnvVarKeys()) {
-    if (!freshCustomKeySet.has(key) && !LIVE_ENV_KEYS.has(key)) {
-      delete hotSwapEnv[key];
-    }
-  }
-
-  // Re-derive GH_TOKEN from live values using the same priority chain
-  // as buildAgentEnv: GITHUB_CLI_PAT > GIT_TOKEN > GITHUB_TOKEN.
-  // syncConfigToContainer updates these on process.env, but buildAgentEnv
-  // only ran once at initial dispatch. When all sources are cleared,
-  // remove GH_TOKEN so the SDK server doesn't retain stale credentials.
-  const liveGhCliPat = process.env.GITHUB_CLI_PAT;
-  const liveGhToken = liveGhCliPat ?? process.env.GIT_TOKEN ?? process.env.GITHUB_TOKEN;
-  if (liveGhToken) {
-    hotSwapEnv.GH_TOKEN = liveGhToken;
-  } else {
-    delete hotSwapEnv.GH_TOKEN;
-  }
+  const hotSwapEnv = buildLiveHotSwapEnv(agent);
 
   try {
     // 4. Create a new SDK server (spawns a fresh kilo serve with updated env)
@@ -1920,14 +2177,26 @@ export async function bootHydration(): Promise<void> {
   const LOG = '[boot-hydration]';
   const apiUrl = process.env.GASTOWN_API_URL;
   const townId = process.env.GASTOWN_TOWN_ID;
-  const token = process.env.GASTOWN_CONTAINER_TOKEN;
+  const initialToken = process.env.GASTOWN_CONTAINER_TOKEN;
 
-  if (!apiUrl || !townId || !token) {
+  if (!apiUrl || !townId || !initialToken) {
     console.log(
       `${LOG} Missing GASTOWN_API_URL, GASTOWN_TOWN_ID, or GASTOWN_CONTAINER_TOKEN — skipping boot hydration`
     );
     return;
   }
+
+  // Proactively refresh the container token if it's near expiry. A cold
+  // container that was last stopped close to the 8h JWT TTL would
+  // otherwise boot with a token about to expire and fail on the first
+  // worker call. The refresh endpoint tolerates tokens that have just
+  // expired so this covers the cold-restart case too.
+  await refreshTokenIfNearExpiry();
+
+  // Re-read the token AFTER the potential refresh so subsequent calls
+  // (registry fetch, and the env maps we hand to hydrated agents) use
+  // the fresh value.
+  const token = process.env.GASTOWN_CONTAINER_TOKEN ?? initialToken;
 
   console.log(`${LOG} Fetching container registry for town=${townId}`);
   let registry: unknown;
@@ -1964,9 +2233,14 @@ export async function bootHydration(): Promise<void> {
       continue;
     }
 
+    // Registry entries were written with the token snapshot at dispatch
+    // time. If we just refreshed, overlay the fresh value so the hydrated
+    // kilo serve child inherits the current token.
+    const hydratedEnv = { ...env, GASTOWN_CONTAINER_TOKEN: token };
+
     console.log(`${LOG} Resuming agent ${agentId} in ${workdir}`);
     try {
-      await startAgent(agentRequest, workdir, env);
+      await startAgent(agentRequest, workdir, hydratedEnv);
       console.log(`${LOG} Agent ${agentId} resumed`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/services/gastown/container/src/token-refresh.ts
+++ b/services/gastown/container/src/token-refresh.ts
@@ -1,0 +1,131 @@
+/**
+ * Container-side helpers for self-refreshing the container JWT.
+ *
+ * Two use cases:
+ *  1. Boot-time: when bootHydration runs, check whether the token is
+ *     near expiry. If so, mint a fresh one before using it.
+ *  2. Reactive: when a call to the worker 401s, mint a fresh token
+ *     and retry once.
+ */
+
+import { log } from './logger';
+
+const MANAGER_LOG = '[token-refresh]';
+
+/**
+ * Return the number of milliseconds until the JWT `exp` claim.
+ * Returns `null` if the token is malformed or has no `exp`.
+ *
+ * This does NOT verify the token — it only reads the claim.
+ */
+export function msUntilTokenExpiry(token: string): number | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length < 2) return null;
+    const payload = parts[1];
+    // Base64-URL decode. Bun / modern runtimes support atob directly,
+    // but jwt uses URL-safe encoding, so we need to normalise first.
+    const normalised = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalised + '='.repeat((4 - (normalised.length % 4)) % 4);
+    const decoded = atob(padded);
+    const parsed: unknown = JSON.parse(decoded);
+    if (!parsed || typeof parsed !== 'object') return null;
+    const exp = (parsed as { exp?: unknown }).exp;
+    if (typeof exp !== 'number') return null;
+    return exp * 1000 - Date.now();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Call the worker's `/refresh-container-token` endpoint to mint a
+ * fresh container JWT. The current token (possibly expired, but
+ * still correctly signed) authenticates the request.
+ *
+ * On success, updates `process.env.GASTOWN_CONTAINER_TOKEN` and
+ * returns the new token. On failure, logs and returns null — the
+ * caller decides whether to proceed with the stale token or bail.
+ */
+export async function fetchFreshContainerToken(): Promise<string | null> {
+  const apiUrl = process.env.GASTOWN_API_URL;
+  const townId = process.env.GASTOWN_TOWN_ID;
+  const currentToken = process.env.GASTOWN_CONTAINER_TOKEN;
+
+  if (!apiUrl || !townId || !currentToken) {
+    log.warn('token_refresh.skipped_missing_env', {
+      hasApiUrl: !!apiUrl,
+      hasTownId: !!townId,
+      hasCurrentToken: !!currentToken,
+    });
+    return null;
+  }
+
+  const t0 = Date.now();
+  try {
+    const resp = await fetch(`${apiUrl}/api/towns/${townId}/refresh-container-token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${currentToken}`,
+      },
+      body: '{}',
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '');
+      log.warn('token_refresh.fetch_failed', {
+        status: resp.status,
+        durationMs: Date.now() - t0,
+        body: text.slice(0, 200),
+      });
+      return null;
+    }
+    const body: unknown = await resp.json();
+    const token =
+      body && typeof body === 'object' && 'data' in body
+        ? (body as { data?: { token?: unknown } }).data?.token
+        : undefined;
+    if (typeof token !== 'string' || token.length === 0) {
+      log.warn('token_refresh.invalid_response', { durationMs: Date.now() - t0 });
+      return null;
+    }
+    process.env.GASTOWN_CONTAINER_TOKEN = token;
+    log.info('token_refresh.succeeded', { durationMs: Date.now() - t0 });
+    return token;
+  } catch (err) {
+    log.warn('token_refresh.network_error', {
+      error: err instanceof Error ? err.message : String(err),
+      durationMs: Date.now() - t0,
+    });
+    return null;
+  }
+}
+
+/**
+ * Boot-time refresh: if the current container token expires within
+ * `thresholdMs` (default 30 minutes), proactively mint a fresh one.
+ */
+export async function refreshTokenIfNearExpiry(thresholdMs = 30 * 60_000): Promise<void> {
+  const current = process.env.GASTOWN_CONTAINER_TOKEN;
+  if (!current) {
+    console.log(`${MANAGER_LOG} no current container token — skipping near-expiry refresh`);
+    return;
+  }
+  const msLeft = msUntilTokenExpiry(current);
+  if (msLeft === null) {
+    console.log(`${MANAGER_LOG} token has no exp claim — skipping near-expiry refresh`);
+    return;
+  }
+  if (msLeft > thresholdMs) {
+    console.log(
+      `${MANAGER_LOG} token valid for ${Math.round(msLeft / 60_000)}m — skipping near-expiry refresh`
+    );
+    return;
+  }
+  log.info('token_refresh.boot_near_expiry', {
+    msUntilExpiry: msLeft,
+    thresholdMs,
+  });
+  await fetchFreshContainerToken();
+}

--- a/services/gastown/container/src/types.ts
+++ b/services/gastown/container/src/types.ts
@@ -308,6 +308,16 @@ export type WorktreeOptions = {
   startPoint?: string;
   /** Default branch name, used as fallback start point (e.g. 'main'). */
   defaultBranch?: string;
+  /**
+   * Env vars with the current GIT_TOKEN. If passed, execWithAuthRetry
+   * mutates this in place on a 401 so subsequent operations use the fresh token.
+   */
+  envVars?: Record<string, string>;
+  /**
+   * Authenticated git URL used to rewrite the `origin` remote if the
+   * embedded token expires during a reused-worktree pull.
+   */
+  gitUrl?: string;
 };
 
 // ── Repo setup (proactive clone + browse worktree) ──────────────────────

--- a/services/gastown/src/gastown.worker.ts
+++ b/services/gastown/src/gastown.worker.ts
@@ -146,6 +146,7 @@ import {
   handleContainerReady,
   handleDrainStatus,
 } from './handlers/town-eviction.handler';
+import { handleRefreshGitToken } from './handlers/refresh-git-token.handler';
 import { handleRefreshContainerToken } from './handlers/town-container-token.handler';
 
 export { GastownUserDO } from './dos/GastownUser.do';
@@ -497,6 +498,16 @@ app.post('/api/towns/:townId/rigs/:rigId/agents/:agentId/nudge-delivered', c =>
 
 // Agent-to-agent nudge: any authenticated agent can nudge another agent in the rig
 app.post('/api/towns/:townId/rigs/:rigId/nudge', c => handleNudge(c, c.req.param()));
+
+// ── Refresh Git Token ──────────────────────────────────────────────────
+// Called by the container when a GIT_TOKEN (GitHub App installation token,
+// 1h TTL) expires mid-task. Returns a fresh token resolved via the
+// standard chain. Authenticated with the container-scoped JWT.
+app.post('/api/towns/:townId/rigs/:rigId/refresh-git-token', c =>
+  instrumented(c, 'POST /api/towns/:townId/rigs/:rigId/refresh-git-token', () =>
+    handleRefreshGitToken(c, c.req.param())
+  )
+);
 
 // ── Agent Events ─────────────────────────────────────────────────────────
 

--- a/services/gastown/src/gastown.worker.ts
+++ b/services/gastown/src/gastown.worker.ts
@@ -146,6 +146,7 @@ import {
   handleContainerReady,
   handleDrainStatus,
 } from './handlers/town-eviction.handler';
+import { handleRefreshContainerToken } from './handlers/town-container-token.handler';
 
 export { GastownUserDO } from './dos/GastownUser.do';
 export { GastownOrgDO } from './dos/GastownOrg.do';
@@ -582,6 +583,12 @@ app.post('/api/towns/:townId/container-eviction', c =>
 app.post('/api/towns/:townId/container-ready', c =>
   instrumented(c, 'POST /api/towns/:townId/container-ready', () =>
     handleContainerReady(c, c.req.param())
+  )
+);
+
+app.post('/api/towns/:townId/refresh-container-token', c =>
+  instrumented(c, 'POST /api/towns/:townId/refresh-container-token', () =>
+    handleRefreshContainerToken(c, c.req.param())
   )
 );
 

--- a/services/gastown/src/handlers/refresh-git-token.handler.ts
+++ b/services/gastown/src/handlers/refresh-git-token.handler.ts
@@ -1,0 +1,66 @@
+import type { Context } from 'hono';
+import { extractBearerToken } from '@kilocode/worker-utils';
+import type { GastownEnv } from '../gastown.worker';
+import { getTownDOStub } from '../dos/Town.do';
+import { verifyContainerJWT } from '../util/jwt.util';
+import { resolveSecret } from '../util/secret.util';
+import { resSuccess, resError } from '../util/res.util';
+import { resolveGitHubToken } from '../dos/town/town-scm';
+
+/**
+ * POST /api/towns/:townId/rigs/:rigId/refresh-git-token
+ *
+ * Called by the container when a git operation fails with 401/403 —
+ * i.e. the GitHub App installation token embedded in GIT_TOKEN has
+ * expired (1h TTL). Resolves a fresh token via the standard chain
+ * (town config → platform integration) and returns it to the caller.
+ *
+ * Authenticated with the container-scoped JWT (same token used for
+ * all other container→worker calls).
+ */
+export async function handleRefreshGitToken(
+  c: Context<GastownEnv>,
+  params: { townId: string; rigId: string }
+): Promise<Response> {
+  const token = extractBearerToken(c.req.header('Authorization'));
+  if (!token) {
+    return c.json(resError('Authentication required'), 401);
+  }
+
+  const secret = await resolveSecret(c.env.GASTOWN_JWT_SECRET);
+  if (!secret) {
+    console.error('[refresh-git-token] failed to resolve GASTOWN_JWT_SECRET');
+    return c.json(resError('Internal server error'), 500);
+  }
+
+  const verified = verifyContainerJWT(token, secret);
+  if (!verified.success) {
+    return c.json(resError(verified.error), 401);
+  }
+
+  if (verified.payload.townId !== params.townId) {
+    return c.json(resError('Cross-town access denied'), 403);
+  }
+
+  const town = getTownDOStub(c.env, params.townId);
+  const rigConfig = await town.getRigConfig(params.rigId);
+
+  const freshToken = await resolveGitHubToken({
+    env: c.env,
+    townId: params.townId,
+    getTownConfig: () => town.getTownConfig(),
+    platformIntegrationId: rigConfig?.platformIntegrationId,
+  });
+
+  if (!freshToken) {
+    console.warn(
+      `[refresh-git-token] no token available for town=${params.townId} rig=${params.rigId}`
+    );
+    return c.json(resError('No git token available for this rig'), 404);
+  }
+
+  console.log(
+    `[refresh-git-token] refreshed git token for town=${params.townId} rig=${params.rigId}`
+  );
+  return c.json(resSuccess({ token: freshToken }), 200);
+}

--- a/services/gastown/src/handlers/town-container-token.handler.ts
+++ b/services/gastown/src/handlers/town-container-token.handler.ts
@@ -1,0 +1,57 @@
+import type { Context } from 'hono';
+import { extractBearerToken } from '@kilocode/worker-utils';
+import type { GastownEnv } from '../gastown.worker';
+import { verifyContainerJWTAllowExpired, signContainerJWT } from '../util/jwt.util';
+import { resolveSecret } from '../util/secret.util';
+import { resSuccess, resError } from '../util/res.util';
+
+/**
+ * POST /api/towns/:townId/refresh-container-token
+ *
+ * Mint a fresh container-scoped JWT for a container whose current
+ * token is near expiry or already expired. The caller authenticates
+ * with its existing container token. The signature must be valid —
+ * we previously issued it — but the token is allowed to be expired
+ * so a container that's been asleep past the 8h TTL can still
+ * bootstrap a new token before calling any other endpoints.
+ *
+ * This endpoint only mints a new token; it does NOT push the token
+ * to the running container (the caller is the container itself;
+ * there's nothing to push). The caller is expected to write the
+ * token into its own `process.env.GASTOWN_CONTAINER_TOKEN` and
+ * invoke the existing `/refresh-token` control-server path if it
+ * needs to propagate the token to spawned kilo serve children.
+ */
+export async function handleRefreshContainerToken(
+  c: Context<GastownEnv>,
+  params: { townId: string }
+): Promise<Response> {
+  const token = extractBearerToken(c.req.header('Authorization'));
+  if (!token) {
+    return c.json(resError('Authentication required'), 401);
+  }
+
+  const secret = await resolveSecret(c.env.GASTOWN_JWT_SECRET);
+  if (!secret) {
+    console.error('[refresh-container-token] failed to resolve GASTOWN_JWT_SECRET');
+    return c.json(resError('Internal server error'), 500);
+  }
+
+  const result = verifyContainerJWTAllowExpired(token, secret);
+  if (!result.success) {
+    return c.json(resError(result.error), 401);
+  }
+
+  if (result.payload.townId !== params.townId) {
+    return c.json(resError('Cross-town access denied'), 403);
+  }
+
+  const freshToken = signContainerJWT(
+    { townId: result.payload.townId, userId: result.payload.userId },
+    secret
+  );
+  console.log(
+    `[refresh-container-token] issued fresh token for town=${params.townId} expiredInbound=${result.expired}`
+  );
+  return c.json(resSuccess({ token: freshToken, expiredInbound: result.expired }), 200);
+}

--- a/services/gastown/src/util/jwt.util.ts
+++ b/services/gastown/src/util/jwt.util.ts
@@ -99,3 +99,63 @@ export function verifyContainerJWT(
     return { success: false, error: 'Token validation failed' };
   }
 }
+
+// Maximum tolerated "past-expiry" window for a container JWT presented
+// to the refresh endpoint. Past this, the token must be re-minted by the
+// TownDO (via ensureContainerToken), not bootstrapped by the container
+// itself. Keeps the renewable window bounded instead of "forever as long
+// as the signature is valid".
+const CONTAINER_REFRESH_GRACE_SECONDS = 24 * 3600;
+
+/**
+ * Verify a container-scoped JWT, tolerating tokens that have just expired.
+ *
+ * Used exclusively by endpoints whose purpose is to mint a replacement
+ * token for a container whose current one has expired. The signature
+ * still has to be valid, so this only accepts tokens we previously
+ * issued — an attacker cannot forge a fresh payload.
+ *
+ * Accepts tokens up to `CONTAINER_REFRESH_GRACE_SECONDS` past their
+ * `exp` claim. Beyond that, the token is considered truly dead and the
+ * refresh request is rejected — this bounds the window during which a
+ * stolen long-expired token could be turned into a fresh one.
+ */
+export function verifyContainerJWTAllowExpired(
+  token: string,
+  secret: string
+):
+  | { success: true; payload: ContainerJWTPayload; expired: boolean }
+  | {
+      success: false;
+      error: string;
+    } {
+  try {
+    const raw = jwt.verify(token, secret, {
+      algorithms: ['HS256'],
+      ignoreExpiration: true,
+    });
+    const parsed = ContainerJWTPayload.safeParse(raw);
+    if (!parsed.success) {
+      return { success: false, error: 'Invalid container token payload' };
+    }
+    const decoded = jwt.decode(token);
+    const exp =
+      decoded && typeof decoded === 'object' && 'exp' in decoded && typeof decoded.exp === 'number'
+        ? decoded.exp
+        : null;
+    if (exp === null) {
+      return { success: false, error: 'Token missing exp claim' };
+    }
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const secondsPastExpiry = nowSeconds - exp;
+    if (secondsPastExpiry > CONTAINER_REFRESH_GRACE_SECONDS) {
+      return { success: false, error: 'Token expired beyond refresh grace period' };
+    }
+    return { success: true, payload: parsed.data, expired: secondsPastExpiry > 0 };
+  } catch (error) {
+    if (error instanceof jwt.JsonWebTokenError) {
+      return { success: false, error: 'Invalid token signature' };
+    }
+    return { success: false, error: 'Token validation failed' };
+  }
+}


### PR DESCRIPTION
## Summary

Convoy landing of three PRs that harden long-running agent sessions in Gastown:

- **Mayor session persistence (#2926)**: Snapshot `kilo.db` immediately after the mayor accepts a user message, so the message survives a container crash mid-response. Wrap `saveDbSnapshot` in a 10s timeout in `drainAll`/`stopAll` with a loud failure log. Abort the WAL snapshot when `PRAGMA wal_checkpoint(TRUNCATE)` reports `busy` or partial drain — previously a live mayor write could overwrite the remote snapshot with a `kilo.db` missing the turn we were trying to preserve.
- **GitHub token auto-refresh (#2921)**: New `POST /api/towns/:townId/rigs/:rigId/refresh-git-token` endpoint resolves a fresh GitHub App installation token via the existing chain. `git-manager.ts` now wraps clone/fetch/push/pull with a retry-on-auth-failure helper that refreshes the token, rewrites per-rig `.git-credentials*` files (scoped to the current rig so other rigs' tokens aren't clobbered), rewrites the `origin` URL, and retries once. Tokens are redacted from all error messages.
- **Container token propagation (#2919)**: `POST /refresh-token` now calls `refreshTokenForAllAgents`, restarting every running agent's SDK server in parallel (per-agent 6s timeout) so the new `GASTOWN_CONTAINER_TOKEN` is inherited by fresh `kilo serve` children. Sessions are preserved via `session.list` resume. New `POST /api/towns/:townId/refresh-container-token` endpoint tolerates a just-expired JWT (up to 24h `CONTAINER_REFRESH_GRACE_SECONDS`) so containers that booted past their 8h TTL can bootstrap themselves. `bootHydration` pre-refreshes tokens within 30m of expiry. Heartbeat and plugin clients retry a 401 once with a freshly-minted token.

## Verification

- Inspected the diff across `services/gastown/container/{plugin/client.ts, src/control-server.ts, src/git-manager.ts, src/heartbeat.ts, src/process-manager.ts, src/token-refresh.ts}` and `services/gastown/src/{gastown.worker.ts, handlers/refresh-git-token.handler.ts, handlers/town-container-token.handler.ts, util/jwt.util.ts}`.
- Confirmed review feedback from the three upstream PRs is applied: token redaction, rig-scoped credential rewrite, origin URL rewrite on retry, parallel agent restart with orphan reaping on timeout, bounded `CONTAINER_REFRESH_GRACE_SECONDS`, duplicate `withTimeout` resolved.

## Visual Changes

N/A

## Reviewer Notes

- These three commits are squash-merges of #2919, #2921, #2926 which already landed individually; this is the convoy roll-up onto `gastown-staging`.
- Risk areas: `refreshTokenForAllAgents` mutates `sdkInstances` and may race with model hot-swap — orphan reaping covers the `ensureSDKServer` timeout case where the spawn resolves after we've restored the old instance.
- `verifyContainerJWTAllowExpired` intentionally accepts signed-but-expired tokens up to 24h — beyond that, rebootstrap must go through the TownDO.