### PR TITLE
fix(profile): prevent insertBefore crash when Chrome translates top-up buttons

### DIFF
--- a/apps/web/src/app/(app)/profile/page.tsx
+++ b/apps/web/src/app/(app)/profile/page.tsx
@@ -11,6 +11,7 @@ import { getOAuthDisplayNames } from '@/lib/user';
 import { getExtensionUrl } from '@/components/auth/getExtensionUrl';
 import { cookies } from 'next/headers';
 import CreditPurchaseOptions from '@/components/payment/CreditPurchaseOptions';
+import { MessageErrorBoundary } from '@/components/cloud-agent/MessageErrorBoundary';
 
 import { Coins } from 'lucide-react';
 import { SurveyCredits } from '@/components/SurveyCredits';
@@ -85,10 +86,12 @@ export default async function ProfilePage({ searchParams }: AppPageProps) {
 
       <div className="flex w-full flex-col gap-4 xl:flex-row xl:items-stretch">
         <div className="flex-3">
-          <CreditPurchaseOptions
-            isFirstPurchase={!customerInfo.hasPaid}
-            showOrganizationWarning={customerInfo.hasOrganizations}
-          />
+          <MessageErrorBoundary>
+            <CreditPurchaseOptions
+              isFirstPurchase={!customerInfo.hasPaid}
+              showOrganizationWarning={customerInfo.hasOrganizations}
+            />
+          </MessageErrorBoundary>
         </div>
       </div>
 

--- a/apps/web/src/components/payment/CreditPurchaseOptions.tsx
+++ b/apps/web/src/components/payment/CreditPurchaseOptions.tsx
@@ -213,16 +213,15 @@ export default function CreditPurchaseOptions({
                           : ''
                       } ${animatingButton === `amount-${amount}` ? 'animate-liquid-ripple' : ''}`}
                     >
-                      {animatingButton === `amount-${amount}` && (
-                        <div
-                          className="pointer-events-none absolute inset-0"
-                          style={{
-                            background: `radial-gradient(circle at ${rippleOrigin.x}% ${rippleOrigin.y}%, rgba(59, 130, 246, 0.15) 0%, rgba(59, 130, 246, 0.05) 50%, transparent 70%)`,
-                            animation: 'liquidRipple 0.6s ease-out forwards',
-                          }}
-                        />
-                      )}
-                      {buttonText}
+                      <div
+                        className="pointer-events-none absolute inset-0"
+                        style={{
+                          background: `radial-gradient(circle at ${rippleOrigin.x}% ${rippleOrigin.y}%, rgba(59, 130, 246, 0.15) 0%, rgba(59, 130, 246, 0.05) 50%, transparent 70%)`,
+                          animation: 'liquidRipple 0.6s ease-out forwards',
+                          visibility: animatingButton === `amount-${amount}` ? 'visible' : 'hidden',
+                        }}
+                      />
+                      <span>{buttonText}</span>
                     </Button>
                   </form>
                 );
@@ -240,16 +239,15 @@ export default function CreditPurchaseOptions({
                     } ${animatingButton === 'custom' ? 'animate-liquid-ripple' : ''}`}
                     disabled={submitting}
                   >
-                    {animatingButton === 'custom' && (
-                      <div
-                        className="pointer-events-none absolute inset-0"
-                        style={{
-                          background: `radial-gradient(circle at ${rippleOrigin.x}% ${rippleOrigin.y}%, rgba(59, 130, 246, 0.15) 0%, rgba(59, 130, 246, 0.05) 50%, transparent 70%)`,
-                          animation: 'liquidRipple 0.6s ease-out forwards',
-                        }}
-                      />
-                    )}
-                    Custom
+                    <div
+                      className="pointer-events-none absolute inset-0"
+                      style={{
+                        background: `radial-gradient(circle at ${rippleOrigin.x}% ${rippleOrigin.y}%, rgba(59, 130, 246, 0.15) 0%, rgba(59, 130, 246, 0.05) 50%, transparent 70%)`,
+                        animation: 'liquidRipple 0.6s ease-out forwards',
+                        visibility: animatingButton === 'custom' ? 'visible' : 'hidden',
+                      }}
+                    />
+                    <span>Custom</span>
                   </Button>
                 </DialogTrigger>
                 <DialogContent className="sm:max-w-[425px]">

--- a/apps/web/src/components/ui/card.client.tsx
+++ b/apps/web/src/components/ui/card.client.tsx
@@ -37,51 +37,26 @@ export const CardLinkFooter = React.forwardRef<HTMLAnchorElement, CardLinkFooter
     };
 
     return (
-      <>
-        <Link
-          ref={ref}
-          onMouseEnter={handleMouseEnter}
-          className={cn(
-            'text-muted-foreground relative mt-6 -mr-6 -mb-6 -ml-6 overflow-hidden rounded-br-2xl rounded-bl-2xl border-t border-t-[#2c2c2c] px-4 py-3 text-sm transition-colors hover:bg-gray-900',
-            isAnimating ? 'animate-liquid-ripple' : '',
-            className
-          )}
-          {...props}
-        >
-          {isAnimating && (
-            <div
-              className="pointer-events-none absolute inset-0 rounded-br-2xl rounded-bl-2xl"
-              style={{
-                background: `radial-gradient(circle at ${rippleOrigin.x}% ${rippleOrigin.y}%, rgba(59, 130, 246, 0.15) 0%, rgba(59, 130, 246, 0.05) 50%, transparent 70%)`,
-                animation: 'liquidRipple 0.6s ease-out forwards',
-              }}
-            />
-          )}
-          {children}
-        </Link>
-        <style jsx>{
-          /* css */ `
-            @keyframes liquidRipple {
-              0% {
-                transform: scale(0);
-                opacity: 1;
-              }
-              50% {
-                transform: scale(1.2);
-                opacity: 0.8;
-              }
-              100% {
-                transform: scale(2);
-                opacity: 0;
-              }
-            }
-
-            .animate-liquid-ripple {
-              position: relative;
-            }
-          `
-        }</style>
-      </>
+      <Link
+        ref={ref}
+        onMouseEnter={handleMouseEnter}
+        className={cn(
+          'text-muted-foreground relative mt-6 -mr-6 -mb-6 -ml-6 overflow-hidden rounded-br-2xl rounded-bl-2xl border-t border-t-[#2c2c2c] px-4 py-3 text-sm transition-colors hover:bg-gray-900',
+          isAnimating ? 'animate-liquid-ripple' : '',
+          className
+        )}
+        {...props}
+      >
+        <div
+          className="pointer-events-none absolute inset-0 rounded-br-2xl rounded-bl-2xl"
+          style={{
+            background: `radial-gradient(circle at ${rippleOrigin.x}% ${rippleOrigin.y}%, rgba(59, 130, 246, 0.15) 0%, rgba(59, 130, 246, 0.05) 50%, transparent 70%)`,
+            animation: 'liquidRipple 0.6s ease-out forwards',
+            visibility: isAnimating ? 'visible' : 'hidden',
+          }}
+        />
+        {children}
+      </Link>
     );
   }
 );


### PR DESCRIPTION
## Summary

Chrome Translate wraps DOM text/element nodes in <font> elements, breaking React's internal node references. The ripple animation was conditionally mounting/unmounting a <div> via insertBefore next to the button text on hover, which throws NotFoundError when Chrome has mutated the sibling node.

## Implementation
Solution is to always render the ripple div and toggle visibility via CSS instead of conditional mounting. React now only updates a style property on hover, never calls insertBefore. Also wrapped CreditPurchaseOptions in MessageErrorBoundary so any future error shows an inline fallback instead of crashing the full page.

Errors: Sentry issue [7436242189](https://kilo-code.sentry.io/issues/7436242189/?environment=production&project=4509565130637312&query=is%3Aunresolved&referrer=issue-stream)

## Verification

- Manual testing locally with changes before and after fix

## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->

| Before | After |
| ------ | ----- |
|   <video src="https://github.com/user-attachments/assets/b88a268f-b066-4bde-b603-dcdff78ecdc7" controls></video> |   <video src="https://github.com/user-attachments/assets/fc31c962-7d85-46e2-b56e-24d8ec882614" controls></video> |

## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
