### PR TITLE
Kiloclaw bulk disable versions

### DIFF
--- a/apps/web/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
+++ b/apps/web/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
@@ -972,25 +972,40 @@ export function VersionsTab() {
         </div>
       )}
 
-      {/* Bulk-disable confirmation. AlertDialog (not Dialog) is the right
-          primitive for destructive confirms — escape-to-dismiss is disabled
-          while the mutation is pending. */}
+      {/* Bulk disable confirmation. AlertDialog wraps Radix Dialog, which
+          fires onOpenChange for both Escape and overlay clicks. The wrapper
+          handler suppresses our own state flip while the mutation is in
+          flight, but Radix still processes the underlying event and would
+          flip its internal open state out from under React. Pass through
+          onEscapeKeyDown and onPointerDownOutside guards so Radix never
+          gets the chance.
+
+          AlertDialogAction is a plain Button (no DialogClose wrapper), so
+          the dialog dismisses through the mutation's onSuccess / onError
+          handlers calling setBulkConfirmOpen(false). */}
       <AlertDialog
         open={bulkConfirmOpen}
         onOpenChange={open => {
           if (!open && !isBulkDisabling) setBulkConfirmOpen(false);
         }}
       >
-        <AlertDialogContent>
+        <AlertDialogContent
+          onEscapeKeyDown={e => {
+            if (isBulkDisabling) e.preventDefault();
+          }}
+          onPointerDownOutside={e => {
+            if (isBulkDisabling) e.preventDefault();
+          }}
+        >
           <AlertDialogHeader>
             <AlertDialogTitle>
               Disable {selectedTags.size} version{selectedTags.size === 1 ? '' : 's'}?
             </AlertDialogTitle>
             <AlertDialogDescription>
               {selectedTags.size === 1 ? 'This image' : `These ${selectedTags.size} images`} will be
-              marked <code>status=&apos;disabled&apos;</code> and any in-flight rollout on{' '}
+              marked <code>status=&apos;disabled&apos;</code> and any in flight rollout on{' '}
               {selectedTags.size === 1 ? 'it' : 'them'} will be cleared. New instances and unpinned
-              upgrades won&apos;t pick {selectedTags.size === 1 ? 'it' : 'them'} up. Already-pinned
+              upgrades won&apos;t pick {selectedTags.size === 1 ? 'it' : 'them'} up. Already pinned
               instances continue running their pinned image untouched.
             </AlertDialogDescription>
           </AlertDialogHeader>

--- a/apps/web/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
+++ b/apps/web/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
@@ -67,6 +67,7 @@ import {
   Plus,
   Minus,
   Ban,
+  Info,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
@@ -640,8 +641,14 @@ export function VersionsTab() {
         </Button>
       </div>
 
-      {/* Bulk action bar — visible only when at least one row is selected. */}
-      {selectedTags.size > 0 && (
+      {/* Bulk action bar — always rendered so the affordance is discoverable.
+          Empty state shows a muted hint; active state shows count + buttons. */}
+      {selectedTags.size === 0 ? (
+        <div className="text-muted-foreground border-border/60 flex items-center gap-2 rounded-md border border-dashed px-3 py-2 text-xs">
+          <Info className="h-3 w-3 opacity-60" />
+          <span>Use the checkboxes to select rows for bulk actions.</span>
+        </div>
+      ) : (
         <div className="flex items-center gap-3 rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2">
           <span className="text-muted-foreground text-sm">{selectedTags.size} selected</span>
           <Button

--- a/apps/web/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
+++ b/apps/web/src/app/admin/components/KiloclawVersions/KiloclawVersionsPage.tsx
@@ -31,6 +31,17 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Command,
@@ -46,6 +57,8 @@ import {
   Loader2,
   AlertTriangle,
   ChevronsUpDown,
+  ChevronUp,
+  ChevronDown,
   X,
   Rocket,
   Anchor,
@@ -359,11 +372,51 @@ function StartRolloutButton({
   );
 }
 
+type SortColumn = 'openclaw_version' | 'image_tag' | 'status' | 'published_at';
+type SortDir = 'asc' | 'desc';
+
+function SortableHeader({
+  column,
+  label,
+  activeSort,
+  activeDir,
+  onSort,
+  className,
+}: {
+  column: SortColumn;
+  label: string;
+  activeSort: SortColumn;
+  activeDir: SortDir;
+  onSort: (column: SortColumn) => void;
+  className?: string;
+}) {
+  const active = activeSort === column;
+  const Icon = active ? (activeDir === 'asc' ? ChevronUp : ChevronDown) : ChevronsUpDown;
+  return (
+    <TableHead className={className}>
+      <button
+        type="button"
+        className={`hover:text-foreground inline-flex items-center gap-1 transition-colors ${
+          active ? 'text-foreground' : 'text-muted-foreground'
+        }`}
+        onClick={() => onSort(column)}
+      >
+        {label}
+        <Icon className={`h-3 w-3 ${active ? 'opacity-100' : 'opacity-50'}`} />
+      </button>
+    </TableHead>
+  );
+}
+
 export function VersionsTab() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const [page, setPage] = useState(0);
   const [statusFilter, setStatusFilter] = useState<'all' | 'available' | 'disabled'>('all');
+  const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set());
+  const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false);
+  const [sortBy, setSortBy] = useState<SortColumn>('published_at');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
   const limit = 25;
 
   const { data, isLoading } = useQuery(
@@ -371,8 +424,18 @@ export function VersionsTab() {
       offset: page * limit,
       limit,
       status: statusFilter === 'all' ? undefined : statusFilter,
+      sortBy,
+      sortDir,
     })
   );
+
+  // Rows that are eligible for bulk disable on the current page. Excludes
+  // :latest (kiloclaw service refuses to disable it) and already-disabled
+  // rows (idempotent). Active candidates ARE eligible — disabling clears
+  // their rollout percent.
+  const eligibleRows = (data?.items ?? []).filter(v => v.status === 'available' && !v.is_latest);
+  const allEligibleSelected =
+    eligibleRows.length > 0 && eligibleRows.every(v => selectedTags.has(v.image_tag));
 
   // After any mutation that changes catalog state, invalidate both the
   // paginated list (table view) AND the active rollout query (hero panel).
@@ -396,6 +459,52 @@ export function VersionsTab() {
       },
     })
   );
+
+  const { mutateAsync: bulkDisable, isPending: isBulkDisabling } = useMutation(
+    trpc.admin.kiloclawVersions.bulkDisableVersions.mutationOptions({
+      onSuccess: result => {
+        const parts: string[] = [];
+        if (result.disabled.length) parts.push(`${result.disabled.length} disabled`);
+        if (result.skippedLatest.length)
+          parts.push(`${result.skippedLatest.length} skipped (:latest)`);
+        if (result.skippedAlreadyDisabled.length)
+          parts.push(`${result.skippedAlreadyDisabled.length} already disabled`);
+        if (result.notFound.length) parts.push(`${result.notFound.length} not found`);
+        if (result.errors.length) parts.push(`${result.errors.length} errored`);
+        const summary = parts.length > 0 ? parts.join(', ') : 'no changes';
+        if (result.errors.length > 0) {
+          toast.error(`Bulk disable: ${summary}`);
+        } else {
+          toast.success(`Bulk disable: ${summary}`);
+        }
+        invalidateRolloutState();
+        setSelectedTags(new Set());
+        setBulkConfirmOpen(false);
+      },
+      onError: err => {
+        toast.error(`Bulk disable failed: ${err.message}`);
+      },
+    })
+  );
+
+  // Clear selection when the page or filter changes — selected tags may no
+  // longer be in the visible list, and silently carrying them through a
+  // pagination click would be confusing.
+  const resetSelection = () => setSelectedTags(new Set());
+
+  // Click a sort header: same column flips direction, new column starts in
+  // the column's natural direction (desc for date/numericish, asc for text).
+  // Resets pagination + selection because the visible row set changes.
+  const handleSort = (column: SortColumn) => {
+    setPage(0);
+    resetSelection();
+    if (sortBy === column) {
+      setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortBy(column);
+      setSortDir(column === 'published_at' ? 'desc' : 'asc');
+    }
+  };
 
   const { mutateAsync: setRolloutPercent } = useMutation(
     trpc.admin.kiloclawVersions.setRolloutPercent.mutationOptions({
@@ -513,6 +622,7 @@ export function VersionsTab() {
             if (v === 'all' || v === 'available' || v === 'disabled') {
               setStatusFilter(v);
               setPage(0);
+              resetSelection();
             }
           }}
         >
@@ -530,17 +640,80 @@ export function VersionsTab() {
         </Button>
       </div>
 
+      {/* Bulk action bar — visible only when at least one row is selected. */}
+      {selectedTags.size > 0 && (
+        <div className="flex items-center gap-3 rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2">
+          <span className="text-muted-foreground text-sm">{selectedTags.size} selected</span>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 border-red-500/30 text-xs text-red-400 hover:bg-red-500/10"
+            onClick={() => setBulkConfirmOpen(true)}
+            disabled={isBulkDisabling}
+          >
+            <Ban className="mr-1 h-3 w-3" />
+            Disable selected
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 text-xs"
+            onClick={resetSelection}
+            disabled={isBulkDisabling}
+          >
+            Clear
+          </Button>
+        </div>
+      )}
+
       {/* Reference catalog table — :latest and candidate rows are accent-bordered */}
       <div className="overflow-hidden rounded-lg border">
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead className="w-[1px]"></TableHead>
-              <TableHead>OpenClaw</TableHead>
-              <TableHead>Image Tag</TableHead>
+              <TableHead className="w-[40px]">
+                <Checkbox
+                  checked={allEligibleSelected}
+                  disabled={eligibleRows.length === 0}
+                  onCheckedChange={() => {
+                    if (allEligibleSelected) {
+                      resetSelection();
+                    } else {
+                      setSelectedTags(new Set(eligibleRows.map(v => v.image_tag)));
+                    }
+                  }}
+                  aria-label="Select all eligible versions"
+                />
+              </TableHead>
+              <SortableHeader
+                column="openclaw_version"
+                label="OpenClaw"
+                activeSort={sortBy}
+                activeDir={sortDir}
+                onSort={handleSort}
+              />
+              <SortableHeader
+                column="image_tag"
+                label="Image Tag"
+                activeSort={sortBy}
+                activeDir={sortDir}
+                onSort={handleSort}
+              />
               <TableHead>Digest</TableHead>
-              <TableHead>State</TableHead>
-              <TableHead>Published</TableHead>
+              <SortableHeader
+                column="status"
+                label="State"
+                activeSort={sortBy}
+                activeDir={sortDir}
+                onSort={handleSort}
+              />
+              <SortableHeader
+                column="published_at"
+                label="Published"
+                activeSort={sortBy}
+                activeDir={sortDir}
+                onSort={handleSort}
+              />
               <TableHead className="w-[140px]">Actions</TableHead>
             </TableRow>
           </TableHeader>
@@ -564,6 +737,8 @@ export function VersionsTab() {
                   !isLatest && version.status === 'available' && version.rollout_percent > 0;
                 const isAvailable = version.status === 'available';
                 const isDisabled = version.status === 'disabled';
+                const isSelectable = isAvailable && !isLatest;
+                const isSelected = selectedTags.has(version.image_tag);
                 const accent = isLatest
                   ? 'border-l-4 border-l-blue-600'
                   : isCandidate
@@ -571,8 +746,25 @@ export function VersionsTab() {
                     : 'border-l-4 border-l-transparent';
                 return (
                   <TableRow key={version.id} className={accent}>
-                    {/* Spacer for the accent bar */}
-                    <TableCell className="p-0"></TableCell>
+                    <TableCell className="py-2">
+                      {isSelectable ? (
+                        <Checkbox
+                          checked={isSelected}
+                          onCheckedChange={() => {
+                            setSelectedTags(prev => {
+                              const next = new Set(prev);
+                              if (next.has(version.image_tag)) {
+                                next.delete(version.image_tag);
+                              } else {
+                                next.add(version.image_tag);
+                              }
+                              return next;
+                            });
+                          }}
+                          aria-label={`Select ${version.image_tag}`}
+                        />
+                      ) : null}
+                    </TableCell>
                     <TableCell className="font-medium">
                       <div className="flex flex-col">
                         <span>{version.openclaw_version}</span>
@@ -750,7 +942,10 @@ export function VersionsTab() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => setPage(p => p - 1)}
+              onClick={() => {
+                setPage(p => p - 1);
+                resetSelection();
+              }}
               disabled={page === 0}
             >
               Previous
@@ -758,7 +953,10 @@ export function VersionsTab() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => setPage(p => p + 1)}
+              onClick={() => {
+                setPage(p => p + 1);
+                resetSelection();
+              }}
               disabled={page + 1 >= data.pagination.totalPages}
             >
               Next
@@ -766,6 +964,45 @@ export function VersionsTab() {
           </div>
         </div>
       )}
+
+      {/* Bulk-disable confirmation. AlertDialog (not Dialog) is the right
+          primitive for destructive confirms — escape-to-dismiss is disabled
+          while the mutation is pending. */}
+      <AlertDialog
+        open={bulkConfirmOpen}
+        onOpenChange={open => {
+          if (!open && !isBulkDisabling) setBulkConfirmOpen(false);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Disable {selectedTags.size} version{selectedTags.size === 1 ? '' : 's'}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {selectedTags.size === 1 ? 'This image' : `These ${selectedTags.size} images`} will be
+              marked <code>status=&apos;disabled&apos;</code> and any in-flight rollout on{' '}
+              {selectedTags.size === 1 ? 'it' : 'them'} will be cleared. New instances and unpinned
+              upgrades won&apos;t pick {selectedTags.size === 1 ? 'it' : 'them'} up. Already-pinned
+              instances continue running their pinned image untouched.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isBulkDisabling}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isBulkDisabling}
+              className="bg-red-600 text-white hover:bg-red-700"
+              onClick={() => {
+                void bulkDisable({ imageTags: Array.from(selectedTags) });
+              }}
+            >
+              {isBulkDisabling
+                ? 'Disabling…'
+                : `Disable ${selectedTags.size} version${selectedTags.size === 1 ? '' : 's'}`}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/apps/web/src/routers/admin-kiloclaw-versions-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-versions-router.test.ts
@@ -136,6 +136,65 @@ describe('admin.kiloclawVersions.listVersions', () => {
       expect(item.status).toBe('disabled');
     }
   });
+
+  it('sorts by image_tag asc', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawVersions.listVersions({
+      sortBy: 'image_tag',
+      sortDir: 'asc',
+      limit: 100,
+    });
+
+    // Scoped assertion: among only our two fixtures, v1 must come before v2.
+    const tags = result.items.map(i => i.image_tag);
+    const v1 = tags.indexOf(catalogEntry.image_tag);
+    const v2 = tags.indexOf(catalogEntry2.image_tag);
+    expect(v1).toBeGreaterThanOrEqual(0);
+    expect(v2).toBeGreaterThan(v1);
+  });
+
+  it('sorts by image_tag desc', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawVersions.listVersions({
+      sortBy: 'image_tag',
+      sortDir: 'desc',
+      limit: 100,
+    });
+
+    const tags = result.items.map(i => i.image_tag);
+    const v1 = tags.indexOf(catalogEntry.image_tag);
+    const v2 = tags.indexOf(catalogEntry2.image_tag);
+    expect(v2).toBeGreaterThanOrEqual(0);
+    expect(v1).toBeGreaterThan(v2);
+  });
+
+  it('sorts by openclaw_version asc', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawVersions.listVersions({
+      sortBy: 'openclaw_version',
+      sortDir: 'asc',
+      limit: 100,
+    });
+
+    const tags = result.items.map(i => i.image_tag);
+    const v1 = tags.indexOf(catalogEntry.image_tag); // 2026.2.9
+    const v2 = tags.indexOf(catalogEntry2.image_tag); // 2026.2.10
+    // openclaw_version is text, so '2026.2.10' sorts before '2026.2.9'
+    // ascending lexicographically. We just check both are present in
+    // a stable order, not their absolute positions.
+    expect(v1).toBeGreaterThanOrEqual(0);
+    expect(v2).toBeGreaterThanOrEqual(0);
+  });
+
+  it('rejects an unknown sort column via zod', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawVersions.listVersions({
+        // @ts-expect-error - invalid sort column for this test
+        sortBy: 'image_digest',
+      })
+    ).rejects.toThrow();
+  });
 });
 
 describe('admin.kiloclawVersions.updateVersionStatus', () => {
@@ -176,6 +235,191 @@ describe('admin.kiloclawVersions.updateVersionStatus', () => {
       .update(kiloclaw_image_catalog)
       .set({ status: 'available' })
       .where(eq(kiloclaw_image_catalog.image_tag, catalogEntry.image_tag));
+  });
+});
+
+describe('admin.kiloclawVersions.bulkDisableVersions', () => {
+  // Each test starts from a clean state: both catalog rows available,
+  // neither marked :latest. Tests that mutate state set their own state up
+  // and reset in afterEach.
+  beforeEach(async () => {
+    await db
+      .update(kiloclaw_image_catalog)
+      .set({ status: 'available', is_latest: false, rollout_percent: 0 })
+      .where(eq(kiloclaw_image_catalog.image_tag, catalogEntry.image_tag));
+    await db
+      .update(kiloclaw_image_catalog)
+      .set({ status: 'available', is_latest: false, rollout_percent: 0 })
+      .where(eq(kiloclaw_image_catalog.image_tag, catalogEntry2.image_tag));
+  });
+
+  it('throws FORBIDDEN for non-admin users', async () => {
+    const caller = await createCallerForUser(regularUser.id);
+    await expect(
+      caller.admin.kiloclawVersions.bulkDisableVersions({
+        imageTags: [catalogEntry.image_tag],
+      })
+    ).rejects.toThrow('Admin access required');
+  });
+
+  it('disables a batch of available, non-:latest rows', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawVersions.bulkDisableVersions({
+      imageTags: [catalogEntry.image_tag, catalogEntry2.image_tag],
+    });
+
+    expect(result.disabled).toEqual(
+      expect.arrayContaining([catalogEntry.image_tag, catalogEntry2.image_tag])
+    );
+    expect(result.disabled).toHaveLength(2);
+    expect(result.skippedLatest).toEqual([]);
+    expect(result.skippedAlreadyDisabled).toEqual([]);
+    expect(result.notFound).toEqual([]);
+    expect(result.errors).toEqual([]);
+
+    const [r1, r2] = await Promise.all([
+      db
+        .select()
+        .from(kiloclaw_image_catalog)
+        .where(eq(kiloclaw_image_catalog.image_tag, catalogEntry.image_tag))
+        .limit(1),
+      db
+        .select()
+        .from(kiloclaw_image_catalog)
+        .where(eq(kiloclaw_image_catalog.image_tag, catalogEntry2.image_tag))
+        .limit(1),
+    ]);
+    expect(r1[0].status).toBe('disabled');
+    expect(r1[0].rollout_percent).toBe(0);
+    expect(r2[0].status).toBe('disabled');
+    expect(r2[0].rollout_percent).toBe(0);
+  });
+
+  it('skips :latest rows without aborting the batch', async () => {
+    await db
+      .update(kiloclaw_image_catalog)
+      .set({ is_latest: true })
+      .where(eq(kiloclaw_image_catalog.image_tag, catalogEntry.image_tag));
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawVersions.bulkDisableVersions({
+      imageTags: [catalogEntry.image_tag, catalogEntry2.image_tag],
+    });
+
+    expect(result.skippedLatest).toEqual([catalogEntry.image_tag]);
+    expect(result.disabled).toEqual([catalogEntry2.image_tag]);
+
+    // :latest row must be untouched.
+    const [latestRow] = await db
+      .select()
+      .from(kiloclaw_image_catalog)
+      .where(eq(kiloclaw_image_catalog.image_tag, catalogEntry.image_tag))
+      .limit(1);
+    expect(latestRow.status).toBe('available');
+    expect(latestRow.is_latest).toBe(true);
+  });
+
+  it('skips already-disabled rows', async () => {
+    await db
+      .update(kiloclaw_image_catalog)
+      .set({ status: 'disabled' })
+      .where(eq(kiloclaw_image_catalog.image_tag, catalogEntry.image_tag));
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawVersions.bulkDisableVersions({
+      imageTags: [catalogEntry.image_tag, catalogEntry2.image_tag],
+    });
+
+    expect(result.skippedAlreadyDisabled).toEqual([catalogEntry.image_tag]);
+    expect(result.disabled).toEqual([catalogEntry2.image_tag]);
+  });
+
+  it('reports unknown tags in notFound and disables the rest', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawVersions.bulkDisableVersions({
+      imageTags: ['does-not-exist', catalogEntry.image_tag],
+    });
+
+    expect(result.notFound).toEqual(['does-not-exist']);
+    expect(result.disabled).toEqual([catalogEntry.image_tag]);
+  });
+
+  it('rejects an empty array', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.kiloclawVersions.bulkDisableVersions({ imageTags: [] })
+    ).rejects.toThrow();
+  });
+
+  it('rejects an oversized array (>50)', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+    const tooMany = Array.from({ length: 51 }, (_, i) => `tag-${i}`);
+    await expect(
+      caller.admin.kiloclawVersions.bulkDisableVersions({ imageTags: tooMany })
+    ).rejects.toThrow();
+  });
+
+  it('handles a mixed batch (1 ok + 1 :latest + 1 missing)', async () => {
+    await db
+      .update(kiloclaw_image_catalog)
+      .set({ is_latest: true })
+      .where(eq(kiloclaw_image_catalog.image_tag, catalogEntry.image_tag));
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloclawVersions.bulkDisableVersions({
+      imageTags: [catalogEntry.image_tag, catalogEntry2.image_tag, 'missing-tag'],
+    });
+
+    expect(result.disabled).toEqual([catalogEntry2.image_tag]);
+    expect(result.skippedLatest).toEqual([catalogEntry.image_tag]);
+    expect(result.notFound).toEqual(['missing-tag']);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('continues the batch when a per-row call throws', async () => {
+    // Override the mock's disableImageAndClearRollout to throw on the first
+    // tag and succeed on the second. The procedure must record the failure
+    // in `errors` and still disable the second tag.
+    const mocked = jest.requireMock('@/lib/kiloclaw/kiloclaw-internal-client') as {
+      KiloClawInternalClient: jest.Mock;
+    };
+    const ClientMock = mocked.KiloClawInternalClient;
+    const originalImpl = ClientMock.getMockImplementation();
+
+    ClientMock.mockImplementationOnce(() => ({
+      disableImageAndClearRollout: jest
+        .fn()
+        .mockImplementation(async (imageTag: string, updatedBy: string) => {
+          if (imageTag === catalogEntry.image_tag) {
+            throw new Error('simulated kiloclaw failure');
+          }
+          await db
+            .update(kiloclaw_image_catalog)
+            .set({
+              status: 'disabled',
+              rollout_percent: 0,
+              updated_by: updatedBy,
+              updated_at: new Date().toISOString(),
+            })
+            .where(eq(kiloclaw_image_catalog.image_tag, imageTag));
+          return { ok: true };
+        }),
+    }));
+
+    try {
+      const caller = await createCallerForUser(adminUser.id);
+      const result = await caller.admin.kiloclawVersions.bulkDisableVersions({
+        imageTags: [catalogEntry.image_tag, catalogEntry2.image_tag],
+      });
+
+      expect(result.errors).toEqual([
+        { imageTag: catalogEntry.image_tag, message: 'simulated kiloclaw failure' },
+      ]);
+      expect(result.disabled).toEqual([catalogEntry2.image_tag]);
+    } finally {
+      // Restore the default mock impl for downstream tests.
+      if (originalImpl) ClientMock.mockImplementation(originalImpl);
+    }
   });
 });
 

--- a/apps/web/src/routers/admin-kiloclaw-versions-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-versions-router.test.ts
@@ -168,7 +168,7 @@ describe('admin.kiloclawVersions.listVersions', () => {
     expect(v1).toBeGreaterThan(v2);
   });
 
-  it('sorts by openclaw_version asc', async () => {
+  it('sorts by openclaw_version asc (numeric, not lex)', async () => {
     const caller = await createCallerForUser(adminUser.id);
     const result = await caller.admin.kiloclawVersions.listVersions({
       sortBy: 'openclaw_version',
@@ -179,11 +179,13 @@ describe('admin.kiloclawVersions.listVersions', () => {
     const tags = result.items.map(i => i.image_tag);
     const v1 = tags.indexOf(catalogEntry.image_tag); // 2026.2.9
     const v2 = tags.indexOf(catalogEntry2.image_tag); // 2026.2.10
-    // openclaw_version is text, so '2026.2.10' sorts before '2026.2.9'
-    // ascending lexicographically. We just check both are present in
-    // a stable order, not their absolute positions.
     expect(v1).toBeGreaterThanOrEqual(0);
     expect(v2).toBeGreaterThanOrEqual(0);
+    // CalVer ordering: 2026.2.9 is OLDER than 2026.2.10, so v1 must
+    // come before v2 in ascending order. A naive text sort would put
+    // '2026.2.10' first ('1' < '9' lex), so this also catches a
+    // regression to lex ordering.
+    expect(v1).toBeLessThan(v2);
   });
 
   it('rejects an unknown sort column via zod', async () => {

--- a/apps/web/src/routers/admin-kiloclaw-versions-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-versions-router.ts
@@ -63,6 +63,10 @@ const UpdateVersionStatusSchema = z.object({
   status: z.enum(['available', 'disabled']),
 });
 
+// max(50) is a defensive bound on the raw payload, NOT a guarantee about
+// distinct operations. The handler dedupes server side via Set, so a caller
+// passing 50 copies of one tag collapses to a single op rather than 50.
+// In practice the UI only sends unique tags from the rendered page.
 const BulkDisableVersionsSchema = z.object({
   imageTags: z.array(z.string().min(1).max(128)).min(1).max(50),
 });
@@ -102,8 +106,17 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
 
     const whereCondition = status ? eq(kiloclaw_image_catalog.status, status) : undefined;
 
-    const sortColumn = SORTABLE_COLUMNS[sortBy];
-    const primaryOrder = sortDir === 'asc' ? asc(sortColumn) : desc(sortColumn);
+    // openclaw_version is stored as text but values follow CalVer
+    // (YYYY.M.D, no zero padding). Plain text ordering would put
+    // '2026.2.10' before '2026.2.9'. Cast components to int[] so the
+    // sort matches what admins expect from a version selector.
+    // Catalog values are validated against /^\d{4}\.\d{1,2}\.\d{1,2}$/
+    // in syncCatalog, so the cast is safe for all rows.
+    const sortExpression =
+      sortBy === 'openclaw_version'
+        ? sql`string_to_array(${kiloclaw_image_catalog.openclaw_version}, '.')::int[]`
+        : SORTABLE_COLUMNS[sortBy];
+    const primaryOrder = sortDir === 'asc' ? asc(sortExpression) : desc(sortExpression);
     // Secondary tiebreaker on image_tag keeps row order stable across pages
     // when the primary column has duplicates (very common for status, less
     // for openclaw_version, rare for published_at).

--- a/apps/web/src/routers/admin-kiloclaw-versions-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-versions-router.ts
@@ -6,7 +6,7 @@ import {
   kiloclaw_version_pins,
   kilocode_users,
 } from '@kilocode/db/schema';
-import { eq, desc, sql, or, ilike, inArray, and, isNull } from 'drizzle-orm';
+import { eq, desc, asc, sql, or, ilike, inArray, and, isNull } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import { TRPCError } from '@trpc/server';
 import { KiloClawInternalClient, KiloClawApiError } from '@/lib/kiloclaw/kiloclaw-internal-client';
@@ -37,15 +37,42 @@ async function requireActivePersonalInstance(userId: string) {
 }
 import * as z from 'zod';
 
+// Columns the admin Versions table allows sorting on. The display column
+// "State" sorts by the underlying `status` field (alphabetic: available
+// before disabled) — sorting by the composite is_latest/candidate/status
+// triplet would be confusing, so we expose the simpler signal.
+const SORTABLE_COLUMNS = {
+  openclaw_version: kiloclaw_image_catalog.openclaw_version,
+  image_tag: kiloclaw_image_catalog.image_tag,
+  status: kiloclaw_image_catalog.status,
+  published_at: kiloclaw_image_catalog.published_at,
+} as const;
+
 const ListVersionsSchema = z.object({
   offset: z.number().min(0).default(0),
   limit: z.number().min(1).max(100).default(25),
   status: z.enum(['available', 'disabled']).optional(),
+  sortBy: z
+    .enum(['openclaw_version', 'image_tag', 'status', 'published_at'])
+    .default('published_at'),
+  sortDir: z.enum(['asc', 'desc']).default('desc'),
 });
 
 const UpdateVersionStatusSchema = z.object({
   imageTag: z.string().min(1),
   status: z.enum(['available', 'disabled']),
+});
+
+const BulkDisableVersionsSchema = z.object({
+  imageTags: z.array(z.string().min(1).max(128)).min(1).max(50),
+});
+
+const BulkDisableVersionsOutputSchema = z.object({
+  disabled: z.array(z.string()),
+  skippedLatest: z.array(z.string()),
+  skippedAlreadyDisabled: z.array(z.string()),
+  notFound: z.array(z.string()),
+  errors: z.array(z.object({ imageTag: z.string(), message: z.string() })),
 });
 
 const ListPinsSchema = z.object({
@@ -71,16 +98,26 @@ const RemovePinSchema = z.object({
 
 export const adminKiloclawVersionsRouter = createTRPCRouter({
   listVersions: adminProcedure.input(ListVersionsSchema).query(async ({ input }) => {
-    const { offset, limit, status } = input;
+    const { offset, limit, status, sortBy, sortDir } = input;
 
     const whereCondition = status ? eq(kiloclaw_image_catalog.status, status) : undefined;
+
+    const sortColumn = SORTABLE_COLUMNS[sortBy];
+    const primaryOrder = sortDir === 'asc' ? asc(sortColumn) : desc(sortColumn);
+    // Secondary tiebreaker on image_tag keeps row order stable across pages
+    // when the primary column has duplicates (very common for status, less
+    // for openclaw_version, rare for published_at).
+    const orderBy =
+      sortBy === 'image_tag'
+        ? [primaryOrder]
+        : [primaryOrder, asc(kiloclaw_image_catalog.image_tag)];
 
     const [items, countResult] = await Promise.all([
       db
         .select()
         .from(kiloclaw_image_catalog)
         .where(whereCondition)
-        .orderBy(desc(kiloclaw_image_catalog.published_at))
+        .orderBy(...orderBy)
         .offset(offset)
         .limit(limit),
       db
@@ -177,6 +214,78 @@ export const adminKiloclawVersionsRouter = createTRPCRouter({
       }
 
       return updated;
+    }),
+
+  /**
+   * Disable many versions in one call. Each tag is routed through the kiloclaw
+   * service's disableImageAndClearRollout (the only path that keeps Postgres +
+   * KV `:latest`/`:candidate` pointers consistent via refreshPointersForVariant).
+   *
+   * Loops sequentially — not parallel — so concurrent refreshPointersForVariant
+   * calls don't race on the same variant. Per-row errors don't abort the batch:
+   * we collect them and return per-bucket arrays.
+   *
+   * Already-pinned instances are NOT affected — pins ignore the catalog row's
+   * status. This procedure only changes which tags are selectable for new
+   * pins/rollouts.
+   */
+  bulkDisableVersions: adminProcedure
+    .input(BulkDisableVersionsSchema)
+    .output(BulkDisableVersionsOutputSchema)
+    .mutation(async ({ input, ctx }) => {
+      const uniqueTags = Array.from(new Set(input.imageTags));
+
+      const rows = await db
+        .select({
+          image_tag: kiloclaw_image_catalog.image_tag,
+          is_latest: kiloclaw_image_catalog.is_latest,
+          status: kiloclaw_image_catalog.status,
+        })
+        .from(kiloclaw_image_catalog)
+        .where(inArray(kiloclaw_image_catalog.image_tag, uniqueTags));
+      const byTag = new Map(rows.map(r => [r.image_tag, r]));
+
+      const disabled: string[] = [];
+      const skippedLatest: string[] = [];
+      const skippedAlreadyDisabled: string[] = [];
+      const notFound: string[] = [];
+      const errors: { imageTag: string; message: string }[] = [];
+
+      const client = new KiloClawInternalClient();
+
+      for (const tag of uniqueTags) {
+        const row = byTag.get(tag);
+        if (!row) {
+          notFound.push(tag);
+          continue;
+        }
+        if (row.is_latest) {
+          skippedLatest.push(tag);
+          continue;
+        }
+        if (row.status === 'disabled') {
+          skippedAlreadyDisabled.push(tag);
+          continue;
+        }
+
+        try {
+          await client.disableImageAndClearRollout(tag, ctx.user.id);
+          disabled.push(tag);
+        } catch (err) {
+          // Surface the kiloclaw service's per-row error rather than aborting
+          // the batch — a concurrent markLatest between our SELECT and this
+          // call gets caught here as a 400 from the service.
+          const message =
+            err instanceof KiloClawApiError
+              ? err.message
+              : err instanceof Error
+                ? err.message
+                : 'Unknown error';
+          errors.push({ imageTag: tag, message });
+        }
+      }
+
+      return { disabled, skippedLatest, skippedAlreadyDisabled, notFound, errors };
     }),
 
   setRolloutPercent: adminProcedure


### PR DESCRIPTION
## Summary

Adds bulk disable on the admin Versions tab at `/admin/kiloclaw?tab=versions` and makes most columns sortable.

**Backend.** New `bulkDisableVersions` tRPC procedure on `admin.kiloclawVersions`. Zod validated input accepts 1 to 50 image tags, each up to 128 chars. Internally the procedure loops the existing `disableImageAndClearRollout`, which is the only code path that keeps Postgres status and KV `:latest` / `:candidate` pointers consistent (via `refreshPointersForVariant`). A bulk SQL `UPDATE` would skip that refresh and corrupt the pointers. Calls run sequentially to avoid two refreshes racing on the same variant. Errors on a single row do not abort the batch. Output groups outcomes into five buckets: `disabled`, `skippedLatest`, `skippedAlreadyDisabled`, `notFound`, `errors`.

**Pin safety.** Already pinned instances are not affected. Pins ignore the catalog row's status, so a disabled tag continues to resolve for any instance currently running it.

**UI.** Header and row checkboxes appear on rows that are available and not `:latest`. Selecting any row reveals a red action area with the selection count and a Disable button, plus a Clear shortcut. When nothing is selected, the same area shows a muted hint ("Use the checkboxes to select rows for bulk actions") so the affordance is always discoverable. Confirmation routes through `AlertDialog`, with the destructive action disabled while the mutation runs. The success toast summarizes outcomes by bucket. Selection clears on filter change, page change, sort change, and on a successful mutation.

**Sortable columns.** `listVersions` now accepts `sortBy` (`openclaw_version`, `image_tag`, `status`, `published_at`) and `sortDir` (`asc`, `desc`). Default ordering is unchanged. A secondary `image_tag asc` tiebreaker keeps page boundaries stable when the primary column has duplicates. The State header sorts on the underlying `status` column. Clicking the active column flips direction; clicking a new column starts in its natural direction (desc for date, asc for text).

**Tests.** 13 new tests covering FORBIDDEN for users without admin access, happy path with DB row assertions, skip on `:latest`, skip on already disabled rows, `notFound`, empty and oversize Zod rejection, mixed batch, and a per row failure that must not abort the batch. Sort tests cover asc and desc on `image_tag`, default on `openclaw_version`, and Zod rejection of unknown sort columns.

## Verification

- [ ] Open `/admin/kiloclaw?tab=versions`. With nothing selected, the muted hint is visible above the table.
- [ ] Select two available rows that are not `:latest`. Red action area shows the count.
- [ ] Click Disable selected, confirm in the dialog, and watch the toast bucket summary.
- [ ] In Postgres: both rows now have `status = 'disabled'` and `rollout_percent = 0`.
- [ ] If one of the rows was the active candidate, run `wrangler kv key get image-version:candidate:default` and confirm the pointer was cleared.
- [ ] Pin an instance to one of the soon to be disabled tags. After bulk disable, the pin row is unchanged and the instance still resolves the tag.
- [ ] Click each sortable column header. Chevron direction toggles, pagination resets to page 1, and selection clears.
- [ ] Try to select the `:latest` row. Its checkbox is not rendered.

## Visual Changes

| Before | After |
| ------ | ----- |
| No way to disable many versions at once. Single row Disable button only. Static column headers with no sort affordance. | Header and row checkboxes on eligible rows, always visible bulk action hint, red confirm bar with count and Disable button when rows are selected, sortable column headers with chevron indicators. |

## Reviewer Notes

- The kiloclaw service is untouched. All KV pointer state still flows through `disableImageAndClearRollout` and `refreshPointersForVariant` exactly as before.
- Sequential loop is intentional. Parallelizing the per tag calls would let two `refreshPointersForVariant` runs race on the same variant.
- The UI uses the existing `Table` from `components/ui` (no TanStack Table). Selection state lives in `useState<Set<string>>` and is reset on any view change so stale selections never carry across pages.
- No schema changes. No migrations.
