### PR TITLE
chore(grafana): chart crashed controller check-ins

### DIFF
--- a/dev/grafana/dashboards/kiloclaw-controller-telemetry.json
+++ b/dev/grafana/dashboards/kiloclaw-controller-telemetry.json
@@ -366,7 +366,7 @@
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 12,
+            "fillOpacity": 18,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -732,8 +732,8 @@
         "x": 12,
         "y": 14
       },
-      "description": "Check-in volume by Fly region (blob7). Highlights regional traffic skew or outages.",
-      "id": 28,
+      "description": "Sample-corrected check-ins reporting supervisor_state = crashed. Use this to spot crash spikes.",
+      "id": 36,
       "options": {
         "legend": {
           "calcs": [],
@@ -762,8 +762,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT $timeSeries AS t, blob7 AS label, SUM(_sample_interval) AS checkins FROM kiloclaw_controller_telemetry WHERE $timeFilter\n  $conditionalTest(AND index1 = ${sandboxId:sqlstring},, $sandboxId)\n  $conditionalTest(AND blob6 IN ($supervisorState),, $supervisorState)\n  $conditionalTest(AND blob7 IN ($flyRegion),, $flyRegion)\n  $conditionalTest(AND blob2 IN ($controllerVersion),, $controllerVersion) AND blob7 != '' GROUP BY t, label ORDER BY t",
-          "rawSql": "SELECT $timeSeries AS t, blob7 AS label, SUM(_sample_interval) AS checkins FROM kiloclaw_controller_telemetry WHERE $timeFilter\n  $conditionalTest(AND index1 = ${sandboxId:sqlstring},, $sandboxId)\n  $conditionalTest(AND blob6 IN ($supervisorState),, $supervisorState)\n  $conditionalTest(AND blob7 IN ($flyRegion),, $flyRegion)\n  $conditionalTest(AND blob2 IN ($controllerVersion),, $controllerVersion) AND blob7 != '' GROUP BY t, label ORDER BY t",
+          "query": "SELECT $timeSeries AS t, 'crashed' AS label, SUM(_sample_interval) AS crashed_checkins FROM kiloclaw_controller_telemetry WHERE $timeFilter\n  AND blob6 = 'crashed'\n  $conditionalTest(AND index1 = ${sandboxId:sqlstring},, $sandboxId)\n  $conditionalTest(AND blob7 IN ($flyRegion),, $flyRegion)\n  $conditionalTest(AND blob2 IN ($controllerVersion),, $controllerVersion) GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'crashed' AS label, SUM(_sample_interval) AS crashed_checkins FROM kiloclaw_controller_telemetry WHERE $timeFilter\n  AND blob6 = 'crashed'\n  $conditionalTest(AND index1 = ${sandboxId:sqlstring},, $sandboxId)\n  $conditionalTest(AND blob7 IN ($flyRegion),, $flyRegion)\n  $conditionalTest(AND blob2 IN ($controllerVersion),, $controllerVersion) GROUP BY t ORDER BY t",
           "refId": "A",
           "round": "0s",
           "showFormattedSQL": false,
@@ -773,7 +773,7 @@
           "useWindowFuncForMacros": true
         }
       ],
-      "title": "Check-ins by Fly Region",
+      "title": "Crashed Check-ins",
       "type": "timeseries"
     },
     {

--- a/dev/grafana/dashboards/kiloclaw-controller-telemetry.json
+++ b/dev/grafana/dashboards/kiloclaw-controller-telemetry.json
@@ -366,7 +366,7 @@
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 18,
+            "fillOpacity": 12,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -688,7 +688,7 @@
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 12,
+            "fillOpacity": 18,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,

--- a/services/kilo-ops/container/provisioning/dashboards/kiloclaw-controller-telemetry.json
+++ b/services/kilo-ops/container/provisioning/dashboards/kiloclaw-controller-telemetry.json
@@ -674,6 +674,7 @@
         "type": "vertamedia-clickhouse-datasource",
         "uid": "${DS_KILOCLAW}"
       },
+      "description": "Sample-corrected check-ins reporting supervisor_state = crashed. Use this to spot crash spikes.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -688,7 +689,7 @@
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 12,
+            "fillOpacity": 18,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -732,8 +733,7 @@
         "x": 12,
         "y": 14
       },
-      "description": "Check-in volume by Fly region (blob7). Highlights regional traffic skew or outages.",
-      "id": 28,
+      "id": 36,
       "options": {
         "legend": {
           "calcs": [],
@@ -762,8 +762,8 @@
           "interval": "",
           "intervalFactor": 1,
           "nullifySparse": false,
-          "query": "SELECT $timeSeries AS t, blob7 AS label, SUM(_sample_interval) AS checkins FROM kiloclaw_controller_telemetry WHERE $timeFilter\n  $conditionalTest(AND index1 = ${sandboxId:sqlstring},, $sandboxId)\n  $conditionalTest(AND blob6 IN ($supervisorState),, $supervisorState)\n  $conditionalTest(AND blob7 IN ($flyRegion),, $flyRegion)\n  $conditionalTest(AND blob2 IN ($controllerVersion),, $controllerVersion) AND blob7 != '' GROUP BY t, label ORDER BY t",
-          "rawSql": "SELECT $timeSeries AS t, blob7 AS label, SUM(_sample_interval) AS checkins FROM kiloclaw_controller_telemetry WHERE $timeFilter\n  $conditionalTest(AND index1 = ${sandboxId:sqlstring},, $sandboxId)\n  $conditionalTest(AND blob6 IN ($supervisorState),, $supervisorState)\n  $conditionalTest(AND blob7 IN ($flyRegion),, $flyRegion)\n  $conditionalTest(AND blob2 IN ($controllerVersion),, $controllerVersion) AND blob7 != '' GROUP BY t, label ORDER BY t",
+          "query": "SELECT $timeSeries AS t, 'crashed' AS label, SUM(_sample_interval) AS crashed_checkins FROM kiloclaw_controller_telemetry WHERE $timeFilter\n  AND blob6 = 'crashed'\n  $conditionalTest(AND index1 = ${sandboxId:sqlstring},, $sandboxId)\n  $conditionalTest(AND blob7 IN ($flyRegion),, $flyRegion)\n  $conditionalTest(AND blob2 IN ($controllerVersion),, $controllerVersion) GROUP BY t ORDER BY t",
+          "rawSql": "SELECT $timeSeries AS t, 'crashed' AS label, SUM(_sample_interval) AS crashed_checkins FROM kiloclaw_controller_telemetry WHERE $timeFilter\n  AND blob6 = 'crashed'\n  $conditionalTest(AND index1 = ${sandboxId:sqlstring},, $sandboxId)\n  $conditionalTest(AND blob7 IN ($flyRegion),, $flyRegion)\n  $conditionalTest(AND blob2 IN ($controllerVersion),, $controllerVersion) GROUP BY t ORDER BY t",
           "refId": "A",
           "round": "0s",
           "showFormattedSQL": false,
@@ -773,7 +773,7 @@
           "useWindowFuncForMacros": true
         }
       ],
-      "title": "Check-ins by Fly Region",
+      "title": "Crashed Check-ins",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
## Summary

- Replace the broken KiloClaw controller telemetry Fly Region chart (we don't actually report region) with a `Crashed Check-ins` time series.
- Graph sample-corrected controller check-ins where `supervisor_state = crashed` so crash spikes are visible

## Verification

- Manually inspected the dashboard diff to confirm both hosted and dev Grafana dashboard copies use the same `crashed_checkins` query.
- Did not manually load Grafana because the change is limited to provisioned dashboard JSON.
- [ ] Add any additional manual verification details.

## Visual Changes

| Before | After |
| ------ | ----- |
| Controller telemetry dashboard showed the broken `Check-ins by Fly Region` chart. | The same dashboard slot now shows `Crashed Check-ins` over time. |

## Reviewer Notes

- The query keeps the existing sandbox, Fly region, and controller version filters, but intentionally does not split by OpenClaw version.
- Dashboard copies are duplicated under `services/kilo-ops/container/provisioning/dashboards/` and `dev/grafana/dashboards/`; both were updated.