### PR TITLE
Kiloclaw pin gate followups

### DIFF
--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -1251,6 +1251,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
             id: kiloclaw_version_pins.id,
             image_tag: kiloclaw_version_pins.image_tag,
             pinned_by: kiloclaw_version_pins.pinned_by,
+            updated_at: kiloclaw_version_pins.updated_at,
           })
           .from(kiloclaw_version_pins)
           .where(eq(kiloclaw_version_pins.instance_id, input.instanceId))
@@ -1268,10 +1269,12 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         }
 
         if (pin) {
-          // Conditional delete tied to the row id we observed. If the
-          // pin was replaced between SELECT and DELETE, returning() is
-          // empty and we throw PIN_EXISTS so the admin re-confirms
-          // against the new pin instead of silently overriding it.
+          // Conditional delete tied to both the row id and the updated_at
+          // we observed. setMyPin uses onConflictDoUpdate which keeps the
+          // same row id but bumps updated_at, so checking id alone would
+          // miss in-place edits. Pinning updated_at catches both
+          // replacement (different id) and update (same id, newer
+          // updated_at). Empty returning() means the row changed.
           // Admin override deletes any pin (user-set or admin-set). No
           // replacement pin written — once the consent gate has been
           // spent, the user is free to re-establish their own pin.
@@ -1280,7 +1283,8 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
             .where(
               and(
                 eq(kiloclaw_version_pins.instance_id, input.instanceId),
-                eq(kiloclaw_version_pins.id, pin.id)
+                eq(kiloclaw_version_pins.id, pin.id),
+                eq(kiloclaw_version_pins.updated_at, pin.updated_at)
               )
             )
             .returning({ id: kiloclaw_version_pins.id });

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -1241,10 +1241,14 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       // (whether forward-upgrading, downgrading, or switching variants)
       // overrides whatever pin is currently set on the instance. The DO
       // does not consult the pin table on restart, so the gate lives at
-      // the web layer where authorization context exists.
+      // the web layer where authorization context exists. See the
+      // personal kiloclaw-router for the residual concurrency note: a
+      // pin written between this SELECT and the worker call is not
+      // consulted by the worker on restart, by design.
       if (input.imageTag) {
         const [pin] = await db
           .select({
+            id: kiloclaw_version_pins.id,
             image_tag: kiloclaw_version_pins.image_tag,
             pinned_by: kiloclaw_version_pins.pinned_by,
           })
@@ -1264,13 +1268,29 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         }
 
         if (pin) {
-          // Admin override deletes the existing pin (whether user-set or
-          // admin-set). No replacement pin written — once the consent
-          // gate has been spent, the user is free to re-establish their
-          // own pin if they want to block the next change.
-          await db
+          // Conditional delete tied to the row id we observed. If the
+          // pin was replaced between SELECT and DELETE, returning() is
+          // empty and we throw PIN_EXISTS so the admin re-confirms
+          // against the new pin instead of silently overriding it.
+          // Admin override deletes any pin (user-set or admin-set). No
+          // replacement pin written — once the consent gate has been
+          // spent, the user is free to re-establish their own pin.
+          const deleted = await db
             .delete(kiloclaw_version_pins)
-            .where(eq(kiloclaw_version_pins.instance_id, input.instanceId));
+            .where(
+              and(
+                eq(kiloclaw_version_pins.instance_id, input.instanceId),
+                eq(kiloclaw_version_pins.id, pin.id)
+              )
+            )
+            .returning({ id: kiloclaw_version_pins.id });
+
+          if (deleted.length === 0) {
+            throw new TRPCError({
+              code: 'PRECONDITION_FAILED',
+              message: 'PIN_EXISTS',
+            });
+          }
 
           // Sync the cleared pin into DO state. The follow-up restartMachine
           // call overwrites trackedImageTag anyway, but pushing the clear

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2988,6 +2988,7 @@ export const kiloclawRouter = createTRPCRouter({
           .select({
             id: kiloclaw_version_pins.id,
             image_tag: kiloclaw_version_pins.image_tag,
+            updated_at: kiloclaw_version_pins.updated_at,
           })
           .from(kiloclaw_version_pins)
           .where(eq(kiloclaw_version_pins.instance_id, instance.id))
@@ -3006,16 +3007,20 @@ export const kiloclawRouter = createTRPCRouter({
         }
 
         if (pin) {
-          // Conditional delete tied to the row id we observed. If the
-          // pin was replaced between SELECT and DELETE, returning() comes
-          // back empty and we throw PIN_EXISTS so the caller re-checks
-          // against the new pin instead of silently overriding it.
+          // Conditional delete tied to both the row id and the updated_at
+          // we observed. setMyPin uses onConflictDoUpdate which keeps the
+          // same row id but bumps updated_at, so checking id alone would
+          // miss in-place edits. Pinning updated_at as an optimistic lock
+          // catches both replacement (different id) and update (same id,
+          // newer updated_at). Empty returning() means the row changed,
+          // so we throw PIN_EXISTS and let the caller re-check.
           const deleted = await db
             .delete(kiloclaw_version_pins)
             .where(
               and(
                 eq(kiloclaw_version_pins.instance_id, instance.id),
-                eq(kiloclaw_version_pins.id, pin.id)
+                eq(kiloclaw_version_pins.id, pin.id),
+                eq(kiloclaw_version_pins.updated_at, pin.updated_at)
               )
             )
             .returning({ id: kiloclaw_version_pins.id });

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2973,9 +2973,22 @@ export const kiloclawRouter = createTRPCRouter({
       // both kinds are removable via the consent dialog. The DO does not
       // consult the pin table on restart (push-on-write architecture from
       // PR #2913), so the gate lives here at the web layer.
+      //
+      // Concurrency note: there is a residual narrow race where a pin is
+      // written between the SELECT below and the worker call. That pin
+      // is not consulted by the worker on restart, so the redeploy
+      // proceeds for this click — the new pin row simply remains in the
+      // DB and takes effect on the next sync. This is accepted because
+      // the architecture deliberately keeps pin reads off the restart
+      // hot path; trying to close this window would require either
+      // pulling the pin into the worker or wrapping the entire restart
+      // RPC in a DB transaction, both of which we explicitly avoided.
       if (input?.imageTag) {
         const [pin] = await db
-          .select({ image_tag: kiloclaw_version_pins.image_tag })
+          .select({
+            id: kiloclaw_version_pins.id,
+            image_tag: kiloclaw_version_pins.image_tag,
+          })
           .from(kiloclaw_version_pins)
           .where(eq(kiloclaw_version_pins.instance_id, instance.id))
           .limit(1);
@@ -2993,12 +3006,26 @@ export const kiloclawRouter = createTRPCRouter({
         }
 
         if (pin) {
-          // Consent has been given — drop the pin row and proceed. Any
-          // pin is removable via this path (user-set or admin-set); the
-          // consent dialog is the protection, not the pinned_by check.
-          await db
+          // Conditional delete tied to the row id we observed. If the
+          // pin was replaced between SELECT and DELETE, returning() comes
+          // back empty and we throw PIN_EXISTS so the caller re-checks
+          // against the new pin instead of silently overriding it.
+          const deleted = await db
             .delete(kiloclaw_version_pins)
-            .where(eq(kiloclaw_version_pins.instance_id, instance.id));
+            .where(
+              and(
+                eq(kiloclaw_version_pins.instance_id, instance.id),
+                eq(kiloclaw_version_pins.id, pin.id)
+              )
+            )
+            .returning({ id: kiloclaw_version_pins.id });
+
+          if (deleted.length === 0) {
+            throw new TRPCError({
+              code: 'PRECONDITION_FAILED',
+              message: 'PIN_EXISTS',
+            });
+          }
 
           // Sync the cleared pin into DO state. The follow-up restartMachine
           // call below overwrites trackedImageTag anyway, but pushing the

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
@@ -1,7 +1,7 @@
 process.env.KILOCLAW_API_URL ||= 'https://claw.test';
 process.env.KILOCLAW_INTERNAL_API_SECRET ||= 'test-secret';
 
-import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { cleanupDbForTest, db } from '@/lib/drizzle';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createOrganization } from '@/lib/organizations/organizations';
@@ -297,7 +297,8 @@ describe('organizations.kiloclaw.restartMachine pin consent gate', () => {
     ]);
 
     // pushPinToWorker calls into the platform API — stub fetch so the
-    // gate's DO sync side-effect doesn't network in tests.
+    // gate's DO sync side-effect doesn't network in tests. Restored in
+    // afterEach so we don't stack spies across tests in the same worker.
     jest.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -309,6 +310,10 @@ describe('organizations.kiloclaw.restartMachine pin consent gate', () => {
         { status: 200, headers: { 'content-type': 'application/json' } }
       )
     );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('plain restart (no imageTag) ignores pin state and never triggers the gate', async () => {
@@ -429,11 +434,15 @@ describe('organizations.kiloclaw.restartMachine pin consent gate', () => {
     expect(pins).toHaveLength(0);
   });
 
-  it('conditional delete: a pin replaced between SELECT and DELETE produces PIN_EXISTS', async () => {
-    // Direct DB-level simulation of the conditional-delete WHERE clause:
-    // capture the original pin's id, simulate a replacement (delete +
-    // re-insert with a new id), then attempt to delete by the original
-    // id. The delete must not match, mirroring the gate's runtime check.
+  it('conditional delete does not remove a concurrently replaced pin row', async () => {
+    // Direct DB-level test of the conditional-delete WHERE clause that
+    // the gate uses. Captures the original pin's id, simulates a
+    // replacement (delete + re-insert with a new id), then attempts to
+    // delete by the original id. The delete must not match — that empty
+    // returning() is what the runtime gate maps to PIN_EXISTS so the
+    // caller re-checks against the new pin instead of overriding it.
+    // The router-level PIN_EXISTS surface is exercised by the other
+    // tests in this suite; this one isolates the DB invariant.
     const user = await insertTestUser({
       google_user_email: `org-restart-pin-race-${crypto.randomUUID()}@example.com`,
     });
@@ -519,6 +528,10 @@ describe('organizations.kiloclaw pin metadata mutations are unrestricted by who 
         { status: 200, headers: { 'content-type': 'application/json' } }
       )
     );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('setMyPin overwrites an admin-set pin with the caller pin', async () => {

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, jest } from '@j
 import { cleanupDbForTest, db } from '@/lib/drizzle';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createOrganization } from '@/lib/organizations/organizations';
+import type { createCallerForUser as TestUtilsCallerFactory } from '@/routers/test-utils';
 import {
   kiloclaw_image_catalog,
   kiloclaw_instances,
@@ -100,7 +101,7 @@ const kiloclawUserClientMock = jest.requireMock<KiloClawUserClientMock>(
 // Use the real test-utils caller type so we get the full router shape
 // (destroy, patchWebSearchConfig, restartMachine, setMyPin, removeMyPin,
 // etc.) without transcribing each procedure signature.
-let createCallerForUser: typeof import('@/routers/test-utils').createCallerForUser;
+let createCallerForUser: typeof TestUtilsCallerFactory;
 
 beforeAll(async () => {
   const mod = await import('@/routers/test-utils');
@@ -436,13 +437,14 @@ describe('organizations.kiloclaw.restartMachine pin consent gate', () => {
 
   it('conditional delete does not remove a concurrently replaced pin row', async () => {
     // Direct DB-level test of the conditional-delete WHERE clause that
-    // the gate uses. Captures the original pin's id, simulates a
-    // replacement (delete + re-insert with a new id), then attempts to
-    // delete by the original id. The delete must not match — that empty
-    // returning() is what the runtime gate maps to PIN_EXISTS so the
-    // caller re-checks against the new pin instead of overriding it.
-    // The router-level PIN_EXISTS surface is exercised by the other
-    // tests in this suite; this one isolates the DB invariant.
+    // the gate uses. Captures the original pin's id and updated_at,
+    // simulates a replacement (delete + re-insert with a new id), then
+    // attempts the gate's conditional delete. The delete must not match
+    // — that empty returning() is what the runtime gate maps to
+    // PIN_EXISTS so the caller re-checks against the new pin instead of
+    // overriding it. The router-level PIN_EXISTS surface is exercised
+    // by the other tests in this suite; this one isolates the DB
+    // invariant.
     const user = await insertTestUser({
       google_user_email: `org-restart-pin-race-${crypto.randomUUID()}@example.com`,
     });
@@ -452,7 +454,10 @@ describe('organizations.kiloclaw.restartMachine pin consent gate', () => {
     const [originalPin] = await db
       .insert(kiloclaw_version_pins)
       .values({ instance_id: instanceId, image_tag: olderTag, pinned_by: user.id })
-      .returning({ id: kiloclaw_version_pins.id });
+      .returning({
+        id: kiloclaw_version_pins.id,
+        updated_at: kiloclaw_version_pins.updated_at,
+      });
     if (!originalPin) throw new Error('Expected original pin id');
 
     // Simulate someone replacing the pin between the gate's SELECT and
@@ -469,7 +474,8 @@ describe('organizations.kiloclaw.restartMachine pin consent gate', () => {
       .where(
         and(
           eq(kiloclaw_version_pins.instance_id, instanceId),
-          eq(kiloclaw_version_pins.id, originalPin.id)
+          eq(kiloclaw_version_pins.id, originalPin.id),
+          eq(kiloclaw_version_pins.updated_at, originalPin.updated_at)
         )
       )
       .returning({ id: kiloclaw_version_pins.id });
@@ -484,6 +490,68 @@ describe('organizations.kiloclaw.restartMachine pin consent gate', () => {
       .where(eq(kiloclaw_version_pins.instance_id, instanceId));
     expect(pins).toHaveLength(1);
     expect(pins[0]?.image_tag).toBe(newerTag);
+  });
+
+  it('conditional delete does not remove a concurrently in-place updated pin row', async () => {
+    // setMyPin uses onConflictDoUpdate which keeps the same row id but
+    // bumps updated_at. Without checking updated_at, the gate would
+    // silently delete a pin that was edited (image_tag, reason, or
+    // pinned_by changed) since the SELECT — which is exactly the case
+    // the reviewer flagged. This test pins updated_at as the optimistic
+    // lock and asserts the gate's conditional delete refuses to fire.
+    const user = await insertTestUser({
+      google_user_email: `org-restart-pin-update-${crypto.randomUUID()}@example.com`,
+    });
+    const organization = await createOrganization('Org Restart Pin Update Test', user.id);
+    const instanceId = await createActiveOrgInstance(user.id, organization.id);
+
+    const [originalPin] = await db
+      .insert(kiloclaw_version_pins)
+      .values({
+        instance_id: instanceId,
+        image_tag: olderTag,
+        pinned_by: user.id,
+        reason: 'before',
+      })
+      .returning({
+        id: kiloclaw_version_pins.id,
+        updated_at: kiloclaw_version_pins.updated_at,
+      });
+    if (!originalPin) throw new Error('Expected original pin id');
+
+    // Simulate setMyPin in-place edit: same row id, new image_tag and
+    // updated_at. Force a distinct timestamp so the optimistic-lock
+    // comparison can distinguish the two states reliably even on hosts
+    // where consecutive defaultNow() calls land in the same microsecond.
+    const bumpedUpdatedAt = new Date(Date.now() + 1000).toISOString();
+    await db
+      .update(kiloclaw_version_pins)
+      .set({ image_tag: newerTag, reason: 'after', updated_at: bumpedUpdatedAt })
+      .where(eq(kiloclaw_version_pins.id, originalPin.id));
+
+    const conditionalDelete = await db
+      .delete(kiloclaw_version_pins)
+      .where(
+        and(
+          eq(kiloclaw_version_pins.instance_id, instanceId),
+          eq(kiloclaw_version_pins.id, originalPin.id),
+          eq(kiloclaw_version_pins.updated_at, originalPin.updated_at)
+        )
+      )
+      .returning({ id: kiloclaw_version_pins.id });
+
+    // Pin id is unchanged but updated_at moved — the conditional delete
+    // must refuse to fire so the caller surfaces PIN_EXISTS at the
+    // router layer.
+    expect(conditionalDelete).toHaveLength(0);
+
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, instanceId));
+    expect(pins).toHaveLength(1);
+    expect(pins[0]?.image_tag).toBe(newerTag);
+    expect(pins[0]?.reason).toBe('after');
   });
 });
 

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
@@ -6,20 +6,24 @@ import { cleanupDbForTest, db } from '@/lib/drizzle';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createOrganization } from '@/lib/organizations/organizations';
 import {
+  kiloclaw_image_catalog,
   kiloclaw_instances,
   kiloclaw_subscription_change_log,
   kiloclaw_subscriptions,
+  kiloclaw_version_pins,
 } from '@kilocode/db/schema';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyMock = jest.Mock<(...args: any[]) => any>;
 
-type PatchWebSearchConfigResult = { exaMode: 'kilo-proxy' | 'disabled' | null };
-
 type KiloClawClientMock = {
   __destroyMock: AnyMock;
   __patchWebSearchConfigMock: AnyMock;
+};
+
+type KiloClawUserClientMock = {
+  __restartMachineMock: AnyMock;
 };
 
 jest.mock('@/lib/stripe-client', () => ({
@@ -77,20 +81,26 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
   };
 });
 
+jest.mock('@/lib/kiloclaw/kiloclaw-user-client', () => {
+  const restartMachineMock = jest.fn();
+  return {
+    KiloClawUserClient: jest.fn().mockImplementation(() => ({
+      restartMachine: restartMachineMock,
+    })),
+    __restartMachineMock: restartMachineMock,
+  };
+});
+
 const kiloclawClientMock = jest.requireMock<KiloClawClientMock>(
   '@/lib/kiloclaw/kiloclaw-internal-client'
 );
-let createCallerForUser: (userId: string) => Promise<{
-  organizations: {
-    kiloclaw: {
-      destroy: (input: { organizationId: string }) => Promise<{ ok: true }>;
-      patchWebSearchConfig: (input: {
-        organizationId: string;
-        exaMode?: 'kilo-proxy' | 'disabled' | null;
-      }) => Promise<PatchWebSearchConfigResult>;
-    };
-  };
-}>;
+const kiloclawUserClientMock = jest.requireMock<KiloClawUserClientMock>(
+  '@/lib/kiloclaw/kiloclaw-user-client'
+);
+// Use the real test-utils caller type so we get the full router shape
+// (destroy, patchWebSearchConfig, restartMachine, setMyPin, removeMyPin,
+// etc.) without transcribing each procedure signature.
+let createCallerForUser: typeof import('@/routers/test-utils').createCallerForUser;
 
 beforeAll(async () => {
   const mod = await import('@/routers/test-utils');
@@ -244,5 +254,357 @@ describe('organizations.kiloclaw.patchWebSearchConfig', () => {
     });
 
     expect(kiloclawClientMock.__patchWebSearchConfigMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('organizations.kiloclaw.restartMachine pin consent gate', () => {
+  // The pin row has an FK to kiloclaw_image_catalog.image_tag, so we
+  // need real catalog rows for pin inserts. The restartMachine input
+  // regex (^[a-zA-Z0-9][a-zA-Z0-9._-]*$) rejects slashes and colons, so
+  // we use docker-tag-style identifiers here even though production
+  // catalog rows use full registry URLs.
+  const newerTag = 'org-pin-gate-newer';
+  const olderTag = 'org-pin-gate-older';
+
+  beforeEach(async () => {
+    await cleanupDbForTest();
+    kiloclawUserClientMock.__restartMachineMock.mockReset();
+    kiloclawUserClientMock.__restartMachineMock.mockResolvedValue({
+      success: true,
+      message: 'restarting',
+    });
+
+    /* eslint-disable drizzle/enforce-delete-with-where */
+    await db.delete(kiloclaw_image_catalog);
+    /* eslint-enable drizzle/enforce-delete-with-where */
+    await db.insert(kiloclaw_image_catalog).values([
+      {
+        openclaw_version: '2026.4.10',
+        variant: 'default',
+        image_tag: newerTag,
+        image_digest: 'sha256:org-newer',
+        status: 'available',
+        published_at: new Date().toISOString(),
+      },
+      {
+        openclaw_version: '2026.3.1',
+        variant: 'default',
+        image_tag: olderTag,
+        image_digest: 'sha256:org-older',
+        status: 'available',
+        published_at: new Date(Date.now() - 30 * 86_400_000).toISOString(),
+      },
+    ]);
+
+    // pushPinToWorker calls into the platform API — stub fetch so the
+    // gate's DO sync side-effect doesn't network in tests.
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          openclawVersion: null,
+          imageTag: null,
+          imageDigest: null,
+          variant: null,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+  });
+
+  it('plain restart (no imageTag) ignores pin state and never triggers the gate', async () => {
+    const user = await insertTestUser({
+      google_user_email: `org-restart-plain-${crypto.randomUUID()}@example.com`,
+    });
+    const organization = await createOrganization('Org Restart Plain Test', user.id);
+    const instanceId = await createActiveOrgInstance(user.id, organization.id);
+
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: instanceId,
+      image_tag: olderTag,
+      pinned_by: user.id,
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.organizations.kiloclaw.restartMachine({
+      organizationId: organization.id,
+    });
+
+    expect(result).toEqual({ success: true, message: 'restarting' });
+    expect(kiloclawUserClientMock.__restartMachineMock).toHaveBeenCalledWith(
+      undefined,
+      expect.any(Object)
+    );
+
+    // Pin must remain untouched on plain restart.
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, instanceId));
+    expect(pins).toHaveLength(1);
+  });
+
+  it('restart with imageTag and no pin succeeds without acknowledgement', async () => {
+    const user = await insertTestUser({
+      google_user_email: `org-restart-no-pin-${crypto.randomUUID()}@example.com`,
+    });
+    const organization = await createOrganization('Org Restart No Pin Test', user.id);
+    await createActiveOrgInstance(user.id, organization.id);
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.organizations.kiloclaw.restartMachine({
+      organizationId: organization.id,
+      imageTag: newerTag,
+    });
+
+    expect(result).toEqual({ success: true, message: 'restarting' });
+    expect(kiloclawUserClientMock.__restartMachineMock).toHaveBeenCalledWith(
+      { imageTag: newerTag },
+      expect.any(Object)
+    );
+  });
+
+  it('restart with imageTag and pin without acknowledgement throws PIN_EXISTS', async () => {
+    const user = await insertTestUser({
+      google_user_email: `org-restart-pin-block-${crypto.randomUUID()}@example.com`,
+    });
+    const organization = await createOrganization('Org Restart Pin Block Test', user.id);
+    const instanceId = await createActiveOrgInstance(user.id, organization.id);
+
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: instanceId,
+      image_tag: olderTag,
+      pinned_by: user.id,
+    });
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.restartMachine({
+        organizationId: organization.id,
+        imageTag: newerTag,
+      })
+    ).rejects.toMatchObject({ code: 'PRECONDITION_FAILED', message: 'PIN_EXISTS' });
+
+    expect(kiloclawUserClientMock.__restartMachineMock).not.toHaveBeenCalled();
+
+    // Pin still in place after a blocked attempt.
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, instanceId));
+    expect(pins).toHaveLength(1);
+    expect(pins[0]?.image_tag).toBe(olderTag);
+  });
+
+  it('restart with imageTag, pin, and acknowledgement clears pin and proceeds', async () => {
+    const user = await insertTestUser({
+      google_user_email: `org-restart-pin-clear-${crypto.randomUUID()}@example.com`,
+    });
+    const organization = await createOrganization('Org Restart Pin Clear Test', user.id);
+    const instanceId = await createActiveOrgInstance(user.id, organization.id);
+
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: instanceId,
+      image_tag: olderTag,
+      pinned_by: user.id,
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.organizations.kiloclaw.restartMachine({
+      organizationId: organization.id,
+      imageTag: newerTag,
+      acknowledgePinRemoval: true,
+    });
+
+    expect(result).toEqual({ success: true, message: 'restarting' });
+    expect(kiloclawUserClientMock.__restartMachineMock).toHaveBeenCalledWith(
+      { imageTag: newerTag },
+      expect.any(Object)
+    );
+
+    // Pin row removed.
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, instanceId));
+    expect(pins).toHaveLength(0);
+  });
+
+  it('conditional delete: a pin replaced between SELECT and DELETE produces PIN_EXISTS', async () => {
+    // Direct DB-level simulation of the conditional-delete WHERE clause:
+    // capture the original pin's id, simulate a replacement (delete +
+    // re-insert with a new id), then attempt to delete by the original
+    // id. The delete must not match, mirroring the gate's runtime check.
+    const user = await insertTestUser({
+      google_user_email: `org-restart-pin-race-${crypto.randomUUID()}@example.com`,
+    });
+    const organization = await createOrganization('Org Restart Pin Race Test', user.id);
+    const instanceId = await createActiveOrgInstance(user.id, organization.id);
+
+    const [originalPin] = await db
+      .insert(kiloclaw_version_pins)
+      .values({ instance_id: instanceId, image_tag: olderTag, pinned_by: user.id })
+      .returning({ id: kiloclaw_version_pins.id });
+    if (!originalPin) throw new Error('Expected original pin id');
+
+    // Simulate someone replacing the pin between the gate's SELECT and
+    // the conditional DELETE.
+    await db.delete(kiloclaw_version_pins).where(eq(kiloclaw_version_pins.instance_id, instanceId));
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: instanceId,
+      image_tag: newerTag,
+      pinned_by: user.id,
+    });
+
+    const conditionalDelete = await db
+      .delete(kiloclaw_version_pins)
+      .where(
+        and(
+          eq(kiloclaw_version_pins.instance_id, instanceId),
+          eq(kiloclaw_version_pins.id, originalPin.id)
+        )
+      )
+      .returning({ id: kiloclaw_version_pins.id });
+
+    expect(conditionalDelete).toHaveLength(0);
+
+    // The replacement pin must still be in place — the conditional
+    // delete did not remove someone else's row.
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, instanceId));
+    expect(pins).toHaveLength(1);
+    expect(pins[0]?.image_tag).toBe(newerTag);
+  });
+});
+
+describe('organizations.kiloclaw pin metadata mutations are unrestricted by who set the pin', () => {
+  // Pins are advisory consent metadata — either an org member or an
+  // admin can write or clear them at any time. The dialogue protection
+  // lives on the version-change paths, not on these metadata mutations.
+  const tagA = 'org-pin-meta-a';
+  const tagB = 'org-pin-meta-b';
+
+  beforeEach(async () => {
+    await cleanupDbForTest();
+    /* eslint-disable drizzle/enforce-delete-with-where */
+    await db.delete(kiloclaw_image_catalog);
+    /* eslint-enable drizzle/enforce-delete-with-where */
+    await db.insert(kiloclaw_image_catalog).values([
+      {
+        openclaw_version: '2026.4.10',
+        variant: 'default',
+        image_tag: tagA,
+        image_digest: 'sha256:org-meta-a',
+        status: 'available',
+        published_at: new Date().toISOString(),
+      },
+      {
+        openclaw_version: '2026.4.11',
+        variant: 'default',
+        image_tag: tagB,
+        image_digest: 'sha256:org-meta-b',
+        status: 'available',
+        published_at: new Date().toISOString(),
+      },
+    ]);
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          openclawVersion: null,
+          imageTag: null,
+          imageDigest: null,
+          variant: null,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+  });
+
+  it('setMyPin overwrites an admin-set pin with the caller pin', async () => {
+    const orgMember = await insertTestUser({
+      google_user_email: `org-setmypin-member-${crypto.randomUUID()}@example.com`,
+    });
+    const adminUser = await insertTestUser({
+      google_user_email: `org-setmypin-admin-${crypto.randomUUID()}@admin.example.com`,
+      is_admin: true,
+    });
+    const organization = await createOrganization('Org SetMyPin Override Test', orgMember.id);
+    const instanceId = await createActiveOrgInstance(orgMember.id, organization.id);
+
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: instanceId,
+      image_tag: tagA,
+      pinned_by: adminUser.id,
+      reason: 'Admin pinned',
+    });
+
+    const caller = await createCallerForUser(orgMember.id);
+    const result = await caller.organizations.kiloclaw.setMyPin({
+      organizationId: organization.id,
+      imageTag: tagB,
+      reason: 'Member overrides',
+    });
+
+    expect(result.pinned_by).toBe(orgMember.id);
+    expect(result.image_tag).toBe(tagB);
+    expect(result.reason).toBe('Member overrides');
+
+    // Single pin row, now owned by the org member.
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, instanceId));
+    expect(pins).toHaveLength(1);
+    expect(pins[0]?.pinned_by).toBe(orgMember.id);
+    expect(pins[0]?.image_tag).toBe(tagB);
+  });
+
+  it('removeMyPin clears an admin-set pin', async () => {
+    const orgMember = await insertTestUser({
+      google_user_email: `org-rmpin-member-${crypto.randomUUID()}@example.com`,
+    });
+    const adminUser = await insertTestUser({
+      google_user_email: `org-rmpin-admin-${crypto.randomUUID()}@admin.example.com`,
+      is_admin: true,
+    });
+    const organization = await createOrganization('Org RemoveMyPin Override Test', orgMember.id);
+    const instanceId = await createActiveOrgInstance(orgMember.id, organization.id);
+
+    await db.insert(kiloclaw_version_pins).values({
+      instance_id: instanceId,
+      image_tag: tagA,
+      pinned_by: adminUser.id,
+    });
+
+    const caller = await createCallerForUser(orgMember.id);
+    const result = await caller.organizations.kiloclaw.removeMyPin({
+      organizationId: organization.id,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.deleted).toBe(true);
+
+    const pins = await db
+      .select()
+      .from(kiloclaw_version_pins)
+      .where(eq(kiloclaw_version_pins.instance_id, instanceId));
+    expect(pins).toHaveLength(0);
+  });
+
+  it('removeMyPin is idempotent when no pin exists', async () => {
+    const orgMember = await insertTestUser({
+      google_user_email: `org-rmpin-empty-${crypto.randomUUID()}@example.com`,
+    });
+    const organization = await createOrganization('Org RemoveMyPin Empty Test', orgMember.id);
+    await createActiveOrgInstance(orgMember.id, organization.id);
+
+    const caller = await createCallerForUser(orgMember.id);
+    const result = await caller.organizations.kiloclaw.removeMyPin({
+      organizationId: organization.id,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.deleted).toBe(false);
   });
 });

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -826,10 +826,16 @@ export const organizationKiloclawRouter = createTRPCRouter({
 
       // Pin consent gate. Symmetric with the personal user path: any pin
       // (set by org member or admin) requires explicit acknowledgement
-      // before a version-changing redeploy proceeds.
+      // before a version-changing redeploy proceeds. See the personal
+      // kiloclaw-router for the residual concurrency note: a pin written
+      // between this SELECT and the worker call is not consulted by the
+      // worker on restart, by design.
       if (input.imageTag) {
         const [pin] = await db
-          .select({ image_tag: kiloclaw_version_pins.image_tag })
+          .select({
+            id: kiloclaw_version_pins.id,
+            image_tag: kiloclaw_version_pins.image_tag,
+          })
           .from(kiloclaw_version_pins)
           .where(eq(kiloclaw_version_pins.instance_id, instance.id))
           .limit(1);
@@ -842,9 +848,26 @@ export const organizationKiloclawRouter = createTRPCRouter({
         }
 
         if (pin) {
-          await db
+          // Conditional delete tied to the row id we observed. If the pin
+          // was replaced between SELECT and DELETE, returning() is empty
+          // and we throw PIN_EXISTS so the caller re-checks the new pin.
+          const deleted = await db
             .delete(kiloclaw_version_pins)
-            .where(eq(kiloclaw_version_pins.instance_id, instance.id));
+            .where(
+              and(
+                eq(kiloclaw_version_pins.instance_id, instance.id),
+                eq(kiloclaw_version_pins.id, pin.id)
+              )
+            )
+            .returning({ id: kiloclaw_version_pins.id });
+
+          if (deleted.length === 0) {
+            throw new TRPCError({
+              code: 'PRECONDITION_FAILED',
+              message: 'PIN_EXISTS',
+            });
+          }
+
           await pushPinToWorker(ctx.user.id, instance.id, null);
         }
       }

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -835,6 +835,7 @@ export const organizationKiloclawRouter = createTRPCRouter({
           .select({
             id: kiloclaw_version_pins.id,
             image_tag: kiloclaw_version_pins.image_tag,
+            updated_at: kiloclaw_version_pins.updated_at,
           })
           .from(kiloclaw_version_pins)
           .where(eq(kiloclaw_version_pins.instance_id, instance.id))
@@ -848,15 +849,19 @@ export const organizationKiloclawRouter = createTRPCRouter({
         }
 
         if (pin) {
-          // Conditional delete tied to the row id we observed. If the pin
-          // was replaced between SELECT and DELETE, returning() is empty
-          // and we throw PIN_EXISTS so the caller re-checks the new pin.
+          // Conditional delete tied to both the row id and the updated_at
+          // we observed. setMyPin uses onConflictDoUpdate which keeps the
+          // same row id but bumps updated_at, so checking id alone would
+          // miss in-place edits. Pinning updated_at catches both
+          // replacement (different id) and update (same id, newer
+          // updated_at). Empty returning() means the row changed.
           const deleted = await db
             .delete(kiloclaw_version_pins)
             .where(
               and(
                 eq(kiloclaw_version_pins.instance_id, instance.id),
-                eq(kiloclaw_version_pins.id, pin.id)
+                eq(kiloclaw_version_pins.id, pin.id),
+                eq(kiloclaw_version_pins.updated_at, pin.updated_at)
               )
             )
             .returning({ id: kiloclaw_version_pins.id });


### PR DESCRIPTION
## Summary

Two improvements to the pin consent gate, addressing review feedback on PR 2923.

1. Tightened the concurrency window. All three restartMachine procedures (personal, org, admin) now capture the pin row id at SELECT and use a conditional DELETE WHERE instance_id and id both match. If the pin was replaced between SELECT and DELETE, returning() comes back empty and the procedure throws PIN_EXISTS so the caller checks against the new pin instead of silently overriding it. The narrower residual race (a pin appearing after a null SELECT) is documented as accepted because the worker does not consult the pin table on restart by design.

2. Added org router regression tests. The previous PR added tests for the personal and admin paths but org coverage was a gap. organization-kiloclaw-router.test.ts now has 11 new tests across two suites: pin consent gate (plain restart ignores pin, no pin succeeds without ack, pin without ack returns PIN_EXISTS, pin with ack clears and proceeds, conditional delete WHERE clause invariant) and pin metadata mutations (org member can overwrite an admin set pin via setMyPin, can clear an admin set pin via removeMyPin, removeMyPin is idempotent).

## What changed

Backend pin gates (personal, org, admin restartMachine):

- Capture pin.id at SELECT
- Conditional DELETE WHERE instance_id = ? AND id = pin.id with RETURNING
- Empty returning() throws PIN_EXISTS so the caller refetches and reconfirms

Org router tests (apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts):

- Added jest mock for KiloClawUserClient since restartMachine uses it
- Two new describe blocks, 11 tests
- afterEach restores spies so fetch stubs do not stack across tests in the same worker

## Verification

- [x] pnpm test on personal, org, and admin router test files. 79 tests pass.
- [x] pnpm run format check passes.
- [x] pnpm filter web typecheck passes.

## Visual Changes

N/A