### PR TITLE
fix(kilo-ops): set wrangler account id

### DIFF
--- a/services/kilo-ops/wrangler.jsonc
+++ b/services/kilo-ops/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
+  "account_id": "e115e769bcdd4c3d66af59d3332cb394",
   "name": "kilo-ops",
   "main": "src/worker.ts",
   "compatibility_date": "2026-02-24",


### PR DESCRIPTION
## Summary
- Add the top-level Wrangler `account_id` to the kilo-ops Worker config (same as other projects)
- Align kilo-ops with other service `wrangler.jsonc` files so deploys target the expected Cloudflare account and avoid `/memberships` auth failures.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
This is a config-only deploy fix for the kilo-ops Worker. Should fix deploys like https://github.com/Kilo-Org/cloud/actions/runs/25135185784/job/73671690671

