### PR TITLE
fix(kiloclaw): stop proxy crash recovery

### DIFF
--- a/services/kiloclaw/DEVELOPMENT.md
+++ b/services/kiloclaw/DEVELOPMENT.md
@@ -574,8 +574,8 @@ User browser ──[JWT cookie]──> catch-all proxy ───┤
   and calls an RPC method.
 - **User routes** (`/api/kiloclaw/*`): JWT cookie auth. Returns user's config/status.
 - **Catch-all proxy**: JWT cookie auth. Resolves the user's per-user sandbox and
-  proxies HTTP/WebSocket to the OpenClaw gateway inside the container. Auto-recovers
-  crashed instances on the next request.
+  proxies HTTP/WebSocket to the OpenClaw gateway inside the container. Unexpected
+  stopped-machine recovery is handled by the reconciliation alarm, not by proxy requests.
 - **Admin routes** (`/api/admin/*`): JWT cookie auth. Storage sync, gateway restart.
   Delegates to the DO via RPC.
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -6749,7 +6749,7 @@ describe('start failure analytics events', () => {
   });
 });
 
-describe('manual and crash recovery analytics events', () => {
+describe('manual lifecycle analytics events', () => {
   it('can record manual start success events through Analytics Engine payloads', () => {
     const env = createFakeEnv();
     const dataset = env.KILOCLAW_AE as { writeDataPoint: Mock };
@@ -6778,37 +6778,6 @@ describe('manual and crash recovery analytics events', () => {
     expect(successEvents).toHaveLength(1);
     expect(successEvents[0].blobs).toEqual(
       expect.arrayContaining(['instance.manual_start_succeeded', 'user-1', 'http'])
-    );
-  });
-
-  it('can record crash recovery failure events through Analytics Engine payloads', () => {
-    const env = createFakeEnv();
-    const dataset = env.KILOCLAW_AE as { writeDataPoint: Mock };
-
-    dataset.writeDataPoint({
-      blobs: [
-        'instance.crash_recovery_failed',
-        'user-1',
-        'http',
-        '',
-        'restart failed',
-        'acct-test',
-        'machine-1',
-        'sandbox-1',
-        'running',
-        '',
-        '',
-        '',
-        '',
-      ],
-      doubles: [34, 0],
-      indexes: ['instance.crash_recovery_failed'],
-    });
-
-    const failureEvents = analyticsEventsByName(env, 'instance.crash_recovery_failed');
-    expect(failureEvents).toHaveLength(1);
-    expect(failureEvents[0].blobs).toEqual(
-      expect.arrayContaining(['instance.crash_recovery_failed', 'user-1', 'http', 'restart failed'])
     );
   });
 });

--- a/services/kiloclaw/src/index.test.ts
+++ b/services/kiloclaw/src/index.test.ts
@@ -461,7 +461,7 @@ describe('proxy routing target usage', () => {
     expect(input).toBe('http://127.0.0.1:45001/api/foo');
   });
 
-  it('rebuilds HTTP retry auth with the refreshed authoritative sandbox id after crash recovery', async () => {
+  it('does not start or retry the default HTTP proxy when the upstream fetch fails', async () => {
     const registryStub = {
       listInstances: vi.fn().mockResolvedValue([
         {
@@ -474,64 +474,25 @@ describe('proxy routing target usage', () => {
       ]),
     };
     const instanceStub = {
-      getStatus: vi
-        .fn()
-        .mockResolvedValueOnce({
-          userId: 'user-1',
-          sandboxId: 'sandbox-old',
-          status: 'running',
-          provider: 'fly',
-          runtimeId: 'machine-old',
-          flyMachineId: 'machine-old',
-          flyAppName: 'test-app',
-        })
-        .mockResolvedValueOnce({
-          userId: 'user-1',
-          sandboxId: 'sandbox-old',
-          status: 'running',
-          provider: 'fly',
-          runtimeId: 'machine-old',
-          flyMachineId: 'machine-old',
-          flyAppName: 'test-app',
-        })
-        .mockResolvedValueOnce({
-          userId: 'user-1',
-          sandboxId: 'sandbox-new',
-          status: 'running',
-          provider: 'fly',
-          runtimeId: 'machine-new',
-          flyMachineId: 'machine-new',
-          flyAppName: 'test-app',
-        })
-        .mockResolvedValueOnce({
-          userId: 'user-1',
-          sandboxId: 'sandbox-new',
-          status: 'running',
-          provider: 'fly',
-          runtimeId: 'machine-new',
-          flyMachineId: 'machine-new',
-          flyAppName: 'test-app',
-        }),
+      getStatus: vi.fn().mockResolvedValue({
+        userId: 'user-1',
+        sandboxId: 'sandbox-1',
+        status: 'running',
+        provider: 'fly',
+        runtimeId: 'machine-1',
+        flyMachineId: 'machine-1',
+        flyAppName: 'test-app',
+      }),
       start: vi.fn().mockResolvedValue({ started: true }),
-      getRoutingTarget: vi
-        .fn()
-        .mockResolvedValueOnce({
-          origin: 'https://test-app.fly.dev',
-          headers: {
-            'fly-force-instance-id': 'machine-old',
-          },
-        })
-        .mockResolvedValueOnce({
-          origin: 'https://test-app.fly.dev',
-          headers: {
-            'fly-force-instance-id': 'machine-new',
-          },
-        }),
+      getRoutingTarget: vi.fn().mockResolvedValue({
+        origin: 'https://test-app.fly.dev',
+        headers: {
+          'fly-force-instance-id': 'machine-1',
+        },
+      }),
     };
     const fetchMock = vi.mocked(fetch) as FetchMock;
-    fetchMock
-      .mockRejectedValueOnce(new Error('socket hang up'))
-      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    fetchMock.mockRejectedValueOnce(new Error('socket hang up'));
 
     const response = await app.fetch(
       new Request('https://example.com/api/foo?bar=baz'),
@@ -548,25 +509,21 @@ describe('proxy routing target usage', () => {
           idFromName: vi.fn().mockReturnValue('instance-id'),
           get: vi.fn().mockReturnValue(instanceStub),
         },
-        KILOCLAW_AE: { writeDataPoint: vi.fn() },
       } as never,
       { waitUntil: vi.fn() } as never
     );
 
-    expect(response.status).toBe(200);
-
-    const retryCall = getFetchCall(fetchMock, 1);
-    if (!(retryCall.init?.headers instanceof Headers)) {
-      throw new Error('Expected retry fetch headers to be a Headers instance');
-    }
-
-    expect(retryCall.init.headers.get('fly-force-instance-id')).toBe('machine-new');
-    expect(retryCall.init.headers.get('x-kiloclaw-proxy-token')).toBe(
-      await deriveGatewayToken('sandbox-new', 'gateway-secret')
-    );
+    expect(response.status).toBe(503);
+    expect(response.headers.get('Retry-After')).toBe('5');
+    await expect(response.json()).resolves.toEqual({
+      error: 'Instance not reachable',
+      hint: 'Your instance may not be running. Start it from the dashboard.',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(instanceStub.start).not.toHaveBeenCalled();
   });
 
-  it('rebuilds WebSocket retry auth with the refreshed authoritative sandbox id after crash recovery', async () => {
+  it('does not start or retry the default WebSocket proxy when the upstream fetch fails', async () => {
     const registryStub = {
       listInstances: vi.fn().mockResolvedValue([
         {
@@ -579,64 +536,25 @@ describe('proxy routing target usage', () => {
       ]),
     };
     const instanceStub = {
-      getStatus: vi
-        .fn()
-        .mockResolvedValueOnce({
-          userId: 'user-1',
-          sandboxId: 'sandbox-old',
-          status: 'running',
-          provider: 'fly',
-          runtimeId: 'machine-old',
-          flyMachineId: 'machine-old',
-          flyAppName: 'test-app',
-        })
-        .mockResolvedValueOnce({
-          userId: 'user-1',
-          sandboxId: 'sandbox-old',
-          status: 'running',
-          provider: 'fly',
-          runtimeId: 'machine-old',
-          flyMachineId: 'machine-old',
-          flyAppName: 'test-app',
-        })
-        .mockResolvedValueOnce({
-          userId: 'user-1',
-          sandboxId: 'sandbox-new',
-          status: 'running',
-          provider: 'fly',
-          runtimeId: 'machine-new',
-          flyMachineId: 'machine-new',
-          flyAppName: 'test-app',
-        })
-        .mockResolvedValueOnce({
-          userId: 'user-1',
-          sandboxId: 'sandbox-new',
-          status: 'running',
-          provider: 'fly',
-          runtimeId: 'machine-new',
-          flyMachineId: 'machine-new',
-          flyAppName: 'test-app',
-        }),
+      getStatus: vi.fn().mockResolvedValue({
+        userId: 'user-1',
+        sandboxId: 'sandbox-1',
+        status: 'running',
+        provider: 'fly',
+        runtimeId: 'machine-1',
+        flyMachineId: 'machine-1',
+        flyAppName: 'test-app',
+      }),
       start: vi.fn().mockResolvedValue({ started: true }),
-      getRoutingTarget: vi
-        .fn()
-        .mockResolvedValueOnce({
-          origin: 'https://test-app.fly.dev',
-          headers: {
-            'fly-force-instance-id': 'machine-old',
-          },
-        })
-        .mockResolvedValueOnce({
-          origin: 'https://test-app.fly.dev',
-          headers: {
-            'fly-force-instance-id': 'machine-new',
-          },
-        }),
+      getRoutingTarget: vi.fn().mockResolvedValue({
+        origin: 'https://test-app.fly.dev',
+        headers: {
+          'fly-force-instance-id': 'machine-1',
+        },
+      }),
     };
     const fetchMock = vi.mocked(fetch) as FetchMock;
-    fetchMock
-      .mockRejectedValueOnce(new Error('socket hang up'))
-      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    fetchMock.mockRejectedValueOnce(new Error('socket hang up'));
 
     const response = await app.fetch(
       new Request('https://example.com/socket', {
@@ -655,21 +573,17 @@ describe('proxy routing target usage', () => {
           idFromName: vi.fn().mockReturnValue('instance-id'),
           get: vi.fn().mockReturnValue(instanceStub),
         },
-        KILOCLAW_AE: { writeDataPoint: vi.fn() },
       } as never,
       { waitUntil: vi.fn() } as never
     );
 
-    expect(response.status).toBe(200);
-
-    const retryCall = getFetchCall(fetchMock, 1);
-    if (!(retryCall.init?.headers instanceof Headers)) {
-      throw new Error('Expected retry fetch headers to be a Headers instance');
-    }
-
-    expect(retryCall.init.headers.get('fly-force-instance-id')).toBe('machine-new');
-    expect(retryCall.init.headers.get('x-kiloclaw-proxy-token')).toBe(
-      await deriveGatewayToken('sandbox-new', 'gateway-secret')
-    );
+    expect(response.status).toBe(503);
+    expect(response.headers.get('Retry-After')).toBe('5');
+    await expect(response.json()).resolves.toEqual({
+      error: 'Instance not reachable',
+      hint: 'Your instance may not be running. Start it from the dashboard.',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(instanceStub.start).not.toHaveBeenCalled();
   });
 });

--- a/services/kiloclaw/src/index.ts
+++ b/services/kiloclaw/src/index.ts
@@ -38,7 +38,6 @@ import { startingUpPage } from './pages/starting-up';
 import { buildForwardHeaders } from './utils/proxy-headers';
 import { KILOCLAW_ACTIVE_INSTANCE_COOKIE } from './config';
 import { timingMiddleware } from './middleware/analytics';
-import { writeEvent } from './utils/analytics';
 import type { RegistryEntry } from './durable-objects/kiloclaw-registry';
 import type { ProviderRoutingTarget } from './providers/types';
 
@@ -535,70 +534,6 @@ async function resolveRegistryEntry(c: Context<AppEnv>) {
 }
 
 /**
- * Attempt crash recovery: if the user's instance has status 'running' but
- * the machine is dead, call start() to restart it transparently.
- */
-async function attemptCrashRecovery(c: Context<AppEnv>): Promise<boolean> {
-  const userId = c.get('userId');
-  if (!userId) return false;
-  const startedAt = performance.now();
-
-  try {
-    const resolved = await resolveRegistryEntry(c);
-    if (!resolved) return false;
-    const { entry } = resolved;
-    const getStub = () =>
-      c.env.KILOCLAW_INSTANCE.get(c.env.KILOCLAW_INSTANCE.idFromName(entry.doKey));
-    const status = await withDORetry(
-      getStub,
-      stub => stub.getStatus(),
-      'KiloClawInstance.getStatus'
-    );
-
-    if (status.status !== 'running') {
-      return false;
-    }
-
-    // Machine dead despite running status -- restart
-    console.log('[PROXY] Instance status is running but machine unreachable, restarting');
-    const { started } = await withDORetry(
-      getStub,
-      stub => stub.start(userId, { reason: 'crash_recovery' }),
-      'KiloClawInstance.start'
-    );
-    if (started) {
-      const freshStatus = await withDORetry(
-        getStub,
-        stub => stub.getStatus(),
-        'KiloClawInstance.getStatus'
-      );
-      writeEvent(c.env, {
-        event: 'instance.crash_recovery_succeeded',
-        delivery: 'http',
-        userId,
-        sandboxId: freshStatus.sandboxId ?? undefined,
-        flyMachineId: freshStatus.flyMachineId ?? undefined,
-        flyAppName: freshStatus.flyAppName ?? undefined,
-        status: freshStatus.status ?? undefined,
-        durationMs: performance.now() - startedAt,
-      });
-    }
-    return true;
-  } catch (err) {
-    writeEvent(c.env, {
-      event: 'instance.crash_recovery_failed',
-      delivery: 'http',
-      userId,
-      sandboxId: c.get('sandboxId') ?? undefined,
-      error: err instanceof Error ? err.message : String(err),
-      durationMs: performance.now() - startedAt,
-    });
-    console.error('[PROXY] Crash recovery failed:', err);
-  }
-  return false;
-}
-
-/**
  * Resolve the active provider runtime id, sandboxId, and status for the current user from their DO.
  * Returns null runtimeId if the instance is destroying (blocks proxy during teardown).
  * Routes through the user registry, which triggers lazy migration on first access.
@@ -911,7 +846,7 @@ app.all('*', async c => {
   if (!routingTarget) {
     return c.json({ error: 'Instance not routable' }, 503);
   }
-  let targetUrl = routingTargetUrl(routingTarget, url.pathname, url.search);
+  const targetUrl = routingTargetUrl(routingTarget, url.pathname, url.search);
 
   console.log('[PROXY] Handling request:', url.pathname, 'runtime:', runtimeId);
 
@@ -929,7 +864,7 @@ app.all('*', async c => {
   // This is critical: instance-keyed DOs derive sandboxId from instanceId (ki_ prefix),
   // which differs from the middleware-derived value (sandboxIdFromUserId). The gateway
   // token must match what the machine expects.
-  let forwardHeaders = await buildForwardHeaders({
+  const forwardHeaders = await buildForwardHeaders({
     requestHeaders: request.headers,
     sandboxId,
     gatewayTokenSecret: c.env.GATEWAY_TOKEN_SECRET,
@@ -947,63 +882,13 @@ app.all('*', async c => {
       });
     } catch (err) {
       console.error('[WS] Fly Proxy fetch failed:', err);
-
-      const recovered = await attemptCrashRecovery(c);
-      if (recovered) {
-        // Machine may have been recreated — refresh the instance routing header
-        const refreshedInstance = await resolveInstance(c);
-        if (
-          !refreshedInstance.runtimeId ||
-          !refreshedInstance.doKey ||
-          !refreshedInstance.sandboxId
-        ) {
-          return c.json(
-            { error: 'Instance not reachable after restart' },
-            { status: 503, headers: { 'Retry-After': '5' } }
-          );
-        }
-        const refreshedDoKey = refreshedInstance.doKey;
-        const getRefreshedStub = () =>
-          c.env.KILOCLAW_INSTANCE.get(c.env.KILOCLAW_INSTANCE.idFromName(refreshedDoKey));
-        const refreshedRoutingTarget = await withDORetry(
-          getRefreshedStub,
-          stub => stub.getRoutingTarget(),
-          'KiloClawInstance.getRoutingTarget'
-        );
-        if (!refreshedRoutingTarget) {
-          return c.json(
-            { error: 'Instance not reachable after restart' },
-            { status: 503, headers: { 'Retry-After': '5' } }
-          );
-        }
-        targetUrl = routingTargetUrl(refreshedRoutingTarget, url.pathname, url.search);
-        forwardHeaders = await buildForwardHeaders({
-          requestHeaders: request.headers,
-          sandboxId: refreshedInstance.sandboxId,
-          gatewayTokenSecret: c.env.GATEWAY_TOKEN_SECRET,
-          providerHeaders: refreshedRoutingTarget.headers,
-        });
-
-        try {
-          containerResponse = await fetch(targetUrl, {
-            headers: forwardHeaders,
-          });
-        } catch (retryErr) {
-          console.error('[WS] Retry after recovery failed:', retryErr);
-          return c.json(
-            { error: 'Instance not reachable after restart attempt' },
-            { status: 503, headers: { 'Retry-After': '5' } }
-          );
-        }
-      } else {
-        return c.json(
-          {
-            error: 'Instance not reachable',
-            hint: 'Your instance may not be running. Start it from the dashboard.',
-          },
-          { status: 503, headers: { 'Retry-After': '5' } }
-        );
-      }
+      return c.json(
+        {
+          error: 'Instance not reachable',
+          hint: 'Your instance may not be running. Start it from the dashboard.',
+        },
+        { status: 503, headers: { 'Retry-After': '5' } }
+      );
     }
     console.log('[WS] Fly Proxy response status:', containerResponse.status);
 
@@ -1121,65 +1006,13 @@ app.all('*', async c => {
     });
   } catch (err) {
     console.error('[HTTP] Fly Proxy fetch failed:', err);
-
-    const recovered = await attemptCrashRecovery(c);
-    if (recovered) {
-      // Machine may have been recreated — refresh the instance routing header
-      const refreshedInstance = await resolveInstance(c);
-      if (
-        !refreshedInstance.runtimeId ||
-        !refreshedInstance.doKey ||
-        !refreshedInstance.sandboxId
-      ) {
-        return c.json(
-          { error: 'Instance not reachable after restart' },
-          { status: 503, headers: { 'Retry-After': '5' } }
-        );
-      }
-      const refreshedHttpDoKey = refreshedInstance.doKey;
-      const getRefreshedHttpStub = () =>
-        c.env.KILOCLAW_INSTANCE.get(c.env.KILOCLAW_INSTANCE.idFromName(refreshedHttpDoKey));
-      const refreshedRoutingTarget = await withDORetry(
-        getRefreshedHttpStub,
-        stub => stub.getRoutingTarget(),
-        'KiloClawInstance.getRoutingTarget'
-      );
-      if (!refreshedRoutingTarget) {
-        return c.json(
-          { error: 'Instance not reachable after restart' },
-          { status: 503, headers: { 'Retry-After': '5' } }
-        );
-      }
-      targetUrl = routingTargetUrl(refreshedRoutingTarget, url.pathname, url.search);
-      forwardHeaders = await buildForwardHeaders({
-        requestHeaders: request.headers,
-        sandboxId: refreshedInstance.sandboxId,
-        gatewayTokenSecret: c.env.GATEWAY_TOKEN_SECRET,
-        providerHeaders: refreshedRoutingTarget.headers,
-      });
-
-      try {
-        httpResponse = await fetch(targetUrl, {
-          method: request.method,
-          headers: forwardHeaders,
-          body: requestBody,
-        });
-      } catch (retryErr) {
-        console.error('[HTTP] Retry after recovery failed:', retryErr);
-        return c.json(
-          { error: 'Instance not reachable after restart attempt' },
-          { status: 503, headers: { 'Retry-After': '5' } }
-        );
-      }
-    } else {
-      return c.json(
-        {
-          error: 'Instance not reachable',
-          hint: 'Your instance may not be running. Start it from the dashboard.',
-        },
-        { status: 503, headers: { 'Retry-After': '5' } }
-      );
-    }
+    return c.json(
+      {
+        error: 'Instance not reachable',
+        hint: 'Your instance may not be running. Start it from the dashboard.',
+      },
+      { status: 503, headers: { 'Retry-After': '5' } }
+    );
   }
   console.log('[HTTP] Response status:', httpResponse.status);
 


### PR DESCRIPTION
## Summary

- Remove proxy-time crash recovery from the default/personal legacy KiloClaw catch-all route so proxy fetch failures no longer call `KiloClawInstance.start()`.
- Preserve the other two proxy routing paths: `/i/:instanceId/*` and active-instance-cookie routing already returned `503` without auto-recovering and remain unchanged.
- Keep unexpected stopped-machine recovery owned by the Durable Object reconciliation alarm, updating tests and development docs to reflect that only the legacy/default route still had proxy-time auto recovery.

## Verification

- No manual verification was performed; this is Worker proxy behavior covered by targeted route tests rather than an easily exercised local browser flow.
- [ ] Add any additional manual verification details.

## Visual Changes

N/A

## Reviewer Notes

- Main behavior change is that default/personal legacy proxy `fetch()` exceptions now return `503` immediately instead of attempting to start/recreate the machine.
- Alarm-driven unexpected-stop recovery remains unchanged and should still be the only recovery path for stopped Fly machines.