### PR TITLE
feat(admin): add bulk cancel + refund Kilo Pass by email

### DIFF
--- a/apps/web/src/app/admin/components/AppSidebar.tsx
+++ b/apps/web/src/app/admin/components/AppSidebar.tsx
@@ -23,6 +23,7 @@ import {
   KeyRound,
   Copy,
   Megaphone,
+  Coins,
 } from 'lucide-react';
 import { useSession } from 'next-auth/react';
 import type { Session } from 'next-auth';
@@ -102,6 +103,11 @@ const financialItems: MenuItem[] = [
     title: () => 'Bulk Credits & Trials',
     url: '/admin/bulk-credits',
     icon: () => <Upload />,
+  },
+  {
+    title: () => 'Kilo Pass Bulk Cancel',
+    url: '/admin/kilo-pass/bulk-cancel',
+    icon: () => <Coins />,
   },
   {
     title: () => 'Revenue KPI',

--- a/apps/web/src/app/admin/components/KiloPassBulkCancel.tsx
+++ b/apps/web/src/app/admin/components/KiloPassBulkCancel.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { toast } from 'sonner';
+import Link from 'next/link';
+
+const MAX_EMAILS = 500;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type BulkResultStatus =
+  | 'cancelled_and_refunded'
+  | 'skipped_no_user'
+  | 'skipped_no_subscription'
+  | 'skipped_already_canceled'
+  | 'error';
+
+type ResultRow = {
+  email: string;
+  userId: string | null;
+  status: BulkResultStatus;
+  refundedAmountCents: number | null;
+  balanceResetAmountUsd: number | null;
+  alreadyBlocked: boolean;
+  error: string | null;
+};
+
+function parseEmails(raw: string): { valid: string[]; invalid: string[] } {
+  const tokens = raw
+    .split(/[\s,]+/)
+    .map(t => t.trim().toLowerCase())
+    .filter(Boolean);
+  const seen = new Set<string>();
+  const valid: string[] = [];
+  const invalid: string[] = [];
+  for (const token of tokens) {
+    if (seen.has(token)) continue;
+    seen.add(token);
+    if (EMAIL_REGEX.test(token)) {
+      valid.push(token);
+    } else {
+      invalid.push(token);
+    }
+  }
+  return { valid, invalid };
+}
+
+const statusLabel: Record<BulkResultStatus, string> = {
+  cancelled_and_refunded: 'Cancelled & Refunded',
+  skipped_no_user: 'User not found',
+  skipped_no_subscription: 'No Kilo Pass',
+  skipped_already_canceled: 'Already cancelled',
+  error: 'Error',
+};
+
+const statusBadgeClass: Record<BulkResultStatus, string> = {
+  cancelled_and_refunded: 'bg-green-900/20 text-green-400',
+  skipped_no_user: 'bg-gray-800 text-gray-300',
+  skipped_no_subscription: 'bg-gray-800 text-gray-300',
+  skipped_already_canceled: 'bg-yellow-900/20 text-yellow-400',
+  error: 'bg-red-900/20 text-red-400',
+};
+
+const statusGroupOrder: BulkResultStatus[] = [
+  'cancelled_and_refunded',
+  'error',
+  'skipped_already_canceled',
+  'skipped_no_subscription',
+  'skipped_no_user',
+];
+
+function formatUsd(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export function KiloPassBulkCancel() {
+  const trpc = useTRPC();
+  const [rawEmails, setRawEmails] = useState('');
+  const [reason, setReason] = useState('');
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const { valid: emails, invalid: invalidEmails } = useMemo(
+    () => parseEmails(rawEmails),
+    [rawEmails]
+  );
+  const overLimit = emails.length > MAX_EMAILS;
+
+  const mutation = useMutation(
+    trpc.admin.kiloPass.cancelAndRefundKiloPassBulk.mutationOptions({
+      onSuccess: outcome => {
+        toast.success(
+          `Done. Cancelled ${outcome.summary.cancelled}, skipped ${outcome.summary.skipped}, errored ${outcome.summary.errored}.`
+        );
+      },
+      onError: err => {
+        toast.error(err.message || 'Bulk cancel failed');
+      },
+    })
+  );
+
+  const canSubmit =
+    emails.length > 0 && !overLimit && reason.trim().length > 0 && !mutation.isPending;
+
+  function handleSubmitClick() {
+    if (!canSubmit) return;
+    setConfirmOpen(true);
+  }
+
+  function handleConfirm() {
+    setConfirmOpen(false);
+    mutation.mutate({ emails, reason: reason.trim() });
+  }
+
+  const results = mutation.data?.results;
+  const summary = mutation.data?.summary;
+
+  const groupedResults = useMemo(() => {
+    if (!results) return null;
+    const groups = new Map<BulkResultStatus, ResultRow[]>();
+    for (const row of results) {
+      const list = groups.get(row.status) ?? [];
+      list.push(row);
+      groups.set(row.status, list);
+    }
+    return groups;
+  }, [results]);
+
+  return (
+    <div className="flex flex-col gap-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Input</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="emails">Emails (newline- or comma-separated, max {MAX_EMAILS})</Label>
+            <Textarea
+              id="emails"
+              rows={10}
+              placeholder="alice@example.com&#10;bob@example.com&#10;..."
+              value={rawEmails}
+              onChange={e => setRawEmails(e.target.value)}
+            />
+            <div className="text-muted-foreground flex flex-wrap gap-x-4 text-xs">
+              <span>{emails.length.toLocaleString()} valid unique emails</span>
+              {invalidEmails.length > 0 && (
+                <span className="text-red-400">
+                  {invalidEmails.length} invalid token{invalidEmails.length === 1 ? '' : 's'}{' '}
+                  ignored
+                </span>
+              )}
+              {overLimit && <span className="text-red-400">Over limit of {MAX_EMAILS}</span>}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="reason">Reason (required)</Label>
+            <Input
+              id="reason"
+              placeholder="e.g. abuse/chargeback-fraud/policy-violation"
+              value={reason}
+              onChange={e => setReason(e.target.value)}
+            />
+          </div>
+
+          <Alert>
+            <AlertDescription>
+              For each email: cancels the Stripe subscription immediately, refunds the latest paid
+              invoice, resets balance to $0, blocks the account if not already blocked, and inserts
+              an admin note tagged <code>[bulk]</code>. Each user runs in its own DB transaction;
+              partial failures leave successful users committed.
+            </AlertDescription>
+          </Alert>
+
+          <div className="flex items-center gap-3">
+            <Button variant="destructive" disabled={!canSubmit} onClick={handleSubmitClick}>
+              {mutation.isPending ? 'Processing…' : 'Cancel + refund + block'}
+            </Button>
+            {mutation.isPending && (
+              <span className="text-muted-foreground text-sm">
+                Running sequentially, please wait…
+              </span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {summary && results && groupedResults && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Results</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+              <SummaryStat label="Total" value={summary.total.toString()} />
+              <SummaryStat
+                label="Refunded total"
+                value={formatUsd(summary.totalRefundedCents)}
+                highlight
+              />
+              <SummaryStat label="Cancelled" value={summary.cancelled.toString()} />
+              <SummaryStat label="Skipped" value={summary.skipped.toString()} />
+              <SummaryStat label="Errored" value={summary.errored.toString()} />
+            </div>
+
+            {statusGroupOrder.map(status => {
+              const rows = groupedResults.get(status);
+              if (!rows || rows.length === 0) return null;
+              return (
+                <div key={status} className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Badge className={statusBadgeClass[status]}>{statusLabel[status]}</Badge>
+                    <span className="text-muted-foreground text-sm">
+                      {rows.length} {rows.length === 1 ? 'user' : 'users'}
+                    </span>
+                  </div>
+                  <div className="rounded-md border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Email</TableHead>
+                          <TableHead>User</TableHead>
+                          <TableHead className="text-right">Refunded</TableHead>
+                          <TableHead className="text-right">Balance reset</TableHead>
+                          <TableHead>Notes</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {rows.map(row => (
+                          <TableRow key={row.email}>
+                            <TableCell className="font-mono text-xs">{row.email}</TableCell>
+                            <TableCell className="text-xs">
+                              {row.userId ? (
+                                <Link
+                                  className="text-primary hover:underline"
+                                  href={`/admin/users/${encodeURIComponent(row.userId)}`}
+                                >
+                                  {row.userId}
+                                </Link>
+                              ) : (
+                                <span className="text-muted-foreground">—</span>
+                              )}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-xs">
+                              {row.refundedAmountCents != null
+                                ? formatUsd(row.refundedAmountCents)
+                                : '—'}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-xs">
+                              {row.balanceResetAmountUsd != null
+                                ? `$${row.balanceResetAmountUsd.toFixed(2)}`
+                                : '—'}
+                            </TableCell>
+                            <TableCell className="text-xs">
+                              {row.status === 'error' ? (
+                                <span className="text-red-400">{row.error}</span>
+                              ) : row.status === 'cancelled_and_refunded' && row.alreadyBlocked ? (
+                                <span className="text-muted-foreground">
+                                  Account was already blocked
+                                </span>
+                              ) : (
+                                ''
+                              )}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      )}
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirm bulk cancel</AlertDialogTitle>
+            <AlertDialogDescription>
+              Cancel + refund Kilo Pass and block {emails.length}{' '}
+              {emails.length === 1 ? 'user' : 'users'}. This is irreversible.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={handleConfirm}>
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+function SummaryStat({
+  label,
+  value,
+  highlight,
+}: {
+  label: string;
+  value: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div className="bg-muted/50 rounded-lg border p-3">
+      <div className="text-muted-foreground text-xs">{label}</div>
+      <div className={`font-mono text-lg font-semibold ${highlight ? 'text-green-400' : ''}`}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/kilo-pass/bulk-cancel/page.tsx
+++ b/apps/web/src/app/admin/kilo-pass/bulk-cancel/page.tsx
@@ -1,0 +1,24 @@
+import AdminPage from '../../components/AdminPage';
+import { BreadcrumbItem, BreadcrumbPage } from '@/components/ui/breadcrumb';
+import { KiloPassBulkCancel } from '../../components/KiloPassBulkCancel';
+
+const breadcrumbs = (
+  <>
+    <BreadcrumbItem>
+      <BreadcrumbPage>Kilo Pass Bulk Cancel</BreadcrumbPage>
+    </BreadcrumbItem>
+  </>
+);
+
+export default function KiloPassBulkCancelPage() {
+  return (
+    <AdminPage breadcrumbs={breadcrumbs}>
+      <div className="flex w-full flex-col gap-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-bold">Kilo Pass Bulk Cancel + Refund</h2>
+        </div>
+        <KiloPassBulkCancel />
+      </div>
+    </AdminPage>
+  );
+}

--- a/apps/web/src/lib/kilo-pass/cancel-and-refund.ts
+++ b/apps/web/src/lib/kilo-pass/cancel-and-refund.ts
@@ -1,0 +1,229 @@
+import 'server-only';
+
+import type Stripe from 'stripe';
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import {
+  credit_transactions,
+  kilo_pass_scheduled_changes,
+  kilo_pass_subscriptions,
+  kilocode_users,
+  user_admin_notes,
+} from '@kilocode/db/schema';
+import type { db as defaultDb } from '@/lib/drizzle';
+import { getKiloPassStateForUser } from '@/lib/kilo-pass/state';
+import { releaseScheduledChangeForSubscription } from '@/lib/kilo-pass/scheduled-change-release';
+import { fromMicrodollars } from '@/lib/utils';
+
+type Db = typeof defaultDb;
+
+export type CancelAndRefundKiloPassStripeClient = Pick<
+  Stripe,
+  'subscriptions' | 'invoices' | 'invoicePayments' | 'refunds' | 'errors' | 'subscriptionSchedules'
+>;
+
+export type CancelAndRefundKiloPassReason =
+  | { kind: 'no_subscription' }
+  | { kind: 'already_canceled' };
+
+export type CancelAndRefundKiloPassResult =
+  | {
+      status: 'cancelled_and_refunded';
+      refundedAmountCents: number | null;
+      balanceResetAmountUsd: number | null;
+      alreadyBlocked: boolean;
+    }
+  | {
+      status: 'skipped';
+      reason: CancelAndRefundKiloPassReason;
+    };
+
+export type CancelAndRefundKiloPassParams = {
+  db: Db;
+  stripe: CancelAndRefundKiloPassStripeClient;
+  userId: string;
+  reason: string;
+  adminKiloUserId: string;
+  noteSuffix?: string;
+};
+
+/**
+ * Cancels and refunds a user's Kilo Pass subscription, zeroes their balance,
+ * blocks the account if not already blocked, and appends an admin note.
+ *
+ * Each invocation runs its own DB transaction for the local mutations; the
+ * Stripe-side calls happen before the transaction to minimize open transaction
+ * time. Expected skip conditions (no subscription / already canceled) are
+ * returned as structured results rather than thrown. Any other error (user not
+ * found, Stripe failure not matching `charge_already_refunded`, DB failure) is
+ * thrown so the caller can decide how to surface it.
+ */
+export async function cancelAndRefundKiloPassForUser({
+  db,
+  stripe,
+  userId,
+  reason,
+  adminKiloUserId,
+  noteSuffix,
+}: CancelAndRefundKiloPassParams): Promise<CancelAndRefundKiloPassResult> {
+  const user = await db.query.kilocode_users.findFirst({
+    columns: {
+      id: true,
+      stripe_customer_id: true,
+      blocked_reason: true,
+    },
+    where: eq(kilocode_users.id, userId),
+  });
+
+  if (!user) {
+    throw new Error(`User not found: ${userId}`);
+  }
+
+  const subscription = await getKiloPassStateForUser(db, userId);
+  if (!subscription) {
+    return { status: 'skipped', reason: { kind: 'no_subscription' } };
+  }
+
+  if (subscription.status === 'canceled') {
+    return { status: 'skipped', reason: { kind: 'already_canceled' } };
+  }
+
+  const scheduledChange = await db.query.kilo_pass_scheduled_changes.findFirst({
+    columns: { stripe_schedule_id: true },
+    where: and(
+      eq(kilo_pass_scheduled_changes.stripe_subscription_id, subscription.stripeSubscriptionId),
+      isNull(kilo_pass_scheduled_changes.deleted_at)
+    ),
+  });
+
+  if (scheduledChange) {
+    await releaseScheduledChangeForSubscription({
+      dbOrTx: db,
+      stripe,
+      stripeSubscriptionId: subscription.stripeSubscriptionId,
+      stripeScheduleIdIfMissingRow: scheduledChange.stripe_schedule_id,
+      kiloUserIdIfMissingRow: userId,
+      reason: 'cancel_subscription',
+    });
+  }
+
+  await stripe.subscriptions.cancel(subscription.stripeSubscriptionId);
+
+  let refundedAmountCents: number | null = null;
+  const paidInvoices = await stripe.invoices.list({
+    subscription: subscription.stripeSubscriptionId,
+    status: 'paid',
+    limit: 1,
+  });
+  const paidInvoice = paidInvoices.data[0];
+  if (paidInvoice) {
+    const payments = await stripe.invoicePayments.list({
+      invoice: paidInvoice.id,
+      status: 'paid',
+      limit: 1,
+    });
+    const rawPaymentIntent = payments.data[0]?.payment.payment_intent;
+    const paymentIntentId =
+      typeof rawPaymentIntent === 'string' ? rawPaymentIntent : rawPaymentIntent?.id;
+    if (paymentIntentId) {
+      try {
+        const refund = await stripe.refunds.create({
+          payment_intent: paymentIntentId,
+        });
+        refundedAmountCents = refund.amount;
+      } catch (err) {
+        if (
+          !(err instanceof stripe.errors.StripeInvalidRequestError) ||
+          err.code !== 'charge_already_refunded'
+        ) {
+          throw err;
+        }
+      }
+    }
+  }
+
+  const balanceResetAmountUsd = await db.transaction(async tx => {
+    await tx
+      .update(kilo_pass_subscriptions)
+      .set({
+        status: 'canceled',
+        cancel_at_period_end: false,
+        ended_at: new Date().toISOString(),
+        current_streak_months: 0,
+      })
+      .where(eq(kilo_pass_subscriptions.stripe_subscription_id, subscription.stripeSubscriptionId));
+
+    if (!user.blocked_reason) {
+      await tx
+        .update(kilocode_users)
+        .set({
+          blocked_reason: reason,
+          blocked_at: new Date().toISOString(),
+          blocked_by_kilo_user_id: adminKiloUserId,
+        })
+        .where(eq(kilocode_users.id, userId));
+    }
+
+    const freshUserRows = await tx
+      .select({
+        microdollars_used: kilocode_users.microdollars_used,
+        total_microdollars_acquired: kilocode_users.total_microdollars_acquired,
+      })
+      .from(kilocode_users)
+      .where(eq(kilocode_users.id, userId))
+      .for('update')
+      .limit(1);
+    const freshUser = freshUserRows[0];
+    const currentBalanceMicrodollars = freshUser
+      ? freshUser.total_microdollars_acquired - freshUser.microdollars_used
+      : 0;
+
+    let balanceReset: number | null = null;
+    if (currentBalanceMicrodollars > 0 && freshUser) {
+      await tx.insert(credit_transactions).values({
+        kilo_user_id: userId,
+        organization_id: null,
+        is_free: true,
+        amount_microdollars: -currentBalanceMicrodollars,
+        credit_category: 'admin-cancel-refund-kilo-pass',
+        description: `Balance zeroed by admin: ${reason}`,
+        original_baseline_microdollars_used: freshUser.microdollars_used,
+      });
+      await tx
+        .update(kilocode_users)
+        .set({
+          total_microdollars_acquired: sql`${kilocode_users.total_microdollars_acquired} - ${currentBalanceMicrodollars}`,
+        })
+        .where(eq(kilocode_users.id, userId));
+      balanceReset = fromMicrodollars(currentBalanceMicrodollars);
+    }
+
+    const noteParts = [
+      `Kilo Pass cancelled and refunded by admin.`,
+      `Reason: ${reason}`,
+      refundedAmountCents != null
+        ? `Refunded: $${(refundedAmountCents / 100).toFixed(2)}`
+        : 'No invoice to refund.',
+      balanceReset != null
+        ? `Balance reset: $${balanceReset.toFixed(2)} zeroed.`
+        : 'Balance was already $0.',
+      !user.blocked_reason ? 'Account blocked.' : 'Account was already blocked.',
+    ];
+    if (noteSuffix) {
+      noteParts.push(noteSuffix);
+    }
+    await tx.insert(user_admin_notes).values({
+      kilo_user_id: userId,
+      note_content: noteParts.join(' '),
+      admin_kilo_user_id: adminKiloUserId,
+    });
+
+    return balanceReset;
+  });
+
+  return {
+    status: 'cancelled_and_refunded',
+    refundedAmountCents,
+    balanceResetAmountUsd,
+    alreadyBlocked: !!user.blocked_reason,
+  };
+}

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -4,7 +4,6 @@ import { insertKiloClawSubscriptionChangeLog, type KiloClawSubscription } from '
 import {
   user_admin_notes,
   kilocode_users,
-  kilo_pass_subscriptions,
   stytch_fingerprints,
   enrichment_data,
   user_auth_provider,
@@ -43,6 +42,7 @@ import { adminCustomLlmRouter } from '@/routers/admin/custom-llm-router';
 import { adminGatewayConfigRouter } from '@/routers/admin/gateway-config-router';
 import { adminBlacklistDomainsRouter } from '@/routers/admin/blacklist-domains-router';
 import { adminBulkBlockRouter } from '@/routers/admin/bulk-block-router';
+import { adminKiloPassRouter } from '@/routers/admin/kilo-pass-router';
 import { adminShellSecurityContentRouter } from '@/routers/admin/shell-security-content-router';
 import { adminWebhookTriggersRouter } from '@/routers/admin-webhook-triggers-router';
 import { adminAlertingRouter } from '@/routers/admin-alerting-router';
@@ -74,8 +74,7 @@ import { revalidatePath } from 'next/cache';
 import { recomputeUserBalances } from '@/lib/recomputeUserBalances';
 import { getStripeInvoices } from '@/lib/stripe';
 import { client as stripeClient } from '@/lib/stripe-client';
-import { releaseScheduledChangeForSubscription } from '@/lib/kilo-pass/scheduled-change-release';
-import { kilo_pass_scheduled_changes } from '@kilocode/db/schema';
+import { cancelAndRefundKiloPassForUser } from '@/lib/kilo-pass/cancel-and-refund';
 import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
 import {
   CurrentPersonalSubscriptionResolutionError,
@@ -1336,174 +1335,40 @@ export const adminRouter = createTRPCRouter({
     cancelAndRefundKiloPass: adminProcedure
       .input(CancelAndRefundKiloPassSchema)
       .mutation(async ({ input, ctx }) => {
-        const user = await db.query.kilocode_users.findFirst({
-          columns: {
-            id: true,
-            stripe_customer_id: true,
-            blocked_reason: true,
-          },
+        const userExists = await db.query.kilocode_users.findFirst({
+          columns: { id: true },
           where: eq(kilocode_users.id, input.userId),
         });
-
-        if (!user) {
+        if (!userExists) {
           throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
         }
 
-        const subscription = await getKiloPassStateForUser(db, input.userId);
-        if (!subscription) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: 'No Kilo Pass subscription found for this user',
-          });
-        }
+        const result = await cancelAndRefundKiloPassForUser({
+          db,
+          stripe: stripeClient,
+          userId: input.userId,
+          reason: input.reason,
+          adminKiloUserId: ctx.user.id,
+        });
 
-        if (subscription.status === 'canceled') {
+        if (result.status === 'skipped') {
+          if (result.reason.kind === 'no_subscription') {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: 'No Kilo Pass subscription found for this user',
+            });
+          }
           throw new TRPCError({
             code: 'BAD_REQUEST',
             message: 'Kilo Pass subscription is already canceled',
           });
         }
 
-        const scheduledChange = await db.query.kilo_pass_scheduled_changes.findFirst({
-          columns: { stripe_schedule_id: true },
-          where: and(
-            eq(
-              kilo_pass_scheduled_changes.stripe_subscription_id,
-              subscription.stripeSubscriptionId
-            ),
-            isNull(kilo_pass_scheduled_changes.deleted_at)
-          ),
-        });
-
-        if (scheduledChange) {
-          await releaseScheduledChangeForSubscription({
-            dbOrTx: db,
-            stripe: stripeClient,
-            stripeSubscriptionId: subscription.stripeSubscriptionId,
-            stripeScheduleIdIfMissingRow: scheduledChange.stripe_schedule_id,
-            kiloUserIdIfMissingRow: input.userId,
-            reason: 'cancel_subscription',
-          });
-        }
-
-        await stripeClient.subscriptions.cancel(subscription.stripeSubscriptionId);
-
-        let refundedAmountCents: number | null = null;
-        const paidInvoices = await stripeClient.invoices.list({
-          subscription: subscription.stripeSubscriptionId,
-          status: 'paid',
-          limit: 1,
-        });
-        const paidInvoice = paidInvoices.data[0];
-        if (paidInvoice) {
-          const payments = await stripeClient.invoicePayments.list({
-            invoice: paidInvoice.id,
-            status: 'paid',
-            limit: 1,
-          });
-          const rawPaymentIntent = payments.data[0]?.payment.payment_intent;
-          const paymentIntentId =
-            typeof rawPaymentIntent === 'string' ? rawPaymentIntent : rawPaymentIntent?.id;
-          if (paymentIntentId) {
-            try {
-              const refund = await stripeClient.refunds.create({
-                payment_intent: paymentIntentId,
-              });
-              refundedAmountCents = refund.amount;
-            } catch (err) {
-              if (
-                !(err instanceof stripeClient.errors.StripeInvalidRequestError) ||
-                err.code !== 'charge_already_refunded'
-              ) {
-                throw err;
-              }
-            }
-          }
-        }
-
-        const balanceResetAmountUsd = await db.transaction(async tx => {
-          await tx
-            .update(kilo_pass_subscriptions)
-            .set({
-              status: 'canceled',
-              cancel_at_period_end: false,
-              ended_at: new Date().toISOString(),
-              current_streak_months: 0,
-            })
-            .where(
-              eq(kilo_pass_subscriptions.stripe_subscription_id, subscription.stripeSubscriptionId)
-            );
-
-          if (!user.blocked_reason) {
-            await tx
-              .update(kilocode_users)
-              .set({
-                blocked_reason: input.reason,
-                blocked_at: new Date().toISOString(),
-                blocked_by_kilo_user_id: ctx.user.id,
-              })
-              .where(eq(kilocode_users.id, input.userId));
-          }
-
-          const freshUserRows = await tx
-            .select({
-              microdollars_used: kilocode_users.microdollars_used,
-              total_microdollars_acquired: kilocode_users.total_microdollars_acquired,
-            })
-            .from(kilocode_users)
-            .where(eq(kilocode_users.id, input.userId))
-            .for('update')
-            .limit(1);
-          const freshUser = freshUserRows[0];
-          const currentBalanceMicrodollars = freshUser
-            ? freshUser.total_microdollars_acquired - freshUser.microdollars_used
-            : 0;
-
-          let balanceReset: number | null = null;
-          if (currentBalanceMicrodollars > 0 && freshUser) {
-            await tx.insert(credit_transactions).values({
-              kilo_user_id: input.userId,
-              organization_id: null,
-              is_free: true,
-              amount_microdollars: -currentBalanceMicrodollars,
-              credit_category: 'admin-cancel-refund-kilo-pass',
-              description: `Balance zeroed by admin: ${input.reason}`,
-              original_baseline_microdollars_used: freshUser.microdollars_used,
-            });
-            await tx
-              .update(kilocode_users)
-              .set({
-                total_microdollars_acquired: sql`${kilocode_users.total_microdollars_acquired} - ${currentBalanceMicrodollars}`,
-              })
-              .where(eq(kilocode_users.id, input.userId));
-            balanceReset = fromMicrodollars(currentBalanceMicrodollars);
-          }
-
-          const noteParts = [
-            `Kilo Pass cancelled and refunded by admin.`,
-            `Reason: ${input.reason}`,
-            refundedAmountCents != null
-              ? `Refunded: $${(refundedAmountCents / 100).toFixed(2)}`
-              : 'No invoice to refund.',
-            balanceReset != null
-              ? `Balance reset: $${balanceReset.toFixed(2)} zeroed.`
-              : 'Balance was already $0.',
-            !user.blocked_reason ? 'Account blocked.' : 'Account was already blocked.',
-          ];
-          await tx.insert(user_admin_notes).values({
-            kilo_user_id: input.userId,
-            note_content: noteParts.join(' '),
-            admin_kilo_user_id: ctx.user.id,
-          });
-
-          return balanceReset;
-        });
-
         return {
           success: true,
-          refundedAmountCents,
-          balanceResetAmountUsd,
-          alreadyBlocked: !!user.blocked_reason,
+          refundedAmountCents: result.refundedAmountCents,
+          balanceResetAmountUsd: result.balanceResetAmountUsd,
+          alreadyBlocked: result.alreadyBlocked,
         };
       }),
   }),
@@ -1981,6 +1846,7 @@ export const adminRouter = createTRPCRouter({
   gatewayConfig: adminGatewayConfigRouter,
   blacklistDomains: adminBlacklistDomainsRouter,
   bulkBlock: adminBulkBlockRouter,
+  kiloPass: adminKiloPassRouter,
   // Key kept as `securityAdvisorContent` for tRPC client compatibility —
   // admin UI consumers reference `trpc.admin.securityAdvisorContent.*`.
   // Backing router renamed to `adminShellSecurityContentRouter` as part of

--- a/apps/web/src/routers/admin/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/admin/kilo-pass-router.test.ts
@@ -446,4 +446,61 @@ describe('admin.kiloPass.cancelAndRefundKiloPassBulk', () => {
     });
     expect(userRow?.blocked_reason).toBe('previous-block');
   });
+
+  it('matches stored mixed-case emails case-insensitively', async () => {
+    const stripeMock = getStripeMock();
+    setupHappyPathStripe(stripeMock);
+
+    const target = await insertTestUser({
+      google_user_email: 'Bulk-MixedCase@Example.com',
+    });
+    await insertActiveKiloPass(target.id, 'sub_mixed_case');
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloPass.cancelAndRefundKiloPassBulk({
+      emails: ['bulk-mixedcase@example.com'],
+      reason: 'case-insensitive',
+    });
+
+    expect(result.summary.cancelled).toBe(1);
+    expect(result.results[0].status).toBe('cancelled_and_refunded');
+    expect(result.results[0].userId).toBe(target.id);
+  });
+
+  it('errors on ambiguous case-only duplicates without touching either account', async () => {
+    const stripeMock = getStripeMock();
+    setupHappyPathStripe(stripeMock);
+
+    const u1 = await insertTestUser({ google_user_email: 'Ambiguous@example.com' });
+    const u2 = await insertTestUser({ google_user_email: 'ambiguous@example.com' });
+    await insertActiveKiloPass(u1.id, 'sub_ambig_1');
+    await insertActiveKiloPass(u2.id, 'sub_ambig_2');
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloPass.cancelAndRefundKiloPassBulk({
+      emails: ['ambiguous@example.com'],
+      reason: 'ambiguity',
+    });
+
+    expect(result.summary).toEqual({
+      total: 1,
+      cancelled: 0,
+      skipped: 0,
+      errored: 1,
+      totalRefundedCents: 0,
+    });
+    expect(result.results[0].status).toBe('error');
+    expect(result.results[0].error).toContain('Multiple accounts match');
+
+    // Neither subscription was canceled
+    const sub1 = await db.query.kilo_pass_subscriptions.findFirst({
+      where: eq(kilo_pass_subscriptions.stripe_subscription_id, 'sub_ambig_1'),
+    });
+    const sub2 = await db.query.kilo_pass_subscriptions.findFirst({
+      where: eq(kilo_pass_subscriptions.stripe_subscription_id, 'sub_ambig_2'),
+    });
+    expect(sub1?.status).toBe('active');
+    expect(sub2?.status).toBe('active');
+    expect(stripeMock.subscriptions.cancel).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/routers/admin/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/admin/kilo-pass-router.test.ts
@@ -1,0 +1,449 @@
+import { describe, expect, it, beforeAll, beforeEach, afterEach, jest } from '@jest/globals';
+import type Stripe from 'stripe';
+
+import { db, cleanupDbForTest } from '@/lib/drizzle';
+import {
+  kilo_pass_subscriptions,
+  kilocode_users,
+  user_admin_notes,
+  credit_transactions,
+} from '@kilocode/db/schema';
+import { KiloPassCadence, KiloPassTier } from '@/lib/kilo-pass/enums';
+import { eq } from 'drizzle-orm';
+
+import { insertTestUser } from '@/tests/helpers/user.helper';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+jest.mock('@/lib/stripe-client', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const { errors } = require('stripe').default ?? require('stripe');
+  const stripeMock = {
+    subscriptions: {
+      cancel: jest.fn(),
+      retrieve: jest.fn(),
+      update: jest.fn(),
+    },
+    subscriptionSchedules: {
+      release: jest.fn(),
+    },
+    invoices: {
+      list: jest.fn(),
+    },
+    invoicePayments: {
+      list: jest.fn(),
+    },
+    refunds: {
+      create: jest.fn(),
+    },
+    errors,
+  };
+  return { client: stripeMock, __stripeMock: stripeMock };
+});
+
+type AnyMock = ReturnType<typeof jest.fn>;
+type StripeMock = {
+  subscriptions: { cancel: AnyMock; retrieve: AnyMock; update: AnyMock };
+  subscriptionSchedules: { release: AnyMock };
+  invoices: { list: AnyMock };
+  invoicePayments: { list: AnyMock };
+  refunds: { create: AnyMock };
+  errors: Stripe['errors'];
+};
+
+function getStripeMock(): StripeMock {
+  const mod: { __stripeMock: StripeMock } = jest.requireMock('@/lib/stripe-client');
+  return mod.__stripeMock;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let createCallerForUser: (userId: string) => Promise<any>;
+
+beforeAll(async () => {
+  ({ createCallerForUser } = await import('@/routers/test-utils'));
+});
+
+async function insertActiveKiloPass(kiloUserId: string, stripeSubscriptionId: string) {
+  const now = new Date().toISOString();
+  await db.insert(kilo_pass_subscriptions).values({
+    kilo_user_id: kiloUserId,
+    stripe_subscription_id: stripeSubscriptionId,
+    tier: KiloPassTier.Tier19,
+    cadence: KiloPassCadence.Monthly,
+    status: 'active',
+    cancel_at_period_end: false,
+    current_streak_months: 1,
+    started_at: now,
+    ended_at: null,
+    next_yearly_issue_at: null,
+  });
+}
+
+async function insertCanceledKiloPass(kiloUserId: string, stripeSubscriptionId: string) {
+  const now = new Date().toISOString();
+  await db.insert(kilo_pass_subscriptions).values({
+    kilo_user_id: kiloUserId,
+    stripe_subscription_id: stripeSubscriptionId,
+    tier: KiloPassTier.Tier19,
+    cadence: KiloPassCadence.Monthly,
+    status: 'canceled',
+    cancel_at_period_end: false,
+    current_streak_months: 0,
+    started_at: now,
+    ended_at: now,
+    next_yearly_issue_at: null,
+  });
+}
+
+function setupHappyPathStripe(stripe: StripeMock, opts?: { refundAmount?: number }) {
+  stripe.subscriptions.cancel.mockResolvedValue({});
+  stripe.invoices.list.mockResolvedValue({
+    data: [{ id: 'in_test_123' }],
+  });
+  stripe.invoicePayments.list.mockResolvedValue({
+    data: [{ payment: { payment_intent: 'pi_test_abc' } }],
+  });
+  stripe.refunds.create.mockResolvedValue({
+    amount: opts?.refundAmount ?? 1900,
+  });
+}
+
+function setupNoInvoiceStripe(stripe: StripeMock) {
+  stripe.subscriptions.cancel.mockResolvedValue({});
+  stripe.invoices.list.mockResolvedValue({ data: [] });
+}
+
+describe('admin.kiloPass.cancelAndRefundKiloPassBulk', () => {
+  let adminUser: Awaited<ReturnType<typeof insertTestUser>>;
+
+  beforeEach(async () => {
+    await cleanupDbForTest();
+    const stripeMock = getStripeMock();
+    stripeMock.subscriptions.cancel.mockReset();
+    stripeMock.subscriptions.retrieve.mockReset();
+    stripeMock.subscriptions.update.mockReset();
+    stripeMock.subscriptionSchedules.release.mockReset();
+    stripeMock.invoices.list.mockReset();
+    stripeMock.invoicePayments.list.mockReset();
+    stripeMock.refunds.create.mockReset();
+
+    adminUser = await insertTestUser({
+      google_user_email: 'bulk-admin@example.com',
+      is_admin: true,
+    });
+  });
+
+  afterEach(async () => {
+    await cleanupDbForTest();
+  });
+
+  it('skips unknown emails without failing the batch', async () => {
+    const stripeMock = getStripeMock();
+    setupHappyPathStripe(stripeMock);
+
+    const target = await insertTestUser({
+      google_user_email: 'bulk-target-unknown-mix@example.com',
+    });
+    await insertActiveKiloPass(target.id, 'sub_unknown_mix');
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloPass.cancelAndRefundKiloPassBulk({
+      emails: ['bulk-target-unknown-mix@example.com', 'does-not-exist@example.com'],
+      reason: 'abuse',
+    });
+
+    expect(result.summary).toEqual({
+      total: 2,
+      cancelled: 1,
+      skipped: 1,
+      errored: 0,
+      totalRefundedCents: 1900,
+    });
+
+    type Row = (typeof result.results)[number];
+    const byEmail = new Map<string, Row>(result.results.map((r: Row) => [r.email, r]));
+    expect(byEmail.get('bulk-target-unknown-mix@example.com')?.status).toBe(
+      'cancelled_and_refunded'
+    );
+    expect(byEmail.get('does-not-exist@example.com')?.status).toBe('skipped_no_user');
+    expect(byEmail.get('does-not-exist@example.com')?.userId).toBeNull();
+  });
+
+  it('skips users with no Kilo Pass subscription', async () => {
+    const stripeMock = getStripeMock();
+    setupHappyPathStripe(stripeMock);
+
+    const target = await insertTestUser({ google_user_email: 'bulk-no-sub@example.com' });
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloPass.cancelAndRefundKiloPassBulk({
+      emails: ['bulk-no-sub@example.com'],
+      reason: 'abuse',
+    });
+
+    expect(result.summary.skipped).toBe(1);
+    expect(result.summary.cancelled).toBe(0);
+    expect(result.results[0].status).toBe('skipped_no_subscription');
+    expect(result.results[0].userId).toBe(target.id);
+    expect(stripeMock.subscriptions.cancel).not.toHaveBeenCalled();
+  });
+
+  it('skips users whose subscription is already canceled', async () => {
+    const stripeMock = getStripeMock();
+    setupHappyPathStripe(stripeMock);
+
+    const target = await insertTestUser({
+      google_user_email: 'bulk-already-canceled@example.com',
+    });
+    await insertCanceledKiloPass(target.id, 'sub_already_canceled');
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloPass.cancelAndRefundKiloPassBulk({
+      emails: ['bulk-already-canceled@example.com'],
+      reason: 'abuse',
+    });
+
+    expect(result.summary.skipped).toBe(1);
+    expect(result.results[0].status).toBe('skipped_already_canceled');
+    expect(stripeMock.subscriptions.cancel).not.toHaveBeenCalled();
+  });
+
+  it('treats charge_already_refunded as a successful cancellation with no refund', async () => {
+    const stripeMock = getStripeMock();
+    stripeMock.subscriptions.cancel.mockResolvedValue({});
+    stripeMock.invoices.list.mockResolvedValue({ data: [{ id: 'in_already_refunded' }] });
+    stripeMock.invoicePayments.list.mockResolvedValue({
+      data: [{ payment: { payment_intent: 'pi_already_refunded' } }],
+    });
+    const alreadyRefundedError = new stripeMock.errors.StripeInvalidRequestError({
+      message: 'charge_already_refunded',
+      type: 'invalid_request_error',
+      code: 'charge_already_refunded',
+    });
+    stripeMock.refunds.create.mockRejectedValue(alreadyRefundedError);
+
+    const target = await insertTestUser({
+      google_user_email: 'bulk-already-refunded@example.com',
+    });
+    await insertActiveKiloPass(target.id, 'sub_already_refunded');
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloPass.cancelAndRefundKiloPassBulk({
+      emails: ['bulk-already-refunded@example.com'],
+      reason: 'chargeback',
+    });
+
+    expect(result.summary).toEqual({
+      total: 1,
+      cancelled: 1,
+      skipped: 0,
+      errored: 0,
+      totalRefundedCents: 0,
+    });
+    expect(result.results[0].status).toBe('cancelled_and_refunded');
+    expect(result.results[0].refundedAmountCents).toBeNull();
+
+    const row = await db.query.kilo_pass_subscriptions.findFirst({
+      where: eq(kilo_pass_subscriptions.stripe_subscription_id, 'sub_already_refunded'),
+    });
+    expect(row?.status).toBe('canceled');
+  });
+
+  it('cancels, refunds, blocks and notes end-to-end for a happy-path user', async () => {
+    const stripeMock = getStripeMock();
+    setupHappyPathStripe(stripeMock);
+
+    const target = await insertTestUser({
+      google_user_email: 'bulk-happy-path@example.com',
+      total_microdollars_acquired: 5_000_000,
+      microdollars_used: 1_000_000,
+    });
+    await insertActiveKiloPass(target.id, 'sub_happy_path');
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloPass.cancelAndRefundKiloPassBulk({
+      emails: ['bulk-happy-path@example.com'],
+      reason: 'fraud-ring',
+    });
+
+    expect(result.summary).toEqual({
+      total: 1,
+      cancelled: 1,
+      skipped: 0,
+      errored: 0,
+      totalRefundedCents: 1900,
+    });
+
+    const row = result.results[0];
+    expect(row.status).toBe('cancelled_and_refunded');
+    expect(row.refundedAmountCents).toBe(1900);
+    expect(row.balanceResetAmountUsd).toBeCloseTo(4, 5);
+    expect(row.alreadyBlocked).toBe(false);
+
+    // Subscription updated
+    const subRow = await db.query.kilo_pass_subscriptions.findFirst({
+      where: eq(kilo_pass_subscriptions.stripe_subscription_id, 'sub_happy_path'),
+    });
+    expect(subRow?.status).toBe('canceled');
+    expect(subRow?.current_streak_months).toBe(0);
+
+    // User blocked
+    const userRow = await db.query.kilocode_users.findFirst({
+      where: eq(kilocode_users.id, target.id),
+    });
+    expect(userRow?.blocked_reason).toBe('fraud-ring');
+    expect(userRow?.blocked_by_kilo_user_id).toBe(adminUser.id);
+    expect(userRow?.total_microdollars_acquired).toBe(1_000_000);
+
+    // Balance-zero credit transaction inserted
+    const txnRows = await db.query.credit_transactions.findMany({
+      where: eq(credit_transactions.kilo_user_id, target.id),
+    });
+    expect(txnRows).toHaveLength(1);
+    expect(txnRows[0].amount_microdollars).toBe(-4_000_000);
+    expect(txnRows[0].credit_category).toBe('admin-cancel-refund-kilo-pass');
+
+    // Admin note inserted with [bulk] suffix
+    const noteRows = await db.query.user_admin_notes.findMany({
+      where: eq(user_admin_notes.kilo_user_id, target.id),
+    });
+    expect(noteRows).toHaveLength(1);
+    expect(noteRows[0].note_content).toContain('Reason: fraud-ring');
+    expect(noteRows[0].note_content).toContain('Refunded: $19.00');
+    expect(noteRows[0].note_content).toContain('Balance reset: $4.00 zeroed.');
+    expect(noteRows[0].note_content).toContain('Account blocked.');
+    expect(noteRows[0].note_content).toContain('[bulk]');
+  });
+
+  it('handles no-invoice users as cancelled with null refund', async () => {
+    const stripeMock = getStripeMock();
+    setupNoInvoiceStripe(stripeMock);
+
+    const target = await insertTestUser({ google_user_email: 'bulk-no-invoice@example.com' });
+    await insertActiveKiloPass(target.id, 'sub_no_invoice');
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloPass.cancelAndRefundKiloPassBulk({
+      emails: ['bulk-no-invoice@example.com'],
+      reason: 'policy',
+    });
+
+    expect(result.summary.cancelled).toBe(1);
+    expect(result.summary.totalRefundedCents).toBe(0);
+    expect(result.results[0].refundedAmountCents).toBeNull();
+  });
+
+  it('continues the batch when one user throws; committed users stay committed', async () => {
+    const stripeMock = getStripeMock();
+    // First user: succeeds. Second user: throws on stripe cancel. Third user: succeeds.
+    stripeMock.subscriptions.cancel
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('Stripe boom'))
+      .mockResolvedValueOnce({});
+    stripeMock.invoices.list.mockResolvedValue({ data: [{ id: 'in_x' }] });
+    stripeMock.invoicePayments.list.mockResolvedValue({
+      data: [{ payment: { payment_intent: 'pi_x' } }],
+    });
+    stripeMock.refunds.create.mockResolvedValue({ amount: 1900 });
+
+    const u1 = await insertTestUser({ google_user_email: 'bulk-seq-1@example.com' });
+    const u2 = await insertTestUser({ google_user_email: 'bulk-seq-2@example.com' });
+    const u3 = await insertTestUser({ google_user_email: 'bulk-seq-3@example.com' });
+    await insertActiveKiloPass(u1.id, 'sub_seq_1');
+    await insertActiveKiloPass(u2.id, 'sub_seq_2');
+    await insertActiveKiloPass(u3.id, 'sub_seq_3');
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloPass.cancelAndRefundKiloPassBulk({
+      emails: ['bulk-seq-1@example.com', 'bulk-seq-2@example.com', 'bulk-seq-3@example.com'],
+      reason: 'mixed-batch',
+    });
+
+    expect(result.summary).toEqual({
+      total: 3,
+      cancelled: 2,
+      skipped: 0,
+      errored: 1,
+      totalRefundedCents: 3800,
+    });
+
+    type Row = (typeof result.results)[number];
+    const byEmail = new Map<string, Row>(result.results.map((r: Row) => [r.email, r]));
+    expect(byEmail.get('bulk-seq-1@example.com')?.status).toBe('cancelled_and_refunded');
+    expect(byEmail.get('bulk-seq-2@example.com')?.status).toBe('error');
+    expect(byEmail.get('bulk-seq-2@example.com')?.error).toContain('Stripe boom');
+    expect(byEmail.get('bulk-seq-3@example.com')?.status).toBe('cancelled_and_refunded');
+
+    // u1 and u3 are committed (blocked); u2 is NOT blocked (rolled back before tx)
+    const u1Row = await db.query.kilocode_users.findFirst({
+      where: eq(kilocode_users.id, u1.id),
+    });
+    const u2Row = await db.query.kilocode_users.findFirst({
+      where: eq(kilocode_users.id, u2.id),
+    });
+    const u3Row = await db.query.kilocode_users.findFirst({
+      where: eq(kilocode_users.id, u3.id),
+    });
+    expect(u1Row?.blocked_reason).toBe('mixed-batch');
+    expect(u2Row?.blocked_reason).toBeNull();
+    expect(u3Row?.blocked_reason).toBe('mixed-batch');
+
+    // Subscriptions for successful users are canceled; the failed user's sub is unchanged
+    const sub1 = await db.query.kilo_pass_subscriptions.findFirst({
+      where: eq(kilo_pass_subscriptions.stripe_subscription_id, 'sub_seq_1'),
+    });
+    const sub2 = await db.query.kilo_pass_subscriptions.findFirst({
+      where: eq(kilo_pass_subscriptions.stripe_subscription_id, 'sub_seq_2'),
+    });
+    const sub3 = await db.query.kilo_pass_subscriptions.findFirst({
+      where: eq(kilo_pass_subscriptions.stripe_subscription_id, 'sub_seq_3'),
+    });
+    expect(sub1?.status).toBe('canceled');
+    expect(sub2?.status).toBe('active');
+    expect(sub3?.status).toBe('canceled');
+  });
+
+  it('deduplicates emails case-insensitively before iterating', async () => {
+    const stripeMock = getStripeMock();
+    setupHappyPathStripe(stripeMock);
+
+    const target = await insertTestUser({ google_user_email: 'bulk-dedupe@example.com' });
+    await insertActiveKiloPass(target.id, 'sub_dedupe');
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloPass.cancelAndRefundKiloPassBulk({
+      emails: ['bulk-dedupe@example.com', 'BULK-DEDUPE@example.com', 'bulk-dedupe@example.com'],
+      reason: 'dedupe',
+    });
+
+    expect(result.summary.total).toBe(1);
+    expect(result.summary.cancelled).toBe(1);
+    expect(stripeMock.subscriptions.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-block users who were already blocked', async () => {
+    const stripeMock = getStripeMock();
+    setupHappyPathStripe(stripeMock);
+
+    const target = await insertTestUser({
+      google_user_email: 'bulk-already-blocked@example.com',
+      blocked_reason: 'previous-block',
+      blocked_at: new Date().toISOString(),
+    });
+    await insertActiveKiloPass(target.id, 'sub_already_blocked');
+
+    const caller = await createCallerForUser(adminUser.id);
+    const result = await caller.admin.kiloPass.cancelAndRefundKiloPassBulk({
+      emails: ['bulk-already-blocked@example.com'],
+      reason: 'new-reason',
+    });
+
+    expect(result.results[0].status).toBe('cancelled_and_refunded');
+    expect(result.results[0].alreadyBlocked).toBe(true);
+
+    const userRow = await db.query.kilocode_users.findFirst({
+      where: eq(kilocode_users.id, target.id),
+    });
+    expect(userRow?.blocked_reason).toBe('previous-block');
+  });
+});

--- a/apps/web/src/routers/admin/kilo-pass-router.ts
+++ b/apps/web/src/routers/admin/kilo-pass-router.ts
@@ -1,7 +1,7 @@
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
 import { kilocode_users } from '@kilocode/db/schema';
-import { eq } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 import * as z from 'zod';
 import { captureException } from '@sentry/nextjs';
 import { client as stripeClient } from '@/lib/stripe-client';
@@ -69,12 +69,17 @@ export async function runBulkCancelAndRefundKiloPass({
   const results: BulkResultRow[] = [];
 
   for (const email of uniqueEmails) {
-    const user = await db.query.kilocode_users.findFirst({
-      columns: { id: true },
-      where: eq(kilocode_users.google_user_email, email),
-    });
+    // `google_user_email` stores the provider email as-is (no case normalization)
+    // and is case-sensitively unique. Look up case-insensitively so pasted
+    // `user@example.com` matches a stored `User@example.com`. If two rows
+    // differ only in case, bail out for that email rather than picking one.
+    const matchingUsers = await db
+      .select({ id: kilocode_users.id })
+      .from(kilocode_users)
+      .where(sql`lower(${kilocode_users.google_user_email}) = ${email}`)
+      .limit(2);
 
-    if (!user) {
+    if (matchingUsers.length === 0) {
       results.push({
         email,
         userId: null,
@@ -86,6 +91,21 @@ export async function runBulkCancelAndRefundKiloPass({
       });
       continue;
     }
+
+    if (matchingUsers.length > 1) {
+      results.push({
+        email,
+        userId: null,
+        status: 'error',
+        refundedAmountCents: null,
+        balanceResetAmountUsd: null,
+        alreadyBlocked: false,
+        error: 'Multiple accounts match this email (case-insensitive); resolve manually',
+      });
+      continue;
+    }
+
+    const user = matchingUsers[0];
 
     try {
       const result = await cancelAndRefundKiloPassForUser({

--- a/apps/web/src/routers/admin/kilo-pass-router.ts
+++ b/apps/web/src/routers/admin/kilo-pass-router.ts
@@ -1,0 +1,178 @@
+import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
+import { db } from '@/lib/drizzle';
+import { kilocode_users } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
+import * as z from 'zod';
+import { captureException } from '@sentry/nextjs';
+import { client as stripeClient } from '@/lib/stripe-client';
+import {
+  cancelAndRefundKiloPassForUser,
+  type CancelAndRefundKiloPassStripeClient,
+} from '@/lib/kilo-pass/cancel-and-refund';
+
+const BulkCancelSchema = z.object({
+  emails: z.array(z.string().email()).min(1).max(500),
+  reason: z.string().min(1).trim(),
+});
+
+type BulkResultStatus =
+  | 'cancelled_and_refunded'
+  | 'skipped_no_user'
+  | 'skipped_no_subscription'
+  | 'skipped_already_canceled'
+  | 'error';
+
+type BulkResultRow = {
+  email: string;
+  userId: string | null;
+  status: BulkResultStatus;
+  refundedAmountCents: number | null;
+  balanceResetAmountUsd: number | null;
+  alreadyBlocked: boolean;
+  error: string | null;
+};
+
+function dedupeEmails(emails: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of emails) {
+    const normalized = raw.trim().toLowerCase();
+    if (!normalized) continue;
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    out.push(normalized);
+  }
+  return out;
+}
+
+export async function runBulkCancelAndRefundKiloPass({
+  emails,
+  reason,
+  adminKiloUserId,
+  stripe,
+}: {
+  emails: readonly string[];
+  reason: string;
+  adminKiloUserId: string;
+  stripe: CancelAndRefundKiloPassStripeClient;
+}): Promise<{
+  results: BulkResultRow[];
+  summary: {
+    total: number;
+    cancelled: number;
+    skipped: number;
+    errored: number;
+    totalRefundedCents: number;
+  };
+}> {
+  const uniqueEmails = dedupeEmails(emails);
+  const results: BulkResultRow[] = [];
+
+  for (const email of uniqueEmails) {
+    const user = await db.query.kilocode_users.findFirst({
+      columns: { id: true },
+      where: eq(kilocode_users.google_user_email, email),
+    });
+
+    if (!user) {
+      results.push({
+        email,
+        userId: null,
+        status: 'skipped_no_user',
+        refundedAmountCents: null,
+        balanceResetAmountUsd: null,
+        alreadyBlocked: false,
+        error: null,
+      });
+      continue;
+    }
+
+    try {
+      const result = await cancelAndRefundKiloPassForUser({
+        db,
+        stripe,
+        userId: user.id,
+        reason,
+        adminKiloUserId,
+        noteSuffix: '[bulk]',
+      });
+
+      if (result.status === 'skipped') {
+        results.push({
+          email,
+          userId: user.id,
+          status:
+            result.reason.kind === 'no_subscription'
+              ? 'skipped_no_subscription'
+              : 'skipped_already_canceled',
+          refundedAmountCents: null,
+          balanceResetAmountUsd: null,
+          alreadyBlocked: false,
+          error: null,
+        });
+        continue;
+      }
+
+      results.push({
+        email,
+        userId: user.id,
+        status: 'cancelled_and_refunded',
+        refundedAmountCents: result.refundedAmountCents,
+        balanceResetAmountUsd: result.balanceResetAmountUsd,
+        alreadyBlocked: result.alreadyBlocked,
+        error: null,
+      });
+    } catch (err) {
+      captureException(err, {
+        tags: { source: 'admin.kiloPass.cancelAndRefundKiloPassBulk' },
+        extra: { email, userId: user.id },
+      });
+      results.push({
+        email,
+        userId: user.id,
+        status: 'error',
+        refundedAmountCents: null,
+        balanceResetAmountUsd: null,
+        alreadyBlocked: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const summary = results.reduce(
+    (acc, row) => {
+      acc.total += 1;
+      if (row.status === 'cancelled_and_refunded') {
+        acc.cancelled += 1;
+        acc.totalRefundedCents += row.refundedAmountCents ?? 0;
+      } else if (row.status === 'error') {
+        acc.errored += 1;
+      } else {
+        acc.skipped += 1;
+      }
+      return acc;
+    },
+    { total: 0, cancelled: 0, skipped: 0, errored: 0, totalRefundedCents: 0 }
+  );
+
+  return { results, summary };
+}
+
+export const adminKiloPassRouter = createTRPCRouter({
+  cancelAndRefundKiloPassBulk: adminProcedure
+    .input(BulkCancelSchema)
+    .mutation(async ({ input, ctx }) => {
+      const outcome = await runBulkCancelAndRefundKiloPass({
+        emails: input.emails,
+        reason: input.reason,
+        adminKiloUserId: ctx.user.id,
+        stripe: stripeClient,
+      });
+
+      console.log(
+        `[admin.kiloPass.cancelAndRefundKiloPassBulk] admin=${ctx.user.id} total=${outcome.summary.total} cancelled=${outcome.summary.cancelled} skipped=${outcome.summary.skipped} errored=${outcome.summary.errored} refundedCents=${outcome.summary.totalRefundedCents}`
+      );
+
+      return outcome;
+    }),
+});


### PR DESCRIPTION
## Summary

- Extracts the single-user `admin.users.cancelAndRefundKiloPass` logic into a reusable helper `cancelAndRefundKiloPassForUser` in `apps/web/src/lib/kilo-pass/cancel-and-refund.ts`. The helper takes `{ db, stripe, userId, reason, adminKiloUserId }` so it can be reused from batch callers without HTTP overhead. The single-user procedure's public interface and behavior are unchanged.
- Adds a new `admin.kiloPass.cancelAndRefundKiloPassBulk` procedure (input: `{ emails: z.array(z.string().email()).min(1).max(500), reason: string }`) that:
  - Dedupes emails case-insensitively.
  - Iterates **sequentially** to stay under Stripe's rate limits.
  - Returns a per-user result array (`cancelled_and_refunded`, `skipped_no_user`, `skipped_no_subscription`, `skipped_already_canceled`, `error`) plus a summary including `totalRefundedCents`.
  - Each user is its own transaction — partial failures leave earlier users committed so the batch is resumable.
  - Treats Stripe `charge_already_refunded` as a successful cancellation (reuses the inline behavior from the original).
  - Captures per-user errors via Sentry and logs a single summary line at the end.
  - Appends `[bulk]` to the admin note so batch actions are auditable.
- Adds a new `/admin/kilo-pass/bulk-cancel` page with a textarea, a required reason field, a confirmation step showing the email count before submit, and a results table grouped by status with the successful refund total at the top. Failed rows render the error message inline.

## Verification

- Will test in prod and follow up if it breaks

## Visual Changes

<img width="1689" height="1237" alt="image" src="https://github.com/user-attachments/assets/c162218e-5fd5-4da7-b569-6c0eb55d689a" />

## Reviewer Notes

- The single-user procedure still lives at `admin.users.cancelAndRefundKiloPass` — the refactor is internal-only and the existing UI caller in `UserAdminKiloPass.tsx` is untouched.
- Sequential execution is intentional: 500 users × ~5 Stripe calls stays well under Stripe's 100 req/sec ceiling and keeps per-user ordering predictable for audit.
- The helper moves the Stripe-side calls **before** the DB transaction to minimize open-transaction time; this matches the pre-existing single-user flow.