### PR TITLE
feat(ai-gateway): apply free-model rate limit to kilo-auto/free

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -82,7 +82,7 @@ import {
 import { normalizeModelId } from '@/lib/ai-gateway/model-utils';
 import { isForbiddenFreeModel } from '@/lib/ai-gateway/forbidden-free-models';
 import { isCloudflareIP } from '@/lib/cloudflare-ip';
-import { isKiloAutoModel } from '@/lib/ai-gateway/kilo-auto';
+import { isKiloAutoModel, KILO_AUTO_FREE_MODEL } from '@/lib/ai-gateway/kilo-auto';
 import { applyResolvedAutoModel } from '@/lib/ai-gateway/kilo-auto/resolution';
 import { fixOpenCodeDuplicateReasoning } from '@/lib/ai-gateway/providers/fixOpenCodeDuplicateReasoning';
 import type { MicrodollarUsageContext, PromptInfo } from '@/lib/ai-gateway/processUsage.types';
@@ -277,7 +277,13 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   // Server-side products (cloud-agent, code-review, app-builder) rate-limit
   // per user when the request comes from Cloudflare IPs (Kilo infrastructure).
   // All other products rate-limit per IP (fast pre-auth path).
-  if (isKiloExclusiveFreeModel(originalModelIdLowerCased)) {
+  //
+  // The gate also covers `kilo-auto/free`: it resolves to a rotating pool that
+  // mixes Kilo-exclusive models with arbitrary OpenRouter `:free` models, and
+  // we want the limit to apply uniformly regardless of which one was picked.
+  const isRateLimitedFreeModelRequest =
+    isKiloExclusiveFreeModel(originalModelIdLowerCased) || autoModel === KILO_AUTO_FREE_MODEL.id;
+  if (isRateLimitedFreeModelRequest) {
     const rateLimit = await resolveRateLimit(feature, ipAddress, authPromise);
     if (rateLimit instanceof NextResponse) return rateLimit;
 
@@ -370,7 +376,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   }
 
   // Log to free_model_usage for rate limiting (at request start, before processing)
-  if (isKiloExclusiveFreeModel(originalModelIdLowerCased)) {
+  if (isRateLimitedFreeModelRequest) {
     await logFreeModelRequest(
       ipAddress,
       originalModelIdLowerCased,

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -277,10 +277,6 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   // Server-side products (cloud-agent, code-review, app-builder) rate-limit
   // per user when the request comes from Cloudflare IPs (Kilo infrastructure).
   // All other products rate-limit per IP (fast pre-auth path).
-  //
-  // The gate also covers `kilo-auto/free`: it resolves to a rotating pool that
-  // mixes Kilo-exclusive models with arbitrary OpenRouter `:free` models, and
-  // we want the limit to apply uniformly regardless of which one was picked.
   const isRateLimitedFreeModelRequest =
     isKiloExclusiveFreeModel(originalModelIdLowerCased) || autoModel === KILO_AUTO_FREE_MODEL.id;
   if (isRateLimitedFreeModelRequest) {


### PR DESCRIPTION
## Summary

Auto Free is a mix of models, some Kilo Exclusive and others via OpenRouters. Since this is a mix of models, we should also apply the rate limit to ensure that there is sufficient quota to provide a good experience for all users.

## Verification

- End-to-end testing against local dev server with seeded Redis OpenRouter model cache:
  - `kilo-auto/free` resolving to `inclusionai/ling-2.6-1t:free` — request logged to `free_model_usage`
  - `kilo-auto/free` resolving to `nvidia/nemotron-3-super-120b-a12b:free` — request logged to `free_model_usage`
  - `kilo-auto/free` resolving to `stepfun/step-3.5-flash:free` — request logged (existing behavior preserved)
  - Saturating an IP with 200 rows and sending a `kilo-auto/free` request returns HTTP 429
  - Direct call to `inclusionai/ling-2.6-1t:free` (not via `kilo-auto/free`) — NOT logged, NOT rate-limited (existing behavior preserved)
  - Direct call to `stepfun/step-3.5-flash:free` from saturated IP — HTTP 429 (existing behavior preserved)

## Visual Changes

N/A

## Reviewer Notes

- The new predicate `isRateLimitedFreeModelRequest` checks both `isKiloExclusiveFreeModel(resolvedModel)` and `autoModel === KILO_AUTO_FREE_MODEL.id`, so the original virtual model ID is what triggers the broader gate.
- The `free_model_usage` table records the *resolved* model slug (not `kilo-auto/free`), consistent with existing logging behavior.
- Admin rate-limit testing panel (`/admin/rate-limit-testing`) can be used to trigger the 429 threshold manually.