### PR TITLE
refactor(bot): make link-account flow platform agnostic

### DIFF
--- a/apps/web/src/app/api/chat/link-account/route.ts
+++ b/apps/web/src/app/api/chat/link-account/route.ts
@@ -1,12 +1,9 @@
 import { bot } from '@/lib/bot';
 import { APP_URL } from '@/lib/constants';
-import { linkKiloUser, verifyLinkToken } from '@/lib/bot-identity';
-import { db } from '@/lib/drizzle';
+import { linkKiloUser, verifyLinkToken, type PlatformIdentity } from '@/lib/bot-identity';
 import { isOrganizationMember } from '@/lib/organizations/organizations';
 import { getUserFromAuth } from '@/lib/user.server';
-import { platform_integrations } from '@kilocode/db';
-import { PLATFORM } from '@/lib/integrations/core/constants';
-import { and, eq } from 'drizzle-orm';
+import { getPlatformIntegration } from '@/lib/bot/platform-helpers';
 
 function errorPage(title: string, message: string, status: number): Response {
   return new Response(
@@ -28,22 +25,13 @@ function errorPage(title: string, message: string, status: number): Response {
  * an org member; for user-owned integrations only the owner may link.
  */
 async function verifyIntegrationAccess(
-  teamId: string,
+  identity: PlatformIdentity,
   kiloUserId: string
 ): Promise<{ ok: true } | { ok: false; error: string }> {
-  const [integration] = await db
-    .select()
-    .from(platform_integrations)
-    .where(
-      and(
-        eq(platform_integrations.platform, PLATFORM.SLACK),
-        eq(platform_integrations.platform_installation_id, teamId)
-      )
-    )
-    .limit(1);
+  const integration = await getPlatformIntegration(identity);
 
   if (!integration) {
-    return { ok: false, error: 'No matching integration found for this workspace.' };
+    return { ok: false, error: 'No matching integration found for this platform.' };
   }
 
   if (integration.owned_by_organization_id) {
@@ -51,12 +39,12 @@ async function verifyIntegrationAccess(
     if (!isMember) {
       return {
         ok: false,
-        error: 'You are not a member of the organization that owns this workspace integration.',
+        error: 'You are not a member of the organization that owns this integration.',
       };
     }
   } else if (integration.owned_by_user_id) {
     if (integration.owned_by_user_id !== kiloUserId) {
-      return { ok: false, error: 'You are not the owner of this workspace integration.' };
+      return { ok: false, error: 'You are not the owner of this integration.' };
     }
   } else {
     return { ok: false, error: 'This integration has invalid ownership data.' };
@@ -106,7 +94,7 @@ export async function GET(request: Request) {
   }
 
   // Verify the user is allowed to link to this integration
-  const access = await verifyIntegrationAccess(identity.teamId, user.id);
+  const access = await verifyIntegrationAccess(identity, user.id);
   if (!access.ok) {
     return errorPage('Access Denied', access.error, 403);
   }

--- a/apps/web/src/lib/bot-identity.ts
+++ b/apps/web/src/lib/bot-identity.ts
@@ -3,6 +3,7 @@ import crypto from 'node:crypto';
 import type { StateAdapter } from 'chat';
 import { NEXTAUTH_SECRET } from '@/lib/config.server';
 import { botIdentityRedisKey } from '@/lib/redis-keys';
+import { PLATFORM } from '@/lib/integrations/core/constants';
 
 const CHAT_SDK_CACHE_KEY_PREFIX = 'chat-sdk:cache:';
 const REDIS_SCAN_BATCH_SIZE = 100;
@@ -27,7 +28,7 @@ function hasRedisClient(state: StateAdapter): state is StateAdapterWithRedisClie
  */
 export type PlatformIdentity = {
   /** e.g. "slack", "discord", "teams", "gchat" */
-  platform: string;
+  platform: (typeof PLATFORM)[keyof typeof PLATFORM];
   /** Workspace / team / guild / tenant ID */
   teamId: string;
   /** Platform-specific user ID (e.g. Slack's "U123ABC") */
@@ -157,7 +158,7 @@ export function verifyLinkToken(token: string): PlatformIdentity | null {
 
   try {
     const data = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as {
-      platform?: string;
+      platform?: PlatformIdentity['platform'];
       teamId?: string;
       userId?: string;
       iat?: number;
@@ -167,7 +168,8 @@ export function verifyLinkToken(token: string): PlatformIdentity | null {
     if (
       typeof data.platform !== 'string' ||
       typeof data.teamId !== 'string' ||
-      typeof data.userId !== 'string'
+      typeof data.userId !== 'string' ||
+      !Object.values(PLATFORM).includes(data.platform)
     ) {
       return null;
     }

--- a/apps/web/src/lib/bot.ts
+++ b/apps/web/src/lib/bot.ts
@@ -137,7 +137,7 @@ function createKiloBot(slackAdapter: ReturnType<typeof createSlackAdapter>) {
   ): Promise<void> {
     const identity = getPlatformIdentity(thread, message);
     const [platformIntegration, kiloUserId] = await Promise.all([
-      getPlatformIntegration(thread, message),
+      getPlatformIntegration(identity),
       resolveKiloUserId(chatBot.getState(), identity),
     ]);
 

--- a/apps/web/src/lib/bot/platform-helpers.test.ts
+++ b/apps/web/src/lib/bot/platform-helpers.test.ts
@@ -20,7 +20,7 @@ describe('platform helpers', () => {
     mockLimit.mockReset();
   });
 
-  it('returns the canonical Slack platform integration for a Slack team', async () => {
+  it('returns the platform integration for a given identity', async () => {
     const integration = {
       id: 'pi_slack',
       platform: PLATFORM.SLACK,
@@ -28,32 +28,28 @@ describe('platform helpers', () => {
     };
     mockLimit.mockResolvedValue([integration]);
 
-    const result = await getPlatformIntegration(
-      { id: 'slack:C123:123.456' } as Parameters<typeof getPlatformIntegration>[0],
-      {
-        raw: { team_id: 'T123' },
-        author: { userId: 'U123' },
-      } as Parameters<typeof getPlatformIntegration>[1]
-    );
+    const result = await getPlatformIntegration({
+      platform: 'slack',
+      teamId: 'T123',
+      userId: 'U123',
+    });
 
     expect(result).toBe(integration);
   });
 
-  it('returns null when no canonical Slack platform integration exists', async () => {
+  it('returns null when no platform integration exists', async () => {
     mockLimit.mockResolvedValue([]);
 
-    const result = await getPlatformIntegration(
-      { id: 'slack:C123:123.456' } as Parameters<typeof getPlatformIntegration>[0],
-      {
-        raw: { team_id: 'T404' },
-        author: { userId: 'U123' },
-      } as Parameters<typeof getPlatformIntegration>[1]
-    );
+    const result = await getPlatformIntegration({
+      platform: 'slack',
+      teamId: 'T404',
+      userId: 'U123',
+    });
 
     expect(result).toBeNull();
   });
 
-  it('returns the Slack platform integration for a bot user id', async () => {
+  it('returns the platform integration for a bot user id', async () => {
     const integration = {
       id: 'pi_slack',
       platform: PLATFORM.SLACK,

--- a/apps/web/src/lib/bot/platform-helpers.ts
+++ b/apps/web/src/lib/bot/platform-helpers.ts
@@ -4,6 +4,7 @@ import { eq, and, sql } from 'drizzle-orm';
 import { type SlackEvent } from '@chat-adapter/slack';
 import { platform_integrations } from '@kilocode/db';
 import type { Message, Thread } from 'chat';
+import { PLATFORM } from '@/lib/integrations/core/constants';
 
 export function getSlackTeamId(message: Message<SlackEvent>): string {
   const teamId = message.raw.team_id ?? message.raw.team;
@@ -21,7 +22,7 @@ export function getPlatformIdentity(thread: Thread, message: Message): PlatformI
   switch (platform) {
     case 'slack': {
       const teamId = getSlackTeamId(message as Message<SlackEvent>);
-      return { platform: 'slack', teamId, userId: message.author.userId };
+      return { platform: PLATFORM.SLACK, teamId, userId: message.author.userId };
     }
     default:
       throw new Error(`PlatformNotSupported: ${platform}`);

--- a/apps/web/src/lib/bot/platform-helpers.ts
+++ b/apps/web/src/lib/bot/platform-helpers.ts
@@ -1,7 +1,6 @@
 import type { PlatformIdentity } from '@/lib/bot-identity';
 import { db } from '@/lib/drizzle';
 import { eq, and, sql } from 'drizzle-orm';
-import { PLATFORM } from '@/lib/integrations/core/constants';
 import { type SlackEvent } from '@chat-adapter/slack';
 import { platform_integrations } from '@kilocode/db';
 import type { Message, Thread } from 'chat';
@@ -29,45 +28,23 @@ export function getPlatformIdentity(thread: Thread, message: Message): PlatformI
   }
 }
 
-async function getSlackPlatformIntegration(teamId: string) {
+/**
+ * Look up the platform integration row for a given identity.
+ * Platform-agnostic: queries by identity.platform + identity.teamId.
+ */
+export async function getPlatformIntegration(identity: PlatformIdentity) {
   const [integration] = await db
     .select()
     .from(platform_integrations)
     .where(
       and(
-        eq(platform_integrations.platform, PLATFORM.SLACK),
-        eq(platform_integrations.platform_installation_id, teamId)
+        eq(platform_integrations.platform, identity.platform),
+        eq(platform_integrations.platform_installation_id, identity.teamId)
       )
     )
     .limit(1);
 
   return integration ?? null;
-}
-
-async function getSlackPlatformIntegrationByBotUserId(botUserId: string) {
-  const [integration] = await db
-    .select()
-    .from(platform_integrations)
-    .where(
-      and(
-        eq(platform_integrations.platform, PLATFORM.SLACK),
-        eq(sql<string>`${platform_integrations.metadata}->>'bot_user_id'`, botUserId)
-      )
-    )
-    .limit(1);
-
-  return integration ?? null;
-}
-
-export async function getPlatformIntegration(thread: Thread, message: Message) {
-  const platform = thread.id.split(':')[0];
-
-  switch (platform) {
-    case 'slack':
-      return await getSlackPlatformIntegration(getSlackTeamId(message as Message<SlackEvent>));
-    default:
-      throw new Error(`PlatformNotSupported: ${platform}`);
-  }
 }
 
 export async function getPlatformIntegrationByBotUserId(
@@ -76,10 +53,16 @@ export async function getPlatformIntegrationByBotUserId(
 ) {
   if (!botUserId) return null;
 
-  switch (platform) {
-    case 'slack':
-      return await getSlackPlatformIntegrationByBotUserId(botUserId);
-    default:
-      throw new Error(`PlatformNotSupported: ${platform}`);
-  }
+  const [integration] = await db
+    .select()
+    .from(platform_integrations)
+    .where(
+      and(
+        eq(platform_integrations.platform, platform),
+        eq(sql<string>`${platform_integrations.metadata}->>'bot_user_id'`, botUserId)
+      )
+    )
+    .limit(1);
+
+  return integration ?? null;
 }


### PR DESCRIPTION
## Summary
- Remove hardcoded `PLATFORM.SLACK` from `verifyIntegrationAccess()` in the link-account API route — now uses `identity.platform` from the signed token
- Make `getPlatformIntegration()` accept a `PlatformIdentity` and query generically by platform + teamId, eliminating Slack-specific intermediary functions
- Make `getPlatformIntegrationByBotUserId()` query by the `platform` parameter directly instead of routing through a per-platform switch

The only remaining platform-specific code is `getPlatformIdentity()` which is the intentional adaptation boundary where per-platform team ID extraction lives.

## Test plan
- [x] Verify Slack link-account flow still works end-to-end (mention bot → card → click → link)