### PR TITLE
fix(gastown): load ClipboardAddon so Mayor OSC 52 clipboard writes work

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -94,6 +94,7 @@
     "@vercel/functions": "^3.4.3",
     "@vercel/otel": "^2.1.1",
     "@workos-inc/node": "catalog:",
+    "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",

--- a/apps/web/src/components/gastown/useXtermPty.ts
+++ b/apps/web/src/components/gastown/useXtermPty.ts
@@ -292,11 +292,14 @@ export function useXtermPty({
       if (!container) return;
 
       // Lazy-load xterm.js to avoid SSR issues and minimize bundle impact
-      const [{ Terminal }, { FitAddon }, { WebLinksAddon }] = await Promise.all([
-        import('@xterm/xterm'),
-        import('@xterm/addon-fit'),
-        import('@xterm/addon-web-links'),
-      ]);
+      const [{ Terminal }, { FitAddon }, { WebLinksAddon }, { ClipboardAddon }] = await Promise.all(
+        [
+          import('@xterm/xterm'),
+          import('@xterm/addon-fit'),
+          import('@xterm/addon-web-links'),
+          import('@xterm/addon-clipboard'),
+        ]
+      );
 
       if (disposed) return;
 
@@ -305,6 +308,7 @@ export function useXtermPty({
 
       const fitAddon = new FitAddon();
       const webLinksAddon = new WebLinksAddon();
+      const clipboardAddon = new ClipboardAddon();
 
       const term = new Terminal({
         cursorBlink: true,
@@ -323,6 +327,7 @@ export function useXtermPty({
 
       term.loadAddon(fitAddon);
       term.loadAddon(webLinksAddon);
+      term.loadAddon(clipboardAddon);
       term.open(container);
       attachKittyEnterHandler(term, wsRef);
       fitAddon.fit();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,6 +655,9 @@ importers:
       '@workos-inc/node':
         specifier: 'catalog:'
         version: 8.9.0
+      '@xterm/addon-clipboard':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
@@ -8439,6 +8442,9 @@ packages:
     engines: {node: '>=10.0.0'}
     deprecated: this version has critical issues, please update to the latest version
 
+  '@xterm/addon-clipboard@0.2.0':
+    resolution: {integrity: sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg==}
+
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
 
@@ -11773,6 +11779,9 @@ packages:
         optional: true
       react:
         optional: true
+
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
@@ -23517,6 +23526,10 @@ snapshots:
 
   '@xmldom/xmldom@0.8.11': {}
 
+  '@xterm/addon-clipboard@0.2.0':
+    dependencies:
+      js-base64: 3.7.8
+
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-web-links@0.12.0': {}
@@ -27591,6 +27604,8 @@ snapshots:
       '@babel/template': 7.28.6
       '@types/react': 19.2.14
       react: 19.2.4
+
+  js-base64@3.7.8: {}
 
   js-cookie@3.0.5: {}
 


### PR DESCRIPTION
## Summary

Loads the xterm `ClipboardAddon` in the Mayor terminal component so OSC 52 clipboard escape sequences from the Mayor are honored and the user's clipboard is written correctly.

## Credit

This is a re-application of the fix originally authored by @Githubguy132010 in #1998. That PR was opened from an external fork which our automation cannot push to, so this PR re-applies the same change on a branch in this repository to get it landed.

Closes #1998

## Verification

Manually confirmed the `ClipboardAddon` is imported from `@xterm/addon-clipboard`, instantiated, and registered via `term.loadAddon(clipboardAddon)` alongside the existing fit and web-links addons in `apps/web/src/components/gastown/useXtermPty.ts`.

## Visual Changes

N/A

## Reviewer Notes

- Dependency added: `@xterm/addon-clipboard@^0.2.0` in `apps/web/package.json`.
- `pnpm-lock.yaml` updated to match.
- The fork's original PR targeted a pre-monorepo layout (`src/components/gastown/useXtermPty.ts` + root `package.json`); the change here is the same logic rebased onto the current monorepo layout (`apps/web/...`).