### PR TITLE
fix(bot): clean up Slack integration on uninstall

### DIFF
--- a/apps/web/src/lib/bot.ts
+++ b/apps/web/src/lib/bot.ts
@@ -1,9 +1,11 @@
-import { Chat, type ActionEvent, type Message, type Thread } from 'chat';
+import crypto from 'node:crypto';
+import { Chat, type ActionEvent, type Message, type Thread, type WebhookOptions } from 'chat';
 import { createSlackAdapter, SlackAdapter } from '@chat-adapter/slack';
 import { captureException } from '@sentry/nextjs';
 import type { HomeView } from '@slack/types';
-import { resolveKiloUserId, unlinkKiloUser } from '@/lib/bot-identity';
+import { resolveKiloUserId, unlinkKiloUser, unlinkTeamKiloUsers } from '@/lib/bot-identity';
 import { isSlackMissingScopeError, postSlackReinstallInstruction } from '@/lib/bot/helpers';
+import { deleteInstallationByTeamId } from '@/lib/integrations/slack-service';
 import {
   getPlatformIdentity,
   getPlatformIntegration,
@@ -37,10 +39,125 @@ const SLACK_ASSISTANT_SUGGESTED_PROMPTS = [
 
 const ASSISTANT_PROMPTS_TITLE = 'Try asking Kilo Bot';
 
+const SLACK_SIGNATURE_VERSION = 'v0';
+const SLACK_SIGNATURE_TOLERANCE_SECONDS = 60 * 5;
+
 const SLACK_CHANNEL_INVITE_MESSAGE = {
   markdown:
     "Hey, I'm Kilo, an AI coding assistant. Mention me in this channel when you want help investigating bugs, reviewing PRs, explaining code, or starting implementation work. AI can make mistakes, so please review responses before relying on them. Sessions created with Kilo from Slack are stored at https://app.kilo.ai.",
 } as const;
+
+type SlackAppUninstalledPayload = {
+  type: 'event_callback';
+  team_id: string;
+  event: {
+    type: 'app_uninstalled';
+  };
+};
+
+function verifySlackSignature(body: string, request: Request): boolean {
+  const timestamp = request.headers.get('x-slack-request-timestamp');
+  const signature = request.headers.get('x-slack-signature');
+
+  if (!timestamp || !signature) return false;
+
+  const timestampSeconds = Number.parseInt(timestamp, 10);
+  if (Number.isNaN(timestampSeconds)) return false;
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (Math.abs(nowSeconds - timestampSeconds) > SLACK_SIGNATURE_TOLERANCE_SECONDS) {
+    return false;
+  }
+
+  const signatureBaseString = `${SLACK_SIGNATURE_VERSION}:${timestamp}:${body}`;
+  const expectedSignature = `${SLACK_SIGNATURE_VERSION}=${crypto
+    .createHmac('sha256', SLACK_SIGNING_SECRET)
+    .update(signatureBaseString)
+    .digest('hex')}`;
+
+  try {
+    return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature));
+  } catch {
+    return false;
+  }
+}
+
+function isSlackAppUninstalledPayload(payload: unknown): payload is SlackAppUninstalledPayload {
+  return (
+    !!payload &&
+    typeof payload === 'object' &&
+    'type' in payload &&
+    payload.type === 'event_callback' &&
+    'team_id' in payload &&
+    typeof payload.team_id === 'string' &&
+    'event' in payload &&
+    !!payload.event &&
+    typeof payload.event === 'object' &&
+    'type' in payload.event &&
+    payload.event.type === 'app_uninstalled'
+  );
+}
+
+async function handleSlackAppUninstalled(
+  teamId: string,
+  chatBot: Chat,
+  slackAdapter: SlackAdapter
+): Promise<void> {
+  await deleteInstallationByTeamId(teamId, {
+    deleteChatSdkInstallation: async teamId => {
+      await slackAdapter.deleteInstallation(teamId);
+    },
+    deleteChatSdkIdentityCache: async teamId => {
+      await unlinkTeamKiloUsers(chatBot.getState(), 'slack', teamId);
+    },
+  });
+}
+
+async function handleSlackWebhook(
+  request: Request,
+  options: WebhookOptions | undefined,
+  chatBot: Chat,
+  slackAdapter: SlackAdapter
+): Promise<Response> {
+  const body = await request.text();
+
+  if (!verifySlackSignature(body, request)) {
+    return new Response('Invalid signature', { status: 401 });
+  }
+
+  await chatBot.initialize();
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return slackAdapter.handleWebhook(cloneSlackRequest(request, body), options);
+  }
+
+  if (isSlackAppUninstalledPayload(payload)) {
+    try {
+      await handleSlackAppUninstalled(payload.team_id, chatBot, slackAdapter);
+    } catch (error) {
+      console.error('[Bot] Failed to handle Slack app_uninstalled event:', error);
+      captureException(error, {
+        tags: { component: 'kilo-bot', op: 'slack-app-uninstalled' },
+        extra: { teamId: payload.team_id },
+      });
+    }
+
+    return new Response('ok', { status: 200 });
+  }
+
+  return slackAdapter.handleWebhook(cloneSlackRequest(request, body), options);
+}
+
+function cloneSlackRequest(request: Request, body: BodyInit): Request {
+  return new Request(request.url, {
+    method: request.method,
+    headers: request.headers,
+    body,
+  });
+}
 
 export function buildSlackAppHomeView() {
   return {
@@ -135,6 +252,9 @@ function createKiloBot(slackAdapter: ReturnType<typeof createSlackAdapter>) {
     },
     state: createChatState(),
   });
+
+  chatBot.webhooks.slack = (request, options) =>
+    handleSlackWebhook(request, options, chatBot, slackAdapter);
 
   chatBot.onNewMention(async function handleIncomingMessage(
     thread: Thread,

--- a/apps/web/src/lib/bot.ts
+++ b/apps/web/src/lib/bot.ts
@@ -98,19 +98,18 @@ function isSlackAppUninstalledPayload(payload: unknown): payload is SlackAppUnin
   );
 }
 
-async function handleSlackAppUninstalled(
-  teamId: string,
-  chatBot: Chat,
-  slackAdapter: SlackAdapter
-): Promise<void> {
-  await deleteInstallationByTeamId(teamId, {
-    deleteChatSdkInstallation: async teamId => {
-      await slackAdapter.deleteInstallation(teamId);
-    },
-    deleteChatSdkIdentityCache: async teamId => {
-      await unlinkTeamKiloUsers(chatBot.getState(), 'slack', teamId);
-    },
-  });
+async function handleSlackAppUninstalled(teamId: string, chatBot: Chat): Promise<void> {
+  try {
+    await deleteInstallationByTeamId(teamId);
+    await slackAdapter.deleteInstallation(teamId);
+    await unlinkTeamKiloUsers(chatBot.getState(), 'slack', teamId);
+  } catch (error) {
+    captureException(error, {
+      level: 'error',
+      tags: { component: 'kilo-bot', op: 'slack-app-uninstalled' },
+      extra: { teamId },
+    });
+  }
 }
 
 async function handleSlackWebhook(
@@ -136,7 +135,7 @@ async function handleSlackWebhook(
 
   if (isSlackAppUninstalledPayload(payload)) {
     try {
-      await handleSlackAppUninstalled(payload.team_id, chatBot, slackAdapter);
+      await handleSlackAppUninstalled(payload.team_id, chatBot);
     } catch (error) {
       console.error('[Bot] Failed to handle Slack app_uninstalled event:', error);
       captureException(error, {

--- a/apps/web/src/lib/integrations/slack-service.test.ts
+++ b/apps/web/src/lib/integrations/slack-service.test.ts
@@ -147,31 +147,13 @@ describe('slack-service deleteInstallationByTeamId', () => {
 
   it('deletes the platform integration and Chat SDK state for a Slack team', async () => {
     mockLimit.mockResolvedValue([buildSlackIntegration()]);
-    const deleteChatSdkInstallation = jest.fn(async (_teamId: string): Promise<void> => {});
-    const deleteChatSdkIdentityCache = jest.fn(async (_teamId: string): Promise<void> => {});
 
-    await expect(
-      deleteInstallationByTeamId('T123', {
-        deleteChatSdkInstallation,
-        deleteChatSdkIdentityCache,
-      })
-    ).resolves.toEqual({ success: true, deleted: true });
+    await expect(deleteInstallationByTeamId('T123')).resolves.toEqual({
+      success: true,
+      deleted: true,
+    });
 
-    expect(deleteChatSdkInstallation).toHaveBeenCalledWith('T123');
-    expect(deleteChatSdkIdentityCache).toHaveBeenCalledWith('T123');
     expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
-  });
-
-  it('succeeds without deleting anything when the Slack team is already unknown', async () => {
-    mockLimit.mockResolvedValue([]);
-    const deleteChatSdkInstallation = jest.fn(async (_teamId: string): Promise<void> => {});
-
-    await expect(
-      deleteInstallationByTeamId('T123', { deleteChatSdkInstallation })
-    ).resolves.toEqual({ success: true, deleted: false });
-
-    expect(deleteChatSdkInstallation).not.toHaveBeenCalled();
-    expect(mockDeleteWhere).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/lib/integrations/slack-service.test.ts
+++ b/apps/web/src/lib/integrations/slack-service.test.ts
@@ -39,6 +39,7 @@ jest.mock('@slack/web-api', () => ({
 import type { Owner } from '@/lib/integrations/core/types';
 import type { SlackInstallation } from '@chat-adapter/slack';
 import {
+  deleteInstallationByTeamId,
   getMissingSlackScopes,
   SLACK_SCOPES,
   testConnection,
@@ -134,6 +135,43 @@ describe('slack-service uninstallApp', () => {
 
     expect(deleteChatSdkInstallation).toHaveBeenCalledWith('T456');
     expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('slack-service deleteInstallationByTeamId', () => {
+  beforeEach(() => {
+    mockLimit.mockReset();
+    mockDeleteWhere.mockReset();
+    mockDeleteWhere.mockResolvedValue(undefined);
+  });
+
+  it('deletes the platform integration and Chat SDK state for a Slack team', async () => {
+    mockLimit.mockResolvedValue([buildSlackIntegration()]);
+    const deleteChatSdkInstallation = jest.fn(async (_teamId: string): Promise<void> => {});
+    const deleteChatSdkIdentityCache = jest.fn(async (_teamId: string): Promise<void> => {});
+
+    await expect(
+      deleteInstallationByTeamId('T123', {
+        deleteChatSdkInstallation,
+        deleteChatSdkIdentityCache,
+      })
+    ).resolves.toEqual({ success: true, deleted: true });
+
+    expect(deleteChatSdkInstallation).toHaveBeenCalledWith('T123');
+    expect(deleteChatSdkIdentityCache).toHaveBeenCalledWith('T123');
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it('succeeds without deleting anything when the Slack team is already unknown', async () => {
+    mockLimit.mockResolvedValue([]);
+    const deleteChatSdkInstallation = jest.fn(async (_teamId: string): Promise<void> => {});
+
+    await expect(
+      deleteInstallationByTeamId('T123', { deleteChatSdkInstallation })
+    ).resolves.toEqual({ success: true, deleted: false });
+
+    expect(deleteChatSdkInstallation).not.toHaveBeenCalled();
+    expect(mockDeleteWhere).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/lib/integrations/slack-service.ts
+++ b/apps/web/src/lib/integrations/slack-service.ts
@@ -264,6 +264,24 @@ export async function uninstallApp(owner: Owner, options: SlackUninstallOptions 
   return { success: true };
 }
 
+export async function deleteInstallationByTeamId(
+  teamId: string,
+  options: SlackUninstallOptions = {}
+) {
+  const integration = await getInstallationByTeamId(teamId);
+
+  if (!integration) {
+    return { success: true, deleted: false };
+  }
+
+  await options.deleteChatSdkInstallation?.(teamId);
+  await options.deleteChatSdkIdentityCache?.(teamId);
+
+  await db.delete(platform_integrations).where(eq(platform_integrations.id, integration.id));
+
+  return { success: true, deleted: true };
+}
+
 /**
  * Remove only the database row for a Slack integration without revoking the token on Slack's side.
  * This is useful for development when you want to re-test the OAuth flow without

--- a/apps/web/src/lib/integrations/slack-service.ts
+++ b/apps/web/src/lib/integrations/slack-service.ts
@@ -264,18 +264,12 @@ export async function uninstallApp(owner: Owner, options: SlackUninstallOptions 
   return { success: true };
 }
 
-export async function deleteInstallationByTeamId(
-  teamId: string,
-  options: SlackUninstallOptions = {}
-) {
+export async function deleteInstallationByTeamId(teamId: string) {
   const integration = await getInstallationByTeamId(teamId);
 
   if (!integration) {
     return { success: true, deleted: false };
   }
-
-  await options.deleteChatSdkInstallation?.(teamId);
-  await options.deleteChatSdkIdentityCache?.(teamId);
 
   await db.delete(platform_integrations).where(eq(platform_integrations.id, integration.id));
 


### PR DESCRIPTION
## Summary
- Listen for Slack `app_uninstalled` webhook events before delegating to the Chat SDK Slack adapter.
- Delete the matching Slack `platform_integrations` row and clear Chat SDK installation and identity state when Slack reports that the app was removed.
- Add focused Slack service coverage for team-id based uninstall cleanup.

## Verification
- I tested this by removing an app from Slack, and then making sure that the platform integration also got removed.

## Visual Changes
N/A

## Reviewer Notes
- The Chat SDK Slack adapter does not currently expose an `app_uninstalled` handler, so `bot.ts` wraps Slack webhook handling to intercept only this event and delegates all other Slack payloads back to the existing adapter.
- Slack app Event Subscriptions must include `app_uninstalled` for this cleanup path to run.