### PR TITLE
feat(bot): replay linked account messages

### DIFF
--- a/apps/web/src/app/api/chat/link-account/route.ts
+++ b/apps/web/src/app/api/chat/link-account/route.ts
@@ -1,9 +1,23 @@
 import { bot } from '@/lib/bot';
 import { APP_URL } from '@/lib/constants';
-import { linkKiloUser, verifyLinkToken, type PlatformIdentity } from '@/lib/bot-identity';
+import {
+  linkKiloUser,
+  verifyLinkToken,
+  type LinkAccountTokenPayload,
+  type PlatformIdentity,
+} from '@/lib/bot-identity';
+import { processAuthenticatedBotMessage } from '@/lib/bot/message-processing';
+import { withBotPlatformAuthContext } from '@/lib/bot/platform-auth-context';
+import { getBotThread } from '@/lib/bot/thread';
 import { isOrganizationMember } from '@/lib/organizations/organizations';
 import { getUserFromAuth } from '@/lib/user.server';
 import { getPlatformIntegration } from '@/lib/bot/platform-helpers';
+import { botLinkAccountReplayRedisKey } from '@/lib/redis-keys';
+import { captureException } from '@sentry/nextjs';
+import { after } from 'next/server';
+import type { User } from '@kilocode/db';
+
+const ORIGINAL_MESSAGE_REPLAY_TTL_MS = 30 * 60 * 1000;
 
 function errorPage(title: string, message: string, status: number): Response {
   return new Response(
@@ -17,6 +31,86 @@ function errorPage(title: string, message: string, status: number): Response {
 </body></html>`,
     { status, headers: { 'content-type': 'text/html; charset=utf-8' } }
   );
+}
+
+async function scheduleOriginalMessageReplay(params: {
+  identity: LinkAccountTokenPayload;
+  user: User;
+}): Promise<boolean> {
+  const { linkContext } = params.identity;
+  if (!linkContext) {
+    return false;
+  }
+
+  const threadPlatform = linkContext.threadId.split(':', 1)[0];
+  if (threadPlatform !== params.identity.platform) {
+    throw new Error('Link-account token thread context does not match the platform identity.');
+  }
+
+  const state = bot.getState();
+  const replayClaimed = await state.setIfNotExists(
+    botLinkAccountReplayRedisKey(params.identity.nonce),
+    {
+      messageId: linkContext.messageId,
+      threadId: linkContext.threadId,
+      userId: params.user.id,
+    },
+    ORIGINAL_MESSAGE_REPLAY_TTL_MS
+  );
+
+  if (!replayClaimed) {
+    return false;
+  }
+
+  after(async () => {
+    try {
+      const platformIntegration = await getPlatformIntegration(params.identity);
+      if (!platformIntegration) {
+        throw new Error('No matching integration found while replaying linked chat message.');
+      }
+
+      const thread = await getBotThread(linkContext.threadId);
+      await withBotPlatformAuthContext(platformIntegration, async () => {
+        const message = await Promise.resolve(
+          thread.adapter.fetchMessage?.(thread.id, linkContext.messageId) ?? null
+        );
+
+        if (!message) {
+          await thread.post({
+            markdown:
+              'Your Kilo account is linked, but I could not find the original message. Please mention Kilo again with your request.',
+          });
+          return;
+        }
+
+        if (message.author.userId !== params.identity.userId) {
+          throw new Error(
+            'Original linked chat message author does not match the linked identity.'
+          );
+        }
+
+        await processAuthenticatedBotMessage({
+          thread,
+          message,
+          platformIntegration,
+          user: params.user,
+        });
+      });
+    } catch (error) {
+      console.error('[BotLinkAccount] Failed to replay original chat message:', error);
+      captureException(error, {
+        tags: { component: 'kilo-bot', op: 'link-account-replay-original-message' },
+        extra: {
+          platform: params.identity.platform,
+          teamId: params.identity.teamId,
+          threadId: linkContext.threadId,
+          messageId: linkContext.messageId,
+        },
+      });
+    }
+  });
+
+  return true;
 }
 
 /**
@@ -103,14 +197,33 @@ export async function GET(request: Request) {
 
   await linkKiloUser(bot.getState(), identity, user.id);
 
+  let originalMessageReplayScheduled = false;
+  try {
+    originalMessageReplayScheduled = await scheduleOriginalMessageReplay({ identity, user });
+  } catch (error) {
+    captureException(error, {
+      tags: { component: 'kilo-bot', op: 'link-account-schedule-original-message' },
+      extra: {
+        platform: identity.platform,
+        teamId: identity.teamId,
+        hasLinkContext: Boolean(identity.linkContext),
+      },
+    });
+  }
+
+  const successMessage = originalMessageReplayScheduled
+    ? `Your ${identity.platform} account has been linked to your Kilo account.<br>
+      You can close this tab. I am processing your original chat message now.`
+    : `Your ${identity.platform} account has been linked to your Kilo account.<br>
+      You can close this tab and @mention Kilo again in your chat.`;
+
   return new Response(
     `<!DOCTYPE html>
 <html><head><meta charset="utf-8"><title>Account Linked</title></head>
 <body style="font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
 <div style="text-align:center">
   <h1>Account linked</h1>
-  <p>Your ${identity.platform} account has been linked to your Kilo account.<br>
-     You can close this tab and @mention Kilo again in your chat.</p>
+  <p>${successMessage}</p>
 </div>
 </body></html>`,
     { headers: { 'content-type': 'text/html; charset=utf-8' } }

--- a/apps/web/src/app/api/internal/bot-session-callback/[botRequestId]/route.ts
+++ b/apps/web/src/app/api/internal/bot-session-callback/[botRequestId]/route.ts
@@ -10,7 +10,6 @@ import {
 } from '@kilocode/db/schema';
 import { and, eq } from 'drizzle-orm';
 import { captureException } from '@sentry/nextjs';
-import { bot } from '@/lib/bot';
 import { MAX_ITERATIONS } from '@/lib/bot/constants';
 import {
   claimBotRequestCloudAgentSessionGroupContinuation,
@@ -26,9 +25,9 @@ import { parseBotCallbackStep } from '@/lib/bot/step-budget';
 import { runBotAgent, type BotAgentMessageLike } from '@/lib/bot/agent-runner';
 import { withBotPlatformAuthContext } from '@/lib/bot/platform-auth-context';
 import { getPlatformIntegrationById } from '@/lib/bot/platform-helpers';
+import { getBotThread } from '@/lib/bot/thread';
 import { findUserById } from '@/lib/user';
-import { PLATFORM } from '@/lib/integrations/core/constants';
-import { ThreadImpl, type Thread } from 'chat';
+import type { Thread } from 'chat';
 
 type ExecutionCallbackPayload = {
   sessionId: string;
@@ -55,31 +54,6 @@ async function getBotRequest(botRequestId: string) {
 
 function logCallback(message: string, extra?: Record<string, unknown>) {
   console.log('[BotSessionCallback]', message, extra ?? {});
-}
-
-async function getBotThread(threadId: string): Promise<Thread> {
-  await bot.initialize();
-  bot.registerSingleton();
-
-  const adapterName = threadId.split(':', 1)[0];
-  if (!adapterName) {
-    throw new Error(`Bot callback thread id is missing an adapter prefix: ${threadId}`);
-  }
-
-  switch (adapterName) {
-    case PLATFORM.SLACK: {
-      const adapter = bot.getAdapter(PLATFORM.SLACK);
-      return new ThreadImpl({
-        adapterName,
-        channelId: adapter.channelIdFromThreadId(threadId),
-        channelVisibility: adapter.getChannelVisibility?.(threadId),
-        id: threadId,
-        isDM: adapter.isDM?.(threadId) ?? false,
-      });
-    }
-    default:
-      throw new Error(`No chat SDK adapter registered for platform ${adapterName}`);
-  }
 }
 
 function parseTerminalCallbackStatus(status: unknown): TerminalCallbackStatus | undefined {

--- a/apps/web/src/lib/bot-identity.test.ts
+++ b/apps/web/src/lib/bot-identity.test.ts
@@ -1,0 +1,39 @@
+import { createLinkToken, verifyLinkToken } from '@/lib/bot-identity';
+
+describe('bot identity link tokens', () => {
+  it('round trips link-account replay context', () => {
+    const token = createLinkToken({
+      platform: 'slack',
+      teamId: 'T123',
+      userId: 'U123',
+      linkContext: {
+        threadId: 'slack:T123:C456:1710000000.000000',
+        messageId: '1710000000.000000',
+      },
+    });
+
+    const payload = verifyLinkToken(token);
+
+    expect(payload).toMatchObject({
+      platform: 'slack',
+      teamId: 'T123',
+      userId: 'U123',
+      linkContext: {
+        threadId: 'slack:T123:C456:1710000000.000000',
+        messageId: '1710000000.000000',
+      },
+    });
+    expect(payload?.nonce).toEqual(expect.any(String));
+  });
+
+  it('rejects invalid replay context payloads', () => {
+    const token = createLinkToken({
+      platform: 'slack',
+      teamId: 'T123',
+      userId: 'U123',
+      linkContext: { threadId: '', messageId: '1710000000.000000' },
+    });
+
+    expect(verifyLinkToken(token)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/bot-identity.ts
+++ b/apps/web/src/lib/bot-identity.ts
@@ -35,6 +35,20 @@ export type PlatformIdentity = {
   userId: string;
 };
 
+export type LinkAccountContext = {
+  threadId: string;
+  messageId: string;
+};
+
+export type LinkAccountTokenPayload = PlatformIdentity & {
+  linkContext?: LinkAccountContext;
+  nonce: string;
+};
+
+export type CreateLinkTokenPayload = PlatformIdentity & {
+  linkContext?: LinkAccountContext;
+};
+
 /**
  * Look up the Kilo user ID linked to a chat-platform user.
  * Returns `null` when no mapping exists yet.
@@ -133,7 +147,7 @@ function hmacSign(data: string): string {
 }
 
 /** Create a signed, time-limited token encoding a PlatformIdentity. */
-export function createLinkToken(identity: PlatformIdentity): string {
+export function createLinkToken(identity: CreateLinkTokenPayload): string {
   const iat = Math.floor(Date.now() / 1000);
   const nonce = crypto.randomBytes(NONCE_BYTES).toString('base64url');
   const payload = Buffer.from(JSON.stringify({ ...identity, iat, nonce })).toString('base64url');
@@ -141,7 +155,7 @@ export function createLinkToken(identity: PlatformIdentity): string {
 }
 
 /** Verify and decode a link token. Returns the identity or `null` on failure. */
-export function verifyLinkToken(token: string): PlatformIdentity | null {
+export function verifyLinkToken(token: string): LinkAccountTokenPayload | null {
   const dotIndex = token.indexOf('.');
   if (dotIndex === -1) return null;
 
@@ -161,6 +175,7 @@ export function verifyLinkToken(token: string): PlatformIdentity | null {
       platform?: PlatformIdentity['platform'];
       teamId?: string;
       userId?: string;
+      linkContext?: unknown;
       iat?: number;
       nonce?: string;
     };
@@ -180,7 +195,34 @@ export function verifyLinkToken(token: string): PlatformIdentity | null {
 
     if (typeof data.nonce !== 'string' || data.nonce.length === 0) return null;
 
-    return { platform: data.platform, teamId: data.teamId, userId: data.userId };
+    let linkContext: LinkAccountContext | undefined;
+    if (data.linkContext !== undefined) {
+      if (
+        !data.linkContext ||
+        typeof data.linkContext !== 'object' ||
+        !('threadId' in data.linkContext) ||
+        typeof data.linkContext.threadId !== 'string' ||
+        data.linkContext.threadId.length === 0 ||
+        !('messageId' in data.linkContext) ||
+        typeof data.linkContext.messageId !== 'string' ||
+        data.linkContext.messageId.length === 0
+      ) {
+        return null;
+      }
+
+      linkContext = {
+        threadId: data.linkContext.threadId,
+        messageId: data.linkContext.messageId,
+      };
+    }
+
+    return {
+      platform: data.platform,
+      teamId: data.teamId,
+      userId: data.userId,
+      linkContext,
+      nonce: data.nonce,
+    };
   } catch {
     return null;
   }

--- a/apps/web/src/lib/bot.ts
+++ b/apps/web/src/lib/bot.ts
@@ -12,9 +12,8 @@ import {
   getPlatformIntegrationByBotUserId,
 } from '@/lib/bot/platform-helpers';
 import { LINK_ACCOUNT_ACTION_PREFIX, promptLinkAccount } from '@/lib/bot/link-account';
-import { createBotRequest, updateBotRequest } from '@/lib/bot/request-logging';
 import { findUserById } from '@/lib/user';
-import { processMessage } from '@/lib/bot/run';
+import { processAuthenticatedBotMessage } from '@/lib/bot/message-processing';
 import { createChatState } from '@/lib/bot/state';
 import { SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, SLACK_SIGNING_SECRET } from '@/lib/config.server';
 
@@ -285,35 +284,8 @@ function createKiloBot(slackAdapter: ReturnType<typeof createSlackAdapter>) {
       return;
     }
 
-    const platform = thread.id.split(':')[0];
-    const botRequestId = await createBotRequest({
-      createdBy: user.id,
-      organizationId: platformIntegration.owned_by_organization_id ?? null,
-      platformIntegrationId: platformIntegration.id,
-      platform,
-      platformThreadId: thread.id,
-      platformMessageId: message.id,
-      userMessage: message.text,
-      modelUsed: undefined,
-    });
-
     chatBot.registerSingleton();
-
-    await thread.startTyping('Thinking...');
-
-    try {
-      await processMessage({ thread, message, platformIntegration, user, botRequestId });
-    } catch (error) {
-      console.error('[Bot] Unhandled error in message handler:', error);
-      if (botRequestId) {
-        const errMsg = error instanceof Error ? error.message : String(error);
-        updateBotRequest(botRequestId, {
-          status: 'error',
-          errorMessage: errMsg.slice(0, 2000),
-        });
-      }
-      await thread.post({ markdown: 'Sorry, something went wrong while processing your message.' });
-    }
+    await processAuthenticatedBotMessage({ thread, message, platformIntegration, user });
   });
 
   // When the user clicks the "Link Account" LinkButton, Slack fires a

--- a/apps/web/src/lib/bot/link-account.ts
+++ b/apps/web/src/lib/bot/link-account.ts
@@ -7,9 +7,22 @@ const LINK_ACCOUNT_PATH = '/api/chat/link-account';
 
 export const LINK_ACCOUNT_ACTION_PREFIX = `link-${APP_URL}${LINK_ACCOUNT_PATH}`;
 
-function buildLinkAccountUrl(identity: PlatformIdentity): string {
+function buildLinkAccountUrl(params: {
+  identity: PlatformIdentity;
+  thread: Thread;
+  message: Message;
+}): string {
   const url = new URL(LINK_ACCOUNT_PATH, APP_URL);
-  url.searchParams.set('token', createLinkToken(identity));
+  url.searchParams.set(
+    'token',
+    createLinkToken({
+      ...params.identity,
+      linkContext: {
+        messageId: params.message.id,
+        threadId: params.thread.id,
+      },
+    })
+  );
   return url.toString();
 }
 
@@ -36,7 +49,11 @@ export async function promptLinkAccount(
   // Post to the channel when the @mention is top-level, otherwise into the thread.
   const target = isChannelLevelMessage(thread, message) ? thread.channel : thread;
 
-  await target.postEphemeral(message.author, linkAccountCard(buildLinkAccountUrl(identity)), {
-    fallbackToDM: true,
-  });
+  await target.postEphemeral(
+    message.author,
+    linkAccountCard(buildLinkAccountUrl({ identity, thread, message })),
+    {
+      fallbackToDM: true,
+    }
+  );
 }

--- a/apps/web/src/lib/bot/message-processing.test.ts
+++ b/apps/web/src/lib/bot/message-processing.test.ts
@@ -1,0 +1,209 @@
+jest.mock('@/lib/bot/request-logging', () => ({
+  createBotRequest: jest.fn(),
+  updateBotRequest: jest.fn(),
+}));
+
+jest.mock('@/lib/bot/run', () => ({
+  processMessage: jest.fn(),
+}));
+
+jest.mock(
+  'chat',
+  () => ({
+    Message: class Message {
+      readonly attachments: unknown[];
+      readonly author: unknown;
+      readonly formatted: unknown;
+      readonly id: string;
+      readonly metadata: unknown;
+      readonly raw: unknown;
+      readonly text: string;
+      readonly threadId: string;
+
+      constructor(data: {
+        attachments: unknown[];
+        author: unknown;
+        formatted: unknown;
+        id: string;
+        metadata: unknown;
+        raw: unknown;
+        text: string;
+        threadId: string;
+      }) {
+        this.attachments = data.attachments;
+        this.author = data.author;
+        this.formatted = data.formatted;
+        this.id = data.id;
+        this.metadata = data.metadata;
+        this.raw = data.raw;
+        this.text = data.text;
+        this.threadId = data.threadId;
+      }
+    },
+  }),
+  { virtual: true }
+);
+
+import { createBotRequest, updateBotRequest } from '@/lib/bot/request-logging';
+import { processMessage } from '@/lib/bot/run';
+import { processAuthenticatedBotMessage } from '@/lib/bot/message-processing';
+import type { PlatformIntegration, User } from '@kilocode/db';
+import { Message } from 'chat';
+import type { Thread } from 'chat';
+
+const mockCreateBotRequest = jest.mocked(createBotRequest);
+const mockUpdateBotRequest = jest.mocked(updateBotRequest);
+const mockProcessMessage = jest.mocked(processMessage);
+
+function createUser(): User {
+  return {
+    id: 'user_1',
+    google_user_email: 'user@example.com',
+    google_user_name: 'Test User',
+    google_user_image_url: '',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    hosted_domain: null,
+    microdollars_used: 0,
+    kilo_pass_threshold: null,
+    stripe_customer_id: 'cus_123',
+    is_admin: false,
+    total_microdollars_acquired: 0,
+    next_credit_expiration_at: null,
+    has_validation_stytch: null,
+    has_validation_novel_card_with_hold: false,
+    blocked_reason: null,
+    blocked_at: null,
+    blocked_by_kilo_user_id: null,
+    api_token_pepper: null,
+    web_session_pepper: null,
+    auto_top_up_enabled: false,
+    is_bot: false,
+    kiloclaw_early_access: false,
+    default_model: null,
+    cohorts: {},
+    completed_welcome_form: false,
+    linkedin_url: null,
+    github_url: null,
+    discord_server_membership_verified_at: null,
+    openrouter_upstream_safety_identifier: null,
+    vercel_downstream_safety_identifier: null,
+    customer_source: null,
+    signup_ip: null,
+    account_deletion_requested_at: null,
+    normalized_email: null,
+    email_domain: null,
+  };
+}
+
+function createPlatformIntegration(): PlatformIntegration {
+  return {
+    id: 'pi_slack',
+    owned_by_user_id: 'user_1',
+    owned_by_organization_id: null,
+    created_by_user_id: null,
+    platform: 'slack',
+    integration_type: 'oauth',
+    platform_installation_id: 'T123',
+    platform_account_id: 'T123',
+    platform_account_login: 'Test Workspace',
+    permissions: null,
+    integration_status: 'active',
+    scopes: null,
+    repository_access: null,
+    repositories: null,
+    repositories_synced_at: null,
+    metadata: {},
+    kilo_requester_user_id: null,
+    platform_requester_account_id: null,
+    suspended_at: null,
+    suspended_by: null,
+    github_app_type: 'standard',
+    installed_at: '2026-01-01T00:00:00.000Z',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function createMessage(): Message {
+  return new Message({
+    id: '1710000000.000000',
+    threadId: 'slack:T123:C456:1710000000.000000',
+    text: 'Please fix this bug',
+    formatted: { type: 'root', children: [] },
+    raw: { type: 'message', team: 'T123', ts: '1710000000.000000' },
+    author: {
+      fullName: 'Test User',
+      isBot: false,
+      isMe: false,
+      userId: 'U123',
+      userName: 'test-user',
+    },
+    metadata: { dateSent: new Date('2026-01-01T00:00:00.000Z'), edited: false },
+    attachments: [],
+  });
+}
+
+describe('processAuthenticatedBotMessage', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockCreateBotRequest.mockResolvedValue('bot_request_1');
+    mockProcessMessage.mockResolvedValue(undefined);
+  });
+
+  it('creates request logging and processes the message', async () => {
+    const thread = {
+      id: 'slack:T123:C456:1710000000.000000',
+      startTyping: jest.fn(),
+      post: jest.fn(),
+    } as unknown as Thread;
+    const message = createMessage();
+    const platformIntegration = createPlatformIntegration();
+    const user = createUser();
+
+    await processAuthenticatedBotMessage({ thread, message, platformIntegration, user });
+
+    expect(mockCreateBotRequest).toHaveBeenCalledWith({
+      createdBy: 'user_1',
+      organizationId: null,
+      platformIntegrationId: 'pi_slack',
+      platform: 'slack',
+      platformThreadId: 'slack:T123:C456:1710000000.000000',
+      platformMessageId: '1710000000.000000',
+      userMessage: 'Please fix this bug',
+      modelUsed: undefined,
+    });
+    expect(thread.startTyping).toHaveBeenCalledWith('Thinking...');
+    expect(mockProcessMessage).toHaveBeenCalledWith({
+      thread,
+      message,
+      platformIntegration,
+      user,
+      botRequestId: 'bot_request_1',
+    });
+  });
+
+  it('records an error and posts a fallback if processing throws', async () => {
+    const thread = {
+      id: 'slack:T123:C456:1710000000.000000',
+      startTyping: jest.fn(),
+      post: jest.fn(),
+    } as unknown as Thread;
+    mockProcessMessage.mockRejectedValue(new Error('model exploded'));
+
+    await processAuthenticatedBotMessage({
+      thread,
+      message: createMessage(),
+      platformIntegration: createPlatformIntegration(),
+      user: createUser(),
+    });
+
+    expect(mockUpdateBotRequest).toHaveBeenCalledWith('bot_request_1', {
+      status: 'error',
+      errorMessage: 'model exploded',
+    });
+    expect(thread.post).toHaveBeenCalledWith({
+      markdown: 'Sorry, something went wrong while processing your message.',
+    });
+  });
+});

--- a/apps/web/src/lib/bot/message-processing.ts
+++ b/apps/web/src/lib/bot/message-processing.ts
@@ -1,0 +1,47 @@
+import { processMessage } from '@/lib/bot/run';
+import { createBotRequest, updateBotRequest } from '@/lib/bot/request-logging';
+import type { PlatformIntegration, User } from '@kilocode/db';
+import type { Message, Thread } from 'chat';
+
+export async function processAuthenticatedBotMessage(params: {
+  thread: Thread;
+  message: Message;
+  platformIntegration: PlatformIntegration;
+  user: User;
+}): Promise<void> {
+  const platform = params.thread.id.split(':')[0];
+  const botRequestId = await createBotRequest({
+    createdBy: params.user.id,
+    organizationId: params.platformIntegration.owned_by_organization_id ?? null,
+    platformIntegrationId: params.platformIntegration.id,
+    platform,
+    platformThreadId: params.thread.id,
+    platformMessageId: params.message.id,
+    userMessage: params.message.text,
+    modelUsed: undefined,
+  });
+
+  await params.thread.startTyping('Thinking...');
+
+  try {
+    await processMessage({
+      thread: params.thread,
+      message: params.message,
+      platformIntegration: params.platformIntegration,
+      user: params.user,
+      botRequestId,
+    });
+  } catch (error) {
+    console.error('[Bot] Unhandled error in message handler:', error);
+    if (botRequestId) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      updateBotRequest(botRequestId, {
+        status: 'error',
+        errorMessage: errMsg.slice(0, 2000),
+      });
+    }
+    await params.thread.post({
+      markdown: 'Sorry, something went wrong while processing your message.',
+    });
+  }
+}

--- a/apps/web/src/lib/bot/thread.test.ts
+++ b/apps/web/src/lib/bot/thread.test.ts
@@ -1,0 +1,69 @@
+jest.mock('@/lib/bot', () => ({
+  bot: {
+    getAdapter: jest.fn(),
+    initialize: jest.fn(),
+    registerSingleton: jest.fn(),
+  },
+}));
+
+jest.mock(
+  'chat',
+  () => ({
+    ThreadImpl: class ThreadImpl {
+      readonly channelId: string;
+      readonly id: string;
+      readonly isDM: boolean;
+
+      constructor(config: { channelId: string; id: string; isDM?: boolean }) {
+        this.channelId = config.channelId;
+        this.id = config.id;
+        this.isDM = config.isDM ?? false;
+      }
+    },
+  }),
+  { virtual: true }
+);
+
+import { getBotThread } from '@/lib/bot/thread';
+
+type MockBotModule = {
+  bot: {
+    getAdapter: jest.Mock;
+    initialize: jest.Mock;
+    registerSingleton: jest.Mock;
+  };
+};
+
+const mockBotModule: MockBotModule = jest.requireMock('@/lib/bot');
+
+describe('getBotThread', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockBotModule.bot.getAdapter.mockReturnValue({
+      channelIdFromThreadId: jest.fn(() => 'slack:T123:C456'),
+      getChannelVisibility: jest.fn(() => 'private'),
+      isDM: jest.fn(() => false),
+    });
+  });
+
+  it('constructs a Chat SDK thread for Slack thread ids', async () => {
+    const thread = await getBotThread('slack:T123:C456:1710000000.000000');
+
+    expect(mockBotModule.bot.initialize).toHaveBeenCalledTimes(1);
+    expect(mockBotModule.bot.registerSingleton).toHaveBeenCalledTimes(1);
+    expect(mockBotModule.bot.getAdapter).toHaveBeenCalledWith('slack');
+    expect(thread.id).toBe('slack:T123:C456:1710000000.000000');
+    expect(thread.channelId).toBe('slack:T123:C456');
+    expect(thread.isDM).toBe(false);
+  });
+
+  it('rejects thread ids without an adapter prefix', async () => {
+    await expect(getBotThread('')).rejects.toThrow('Bot thread id is missing an adapter prefix');
+  });
+
+  it('rejects unsupported adapter prefixes', async () => {
+    await expect(getBotThread('discord:guild:channel:thread')).rejects.toThrow(
+      'No chat SDK adapter registered for platform discord'
+    );
+  });
+});

--- a/apps/web/src/lib/bot/thread.ts
+++ b/apps/web/src/lib/bot/thread.ts
@@ -1,0 +1,28 @@
+import { bot } from '@/lib/bot';
+import { PLATFORM } from '@/lib/integrations/core/constants';
+import { ThreadImpl, type Thread } from 'chat';
+
+export async function getBotThread(threadId: string): Promise<Thread> {
+  await bot.initialize();
+  bot.registerSingleton();
+
+  const adapterName = threadId.split(':', 1)[0];
+  if (!adapterName) {
+    throw new Error(`Bot thread id is missing an adapter prefix: ${threadId}`);
+  }
+
+  switch (adapterName) {
+    case PLATFORM.SLACK: {
+      const adapter = bot.getAdapter(PLATFORM.SLACK);
+      return new ThreadImpl({
+        adapterName,
+        channelId: adapter.channelIdFromThreadId(threadId),
+        channelVisibility: adapter.getChannelVisibility?.(threadId),
+        id: threadId,
+        isDM: adapter.isDM?.(threadId) ?? false,
+      });
+    }
+    default:
+      throw new Error(`No chat SDK adapter registered for platform ${adapterName}`);
+  }
+}

--- a/apps/web/src/lib/redis-keys.ts
+++ b/apps/web/src/lib/redis-keys.ts
@@ -35,3 +35,6 @@ export const requestLogRedisKey = (hash: string) => redisKey(`ai-gateway.request
 
 export const botIdentityRedisKey = (platform: string, teamId: string, userId: string) =>
   redisKey(`identity:${platform}:${teamId}:${userId}`);
+
+export const botLinkAccountReplayRedisKey = (nonce: string) =>
+  redisKey(`bot:link-account-replay:${nonce}`);


### PR DESCRIPTION
## Summary

- Replay the original chat message after a user links their Kilo account, so they do not need to resend the request.
- Extract Chat SDK thread reconstruction and authenticated bot message processing into shared modules used by both the callback and link-account flows.
- Extend link-account tokens with signed replay context and dedupe replay attempts by token nonce.

## Verification

Manual browser verification not performed; this change is in the chat-platform callback/linking flow and was validated with targeted automated checks locally.

## Visual Changes

N/A

## Reviewer Notes

- Replay depends on the adapter supporting `fetchMessage`; if unavailable or the message cannot be found, the bot posts a fallback asking the user to mention Kilo again.
- The replay path verifies the fetched message author matches the linked platform identity before processing.