### PR TITLE
chore(kiloclaw): update runtime dependencies

### DIFF
--- a/apps/web/src/app/(app)/claw/components/changelog-data.ts
+++ b/apps/web/src/app/(app)/claw/components/changelog-data.ts
@@ -11,6 +11,12 @@ export type ChangelogEntry = {
 // Newest entries first. Developers add new entries to the top of this array.
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-05-01',
+    description: 'Updated OpenClaw to 2026.4.23.',
+    category: 'feature',
+    deployHint: 'redeploy_suggested',
+  },
+  {
     date: '2026-04-28',
     description:
       'Added an Early Access opt-in under Settings → Manage Version. Turn it on to receive new KiloClaw versions while they are still rolling out, instead of waiting for full availability. Applies to all of your instances, personal and org. A version pin always wins per instance, so a pinned instance ignores Early Access until you unpin.',

--- a/services/kiloclaw/.dev.vars.example
+++ b/services/kiloclaw/.dev.vars.example
@@ -119,7 +119,7 @@ FLY_IMAGE_DIGEST=
 # Used by the worker to self-register the version → image tag mapping in KV,
 # enabling per-user version tracking. Without this, version tracking fields
 # will be null and instances fall back to FLY_IMAGE_TAG directly.
-OPENCLAW_VERSION=2026.4.15
+OPENCLAW_VERSION=2026.4.23
 
 # Legacy fallback for existing instances without per-user apps.
 # New instances get per-user apps (acct-{hash}) created automatically.

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -2,10 +2,10 @@
 ARG CONTROLLER_COMMIT=unknown
 ARG CONTROLLER_CACHE_BUST=1
 
-FROM debian:bookworm-slim AS runtime
+FROM debian:trixie-slim AS runtime
 
 # Install Node.js 24 (required by OpenClaw)
-ENV NODE_VERSION=24.14.1
+ENV NODE_VERSION=24.15.0
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        ca-certificates curl gnupg git xz-utils unzip jq ripgrep rsync zstd \
@@ -105,10 +105,10 @@ RUN npm install -g github:Kilo-Org/openclaw-channel-streamchat#fix/plugin-name-r
 RUN npm install -g @steipete/summarize@0.12.0
 
 # Install Kilo CLI (agentic coding assistant for the terminal)
-RUN npm install -g @kilocode/cli@7.2.22
+RUN npm install -g @kilocode/cli@7.2.31
 
 # Install Go (available at runtime for users to `go install` additional tools)
-ENV GO_VERSION=1.26.0
+ENV GO_VERSION=1.26.2
 RUN ARCH="$(dpkg --print-architecture)" \
     && curl -fsSL https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz -o /tmp/go.tar.gz \
     && EXPECTED_SHA256="$(curl -fsSL https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz.sha256)" \
@@ -122,11 +122,13 @@ RUN ARCH="$(dpkg --print-architecture)" \
 #   so user-installed tools persist across restarts and are included in snapshots.
 # - npm/Node (installed to /usr/local) and apt packages (/usr/bin) are unaffected.
 ENV PATH="/usr/local/go/bin:/root/go/bin:$PATH"
-RUN GOBIN=/usr/local/bin go install github.com/steipete/gogcli/cmd/gog@v0.12.0 \
+RUN ARCH="$(dpkg --print-architecture)" \
+    && curl -fsSL "https://github.com/steipete/gogcli/releases/download/v0.14.0/gogcli_0.14.0_linux_${ARCH}.tar.gz" \
+       | tar xz -C /usr/local/bin gog \
     && mv /usr/local/bin/gog /usr/local/bin/gog.real \
     && GOBIN=/usr/local/bin go install github.com/steipete/goplaces/cmd/goplaces@v0.3.0 \
     && GOBIN=/usr/local/bin go install github.com/Hyaxia/blogwatcher/cmd/blogwatcher@v0.0.2 \
-    && GOBIN=/usr/local/bin go install github.com/xdevplatform/xurl@v1.0.3 \
+    && GOBIN=/usr/local/bin go install github.com/xdevplatform/xurl@v1.1.0 \
     && GOBIN=/usr/local/bin go install github.com/steipete/gifgrep/cmd/gifgrep@v0.2.3 \
     && go clean -cache -modcache
 
@@ -176,11 +178,11 @@ RUN cd /tmp/kiloclaw-morning-briefing \
 # file. By building in a separate stage, Bun (~100MB) stays out of the
 # final image. Bun installed to /root/.bun/ which gets shadowed by the
 # Fly Volume mount at /root, so it was unreachable at runtime anyway.
-FROM debian:bookworm-slim AS controller-builder
+FROM debian:trixie-slim AS controller-builder
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl unzip \
-    && curl -fsSL https://bun.sh/install | bash -s "bun-v1.2.4" \
+    && curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.13" \
     && rm -rf /var/lib/apt/lists/*
 ENV PATH="/root/.bun/bin:$PATH"
 

--- a/services/kiloclaw/Dockerfile
+++ b/services/kiloclaw/Dockerfile
@@ -55,7 +55,7 @@ RUN npm install -g pnpm
 # Patch: bump model discovery timeout from 5s to 60s — shared-cpu machines
 # under boot load routinely need 27-35s for the first TLS+fetch to complete.
 # Remove this sed patch once openclaw exposes a configurable timeout.
-RUN npm install -g openclaw@2026.4.15 \
+RUN npm install -g openclaw@2026.4.23 \
     && OC_DIST=/usr/local/lib/node_modules/openclaw/dist \
     && FOUND_FILES=$(find "$OC_DIST" -name 'provider-models-*.js' | wc -l | tr -d ' ') \
     && if [ "$FOUND_FILES" -eq 0 ]; then echo "ERROR: provider-models-*.js not found in openclaw dist" >&2; exit 1; fi \
@@ -228,8 +228,8 @@ RUN mkdir -p /root/.openclaw \
     && mkdir -p /root/clawd/skills
 
 # Copy helper scripts (used at runtime by the controller/gateway)
-# Build cache bust: 2026-04-24-v66-openclaw-2026.4.15-add-kilo-chat-plugin
-RUN echo "12"
+# Build cache bust: 2026-05-01-v67-openclaw-2026.4.23
+RUN echo "13"
 COPY openclaw-pairing-list.js /usr/local/bin/openclaw-pairing-list.js
 COPY openclaw-device-pairing-list.js /usr/local/bin/openclaw-device-pairing-list.js
 

--- a/services/kiloclaw/Dockerfile.local
+++ b/services/kiloclaw/Dockerfile.local
@@ -1,7 +1,7 @@
-FROM debian:bookworm-slim AS runtime
+FROM debian:trixie-slim AS runtime
 
 # Install Node.js 24 (required by OpenClaw)
-ENV NODE_VERSION=24.14.1
+ENV NODE_VERSION=24.15.0
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        ca-certificates curl gnupg git xz-utils unzip jq ripgrep rsync zstd \
@@ -59,10 +59,10 @@ RUN npm install -g github:Kilo-Org/openclaw-channel-streamchat#fix/plugin-name-r
 RUN npm install -g @steipete/summarize@0.12.0
 
 # Install Kilo CLI (agentic coding assistant for the terminal)
-RUN npm install -g @kilocode/cli@7.2.22
+RUN npm install -g @kilocode/cli@7.2.31
 
 # Install Go (available at runtime for users to `go install` additional tools)
-ENV GO_VERSION=1.26.0
+ENV GO_VERSION=1.26.2
 RUN ARCH="$(dpkg --print-architecture)" \
     && curl -fsSL https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz -o /tmp/go.tar.gz \
     && EXPECTED_SHA256="$(curl -fsSL https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz.sha256)" \
@@ -76,11 +76,13 @@ RUN ARCH="$(dpkg --print-architecture)" \
 #   so user-installed tools persist across restarts and are included in snapshots.
 # - npm/Node (installed to /usr/local) and apt packages (/usr/bin) are unaffected.
 ENV PATH="/usr/local/go/bin:/root/go/bin:$PATH"
-RUN GOBIN=/usr/local/bin go install github.com/steipete/gogcli/cmd/gog@v0.12.0 \
+RUN ARCH="$(dpkg --print-architecture)" \
+    && curl -fsSL "https://github.com/steipete/gogcli/releases/download/v0.14.0/gogcli_0.14.0_linux_${ARCH}.tar.gz" \
+       | tar xz -C /usr/local/bin gog \
     && mv /usr/local/bin/gog /usr/local/bin/gog.real \
     && GOBIN=/usr/local/bin go install github.com/steipete/goplaces/cmd/goplaces@v0.3.0 \
     && GOBIN=/usr/local/bin go install github.com/Hyaxia/blogwatcher/cmd/blogwatcher@v0.0.2 \
-    && GOBIN=/usr/local/bin go install github.com/xdevplatform/xurl@v1.0.3 \
+    && GOBIN=/usr/local/bin go install github.com/xdevplatform/xurl@v1.1.0 \
     && GOBIN=/usr/local/bin go install github.com/steipete/gifgrep/cmd/gifgrep@v0.2.3 \
     && go clean -cache -modcache
 
@@ -90,7 +92,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/b
     && uv --version
 
 # Install pinned Bun (build-time only) and compile the controller bundle.
-ARG BUN_VERSION=1.2.4
+ARG BUN_VERSION=1.3.13
 RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
 ENV PATH="/root/.bun/bin:$PATH"
 

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -955,6 +955,7 @@ describe('generateBaseConfig', () => {
     expect(config.hooks.enabled).toBe(true);
     expect(config.hooks.token).toBe('test-hooks-token');
     expect(config.hooks.path).toBe('/hooks');
+    expect(config.hooks.allowedSessionKeyPrefixes).toEqual(['hook:', 'inbound-email:']);
     expect(config.hooks.presets).toBeUndefined();
     expect(config.hooks.mappings).toContainEqual({
       id: 'cloudflare-email-inbound',
@@ -1018,6 +1019,18 @@ describe('generateBaseConfig', () => {
     expect(config.hooks.mappings).toContainEqual(
       expect.objectContaining({ id: 'cloudflare-email-inbound', wakeMode: 'now' })
     );
+    expect(config.hooks.allowedSessionKeyPrefixes).toEqual(['hook:', 'inbound-email:']);
+  });
+
+  it('preserves existing hook session key prefixes without duplicating inbound email', () => {
+    const existing = JSON.stringify({
+      hooks: { allowedSessionKeyPrefixes: ['custom:', 'hook:', 'inbound-email:'] },
+    });
+    const { deps } = fakeDeps(existing);
+    const env = { ...minimalEnv(), KILOCLAW_HOOKS_TOKEN: 'test-hooks-token' };
+    const config = generateBaseConfig(env, '/tmp/openclaw.json', deps);
+
+    expect(config.hooks.allowedSessionKeyPrefixes).toEqual(['custom:', 'hook:', 'inbound-email:']);
   });
 
   it('adds gmail preset when Gog credentials are configured', () => {

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -105,6 +105,8 @@ type ConfigObject = Record<string, any>;
 type EnvLike = Record<string, string | undefined>;
 
 const INBOUND_EMAIL_HOOK_ID = 'cloudflare-email-inbound';
+const DEFAULT_HOOK_SESSION_KEY_PREFIX = 'hook:';
+const INBOUND_EMAIL_SESSION_KEY_PREFIX = 'inbound-email:';
 
 function migrateHookMapping(mapping: ConfigObject): ConfigObject {
   if (mapping.id === INBOUND_EMAIL_HOOK_ID) {
@@ -541,6 +543,23 @@ export function generateBaseConfig(
     config.hooks.enabled = true;
     config.hooks.token = env.KILOCLAW_HOOKS_TOKEN;
     config.hooks.path = '/hooks';
+    config.hooks.allowedSessionKeyPrefixes = Array.isArray(config.hooks.allowedSessionKeyPrefixes)
+      ? config.hooks.allowedSessionKeyPrefixes
+      : [];
+    if (
+      !(config.hooks.allowedSessionKeyPrefixes as string[]).includes(
+        DEFAULT_HOOK_SESSION_KEY_PREFIX
+      )
+    ) {
+      (config.hooks.allowedSessionKeyPrefixes as string[]).push(DEFAULT_HOOK_SESSION_KEY_PREFIX);
+    }
+    if (
+      !(config.hooks.allowedSessionKeyPrefixes as string[]).includes(
+        INBOUND_EMAIL_SESSION_KEY_PREFIX
+      )
+    ) {
+      (config.hooks.allowedSessionKeyPrefixes as string[]).push(INBOUND_EMAIL_SESSION_KEY_PREFIX);
+    }
 
     config.hooks.mappings = Array.isArray(config.hooks.mappings)
       ? config.hooks.mappings.map((mapping: ConfigObject) => migrateHookMapping(mapping))

--- a/services/kiloclaw/controller/src/pairing-cache.ts
+++ b/services/kiloclaw/controller/src/pairing-cache.ts
@@ -72,10 +72,9 @@ export const DEBOUNCE_DELAY_MS = 2_000;
 
 export const FAILURE_RETRY_BASE_MS = 30_000;
 export const FAILURE_RETRY_MAX_MS = 300_000;
-// TEMPORARY: bumped from 45_000 to 180_000 because openclaw 2026.4.15 CLI
-// startup takes ~65s (CPU profile shows ~55% in jiti normalizeAliases/createJiti
-// from per-plugin loader churn). Revert to 45_000 once openclaw upstream
-// reduces startup time. Tracking: <openclaw issue link TBD>.
+// TEMPORARY: bumped from 45_000 to 180_000 because OpenClaw CLI startup can
+// exceed 60s on shared-cpu instances. Revert to 45_000 once upstream startup
+// is consistently below the old timeout on full KiloClaw images.
 export const APPROVE_TIMEOUT_MS = 180_000;
 export const CONFIG_PATH = '/root/.openclaw/openclaw.json';
 

--- a/services/kiloclaw/e2e/docker-image-testing.md
+++ b/services/kiloclaw/e2e/docker-image-testing.md
@@ -140,8 +140,8 @@ docker rm kiloclaw-gateway
 
 ```bash
 # Check versions
-docker run --rm kiloclaw:test node --version        # v24.14.1
-docker run --rm kiloclaw:test openclaw --version    # 2026.4.15
+docker run --rm kiloclaw:test node --version        # v24.15.0
+docker run --rm kiloclaw:test openclaw --version    # 2026.4.23
 
 # Check directories
 docker run --rm kiloclaw:test ls -la /root/.openclaw

--- a/services/kiloclaw/google-setup/Dockerfile
+++ b/services/kiloclaw/google-setup/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-slim
+FROM node:24-trixie-slim
 
 # Install dependencies for gcloud CLI + readline for interactive prompts
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -16,10 +16,10 @@ RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dea
   && apt-get update && apt-get install -y --no-install-recommends google-cloud-cli \
   && rm -rf /var/lib/apt/lists/*
 
-# Install gogcli v0.12.0 pre-built binary (arch-aware)
+# Install gogcli v0.14.0 pre-built binary (arch-aware)
 ARG TARGETARCH
 RUN GOARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") \
-  && curl -fsSL "https://github.com/steipete/gogcli/releases/download/v0.12.0/gogcli_0.12.0_linux_${GOARCH}.tar.gz" \
+  && curl -fsSL "https://github.com/steipete/gogcli/releases/download/v0.14.0/gogcli_0.14.0_linux_${GOARCH}.tar.gz" \
     | tar xz -C /usr/local/bin gog \
   && chmod +x /usr/local/bin/gog
 

--- a/services/kiloclaw/plugins/kilo-chat/package.json
+++ b/services/kiloclaw/plugins/kilo-chat/package.json
@@ -28,7 +28,7 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "openclaw": "2026.4.15"
+    "openclaw": "2026.4.23"
   },
   "devDependencies": {
     "esbuild": "^0.25.2",

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -7306,9 +7306,9 @@ describe('applyPinnedVersion', () => {
     });
 
     (selectImageVersionForInstance as Mock).mockResolvedValueOnce({
-      openclawVersion: '2026.4.15',
+      openclawVersion: '2026.4.23',
       variant: 'default',
-      imageTag: '2026-04-15',
+      imageTag: '2026-04-23',
       imageDigest: 'sha256:latest',
       publishedAt: new Date().toISOString(),
       rolloutPercent: 100,
@@ -7317,11 +7317,11 @@ describe('applyPinnedVersion', () => {
 
     const applied = await instance.applyPinnedVersion(null);
 
-    expect(applied.imageTag).toBe('2026-04-15');
-    expect(applied.openclawVersion).toBe('2026.4.15');
+    expect(applied.imageTag).toBe('2026-04-23');
+    expect(applied.openclawVersion).toBe('2026.4.23');
     expect(selectImageVersionForInstance).toHaveBeenCalledOnce();
     expect(resolveVersionByTag).not.toHaveBeenCalled();
-    expect(storage._store.get('trackedImageTag')).toBe('2026-04-15');
+    expect(storage._store.get('trackedImageTag')).toBe('2026-04-23');
   });
 
   it('when cleared, passes currentImageTag=null to the selector so non-cohort users can fall off the pinned candidate', async () => {
@@ -7338,7 +7338,7 @@ describe('applyPinnedVersion', () => {
     // ignoreCurrentImageTag, it should instead be invoked with
     // currentImageTag=null and return :latest.
     (selectImageVersionForInstance as Mock).mockResolvedValueOnce({
-      openclawVersion: '2026.4.15',
+      openclawVersion: '2026.4.23',
       variant: 'default',
       imageTag: 'latest-tag',
       imageDigest: 'sha256:latest',

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/pairing.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/pairing.ts
@@ -184,8 +184,8 @@ export async function approvePairingRequest(
       'POST',
       ControllerPairingApproveResponseSchema,
       { channel, code },
-      // TEMPORARY: 180s timeout — openclaw 2026.4.15 CLI startup is ~65s
-      // (jiti loader churn). Revert to default 30s once openclaw startup is fixed.
+      // TEMPORARY: 180s timeout while OpenClaw CLI startup can exceed 60s on
+      // shared-cpu instances. Revert once full-image startup is consistently fast.
       { timeoutMs: 180_000 }
     );
   } catch (error) {
@@ -389,8 +389,8 @@ export async function approveDevicePairingRequest(
       'POST',
       ControllerPairingApproveResponseSchema,
       { requestId },
-      // TEMPORARY: 180s timeout — openclaw 2026.4.15 CLI startup is ~65s
-      // (jiti loader churn). Revert to default 30s once openclaw startup is fixed.
+      // TEMPORARY: 180s timeout while OpenClaw CLI startup can exceed 60s on
+      // shared-cpu instances. Revert once full-image startup is consistently fast.
       { timeoutMs: 180_000 }
     );
   } catch (error) {

--- a/services/kiloclaw/src/lib/rollout-bucket.test.ts
+++ b/services/kiloclaw/src/lib/rollout-bucket.test.ts
@@ -11,7 +11,7 @@ describe('rolloutBucket', () => {
   });
 
   it('is deterministic for the same key', async () => {
-    const key = 'tag:kiloclaw-2026.4.15-abc:instance:550e8400-e29b-41d4-a716-446655440000';
+    const key = 'tag:kiloclaw-2026.4.23-abc:instance:550e8400-e29b-41d4-a716-446655440000';
     const a = await rolloutBucket(key);
     const b = await rolloutBucket(key);
     expect(a).toBe(b);
@@ -37,8 +37,8 @@ describe('rolloutBucket', () => {
 
   it('changes the bucket for a fixed instanceId when the salt (imageTag) changes', async () => {
     const instanceId = '550e8400-e29b-41d4-a716-446655440001';
-    const a = await rolloutBucket(`tag:kiloclaw-2026.4.15-aaa:instance:${instanceId}`);
-    const b = await rolloutBucket(`tag:kiloclaw-2026.4.15-bbb:instance:${instanceId}`);
+    const a = await rolloutBucket(`tag:kiloclaw-2026.4.23-aaa:instance:${instanceId}`);
+    const b = await rolloutBucket(`tag:kiloclaw-2026.4.23-bbb:instance:${instanceId}`);
     // Two different salts (rebuilds of the same upstream version) must produce
     // independent draws so the same instance is not always the canary.
     expect(a).not.toBe(b);

--- a/services/kiloclaw/src/lib/version-rollout.test.ts
+++ b/services/kiloclaw/src/lib/version-rollout.test.ts
@@ -28,7 +28,7 @@ function createJsonKV(): KVNamespace & { _store: Map<string, string> } {
 
 function entry(imageTag: string, rolloutPercent: number, isLatest = false): ImageVersionEntry {
   return {
-    openclawVersion: '2026.4.15',
+    openclawVersion: '2026.4.23',
     variant: 'default',
     imageTag,
     imageDigest: null,


### PR DESCRIPTION
## Summary

- Updates the KiloClaw instance base runtime from Debian bookworm to trixie and Node 24.14.1 to 24.15.0.
- Updates pinned runtime tools used inside KiloClaw instances, including Kilo CLI, Go, gogcli, xurl, and Bun for controller bundling.
- Aligns the Google setup image with the trixie Node 24 base and gogcli 0.14.0.

## Verification

- Built the updated KiloClaw image locally and ran the controller smoke scripts.
- Built the Google setup image locally and verified its runtime tools.

## Visual Changes

N/A

## Reviewer Notes

- This PR intentionally leaves OpenClaw pinned at 2026.4.15; the OpenClaw bump is split into a stacked follow-up PR.
- gogcli is installed from the prebuilt release artifact instead of `go install` because the source-built 0.14.0 binary reported a stale dev version.