### PR TITLE
fix(models-up): temporarily exclude gemma-4-31b-it from health alerts

### DIFF
--- a/apps/web/src/app/api/models/up/route.ts
+++ b/apps/web/src/app/api/models/up/route.ts
@@ -57,6 +57,8 @@ const HEALTH_CHECK_EXCLUSIONS = new Set([
   'openrouter/elephant-alpha',
   'openai/gpt-5.4',
   'openai/gpt-5.5',
+  // Temporarily excluded: a single BYOK user spiked to 14k+ req/15min and affected baseline
+  'google/gemma-4-31b-it',
 ]);
 
 function emptyMetrics(): Omit<ModelHealthMetrics, 'monitored'> {


### PR DESCRIPTION
## Summary

A single BYOK user spiked to 14k+ req/15min on 2026-05-02, poisoning the 2h baseline window and triggering repeated false-positive BetterStack alerts after the spike ended.

## Verification

N/A - filtering model from the health monitor

## Visual Changes

N/A

## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
