### PR TITLE
refactor(bot): use Chat SDK thread helper

### DIFF
--- a/apps/web/src/app/api/internal/bot-session-callback/[botRequestId]/route.ts
+++ b/apps/web/src/app/api/internal/bot-session-callback/[botRequestId]/route.ts
@@ -27,8 +27,7 @@ import { runBotAgent, type BotAgentMessageLike } from '@/lib/bot/agent-runner';
 import { withBotPlatformAuthContext } from '@/lib/bot/platform-auth-context';
 import { getPlatformIntegrationById } from '@/lib/bot/platform-helpers';
 import { findUserById } from '@/lib/user';
-import { PLATFORM } from '@/lib/integrations/core/constants';
-import { ThreadImpl, type Thread } from 'chat';
+import type { Thread } from 'chat';
 
 type ExecutionCallbackPayload = {
   sessionId: string;
@@ -55,31 +54,6 @@ async function getBotRequest(botRequestId: string) {
 
 function logCallback(message: string, extra?: Record<string, unknown>) {
   console.log('[BotSessionCallback]', message, extra ?? {});
-}
-
-async function getBotThread(threadId: string): Promise<Thread> {
-  await bot.initialize();
-  bot.registerSingleton();
-
-  const adapterName = threadId.split(':', 1)[0];
-  if (!adapterName) {
-    throw new Error(`Bot callback thread id is missing an adapter prefix: ${threadId}`);
-  }
-
-  switch (adapterName) {
-    case PLATFORM.SLACK: {
-      const adapter = bot.getAdapter(PLATFORM.SLACK);
-      return new ThreadImpl({
-        adapterName,
-        channelId: adapter.channelIdFromThreadId(threadId),
-        channelVisibility: adapter.getChannelVisibility?.(threadId),
-        id: threadId,
-        isDM: adapter.isDM?.(threadId) ?? false,
-      });
-    }
-    default:
-      throw new Error(`No chat SDK adapter registered for platform ${adapterName}`);
-  }
 }
 
 function parseTerminalCallbackStatus(status: unknown): TerminalCallbackStatus | undefined {
@@ -906,7 +880,9 @@ export async function POST(
         const platformIntegration = await getPlatformIntegrationById(
           requestRow.platform_integration_id
         );
-        const thread = await getBotThread(requestRow.platform_thread_id);
+        await bot.initialize();
+        bot.registerSingleton();
+        const thread = bot.thread(requestRow.platform_thread_id);
 
         if (childSessionStatus && trackedCallbackSession) {
           try {


### PR DESCRIPTION
## Summary
- Replace the bespoke bot callback thread reconstruction with the new `bot.thread(threadId)` Chat SDK helper.
- Keep bot initialization and singleton registration before deferred callback processing posts or fetches thread messages.
- Remove Slack-specific thread construction from the callback route so future adapter support can rely on the SDK abstraction.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
- Push hooks ran formatting, targeted typecheck, and lint checks successfully.
- Local verification before commit: `pnpm format` and `pnpm --filter web typecheck`.