### PR TITLE
fix(bot): harden cloud agent callbacks

### DIFF
--- a/apps/web/src/app/api/internal/bot-session-callback/[botRequestId]/route.ts
+++ b/apps/web/src/app/api/internal/bot-session-callback/[botRequestId]/route.ts
@@ -18,6 +18,10 @@ import {
   getBotRequestCloudAgentSessionGroupReadiness,
 } from '@/lib/bot/cloud-agent-session-groups';
 import {
+  buildCallbackThreadPostChunks,
+  formatCallbackContinuationFailureMessage,
+} from '@/lib/bot/callback-hardening';
+import {
   markBotRequestCloudAgentSessionTerminalStrict,
   recordBotRequestCloudAgentSessionResultErrorStrict,
   recordBotRequestCloudAgentSessionResultStrict,
@@ -176,20 +180,29 @@ async function postBotThreadMessage(params: {
   markdown: string;
   platformIntegration: PlatformIntegration;
 }): Promise<void> {
+  const chunks = buildCallbackThreadPostChunks(params.markdown);
   logCallback('Posting callback thread message', {
     threadId: params.thread.id,
     markdownLength: params.markdown.length,
+    messageCount: chunks.length,
     platform: params.platformIntegration.platform,
     platformIntegrationId: params.platformIntegration.id,
   });
 
-  const posted = await withBotPlatformAuthContext(
+  const postedMessageIds = await withBotPlatformAuthContext(
     params.platformIntegration,
-    async () => await params.thread.post({ markdown: params.markdown })
+    async () => {
+      const messageIds: string[] = [];
+      for (const chunk of chunks) {
+        const posted = await params.thread.post(chunk);
+        messageIds.push(posted.id);
+      }
+      return messageIds;
+    }
   );
   logCallback('Callback thread message posted', {
     threadId: params.thread.id,
-    messageId: posted.id,
+    messageIds: postedMessageIds,
     platform: params.platformIntegration.platform,
   });
 }
@@ -662,14 +675,51 @@ ${cloudAgentResultsForPrompt}`;
     botRequestId,
   });
 
-  const continuation = await continueBotAgentAfterCallback({
-    botRequestId,
-    requestRow,
-    platformIntegration,
-    thread,
-    continuationPrompt,
-    completedStepCount,
-  });
+  let continuation: Awaited<ReturnType<typeof continueBotAgentAfterCallback>>;
+  try {
+    continuation = await continueBotAgentAfterCallback({
+      botRequestId,
+      requestRow,
+      platformIntegration,
+      thread,
+      continuationPrompt,
+      completedStepCount,
+    });
+  } catch (error) {
+    const errorMessage = formatCallbackContinuationFailureMessage(error);
+    captureException(error, {
+      tags: {
+        source: 'bot-session-callback-api',
+        op: 'continue-bot-agent-after-callback',
+      },
+      extra: {
+        botRequestId,
+      },
+    });
+
+    const updated = await failBotRequest({
+      botRequestId,
+      expectedCloudAgentSessionId,
+      errorMessage,
+      responseTimeMs: Date.now() - startedAt,
+    });
+
+    logCallback('Completed callback failed while continuing ToolLoopAgent', {
+      botRequestId,
+      updated: Boolean(updated),
+      errorMessage,
+    });
+
+    if (updated) {
+      await postBotThreadMessage({
+        thread,
+        markdown: errorMessage,
+        platformIntegration,
+      });
+    }
+
+    return;
+  }
 
   logCallback('Completed callback continued ToolLoopAgent', {
     botRequestId,

--- a/apps/web/src/lib/bot/callback-hardening.test.ts
+++ b/apps/web/src/lib/bot/callback-hardening.test.ts
@@ -1,0 +1,48 @@
+import {
+  buildCallbackThreadPostChunks,
+  formatCallbackContinuationFailureMessage,
+  getCallbackErrorMessage,
+} from '@/lib/bot/callback-hardening';
+
+describe('bot callback hardening', () => {
+  it('keeps ordinary callback messages as a single raw text post', () => {
+    const chunks = buildCallbackThreadPostChunks('Cloud Agent result with **markdown**');
+
+    expect(chunks).toEqual(['Cloud Agent result with **markdown**']);
+  });
+
+  it('splits very large callback messages into Slack-sized raw text posts', () => {
+    const longMessage = `${'a'.repeat(20_000)}\n\n${'b'.repeat(20_000)}\n\n${'c'.repeat(20_000)}`;
+    const chunks = buildCallbackThreadPostChunks(longMessage);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join('')).toContain('a'.repeat(20_000));
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(39_000);
+    }
+  });
+
+  it('formats credit-related callback continuation failures as user-actionable terminal messages', () => {
+    expect(
+      formatCallbackContinuationFailureMessage(
+        new Error('AI gateway returned 402: insufficient credits')
+      )
+    ).toBe(
+      'Cloud Agent finished, but Kilo Bot could not continue because credits are required. Add credits to continue, then send a new message if more work is needed.'
+    );
+  });
+
+  it('formats non-credit callback continuation failures with bounded detail', () => {
+    const message = formatCallbackContinuationFailureMessage(new Error('upstream timeout'));
+
+    expect(message).toBe(
+      'Cloud Agent finished, but Kilo Bot could not continue after the callback: upstream timeout'
+    );
+  });
+
+  it('normalizes non-error thrown values', () => {
+    expect(getCallbackErrorMessage({ message: 'plain object failure' })).toBe(
+      '{"message":"plain object failure"}'
+    );
+  });
+});

--- a/apps/web/src/lib/bot/callback-hardening.ts
+++ b/apps/web/src/lib/bot/callback-hardening.ts
@@ -1,0 +1,81 @@
+const CALLBACK_THREAD_MESSAGE_CHUNK_LIMIT = 39_000;
+const CALLBACK_THREAD_MESSAGE_CHUNK_PREFIX_RESERVE = 100;
+const CALLBACK_FAILURE_DETAIL_LIMIT = 500;
+
+function splitTextForCallbackPosts(text: string, chunkLimit: number): string[] {
+  const chunks: string[] = [];
+  let start = 0;
+  const chunkBodyLimit = Math.max(1, chunkLimit - CALLBACK_THREAD_MESSAGE_CHUNK_PREFIX_RESERVE);
+
+  while (start < text.length) {
+    const hardEnd = Math.min(start + chunkBodyLimit, text.length);
+    if (hardEnd === text.length) {
+      chunks.push(text.slice(start));
+      break;
+    }
+
+    const minSoftEnd = start + Math.floor(chunkBodyLimit / 2);
+    const softBreaks = ['\n\n', '\n', ' '];
+    let splitAt = hardEnd;
+
+    for (const softBreak of softBreaks) {
+      const candidate = text.lastIndexOf(softBreak, hardEnd);
+      if (candidate > minSoftEnd) {
+        splitAt = candidate + softBreak.length;
+        break;
+      }
+    }
+
+    chunks.push(text.slice(start, splitAt));
+    start = splitAt;
+  }
+
+  return chunks;
+}
+
+export function buildCallbackThreadPostChunks(markdown: string): string[] {
+  if (markdown.length <= CALLBACK_THREAD_MESSAGE_CHUNK_LIMIT) {
+    return [markdown || ' '];
+  }
+
+  const chunks = splitTextForCallbackPosts(markdown, CALLBACK_THREAD_MESSAGE_CHUNK_LIMIT);
+  return chunks.map((chunk, index) => {
+    const part = index + 1;
+    return `Cloud Agent callback result (${part}/${chunks.length}):\n\n${chunk}`;
+  });
+}
+
+export function getCallbackErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  const serialized = JSON.stringify(error);
+  return serialized || String(error);
+}
+
+function isCreditRelatedErrorMessage(message: string): boolean {
+  const lowerMessage = message.toLowerCase();
+  return (
+    lowerMessage.includes('402') ||
+    lowerMessage.includes('payment') ||
+    lowerMessage.includes('credit') ||
+    lowerMessage.includes('balance') ||
+    lowerMessage.includes('usage_limit_exceeded')
+  );
+}
+
+export function formatCallbackContinuationFailureMessage(error: unknown): string {
+  const errorMessage = getCallbackErrorMessage(error);
+
+  if (isCreditRelatedErrorMessage(errorMessage)) {
+    return 'Cloud Agent finished, but Kilo Bot could not continue because credits are required. Add credits to continue, then send a new message if more work is needed.';
+  }
+
+  const detail = errorMessage.slice(0, CALLBACK_FAILURE_DETAIL_LIMIT);
+  return `Cloud Agent finished, but Kilo Bot could not continue after the callback: ${detail}`;
+}


### PR DESCRIPTION
## Summary
- Split oversized Cloud Agent callback responses into multiple raw text posts to avoid Slack block size failures.
- Mark bot requests as failed and post a terminal message when callback continuation fails, including a clearer credits-required path.
- Add focused unit coverage for callback message chunking and continuation failure formatting.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
- The callback thread post path intentionally uses raw text rather than markdown so Slack does not convert large callback output into over-limit block payloads.
- Automated checks run locally: `pnpm --filter web test -- src/lib/bot/callback-hardening.test.ts`, `pnpm format`, `pnpm --filter web typecheck`, `pnpm --filter web lint`.