### PR TITLE
fix(reviews): stop queued starvation

### DIFF
--- a/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.test.ts
+++ b/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.test.ts
@@ -408,4 +408,58 @@ describe('tryDispatchPendingReviews', () => {
     });
     expect(mockDispatchReview).not.toHaveBeenCalled();
   });
+
+  it('prioritizes fresh pending reviews over older stale queued recovery reviews', async () => {
+    const staleQueuedCreatedAt = minutesAgo(30);
+    const staleQueuedUpdatedAt = minutesAgo(6);
+    const pendingCreatedAt = minutesAgo(1);
+    const owner = { type: 'user', id: testUser.id } satisfies ReviewOwner;
+    await setTestUserBalance(DEFAULT_TIER_BALANCE_MICRODOLLARS);
+
+    const insertedReviews = await db
+      .insert(cloud_agent_code_reviews)
+      .values([
+        reviewValues({
+          owner,
+          status: 'queued',
+          createdAt: staleQueuedCreatedAt,
+          updatedAt: staleQueuedUpdatedAt,
+        }),
+        reviewValues({
+          owner,
+          status: 'pending',
+          createdAt: pendingCreatedAt,
+          updatedAt: pendingCreatedAt,
+        }),
+      ])
+      .returning({ id: cloud_agent_code_reviews.id });
+    const staleQueuedReview = insertedReviews[0];
+    const pendingReview = insertedReviews[1];
+
+    if (!staleQueuedReview || !pendingReview) {
+      throw new Error('Expected stale queued and pending reviews to be inserted');
+    }
+
+    const result = await tryDispatchPendingReviews({
+      type: 'user',
+      id: testUser.id,
+      userId: testUser.id,
+    });
+
+    expect(result).toEqual({
+      dispatched: 1,
+      pending: 0,
+      activeCount: 1,
+    });
+    expect(mockDispatchReview).toHaveBeenCalledTimes(1);
+    expect(mockPrepareReviewPayload).toHaveBeenCalledWith({
+      reviewId: pendingReview.id,
+      owner: { type: 'user', id: testUser.id, userId: testUser.id },
+      agentConfig: { id: 'test-agent-config', config: {} },
+      platform: 'github',
+    });
+    expect(mockPrepareReviewPayload).not.toHaveBeenCalledWith(
+      expect.objectContaining({ reviewId: staleQueuedReview.id })
+    );
+  });
 });

--- a/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.ts
+++ b/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.ts
@@ -140,7 +140,11 @@ export async function tryDispatchPendingReviews(owner: Owner): Promise<DispatchR
           )
         )
       )
-      .orderBy(cloud_agent_code_reviews.created_at)
+      .orderBy(
+        // Stale queued rows are recovery work and must not starve fresh pending reviews.
+        sql`CASE WHEN ${cloud_agent_code_reviews.status} = 'pending' THEN 0 ELSE 1 END`,
+        cloud_agent_code_reviews.created_at
+      )
       .limit(availableSlots);
 
     logExceptInTest('[tryDispatchPendingReviews] Found pending reviews', {


### PR DESCRIPTION
## Why

Some new reviews could get stuck behind an older retry. The older retry looked ready to run, but the worker was already busy with it, so the new review never got a turn.

## What changed

New reviews now get picked before old retry work when there is only one open slot. Old retry work can still run later when there is room. This keeps new reviews moving without changing how worker state is stored or cleaned up. A test covers the stuck case where an old queued review used to block a newer pending review.

## How to test

1. Run `pnpm test -- apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.test.ts`.
2. Confirm the test for pending reviews before stale queued recovery reviews passes.
3. Confirm the existing concurrency tests still pass.