### PR TITLE
chore: worktree-safe dev teardown + glab OAuth2 support

### DIFF
--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -177,7 +177,11 @@ async function cmdUp(targets: string[], repoRoot: string): Promise<void> {
   }
 
   // --- Create tmux session ---
-  createSession(sessionName);
+  // Pass KILO_PORT_OFFSET into the session environment so panes see it even
+  // when an existing tmux server (from a sibling worktree) is running with a
+  // different offset. Without this, new windows inherit the server env, not
+  // ours, and services bind to base ports — causing conflicts.
+  createSession(sessionName, { KILO_PORT_OFFSET: String(portOffset) });
 
   // --- Start each service in its own tmux window ---
   const SIDEBAR_WIDTH = 40;
@@ -499,7 +503,7 @@ async function cmdRestart(serviceName: string, repoRoot: string): Promise<void> 
   console.log(`Restarted ${serviceName}`);
 }
 
-async function cmdStop(repoRoot: string): Promise<void> {
+async function cmdStop(repoRoot: string, force: boolean): Promise<void> {
   const sessionName = getSessionName();
 
   if (sessionExists(sessionName)) {
@@ -507,12 +511,24 @@ async function cmdStop(repoRoot: string): Promise<void> {
     console.log(`Killed tmux session ${sessionName}`);
   }
 
-  console.log('Stopping Docker infrastructure…');
-  try {
-    const [cmd, args] = buildInfraDownArgs();
-    execFileSync(cmd, args, { cwd: repoRoot, stdio: 'inherit' });
-  } catch {
-    // docker compose down may fail if nothing is running
+  // Docker Compose uses project name "dev" for every worktree, so containers
+  // (postgres, redis, grafana) are shared singletons. Tearing them down here
+  // would break any other worktree's running session — skip when siblings
+  // are active unless --force is passed.
+  const otherSessions = findOtherKiloDevSessions();
+  if (otherSessions.length > 0 && !force) {
+    console.log(
+      `Leaving Docker infrastructure running (other sessions active: ${otherSessions.join(', ')})`
+    );
+    console.log('  Pass --force to tear down shared containers anyway.');
+  } else {
+    console.log('Stopping Docker infrastructure…');
+    try {
+      const [cmd, args] = buildInfraDownArgs();
+      execFileSync(cmd, args, { cwd: repoRoot, stdio: 'inherit' });
+    } catch {
+      // docker compose down may fail if nothing is running
+    }
   }
 
   console.log(`${GREEN}All services stopped.${RESET}`);
@@ -543,7 +559,8 @@ function printUsage(): void {
   console.log(`
 Usage:
   dev:start [targets...]  Start services (default: core)
-  dev:stop                Stop all services
+  dev:stop [--force]      Stop all services (skips shared Docker infra if
+                          other kilo-dev sessions are running; --force overrides)
   dev:status [--json]     Show running services and their ports
   dev:restart <service>   Restart a running service
   dev:env [targets...]    Sync env vars (.dev.vars + .env.development.local)
@@ -568,7 +585,7 @@ async function main() {
       await cmdUp(args.slice(1), repoRoot);
       break;
     case 'stop':
-      await cmdStop(repoRoot);
+      await cmdStop(repoRoot, args.includes('--force') || args.includes('-f'));
       break;
     case 'status':
       await cmdStatus(repoRoot, args.includes('--json'));

--- a/dev/local/dashboard.tsx
+++ b/dev/local/dashboard.tsx
@@ -11,7 +11,7 @@ import {
   resolveGroupTransitiveDeps,
 } from './services';
 import type { ServiceGroup } from './services';
-import { getSessionName, killSession } from './tmux';
+import { getSessionName, killSession, findOtherKiloDevSessions } from './tmux';
 import {
   findRepoRoot,
   probePort,
@@ -143,11 +143,17 @@ function doShowGroup(
 }
 
 function doCleanup(): void {
-  try {
-    const [cmd, args] = buildInfraDownArgs();
-    execFileSync(cmd, args, { stdio: 'ignore' });
-  } catch {
-    // ignore
+  // Docker Compose uses project name "dev" for every worktree — postgres,
+  // redis, and grafana are shared singletons. Skip `compose down` if any
+  // sibling kilo-dev-* tmux session is still running, otherwise closing this
+  // worktree would take down the other worktree's database.
+  if (findOtherKiloDevSessions().length === 0) {
+    try {
+      const [cmd, args] = buildInfraDownArgs();
+      execFileSync(cmd, args, { stdio: 'ignore' });
+    } catch {
+      // ignore
+    }
   }
   try {
     killSession(sessionName);

--- a/dev/local/tmux.ts
+++ b/dev/local/tmux.ts
@@ -57,9 +57,19 @@ function findOtherKiloDevSessions(): string[] {
   }
 }
 
-function createSession(sessionName: string): void {
+function createSession(sessionName: string, env?: Record<string, string>): void {
   const repoRoot = getWorktreeRoot();
-  execSync(`tmux new-session -d -s ${sessionName} -n dashboard -c ${repoRoot}`, {
+  // When another tmux server is already running (e.g. from a sibling worktree),
+  // `tmux new-session` attaches to that existing server and inherits its
+  // environment — NOT our current process.env. Pass critical vars with -e so
+  // panes see this worktree's values (e.g. KILO_PORT_OFFSET).
+  const envArgs = env
+    ? Object.entries(env)
+        .map(([k, v]) => `-e ${escapeForShell(`${k}=${v}`)}`)
+        .join(' ')
+    : '';
+  const envPrefix = envArgs ? `${envArgs} ` : '';
+  execSync(`tmux new-session -d ${envPrefix}-s ${sessionName} -n dashboard -c ${repoRoot}`, {
     stdio: 'ignore',
   });
   // Destroy the session when no clients are attached (e.g. terminal window closed).

--- a/services/cloud-agent-next/Dockerfile
+++ b/services/cloud-agent-next/Dockerfile
@@ -12,10 +12,13 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
 	&& mkdir -p -m 755 /etc/apt/sources.list.d \
 	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
 	&& apt update \
-	&& apt install gh git-lfs jq -y
+	&& apt install gh git-lfs jq openssh-client -y
 
-# Install GitLab CLI (glab) - download official .deb from GitLab releases
-RUN GLAB_VERSION="1.80.4" \
+# Install GitLab CLI (glab) - download official .deb from GitLab releases.
+# Version 1.82.0+ is required so OAuth2 access tokens sent via GITLAB_TOKEN are
+# authenticated with `Authorization: Bearer` instead of `PRIVATE-TOKEN` (which
+# GitLab rejects for OAuth tokens). Enabled via `GLAB_IS_OAUTH2=true` at runtime.
+RUN GLAB_VERSION="1.93.0" \
 	&& wget -nv -O /tmp/glab.deb "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_amd64.deb" \
 	&& dpkg -i /tmp/glab.deb \
 	&& rm /tmp/glab.deb

--- a/services/cloud-agent-next/Dockerfile.dev
+++ b/services/cloud-agent-next/Dockerfile.dev
@@ -12,7 +12,7 @@ ARG KILOCODE_CLI_VERSION="7.1.23"
 # This builds kilo-cli from source and copies the linux-x64 binary here.
 
 # Install CLI tools and generate locales to suppress setlocale warnings
-RUN apt-get update && apt-get install -y --no-install-recommends git-lfs jq locales ripgrep && \
+RUN apt-get update && apt-get install -y --no-install-recommends git-lfs jq locales ripgrep openssh-client && \
 	   sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
 	   locale-gen && \
 	   apt-get clean && \
@@ -21,8 +21,9 @@ ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 
 
-# Install GitLab CLI (glab) - download official .deb from GitLab releases
-RUN GLAB_VERSION="1.80.4" \
+# Install GitLab CLI (glab) - download official .deb from GitLab releases.
+# Version 1.82.0+ is required for OAuth2 access token support (GLAB_IS_OAUTH2).
+RUN GLAB_VERSION="1.93.0" \
 	&& wget -nv -O /tmp/glab.deb "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_amd64.deb" \
 	&& dpkg -i /tmp/glab.deb \
 	&& rm /tmp/glab.deb

--- a/services/cloud-agent-next/src/session-service.test.ts
+++ b/services/cloud-agent-next/src/session-service.test.ts
@@ -1796,6 +1796,102 @@ describe('SessionService', () => {
     });
   });
 
+  describe('GITLAB_TOKEN / GLAB_IS_OAUTH2 Auto-Setting', () => {
+    function setupSandbox(sessionId: SessionId) {
+      const fakeSession = {
+        exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+        gitCheckout: vi.fn().mockResolvedValue({ success: true, exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+        deleteFile: vi.fn().mockResolvedValue(undefined),
+      };
+      const sandboxCreateSession = vi.fn().mockResolvedValue(fakeSession);
+      const sandbox = {
+        createSession: sandboxCreateSession,
+        mkdir: vi.fn().mockResolvedValue(undefined),
+        exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SandboxInstance;
+      mockedSetupWorkspace.mockResolvedValue({
+        workspacePath: `/workspace/org/user/sessions/${sessionId}`,
+        sessionHome: `/home/${sessionId}`,
+      });
+      return { sandbox, sandboxCreateSession };
+    }
+
+    // glab >=1.82.0 sends GITLAB_TOKEN as `Authorization: Bearer $token` when
+    // GLAB_IS_OAUTH2=true, otherwise as `PRIVATE-TOKEN: $token`. GitLab rejects
+    // OAuth tokens sent via PRIVATE-TOKEN with 401; PATs accept both. Setting
+    // GLAB_IS_OAUTH2=true unconditionally works for every token type we inject.
+    it('sets GITLAB_TOKEN, GITLAB_HOST, and GLAB_IS_OAUTH2 for GitLab sessions', async () => {
+      const sessionId: SessionId = 'agent_gitlab_token';
+      const { sandbox, sandboxCreateSession } = setupSandbox(sessionId);
+
+      await new SessionService().initiate({
+        sandbox,
+        sandboxId: 'org__user',
+        orgId: 'org',
+        userId: 'user',
+        sessionId,
+        kilocodeToken: 'token',
+        kilocodeModel: 'test-model',
+        gitUrl: 'https://gitlab.com/acme/repo.git',
+        gitToken: 'access-token',
+        platform: 'gitlab',
+        env: mockEnv,
+      });
+
+      const callArgs = sandboxCreateSession.mock.calls[0][0] as { env: Record<string, string> };
+      expect(callArgs.env.GITLAB_TOKEN).toBe('access-token');
+      expect(callArgs.env.GITLAB_HOST).toBe('gitlab.com');
+      expect(callArgs.env.GLAB_IS_OAUTH2).toBe('true');
+    });
+
+    it('does not overwrite user-provided GLAB_IS_OAUTH2 env var', async () => {
+      const sessionId: SessionId = 'agent_gitlab_user_override';
+      const { sandbox, sandboxCreateSession } = setupSandbox(sessionId);
+
+      await new SessionService().initiate({
+        sandbox,
+        sandboxId: 'org__user',
+        orgId: 'org',
+        userId: 'user',
+        sessionId,
+        kilocodeToken: 'token',
+        kilocodeModel: 'test-model',
+        gitUrl: 'https://gitlab.com/acme/repo.git',
+        gitToken: 'access-token',
+        platform: 'gitlab',
+        envVars: { GLAB_IS_OAUTH2: 'false' },
+        env: mockEnv,
+      });
+
+      const callArgs = sandboxCreateSession.mock.calls[0][0] as { env: Record<string, string> };
+      expect(callArgs.env.GLAB_IS_OAUTH2).toBe('false');
+    });
+
+    it('picks up self-managed GitLab host from the gitUrl', async () => {
+      const sessionId: SessionId = 'agent_gitlab_selfhosted';
+      const { sandbox, sandboxCreateSession } = setupSandbox(sessionId);
+
+      await new SessionService().initiate({
+        sandbox,
+        sandboxId: 'org__user',
+        orgId: 'org',
+        userId: 'user',
+        sessionId,
+        kilocodeToken: 'token',
+        kilocodeModel: 'test-model',
+        gitUrl: 'https://gitlab.acme.internal/team/repo.git',
+        gitToken: 'access-token',
+        platform: 'gitlab',
+        env: mockEnv,
+      });
+
+      const callArgs = sandboxCreateSession.mock.calls[0][0] as { env: Record<string, string> };
+      expect(callArgs.env.GITLAB_HOST).toBe('gitlab.acme.internal');
+    });
+  });
+
   describe('Setup Commands Execution', () => {
     it('should continue executing commands when one fails during resume (lenient)', async () => {
       const metadata = {

--- a/services/cloud-agent-next/src/session-service.ts
+++ b/services/cloud-agent-next/src/session-service.ts
@@ -702,7 +702,16 @@ export class SessionService {
     // Determine effective platform: use explicit platform param, or infer from gitUrl as fallback
     const effectivePlatform = platform ?? (gitUrl?.includes('gitlab') ? 'gitlab' : undefined);
 
-    // Set GITLAB_TOKEN for GitLab repos, respecting user overrides
+    // Set GITLAB_TOKEN for GitLab repos, respecting user overrides.
+    //
+    // We also set GLAB_IS_OAUTH2=true unconditionally so that `glab` (>=1.82.0)
+    // sends `Authorization: Bearer $token` instead of `PRIVATE-TOKEN: $token`.
+    // This is required for OAuth access tokens (which GitLab rejects with 401
+    // when sent via PRIVATE-TOKEN) and is also valid for PATs — per GitLab
+    // REST API docs, personal/project/group access tokens accept OAuth-compliant
+    // headers (https://docs.gitlab.com/api/rest/authentication/). Treating both
+    // token types uniformly avoids threading the auth type through the session
+    // request/DO/metadata stack.
     if (gitToken && effectivePlatform === 'gitlab' && !baseEnvVars.GITLAB_TOKEN) {
       envVars.GITLAB_TOKEN = gitToken;
       if (!baseEnvVars.GITLAB_HOST) {
@@ -717,13 +726,16 @@ export class SessionService {
           envVars.GITLAB_HOST = 'gitlab.com';
         }
       }
+      if (!baseEnvVars.GLAB_IS_OAUTH2) {
+        envVars.GLAB_IS_OAUTH2 = 'true';
+      }
       logger
         .withFields({
           gitUrl,
           gitlabHost: envVars.GITLAB_HOST,
           gitTokenLength: gitToken.length,
         })
-        .info('[GITLAB] Setting GITLAB_TOKEN and GITLAB_HOST for GitLab session');
+        .info('[GITLAB] Setting GITLAB_TOKEN, GITLAB_HOST, and GLAB_IS_OAUTH2 for GitLab session');
     }
 
     // Only add KILOCODE_ORG_ID if we have an org (personal accounts don't have one)


### PR DESCRIPTION
## Summary

Two independent fixes rolled into one branch:

1. **Dev tooling — multi-worktree safety (`dev/local/*.ts`)**
   - `dev:stop` and the dashboard's quit/SIGHUP cleanup path no longer run `docker compose down` when another `kilo-dev-*` tmux session is active. Docker Compose uses project name `dev` for every worktree, so postgres/redis/grafana are shared singletons — previously, tearing down one worktree killed another worktree's database.
   - Added `dev:stop --force` (`-f`) as an escape hatch that restores the old behavior.
   - `createSession` now accepts an optional env record and forwards it to tmux via `-e`. `dev:start` uses this to push `KILO_PORT_OFFSET` into every pane, so when an existing tmux server from a sibling worktree is already running, panes see this worktree's offset instead of inheriting the server's environment (which would have caused port conflicts).

2. **cloud-agent-next — GitLab OAuth2 token support (`Dockerfile`, `Dockerfile.dev`, `session-service.ts`)**
   - Upgraded `glab` 1.80.4 → 1.93.0 (≥1.82.0 required for OAuth2 support) and added `openssh-client` for SSH-based git operations.
   - `SessionService.getSaferEnvVars` now sets `GLAB_IS_OAUTH2=true` alongside `GITLAB_TOKEN`/`GITLAB_HOST` for GitLab sessions. This makes `glab` send `Authorization: Bearer $token` instead of `PRIVATE-TOKEN: $token`, which GitLab rejects for OAuth access tokens with 401. Per GitLab docs, PATs and group/project access tokens accept both headers, so the flag is safe to set for every injected token type — no need to thread the auth type through the session request / DO / metadata stack.
   - User-provided `GLAB_IS_OAUTH2` is still respected (matches the existing override pattern for `GITLAB_TOKEN` / `GH_TOKEN`).
   - Tests cover: token/host/flag set correctly, user override not clobbered, self-managed GitLab host picked up from `gitUrl`.

## Verification

- [x] Tested locally.
- [ ]

## Visual Changes

N/A — no UI surfaces are touched. The `dashboard.tsx` change only modifies the cleanup function, not any rendered output.

## Reviewer Notes

- Two independent topics in one PR — happy to split if preferred.
- Shared Docker containers: the Compose project name is `dev` regardless of worktree. Both code paths (`cmdStop` in `cli.ts` and `doCleanup` in `dashboard.tsx`) now guard on `findOtherKiloDevSessions().length`.
- `GLAB_IS_OAUTH2=true` is unconditional when we inject `GITLAB_TOKEN` for a GitLab session; the user-override guard (`!baseEnvVars.GLAB_IS_OAUTH2`) follows the same pattern as `GITLAB_TOKEN` and `GH_TOKEN` elsewhere in `getSaferEnvVars`.
- New tmux `-e` path goes through the existing `escapeForShell` helper; only caller passes `String(portOffset)` (digits only), so shell-injection risk is nil.
- `glab` jumped 1.80.4 → 1.93.0 (required floor is 1.82.0); picking the latest stable to avoid a near-term bump.
- `openssh-client` added to both production and dev sandbox images to support SSH-based git operations inside the sandbox.