### PR TITLE
feat(slack): recover marketplace bot installs

### DIFF
--- a/apps/web/src/app/api/integrations/slack/callback/route.test.ts
+++ b/apps/web/src/app/api/integrations/slack/callback/route.test.ts
@@ -1,0 +1,133 @@
+process.env.NEXTAUTH_SECRET ||= 'test-nextauth-secret';
+
+jest.mock('@/lib/bot', () => ({
+  bot: {
+    getState: jest.fn(() => ({ state: true })),
+    initialize: jest.fn(),
+    getAdapter: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/bot-identity', () => ({
+  linkKiloUser: jest.fn(),
+  verifyPlatformInstallToken: jest.fn(),
+}));
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+import { captureMessage } from '@sentry/nextjs';
+import {
+  buildSlackRedirectPath,
+  completeSlackMarketplaceInstall,
+} from '@/lib/integrations/slack-callback-helpers';
+import { linkKiloUser, verifyPlatformInstallToken } from '@/lib/bot-identity';
+import { createOAuthState } from '@/lib/integrations/oauth-state';
+
+const mockedLinkKiloUser = jest.mocked(linkKiloUser);
+const mockedVerifyPlatformInstallToken = jest.mocked(verifyPlatformInstallToken);
+const mockedCaptureMessage = jest.mocked(captureMessage);
+
+function buildVerifiedMarketplaceState(installToken = 'install-token') {
+  return {
+    owner: 'user_user-1',
+    userId: 'user-1',
+    metadata: {
+      source: 'slack_marketplace_install',
+      installToken,
+    },
+  } as const;
+}
+
+describe('Slack OAuth callback helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('routes marketplace install redirects back to get-started with namespaced status params', () => {
+    const state = createOAuthState('user_user-1', 'user-1', {
+      source: 'slack_marketplace_install',
+      installToken: 'install-token',
+    });
+
+    const successPath = buildSlackRedirectPath(state, { success: 'installed' });
+    expect(successPath.startsWith('/get-started/slack?')).toBe(true);
+    const successParams = new URLSearchParams(successPath.split('?')[1]);
+    expect(successParams.get('slackSuccess')).toBe('installed');
+    expect(successParams.get('source')).toBe('slack_marketplace_install');
+    expect(successParams.get('installToken')).toBe('install-token');
+
+    const errorPath = buildSlackRedirectPath(state, { error: 'workspace_mismatch' });
+    expect(errorPath.startsWith('/get-started/slack?')).toBe(true);
+    const params = new URLSearchParams(errorPath.split('?')[1]);
+    expect(params.get('slackError')).toBe('workspace_mismatch');
+    expect(params.get('source')).toBe('slack_marketplace_install');
+    expect(params.get('installToken')).toBe('install-token');
+  });
+
+  it('keeps normal personal Slack redirects on integrations pages', () => {
+    const state = createOAuthState('user_user-1', 'user-1');
+
+    expect(buildSlackRedirectPath(state, { success: 'installed' })).toBe(
+      '/integrations/slack?success=installed'
+    );
+  });
+
+  it('links the Slack identity and posts a confirmation for marketplace installs', async () => {
+    const postMessage = jest.fn(async () => {});
+    mockedVerifyPlatformInstallToken.mockReturnValue({
+      platform: 'slack',
+      teamId: 'T123',
+      userId: 'U456',
+      threadId: 'slack:T123:C123:1700000000.000100',
+    });
+
+    await expect(
+      completeSlackMarketplaceInstall({
+        verified: buildVerifiedMarketplaceState(),
+        teamId: 'T123',
+        userId: 'user-1',
+        teamName: 'Kilo Team',
+        slackAdapter: { postMessage } as never,
+      })
+    ).resolves.toEqual({ ok: true });
+
+    expect(mockedLinkKiloUser).toHaveBeenCalledWith(
+      { state: true },
+      { platform: 'slack', teamId: 'T123', userId: 'U456' },
+      'user-1'
+    );
+    expect(postMessage).toHaveBeenCalledWith(
+      'slack:T123:C123:1700000000.000100',
+      expect.objectContaining({
+        markdown: expect.stringContaining('Kilo is connected to Kilo Team'),
+      })
+    );
+  });
+
+  it('rejects marketplace installs when the token Slack team does not match OAuth', async () => {
+    mockedVerifyPlatformInstallToken.mockReturnValue({
+      platform: 'slack',
+      teamId: 'T999',
+      userId: 'U456',
+    });
+
+    await expect(
+      completeSlackMarketplaceInstall({
+        verified: buildVerifiedMarketplaceState(),
+        teamId: 'T123',
+        userId: 'user-1',
+        teamName: 'Kilo Team',
+        slackAdapter: { postMessage: jest.fn() } as never,
+      })
+    ).resolves.toEqual({ ok: false, error: 'workspace_mismatch' });
+
+    expect(mockedLinkKiloUser).not.toHaveBeenCalled();
+    expect(mockedCaptureMessage).toHaveBeenCalledWith(
+      'Slack marketplace install team mismatch',
+      expect.any(Object)
+    );
+  });
+});

--- a/apps/web/src/app/api/integrations/slack/callback/route.ts
+++ b/apps/web/src/app/api/integrations/slack/callback/route.ts
@@ -11,21 +11,13 @@ import {
 import { verifyOAuthState } from '@/lib/integrations/oauth-state';
 import { APP_URL } from '@/lib/constants';
 import { bot } from '@/lib/bot';
+import {
+  buildSlackRedirectPath,
+  completeSlackMarketplaceInstall,
+} from '@/lib/integrations/slack-callback-helpers';
 
 const SLACK_REDIRECT_URI = `${APP_URL}/api/integrations/slack/callback`;
-
-const buildSlackRedirectPath = (state: string | null, queryParam: string): string => {
-  const verified = state ? verifyOAuthState(state) : null;
-  const owner = verified?.owner;
-
-  if (owner?.startsWith('org_')) {
-    return `/organizations/${owner.replace('org_', '')}/integrations/slack?${queryParam}`;
-  }
-  if (owner?.startsWith('user_')) {
-    return `/integrations/slack?${queryParam}`;
-  }
-  return `/integrations?${queryParam}`;
-};
+const SLACK_MARKETPLACE_SOURCE = 'slack_marketplace_install';
 
 /**
  * Slack OAuth Callback
@@ -51,12 +43,10 @@ export async function GET(request: NextRequest) {
       captureMessage('Slack OAuth error', {
         level: 'warning',
         tags: { endpoint: 'slack/callback', source: 'slack_oauth' },
-        extra: { error, state },
+        extra: { error, hasState: !!state },
       });
 
-      return NextResponse.redirect(
-        new URL(buildSlackRedirectPath(state, `error=${error}`), APP_URL)
-      );
+      return NextResponse.redirect(new URL(buildSlackRedirectPath(state, { error }), APP_URL));
     }
 
     // Validate code is present
@@ -64,11 +54,11 @@ export async function GET(request: NextRequest) {
       captureMessage('Slack callback missing code', {
         level: 'warning',
         tags: { endpoint: 'slack/callback', source: 'slack_oauth' },
-        extra: { state, allParams: Object.fromEntries(searchParams.entries()) },
+        extra: { hasState: !!state, hasError: !!error },
       });
 
       return NextResponse.redirect(
-        new URL(buildSlackRedirectPath(state, 'error=missing_code'), APP_URL)
+        new URL(buildSlackRedirectPath(state, { error: 'missing_code' }), APP_URL)
       );
     }
 
@@ -78,7 +68,7 @@ export async function GET(request: NextRequest) {
       captureMessage('Slack callback invalid or tampered state signature', {
         level: 'warning',
         tags: { endpoint: 'slack/callback', source: 'slack_oauth' },
-        extra: { code: '***', state, allParams: Object.fromEntries(searchParams.entries()) },
+        extra: { hasCode: true, hasState: !!state },
       });
       return NextResponse.redirect(new URL('/integrations?error=invalid_state', APP_URL));
     }
@@ -136,11 +126,36 @@ export async function GET(request: NextRequest) {
     } catch (error) {
       if (error instanceof SlackWorkspaceAlreadyConnectedError) {
         return NextResponse.redirect(
-          new URL(buildSlackRedirectPath(state, 'error=workspace_already_connected'), APP_URL)
+          new URL(buildSlackRedirectPath(state, { error: 'workspace_already_connected' }), APP_URL)
         );
       }
 
       throw error;
+    }
+
+    const marketplaceInstall = await completeSlackMarketplaceInstall({
+      verified,
+      teamId,
+      userId: user.id,
+      teamName: installation.teamName,
+      slackAdapter,
+    });
+
+    if (!marketplaceInstall.ok) {
+      return NextResponse.redirect(
+        new URL(buildSlackRedirectPath(state, { error: marketplaceInstall.error }), APP_URL)
+      );
+    }
+
+    if (verified.metadata?.source === SLACK_MARKETPLACE_SOURCE) {
+      return NextResponse.redirect(
+        new URL(
+          buildSlackRedirectPath(state, {
+            success: 'installed',
+          }),
+          APP_URL
+        )
+      );
     }
 
     // 9. Redirect to success page
@@ -163,13 +178,13 @@ export async function GET(request: NextRequest) {
         source: 'slack_oauth',
       },
       extra: {
-        state,
+        hasState: !!state,
         hasCode: !!searchParams.get('code'),
       },
     });
 
     return NextResponse.redirect(
-      new URL(buildSlackRedirectPath(state, 'error=installation_failed'), APP_URL)
+      new URL(buildSlackRedirectPath(state, { error: 'installation_failed' }), APP_URL)
     );
   }
 }

--- a/apps/web/src/app/get-started/slack/_components/SlackConnectStep.tsx
+++ b/apps/web/src/app/get-started/slack/_components/SlackConnectStep.tsx
@@ -4,33 +4,50 @@ import { useQuery } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { ArrowLeft, MessageSquare, CheckCircle2, Building2, User } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import {
+  ArrowLeft,
+  MessageSquare,
+  CheckCircle2,
+  Building2,
+  User,
+  TriangleAlert,
+} from 'lucide-react';
 import type { WorkspaceSelection } from './types';
 import { useState } from 'react';
 
 type SlackConnectStepProps = {
   workspace: WorkspaceSelection;
   onBack: () => void;
+  installToken?: string;
 };
 
-export function SlackConnectStep({ workspace, onBack }: SlackConnectStepProps) {
+export function SlackConnectStep({ workspace, onBack, installToken }: SlackConnectStepProps) {
   const trpc = useTRPC();
   const [isStartingSlackConnection, setIsStartingSlackConnection] = useState(false);
+  const [connectionError, setConnectionError] = useState<string | null>(null);
+  const slackOAuthUrlInputValue = {
+    ...(workspace.type === 'org' ? { organizationId: workspace.id } : {}),
+    ...(installToken ? { installToken } : {}),
+  };
+  const slackOAuthUrlInput = Object.keys(slackOAuthUrlInputValue).length
+    ? slackOAuthUrlInputValue
+    : undefined;
 
   // Get OAuth URL only when the user clicks Connect so the signed state is fresh.
   const { refetch: refetchOAuthUrl, isFetching: isFetchingOAuthUrl } = useQuery(
-    trpc.slack.getOAuthUrl.queryOptions(
-      workspace.type === 'org' ? { organizationId: workspace.id } : undefined,
-      { enabled: false }
-    )
+    trpc.slack.getOAuthUrl.queryOptions(slackOAuthUrlInput, { enabled: false })
   );
 
   const handleConnectSlack = async () => {
+    setConnectionError(null);
     setIsStartingSlackConnection(true);
     const result = await refetchOAuthUrl();
     if (result.data?.url) {
       window.location.href = result.data.url;
+    } else if (result.error) {
+      setConnectionError(result.error.message);
+      setIsStartingSlackConnection(false);
     } else {
       setIsStartingSlackConnection(false);
     }
@@ -80,10 +97,19 @@ export function SlackConnectStep({ workspace, onBack }: SlackConnectStepProps) {
         <CardContent className="space-y-4">
           <Alert>
             <AlertDescription>
-              After connecting, you&apos;ll be able to message Kilo directly in Slack to create PRs,
-              debug code, ask questions about your repos, and more.
+              {installToken
+                ? 'After setup, Kilo will post a confirmation back in Slack and you can mention it again right away.'
+                : "After connecting, you'll be able to message Kilo directly in Slack to create PRs, debug code, ask questions about your repos, and more."}
             </AlertDescription>
           </Alert>
+
+          {connectionError && (
+            <Alert variant="destructive">
+              <TriangleAlert className="h-4 w-4" />
+              <AlertTitle>Could not start Slack setup</AlertTitle>
+              <AlertDescription>{connectionError}</AlertDescription>
+            </Alert>
+          )}
 
           <div className="space-y-2 rounded-lg border p-4">
             <h4 className="font-medium">What you&apos;ll get:</h4>

--- a/apps/web/src/app/get-started/slack/_components/SlackGetStartedFlow.tsx
+++ b/apps/web/src/app/get-started/slack/_components/SlackGetStartedFlow.tsx
@@ -6,10 +6,76 @@ import { WorkspaceSelector } from './WorkspaceSelector';
 import { SlackConnectStep } from './SlackConnectStep';
 import { motion, AnimatePresence } from 'motion/react';
 import type { WorkspaceSelection } from './types';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { CheckCircle2, ExternalLink, MessageSquare, TriangleAlert } from 'lucide-react';
+import Link from 'next/link';
 
 type FlowStep = 'workspace-selection' | 'slack-connect';
 
-export function SlackGetStartedFlow() {
+type SlackGetStartedFlowProps = {
+  installToken?: string;
+  source?: string;
+  slackSuccess?: string;
+  slackError?: string;
+};
+
+const slackErrorMessages: Record<string, string> = {
+  invalid_install_token:
+    'This Slack setup link is invalid or expired. Mention Kilo in Slack again to get a fresh link.',
+  workspace_mismatch:
+    'The Slack workspace selected during authorization did not match the original setup link. Start again from the Slack workspace where you mentioned Kilo.',
+  workspace_already_connected:
+    'This Slack workspace is already connected to another Kilo account or organization. Disconnect it there before connecting it here.',
+  installation_failed: 'Slack installation failed. Mention Kilo in Slack again and retry setup.',
+  missing_code: 'Slack did not return an authorization code. Please retry setup from Slack.',
+  unauthorized: 'You are not authorized to finish this Slack setup.',
+};
+
+function getSlackErrorMessage(error: string): string {
+  return slackErrorMessages[error] ?? `Slack setup failed: ${error}`;
+}
+
+function SlackSetupSuccess() {
+  return (
+    <Card>
+      <CardContent className="space-y-6 pt-6 text-center">
+        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-green-500/10">
+          <CheckCircle2 className="h-7 w-7 text-green-500" />
+        </div>
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold">Kilo is ready in Slack</h2>
+          <p className="text-muted-foreground">
+            I posted a confirmation back in Slack. Return there and mention Kilo again to start a
+            coding session, review a PR, or ask a repo question.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+          <Link href="https://kilo.ai/docs/advanced-usage/slackbot" target="_blank">
+            <Button variant="outline" className="gap-2">
+              Read the docs
+              <ExternalLink className="h-4 w-4" />
+            </Button>
+          </Link>
+          <Link href="/integrations/slack">
+            <Button variant="primary" className="gap-2">
+              Open Slack settings
+              <MessageSquare className="h-4 w-4" />
+            </Button>
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function SlackGetStartedFlow({
+  installToken,
+  source,
+  slackSuccess,
+  slackError,
+}: SlackGetStartedFlowProps) {
   const [currentStep, setCurrentStep] = useState<FlowStep>('workspace-selection');
   const [selectedWorkspace, setSelectedWorkspace] = useState<WorkspaceSelection | null>(null);
 
@@ -23,8 +89,37 @@ export function SlackGetStartedFlow() {
     setSelectedWorkspace(null);
   };
 
+  if (slackSuccess === 'installed') {
+    return (
+      <KiloCardLayout title="Get Started with Kilo for Slack" className="max-w-2xl">
+        <SlackSetupSuccess />
+      </KiloCardLayout>
+    );
+  }
+
+  const isMarketplaceInstall = source === 'slack_marketplace_install' || !!installToken;
+
   return (
     <KiloCardLayout title="Get Started with Kilo for Slack" className="max-w-2xl">
+      <div className="mb-6 space-y-3">
+        {isMarketplaceInstall && (
+          <Alert variant="notice">
+            <MessageSquare className="h-4 w-4" />
+            <AlertTitle>Finish Slack setup</AlertTitle>
+            <AlertDescription>
+              Kilo is already installed in Slack. Choose where it should live in Kilo, then approve
+              Slack access to finish connecting the workspace.
+            </AlertDescription>
+          </Alert>
+        )}
+        {slackError && (
+          <Alert variant="destructive">
+            <TriangleAlert className="h-4 w-4" />
+            <AlertTitle>Slack setup needs attention</AlertTitle>
+            <AlertDescription>{getSlackErrorMessage(slackError)}</AlertDescription>
+          </Alert>
+        )}
+      </div>
       <AnimatePresence mode="wait">
         {currentStep === 'workspace-selection' && (
           <motion.div
@@ -46,7 +141,11 @@ export function SlackGetStartedFlow() {
             exit={{ opacity: 0, x: 20 }}
             transition={{ duration: 0.2 }}
           >
-            <SlackConnectStep workspace={selectedWorkspace} onBack={handleBack} />
+            <SlackConnectStep
+              workspace={selectedWorkspace}
+              onBack={handleBack}
+              installToken={installToken}
+            />
           </motion.div>
         )}
       </AnimatePresence>

--- a/apps/web/src/app/get-started/slack/page.tsx
+++ b/apps/web/src/app/get-started/slack/page.tsx
@@ -6,21 +6,35 @@ import { SignInForm } from '@/components/auth/SignInForm';
 import { allow_fake_login } from '@/lib/constants';
 import { SlackGetStartedFlow } from './_components/SlackGetStartedFlow';
 
+function buildSlackGetStartedCallbackPath(params: Record<string, string>): string {
+  const callbackParams = new URLSearchParams();
+
+  for (const key of ['installToken', 'source']) {
+    const value = params[key];
+    if (value) callbackParams.set(key, value);
+  }
+
+  const query = callbackParams.toString();
+  return query ? `/get-started/slack?${query}` : '/get-started/slack';
+}
+
 export default async function GetStartedSlackPage({
   searchParams,
 }: {
   searchParams: Promise<Record<string, string>>;
 }) {
   const { user } = await getUserFromAuth({ adminOnly: false, DANGEROUS_allowBlockedUsers: true });
+  const params = await searchParams;
+  const callbackPath = buildSlackGetStartedCallbackPath(params);
 
   // If user is not authenticated, show sign-up form
   if (!user) {
-    const { params, error } = await getAuthPageProps(searchParams);
+    const { error } = await getAuthPageProps(Promise.resolve(params));
     return (
       <AuthPageLayout>
         <div className="mt-4 flex flex-col items-center">
           <SignInForm
-            searchParams={{ ...params, callbackPath: '/get-started/slack' }}
+            searchParams={{ ...params, callbackPath }}
             error={error}
             isSignUp={true}
             allowFakeLogin={allow_fake_login}
@@ -33,8 +47,15 @@ export default async function GetStartedSlackPage({
   }
 
   if (user.has_validation_stytch === null) {
-    redirect('/account-verification?callbackPath=/get-started/slack');
+    redirect(`/account-verification?callbackPath=${encodeURIComponent(callbackPath)}`);
   }
 
-  return <SlackGetStartedFlow />;
+  return (
+    <SlackGetStartedFlow
+      installToken={params.installToken}
+      source={params.source}
+      slackSuccess={params.slackSuccess}
+      slackError={params.slackError}
+    />
+  );
 }

--- a/apps/web/src/components/auth/SignInForm.tsx
+++ b/apps/web/src/components/auth/SignInForm.tsx
@@ -33,6 +33,13 @@ function signInHrefFromSearchParams(searchParams: Record<string, string>): strin
   return query ? `/users/sign_in?${query}` : '/users/sign_in';
 }
 
+function ssoHrefFromSearchParams(searchParams: Record<string, string>): string {
+  const params = new URLSearchParams(searchParams);
+  params.set('sso', 'true');
+  const query = params.toString();
+  return query ? `/users/sign_in?${query}` : '/users/sign_in?sso=true';
+}
+
 export function SignInForm({
   searchParams,
   error: initialError,
@@ -321,7 +328,7 @@ export function SignInForm({
                   </div>
 
                   <div className="mx-auto max-w-md">
-                    <Link href="/users/sign_in?sso=true" className="block">
+                    <Link href={ssoHrefFromSearchParams(searchParams)} className="block">
                       <SignInButton>
                         <SquareUserRound />
                         Enterprise SSO

--- a/apps/web/src/lib/bot-identity.test.ts
+++ b/apps/web/src/lib/bot-identity.test.ts
@@ -1,0 +1,72 @@
+process.env.NEXTAUTH_SECRET ||= 'test-nextauth-secret';
+
+import {
+  createLinkToken,
+  createPlatformInstallToken,
+  verifyLinkToken,
+  verifyPlatformInstallToken,
+  type PlatformIdentity,
+} from '@/lib/bot-identity';
+
+const identity = {
+  platform: 'slack',
+  teamId: 'T123',
+  userId: 'U456',
+} satisfies PlatformIdentity;
+
+function tamperToken(token: string): string {
+  const dotIndex = token.indexOf('.');
+  const payload = token.slice(0, dotIndex);
+  const signature = token.slice(dotIndex + 1);
+  const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+  const tamperedPayload = Buffer.from(JSON.stringify({ ...decoded, teamId: 'T999' })).toString(
+    'base64url'
+  );
+  return `${tamperedPayload}.${signature}`;
+}
+
+describe('bot identity tokens', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('round-trips link tokens without exposing install context', () => {
+    const token = createLinkToken(identity);
+
+    expect(verifyLinkToken(token)).toEqual(identity);
+  });
+
+  it('round-trips platform install tokens with Slack return context', () => {
+    const token = createPlatformInstallToken({
+      ...identity,
+      threadId: 'slack:T123:C123:1700000000.000100',
+      messageId: '1700000000.000100',
+    });
+
+    expect(verifyPlatformInstallToken(token)).toEqual({
+      ...identity,
+      threadId: 'slack:T123:C123:1700000000.000100',
+      messageId: '1700000000.000100',
+    });
+    expect(verifyLinkToken(token)).toEqual(identity);
+  });
+
+  it('rejects tampered install tokens', () => {
+    const token = createPlatformInstallToken(identity);
+
+    expect(verifyPlatformInstallToken(tamperToken(token))).toBeNull();
+  });
+
+  it('rejects expired install tokens', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-04T10:00:00Z'));
+    const token = createPlatformInstallToken(identity);
+
+    jest.setSystemTime(new Date('2026-05-04T10:31:00Z'));
+
+    expect(verifyPlatformInstallToken(token)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/bot-identity.ts
+++ b/apps/web/src/lib/bot-identity.ts
@@ -35,6 +35,11 @@ export type PlatformIdentity = {
   userId: string;
 };
 
+export type PlatformInstallTokenData = PlatformIdentity & {
+  threadId?: string;
+  messageId?: string;
+};
+
 /**
  * Look up the Kilo user ID linked to a chat-platform user.
  * Returns `null` when no mapping exists yet.
@@ -132,16 +137,25 @@ function hmacSign(data: string): string {
   return crypto.createHmac(HMAC_ALGORITHM, NEXTAUTH_SECRET).update(data).digest('base64url');
 }
 
-/** Create a signed, time-limited token encoding a PlatformIdentity. */
-export function createLinkToken(identity: PlatformIdentity): string {
+function createSignedIdentityToken(identity: PlatformInstallTokenData): string {
   const iat = Math.floor(Date.now() / 1000);
   const nonce = crypto.randomBytes(NONCE_BYTES).toString('base64url');
   const payload = Buffer.from(JSON.stringify({ ...identity, iat, nonce })).toString('base64url');
   return `${payload}.${hmacSign(payload)}`;
 }
 
-/** Verify and decode a link token. Returns the identity or `null` on failure. */
-export function verifyLinkToken(token: string): PlatformIdentity | null {
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isPlatform(value: unknown): value is PlatformIdentity['platform'] {
+  return (
+    typeof value === 'string' &&
+    Object.values(PLATFORM).includes(value as PlatformIdentity['platform'])
+  );
+}
+
+function verifySignedIdentityToken(token: string): PlatformInstallTokenData | null {
   const dotIndex = token.indexOf('.');
   if (dotIndex === -1) return null;
 
@@ -157,19 +171,13 @@ export function verifyLinkToken(token: string): PlatformIdentity | null {
   }
 
   try {
-    const data = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as {
-      platform?: PlatformIdentity['platform'];
-      teamId?: string;
-      userId?: string;
-      iat?: number;
-      nonce?: string;
-    };
+    const data = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+    if (!isUnknownRecord(data)) return null;
 
     if (
-      typeof data.platform !== 'string' ||
+      !isPlatform(data.platform) ||
       typeof data.teamId !== 'string' ||
-      typeof data.userId !== 'string' ||
-      !Object.values(PLATFORM).includes(data.platform)
+      typeof data.userId !== 'string'
     ) {
       return null;
     }
@@ -180,8 +188,40 @@ export function verifyLinkToken(token: string): PlatformIdentity | null {
 
     if (typeof data.nonce !== 'string' || data.nonce.length === 0) return null;
 
-    return { platform: data.platform, teamId: data.teamId, userId: data.userId };
+    const threadId = data.threadId;
+    const messageId = data.messageId;
+
+    if (threadId !== undefined && typeof threadId !== 'string') return null;
+    if (messageId !== undefined && typeof messageId !== 'string') return null;
+
+    return {
+      platform: data.platform,
+      teamId: data.teamId,
+      userId: data.userId,
+      ...(threadId ? { threadId } : {}),
+      ...(messageId ? { messageId } : {}),
+    };
   } catch {
     return null;
   }
+}
+
+/** Create a signed, time-limited token encoding a PlatformIdentity. */
+export function createLinkToken(identity: PlatformIdentity): string {
+  return createSignedIdentityToken(identity);
+}
+
+/** Verify and decode a link token. Returns the identity or `null` on failure. */
+export function verifyLinkToken(token: string): PlatformIdentity | null {
+  const identity = verifySignedIdentityToken(token);
+  if (!identity) return null;
+  return { platform: identity.platform, teamId: identity.teamId, userId: identity.userId };
+}
+
+export function createPlatformInstallToken(data: PlatformInstallTokenData): string {
+  return createSignedIdentityToken(data);
+}
+
+export function verifyPlatformInstallToken(token: string): PlatformInstallTokenData | null {
+  return verifySignedIdentityToken(token);
 }

--- a/apps/web/src/lib/bot.ts
+++ b/apps/web/src/lib/bot.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import { Chat, type ActionEvent, type Message, type Thread, type WebhookOptions } from 'chat';
 import { createSlackAdapter, SlackAdapter } from '@chat-adapter/slack';
-import { captureException } from '@sentry/nextjs';
+import { captureException, captureMessage } from '@sentry/nextjs';
 import type { HomeView } from '@slack/types';
 import { resolveKiloUserId, unlinkKiloUser, unlinkTeamKiloUsers } from '@/lib/bot-identity';
 import { isSlackMissingScopeError, postSlackReinstallInstruction } from '@/lib/bot/helpers';
@@ -11,7 +11,12 @@ import {
   getPlatformIntegration,
   getPlatformIntegrationByBotUserId,
 } from '@/lib/bot/platform-helpers';
-import { LINK_ACCOUNT_ACTION_PREFIX, promptLinkAccount } from '@/lib/bot/link-account';
+import {
+  INSTALL_INTEGRATION_ACTION_PREFIX,
+  LINK_ACCOUNT_ACTION_PREFIX,
+  promptInstallIntegration,
+  promptLinkAccount,
+} from '@/lib/bot/link-account';
 import { createBotRequest, updateBotRequest } from '@/lib/bot/request-logging';
 import { findUserById } from '@/lib/user';
 import { processMessage } from '@/lib/bot/run';
@@ -260,17 +265,19 @@ function createKiloBot(slackAdapter: ReturnType<typeof createSlackAdapter>) {
     message: Message
   ): Promise<void> {
     const identity = getPlatformIdentity(thread, message);
-    const [platformIntegration, kiloUserId] = await Promise.all([
-      getPlatformIntegration(identity),
-      resolveKiloUserId(chatBot.getState(), identity),
-    ]);
+    const platformIntegration = await getPlatformIntegration(identity);
 
     if (!platformIntegration) {
-      captureException(new Error('No active platform integration found'), {
+      captureMessage('No active platform integration found for bot mention', {
+        level: 'warning',
+        tags: { component: 'kilo-bot', op: 'missing-platform-integration' },
         extra: { platform: identity.platform, teamId: identity.teamId },
       });
+      await promptInstallIntegration(thread, message, identity);
       return;
     }
+
+    const kiloUserId = await resolveKiloUserId(chatBot.getState(), identity);
 
     if (!kiloUserId) {
       await promptLinkAccount(thread, message, identity);
@@ -321,8 +328,13 @@ function createKiloBot(slackAdapter: ReturnType<typeof createSlackAdapter>) {
   // For ephemeral messages the adapter encodes the response_url into the
   // messageId, so deleteMessage sends `{ delete_original: true }` — removing
   // the ephemeral card from the user's view.
-  chatBot.onAction(async function handleLinkAccountClick(event: ActionEvent): Promise<void> {
-    if (!event.actionId.startsWith(LINK_ACCOUNT_ACTION_PREFIX)) return;
+  chatBot.onAction(async function handleSetupLinkClick(event: ActionEvent): Promise<void> {
+    if (
+      !event.actionId.startsWith(LINK_ACCOUNT_ACTION_PREFIX) &&
+      !event.actionId.startsWith(INSTALL_INTEGRATION_ACTION_PREFIX)
+    ) {
+      return;
+    }
 
     try {
       await event.adapter.deleteMessage(event.threadId, event.messageId);

--- a/apps/web/src/lib/bot/link-account.ts
+++ b/apps/web/src/lib/bot/link-account.ts
@@ -1,11 +1,17 @@
 import { Actions, Card, LinkButton, Section, CardText, type Message, type Thread } from 'chat';
-import { createLinkToken, type PlatformIdentity } from '@/lib/bot-identity';
+import {
+  createLinkToken,
+  createPlatformInstallToken,
+  type PlatformIdentity,
+} from '@/lib/bot-identity';
 import { APP_URL } from '@/lib/constants';
 import { isChannelLevelMessage } from '@/lib/bot/helpers';
 
 const LINK_ACCOUNT_PATH = '/api/chat/link-account';
+const SLACK_GET_STARTED_PATH = '/get-started/slack';
 
 export const LINK_ACCOUNT_ACTION_PREFIX = `link-${APP_URL}${LINK_ACCOUNT_PATH}`;
+export const INSTALL_INTEGRATION_ACTION_PREFIX = `link-${APP_URL}${SLACK_GET_STARTED_PATH}`;
 
 function buildLinkAccountUrl(identity: PlatformIdentity): string {
   const url = new URL(LINK_ACCOUNT_PATH, APP_URL);
@@ -28,6 +34,38 @@ function linkAccountCard(linkUrl: string) {
   });
 }
 
+function buildInstallIntegrationUrl(
+  identity: PlatformIdentity,
+  thread: Thread,
+  message: Message
+): string {
+  const url = new URL(SLACK_GET_STARTED_PATH, APP_URL);
+  url.searchParams.set(
+    'installToken',
+    createPlatformInstallToken({
+      ...identity,
+      threadId: thread.id,
+      messageId: message.id,
+    })
+  );
+  return url.toString();
+}
+
+function installIntegrationCard(linkUrl: string) {
+  return Card({
+    title: 'Finish connecting Kilo',
+    children: [
+      Section([
+        CardText(
+          'Kilo is installed in this Slack workspace, but it is not connected to a Kilo workspace yet. ' +
+            'Sign in or create an account to choose where this Slack app should live.'
+        ),
+      ]),
+      Actions([LinkButton({ label: 'Finish setup', url: linkUrl, style: 'primary' })]),
+    ],
+  });
+}
+
 export async function promptLinkAccount(
   thread: Thread,
   message: Message,
@@ -39,4 +77,18 @@ export async function promptLinkAccount(
   await target.postEphemeral(message.author, linkAccountCard(buildLinkAccountUrl(identity)), {
     fallbackToDM: true,
   });
+}
+
+export async function promptInstallIntegration(
+  thread: Thread,
+  message: Message,
+  identity: PlatformIdentity
+): Promise<void> {
+  const target = isChannelLevelMessage(thread, message) ? thread.channel : thread;
+
+  await target.postEphemeral(
+    message.author,
+    installIntegrationCard(buildInstallIntegrationUrl(identity, thread, message)),
+    { fallbackToDM: true }
+  );
 }

--- a/apps/web/src/lib/integrations/oauth-state.test.ts
+++ b/apps/web/src/lib/integrations/oauth-state.test.ts
@@ -1,0 +1,60 @@
+process.env.NEXTAUTH_SECRET ||= 'test-nextauth-secret';
+
+import { createOAuthState, verifyOAuthState } from '@/lib/integrations/oauth-state';
+
+function tamperState(state: string): string {
+  const dotIndex = state.indexOf('.');
+  const payload = state.slice(0, dotIndex);
+  const signature = state.slice(dotIndex + 1);
+  const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+  const tamperedPayload = Buffer.from(JSON.stringify({ ...decoded, owner: 'user-other' })).toString(
+    'base64url'
+  );
+  return `${tamperedPayload}.${signature}`;
+}
+
+describe('OAuth state', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('round-trips owner and user data', () => {
+    const state = createOAuthState('user_user-1', 'user-1');
+
+    expect(verifyOAuthState(state)).toEqual({ owner: 'user_user-1', userId: 'user-1' });
+  });
+
+  it('round-trips Slack marketplace install metadata', () => {
+    const metadata = {
+      source: 'slack_marketplace_install',
+      installToken: 'signed-install-token',
+    } as const;
+
+    const state = createOAuthState('org_org-1', 'user-1', metadata);
+
+    expect(verifyOAuthState(state)).toEqual({
+      owner: 'org_org-1',
+      userId: 'user-1',
+      metadata,
+    });
+  });
+
+  it('rejects tampered states', () => {
+    const state = createOAuthState('user_user-1', 'user-1');
+
+    expect(verifyOAuthState(tamperState(state))).toBeNull();
+  });
+
+  it('rejects expired states', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-04T10:00:00Z'));
+    const state = createOAuthState('user_user-1', 'user-1');
+
+    jest.setSystemTime(new Date('2026-05-04T10:11:00Z'));
+
+    expect(verifyOAuthState(state)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/integrations/oauth-state.ts
+++ b/apps/web/src/lib/integrations/oauth-state.ts
@@ -2,6 +2,13 @@ import 'server-only';
 import crypto from 'node:crypto';
 import { NEXTAUTH_SECRET } from '@/lib/config.server';
 
+export type SlackMarketplaceInstallOAuthMetadata = {
+  source: 'slack_marketplace_install';
+  installToken: string;
+};
+
+export type OAuthStateMetadata = SlackMarketplaceInstallOAuthMetadata;
+
 /**
  * HMAC-signed OAuth state parameter.
  *
@@ -40,18 +47,26 @@ function sign(data: string): string {
   return crypto.createHmac(HMAC_ALGORITHM, NEXTAUTH_SECRET).update(data).digest('base64url');
 }
 
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
 /**
  * Build a signed OAuth state parameter.
  *
  * @param owner  – owner string, e.g. `user_abc123` or `org_xyz789`
  * @param userId – the ID of the currently-authenticated user initiating the flow
  */
-export function createOAuthState(owner: string, userId: string): string {
+export function createOAuthState(
+  owner: string,
+  userId: string,
+  metadata?: OAuthStateMetadata
+): string {
   const iat = Math.floor(Date.now() / 1000);
   const nonce = crypto.randomBytes(NONCE_BYTES).toString('base64url');
-  const payload = Buffer.from(JSON.stringify({ owner, uid: userId, iat, nonce })).toString(
-    'base64url'
-  );
+  const payload = Buffer.from(
+    JSON.stringify({ owner, uid: userId, iat, nonce, metadata })
+  ).toString('base64url');
   const signature = sign(payload);
   return `${payload}.${signature}`;
 }
@@ -61,7 +76,25 @@ export type VerifiedOAuthState = {
   owner: string;
   /** The user ID that initiated the OAuth flow */
   userId: string;
+  metadata?: OAuthStateMetadata;
 };
+
+function parseOAuthStateMetadata(value: unknown): OAuthStateMetadata | undefined | null {
+  if (value === undefined) return undefined;
+  if (!isUnknownRecord(value)) return null;
+
+  if (
+    'source' in value &&
+    value.source === 'slack_marketplace_install' &&
+    'installToken' in value &&
+    typeof value.installToken === 'string' &&
+    value.installToken.length > 0
+  ) {
+    return { source: value.source, installToken: value.installToken };
+  }
+
+  return null;
+}
 
 /**
  * Verify a signed OAuth state parameter and return the embedded payload.
@@ -88,12 +121,8 @@ export function verifyOAuthState(state: string | null): VerifiedOAuthState | nul
   }
 
   try {
-    const data = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as {
-      owner?: string;
-      uid?: string;
-      iat?: number;
-      nonce?: string;
-    };
+    const data = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+    if (!isUnknownRecord(data)) return null;
     if (typeof data.owner !== 'string' || typeof data.uid !== 'string') return null;
 
     // Enforce TTL: reject tokens that are too old or have no timestamp
@@ -104,7 +133,10 @@ export function verifyOAuthState(state: string | null): VerifiedOAuthState | nul
     // Require nonce to be present (guards against old-format tokens)
     if (typeof data.nonce !== 'string' || data.nonce.length === 0) return null;
 
-    return { owner: data.owner, userId: data.uid };
+    const metadata = parseOAuthStateMetadata(data.metadata);
+    if (metadata === null) return null;
+
+    return { owner: data.owner, userId: data.uid, ...(metadata ? { metadata } : {}) };
   } catch {
     return null;
   }

--- a/apps/web/src/lib/integrations/slack-callback-helpers.ts
+++ b/apps/web/src/lib/integrations/slack-callback-helpers.ts
@@ -1,0 +1,107 @@
+import 'server-only';
+import type { SlackAdapter } from '@chat-adapter/slack';
+import { captureException, captureMessage } from '@sentry/nextjs';
+import { bot } from '@/lib/bot';
+import { linkKiloUser, verifyPlatformInstallToken } from '@/lib/bot-identity';
+import { PLATFORM } from '@/lib/integrations/core/constants';
+import { verifyOAuthState, type VerifiedOAuthState } from '@/lib/integrations/oauth-state';
+
+const SLACK_MARKETPLACE_SOURCE = 'slack_marketplace_install';
+
+export function buildSlackRedirectPath(
+  state: string | null,
+  params: Record<string, string>
+): string {
+  const verified = state ? verifyOAuthState(state) : null;
+  const owner = verified?.owner;
+  const search = new URLSearchParams(params);
+
+  if (verified?.metadata?.source === SLACK_MARKETPLACE_SOURCE) {
+    const error = search.get('error');
+    if (error) {
+      search.delete('error');
+      search.set('slackError', error);
+    }
+    const success = search.get('success');
+    if (success) {
+      search.delete('success');
+      search.set('slackSuccess', success);
+    }
+    search.set('source', SLACK_MARKETPLACE_SOURCE);
+    search.set('installToken', verified.metadata.installToken);
+    return `/get-started/slack?${search.toString()}`;
+  }
+
+  if (owner?.startsWith('org_')) {
+    return `/organizations/${owner.replace('org_', '')}/integrations/slack?${search.toString()}`;
+  }
+  if (owner?.startsWith('user_')) {
+    return `/integrations/slack?${search.toString()}`;
+  }
+  return `/integrations?${search.toString()}`;
+}
+
+async function postSlackMarketplaceInstallConfirmation(
+  slackAdapter: SlackAdapter,
+  threadId: string,
+  teamName: string | undefined
+): Promise<void> {
+  try {
+    await slackAdapter.postMessage(threadId, {
+      markdown:
+        `Kilo is connected${teamName ? ` to ${teamName}` : ''}. ` +
+        'Mention me here whenever you want help debugging code, reviewing PRs, or answering questions about your repos.',
+    });
+  } catch (error) {
+    captureException(error, {
+      level: 'warning',
+      tags: { component: 'kilo-bot', op: 'marketplace-install-confirmation' },
+      extra: { threadId },
+    });
+  }
+}
+
+export async function completeSlackMarketplaceInstall(params: {
+  verified: VerifiedOAuthState;
+  teamId: string;
+  userId: string;
+  teamName: string | undefined;
+  slackAdapter: SlackAdapter;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  const metadata = params.verified.metadata;
+  if (metadata?.source !== SLACK_MARKETPLACE_SOURCE) return { ok: true };
+
+  const installTokenData = verifyPlatformInstallToken(metadata.installToken);
+  if (!installTokenData || installTokenData.platform !== PLATFORM.SLACK) {
+    return { ok: false, error: 'invalid_install_token' };
+  }
+
+  if (installTokenData.teamId !== params.teamId) {
+    captureMessage('Slack marketplace install team mismatch', {
+      level: 'warning',
+      tags: { endpoint: 'slack/callback', source: 'slack_oauth' },
+      extra: { tokenTeamId: installTokenData.teamId, callbackTeamId: params.teamId },
+    });
+    return { ok: false, error: 'workspace_mismatch' };
+  }
+
+  await linkKiloUser(
+    bot.getState(),
+    {
+      platform: installTokenData.platform,
+      teamId: installTokenData.teamId,
+      userId: installTokenData.userId,
+    },
+    params.userId
+  );
+
+  if (installTokenData.threadId) {
+    await postSlackMarketplaceInstallConfirmation(
+      params.slackAdapter,
+      installTokenData.threadId,
+      params.teamName
+    );
+  }
+
+  return { ok: true };
+}

--- a/apps/web/src/routers/slack-router.ts
+++ b/apps/web/src/routers/slack-router.ts
@@ -12,7 +12,15 @@ import {
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { requireActiveSubscriptionOrTrial } from '@/lib/organizations/trial-middleware';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
-import { unlinkTeamKiloUsers } from '@/lib/bot-identity';
+import { unlinkTeamKiloUsers, verifyPlatformInstallToken } from '@/lib/bot-identity';
+import { PLATFORM } from '@/lib/integrations/core/constants';
+
+const slackOAuthUrlInput = z
+  .object({
+    organizationId: z.string().uuid().optional(),
+    installToken: z.string().optional(),
+  })
+  .optional();
 
 async function getInitializedBot() {
   const { bot } = await import('@/lib/bot');
@@ -66,14 +74,35 @@ export const slackRouter = createTRPCRouter({
   }),
 
   // Get OAuth URL for initiating Slack OAuth flow
-  getOAuthUrl: baseProcedure.input(optionalOrgInput).query(async ({ ctx, input }) => {
+  getOAuthUrl: baseProcedure.input(slackOAuthUrlInput).query(async ({ ctx, input }) => {
     if (input?.organizationId) {
       await ensureOrganizationAccess(ctx, input.organizationId);
     }
+
+    const installTokenData = input?.installToken
+      ? verifyPlatformInstallToken(input.installToken)
+      : null;
+
+    if (
+      input?.installToken &&
+      (!installTokenData || installTokenData.platform !== PLATFORM.SLACK)
+    ) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Invalid or expired Slack setup link. Please mention Kilo in Slack again.',
+      });
+    }
+
     const statePrefix = input?.organizationId
       ? `org_${input.organizationId}`
       : `user_${ctx.user.id}`;
-    const state = createOAuthState(statePrefix, ctx.user.id);
+    const state = createOAuthState(
+      statePrefix,
+      ctx.user.id,
+      input?.installToken
+        ? { source: 'slack_marketplace_install', installToken: input.installToken }
+        : undefined
+    );
     return {
       url: slackService.getSlackOAuthUrl(state),
     };


### PR DESCRIPTION
## Summary

- Add a signed Slack marketplace setup token so bot mentions from unclaimed Slack installs can safely route users into Kilo onboarding.
- Extend the Slack get-started and OAuth callback flows to preserve setup state, let users choose personal/org ownership, link the Slack identity, and post a confirmation message.
- Add focused coverage for bot identity tokens, OAuth state metadata, and Slack marketplace callback helpers.

## Verification

- Manual browser verification was not run; this flow requires a Slack OAuth installation context and Slack workspace event setup.

## Visual Changes

N/A - UI flow changed, but screenshots were not captured because the Slack marketplace setup path requires a live Slack install context.

## Reviewer Notes

- The Slack confirmation post is best-effort after OAuth succeeds, so setup is not rolled back if Slack posting fails.
- `success`/`error` are namespaced to `slackSuccess`/`slackError` on `/get-started/slack` to avoid colliding with auth errors.