### PR TITLE
Revert "fix(models-up): temporarily exclude gemma-4-31b-it from health checks"

### DIFF
--- a/apps/web/src/app/api/models/up/route.ts
+++ b/apps/web/src/app/api/models/up/route.ts
@@ -57,8 +57,6 @@ const HEALTH_CHECK_EXCLUSIONS = new Set([
   'openrouter/elephant-alpha',
   'openai/gpt-5.4',
   'openai/gpt-5.5',
-  // Temporarily excluded: a single BYOK user spiked to 14k+ req/15min and affected baseline
-  'google/gemma-4-31b-it',
 ]);
 
 function emptyMetrics(): Omit<ModelHealthMetrics, 'monitored'> {


### PR DESCRIPTION
## Summary

Revert "fix(models-up): temporarily exclude gemma-4-31b-it from health checks" 

This reverts commit 5f135d0e8115301e4702518f6125b81301ce6c41. #3010

## Verification

N/A

## Visual Changes

N/A

## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
