### PR TITLE
fix(web): skip empty APP_URL_OVERRIDE export in dev

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -69,7 +69,11 @@ export PORT
 APP_URL_OVERRIDE="${APP_URL_OVERRIDE:-$(read_env_value APP_URL_OVERRIDE)}"
 NEXTAUTH_URL="${NEXTAUTH_URL:-$(read_env_value NEXTAUTH_URL)}"
 NEXT_DEV_HOSTNAME="${NEXT_DEV_HOSTNAME:-0.0.0.0}"
-export APP_URL_OVERRIDE
+# Only export APP_URL_OVERRIDE when set; an empty export becomes "" in
+# process.env and defeats the `??` fallback in apps/web/src/lib/constants.ts.
+if [ -n "$APP_URL_OVERRIDE" ]; then
+  export APP_URL_OVERRIDE
+fi
 export NEXT_DEV_HOSTNAME
 export NEXTAUTH_URL="${NEXTAUTH_URL:-${APP_URL_OVERRIDE:-http://localhost:$PORT}}"
 exec next dev -H "$NEXT_DEV_HOSTNAME" -p "$PORT" "$@"


### PR DESCRIPTION



<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

- Regression from d773511e25. Unconditionally exporting APP_URL_OVERRIDE made process.env.APP_URL_OVERRIDE an empty string when nothing in the env files defined it, which defeats the `??` fallback in apps/web/src/lib/constants.ts and crashes Turbopack with 'Invalid URL' at `new URL(APP_URL)` in app/layout.tsx.
- Only export when non-empty so the variable stays undefined and the localhost fallback fires.
- Only affected dev

<!-- What changed and why? Keep this brief and outcome-focused. -->
<!-- Include any architectural changes and enough context for a reviewer unfamiliar with this code area. -->

## Verification

<!-- Only list manually tested paths, not automated tests. If you didn't run any manual tests, point that out, and explain why. -->

- [X] Local dev verified

## Visual Changes

N/A
## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
N/A