### PR TITLE
feat(dev-seed): improve local seed scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,5 @@ supabase/.temp
 TMP_CI_commit_msg.txt
 *.csv
 run-milvus-test.sh
-.env*.local
 
 .beads/

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ TMP_CI_commit_msg.txt
 *.csv
 run-milvus-test.sh
 .env*.local
+
+.beads/

--- a/dev/seed/AGENTS.md
+++ b/dev/seed/AGENTS.md
@@ -1,0 +1,89 @@
+# AGENTS.md — `dev/seed/`
+
+Contract for `pnpm dev:seed` runner/topic modules. Read before adding, modifying, or invoking seeds.
+
+## Layout
+
+```
+dev/seed/
+  index.ts                 Runner: args, listing, result output.
+  lib/
+    preflight.ts           Import FIRST; mutates process.env from argv.
+    db.ts                  Lazy drizzle client.
+    stripe.ts              Lazy Stripe test-mode client/customer helpers.
+  <scope>/<topic>.ts       Topic module. Scope = folder; topic = filename.
+```
+
+Runner globs `<scope>/*.ts`. Any top-level dir except `lib/` is a scope. Scope folders must contain only topic files; shared code goes in `lib/`.
+
+## Invocation
+
+```sh
+pnpm dev:seed <scope>:<topic> [args...]   # canonical
+pnpm dev:seed <scope> <topic> [args...]   # accepted
+pnpm dev:seed                             # list topics + usage
+```
+
+Global flag:
+
+- `--json`: suppress topic stdout; print exactly one `JSON.stringify(result)` line. Use `pnpm -s` for clean pipes:
+  ```sh
+  USER_ID=$(pnpm -s dev:seed app:create-user "Foo" foo@example.com --json | jq -r .userId)
+  ```
+  Implementation: `preflight.ts` sets `DOTENV_CONFIG_QUIET=true` before other imports; runner suppresses `console.log/info/warn` during `run()`. Do not bypass with `process.stdout.write`.
+
+## Topic contract
+
+Topic files MUST:
+
+- Export `run(...args: string[]): Promise<SeedResult | void> | SeedResult | void`.
+  - `type SeedResult = Record<string, string | number | boolean | null>`: flat JSON primitives only; no nested objects; stringify Dates.
+  - Return every id/email/handle/balance needed by follow-up commands; the runner formats all output from this object.
+- Support `--help`/`-h` via local `printUsage()` and early return.
+- Reset only their own data at start for idempotent reruns. Delete by stable ids/emails, stable sandbox prefixes, or `dev-seed:` category prefixes.
+- Avoid module-level side effects (DB writes/network); no-args listing imports modules.
+
+Topic files SHOULD:
+
+- Export `const usage = '<arg> <arg> [options]'`; omit if no args.
+- Print short context before returning (`This fixture represents:`, `Note:`, `Suggested next step:`). Runner appends the Result block.
+
+Topic files MUST NOT:
+
+- Write stdout in `--json` beyond the runner's single JSON line; `console.*` is suppressed during `run()`, but `process.stdout.write` is not.
+- Print completion blocks or `key: value` lines duplicating `SeedResult`.
+- Use `as` casts or `!` assertions; prefer `satisfies typeof <table>.$inferInsert`.
+- Import from `apps/web/src/...` (server-only/Next runtime); replicate minimal logic in `lib/`.
+- Return nested objects or non-primitives in `SeedResult`; flatten with prefixed keys (`eligibleUserId`, `eligibleInstanceId`, ...).
+
+## Helpers
+
+- `getSeedDb()`: lazy singleton drizzle client, safe from any topic; pool cap 1.
+- `closeSeedDb()`: runner calls in `finally`; topics should not.
+- `createSeedStripeCustomer({ email, name, kiloUserId })`: creates real Stripe test-mode customer with `metadata: { kiloUserId, source: 'dev-seed' }`.
+- `deleteSeedStripeCustomer(id)`: rollback helper; swallows "no such customer".
+- `lib/stripe.ts` rejects missing/non-`sk_test_...` `STRIPE_SECRET_KEY`.
+- For seeded users used by Stripe-touching app code (`/profile`, billing pages, KiloClaw subscriptions), create a real Stripe customer. Never use `cus_seed_...`: it causes `StripeInvalidRequestError: No such customer` 400s. Order matches `createUserOnSignIn`: create Stripe customer, insert DB row, delete Stripe customer in `catch` on insert failure.
+
+## Direct user inserts
+
+Bare `kilocode_users` inserts leave users trapped in onboarding. To reach product surfaces, set:
+
+- `has_validation_stytch: true` — bypasses `/account-verification` (`!== null`).
+- `customer_source: 'dev-seed'` — bypasses `/customer-source-survey` (`!== null`; `''` means skipped).
+
+Canonical example: `app/create-user.ts`. Gate code: `apps/web/src/lib/stytch.ts` (`getStytchStatus`) and `apps/web/src/lib/survey-redirect.ts` (`maybeInterceptWithSurvey`). When adding a gate, update this section and `app/create-user.ts` together.
+
+## New-topic checklist
+
+1. Add `<scope>/<topic>.ts` (new top-level dirs become scopes).
+2. Export `run()` and usually `usage`.
+3. Use `getSeedDb()`; use `createSeedStripeCustomer` for app users needing Stripe.
+4. Reset only own fixtures idempotently.
+5. Return flat `SeedResult` with every follow-up id.
+6. Verify both modes:
+   ```sh
+   pnpm dev:seed <scope>:<topic> <args>             # human-readable Result block
+   pnpm -s dev:seed <scope>:<topic> <args> --json   # single JSON line
+   ```
+7. Run `pnpm format` and `pnpm lint`. Skip `pnpm typecheck`: `dev/seed/` runs via `tsx` and is outside tsconfig; runtime is the type check.

--- a/dev/seed/app/add-credits.ts
+++ b/dev/seed/app/add-credits.ts
@@ -104,7 +104,6 @@ function parseArgs(args: string[]): AddCreditsOptions {
   let categoryProvided = false;
   let isIdempotent = false;
   let expiryDateIso: string | null = null;
-  let positionalUsdSeen = false;
 
   for (const arg of args.slice(1)) {
     if (arg === '--help' || arg === '-h') {
@@ -189,11 +188,10 @@ function parseArgs(args: string[]): AddCreditsOptions {
       throw new Error(`Unknown argument: ${arg}`);
     }
 
-    if (positionalUsdSeen || amountMicrodollars !== null) {
+    if (amountMicrodollars !== null) {
       throw new Error(`Unexpected positional argument: ${arg}`);
     }
     amountMicrodollars = parseUsdToMicrodollars(arg, 'amount');
-    positionalUsdSeen = true;
   }
 
   if (amountMicrodollars === null) {

--- a/dev/seed/app/add-credits.ts
+++ b/dev/seed/app/add-credits.ts
@@ -1,0 +1,327 @@
+import { randomUUID } from 'node:crypto';
+
+import { credit_transactions, kilocode_users } from '@kilocode/db/schema';
+import { eq, sql } from 'drizzle-orm';
+
+import { getSeedDb } from '../lib/db';
+import type { SeedResult } from '../index';
+
+const MICRODOLLARS_PER_DOLLAR = 1_000_000;
+
+export const usage = '<user-id> <usd> [options]';
+
+function printUsage(): void {
+  console.log('Usage: pnpm dev:seed app:add-credits <user-id> <usd> [options]');
+  console.log('       pnpm dev:seed app:add-credits <user-id> --usd=<amount> [options]');
+  console.log('       pnpm dev:seed app:add-credits <user-id> --microdollars=<amount> [options]');
+  console.log('');
+  console.log('Options:');
+  console.log('  --free                         Mark the credit transaction as free (default)');
+  console.log('  --paid                         Mark the credit transaction as paid/non-free');
+  console.log('  --description=<text>           Transaction description');
+  console.log('  --category=<text>              credit_category value');
+  console.log('  --idempotent                   Enforce one transaction per user/category');
+  console.log('  --expires-at=<iso-date>        Expiration timestamp');
+  console.log('  --expires-in-days=<number>     Expiration offset from now');
+  console.log('');
+  console.log('Examples:');
+  console.log('  pnpm dev:seed app:add-credits user_123 25');
+  console.log('  pnpm dev:seed app:add-credits user_123 --usd=50 --paid');
+  console.log(
+    '  pnpm dev:seed app:add-credits user_123 --microdollars=9000000 --category=dev:kilo'
+  );
+}
+
+type AddCreditsOptions = {
+  userId: string;
+  amountMicrodollars: number;
+  isFree: boolean;
+  description: string;
+  creditCategory: string;
+  isIdempotent: boolean;
+  expiryDateIso: string | null;
+};
+
+function parsePositiveInteger(value: string, flagName: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${flagName} must be a positive integer`);
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flagName} must be a positive safe integer`);
+  }
+
+  return parsed;
+}
+
+function parseUsdToMicrodollars(value: string, flagName: string): number {
+  const trimmed = value.trim();
+  const match = /^(\d+)(?:\.(\d{1,6}))?$/.exec(trimmed);
+  if (!match) {
+    throw new Error(`${flagName} must be a positive dollar amount with up to 6 decimals`);
+  }
+
+  const dollars = Number(match[1]);
+  const fractional = (match[2] ?? '').padEnd(6, '0');
+  const microdollars = dollars * MICRODOLLARS_PER_DOLLAR + Number(fractional);
+
+  if (!Number.isSafeInteger(microdollars) || microdollars <= 0) {
+    throw new Error(`${flagName} must be greater than 0 and fit in a safe integer`);
+  }
+
+  return microdollars;
+}
+
+function parseExpiryDate(value: string, flagName: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${flagName} must be a valid date`);
+  }
+  if (parsed.getTime() <= Date.now()) {
+    throw new Error(`${flagName} must be in the future`);
+  }
+  return parsed.toISOString();
+}
+
+function addDays(date: Date, days: number): string {
+  const result = new Date(date);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result.toISOString();
+}
+
+function parseArgs(args: string[]): AddCreditsOptions {
+  const userId = args[0]?.trim();
+  if (!userId || userId === '--help' || userId === '-h') {
+    printUsage();
+    throw new Error('user-id is required');
+  }
+
+  let amountMicrodollars: number | null = null;
+  let isFree = true;
+  let description = 'Dev seed credits';
+  let creditCategory = `dev-seed:add-credits:${randomUUID()}`;
+  let categoryProvided = false;
+  let isIdempotent = false;
+  let expiryDateIso: string | null = null;
+  let positionalUsdSeen = false;
+
+  for (const arg of args.slice(1)) {
+    if (arg === '--help' || arg === '-h') {
+      printUsage();
+      throw new Error('help requested');
+    }
+
+    if (arg === '--free') {
+      isFree = true;
+      continue;
+    }
+
+    if (arg === '--paid') {
+      isFree = false;
+      continue;
+    }
+
+    if (arg === '--idempotent') {
+      isIdempotent = true;
+      continue;
+    }
+
+    if (arg.startsWith('--usd=')) {
+      if (amountMicrodollars !== null) {
+        throw new Error('Specify only one amount');
+      }
+      amountMicrodollars = parseUsdToMicrodollars(arg.slice('--usd='.length), '--usd');
+      continue;
+    }
+
+    if (arg.startsWith('--microdollars=')) {
+      if (amountMicrodollars !== null) {
+        throw new Error('Specify only one amount');
+      }
+      amountMicrodollars = parsePositiveInteger(
+        arg.slice('--microdollars='.length).trim(),
+        '--microdollars'
+      );
+      continue;
+    }
+
+    if (arg.startsWith('--description=')) {
+      const parsedDescription = arg.slice('--description='.length).trim();
+      if (!parsedDescription) {
+        throw new Error('--description must not be empty');
+      }
+      description = parsedDescription;
+      continue;
+    }
+
+    if (arg.startsWith('--category=')) {
+      const parsedCategory = arg.slice('--category='.length).trim();
+      if (!parsedCategory) {
+        throw new Error('--category must not be empty');
+      }
+      creditCategory = parsedCategory;
+      categoryProvided = true;
+      continue;
+    }
+
+    if (arg.startsWith('--expires-at=')) {
+      if (expiryDateIso !== null) {
+        throw new Error('Specify only one expiration option');
+      }
+      expiryDateIso = parseExpiryDate(arg.slice('--expires-at='.length), '--expires-at');
+      continue;
+    }
+
+    if (arg.startsWith('--expires-in-days=')) {
+      if (expiryDateIso !== null) {
+        throw new Error('Specify only one expiration option');
+      }
+      const days = parsePositiveInteger(
+        arg.slice('--expires-in-days='.length).trim(),
+        '--expires-in-days'
+      );
+      expiryDateIso = addDays(new Date(), days);
+      continue;
+    }
+
+    if (arg.startsWith('--')) {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+
+    if (positionalUsdSeen || amountMicrodollars !== null) {
+      throw new Error(`Unexpected positional argument: ${arg}`);
+    }
+    amountMicrodollars = parseUsdToMicrodollars(arg, 'amount');
+    positionalUsdSeen = true;
+  }
+
+  if (amountMicrodollars === null) {
+    printUsage();
+    throw new Error('credit amount is required');
+  }
+
+  if (isIdempotent && !categoryProvided) {
+    throw new Error('--idempotent requires --category');
+  }
+
+  return {
+    userId,
+    amountMicrodollars,
+    isFree,
+    description,
+    creditCategory,
+    isIdempotent,
+    expiryDateIso,
+  };
+}
+
+function formatMicrodollarsAsUsd(amountMicrodollars: number): string {
+  const sign = amountMicrodollars < 0 ? '-' : '';
+  const absolute = Math.abs(amountMicrodollars);
+  const dollars = Math.floor(absolute / MICRODOLLARS_PER_DOLLAR);
+  const fractional = String(absolute % MICRODOLLARS_PER_DOLLAR).padStart(6, '0');
+  return `${sign}$${dollars}.${fractional}`;
+}
+
+export async function run(...args: string[]): Promise<SeedResult | void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const options = parseArgs(args);
+  const db = getSeedDb();
+
+  const result = await db.transaction(async tx => {
+    const [user] = await tx
+      .select({
+        id: kilocode_users.id,
+        email: kilocode_users.google_user_email,
+        microdollarsUsed: kilocode_users.microdollars_used,
+        totalMicrodollarsAcquired: kilocode_users.total_microdollars_acquired,
+      })
+      .from(kilocode_users)
+      .where(eq(kilocode_users.id, options.userId))
+      .limit(1);
+
+    if (!user) {
+      throw new Error(`User ${options.userId} was not found. Sign in locally first.`);
+    }
+
+    const nowIso = new Date().toISOString();
+    const transactionValues = {
+      id: randomUUID(),
+      kilo_user_id: user.id,
+      amount_microdollars: options.amountMicrodollars,
+      is_free: options.isFree,
+      description: options.description,
+      credit_category: options.creditCategory,
+      created_at: nowIso,
+      expiry_date: options.expiryDateIso,
+      original_baseline_microdollars_used: user.microdollarsUsed,
+      expiration_baseline_microdollars_used: options.expiryDateIso ? user.microdollarsUsed : null,
+      check_category_uniqueness: options.isIdempotent,
+    } satisfies typeof credit_transactions.$inferInsert;
+
+    const insertStatement = tx.insert(credit_transactions).values(transactionValues);
+    const insertedTransactions = options.isIdempotent
+      ? await insertStatement.onConflictDoNothing().returning({ id: credit_transactions.id })
+      : await insertStatement.returning({ id: credit_transactions.id });
+    const insertedTransaction = insertedTransactions[0];
+
+    if (!insertedTransaction) {
+      return {
+        inserted: false,
+        user,
+        transactionId: null,
+        beforeBalanceMicrodollars: user.totalMicrodollarsAcquired - user.microdollarsUsed,
+        afterBalanceMicrodollars: user.totalMicrodollarsAcquired - user.microdollarsUsed,
+      };
+    }
+
+    await tx
+      .update(kilocode_users)
+      .set({
+        total_microdollars_acquired: sql`${kilocode_users.total_microdollars_acquired} + ${options.amountMicrodollars}`,
+        ...(options.expiryDateIso
+          ? {
+              next_credit_expiration_at: sql`COALESCE(LEAST(${kilocode_users.next_credit_expiration_at}, ${options.expiryDateIso}), ${options.expiryDateIso})`,
+            }
+          : {}),
+      })
+      .where(eq(kilocode_users.id, user.id));
+
+    return {
+      inserted: true,
+      user,
+      transactionId: insertedTransaction.id,
+      beforeBalanceMicrodollars: user.totalMicrodollarsAcquired - user.microdollarsUsed,
+      afterBalanceMicrodollars:
+        user.totalMicrodollarsAcquired - user.microdollarsUsed + options.amountMicrodollars,
+    };
+  });
+
+  if (!result.inserted) {
+    console.log('');
+    console.log(
+      'No transaction inserted because --idempotent found an existing user/category row.'
+    );
+  }
+
+  return {
+    userId: options.userId,
+    email: result.user.email,
+    inserted: result.inserted,
+    transactionId: result.transactionId,
+    amountMicrodollars: options.amountMicrodollars,
+    amountUsd: formatMicrodollarsAsUsd(options.amountMicrodollars),
+    isFree: options.isFree,
+    creditCategory: options.creditCategory,
+    expiresAt: options.expiryDateIso,
+    beforeBalanceMicrodollars: result.beforeBalanceMicrodollars,
+    beforeBalanceUsd: formatMicrodollarsAsUsd(result.beforeBalanceMicrodollars),
+    afterBalanceMicrodollars: result.afterBalanceMicrodollars,
+    afterBalanceUsd: formatMicrodollarsAsUsd(result.afterBalanceMicrodollars),
+  };
+}

--- a/dev/seed/app/create-user.ts
+++ b/dev/seed/app/create-user.ts
@@ -1,0 +1,108 @@
+import { randomUUID } from 'node:crypto';
+
+import { kilocode_users } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
+
+import { getSeedDb } from '../lib/db';
+import { createSeedStripeCustomer, deleteSeedStripeCustomer } from '../lib/stripe';
+import type { SeedResult } from '../index';
+
+export const usage = '<name> <email>';
+
+function printUsage(): void {
+  console.log(`Usage: pnpm dev:seed app:create-user ${usage}`);
+  console.log('');
+  console.log('Creates a Kilo Code user for local development. Skips Stripe/OAuth flows;');
+  console.log('the inserted row is wired up with placeholder identifiers so it works in the');
+  console.log('app, but the user has no auth provider linked. Sign in via the normal flow if');
+  console.log('you need a real session.');
+  console.log('');
+  console.log('Examples:');
+  console.log('  pnpm dev:seed app:create-user "Ada Lovelace" ada@example.com');
+}
+
+function isValidEmail(email: string): boolean {
+  // Intentionally permissive; we only guard against obvious nonsense in dev.
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+export async function run(...args: string[]): Promise<SeedResult | void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const [name, email, ...rest] = args;
+  if (!name || !email) {
+    printUsage();
+    throw new Error('name and email are required');
+  }
+  if (rest.length > 0) {
+    printUsage();
+    throw new Error(`Unexpected extra arguments: ${rest.join(' ')}`);
+  }
+  if (!isValidEmail(email)) {
+    throw new Error(`email is not a valid address: ${email}`);
+  }
+
+  const db = getSeedDb();
+  const trimmedName = name.trim();
+  const trimmedEmail = email.trim();
+  const normalizedEmail = trimmedEmail.toLowerCase();
+
+  const existing = await db
+    .select({ id: kilocode_users.id })
+    .from(kilocode_users)
+    .where(eq(kilocode_users.google_user_email, trimmedEmail))
+    .limit(1);
+
+  if (existing.length > 0) {
+    throw new Error(
+      `A user with email ${trimmedEmail} already exists (id=${existing[0].id}). ` +
+        `Delete it first or pick a different email.`
+    );
+  }
+
+  const userId = randomUUID();
+
+  // Create a real Stripe test-mode customer first so that pages like /profile
+  // (which call into Stripe with stripe_customer_id) don't 400 with
+  // `No such customer`. Mirrors apps/web/src/lib/user.ts createUserOnSignIn.
+  const stripeCustomer = await createSeedStripeCustomer({
+    email: trimmedEmail,
+    name: trimmedName,
+    kiloUserId: userId,
+  });
+
+  // Pre-set the onboarding gates so seeded users can hit dashboards without
+  // bouncing through `/account-verification` (gated on
+  // `has_validation_stytch !== null`) or `/customer-source-survey` (gated on
+  // `customer_source !== null`). See apps/web/src/lib/stytch.ts and
+  // apps/web/src/lib/survey-redirect.ts.
+  try {
+    await db.insert(kilocode_users).values({
+      id: userId,
+      google_user_email: trimmedEmail,
+      google_user_name: trimmedName,
+      google_user_image_url: `https://example.com/${encodeURIComponent(userId)}.png`,
+      stripe_customer_id: stripeCustomer.id,
+      normalized_email: normalizedEmail,
+      has_validation_stytch: true,
+      customer_source: 'dev-seed',
+    });
+  } catch (error) {
+    // The DB insert failed after we already created a Stripe customer; clean
+    // it up so we don't leave orphans in the test-mode account.
+    await deleteSeedStripeCustomer(stripeCustomer.id);
+    throw error;
+  }
+
+  return {
+    userId,
+    name: trimmedName,
+    email: trimmedEmail,
+    stripeCustomerId: stripeCustomer.id,
+    hasValidationStytch: true,
+    customerSource: 'dev-seed',
+  };
+}

--- a/dev/seed/app/create-user.ts
+++ b/dev/seed/app/create-user.ts
@@ -4,6 +4,7 @@ import { kilocode_users } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 
 import { getSeedDb } from '../lib/db';
+import { normalizeSeedEmail } from '../lib/email';
 import { createSeedStripeCustomer, deleteSeedStripeCustomer } from '../lib/stripe';
 import type { SeedResult } from '../index';
 
@@ -48,12 +49,12 @@ export async function run(...args: string[]): Promise<SeedResult | void> {
   const db = getSeedDb();
   const trimmedName = name.trim();
   const trimmedEmail = email.trim();
-  const normalizedEmail = trimmedEmail.toLowerCase();
+  const normalizedEmail = normalizeSeedEmail(trimmedEmail);
 
   const existing = await db
     .select({ id: kilocode_users.id })
     .from(kilocode_users)
-    .where(eq(kilocode_users.google_user_email, trimmedEmail))
+    .where(eq(kilocode_users.normalized_email, normalizedEmail))
     .limit(1);
 
   if (existing.length > 0) {

--- a/dev/seed/index.ts
+++ b/dev/seed/index.ts
@@ -1,15 +1,56 @@
+// Must be the first import: it tweaks process.env based on argv (e.g. silences
+// dotenv tips in --json mode) before any module-level side effects run.
+import './lib/preflight';
+
 import { readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { closeSeedDb } from './lib/db';
 
+const JSON_FLAG = '--json';
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const args = process.argv.slice(2);
 
+export type SeedResultValue = string | number | boolean | null;
+export type SeedResult = Record<string, SeedResultValue>;
+
 type SeedModule = {
-  run?: (...args: string[]) => Promise<void> | void;
+  run?: (...args: string[]) => Promise<SeedResult | void> | SeedResult | void;
+  usage?: string;
 };
+
+function printSeedResult(scope: string, topic: string, result: SeedResult): void {
+  const label = `${scope}:${topic}`;
+  const entries = Object.entries(result);
+  console.log('');
+  console.log(`[${label}] Result:`);
+  if (entries.length === 0) {
+    console.log('  (no result fields)');
+    return;
+  }
+  const keyWidth = Math.max(...entries.map(([key]) => key.length));
+  for (const [key, value] of entries) {
+    console.log(`  ${key.padEnd(keyWidth)}  ${value ?? 'null'}`);
+  }
+}
+
+async function runWithSuppressedStdout<T>(fn: () => Promise<T>): Promise<T> {
+  const originalLog = console.log;
+  const originalInfo = console.info;
+  const originalWarn = console.warn;
+  const noop = (): void => {};
+  console.log = noop;
+  console.info = noop;
+  console.warn = noop;
+  try {
+    return await fn();
+  } finally {
+    console.log = originalLog;
+    console.info = originalInfo;
+    console.warn = originalWarn;
+  }
+}
 
 function listSeedScopes() {
   return readdirSync(currentDir, { withFileTypes: true })
@@ -26,34 +67,80 @@ function listTopics(scope: string): string[] {
     .sort();
 }
 
-function printUsage() {
+async function loadSeedModule(scope: string, topic: string): Promise<SeedModule> {
+  const seedPath = join(currentDir, scope, `${topic}.ts`);
+  return (await import(pathToFileURL(seedPath).href)) as SeedModule;
+}
+
+async function loadTopicUsage(scope: string, topic: string): Promise<string | null> {
+  try {
+    const seedModule = await loadSeedModule(scope, topic);
+    return seedModule.usage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function printUsage() {
   const scopes = listSeedScopes();
 
-  console.log('Usage: pnpm dev:seed <service|app> <topic>');
+  console.log('Usage: pnpm dev:seed <scope>:<topic> [args...]');
+  console.log('       pnpm dev:seed <scope> <topic> [args...]');
+  console.log('');
+  console.log('Global flags:');
+  console.log('  --json   Print only the result as a single JSON object on stdout.');
+  console.log('           Combine with `pnpm -s` to also silence pnpm lifecycle banners,');
+  console.log('           e.g. `pnpm -s dev:seed app:create-user "Foo" foo@example.com --json`.');
   console.log('');
   console.log('Available seed topics:');
 
   for (const scope of scopes) {
     console.log(`- ${scope}`);
-    for (const topic of listTopics(scope)) {
-      console.log(`  - ${topic}`);
+    const topics = listTopics(scope);
+    const usages = await Promise.all(topics.map(topic => loadTopicUsage(scope, topic)));
+    for (const [index, topic] of topics.entries()) {
+      const usage = usages[index];
+      console.log(`  - ${scope}:${topic}${usage ? ` ${usage}` : ''}`);
     }
   }
 }
 
+function parseInvocation(
+  rawArgs: string[]
+): { scope: string; topic: string; topicArgs: string[] } | null {
+  if (rawArgs.length === 0) return null;
+
+  const [first, ...rest] = rawArgs;
+  if (first.includes(':')) {
+    const colonIndex = first.indexOf(':');
+    const scope = first.slice(0, colonIndex);
+    const topic = first.slice(colonIndex + 1);
+    if (!scope || !topic) return null;
+    return { scope, topic, topicArgs: rest };
+  }
+
+  if (rest.length === 0) return null;
+  const [topic, ...topicArgs] = rest;
+  return { scope: first, topic, topicArgs };
+}
+
 async function main() {
-  if (args.length < 2) {
-    printUsage();
+  const wantJson = args.includes(JSON_FLAG);
+  const cleanedArgs = args.filter(arg => arg !== JSON_FLAG);
+
+  const invocation = parseInvocation(cleanedArgs);
+  if (!invocation) {
+    await printUsage();
     process.exitCode = 1;
     return;
   }
 
-  const [scope, topic, ...topicArgs] = args;
+  const { scope, topic, topicArgs } = invocation;
   const scopes = listSeedScopes();
 
   if (!scopes.includes(scope)) {
     console.error(`Unknown seed scope: ${scope}`);
-    printUsage();
+    await printUsage();
     process.exitCode = 1;
     return;
   }
@@ -66,14 +153,24 @@ async function main() {
     return;
   }
 
-  const seedPath = join(currentDir, scope, `${topic}.ts`);
-  const seedModule = (await import(pathToFileURL(seedPath).href)) as SeedModule;
+  const seedModule = await loadSeedModule(scope, topic);
 
   if (typeof seedModule.run !== 'function') {
     throw new Error(`Seed module ${scope}/${topic} does not export a run() function`);
   }
 
-  await seedModule.run(...topicArgs);
+  const runSeed = seedModule.run;
+
+  if (wantJson) {
+    const result = await runWithSuppressedStdout(() => Promise.resolve(runSeed(...topicArgs)));
+    process.stdout.write(`${JSON.stringify(result ?? null)}\n`);
+    return;
+  }
+
+  const result = await runSeed(...topicArgs);
+  if (result && typeof result === 'object') {
+    printSeedResult(scope, topic, result);
+  }
 }
 
 main()

--- a/dev/seed/kiloclaw-billing/inactive-trials.ts
+++ b/dev/seed/kiloclaw-billing/inactive-trials.ts
@@ -10,6 +10,7 @@ import {
 import { and, eq, inArray, isNull } from 'drizzle-orm';
 
 import { getSeedDb } from '../lib/db';
+import type { SeedResult } from '../index';
 
 type SeedUser = typeof kilocode_users.$inferInsert;
 type SeedInstance = typeof kiloclaw_instances.$inferInsert;
@@ -30,6 +31,12 @@ const MARKED_INSTANCE_ID = '7e6dfbd9-fb9d-4e1b-b18d-e4513cc83f40';
 const MARKED_SUBSCRIPTION_ID = 'c90dc5ea-bd1e-442e-a16c-5f3d0d6143dd';
 const RECENT_INSTANCE_ID = '7bfef6d2-5250-4c73-a470-8bfd21cb9455';
 const RECENT_SUBSCRIPTION_ID = '3a2fbd7f-5d44-4fd4-8a5f-0e6d59eaa3f2';
+
+function printUsage(): void {
+  console.log('Usage: pnpm dev:seed kiloclaw-billing:inactive-trials');
+  console.log('');
+  console.log('Seeds one provisioned inactive trial candidate and DB-only comparison fixtures.');
+}
 
 const seedUsers = [
   {
@@ -358,7 +365,16 @@ async function loadEligibleFixtureSummary(): Promise<{
   };
 }
 
-export async function run(): Promise<void> {
+export async function run(...args: string[]): Promise<SeedResult | void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+  if (args.length > 0) {
+    printUsage();
+    throw new Error(`Unexpected arguments: ${args.join(' ')}`);
+  }
+
   console.log(`[${SEED_SCOPE}] Resetting existing seed data`);
   await destroySeedInstancesBestEffort();
   await cleanupExistingSeedRows();
@@ -374,27 +390,23 @@ export async function run(): Promise<void> {
   await insertAdditionalSeedRows();
 
   const eligible = await loadEligibleFixtureSummary();
+  const recentUser = seedUsers.find(user => user.id === RECENT_USER_ID);
+  const markedUser = seedUsers.find(user => user.id === MARKED_USER_ID);
 
   console.log('');
-  console.log(`[${SEED_SCOPE}] Seed complete`);
-  console.log('');
-  console.log('Eligible stop candidate (real provisioned local instance):');
-  console.log(`  email: ${eligible.user.google_user_email}`);
-  console.log(`  userId: ${eligible.user.id}`);
-  console.log(`  instanceId: ${eligible.instance.id}`);
-  console.log(`  subscriptionId: ${eligible.subscriptionId}`);
-  console.log(`  sandboxId: ${eligible.instance.sandbox_id}`);
-  console.log(`  createdAt: ${eligible.instance.created_at}`);
-  console.log('');
-  console.log('Comparison fixtures (DB-only):');
-  console.log(
-    `  recent trial user: ${seedUsers.find(user => user.id === RECENT_USER_ID)?.google_user_email}`
-  );
-  console.log(
-    `  inactive-trial-stopped user: ${seedUsers.find(user => user.id === MARKED_USER_ID)?.google_user_email}`
-  );
-  console.log('');
   console.log('You can now run:');
-  console.log('  pnpm dev:seed kiloclaw-billing inactive-trials');
   console.log('  curl "http://localhost:8807/__scheduled?cron=0+8+*+*+*"');
+
+  return {
+    eligibleUserId: eligible.user.id,
+    eligibleEmail: eligible.user.google_user_email,
+    eligibleInstanceId: eligible.instance.id,
+    eligibleSubscriptionId: eligible.subscriptionId,
+    eligibleSandboxId: eligible.instance.sandbox_id,
+    eligibleCreatedAt: eligible.instance.created_at,
+    recentUserId: RECENT_USER_ID,
+    recentEmail: recentUser?.google_user_email ?? null,
+    markedUserId: MARKED_USER_ID,
+    markedEmail: markedUser?.google_user_email ?? null,
+  };
 }

--- a/dev/seed/kiloclaw/fake-instance.ts
+++ b/dev/seed/kiloclaw/fake-instance.ts
@@ -2,9 +2,9 @@ import { randomUUID } from 'node:crypto';
 
 import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
 import {
+  credit_transactions,
   kilocode_users,
   kiloclaw_instances,
-  kiloclaw_subscription_change_log,
   kiloclaw_subscriptions,
 } from '@kilocode/db/schema';
 import {
@@ -15,7 +15,7 @@ import {
   KiloClawSubscriptionChangeActorType,
   KiloClawSubscriptionStatus,
 } from '@kilocode/db/schema-types';
-import { and, eq, inArray, isNull, like, ne } from 'drizzle-orm';
+import { and, eq, inArray, isNull, like, sql } from 'drizzle-orm';
 
 import { getSeedDb } from '../lib/db';
 import type { SeedResult } from '../index';
@@ -34,7 +34,7 @@ function printUsage(): void {
   console.log('  --name=<name>                  Instance name (default: Fake local KiloClaw)');
   console.log('');
   console.log(
-    'The script deletes prior fake instances for the same user (sandbox_id starts with ki_fake_)'
+    'The script retires prior fake instances for the same user (sandbox_id starts with ki_fake_)'
   );
   console.log('and refuses to run if the user already has a non-fake active personal instance.');
 }
@@ -143,6 +143,29 @@ function paymentSourceForPlan(plan: KiloClawPlan): KiloClawPaymentSource | null 
   return plan === KiloClawPlan.Trial ? null : KiloClawPaymentSource.Credits;
 }
 
+function costMicrodollarsForPlan(plan: KiloClawPlan): number | null {
+  switch (plan) {
+    case KiloClawPlan.Trial:
+      return null;
+    case KiloClawPlan.Standard:
+      return 9_000_000;
+    case KiloClawPlan.Commit:
+      return 48_000_000;
+  }
+}
+
+function periodKey(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+}
+
+function deductionCategoryForPlan(plan: KiloClawPlan, instanceId: string, date: Date): string {
+  const prefix =
+    plan === KiloClawPlan.Commit ? 'kiloclaw-subscription-commit' : 'kiloclaw-subscription';
+  return `${prefix}:${instanceId}:${periodKey(date)}`;
+}
+
 async function assertUserExists(userId: string): Promise<void> {
   const db = getSeedDb();
   const [user] = await db
@@ -181,6 +204,7 @@ export async function run(...args: string[]): Promise<SeedResult | void> {
         and(
           eq(kiloclaw_instances.user_id, options.userId),
           isNull(kiloclaw_instances.organization_id),
+          isNull(kiloclaw_instances.destroyed_at),
           like(kiloclaw_instances.sandbox_id, `${FAKE_SANDBOX_PREFIX}%`)
         )
       );
@@ -188,25 +212,49 @@ export async function run(...args: string[]): Promise<SeedResult | void> {
 
     if (priorFakeInstanceIds.length > 0) {
       const priorFakeSubscriptions = await tx
-        .select({ id: kiloclaw_subscriptions.id })
+        .select()
         .from(kiloclaw_subscriptions)
         .where(inArray(kiloclaw_subscriptions.instance_id, priorFakeInstanceIds));
       const priorFakeSubscriptionIds = priorFakeSubscriptions.map(subscription => subscription.id);
 
       if (priorFakeSubscriptionIds.length > 0) {
-        await tx
-          .delete(kiloclaw_subscription_change_log)
-          .where(
-            inArray(kiloclaw_subscription_change_log.subscription_id, priorFakeSubscriptionIds)
+        const retiredSubscriptions = await tx
+          .update(kiloclaw_subscriptions)
+          .set({
+            status: KiloClawSubscriptionStatus.Canceled,
+            cancel_at_period_end: false,
+            pending_conversion: false,
+          })
+          .where(inArray(kiloclaw_subscriptions.id, priorFakeSubscriptionIds))
+          .returning();
+
+        for (const retiredSubscription of retiredSubscriptions) {
+          const priorSubscription = priorFakeSubscriptions.find(
+            subscription => subscription.id === retiredSubscription.id
           );
-        await tx
-          .delete(kiloclaw_subscriptions)
-          .where(inArray(kiloclaw_subscriptions.id, priorFakeSubscriptionIds));
+          await insertKiloClawSubscriptionChangeLog(tx, {
+            subscriptionId: retiredSubscription.id,
+            actor: {
+              actorType: KiloClawSubscriptionChangeActorType.System,
+              actorId: 'dev-seed:kiloclaw/fake-instance',
+            },
+            action: KiloClawSubscriptionChangeAction.Canceled,
+            reason: 'dev_seed:replace_fake_instance',
+            before: priorSubscription ?? null,
+            after: retiredSubscription,
+          });
+        }
       }
 
       await tx
-        .delete(kiloclaw_instances)
-        .where(inArray(kiloclaw_instances.id, priorFakeInstanceIds));
+        .update(kiloclaw_instances)
+        .set({ destroyed_at: nowIso })
+        .where(
+          and(
+            inArray(kiloclaw_instances.id, priorFakeInstanceIds),
+            isNull(kiloclaw_instances.destroyed_at)
+          )
+        );
     }
 
     const activePersonalInstances = await tx
@@ -216,8 +264,7 @@ export async function run(...args: string[]): Promise<SeedResult | void> {
         and(
           eq(kiloclaw_instances.user_id, options.userId),
           isNull(kiloclaw_instances.organization_id),
-          isNull(kiloclaw_instances.destroyed_at),
-          ne(kiloclaw_instances.sandbox_id, sandboxId)
+          isNull(kiloclaw_instances.destroyed_at)
         )
       );
 
@@ -246,6 +293,65 @@ export async function run(...args: string[]): Promise<SeedResult | void> {
         tracked_image_tag: 'fake-local-instance',
       })
       .returning();
+
+    const costMicrodollars = costMicrodollarsForPlan(options.plan);
+    if (costMicrodollars !== null) {
+      const [user] = await tx
+        .select({
+          microdollarsUsed: kilocode_users.microdollars_used,
+          totalMicrodollarsAcquired: kilocode_users.total_microdollars_acquired,
+        })
+        .from(kilocode_users)
+        .where(eq(kilocode_users.id, options.userId))
+        .limit(1);
+
+      if (!user) {
+        throw new Error(`User ${options.userId} was not found. Sign in locally first.`);
+      }
+
+      const balanceMicrodollars = user.totalMicrodollarsAcquired - user.microdollarsUsed;
+      const creditGrantMicrodollars = Math.max(costMicrodollars - balanceMicrodollars, 0);
+
+      if (creditGrantMicrodollars > 0) {
+        await tx.insert(credit_transactions).values({
+          id: randomUUID(),
+          kilo_user_id: options.userId,
+          amount_microdollars: creditGrantMicrodollars,
+          is_free: true,
+          description: `Dev seed credits for KiloClaw ${options.plan} enrollment`,
+          credit_category: `dev-seed:kiloclaw-fake-instance-credit:${instance.id}`,
+          check_category_uniqueness: true,
+          original_baseline_microdollars_used: user.microdollarsUsed,
+          created_at: nowIso,
+        });
+
+        await tx
+          .update(kilocode_users)
+          .set({
+            total_microdollars_acquired: sql`${kilocode_users.total_microdollars_acquired} + ${creditGrantMicrodollars}`,
+          })
+          .where(eq(kilocode_users.id, options.userId));
+      }
+
+      await tx.insert(credit_transactions).values({
+        id: randomUUID(),
+        kilo_user_id: options.userId,
+        amount_microdollars: -costMicrodollars,
+        is_free: false,
+        description: `Dev seed KiloClaw ${options.plan} enrollment`,
+        credit_category: deductionCategoryForPlan(options.plan, instance.id, now),
+        check_category_uniqueness: true,
+        original_baseline_microdollars_used: user.microdollarsUsed,
+        created_at: nowIso,
+      });
+
+      await tx
+        .update(kilocode_users)
+        .set({
+          microdollars_used: sql`${kilocode_users.microdollars_used} + ${costMicrodollars}`,
+        })
+        .where(eq(kilocode_users.id, options.userId));
+    }
 
     const [subscription] = await tx
       .insert(kiloclaw_subscriptions)
@@ -278,7 +384,7 @@ export async function run(...args: string[]): Promise<SeedResult | void> {
       after: subscription,
     });
 
-    return { instance, subscription, deletedPriorFakeInstances: priorFakeInstanceIds.length };
+    return { instance, subscription, retiredPriorFakeInstances: priorFakeInstanceIds.length };
   });
 
   console.log('');
@@ -292,6 +398,6 @@ export async function run(...args: string[]): Promise<SeedResult | void> {
     plan: result.subscription.plan,
     status: result.subscription.status,
     periodEnd: result.subscription.current_period_end ?? result.subscription.trial_ends_at,
-    deletedPriorFakeInstances: result.deletedPriorFakeInstances,
+    retiredPriorFakeInstances: result.retiredPriorFakeInstances,
   };
 }

--- a/dev/seed/kiloclaw/fake-instance.ts
+++ b/dev/seed/kiloclaw/fake-instance.ts
@@ -1,0 +1,297 @@
+import { randomUUID } from 'node:crypto';
+
+import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
+import {
+  kilocode_users,
+  kiloclaw_instances,
+  kiloclaw_subscription_change_log,
+  kiloclaw_subscriptions,
+} from '@kilocode/db/schema';
+import {
+  KiloClawPaymentSource,
+  KiloClawPlan,
+  KiloClawProvider,
+  KiloClawSubscriptionChangeAction,
+  KiloClawSubscriptionChangeActorType,
+  KiloClawSubscriptionStatus,
+} from '@kilocode/db/schema-types';
+import { and, eq, inArray, isNull, like, ne } from 'drizzle-orm';
+
+import { getSeedDb } from '../lib/db';
+import type { SeedResult } from '../index';
+
+const FAKE_SANDBOX_PREFIX = 'ki_fake_';
+const DEFAULT_INSTANCE_NAME = 'Fake local KiloClaw';
+
+export const usage = '<user-id> [options]';
+
+function printUsage(): void {
+  console.log('Usage: pnpm dev:seed kiloclaw:fake-instance <user-id> [options]');
+  console.log('');
+  console.log('Options:');
+  console.log('  --plan=standard|trial|commit   Subscription plan to create (default: standard)');
+  console.log('  --days=<number>                Days until period/trial end');
+  console.log('  --name=<name>                  Instance name (default: Fake local KiloClaw)');
+  console.log('');
+  console.log(
+    'The script deletes prior fake instances for the same user (sandbox_id starts with ki_fake_)'
+  );
+  console.log('and refuses to run if the user already has a non-fake active personal instance.');
+}
+
+function parsePlan(value: string): KiloClawPlan {
+  switch (value) {
+    case KiloClawPlan.Trial:
+      return KiloClawPlan.Trial;
+    case KiloClawPlan.Standard:
+      return KiloClawPlan.Standard;
+    case KiloClawPlan.Commit:
+      return KiloClawPlan.Commit;
+    default:
+      throw new Error(`Unsupported --plan value: ${value}`);
+  }
+}
+
+function defaultDaysForPlan(plan: KiloClawPlan): number {
+  switch (plan) {
+    case KiloClawPlan.Trial:
+      return 7;
+    case KiloClawPlan.Standard:
+      return 30;
+    case KiloClawPlan.Commit:
+      return 180;
+  }
+}
+
+function parsePositiveInteger(value: string, flagName: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flagName} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseArgs(args: string[]): {
+  userId: string;
+  plan: KiloClawPlan;
+  days: number;
+  name: string;
+} {
+  const userId = args[0]?.trim();
+  if (!userId || userId === '--help' || userId === '-h') {
+    printUsage();
+    throw new Error('user-id is required');
+  }
+
+  let plan = KiloClawPlan.Standard;
+  let days: number | null = null;
+  let name = DEFAULT_INSTANCE_NAME;
+
+  for (const arg of args.slice(1)) {
+    if (arg === '--help' || arg === '-h') {
+      printUsage();
+      throw new Error('help requested');
+    }
+
+    if (arg.startsWith('--plan=')) {
+      plan = parsePlan(arg.slice('--plan='.length).trim());
+      continue;
+    }
+
+    if (arg.startsWith('--days=')) {
+      days = parsePositiveInteger(arg.slice('--days='.length).trim(), '--days');
+      continue;
+    }
+
+    if (arg.startsWith('--name=')) {
+      const parsedName = arg.slice('--name='.length).trim();
+      if (!parsedName) {
+        throw new Error('--name must not be empty');
+      }
+      name = parsedName;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    userId,
+    plan,
+    days: days ?? defaultDaysForPlan(plan),
+    name,
+  };
+}
+
+function addDays(date: Date, days: number): string {
+  const result = new Date(date);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result.toISOString();
+}
+
+function sandboxIdForInstance(instanceId: string): string {
+  return `${FAKE_SANDBOX_PREFIX}${instanceId.replaceAll('-', '')}`;
+}
+
+function statusForPlan(plan: KiloClawPlan): KiloClawSubscriptionStatus {
+  return plan === KiloClawPlan.Trial
+    ? KiloClawSubscriptionStatus.Trialing
+    : KiloClawSubscriptionStatus.Active;
+}
+
+function paymentSourceForPlan(plan: KiloClawPlan): KiloClawPaymentSource | null {
+  return plan === KiloClawPlan.Trial ? null : KiloClawPaymentSource.Credits;
+}
+
+async function assertUserExists(userId: string): Promise<void> {
+  const db = getSeedDb();
+  const [user] = await db
+    .select({ id: kilocode_users.id, email: kilocode_users.google_user_email })
+    .from(kilocode_users)
+    .where(eq(kilocode_users.id, userId))
+    .limit(1);
+
+  if (!user) {
+    throw new Error(`User ${userId} was not found. Sign in locally first or seed/create the user.`);
+  }
+}
+
+export async function run(...args: string[]): Promise<SeedResult | void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const options = parseArgs(args);
+  const db = getSeedDb();
+
+  await assertUserExists(options.userId);
+
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const periodEndIso = addDays(now, options.days);
+  const instanceId = randomUUID();
+  const sandboxId = sandboxIdForInstance(instanceId);
+
+  const result = await db.transaction(async tx => {
+    const priorFakeInstances = await tx
+      .select({ id: kiloclaw_instances.id })
+      .from(kiloclaw_instances)
+      .where(
+        and(
+          eq(kiloclaw_instances.user_id, options.userId),
+          isNull(kiloclaw_instances.organization_id),
+          like(kiloclaw_instances.sandbox_id, `${FAKE_SANDBOX_PREFIX}%`)
+        )
+      );
+    const priorFakeInstanceIds = priorFakeInstances.map(instance => instance.id);
+
+    if (priorFakeInstanceIds.length > 0) {
+      const priorFakeSubscriptions = await tx
+        .select({ id: kiloclaw_subscriptions.id })
+        .from(kiloclaw_subscriptions)
+        .where(inArray(kiloclaw_subscriptions.instance_id, priorFakeInstanceIds));
+      const priorFakeSubscriptionIds = priorFakeSubscriptions.map(subscription => subscription.id);
+
+      if (priorFakeSubscriptionIds.length > 0) {
+        await tx
+          .delete(kiloclaw_subscription_change_log)
+          .where(
+            inArray(kiloclaw_subscription_change_log.subscription_id, priorFakeSubscriptionIds)
+          );
+        await tx
+          .delete(kiloclaw_subscriptions)
+          .where(inArray(kiloclaw_subscriptions.id, priorFakeSubscriptionIds));
+      }
+
+      await tx
+        .delete(kiloclaw_instances)
+        .where(inArray(kiloclaw_instances.id, priorFakeInstanceIds));
+    }
+
+    const activePersonalInstances = await tx
+      .select({ id: kiloclaw_instances.id, sandboxId: kiloclaw_instances.sandbox_id })
+      .from(kiloclaw_instances)
+      .where(
+        and(
+          eq(kiloclaw_instances.user_id, options.userId),
+          isNull(kiloclaw_instances.organization_id),
+          isNull(kiloclaw_instances.destroyed_at),
+          ne(kiloclaw_instances.sandbox_id, sandboxId)
+        )
+      );
+
+    if (activePersonalInstances.length > 0) {
+      const instanceList = activePersonalInstances
+        .map(instance => `${instance.id} (${instance.sandboxId})`)
+        .join(', ');
+      throw new Error(
+        `User ${options.userId} already has active personal KiloClaw instance(s): ${instanceList}`
+      );
+    }
+
+    const [instance] = await tx
+      .insert(kiloclaw_instances)
+      .values({
+        id: instanceId,
+        user_id: options.userId,
+        sandbox_id: sandboxId,
+        provider: KiloClawProvider.DockerLocal,
+        organization_id: null,
+        name: options.name,
+        inbound_email_enabled: true,
+        inactive_trial_stopped_at: null,
+        created_at: nowIso,
+        destroyed_at: null,
+        tracked_image_tag: 'fake-local-instance',
+      })
+      .returning();
+
+    const [subscription] = await tx
+      .insert(kiloclaw_subscriptions)
+      .values({
+        user_id: options.userId,
+        instance_id: instance.id,
+        payment_source: paymentSourceForPlan(options.plan),
+        plan: options.plan,
+        status: statusForPlan(options.plan),
+        cancel_at_period_end: false,
+        pending_conversion: false,
+        trial_started_at: options.plan === KiloClawPlan.Trial ? nowIso : null,
+        trial_ends_at: options.plan === KiloClawPlan.Trial ? periodEndIso : null,
+        current_period_start: options.plan === KiloClawPlan.Trial ? null : nowIso,
+        current_period_end: options.plan === KiloClawPlan.Trial ? null : periodEndIso,
+        credit_renewal_at: options.plan === KiloClawPlan.Trial ? null : periodEndIso,
+        commit_ends_at: options.plan === KiloClawPlan.Commit ? periodEndIso : null,
+      })
+      .returning();
+
+    await insertKiloClawSubscriptionChangeLog(tx, {
+      subscriptionId: subscription.id,
+      actor: {
+        actorType: KiloClawSubscriptionChangeActorType.System,
+        actorId: 'dev-seed:kiloclaw/fake-instance',
+      },
+      action: KiloClawSubscriptionChangeAction.Created,
+      reason: 'dev_seed:fake_instance',
+      before: null,
+      after: subscription,
+    });
+
+    return { instance, subscription, deletedPriorFakeInstances: priorFakeInstanceIds.length };
+  });
+
+  console.log('');
+  console.log('Note: this is DB-only. No Durable Object, container, or provider resource exists.');
+
+  return {
+    userId: options.userId,
+    instanceId: result.instance.id,
+    sandboxId: result.instance.sandbox_id,
+    subscriptionId: result.subscription.id,
+    plan: result.subscription.plan,
+    status: result.subscription.status,
+    periodEnd: result.subscription.current_period_end ?? result.subscription.trial_ends_at,
+    deletedPriorFakeInstances: result.deletedPriorFakeInstances,
+  };
+}

--- a/dev/seed/lib/email.ts
+++ b/dev/seed/lib/email.ts
@@ -1,0 +1,20 @@
+export function normalizeSeedEmail(email: string): string {
+  const trimmed = email.trim().toLowerCase();
+  const atIndex = trimmed.lastIndexOf('@');
+  if (atIndex === -1) return trimmed;
+
+  let local = trimmed.slice(0, atIndex);
+  const domain = trimmed.slice(atIndex + 1);
+
+  const plusIndex = local.indexOf('+');
+  if (plusIndex !== -1) {
+    local = local.slice(0, plusIndex);
+  }
+
+  const isGmail = domain === 'gmail.com' || domain === 'googlemail.com';
+  if (isGmail) {
+    local = local.replace(/\./g, '');
+  }
+
+  return `${local}@${isGmail ? 'gmail.com' : domain}`;
+}

--- a/dev/seed/lib/preflight.ts
+++ b/dev/seed/lib/preflight.ts
@@ -1,0 +1,10 @@
+// Runs before any other module is loaded so we can influence module-level side
+// effects (notably dotenv's tip banner). Imported as the very first statement
+// in dev/seed/index.ts.
+
+if (process.argv.includes('--json')) {
+  // dotenv@17 reads DOTENV_CONFIG_QUIET to suppress its tip banner. We set it
+  // here so that `apps/web/src/lib/load-env` (loaded transitively from
+  // `./lib/db`) stays silent in machine-readable mode.
+  process.env.DOTENV_CONFIG_QUIET = 'true';
+}

--- a/dev/seed/lib/stripe.ts
+++ b/dev/seed/lib/stripe.ts
@@ -1,0 +1,47 @@
+import Stripe from 'stripe';
+
+let cachedClient: Stripe | null = null;
+
+function getSeedStripeClient(): Stripe {
+  if (cachedClient) return cachedClient;
+
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    throw new Error(
+      'STRIPE_SECRET_KEY is not set. Run `vercel env pull` so dev seeds can create Stripe ' +
+        'customers (the real signup flow does the same).'
+    );
+  }
+  if (!secretKey.startsWith('sk_test_')) {
+    throw new Error(
+      `STRIPE_SECRET_KEY does not look like a test-mode key (expected sk_test_…). Refusing ` +
+        `to create real Stripe customers from a dev seed script.`
+    );
+  }
+
+  cachedClient = new Stripe(secretKey);
+  return cachedClient;
+}
+
+export async function createSeedStripeCustomer(params: {
+  email: string;
+  name: string;
+  kiloUserId: string;
+}): Promise<Stripe.Customer> {
+  return getSeedStripeClient().customers.create({
+    email: params.email,
+    name: params.name,
+    metadata: { kiloUserId: params.kiloUserId, source: 'dev-seed' },
+  });
+}
+
+export async function deleteSeedStripeCustomer(stripeCustomerId: string): Promise<void> {
+  try {
+    await getSeedStripeClient().customers.del(stripeCustomerId);
+  } catch (error) {
+    console.warn(
+      `[dev-seed] Failed to clean up Stripe customer ${stripeCustomerId}:`,
+      error instanceof Error ? error.message : error
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Adds a reusable local seed runner and development fixtures for app users, credits, and KiloClaw test data.

### Why this change is needed
Local setup and debugging need repeatable seed commands that create realistic data without requiring manual database edits or production-like onboarding flows. The KiloClaw fixtures also need to preserve billing/data-model invariants so local debugging does not rely on impossible states.

### How this is addressed
- Adds a `pnpm dev:seed` runner that discovers seed topics, supports `scope:topic` and `scope topic` invocation, and can emit clean JSON for scripts.
- Adds seed topics for creating local app users, adding credits, creating fake KiloClaw instances, and preparing inactive trial fixtures.
- Creates real Stripe test-mode customers for seeded app users so Stripe-touching local pages do not fail on placeholder customer IDs.
- Aligns fake KiloClaw paid subscriptions with the credit ledger by adding matching credit grants/deductions and spend counter updates.
- Retires prior fake KiloClaw instances instead of deleting canonical instance, subscription, and audit-history rows.
- Documents the `dev/seed` topic contract for future seed additions.

## Human Verification
<details>
<summary>Completed in-session checks</summary>

- Reviewed branch changes against the KiloClaw billing, data model, and controller specs where relevant.
- Ran help-output smoke checks for:
  - `pnpm -s dev:seed app:create-user --help`
  - `pnpm -s dev:seed kiloclaw:fake-instance --help`
  - `pnpm -s dev:seed app:add-credits --help`

</details>

## Reviewer Notes
### Human Reviewer Flags
- `dev/seed` is intentionally outside the main TypeScript project checks and runs through `tsx`; `dev/seed/AGENTS.md` documents this workflow.
- Fake KiloClaw instances are DB-only fixtures. They do not create Durable Objects, containers, or provider resources.
- The KiloClaw fake-instance seed now preserves canonical history by retiring prior fake rows instead of hard-deleting them.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Seeded user email normalization is mirrored locally in `dev/seed/lib/email.ts` to avoid importing from `apps/web/src/...` while matching production duplicate-detection behavior.
- Paid fake KiloClaw subscriptions insert credit transactions and update `kilocode_users.microdollars_used` in the same transaction as the subscription fixture.
- Prior fake subscriptions receive subscription change-log entries when replaced, preserving auditability for local lifecycle debugging.

</details>
