### PR TITLE
fix(slack): remove unused files:write and users:read.email scopes

### DIFF
--- a/apps/web/src/lib/integrations/slack-service.ts
+++ b/apps/web/src/lib/integrations/slack-service.ts
@@ -40,7 +40,6 @@ export const SLACK_SCOPES = [
   'channels:read',
   'chat:write',
   'files:read',
-  'files:write',
   'groups:history',
   'groups:read',
   'im:history',
@@ -51,7 +50,6 @@ export const SLACK_SCOPES = [
   'reactions:write',
   'team:read',
   'users:read',
-  'users:read.email',
 ];
 
 export function getMissingSlackScopes(installedScopes: string[] | null): string[] {

--- a/apps/web/src/lib/slack-bot/slack-utils.ts
+++ b/apps/web/src/lib/slack-bot/slack-utils.ts
@@ -1,4 +1,4 @@
-import { WebClient, type SlackEvent } from '@slack/web-api';
+import type { WebClient, SlackEvent } from '@slack/web-api';
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -36,57 +36,6 @@ export async function getSlackUserDisplayAndRealName(
   } catch {
     return undefined;
   }
-}
-
-/**
- * Get a Slack user's email address.
- * Requires the `users:read.email` scope on the Slack app.
- *
- * @param client - The Slack WebClient initialized with the workspace access token
- * @param userId - The Slack user ID (e.g., "U1234567890")
- * @returns The user's email address, or undefined if not available
- */
-export async function getSlackUserEmail(
-  client: WebClient,
-  userId: string
-): Promise<string | undefined> {
-  try {
-    const result = await client.users.info({ user: userId });
-
-    if (!result.ok || !result.user) {
-      return undefined;
-    }
-
-    return result.user.profile?.email;
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Get a Slack user's email using an installation's access token.
- * Requires the `users:read.email` scope on the Slack app.
- *
- * @param installation - The Slack installation with metadata containing access_token
- * @param userId - The Slack user ID (e.g., "U1234567890")
- * @returns The user's email address, or undefined if not available
- */
-export async function getSlackUserEmailFromInstallation(
-  installation: { metadata: unknown } | null,
-  userId: string
-): Promise<string | undefined> {
-  const metadata = installation?.metadata;
-  if (!isRecord(metadata)) {
-    return undefined;
-  }
-
-  const accessToken = metadata['access_token'];
-  if (typeof accessToken !== 'string') {
-    return undefined;
-  }
-
-  const client = new WebClient(accessToken);
-  return getSlackUserEmail(client, userId);
 }
 
 export function formatSlackUserDisplayAndRealName(


### PR DESCRIPTION
## Summary

Slack marketplace review flagged that our OAuth URL requested two scopes that were not declared in the marketplace submission: `files:write` and `users:read.email`. Removing them from `SLACK_SCOPES` in `apps/web/src/lib/integrations/slack-service.ts` so the OAuth URL Slack issues to new installs only asks for the 16 scopes we actually documented.

Neither scope is exercised by the bot today:

- `files:write` — no `files.upload` / `filesUpload` / `uploadV2` calls anywhere in the repo.
- `users:read.email` — only consumed by `getSlackUserEmail` and `getSlackUserEmailFromInstallation` in `apps/web/src/lib/slack-bot/slack-utils.ts`, both of which had zero callers. Removed those helpers as well so the scope can't sneak back in via a future caller without the marketplace listing being updated first.

## Verification

- Re-read `apps/web/src/lib/integrations/slack-service.ts` and confirmed `SLACK_SCOPES` matches the 16 scopes listed in the marketplace submission, in the same order.
- `rg "getSlackUserEmail|files:write|files\.upload|filesUpload"` returns no hits after the change.

## Visual Changes

N/A

## Reviewer Notes

- Existing installations keep whatever scopes they were originally granted; this only affects the scope list new installs (and `Reinstall` flows) request. The `getMissingSlackScopes` helper used in the connect-status UI will now stop flagging these two as missing for older installs that never had them.
- If we ever do want to ingest user emails from Slack, we'll need to add `users:read.email` back to both the marketplace submission and `SLACK_SCOPES`, and re-add a vetted helper.