### PR TITLE
fix(bot): gate GitHub replies to linked repos

### DIFF
--- a/apps/web/src/lib/bot.ts
+++ b/apps/web/src/lib/bot.ts
@@ -8,10 +8,12 @@ import { resolveKiloUserId, unlinkKiloUser, unlinkTeamKiloUsers } from '@/lib/bo
 import { isSlackMissingScopeError, postSlackReinstallInstruction } from '@/lib/bot/helpers';
 import { deleteInstallationByTeamId } from '@/lib/integrations/slack-service';
 import {
+  getGitHubRepositoryReference,
   getPlatformIdentity,
   getPlatformIntegration,
   getPlatformIntegrationByBotUserId,
   isGitHubBotEnabled,
+  isGitHubRepositoryLinked,
 } from '@/lib/bot/platform-helpers';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import { LINK_ACCOUNT_ACTION_PREFIX, promptLinkAccount } from '@/lib/bot/link-account';
@@ -287,6 +289,13 @@ function createKiloBot(
     // handler runs, but we drop out before any user-visible side effects
     // (no link prompt, no agent run, no GitHub API calls).
     if (identity.platform === PLATFORM.GITHUB && !isGitHubBotEnabled(platformIntegration)) {
+      return;
+    }
+
+    if (
+      identity.platform === PLATFORM.GITHUB &&
+      !isGitHubRepositoryLinked(platformIntegration, getGitHubRepositoryReference(thread, message))
+    ) {
       return;
     }
 

--- a/apps/web/src/lib/bot/platform-helpers.test.ts
+++ b/apps/web/src/lib/bot/platform-helpers.test.ts
@@ -15,9 +15,11 @@ jest.mock('@/lib/drizzle', () => ({
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import {
   getBotDocumentationUrl,
+  getGitHubRepositoryReference,
   getPlatformIdentity,
   getPlatformIntegration,
   getPlatformIntegrationByBotUserId,
+  isGitHubRepositoryLinked,
   getPlatformIntegrationById,
   isGitHubBotEnabled,
 } from './platform-helpers';
@@ -169,6 +171,105 @@ describe('platform helpers', () => {
 
     it('returns false when explicitly disabled', () => {
       expect(isGitHubBotEnabled(integrationWithMetadata({ bot_enabled: false }))).toBe(false);
+    });
+  });
+
+  describe('getGitHubRepositoryReference', () => {
+    it('uses GitHub webhook repository metadata when available', () => {
+      const reference = getGitHubRepositoryReference(
+        {
+          adapter: { name: PLATFORM.GITHUB },
+          channelId: 'github:acme/fallback',
+          id: 'github:acme/fallback:42',
+        } as Thread,
+        {
+          raw: {
+            repository: {
+              id: 123,
+              full_name: 'acme/widgets',
+            },
+          },
+        } as Message
+      );
+
+      expect(reference).toEqual({ id: 123, fullName: 'acme/widgets' });
+    });
+
+    it('falls back to the repository encoded in the GitHub thread id', () => {
+      const reference = getGitHubRepositoryReference(
+        {
+          adapter: { name: PLATFORM.GITHUB },
+          channelId: 'github:acme/widgets',
+          id: 'github:acme/widgets:issue:42',
+        } as Thread,
+        { raw: {} } as Message
+      );
+
+      expect(reference).toEqual({ id: null, fullName: 'acme/widgets' });
+    });
+
+    it('falls back to the repository encoded in the GitHub channel id', () => {
+      const reference = getGitHubRepositoryReference(
+        {
+          adapter: { name: PLATFORM.GITHUB },
+          channelId: 'github:acme/widgets',
+          id: 'github:malformed',
+        } as Thread,
+        { raw: {} } as Message
+      );
+
+      expect(reference).toEqual({ id: null, fullName: 'acme/widgets' });
+    });
+  });
+
+  describe('isGitHubRepositoryLinked', () => {
+    function integrationWithRepositoryAccess(
+      repositoryAccess: PlatformIntegration['repository_access'],
+      repositories: PlatformIntegration['repositories']
+    ): PlatformIntegration {
+      return { repository_access: repositoryAccess, repositories } as PlatformIntegration;
+    }
+
+    const selectedIntegration = integrationWithRepositoryAccess('selected', [
+      { id: 123, name: 'widgets', full_name: 'acme/widgets', private: true },
+    ]);
+
+    it('allows all repositories when the integration has all repository access', () => {
+      const integration = integrationWithRepositoryAccess('all', null);
+
+      expect(isGitHubRepositoryLinked(integration, { id: null, fullName: 'acme/widgets' })).toBe(
+        true
+      );
+    });
+
+    it('allows selected repositories by id', () => {
+      expect(isGitHubRepositoryLinked(selectedIntegration, { id: 123, fullName: null })).toBe(true);
+    });
+
+    it('allows selected repositories by case-insensitive full name', () => {
+      expect(
+        isGitHubRepositoryLinked(selectedIntegration, { id: null, fullName: 'ACME/Widgets' })
+      ).toBe(true);
+    });
+
+    it('blocks repositories not selected for the installation', () => {
+      expect(
+        isGitHubRepositoryLinked(selectedIntegration, { id: 456, fullName: 'acme/other' })
+      ).toBe(false);
+    });
+
+    it('blocks when repository access has not been synced yet', () => {
+      const integration = integrationWithRepositoryAccess(null, null);
+
+      expect(isGitHubRepositoryLinked(integration, { id: 123, fullName: 'acme/widgets' })).toBe(
+        false
+      );
+    });
+
+    it('blocks when the repository cannot be identified', () => {
+      const integration = integrationWithRepositoryAccess('all', null);
+
+      expect(isGitHubRepositoryLinked(integration, { id: null, fullName: null })).toBe(false);
     });
   });
 

--- a/apps/web/src/lib/bot/platform-helpers.ts
+++ b/apps/web/src/lib/bot/platform-helpers.ts
@@ -8,6 +8,60 @@ import { type SlackEvent } from '@chat-adapter/slack';
 
 type GetGitHubInstallationId = (thread: Thread) => Promise<string | number | null | undefined>;
 
+export type GitHubRepositoryReference = {
+  id: number | null;
+  fullName: string | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getStringProperty(value: Record<string, unknown>, key: string): string | null {
+  const property = value[key];
+  return typeof property === 'string' && property.length > 0 ? property : null;
+}
+
+function getNumberProperty(value: Record<string, unknown>, key: string): number | null {
+  const property = value[key];
+  return typeof property === 'number' && Number.isFinite(property) ? property : null;
+}
+
+function parseGitHubRepositoryFullName(id: string | undefined): string | null {
+  if (!id) return null;
+
+  const match = id.match(/^github:([^/]+\/[^:]+)(?::|$)/);
+  if (!match) return null;
+
+  return match[1] ?? null;
+}
+
+function getGitHubRepositoryReferenceFromRaw(raw: unknown): GitHubRepositoryReference {
+  if (!isRecord(raw)) return { id: null, fullName: null };
+
+  const repository = raw.repository;
+  if (!isRecord(repository)) return { id: null, fullName: null };
+
+  return {
+    id: getNumberProperty(repository, 'id'),
+    fullName: getStringProperty(repository, 'full_name'),
+  };
+}
+
+export function getGitHubRepositoryReference(
+  thread: Thread,
+  message: Message
+): GitHubRepositoryReference {
+  const rawReference = getGitHubRepositoryReferenceFromRaw(message.raw);
+  return {
+    id: rawReference.id,
+    fullName:
+      rawReference.fullName ??
+      parseGitHubRepositoryFullName(thread.id) ??
+      parseGitHubRepositoryFullName(thread.channelId),
+  };
+}
+
 function getSlackTeamId(message: Message<SlackEvent>): string {
   const teamId = message.raw.team_id ?? message.raw.team;
 
@@ -112,6 +166,26 @@ export async function getPlatformIntegrationByBotUserId(
 export function isGitHubBotEnabled(integration: PlatformIntegration): boolean {
   const metadata = (integration.metadata ?? {}) as { bot_enabled?: unknown };
   return metadata.bot_enabled === true;
+}
+
+export function isGitHubRepositoryLinked(
+  integration: PlatformIntegration,
+  repository: GitHubRepositoryReference
+): boolean {
+  if (repository.id === null && repository.fullName === null) return false;
+
+  if (integration.repository_access === 'all') return true;
+  if (integration.repository_access !== 'selected') return false;
+
+  const repositories = integration.repositories ?? [];
+  return repositories.some(linkedRepository => {
+    if (repository.id !== null && linkedRepository.id === repository.id) return true;
+
+    return (
+      repository.fullName !== null &&
+      linkedRepository.full_name.toLowerCase() === repository.fullName.toLowerCase()
+    );
+  });
 }
 
 export function getBotDocumentationUrl(platform: string): string {

--- a/apps/web/src/lib/bot/platform-helpers.ts
+++ b/apps/web/src/lib/bot/platform-helpers.ts
@@ -3,6 +3,7 @@ import { db } from '@/lib/drizzle';
 import { eq, and, sql } from 'drizzle-orm';
 import { platform_integrations, type PlatformIntegration } from '@kilocode/db';
 import type { Message, Thread } from 'chat';
+import type { GitHubRawMessage } from '@chat-adapter/github';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import { type SlackEvent } from '@chat-adapter/slack';
 
@@ -12,20 +13,6 @@ export type GitHubRepositoryReference = {
   id: number | null;
   fullName: string | null;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function getStringProperty(value: Record<string, unknown>, key: string): string | null {
-  const property = value[key];
-  return typeof property === 'string' && property.length > 0 ? property : null;
-}
-
-function getNumberProperty(value: Record<string, unknown>, key: string): number | null {
-  const property = value[key];
-  return typeof property === 'number' && Number.isFinite(property) ? property : null;
-}
 
 function parseGitHubRepositoryFullName(id: string | undefined): string | null {
   if (!id) return null;
@@ -37,14 +24,11 @@ function parseGitHubRepositoryFullName(id: string | undefined): string | null {
 }
 
 function getGitHubRepositoryReferenceFromRaw(raw: unknown): GitHubRepositoryReference {
-  if (!isRecord(raw)) return { id: null, fullName: null };
-
-  const repository = raw.repository;
-  if (!isRecord(repository)) return { id: null, fullName: null };
+  const repository = (raw as Partial<GitHubRawMessage>).repository;
 
   return {
-    id: getNumberProperty(repository, 'id'),
-    fullName: getStringProperty(repository, 'full_name'),
+    id: repository?.id ?? null,
+    fullName: repository?.full_name ?? null,
   };
 }
 

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.test.ts
@@ -1,5 +1,65 @@
+const mockGetBotUserId = jest.fn();
+const mockGetAgentConfigForOwner = jest.fn();
+
+jest.mock('@/lib/bot-users/bot-user-service', () => ({
+  getBotUserId: (organizationId: string, botType: string) =>
+    mockGetBotUserId(organizationId, botType),
+}));
+
+jest.mock('@/lib/agent-config/db/agent-configs', () => ({
+  getAgentConfigForOwner: (owner: unknown, agentType: string, platform: string) =>
+    mockGetAgentConfigForOwner(owner, agentType, platform),
+}));
+
 import { resolvePullRequestCheckoutRef } from '@/lib/integrations/platforms/github/webhook-handlers/pull-request-checkout-ref';
-import { shouldSkipSynchronizeForMergeCommit } from '@/lib/integrations/platforms/github/webhook-handlers/pull-request-handler';
+import {
+  handlePullRequest,
+  shouldSkipSynchronizeForMergeCommit,
+} from '@/lib/integrations/platforms/github/webhook-handlers/pull-request-handler';
+import type { PullRequestPayload } from '@/lib/integrations/platforms/github/webhook-schemas';
+import type { PlatformIntegration } from '@kilocode/db/schema';
+
+function pullRequestPayload(overrides: Partial<PullRequestPayload> = {}): PullRequestPayload {
+  return {
+    action: 'synchronize',
+    installation: { id: 98765 },
+    repository: {
+      id: 123,
+      name: 'widgets',
+      full_name: 'acme/widgets',
+      owner: { login: 'acme' },
+    },
+    pull_request: {
+      number: 42,
+      title: 'Add widgets',
+      state: 'open',
+      draft: false,
+      html_url: 'https://github.com/acme/widgets/pull/42',
+      user: { id: 111, login: 'alice', avatar_url: 'https://example.com/a.png' },
+      head: { sha: 'abc123', ref: 'feature/widgets', repo: { full_name: 'acme/widgets' } },
+      base: { sha: 'def456', ref: 'main' },
+    },
+    ...overrides,
+  };
+}
+
+function platformIntegration(overrides: Partial<PlatformIntegration> = {}): PlatformIntegration {
+  return {
+    id: '8b2ff443-8396-4b07-99ae-7015789da7dd',
+    owned_by_organization_id: 'f2aa36d7-9c1b-4db9-ae4a-a4492618796d',
+    owned_by_user_id: null,
+    kilo_requester_user_id: null,
+    platform_installation_id: '98765',
+    github_app_type: 'standard',
+    ...overrides,
+  } as PlatformIntegration;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetBotUserId.mockResolvedValue(null);
+  mockGetAgentConfigForOwner.mockResolvedValue(null);
+});
 
 describe('resolvePullRequestCheckoutRef', () => {
   it('uses head.ref for same-repo PRs', () => {
@@ -123,5 +183,19 @@ describe('shouldSkipSynchronizeForMergeCommit', () => {
     });
 
     expect(calls).toEqual([['inst-1', 'acme', 'widgets', 'deadbeef', 'standard']]);
+  });
+});
+
+describe('handlePullRequest', () => {
+  it('acknowledges org integrations that do not have a code review user context', async () => {
+    const response = await handlePullRequest(pullRequestPayload(), platformIntegration());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ message: 'Code review user context not configured' });
+    expect(mockGetBotUserId).toHaveBeenCalledWith(
+      'f2aa36d7-9c1b-4db9-ae4a-a4492618796d',
+      'code-review'
+    );
+    expect(mockGetAgentConfigForOwner).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.ts
@@ -104,7 +104,10 @@ export async function handlePullRequestCodeReview(
         ownedByUserId: integration.owned_by_user_id,
         kiloRequesterId: integration.kilo_requester_user_id,
       });
-      return NextResponse.json({ message: 'Integration missing user context' }, { status: 500 });
+      return NextResponse.json(
+        { message: 'Code review user context not configured' },
+        { status: 200 }
+      );
     }
 
     // 2. Check if code review agent is enabled for this owner


### PR DESCRIPTION
## Summary
- Gate GitHub bot mention handling to repositories linked to the installation, using webhook repository metadata with thread/channel fallbacks.
- Add coverage for GitHub repository reference extraction and selected/all repository access decisions.
- Acknowledge pull request webhooks without code review user context as non-actionable instead of returning 500.

## Verification
- Mentioned Kilo from a GitHub issue thread during local webhook testing and confirmed the failure path was from the pull request code-review handler, not the bot mention path.

## Visual Changes
N/A

## Reviewer Notes
- GitHub bot mentions in repositories not included in a selected-repository installation are silently ignored before link prompts or agent runs.
- Full monorepo typecheck was intentionally not run; used the narrower web package check per repo guidance.