### PR TITLE
chore(gastown): fix format and lint CI failures

### DIFF
--- a/services/gastown/container/src/main.ts
+++ b/services/gastown/container/src/main.ts
@@ -33,7 +33,7 @@ process.on('unhandledRejection', (reason, promise) => {
     townId: TOWN_ID,
     uptimeMs: getUptime(),
     activeAgents: activeAgentCount(),
-    promise: String(promise),
+    event: 'unhandled_rejection',
   });
 });
 

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -47,11 +47,7 @@ import { agent_metadata } from '../db/tables/agent-metadata.table';
 import { escalation_metadata } from '../db/tables/escalation-metadata.table';
 import { convoy_metadata } from '../db/tables/convoy-metadata.table';
 import { bead_dependencies } from '../db/tables/bead-dependencies.table';
-import {
-  town_events,
-  TownEventRecord,
-  type TownEventType,
-} from '../db/tables/town-events.table';
+import { town_events, TownEventRecord, type TownEventType } from '../db/tables/town-events.table';
 import {
   agent_nudges,
   AgentNudgeRecord,
@@ -3905,8 +3901,7 @@ export class TownDO extends DurableObject<Env> {
           // succeed on retry — mark them processed so the drain loop
           // stops re-running them every alarm tick.
           const isMissingEntity =
-            err instanceof Error &&
-            /\b(Bead|Agent) [0-9a-f-]{36} not found\b/.test(err.message);
+            err instanceof Error && /\b(Bead|Agent) [0-9a-f-]{36} not found\b/.test(err.message);
           if (isMissingEntity) {
             logger.warn('reconciler: applyEvent skipped (missing entity)', {
               eventId: event.event_id,

--- a/services/gastown/test/integration/event-cleanup.test.ts
+++ b/services/gastown/test/integration/event-cleanup.test.ts
@@ -59,9 +59,9 @@ describe('town_events cleanup on bead deletion (#fix-1)', () => {
       bead_id: string | null;
       agent_id: string | null;
     }>;
-    expect(
-      pendingAfter.some(e => e.bead_id === bead.bead_id || e.agent_id === bead.bead_id)
-    ).toBe(false);
+    expect(pendingAfter.some(e => e.bead_id === bead.bead_id || e.agent_id === bead.bead_id)).toBe(
+      false
+    );
   });
 
   it('deleteBead also removes events referencing the bead as agent_id (agents are beads)', async () => {


### PR DESCRIPTION
## Summary
Fixes two CI failures blocking the `gastown-staging` → `main` batch PR (#2974).

### format-check failure
Two files were not formatted with `oxfmt`:
- `services/gastown/src/dos/Town.do.ts`
- `services/gastown/test/integration/event-cleanup.test.ts`

### lint failure (oxlint: `no-base-to-string`)
`services/gastown/container/src/main.ts:36` — `String(promise)` stringifies a Promise as `[object Object]`. Replaced with `event: 'unhandled_rejection'` string marker. The rejected promise's value is already captured in the `reason` field.