### PR TITLE
chore(gastown): drop unused promise param from unhandledRejection handler

### DIFF
--- a/services/gastown/container/src/main.ts
+++ b/services/gastown/container/src/main.ts
@@ -23,7 +23,7 @@ log.info('container.cold_start', {
 // We deliberately DO NOT call process.exit here: visibility is the goal.
 // If a specific rejection turns out to be fatal state corruption we can
 // escalate it individually.
-process.on('unhandledRejection', (reason, promise) => {
+process.on('unhandledRejection', reason => {
   const err =
     reason instanceof Error
       ? { message: reason.message, stack: reason.stack, name: reason.name }
@@ -33,7 +33,6 @@ process.on('unhandledRejection', (reason, promise) => {
     townId: TOWN_ID,
     uptimeMs: getUptime(),
     activeAgents: activeAgentCount(),
-    event: 'unhandled_rejection',
   });
 });
 


### PR DESCRIPTION
Follow-up to #3072. Toast removed `String(promise)` (the no-base-to-string lint error) but left the `promise` parameter declared, tripping a different lint rule:

```
Parameter 'promise' is declared but never used. Unused parameters should start with a '_'.
```

Drops the parameter entirely. Also removes the now-redundant `event: 'unhandled_rejection'` field from the log payload — the log key (`container.unhandled_rejection`) already conveys that.

Unblocks PR #2974 (`gastown-staging` → `main` promote).