### PR TITLE
fix(github): use app.kilocode.ai for OAuth redirect_uri in prod

### DIFF
--- a/apps/web/src/app/github/link/route.ts
+++ b/apps/web/src/app/github/link/route.ts
@@ -10,6 +10,12 @@ import { isOrganizationMember } from '@/lib/organizations/organizations';
 
 const GITHUB_AUTHORIZE_URL = 'https://github.com/login/oauth/authorize';
 const GITHUB_CALLBACK_PATH = '/api/integrations/github/callback';
+// In production the redirect_uri must exactly match the URL registered with
+// the GitHub OAuth app (app.kilocode.ai), regardless of which host the user
+// hit. APP_URL points to app.kilo.ai in production, so we override it here.
+// In development we keep using APP_URL so localhost works.
+const GITHUB_CALLBACK_BASE_URL =
+  process.env.NODE_ENV === 'production' ? 'https://app.kilocode.ai' : APP_URL;
 
 function errorPage(title: string, message: string, status: number): Response {
   return new Response(
@@ -78,7 +84,10 @@ export async function GET(request: NextRequest) {
   const credentials = getGitHubAppCredentials(appType);
   const authorizeUrl = new URL(GITHUB_AUTHORIZE_URL);
   authorizeUrl.searchParams.set('client_id', credentials.clientId);
-  authorizeUrl.searchParams.set('redirect_uri', new URL(GITHUB_CALLBACK_PATH, APP_URL).toString());
+  authorizeUrl.searchParams.set(
+    'redirect_uri',
+    new URL(GITHUB_CALLBACK_PATH, GITHUB_CALLBACK_BASE_URL).toString()
+  );
   authorizeUrl.searchParams.set(
     'state',
     createGitHubBotLinkState(user.id, verifiedToken.installationId)


### PR DESCRIPTION
## Summary

The GitHub OAuth `redirect_uri` was being built from `APP_URL`, which resolves to `https://app.kilo.ai` in production. The GitHub OAuth app only has `https://app.kilocode.ai/api/integrations/github/callback` registered as a valid callback, so production link flows were failing with a redirect_uri mismatch. This pins the production callback host to `app.kilocode.ai` for this single OAuth handshake while leaving `APP_URL` untouched for everything else; development still uses `APP_URL` so localhost flows keep working.

## Verification

- Hit `/github/link?token=...` locally and confirmed the resulting GitHub authorize URL still uses `http://localhost:3000/api/integrations/github/callback`.
- Reasoned through the production branch: `NODE_ENV=production` selects the hardcoded `https://app.kilocode.ai` base, producing the only `redirect_uri` GitHub accepts.

## Visual Changes

N/A

## Reviewer Notes

- Scope is intentionally narrow: only the GitHub OAuth `redirect_uri` is overridden. Other `APP_URL` usages (sign-in redirect, etc.) are unchanged because the user's session still lives on `app.kilo.ai`.
- If/when `APP_URL` itself moves to `app.kilocode.ai`, this override becomes a no-op and can be removed.