### PR TITLE
Feat/claw auto route to chat

### DIFF
--- a/apps/web/src/app/(app)/claw/chat/layout.tsx
+++ b/apps/web/src/app/(app)/claw/chat/layout.tsx
@@ -23,6 +23,7 @@ export default function ChatRootLayout({ children }: { children: React.ReactNode
       instanceErrorMessage={instanceErrorMessage}
       onRetryInstanceStatus={() => void refetch()}
       assistantName={status?.botName ?? null}
+      assistantEmoji={status?.botEmoji ?? null}
       className="flex-1"
     >
       {children}

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFakeWalkthrough.tsx
@@ -271,7 +271,7 @@ function renderFakeStep({
       );
     }
     case 'complete':
-      return <ClawSetupCompleteStep status={fakeStatus} gatewayReady basePath={basePath} />;
+      return <ClawSetupCompleteStep gatewayReady />;
     case 'error':
       return <ClawSetupErrorStep basePath={basePath} />;
   }

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -218,6 +218,11 @@ function ClawOnboardingFlowInner({
 
   const basePath = organizationId ? `/organizations/${organizationId}/claw` : '/claw';
 
+  // NOTE: When mode === 'post-provisioning' (i.e. an existing instance is
+  // already running) and the gateway is ready, renderStep is 'complete' on
+  // first render and the redirect below fires immediately. This is intentional:
+  // the onboarding wizard is for new users; returning users with a working
+  // instance go straight to chat rather than seeing a wizard surface.
   const hasRedirectedToChat = useRef(false);
   useEffect(() => {
     // Wait for the gateway to actually be ready before redirecting; the chat

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -385,23 +385,21 @@ function ClawOnboardingFlowInner({
   }
 
   function renderCompleteStep() {
-    // While the gateway is still warming up, keep the user on a simple
-    // "almost ready" card instead of redirecting them to a chat page whose
-    // conversation requests would hang. Once gatewayReady flips true, the
-    // auto-redirect effect above takes over and pushes to /chat.
-    if (!flowState.gatewayReady) {
-      return (
-        <Card className="mt-6 overflow-hidden">
-          <CardContent className="flex flex-col items-center justify-center gap-4 pt-12">
-            <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
-            <p className="text-muted-foreground text-sm">
-              Almost ready &mdash; finishing up your instance&hellip;
-            </p>
-          </CardContent>
-        </Card>
-      );
-    }
-    return null;
+    // Keep showing the spinner through both the gateway-warming-up phase and
+    // the brief window between gatewayReady flipping true and router.push
+    // completing. Otherwise the screen flashes blank during navigation.
+    return (
+      <Card className="mt-6 overflow-hidden">
+        <CardContent className="flex flex-col items-center justify-center gap-4 pt-12">
+          <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
+          <p className="text-muted-foreground text-sm">
+            {flowState.gatewayReady
+              ? 'Opening chat…'
+              : 'Almost ready — finishing up your instance…'}
+          </p>
+        </CardContent>
+      </Card>
+    );
   }
 
   function renderErrorStep() {

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useFeatureFlagVariantKey, usePostHog } from 'posthog-js/react';
 import { toast } from 'sonner';
-import { Check, Loader2, Sparkles, TriangleAlert, X } from 'lucide-react';
+import { Loader2, TriangleAlert, X } from 'lucide-react';
 import { KILO_AUTO_BALANCED_MODEL } from '@/lib/ai-gateway/kilo-auto';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { useKiloClawGatewayStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
@@ -31,7 +31,6 @@ import {
   isPairingChannel,
   type ClawOnboardingMode,
   type OnboardingStep,
-  type PopulatedClawStatus,
 } from './ClawOnboardingFlow.state';
 
 function MaybeBillingWrapper({
@@ -390,21 +389,7 @@ function ClawOnboardingFlowInner({
   }
 
   function renderCompleteStep() {
-    // Keep showing the spinner through both the gateway-warming-up phase and
-    // the brief window between gatewayReady flipping true and router.push
-    // completing. Otherwise the screen flashes blank during navigation.
-    return (
-      <Card className="mt-6 overflow-hidden">
-        <CardContent className="flex flex-col items-center justify-center gap-4 pt-12">
-          <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
-          <p className="text-muted-foreground text-sm">
-            {flowState.gatewayReady
-              ? 'Opening chat…'
-              : 'Almost ready — finishing up your instance…'}
-          </p>
-        </CardContent>
-      </Card>
-    );
+    return <ClawSetupCompleteStep gatewayReady={flowState.gatewayReady} />;
   }
 
   function renderErrorStep() {
@@ -508,73 +493,19 @@ export function ClawSetupErrorStep({ basePath }: { basePath: string }) {
   );
 }
 
-export function ClawSetupCompleteStep({
-  status,
-  gatewayReady,
-  basePath,
-}: {
-  status: PopulatedClawStatus | null;
-  gatewayReady: boolean;
-  basePath: string;
-}) {
-  const posthog = usePostHog();
-
+// Renders the "complete" step in the onboarding flow. Production use is brief:
+// it shows during the warmup window after provisioning finishes, then the
+// auto-redirect effect in ClawOnboardingFlowInner pushes the user to /chat as
+// soon as gatewayReady flips true. Also rendered by ClawOnboardingFakeWalkthrough
+// so designers can preview this state.
+export function ClawSetupCompleteStep({ gatewayReady }: { gatewayReady: boolean }) {
   return (
     <Card className="mt-6 overflow-hidden">
-      <CardContent className="flex flex-col items-center justify-center gap-6 pt-12">
-        <div className="relative">
-          <div className="flex h-20 w-20 items-center justify-center rounded-2xl border border-emerald-700/30 bg-emerald-900/50">
-            <div className="flex h-12 w-12 items-center justify-center rounded-full border-2 border-emerald-500">
-              <Check className="h-6 w-6 text-emerald-500" />
-            </div>
-          </div>
-          <div className="absolute -top-3 -right-3 flex h-6 w-6 items-center justify-center rounded-full bg-[#09090b] text-amber-400">
-            <Sparkles className="h-4 w-4" />
-          </div>
-        </div>
-
-        <div className="flex flex-col items-center gap-2">
-          <h2 className="text-2xl font-bold">Your instance is ready!</h2>
-          <p className="text-muted-foreground max-w-md text-center">
-            KiloClaw has been provisioned and configured with your settings. You&apos;re all set to
-            start.
-          </p>
-        </div>
-
-        {status?.flyRegion && (
-          <div className="border-border/50 flex items-center gap-2 rounded-full border px-4 py-2">
-            <span className="relative flex h-1.5 w-1.5">
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-60" />
-              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
-            </span>
-            <span className="text-muted-foreground flex items-center gap-2 text-sm">
-              Active ·{' '}
-              <span className="text-foreground font-bold">{status.flyRegion.toUpperCase()}</span>{' '}
-              region
-            </span>
-          </div>
-        )}
-        <div className="flex w-full flex-col gap-3">
-          {gatewayReady && (
-            <Button
-              asChild
-              variant="primary"
-              className="w-full min-w-[180px] bg-emerald-600 py-6 text-base text-white hover:bg-emerald-700"
-              onClick={() => posthog?.capture('claw_setup_open_chat_clicked')}
-            >
-              <Link href={`${basePath}/chat`}>Open KiloClaw</Link>
-            </Button>
-          )}
-          <Button asChild className="w-full py-6 text-base" variant="outline">
-            <Link
-              href={basePath}
-              onClick={() => posthog?.capture('claw_setup_close_wizard_clicked')}
-            >
-              <X className="mr-2 h-4 w-4" />
-              Close Wizard
-            </Link>
-          </Button>
-        </div>
+      <CardContent className="flex flex-col items-center justify-center gap-4 pt-12">
+        <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
+        <p className="text-muted-foreground text-sm">
+          {gatewayReady ? 'Opening chat…' : 'Almost ready — finishing up your instance…'}
+        </p>
       </CardContent>
     </Card>
   );

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -2,9 +2,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useFeatureFlagVariantKey, usePostHog } from 'posthog-js/react';
 import { toast } from 'sonner';
-import { Check, Sparkles, TriangleAlert, X } from 'lucide-react';
+import { Check, Loader2, Sparkles, TriangleAlert, X } from 'lucide-react';
 import { KILO_AUTO_BALANCED_MODEL } from '@/lib/ai-gateway/kilo-auto';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { useKiloClawGatewayStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
@@ -158,6 +159,7 @@ function ClawOnboardingFlowInner({
   const { data: isServiceDegraded } = useClawServiceDegraded();
   useFeatureFlagVariantKey('button-vs-card');
   const posthog = usePostHog();
+  const router = useRouter();
 
   // Save bot identity, exec preset, and channel tokens as soon as the instance
   // row exists. This closes the tab-close window where customizations entered
@@ -215,6 +217,23 @@ function ClawOnboardingFlowInner({
   }, [onCreateFlowFailed, resetWizardSelections]);
 
   const basePath = organizationId ? `/organizations/${organizationId}/claw` : '/claw';
+
+  const hasRedirectedToChat = useRef(false);
+  useEffect(() => {
+    // Wait for the gateway to actually be ready before redirecting; the chat
+    // page's conversation requests will hang indefinitely if the gateway is
+    // still warming up.
+    if (
+      flowState.renderStep !== 'complete' ||
+      !flowState.gatewayReady ||
+      hasRedirectedToChat.current
+    ) {
+      return;
+    }
+    hasRedirectedToChat.current = true;
+    posthog?.capture('claw_setup_open_chat_clicked', { auto_redirect: true });
+    router.push(`${basePath}/chat`);
+  }, [flowState.renderStep, flowState.gatewayReady, basePath, router, posthog]);
 
   function provisionInstance(userLocation?: string) {
     handleCreateFlowStarted();
@@ -366,13 +385,23 @@ function ClawOnboardingFlowInner({
   }
 
   function renderCompleteStep() {
-    return (
-      <ClawSetupCompleteStep
-        status={flowState.instanceStatus}
-        gatewayReady={flowState.gatewayReady}
-        basePath={basePath}
-      />
-    );
+    // While the gateway is still warming up, keep the user on a simple
+    // "almost ready" card instead of redirecting them to a chat page whose
+    // conversation requests would hang. Once gatewayReady flips true, the
+    // auto-redirect effect above takes over and pushes to /chat.
+    if (!flowState.gatewayReady) {
+      return (
+        <Card className="mt-6 overflow-hidden">
+          <CardContent className="flex flex-col items-center justify-center gap-4 pt-12">
+            <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
+            <p className="text-muted-foreground text-sm">
+              Almost ready &mdash; finishing up your instance&hellip;
+            </p>
+          </CardContent>
+        </Card>
+      );
+    }
+    return null;
   }
 
   function renderErrorStep() {

--- a/apps/web/src/app/(app)/claw/kilo-chat/components/ConversationItem.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-chat/components/ConversationItem.tsx
@@ -87,7 +87,7 @@ export function ConversationItem({
     setIsConfirmingLeave(false);
   }, []);
 
-  const title = conversation.title ?? 'Untitled';
+  const title = conversation.title ?? 'New chat';
 
   const isUnread =
     !isActive &&

--- a/apps/web/src/app/(app)/claw/kilo-chat/components/KiloChatLayout.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-chat/components/KiloChatLayout.tsx
@@ -194,8 +194,13 @@ export function KiloChatLayout({
 
   // First-run auto-create: when a user lands on the chat root with zero
   // conversations (e.g. straight after onboarding), kick off a fresh
-  // conversation so they never sit on a blank index page.
+  // conversation so they never sit on a blank index page. Reset the guard
+  // when sandboxId changes so switching between instances (e.g. between
+  // organizations) re-evaluates without remounting.
   const hasAutoCreatedConversation = useRef(false);
+  useEffect(() => {
+    hasAutoCreatedConversation.current = false;
+  }, [sandboxId]);
   useEffect(() => {
     if (
       hasAutoCreatedConversation.current ||

--- a/apps/web/src/app/(app)/claw/kilo-chat/components/KiloChatLayout.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-chat/components/KiloChatLayout.tsx
@@ -32,7 +32,7 @@ type KiloChatLayoutProps = {
   onRetryInstanceStatus: () => void;
   instanceStatus: string | null;
   assistantName: string | null;
-  assistantEmoji?: string | null;
+  assistantEmoji: string | null;
   className?: string;
   children: React.ReactNode;
 };
@@ -48,7 +48,7 @@ export function KiloChatLayout({
   onRetryInstanceStatus,
   instanceStatus,
   assistantName,
-  assistantEmoji = null,
+  assistantEmoji,
   className,
   children,
 }: KiloChatLayoutProps) {

--- a/apps/web/src/app/(app)/claw/kilo-chat/components/KiloChatLayout.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-chat/components/KiloChatLayout.tsx
@@ -197,6 +197,11 @@ export function KiloChatLayout({
   // conversation so they never sit on a blank index page. Reset the guard
   // when sandboxId changes so switching between instances (e.g. between
   // organizations) re-evaluates without remounting.
+  //
+  // The ref intentionally stays set even after a failed mutation: if the
+  // server-side create fails, retrying via this effect would loop on
+  // persistent errors. The manual "+ New conversation" button in
+  // ConversationList is the recovery path.
   const hasAutoCreatedConversation = useRef(false);
   useEffect(() => {
     hasAutoCreatedConversation.current = false;
@@ -209,7 +214,7 @@ export function KiloChatLayout({
       !sandboxId ||
       createConversation.isPending ||
       !data ||
-      (data.conversations?.length ?? 0) > 0
+      data.conversations.length > 0
     ) {
       return;
     }

--- a/apps/web/src/app/(app)/claw/kilo-chat/components/KiloChatLayout.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-chat/components/KiloChatLayout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useRef, useState, useCallback, useEffect, useMemo } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
@@ -32,6 +32,7 @@ type KiloChatLayoutProps = {
   onRetryInstanceStatus: () => void;
   instanceStatus: string | null;
   assistantName: string | null;
+  assistantEmoji?: string | null;
   className?: string;
   children: React.ReactNode;
 };
@@ -47,6 +48,7 @@ export function KiloChatLayout({
   onRetryInstanceStatus,
   instanceStatus,
   assistantName,
+  assistantEmoji = null,
   className,
   children,
 }: KiloChatLayoutProps) {
@@ -161,6 +163,7 @@ export function KiloChatLayout({
       instanceStatus,
       leavingConversationId,
       assistantName,
+      assistantEmoji,
       sandboxId,
       basePath,
       noInstanceRedirect,
@@ -176,6 +179,7 @@ export function KiloChatLayout({
       instanceStatus,
       leavingConversationId,
       assistantName,
+      assistantEmoji,
       sandboxId,
       basePath,
       noInstanceRedirect,
@@ -187,6 +191,33 @@ export function KiloChatLayout({
       kiloChatClient,
     ]
   );
+
+  // First-run auto-create: when a user lands on the chat root with zero
+  // conversations (e.g. straight after onboarding), kick off a fresh
+  // conversation so they never sit on a blank index page.
+  const hasAutoCreatedConversation = useRef(false);
+  useEffect(() => {
+    if (
+      hasAutoCreatedConversation.current ||
+      params?.conversationId ||
+      isLoading ||
+      !sandboxId ||
+      createConversation.isPending ||
+      !data ||
+      (data.conversations?.length ?? 0) > 0
+    ) {
+      return;
+    }
+    hasAutoCreatedConversation.current = true;
+    handleNewConversation();
+  }, [
+    params?.conversationId,
+    isLoading,
+    sandboxId,
+    createConversation.isPending,
+    data,
+    handleNewConversation,
+  ]);
 
   return (
     <KiloChatContext.Provider value={contextValue}>

--- a/apps/web/src/app/(app)/claw/kilo-chat/components/MessageArea.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-chat/components/MessageArea.tsx
@@ -41,6 +41,7 @@ import { toast } from 'sonner';
 import { MessageBubble } from './MessageBubble';
 import { MessageInput } from './MessageInput';
 import { TypingIndicator } from './TypingIndicator';
+import { WelcomeBubble } from './WelcomeBubble';
 import { BotStatus, computeBotDisplay, useNowTicker } from './BotStatus';
 import { ContextUsageRing } from './ContextUsageRing';
 import { useBotStatus } from '../hooks/useBotStatus';
@@ -67,7 +68,7 @@ import {
   capturePrependScrollAnchor,
   type PrependScrollAnchorSnapshot,
 } from './message-scroll-anchor';
-import { MessageCircle, ArrowDown } from 'lucide-react';
+import { ArrowDown } from 'lucide-react';
 
 type MessageAreaProps = {
   conversationId: string;
@@ -87,8 +88,15 @@ function toEditableContent(content: ContentBlock[]): EditMessageRequest['content
 }
 
 export function MessageArea({ conversationId }: MessageAreaProps) {
-  const { currentUserId, instanceStatus, assistantName, sandboxId, eventService, kiloChatClient } =
-    useKiloChatContext();
+  const {
+    currentUserId,
+    instanceStatus,
+    assistantName,
+    assistantEmoji,
+    sandboxId,
+    eventService,
+    kiloChatClient,
+  } = useKiloChatContext();
   const botStatus = useBotStatus();
   const presence = botStatus ? { online: botStatus.online, lastAt: botStatus.at } : undefined;
   const ctxUsage = useConversationStatus(conversationId);
@@ -459,7 +467,7 @@ export function MessageArea({ conversationId }: MessageAreaProps) {
 
   const messageMap = useMemo(() => new Map(messages.map(m => [m.id, m])), [messages]);
 
-  const title = conversationDetail.data?.title ?? 'Untitled';
+  const title = conversationDetail.data?.title ?? 'New chat';
 
   function handleTitleClick() {
     setRenameText(title);
@@ -547,16 +555,7 @@ export function MessageArea({ conversationId }: MessageAreaProps) {
               </div>
             )}
             {messages.length === 0 && !isFetchingNextPage && (
-              <div className="flex flex-1 flex-col items-center justify-center px-6">
-                <div className="border-border bg-muted/50 flex flex-col items-center gap-3 rounded-lg border px-8 py-6">
-                  <MessageCircle className="text-muted-foreground/60 h-8 w-8" />
-                  <p className="text-muted-foreground text-sm">
-                    Ask {assistantName ?? 'KiloClaw'} to draft a message, make a checklist,
-                    <br />
-                    or help you think through a decision.
-                  </p>
-                </div>
-              </div>
+              <WelcomeBubble assistantName={assistantName} assistantEmoji={assistantEmoji} />
             )}
             {messages.map(msg => (
               <MessageBubble

--- a/apps/web/src/app/(app)/claw/kilo-chat/components/WelcomeBubble.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-chat/components/WelcomeBubble.tsx
@@ -12,7 +12,7 @@ export function WelcomeBubble({ assistantName, assistantEmoji }: WelcomeBubblePr
 
   return (
     <div className="flex flex-1 items-start gap-3 px-4 py-6">
-      <div className="bg-muted text-foreground flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-lg leading-none">
+      <div className="bg-muted text-foreground flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full text-lg leading-none">
         {assistantEmoji ? <span>{assistantEmoji}</span> : <Sparkles className="h-4 w-4" />}
       </div>
       <div className="flex flex-col gap-1">

--- a/apps/web/src/app/(app)/claw/kilo-chat/components/WelcomeBubble.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-chat/components/WelcomeBubble.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { Sparkles } from 'lucide-react';
+
+type WelcomeBubbleProps = {
+  assistantName: string | null;
+  assistantEmoji: string | null;
+};
+
+export function WelcomeBubble({ assistantName, assistantEmoji }: WelcomeBubbleProps) {
+  const name = assistantName ?? 'KiloClaw';
+
+  return (
+    <div className="flex flex-1 items-start gap-3 px-4 py-6">
+      <div className="bg-muted text-foreground flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-lg leading-none">
+        {assistantEmoji ? <span>{assistantEmoji}</span> : <Sparkles className="h-4 w-4" />}
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="text-muted-foreground text-xs font-medium">{name}</span>
+        <div className="bg-muted/50 border-border max-w-prose rounded-2xl rounded-tl-sm border px-4 py-3">
+          <p className="text-foreground text-sm leading-relaxed">
+            Hi! I&apos;m {name}. Ask me to draft a message, make a checklist, or help you think
+            through a decision.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/claw/kilo-chat/components/kiloChatContext.ts
+++ b/apps/web/src/app/(app)/claw/kilo-chat/components/kiloChatContext.ts
@@ -9,6 +9,7 @@ export type KiloChatContextValue = {
   instanceStatus: string | null;
   leavingConversationId: string | null;
   assistantName: string | null;
+  assistantEmoji: string | null;
   sandboxId: string | null;
   basePath: string;
   noInstanceRedirect: string;

--- a/apps/web/src/app/(app)/claw/kilo-chat/layout.tsx
+++ b/apps/web/src/app/(app)/claw/kilo-chat/layout.tsx
@@ -22,6 +22,7 @@ export default function KiloChatRootLayout({ children }: { children: React.React
       instanceErrorMessage={instanceErrorMessage}
       onRetryInstanceStatus={() => void refetch()}
       assistantName={status?.botName ?? null}
+      assistantEmoji={status?.botEmoji ?? null}
     >
       {children}
     </KiloChatLayout>

--- a/apps/web/src/app/(app)/organizations/[id]/claw/chat/OrgChatRootLayoutClient.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/claw/chat/OrgChatRootLayoutClient.tsx
@@ -28,6 +28,7 @@ export function OrgChatRootLayoutClient({
       instanceErrorMessage={instanceErrorMessage}
       onRetryInstanceStatus={() => void refetch()}
       assistantName={status?.botName ?? null}
+      assistantEmoji={status?.botEmoji ?? null}
     >
       {children}
     </KiloChatLayout>

--- a/apps/web/src/app/(app)/organizations/[id]/claw/kilo-chat/layout.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/claw/kilo-chat/layout.tsx
@@ -28,6 +28,7 @@ export default function OrgKiloChatRootLayout({ children }: { children: React.Re
       instanceErrorMessage={instanceErrorMessage}
       onRetryInstanceStatus={() => void refetch()}
       assistantName={status?.botName ?? null}
+      assistantEmoji={status?.botEmoji ?? null}
     >
       {children}
     </KiloChatLayout>


### PR DESCRIPTION
## Summary

Replace the static "Your instance is ready!" success screen with an automatic redirect to /claw/chat once the gateway is ready. While the gateway warms up, render a small spinner card so the user has a visible state instead of a flash of nothing. To avoid landing the user on a blank conversation index, also:

- When the chat root loads with zero conversations, automatically create a fresh conversation and route the user into it. Guarded by a ref so it only fires once per mount, and resets when sandboxId changes so switching between organizations evaluates the conditions again.
- Render a new WelcomeBubble component as the empty message area placeholder. Styled as a left aligned bot bubble with the bot's emoji avatar and a greeting using the bot's chosen name.
- Thread botEmoji through KiloChatContext so the welcome bubble can use the user's selected avatar in both personal and organization chats. assistantEmoji is required on KiloChatLayoutProps so any future caller that forgets to pass it fails typecheck.
- Replace the "Untitled" thread fallback with "New chat" in both the conversation list and the message area header. The backend automatic title from first message takes over once the user sends.

No backend or per instance image changes. The gateway, kilo-chat, and event-service contracts are unchanged. Everything is in the Next.js app and the existing context plumbing.

## Verification

- [x] Provisioned a fresh kiloclaw instance from /claw/new. Watched the spinner during gateway warmup, then was redirected to /claw/chat/{newId} with the welcome bubble visible.
- [x] Confirmed the welcome bubble renders the configured bot emoji as the avatar and uses the chosen bot name in the greeting copy.
- [x] Sent a first message; bubble disappeared, backend renamed the thread from "New chat" using first message text.
- [x] Pressed "+ New conversation" on an existing instance; new thread was created, welcome bubble appeared in the empty state.
- [x] Reloaded /claw/chat with conversations already present; automatic creation did not fire (intended).
- [x] Restarted the dev wranglers (kilo-chat, event-service) and reproduced the full flow end to end.

## Visual Changes

- Replace the static "Your instance is ready!" success screen with an automatic redirect to /claw/chat 

## Reviewer Notes

- The redirect is gated on flowState.gatewayReady so the user does not land on a chat page whose conversation requests would hang while the gateway is still warming up. Spinner copy varies by readiness.
- When a user with an already running instance navigates to /claw/new, mode is 'post-provisioning', renderStep reaches 'complete' on first render, and the redirect fires immediately. This is intentional: the wizard is for new users only. Documented inline.
- hasAutoCreatedConversation intentionally stays set after a failed mutation. Retrying inside the effect would loop on persistent errors. The "+ New conversation" button is the recovery path.