### PR TITLE
Cloud - Gate auto-triage and auto-fix behind PostHog feature flag

### DIFF
--- a/apps/web/src/app/(app)/auto-triage/page.tsx
+++ b/apps/web/src/app/(app)/auto-triage/page.tsx
@@ -1,3 +1,5 @@
+import { notFound } from 'next/navigation';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { getUserFromAuthOrRedirect } from '@/lib/user.server';
 import { AutoTriagePageClient } from './AutoTriagePageClient';
 
@@ -8,6 +10,13 @@ type AutoTriagePageProps = {
 export default async function PersonalAutoTriagePage({ searchParams }: AutoTriagePageProps) {
   const search = await searchParams;
   const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/auto-triage');
+
+  const isAutoTriageFeatureEnabled = await isFeatureFlagEnabled('auto-triage-feature', user.id);
+  const isDevelopment = process.env.NODE_ENV === 'development';
+
+  if (!isAutoTriageFeatureEnabled && !isDevelopment) {
+    return notFound();
+  }
 
   return (
     <AutoTriagePageClient

--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -204,13 +204,15 @@ export default function OrganizationAppSidebar({
       icon: Shield,
       url: `/organizations/${organizationId}/security-agent`,
     },
-    {
-      title: 'Auto Triage',
-      icon: ListChecks,
-      url: `/organizations/${organizationId}/auto-triage`,
-    },
     ...(isAutoTriageFeatureEnabled || isDevelopment
-      ? [{ title: 'Auto Fix', icon: Wrench, url: `/organizations/${organizationId}/auto-fix` }]
+      ? [
+          {
+            title: 'Auto Triage',
+            icon: ListChecks,
+            url: `/organizations/${organizationId}/auto-triage`,
+          },
+          { title: 'Auto Fix', icon: Wrench, url: `/organizations/${organizationId}/auto-fix` },
+        ]
       : []),
     ...(ENABLE_DEPLOY_FEATURE
       ? [

--- a/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -147,13 +147,11 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
       icon: Shield,
       url: '/security-agent',
     },
-    {
-      title: 'Auto Triage',
-      icon: ListChecks,
-      url: '/auto-triage',
-    },
     ...(isAutoTriageFeatureEnabled || isDevelopment
-      ? [{ title: 'Auto Fix', icon: Wrench, url: '/auto-fix' }]
+      ? [
+          { title: 'Auto Triage', icon: ListChecks, url: '/auto-triage' },
+          { title: 'Auto Fix', icon: Wrench, url: '/auto-fix' },
+        ]
       : []),
     ...(ENABLE_DEPLOY_FEATURE
       ? [

--- a/apps/web/src/app/(app)/organizations/[id]/auto-triage/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/auto-triage/page.tsx
@@ -1,4 +1,6 @@
+import { notFound } from 'next/navigation';
 import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { AutoTriagePageClient } from './AutoTriagePageClient';
 
 type AutoTriagePageProps = {
@@ -7,7 +9,19 @@ type AutoTriagePageProps = {
 };
 
 export default async function AutoTriagePage({ params, searchParams }: AutoTriagePageProps) {
+  const { id: organizationId } = await params;
   const search = await searchParams;
+
+  // Feature flags - use server-side check with organization ID as distinct ID
+  const isAutoTriageFeatureEnabled = await isFeatureFlagEnabled(
+    'auto-triage-feature',
+    organizationId
+  );
+  const isDevelopment = process.env.NODE_ENV === 'development';
+
+  if (!isAutoTriageFeatureEnabled && !isDevelopment) {
+    return notFound();
+  }
 
   return (
     <OrganizationByPageLayout


### PR DESCRIPTION
## Summary

- Gates `/auto-triage` (personal and org routes) behind the `auto-triage-feature` PostHog flag. Flag-disabled users get `notFound()` in non-development environments.
- Org pages use the organization ID as the PostHog `distinctId`; personal pages use the user ID.
- Auto Triage sidebar entries are hidden when the flag is off.
- `/auto-fix` (personal and org) was already gated behind the same flag on main; this PR brings auto-triage to parity.

## Verification

- Load `/auto-triage` and `/organizations/<id>/auto-triage` as a flag-disabled user in non-development and confirm both 404.
- Load the same routes in development and confirm they render normally.
- Confirm both sidebar entries (Auto Triage, Auto Fix) are hidden when the PostHog flag is off.

## Visual Changes

N/A

## Reviewer Notes

PostHog flag `auto-triage-feature` should be configured with a static cohort of existing org IDs and user IDs (those who previously used the feature) to prevent new users from gaining access.