### PR TITLE
Fix/kiloclaw morning briefing graceful unavailable

### DIFF
--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -561,6 +561,10 @@ function MorningBriefingCard({
     mutations.disableMorningBriefing.isPending;
 
   const statusLabel = (() => {
+    if (isControllerOutOfDate) {
+      return 'Upgrade Required';
+    }
+
     if (isWarmupState) {
       return 'Instance Warming Up';
     }
@@ -593,13 +597,14 @@ function MorningBriefingCard({
 
     return observedEnabled ? 'Enabled' : 'Disabled';
   })();
-  const statusVariant = isWarmupState
-    ? 'secondary'
-    : statusLabel === 'Instance Stopped'
+  const statusVariant =
+    isControllerOutOfDate || isWarmupState
       ? 'secondary'
-      : observedEnabled || (isTransitioning && desiredEnabled)
-        ? 'default'
-        : 'secondary';
+      : statusLabel === 'Instance Stopped'
+        ? 'secondary'
+        : observedEnabled || (isTransitioning && desiredEnabled)
+          ? 'default'
+          : 'secondary';
 
   const readySources = [
     sourceReadiness.github.configured ? 'GitHub' : null,
@@ -624,7 +629,11 @@ function MorningBriefingCard({
   const canUseBriefingControls = controlsEnabled && desiredEnabled;
   const lastDelivery = briefingStatus?.lastDelivery ?? [];
   const showLastDelivery =
-    !isWarmupState && actionsReady && hasResolvedBriefingToggleState && lastDelivery.length > 0;
+    !isWarmupState &&
+    !isControllerOutOfDate &&
+    actionsReady &&
+    hasResolvedBriefingToggleState &&
+    lastDelivery.length > 0;
   const deliveryChannelLabel = {
     telegram: 'Telegram',
     discord: 'Discord',

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -501,6 +501,7 @@ function MorningBriefingCard({
   fallbackReadiness,
   isRunning,
   actionsReady,
+  onRequestUpgrade,
 }: {
   mutations: ClawMutations;
   briefingStatus: MorningBriefingStatusLite | undefined;
@@ -511,6 +512,8 @@ function MorningBriefingCard({
   };
   isRunning: boolean;
   actionsReady: boolean;
+  /** Callback that opens the focused upgrade confirmation flow. */
+  onRequestUpgrade?: () => void;
 }) {
   const [requestedDay, setRequestedDay] = useState<'today' | 'yesterday' | null>(null);
   const { data: readData, isFetching: isReading } = useClawReadMorningBriefing(requestedDay, true);
@@ -539,12 +542,17 @@ function MorningBriefingCard({
     } as const);
 
   const hasSchedule = Boolean(briefingStatus?.cron && briefingStatus?.timezone);
-  const { desiredEnabled, observedEnabled, hasResolvedBriefingToggleState, isWarmupState } =
-    deriveMorningBriefingCardState({
-      isRunning,
-      actionsReady,
-      briefingStatus,
-    });
+  const {
+    desiredEnabled,
+    observedEnabled,
+    hasResolvedBriefingToggleState,
+    isWarmupState,
+    isControllerOutOfDate,
+  } = deriveMorningBriefingCardState({
+    isRunning,
+    actionsReady,
+    briefingStatus,
+  });
   const reconcileState = briefingStatus?.reconcileState ?? 'idle';
   const lastReconcileAction = briefingStatus?.lastReconcileAction ?? null;
   const isTransitioning =
@@ -610,8 +618,9 @@ function MorningBriefingCard({
       : readySources.length === 0
         ? 'No sources are connected yet. Configure GitHub, Linear, or Web Search to generate richer briefings.'
         : `Connected sources: ${joinFriendlyList(readySources)}. Disconnected sources: ${joinFriendlyList(missingSources)}.`;
-  const showScheduleDetails = !isWarmupState && hasSchedule && desiredEnabled;
-  const controlsEnabled = actionsReady && !isWarmupState;
+  const showScheduleDetails =
+    !isWarmupState && !isControllerOutOfDate && hasSchedule && desiredEnabled;
+  const controlsEnabled = actionsReady && !isWarmupState && !isControllerOutOfDate;
   const canUseBriefingControls = controlsEnabled && desiredEnabled;
   const lastDelivery = briefingStatus?.lastDelivery ?? [];
   const showLastDelivery =
@@ -635,6 +644,28 @@ function MorningBriefingCard({
 
   return (
     <div className="rounded-lg border px-4 py-3">
+      {isControllerOutOfDate && (
+        <div className="mb-3 flex items-start gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 p-3">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium text-amber-200">Upgrade required</p>
+            <p className="text-muted-foreground text-xs">
+              Morning Briefing requires a newer KiloClaw version. Upgrade to enable scheduling and
+              delivery.
+            </p>
+          </div>
+          {onRequestUpgrade && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="border-amber-500/30 text-amber-400 hover:bg-amber-500/20 hover:text-amber-300"
+              onClick={onRequestUpgrade}
+            >
+              Upgrade
+            </Button>
+          )}
+        </div>
+      )}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex items-start gap-3">
           <Newspaper className="text-muted-foreground h-5 w-5 shrink-0" />
@@ -1925,6 +1956,7 @@ export function SettingsTab({
               briefingStatus={morningBriefingStatus}
               isRunning={isRunning}
               actionsReady={morningBriefingActionsReady}
+              onRequestUpgrade={onRequestUpgrade}
               fallbackReadiness={{
                 githubConfigured: configuredSecrets.github ?? false,
                 linearConfigured: configuredSecrets.linear ?? false,

--- a/apps/web/src/app/(app)/claw/components/morning-briefing-card-state.test.ts
+++ b/apps/web/src/app/(app)/claw/components/morning-briefing-card-state.test.ts
@@ -35,4 +35,23 @@ describe('deriveMorningBriefingCardState', () => {
     expect(state.desiredEnabled).toBe(true);
     expect(state.observedEnabled).toBe(true);
   });
+
+  test('flags controller_route_unavailable and suppresses warmup state', () => {
+    const state = deriveMorningBriefingCardState({
+      isRunning: true,
+      actionsReady: true,
+      briefingStatus: {
+        code: 'controller_route_unavailable',
+        enabled: false,
+        desiredEnabled: false,
+        observedEnabled: false,
+        reconcileState: 'idle',
+      },
+    });
+
+    expect(state.isControllerOutOfDate).toBe(true);
+    // Warmup must be suppressed so the upgrade banner is the only signal —
+    // otherwise an out-of-date controller would also render as "warming up".
+    expect(state.isWarmupState).toBe(false);
+  });
 });

--- a/apps/web/src/app/(app)/claw/components/morning-briefing-card-state.ts
+++ b/apps/web/src/app/(app)/claw/components/morning-briefing-card-state.ts
@@ -12,6 +12,7 @@ export type MorningBriefingCardState = {
   hasResolvedBriefingToggleState: boolean;
   isGatewayWarmupStatus: boolean;
   isWarmupState: boolean;
+  isControllerOutOfDate: boolean;
 };
 
 export function deriveMorningBriefingCardState(
@@ -21,11 +22,15 @@ export function deriveMorningBriefingCardState(
   const observedEnabledValue =
     input.briefingStatus?.observedEnabled ?? input.briefingStatus?.enabled;
   const isGatewayWarmupStatus = input.briefingStatus?.code === 'gateway_warming_up';
+  const isControllerOutOfDate = input.briefingStatus?.code === 'controller_route_unavailable';
   const hasResolvedBriefingToggleState =
     typeof desiredEnabledValue === 'boolean' && typeof observedEnabledValue === 'boolean';
   const desiredEnabled = desiredEnabledValue ?? false;
   const observedEnabled = observedEnabledValue ?? false;
+  // Out-of-date controller takes precedence over warmup: the user needs to act
+  // (upgrade), not wait. Suppress warmup so the two banners don't fight.
   const isWarmupState =
+    !isControllerOutOfDate &&
     input.isRunning &&
     (input.actionsReady === false || isGatewayWarmupStatus || !hasResolvedBriefingToggleState);
 
@@ -35,5 +40,6 @@ export function deriveMorningBriefingCardState(
     hasResolvedBriefingToggleState,
     isGatewayWarmupStatus,
     isWarmupState,
+    isControllerOutOfDate,
   };
 }

--- a/services/kiloclaw/src/routes/platform-morning-briefing.test.ts
+++ b/services/kiloclaw/src/routes/platform-morning-briefing.test.ts
@@ -102,6 +102,26 @@ describe('platform morning-briefing warm-up handling', () => {
     });
   });
 
+  it('returns graceful unavailable payload at 200 when controller predates the status route', async () => {
+    // The DO returns null when the controller route is missing (controller
+    // predates the morning-briefing route). The dashboard polls this endpoint
+    // every 30s, so 404 here would generate continuous user-facing errors.
+    const getMorningBriefingStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(null);
+    const env = baseEnv({ getMorningBriefingStatus });
+
+    const response = await platform.request('/morning-briefing/status?userId=user-1', {}, env);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      enabled: false,
+      desiredEnabled: false,
+      observedEnabled: false,
+      reconcileState: 'idle',
+      code: 'controller_route_unavailable',
+    });
+  });
+
   it('does not treat 401 as warm-up for enable retries', async () => {
     const enableMorningBriefing = vi
       .fn<() => Promise<{ ok: boolean; enabled: boolean }>>()

--- a/services/kiloclaw/src/routes/platform-morning-briefing.test.ts
+++ b/services/kiloclaw/src/routes/platform-morning-briefing.test.ts
@@ -119,6 +119,7 @@ describe('platform morning-briefing warm-up handling', () => {
       observedEnabled: false,
       reconcileState: 'idle',
       code: 'controller_route_unavailable',
+      error: 'Morning Briefing unavailable (controller too old)',
     });
   });
 

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -1993,10 +1993,21 @@ platform.get('/morning-briefing/status', async c => {
       'getMorningBriefingStatus'
     );
     if (!result) {
-      return jsonError(
-        'Morning Briefing unavailable (controller too old)',
-        404,
-        'controller_route_unavailable'
+      // Controller predates this route. The dashboard polls status every 30s,
+      // so a 404 here would generate continuous user-facing errors. Return a
+      // typed "unavailable" payload at 200 instead — same shape pattern as
+      // the gateway_warming_up branch below.
+      return c.json(
+        {
+          ok: false,
+          enabled: false,
+          desiredEnabled: false,
+          observedEnabled: false,
+          reconcileState: 'idle' as const,
+          code: 'controller_route_unavailable',
+          error: 'Morning Briefing unavailable (controller too old)',
+        },
+        200
       );
     }
     return c.json(result, 200);

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -2003,7 +2003,7 @@ platform.get('/morning-briefing/status', async c => {
           enabled: false,
           desiredEnabled: false,
           observedEnabled: false,
-          reconcileState: 'idle' as const,
+          reconcileState: 'idle',
           code: 'controller_route_unavailable',
           error: 'Morning Briefing unavailable (controller too old)',
         },


### PR DESCRIPTION
## Summary

When a KiloClaw instance runs an image that predates the Morning Briefing status route, the worker now responds with HTTP 200 and a typed payload that includes `code: controller_route_unavailable`, instead of returning HTTP 404. The web UI reads this code on the Settings tab and renders an upgrade affordance inside the Morning Briefing card. The card disables the Enable, Disable, and Generate controls while the user is on an older image and routes the upgrade button into the upgrade modal that already exists for the Memory section. Warmup state is suppressed when the upgrade banner is shown so the two states do not compete.

## Verification

- [x] Personal `/claw/settings` on a current image: Morning Briefing card renders as before with status, schedule, last delivery, and working controls.
- [x] Personal `/claw/settings` with the worker stubbed to return `code: controller_route_unavailable`: amber Upgrade Required banner shows inside the card, badge reads Upgrade Required, schedule and last delivery rows are hidden, controls are disabled, clicking Upgrade opens the upgrade modal.
- [x] Organization `/organizations/[id]/claw/settings`: same two cases as above.

## Visual Changes

| Before | After |
| ------ | ----- |
|        |       |

## Reviewer Notes

The new payload mirrors the gateway warming up branch in the same worker handler, so the frontend can key on `briefingStatus.code` without tRPC changes.
