### PR TITLE
Fix/usage timezone handling

### DIFF
--- a/apps/web/src/app/(app)/usage/page.tsx
+++ b/apps/web/src/app/(app)/usage/page.tsx
@@ -162,7 +162,7 @@ export default function UsagePage() {
   const [groupByModel, setGroupByModel] = useState(false);
   const [viewType, setViewType] = useState<string>('personal');
   const [period, setPeriod] = useState<Period>('week');
-  const [timeZone, setTimeZone] = useState<string>(
+  const [timeZone] = useState<string>(
     () => Intl.DateTimeFormat().resolvedOptions().timeZone
   );
 

--- a/apps/web/src/app/(app)/usage/page.tsx
+++ b/apps/web/src/app/(app)/usage/page.tsx
@@ -162,12 +162,9 @@ export default function UsagePage() {
   const [groupByModel, setGroupByModel] = useState(false);
   const [viewType, setViewType] = useState<string>('personal');
   const [period, setPeriod] = useState<Period>('week');
-  const [timeZone, setTimeZone] = useState<string | null>(null);
-
-  // Detect browser timezone on mount
-  useEffect(() => {
-    setTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
-  }, []);
+  const [timeZone, setTimeZone] = useState<string>(
+    () => Intl.DateTimeFormat().resolvedOptions().timeZone
+  );
 
   const {
     data: usageData,
@@ -176,11 +173,7 @@ export default function UsagePage() {
     refetch,
   } = useQuery({
     queryKey: ['usage-data', groupByModel, viewType, period, timeZone],
-    queryFn: () => {
-      if (!timeZone) throw new Error('Timezone not detected');
-      return fetchUsageData(groupByModel, viewType, period, timeZone);
-    },
-    enabled: timeZone !== null,
+    queryFn: () => fetchUsageData(groupByModel, viewType, period, timeZone),
   });
 
   const { data: autocompleteMetrics, isLoading: isLoadingAutocompleteMetrics } = useQuery(
@@ -198,7 +191,7 @@ export default function UsagePage() {
 
   const periodLabel = PERIOD_LABELS[period];
 
-  if (!timeZone || isLoading) {
+  if (isLoading) {
     return (
       <PageLayout title="Usage">
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">

--- a/apps/web/src/app/(app)/usage/page.tsx
+++ b/apps/web/src/app/(app)/usage/page.tsx
@@ -48,10 +48,11 @@ type UsageResponse = {
 async function fetchUsageData(
   groupByModel: boolean,
   viewType: string,
-  period: Period
+  period: Period,
+  timeZone: string
 ): Promise<UsageResponse> {
   const response = await fetch(
-    `/api/profile/usage?groupByModel=${groupByModel}&viewType=${viewType}&period=${period}`
+    `/api/profile/usage?groupByModel=${groupByModel}&viewType=${viewType}&period=${period}&timeZone=${encodeURIComponent(timeZone)}`
   );
   if (!response.ok) {
     if (response.status === 401) {
@@ -66,6 +67,12 @@ async function fetchUsageData(
   return data;
 }
 
+// Formats a date in the given timezone as YYYY-MM-DD
+// Uses 'en-CA' locale because it formats dates as YYYY-MM-DD by default
+function formatDateInTimeZone(date: Date, timeZone: string): string {
+  return date.toLocaleDateString('en-CA', { timeZone });
+}
+
 function calculateTotals(usage: UsageData[]) {
   return usage.reduce(
     (totals, item) => ({
@@ -77,7 +84,7 @@ function calculateTotals(usage: UsageData[]) {
   );
 }
 
-function calculateStreak(usageData: UsageData[]): number {
+function calculateStreak(usageData: UsageData[], timeZone: string): number {
   // Create a set of dates that have usage (any requests > 0)
   const usageDates = new Set(
     usageData.filter(item => item.request_count > 0).map(item => item.date)
@@ -93,7 +100,8 @@ function calculateStreak(usageData: UsageData[]): number {
     // Max 365 days to prevent infinite loop
     const checkDate = new Date(today);
     checkDate.setDate(today.getDate() - i);
-    const dateString = checkDate.toISOString().split('T')[0]; // YYYY-MM-DD format
+    // Use timezone-aware date formatting (YYYY-MM-DD)
+    const dateString = formatDateInTimeZone(checkDate, timeZone);
 
     if (usageDates.has(dateString)) {
       streak++;
@@ -108,7 +116,8 @@ function calculateStreak(usageData: UsageData[]): number {
 }
 
 function transformUsageDataForStreakCalendar(
-  usageData: UsageData[]
+  usageData: UsageData[],
+  timeZone: string
 ): { date: string; count: number }[] {
   // Create a map of date -> total request count for that date
   const dateRequestMap = new Map<string, number>();
@@ -126,7 +135,8 @@ function transformUsageDataForStreakCalendar(
   for (let i = 83; i >= 0; i--) {
     const date = new Date(today);
     date.setDate(date.getDate() - i);
-    const dateString = date.toISOString().split('T')[0]; // YYYY-MM-DD format
+    // Use timezone-aware date formatting (YYYY-MM-DD)
+    const dateString = formatDateInTimeZone(date, timeZone);
 
     const requestCount = dateRequestMap.get(dateString) || 0;
 
@@ -152,6 +162,12 @@ export default function UsagePage() {
   const [groupByModel, setGroupByModel] = useState(false);
   const [viewType, setViewType] = useState<string>('personal');
   const [period, setPeriod] = useState<Period>('week');
+  const [timeZone, setTimeZone] = useState<string | null>(null);
+
+  // Detect browser timezone on mount
+  useEffect(() => {
+    setTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
+  }, []);
 
   const {
     data: usageData,
@@ -159,8 +175,12 @@ export default function UsagePage() {
     error,
     refetch,
   } = useQuery({
-    queryKey: ['usage-data', groupByModel, viewType, period],
-    queryFn: () => fetchUsageData(groupByModel, viewType, period),
+    queryKey: ['usage-data', groupByModel, viewType, period, timeZone],
+    queryFn: () => {
+      if (!timeZone) throw new Error('Timezone not detected');
+      return fetchUsageData(groupByModel, viewType, period, timeZone);
+    },
+    enabled: timeZone !== null,
   });
 
   const { data: autocompleteMetrics, isLoading: isLoadingAutocompleteMetrics } = useQuery(
@@ -178,7 +198,7 @@ export default function UsagePage() {
 
   const periodLabel = PERIOD_LABELS[period];
 
-  if (isLoading) {
+  if (!timeZone || isLoading) {
     return (
       <PageLayout title="Usage">
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
@@ -366,8 +386,8 @@ export default function UsagePage() {
   }
 
   const { totalCost, totalRequests, totalTokens } = calculateTotals(usageData.usage);
-  const streak = calculateStreak(usageData.usage);
-  const streakCalendarData = transformUsageDataForStreakCalendar(usageData.usage);
+  const streak = calculateStreak(usageData.usage, timeZone);
+  const streakCalendarData = transformUsageDataForStreakCalendar(usageData.usage, timeZone);
 
   // Prepare table data
   const tableColumns: UsageTableColumn[] = [

--- a/apps/web/src/app/api/profile/usage/route.ts
+++ b/apps/web/src/app/api/profile/usage/route.ts
@@ -9,6 +9,16 @@ import { getDateThreshold, type Period } from '@/routers/user-router';
 
 const VALID_PERIODS = new Set(['week', 'month', 'year', 'all']);
 
+// Validate IANA timezone string to prevent SQL injection
+function isValidTimezone(tz: string): boolean {
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: tz });
+    return true;
+  } catch (_e) {
+    return false;
+  }
+}
+
 export async function GET(request: NextRequest) {
   const { user, authFailedResponse } = await getUserFromAuth({
     adminOnly: false,
@@ -21,12 +31,23 @@ export async function GET(request: NextRequest) {
   const viewType = searchParams.get('viewType') || 'personal'; // 'personal', 'all', or organization ID
   const periodParam = searchParams.get('period') || 'week';
   const period: Period = VALID_PERIODS.has(periodParam) ? (periodParam as Period) : 'week';
+  const timeZoneParam = searchParams.get('timeZone');
+  const userTimeZone = timeZoneParam && isValidTimezone(timeZoneParam) ? timeZoneParam : 'UTC';
 
   const userId = user.id;
 
+  // Helper to get timezone-aware date SQL
+  const getDateSql = () => {
+    if (userTimeZone === 'UTC') {
+      return sql<string>`DATE(${microdollar_usage.created_at})`;
+    }
+    return sql<string>`(${microdollar_usage.created_at} AT TIME ZONE 'UTC' AT TIME ZONE ${userTimeZone})::date`;
+  };
+
   // Build the select object conditionally
+  const dateSql = getDateSql();
   const selectFields = {
-    date: sql<string>`DATE(${microdollar_usage.created_at})`,
+    date: dateSql,
     ...(groupByModel && {
       model: sql<
         string | null
@@ -42,13 +63,13 @@ export async function GET(request: NextRequest) {
 
   // Build the group by and order by clauses conditionally
   const groupByClause = [
-    sql`DATE(${microdollar_usage.created_at})`,
+    dateSql,
     ...(groupByModel
       ? [sql`COALESCE(${microdollar_usage.requested_model}, ${microdollar_usage.model})`]
       : []),
   ];
   const orderByClause = [
-    desc(sql`DATE(${microdollar_usage.created_at})`),
+    desc(dateSql),
     ...(groupByModel
       ? [sql`COALESCE(${microdollar_usage.requested_model}, ${microdollar_usage.model})`]
       : []),

--- a/apps/web/src/app/api/profile/usage/route.ts
+++ b/apps/web/src/app/api/profile/usage/route.ts
@@ -41,7 +41,8 @@ export async function GET(request: NextRequest) {
     if (userTimeZone === 'UTC') {
       return sql<string>`DATE(${microdollar_usage.created_at})`;
     }
-    return sql<string>`(${microdollar_usage.created_at} AT TIME ZONE 'UTC' AT TIME ZONE ${userTimeZone})::date`;
+    // created_at is timestamptz (stored as UTC), convert directly to user's timezone
+    return sql<string>`(${microdollar_usage.created_at} AT TIME ZONE ${userTimeZone})::date`;
   };
 
   // Build the select object conditionally

--- a/apps/web/src/app/api/profile/usage/route.ts
+++ b/apps/web/src/app/api/profile/usage/route.ts
@@ -14,7 +14,7 @@ function isValidTimezone(tz: string): boolean {
   try {
     Intl.DateTimeFormat(undefined, { timeZone: tz });
     return true;
-  } catch (_e) {
+  } catch {
     return false;
   }
 }


### PR DESCRIPTION
## Summary
Fix timezone handling in the usage tab so dates are grouped by the user's local timezone instead of UTC. This affects "By Day", "By Model & Day" views, streak calculation, and streak calendar.

Closes #3085

**Changes:**
- API route `/api/profile/usage` now accepts `timeZone` parameter and uses PostgreSQL `AT TIME ZONE` for timezone-aware date grouping
- Client detects browser timezone via `Intl.DateTimeFormat().resolvedOptions().timeZone`
- Streak calculation and calendar data generation now use `toLocaleDateString('en-CA', { timeZone })` for correct local date formatting
- Initial timezone state is `null` to defer query until browser timezone is detected

## Visual Changes
N/A - functionality fix, dates now correctly reflect user's local timezone.

## Reviewer Notes
- The `en-CA` locale is used because it formats dates as `YYYY-MM-DD` by default
- Added `isValidTimezone()` function to validate IANA timezone strings and prevent SQL injection
- API falls back to UTC if invalid or missing timezone parameter