### PR TITLE
CloudAgentNext - Map User-Caused Prepare Errors To 400

### DIFF
--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -14,6 +14,7 @@ import { logger, withLogTags } from '../../logger.js';
 import {
   generateSessionId,
   SessionService,
+  SetupCommandFailedError,
   determineBranchName,
   runSetupCommands,
   writeAuthFile,
@@ -31,11 +32,13 @@ import {
 } from '../schemas.js';
 import { generateSandboxId, getSandboxNamespace } from '../../sandbox-id.js';
 import {
+  BranchNotFoundError,
   checkDiskAndCleanBeforeSetup,
-  setupWorkspace,
   cloneGitHubRepo,
   cloneGitRepo,
+  GitRepositoryNotFoundError,
   manageBranch,
+  setupWorkspace,
 } from '../../workspace.js';
 import { WrapperClient } from '../../kilo/wrapper-client.js';
 import { withDORetry } from '../../utils/do-retry.js';
@@ -474,52 +477,66 @@ const prepareSessionHandler = internalApiProtectedProcedure
         // 7. Clone repository
         const cloneOptions = input.shallow ? { shallow: true } : undefined;
         logger.info('Cloning repository');
-        if (input.gitUrl) {
-          await cloneGitRepo(
-            session,
-            workspacePath,
-            input.gitUrl,
-            resolvedGitToken,
-            undefined,
-            cloneOptions
-          );
-        } else if (input.githubRepo) {
-          await cloneGitHubRepo(
-            session,
-            workspacePath,
-            input.githubRepo,
-            resolvedGithubToken,
-            {
-              GITHUB_APP_SLUG: ctx.env.GITHUB_APP_SLUG,
-              GITHUB_APP_BOT_USER_ID: ctx.env.GITHUB_APP_BOT_USER_ID,
-            },
-            cloneOptions
-          );
-        } else {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: 'Either githubRepo or gitUrl must be provided',
-          });
+        try {
+          if (input.gitUrl) {
+            await cloneGitRepo(
+              session,
+              workspacePath,
+              input.gitUrl,
+              resolvedGitToken,
+              undefined,
+              cloneOptions
+            );
+          } else if (input.githubRepo) {
+            await cloneGitHubRepo(
+              session,
+              workspacePath,
+              input.githubRepo,
+              resolvedGithubToken,
+              {
+                GITHUB_APP_SLUG: ctx.env.GITHUB_APP_SLUG,
+                GITHUB_APP_BOT_USER_ID: ctx.env.GITHUB_APP_BOT_USER_ID,
+              },
+              cloneOptions
+            );
+          } else {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: 'Either githubRepo or gitUrl must be provided',
+            });
+          }
+        } catch (error) {
+          if (error instanceof GitRepositoryNotFoundError) {
+            throw new TRPCError({ code: 'BAD_REQUEST', message: error.message });
+          }
+          throw error;
         }
 
         // 8. Branch management
         logger
           .withFields({ branchName, upstreamBranch: input.upstreamBranch })
           .info('Managing branch');
-        if (input.upstreamBranch) {
-          // For upstream branches, use manageBranch (verifies exists remotely)
-          await manageBranch(session, workspacePath, branchName, true);
-        } else {
-          // For session branches, create directly (can't exist remotely with UUID-based name)
-          const result = await session.exec(
-            `cd ${workspacePath} && git checkout -b '${branchName}'`
-          );
-          if (result.exitCode !== 0) {
-            throw new TRPCError({
-              code: 'INTERNAL_SERVER_ERROR',
-              message: `Failed to create branch ${branchName}: ${result.stderr || result.stdout}`,
-            });
+        try {
+          if (input.upstreamBranch) {
+            // For upstream branches, use manageBranch (verifies exists remotely)
+            await manageBranch(session, workspacePath, branchName, true);
+          } else {
+            // For session branches, create directly (can't exist remotely with UUID-based name)
+            const result = await session.exec(
+              `cd ${workspacePath} && git checkout -b '${branchName}'`
+            );
+            if (result.exitCode !== 0) {
+              throw new TRPCError({
+                code: 'INTERNAL_SERVER_ERROR',
+                message: `Failed to create branch ${branchName}: ${result.stderr || result.stdout}`,
+              });
+            }
           }
+        } catch (error) {
+          if (error instanceof BranchNotFoundError) {
+            throw new TRPCError({ code: 'BAD_REQUEST', message: error.message });
+          }
+          throw error;
         }
 
         // 9. Run setup commands
@@ -527,7 +544,14 @@ const prepareSessionHandler = internalApiProtectedProcedure
           logger
             .withFields({ count: effective.setupCommands.length })
             .info('Running setup commands');
-          await runSetupCommands(session, context, effective.setupCommands, true); // fail-fast
+          try {
+            await runSetupCommands(session, context, effective.setupCommands, true); // fail-fast
+          } catch (error) {
+            if (error instanceof SetupCommandFailedError) {
+              throw new TRPCError({ code: 'BAD_REQUEST', message: error.message });
+            }
+            throw error;
+          }
         }
 
         // 10. Write auth file for session ingest, plus global rules.

--- a/services/cloud-agent-next/src/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/session-prepare.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as schemas from './router/schemas.js';
 import * as schemaLimits from './schema.js';
+import type * as WorkspaceModule from './workspace.js';
+import type * as SessionServiceModule from './session-service.js';
 
 // Create a mock execution session
 const createMockExecutionSession = () => ({
@@ -34,17 +36,22 @@ vi.mock('@cloudflare/sandbox', () => ({
   getSandbox: vi.fn(() => createMockSandbox()),
 }));
 
-// Mock workspace functions
-vi.mock('./workspace.js', () => ({
-  checkDiskAndCleanBeforeSetup: vi.fn().mockResolvedValue(undefined),
-  setupWorkspace: vi.fn().mockResolvedValue({
-    workspacePath: '/workspace/test',
-    sessionHome: '/home/test',
-  }),
-  cloneGitHubRepo: vi.fn().mockResolvedValue(undefined),
-  cloneGitRepo: vi.fn().mockResolvedValue(undefined),
-  manageBranch: vi.fn().mockResolvedValue(undefined),
-}));
+// Mock workspace functions, but keep the real exported error classes so
+// `instanceof` checks in the handler work against the same constructors.
+vi.mock('./workspace.js', async importOriginal => {
+  const actual = await importOriginal<typeof WorkspaceModule>();
+  return {
+    ...actual,
+    checkDiskAndCleanBeforeSetup: vi.fn().mockResolvedValue(undefined),
+    setupWorkspace: vi.fn().mockResolvedValue({
+      workspacePath: '/workspace/test',
+      sessionHome: '/home/test',
+    }),
+    cloneGitHubRepo: vi.fn().mockResolvedValue(undefined),
+    cloneGitRepo: vi.fn().mockResolvedValue(undefined),
+    manageBranch: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 // Mock WrapperClient.ensureWrapper (wrapper now starts kilo server in-process)
 vi.mock('./kilo/wrapper-client.js', () => ({
@@ -68,45 +75,52 @@ const {
   deleteCliSessionViaSessionIngestMock: vi.fn().mockResolvedValue(undefined),
 }));
 
-// Mock session-service to isolate router tests
-vi.mock('./session-service.js', () => ({
-  generateSessionId: () => generateSessionIdMock(),
-  fetchSessionMetadata: vi.fn(),
-  determineBranchName: vi.fn(
-    (sessionId: string, upstreamBranch?: string) => upstreamBranch || `session/${sessionId}`
-  ),
-  runSetupCommands: vi.fn().mockResolvedValue(undefined),
-  writeAuthFile: vi.fn().mockResolvedValue(undefined),
-  writeGlobalRules: vi.fn().mockResolvedValue(undefined),
-  writeRuntimeSkills: vi.fn().mockResolvedValue(undefined),
-  InvalidSessionMetadataError: class InvalidSessionMetadataError extends Error {
-    constructor(
-      public readonly userId: string,
-      public readonly sessionId: string,
-      public readonly details?: string
-    ) {
-      super(`Invalid session metadata for session ${sessionId}`);
-      this.name = 'InvalidSessionMetadataError';
-    }
-  },
-  SessionService: class SessionService {
-    createCliSessionViaSessionIngest = createCliSessionViaSessionIngestMock;
-    deleteCliSessionViaSessionIngest = deleteCliSessionViaSessionIngestMock;
-    getOrCreateSession = vi.fn().mockResolvedValue(createMockExecutionSession());
-    buildContext = vi.fn().mockReturnValue({
-      sandboxId: 'test-sandbox',
-      orgId: 'test-org',
-      userId: 'test-user',
-      sessionId: 'test-session',
-      workspacePath: '/workspace/test',
-      sessionHome: '/home/test',
-    });
-  },
-}));
+// Mock session-service to isolate router tests, but keep the real exported
+// error classes (`SetupCommandFailedError`, `InvalidSessionMetadataError`)
+// so `instanceof` checks in the handler resolve to the same constructors
+// the production code throws.
+vi.mock('./session-service.js', async importOriginal => {
+  const actual = await importOriginal<typeof SessionServiceModule>();
+  return {
+    ...actual,
+    generateSessionId: () => generateSessionIdMock(),
+    fetchSessionMetadata: vi.fn(),
+    determineBranchName: vi.fn(
+      (sessionId: string, upstreamBranch?: string) => upstreamBranch || `session/${sessionId}`
+    ),
+    runSetupCommands: vi.fn().mockResolvedValue(undefined),
+    writeAuthFile: vi.fn().mockResolvedValue(undefined),
+    writeGlobalRules: vi.fn().mockResolvedValue(undefined),
+    writeRuntimeSkills: vi.fn().mockResolvedValue(undefined),
+    SessionService: class SessionService {
+      createCliSessionViaSessionIngest = createCliSessionViaSessionIngestMock;
+      deleteCliSessionViaSessionIngest = deleteCliSessionViaSessionIngestMock;
+      getOrCreateSession = vi.fn().mockResolvedValue(createMockExecutionSession());
+      buildContext = vi.fn().mockReturnValue({
+        sandboxId: 'test-sandbox',
+        orgId: 'test-org',
+        userId: 'test-user',
+        sessionId: 'test-session',
+        workspacePath: '/workspace/test',
+        sessionHome: '/home/test',
+      });
+    },
+  };
+});
 
 import { appRouter } from './router.js';
 import type { TRPCContext, SessionId } from './types.js';
 import type { CloudAgentSessionState } from './persistence/types.js';
+import {
+  BranchNotFoundError,
+  GitRepositoryNotFoundError,
+  cloneGitHubRepo as mockedCloneGitHubRepo,
+  manageBranch as mockedManageBranch,
+} from './workspace.js';
+import {
+  SetupCommandFailedError,
+  runSetupCommands as mockedRunSetupCommands,
+} from './session-service.js';
 
 // Helper to create a mock DO stub
 function createMockDOStub(
@@ -466,6 +480,87 @@ describe('prepareSession endpoint', () => {
     // NOTE: CLI session creation (createCliSessionViaSessionIngest) is handled via session-ingest.
     // The kiloSessionId now comes from the kilo CLI server's POST /session API.
     // Tests for backend session creation error handling and rollback have been removed.
+  });
+
+  describe('user-error mapping (HTTP 400)', () => {
+    it('returns BAD_REQUEST when the repository is not found', async () => {
+      const doStub = createMockDOStub();
+      vi.mocked(mockedCloneGitHubRepo).mockRejectedValueOnce(
+        new GitRepositoryNotFoundError('https://github.com/acme/missing.git')
+      );
+
+      const ctx = createInternalApiContext({ doStub });
+      const caller = appRouter.createCaller(ctx);
+
+      await expect(
+        caller.prepareSession({
+          prompt: 'Test prompt',
+          mode: 'code',
+          model: 'claude-3',
+          githubRepo: 'acme/missing',
+          githubToken: 'ghp_test_token',
+        })
+      ).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: expect.stringContaining('Repository not found') as unknown as string,
+      });
+
+      expect(doStub.prepare).not.toHaveBeenCalled();
+    });
+
+    it('returns BAD_REQUEST when the upstream branch is missing', async () => {
+      const doStub = createMockDOStub();
+      vi.mocked(mockedManageBranch).mockRejectedValueOnce(
+        new BranchNotFoundError('feature/does-not-exist')
+      );
+
+      const ctx = createInternalApiContext({ doStub });
+      const caller = appRouter.createCaller(ctx);
+
+      await expect(
+        caller.prepareSession({
+          prompt: 'Test prompt',
+          mode: 'code',
+          model: 'claude-3',
+          githubRepo: 'acme/repo',
+          githubToken: 'ghp_test_token',
+          upstreamBranch: 'feature/does-not-exist',
+        })
+      ).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: expect.stringContaining(
+          'Branch "feature/does-not-exist" not found'
+        ) as unknown as string,
+      });
+
+      expect(doStub.prepare).not.toHaveBeenCalled();
+    });
+
+    it('returns BAD_REQUEST when a setup command fails', async () => {
+      const doStub = createMockDOStub();
+      vi.mocked(mockedRunSetupCommands).mockRejectedValueOnce(
+        new SetupCommandFailedError('npm install', 1, 'ENOENT')
+      );
+
+      const ctx = createInternalApiContext({ doStub });
+      const caller = appRouter.createCaller(ctx);
+
+      await expect(
+        caller.prepareSession({
+          prompt: 'Test prompt',
+          mode: 'code',
+          model: 'claude-3',
+          githubRepo: 'acme/repo',
+          githubToken: 'ghp_test_token',
+          setupCommands: ['npm install'],
+        })
+      ).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: expect.stringContaining('Setup command failed') as unknown as string,
+      });
+
+      expect(doStub.prepare).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/services/cloud-agent-next/src/workspace.test.ts
+++ b/services/cloud-agent-next/src/workspace.test.ts
@@ -26,6 +26,9 @@ vi.mock('./logger.js', () => ({
     descriptor,
 }));
 import {
+  BranchNotFoundError,
+  GitCloneFailedError,
+  GitRepositoryNotFoundError,
   manageBranch,
   cloneGitHubRepo,
   cloneGitRepo,
@@ -188,15 +191,15 @@ describe('manageBranch', () => {
         ).rejects.toThrow('Failed to fetch pull ref refs/pull/42/head');
       });
 
-      it('should throw error', async () => {
+      it('should throw BranchNotFoundError', async () => {
         mockExec
           .mockResolvedValueOnce({ exitCode: 0 }) // git fetch
           .mockResolvedValueOnce({ exitCode: 1 }) // local check (does not exist)
           .mockResolvedValueOnce({ exitCode: 1 }); // remote check (does not exist)
 
-        await expect(manageBranch(fakeSession, '/workspace', 'main', true)).rejects.toThrow(
-          'Branch "main" not found in repository'
-        );
+        const promise = manageBranch(fakeSession, '/workspace', 'main', true);
+        await expect(promise).rejects.toBeInstanceOf(BranchNotFoundError);
+        await expect(promise).rejects.toThrow('Branch "main" not found in repository');
       });
     });
   });
@@ -599,6 +602,65 @@ describe('disk space checking', () => {
       await expect(
         cloneGitRepo(fakeSession, '/workspace', 'https://example.com/repo.git')
       ).rejects.toBe(error);
+    });
+
+    it('throws GitRepositoryNotFoundError when git stderr says repository not found', async () => {
+      mockGitCheckout.mockRejectedValueOnce(
+        new Error(
+          "remote: Repository not found.\nfatal: repository 'https://example.com/repo' not found"
+        )
+      );
+
+      const promise = cloneGitRepo(fakeSession, '/workspace', 'https://example.com/repo.git');
+      await expect(promise).rejects.toBeInstanceOf(GitRepositoryNotFoundError);
+      await expect(promise).rejects.toThrow('Repository not found: https://example.com/repo.git');
+    });
+
+    it('throws GitRepositoryNotFoundError when stderr field on the SDK error contains the pattern', async () => {
+      const sdkError = Object.assign(new Error('Git checkout failed'), {
+        name: 'GitCheckoutError',
+        stderr: "remote: Repository not found.\nfatal: repository '...' not found",
+      });
+      mockGitCheckout.mockRejectedValueOnce(sdkError);
+
+      const promise = cloneGitRepo(fakeSession, '/workspace', 'https://example.com/repo.git');
+      await expect(promise).rejects.toBeInstanceOf(GitRepositoryNotFoundError);
+    });
+
+    it('throws GitCloneFailedError for LFS smudge failures (not repo-not-found)', async () => {
+      mockGitCheckout.mockRejectedValueOnce(
+        new Error(
+          "error: external filter 'git-lfs filter-process' failed: smudge filter lfs failed"
+        )
+      );
+
+      const promise = cloneGitRepo(fakeSession, '/workspace', 'https://example.com/repo.git');
+      await expect(promise).rejects.toBeInstanceOf(GitCloneFailedError);
+      await expect(promise).rejects.toThrow(
+        'Failed to clone repository from https://example.com/repo.git'
+      );
+    });
+
+    it('throws GitCloneFailedError when gitCheckout returns success=false', async () => {
+      mockGitCheckout.mockResolvedValue({ success: false, exitCode: 128 });
+
+      const promise = cloneGitRepo(fakeSession, '/workspace', 'https://example.com/repo.git');
+      await expect(promise).rejects.toBeInstanceOf(GitCloneFailedError);
+    });
+
+    it('sanitizes tokens out of GitCloneFailedError reason', async () => {
+      mockGitCheckout.mockRejectedValueOnce(
+        new Error('clone failed at https://x-access-token:secret123@example.com/repo.git')
+      );
+
+      try {
+        await cloneGitRepo(fakeSession, '/workspace', 'https://example.com/repo.git');
+        throw new Error('Expected cloneGitRepo to reject');
+      } catch (err) {
+        expect(err).toBeInstanceOf(GitCloneFailedError);
+        expect((err as Error).message).not.toContain('secret123');
+        expect((err as Error).message).toContain('x-access-token:***@');
+      }
     });
   });
 

--- a/services/cloud-agent-next/src/workspace.ts
+++ b/services/cloud-agent-next/src/workspace.ts
@@ -51,6 +51,62 @@ function sanitizeGitOutput(output: string): string {
   return output.replace(/(oauth2|x-access-token|x-token-auth):([^@]+)@/gi, '$1:***@');
 }
 
+/**
+ * Thrown when a git remote returns "repository not found" during clone.
+ * Caused by a missing repo or a token without access — a user error, not infra.
+ */
+export class GitRepositoryNotFoundError extends Error {
+  constructor(gitUrl: string) {
+    super(`Repository not found: ${gitUrl}`);
+    this.name = 'GitRepositoryNotFoundError';
+  }
+}
+
+/**
+ * Thrown for clone failures other than "repository not found"
+ * (LFS smudge errors, network issues, etc.). Distinct from
+ * GitRepositoryNotFoundError so callers can map only the user-error
+ * cases to BAD_REQUEST.
+ */
+export class GitCloneFailedError extends Error {
+  constructor(gitUrl: string, reason: string) {
+    super(`Failed to clone repository from ${gitUrl}: ${reason}`);
+    this.name = 'GitCloneFailedError';
+  }
+}
+
+/**
+ * Thrown when an upstream branch does not exist locally or remotely.
+ * This is a user error (caller asked for a non-existent branch).
+ */
+export class BranchNotFoundError extends Error {
+  constructor(branchName: string) {
+    super(
+      `Branch "${branchName}" not found in repository. Please ensure the branch exists remotely.`
+    );
+    this.name = 'BranchNotFoundError';
+  }
+}
+
+// Detect "remote repository not found" in git stderr. The two patterns we
+// care about, observed from GitHub/GitLab/Bitbucket:
+//   "remote: Repository not found."
+//   "fatal: repository '...' not found"
+// We deliberately avoid an unanchored `.*` so the regex can't match
+// unrelated git messages that happen to contain both words.
+const REPO_NOT_FOUND_PATTERN = /repository '[^']*' not found|remote:\s+repository not found/i;
+
+/**
+ * Best-effort extraction of `stderr` from sandbox SDK errors that expose it
+ * (e.g., GitCheckoutError). Returns empty string when not present.
+ */
+function extractStderr(err: unknown): string {
+  if (err && typeof err === 'object' && 'stderr' in err && typeof err.stderr === 'string') {
+    return err.stderr;
+  }
+  return '';
+}
+
 const SESSION_HOME_ROOT = `/home`;
 const KILOCODE_DIR = `.kilocode`;
 const CLI_DIR = `${KILOCODE_DIR}/cli`;
@@ -557,8 +613,9 @@ export async function cloneGitRepo(
     logger.info('Successfully cloned generic git repository');
   } catch (err) {
     // Log actual error for debugging
+    const errorMessage = err instanceof Error ? err.message : String(err);
     logger.error('Git clone failed', {
-      error: err instanceof Error ? err.message : String(err),
+      error: errorMessage,
       gitUrl: sanitizedGitUrl,
     });
 
@@ -566,8 +623,24 @@ export async function cloneGitRepo(
       throw err;
     }
 
-    // Throw generic error to avoid leaking token in response
-    throw new Error(`Failed to clone repository from ${sanitizedGitUrl}`);
+    // Detect "repository not found" — a user-caused error (bad repo or
+    // missing access). The sandbox SDK surfaces git stderr in the error
+    // message, including patterns like:
+    //   "remote: Repository not found."
+    //   "fatal: repository '...' not found"
+    // We also pull stderr from a typed GitCheckoutError if present.
+    const stderr = extractStderr(err);
+    const haystack = `${errorMessage}\n${stderr}`;
+    if (REPO_NOT_FOUND_PATTERN.test(haystack)) {
+      throw new GitRepositoryNotFoundError(sanitizedGitUrl);
+    }
+
+    // All other failures (LFS, network, timeouts, etc.) — wrap as a
+    // typed clone-failure error. Defense-in-depth: tokens shouldn't reach
+    // this point (the SDK strips them and `sanitizedGitUrl` has been
+    // masked), but we still run `sanitizeGitOutput` in case a future code
+    // path inlines an authenticated URL into the error message.
+    throw new GitCloneFailedError(sanitizedGitUrl, sanitizeGitOutput(errorMessage));
   }
 }
 
@@ -856,9 +929,7 @@ export async function manageBranch(
         return branchName;
       }
 
-      throw new Error(
-        `Branch "${branchName}" not found in repository. Please ensure the branch exists remotely.`
-      );
+      throw new BranchNotFoundError(branchName);
     }
     await createNewBranch(session, workspacePath, branchName);
   }

--- a/services/cloud-agent-next/src/workspace.ts
+++ b/services/cloud-agent-next/src/workspace.ts
@@ -615,7 +615,7 @@ export async function cloneGitRepo(
     // Log actual error for debugging
     const errorMessage = err instanceof Error ? err.message : String(err);
     logger.error('Git clone failed', {
-      error: errorMessage,
+      error: sanitizeGitOutput(errorMessage),
       gitUrl: sanitizedGitUrl,
     });
 


### PR DESCRIPTION
## Summary

- Introduces typed error classes (`GitRepositoryNotFoundError`, `GitCloneFailedError`, `BranchNotFoundError`, and re-exported `SetupCommandFailedError`) so the prepare pipeline can distinguish user-caused failures from infra failures.
- `cloneGitRepo` now inspects git stderr for the canonical "repository not found" patterns and throws `GitRepositoryNotFoundError`; other clone failures become `GitCloneFailedError` with tokens sanitized out of the reason string.
- `manageBranch` throws `BranchNotFoundError` instead of a generic `Error` when an upstream branch is missing both locally and remotely.
- `prepareSession` handler catches these domain errors and maps them to `TRPCError` `BAD_REQUEST` (HTTP 400), so callers see actionable user errors instead of opaque 500s.

## Verification

- Ran `pnpm --filter @kilocode/cloud-agent-next test` against the updated workspace and router tests (new cases cover repo-not-found, branch-not-found, setup-command-failed, LFS smudge, `success: false`, and token-sanitization paths).
- Confirmed `pnpm lint` and targeted typecheck on `services/cloud-agent-next` pass cleanly.

## Visual Changes

N/A — server-side error mapping only.

## Reviewer Notes

- The "repository not found" detection uses a tight regex (`repository '...' not found` / `remote: Repository not found`) to avoid misclassifying unrelated git errors as user errors. Worth a second look to make sure we're not missing a variant surfaced by the sandbox SDK.
- `GitCloneFailedError` passes `sanitizeGitOutput(errorMessage)` through defensively; tokens should already be stripped by the SDK and by the masked `sanitizedGitUrl`, but the extra pass is cheap insurance.
- Tests keep the existing `vi.mock('./workspace.js', ...)` / `vi.mock('./session-service.js', ...)` behavior but use `importOriginal` so the real error classes are exported. This keeps `instanceof` checks in the handler working against the same constructors the mocks throw.