### PR TITLE
feat(gateway): expose embedding model catalog

### DIFF
--- a/apps/web/src/app/(app)/claw/components/embeddingModels.ts
+++ b/apps/web/src/app/(app)/claw/components/embeddingModels.ts
@@ -1,26 +1,16 @@
-/**
- * Hardcoded catalog of embedding models available through the Kilo Gateway.
- * These models are all routed through OpenRouter and known to work with
- * the gateway's /api/gateway/embeddings endpoint.
- */
+import {
+  KILO_DEFAULT_EMBEDDING_MODEL,
+  KILO_EMBEDDING_MODELS,
+} from '@/lib/ai-gateway/embeddings/kilo-embedding-models';
 
 export type EmbeddingModelOption = {
   id: string;
   name: string;
 };
 
-export const EMBEDDING_MODELS: EmbeddingModelOption[] = [
-  { id: 'mistralai/mistral-embed-2312', name: 'Mistral Embed' },
-  { id: 'openai/text-embedding-3-small', name: 'OpenAI Text Embedding 3 Small' },
-  { id: 'openai/text-embedding-3-large', name: 'OpenAI Text Embedding 3 Large' },
-  { id: 'google/gemini-embedding-001', name: 'Google Gemini Embedding 001' },
-  { id: 'mistralai/codestral-embed-2505', name: 'Codestral Embed' },
-];
+export const EMBEDDING_MODELS: EmbeddingModelOption[] = KILO_EMBEDDING_MODELS.map(model => ({
+  id: model.id,
+  name: model.name,
+}));
 
-/**
- * Source of truth: `services/kiloclaw/src/schemas/instance-config.ts` →
- * `DEFAULT_VECTOR_MEMORY_MODEL`. Duplicated here because the web bundle does
- * not import from the worker tree. Keep in sync across worker, controller
- * (`controller/src/config-writer.ts`), and this file.
- */
-export const DEFAULT_EMBEDDING_MODEL = 'mistralai/mistral-embed-2312';
+export const DEFAULT_EMBEDDING_MODEL = KILO_DEFAULT_EMBEDDING_MODEL;

--- a/apps/web/src/app/api/gateway/embedding-models/route.test.ts
+++ b/apps/web/src/app/api/gateway/embedding-models/route.test.ts
@@ -17,11 +17,18 @@ describe('GET /api/gateway/embedding-models', () => {
 
   test('catalog includes default model metadata and aliases', () => {
     expect(KILO_EMBEDDING_MODEL_CATALOG.defaultModel).toBe(KILO_DEFAULT_EMBEDDING_MODEL);
-    expect(getKiloEmbeddingModel('codestral-embed-2505')).toMatchObject({
+    expect(getKiloEmbeddingModel(KILO_DEFAULT_EMBEDDING_MODEL)).toMatchObject({
       id: KILO_DEFAULT_EMBEDDING_MODEL,
-      dimension: 1536,
+      dimension: 1024,
       scoreThreshold: 0.35,
     });
-    expect(normalizeKiloEmbeddingModelId('text-embedding-3-small')).toBe('openai/text-embedding-3-small');
+    expect(getKiloEmbeddingModel('codestral-embed-2505')).toMatchObject({
+      id: 'mistralai/codestral-embed-2505',
+      dimension: 256,
+      scoreThreshold: 0.35,
+    });
+    expect(normalizeKiloEmbeddingModelId('text-embedding-3-small')).toBe(
+      'openai/text-embedding-3-small'
+    );
   });
 });

--- a/apps/web/src/app/api/gateway/embedding-models/route.test.ts
+++ b/apps/web/src/app/api/gateway/embedding-models/route.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from '@jest/globals';
+import { GET } from './route';
+import {
+  KILO_DEFAULT_EMBEDDING_MODEL,
+  KILO_EMBEDDING_MODEL_CATALOG,
+  getKiloEmbeddingModel,
+  normalizeKiloEmbeddingModelId,
+} from '@/lib/ai-gateway/embeddings/kilo-embedding-models';
+
+describe('GET /api/gateway/embedding-models', () => {
+  test('returns the Kilo embedding model catalog', async () => {
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(KILO_EMBEDDING_MODEL_CATALOG);
+  });
+
+  test('catalog includes default model metadata and aliases', () => {
+    expect(KILO_EMBEDDING_MODEL_CATALOG.defaultModel).toBe(KILO_DEFAULT_EMBEDDING_MODEL);
+    expect(getKiloEmbeddingModel('codestral-embed-2505')).toMatchObject({
+      id: KILO_DEFAULT_EMBEDDING_MODEL,
+      dimension: 1536,
+      scoreThreshold: 0.35,
+    });
+    expect(normalizeKiloEmbeddingModelId('text-embedding-3-small')).toBe('openai/text-embedding-3-small');
+  });
+});

--- a/apps/web/src/app/api/gateway/embedding-models/route.ts
+++ b/apps/web/src/app/api/gateway/embedding-models/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { KILO_EMBEDDING_MODEL_CATALOG } from '@/lib/ai-gateway/embeddings/kilo-embedding-models';
+
+export async function GET(): Promise<NextResponse> {
+  return NextResponse.json(KILO_EMBEDDING_MODEL_CATALOG);
+}

--- a/apps/web/src/lib/ai-gateway/embeddings/kilo-embedding-models.ts
+++ b/apps/web/src/lib/ai-gateway/embeddings/kilo-embedding-models.ts
@@ -12,17 +12,22 @@ export type KiloEmbeddingModelCatalog = {
   aliases: Record<string, string>;
 };
 
-export const KILO_DEFAULT_EMBEDDING_MODEL = 'mistralai/codestral-embed-2505';
+export const KILO_DEFAULT_EMBEDDING_MODEL = 'mistralai/mistral-embed-2312';
 
 export const KILO_EMBEDDING_MODELS = [
   {
-    id: KILO_DEFAULT_EMBEDDING_MODEL,
+    id: 'mistralai/codestral-embed-2505',
     name: 'Codestral Embed 2505',
-    dimension: 1536,
+    dimension: 256,
     scoreThreshold: 0.35,
     note: 'code',
   },
-  { id: 'mistralai/mistral-embed-2312', name: 'Mistral Embed 2312', dimension: 1024, scoreThreshold: 0.35 },
+  {
+    id: KILO_DEFAULT_EMBEDDING_MODEL,
+    name: 'Mistral Embed 2312',
+    dimension: 1024,
+    scoreThreshold: 0.35,
+  },
   {
     id: 'openai/text-embedding-3-small',
     name: 'OpenAI Text Embedding 3 Small',
@@ -41,9 +46,24 @@ export const KILO_EMBEDDING_MODELS = [
     dimension: 1536,
     scoreThreshold: 0.4,
   },
-  { id: 'google/gemini-embedding-001', name: 'Gemini Embedding 001', dimension: 3072, scoreThreshold: 0.35 },
-  { id: 'qwen/qwen3-embedding-8b', name: 'Qwen3 Embedding 8B', dimension: 4096, scoreThreshold: 0.35 },
-  { id: 'qwen/qwen3-embedding-4b', name: 'Qwen3 Embedding 4B', dimension: 2560, scoreThreshold: 0.35 },
+  {
+    id: 'google/gemini-embedding-001',
+    name: 'Gemini Embedding 001',
+    dimension: 3072,
+    scoreThreshold: 0.35,
+  },
+  {
+    id: 'qwen/qwen3-embedding-8b',
+    name: 'Qwen3 Embedding 8B',
+    dimension: 4096,
+    scoreThreshold: 0.35,
+  },
+  {
+    id: 'qwen/qwen3-embedding-4b',
+    name: 'Qwen3 Embedding 4B',
+    dimension: 2560,
+    scoreThreshold: 0.35,
+  },
   {
     id: 'perplexity/pplx-embed-v1-4b',
     name: 'Perplexity Embed V1 4B',
@@ -57,8 +77,18 @@ export const KILO_EMBEDDING_MODELS = [
     scoreThreshold: 0.35,
   },
   { id: 'baai/bge-m3', name: 'BAAI bge-m3', dimension: 1024, scoreThreshold: 0.35 },
-  { id: 'baai/bge-large-en-v1.5', name: 'BAAI bge-large-en-v1.5', dimension: 1024, scoreThreshold: 0.35 },
-  { id: 'baai/bge-base-en-v1.5', name: 'BAAI bge-base-en-v1.5', dimension: 768, scoreThreshold: 0.35 },
+  {
+    id: 'baai/bge-large-en-v1.5',
+    name: 'BAAI bge-large-en-v1.5',
+    dimension: 1024,
+    scoreThreshold: 0.35,
+  },
+  {
+    id: 'baai/bge-base-en-v1.5',
+    name: 'BAAI bge-base-en-v1.5',
+    dimension: 768,
+    scoreThreshold: 0.35,
+  },
   { id: 'thenlper/gte-large', name: 'GTE Large', dimension: 1024, scoreThreshold: 0.35 },
   { id: 'thenlper/gte-base', name: 'GTE Base', dimension: 768, scoreThreshold: 0.35 },
   { id: 'intfloat/e5-large-v2', name: 'E5 Large v2', dimension: 1024, scoreThreshold: 0.35 },
@@ -105,8 +135,8 @@ export const KILO_EMBEDDING_MODEL_ALIASES: Record<string, string> = {
   'text-embedding-3-small': 'openai/text-embedding-3-small',
   'text-embedding-3-large': 'openai/text-embedding-3-large',
   'text-embedding-ada-002': 'openai/text-embedding-ada-002',
-  'codestral-embed-2505': KILO_DEFAULT_EMBEDDING_MODEL,
-  'mistral-embed-2312': 'mistralai/mistral-embed-2312',
+  'codestral-embed-2505': 'mistralai/codestral-embed-2505',
+  'mistral-embed-2312': KILO_DEFAULT_EMBEDDING_MODEL,
 };
 
 export const KILO_EMBEDDING_MODEL_CATALOG = {

--- a/apps/web/src/lib/ai-gateway/embeddings/kilo-embedding-models.ts
+++ b/apps/web/src/lib/ai-gateway/embeddings/kilo-embedding-models.ts
@@ -1,0 +1,126 @@
+export type KiloEmbeddingModel = {
+  id: string;
+  name: string;
+  dimension: number;
+  scoreThreshold: number;
+  note?: string;
+};
+
+export type KiloEmbeddingModelCatalog = {
+  defaultModel: string;
+  models: KiloEmbeddingModel[];
+  aliases: Record<string, string>;
+};
+
+export const KILO_DEFAULT_EMBEDDING_MODEL = 'mistralai/codestral-embed-2505';
+
+export const KILO_EMBEDDING_MODELS = [
+  {
+    id: KILO_DEFAULT_EMBEDDING_MODEL,
+    name: 'Codestral Embed 2505',
+    dimension: 1536,
+    scoreThreshold: 0.35,
+    note: 'code',
+  },
+  { id: 'mistralai/mistral-embed-2312', name: 'Mistral Embed 2312', dimension: 1024, scoreThreshold: 0.35 },
+  {
+    id: 'openai/text-embedding-3-small',
+    name: 'OpenAI Text Embedding 3 Small',
+    dimension: 1536,
+    scoreThreshold: 0.4,
+  },
+  {
+    id: 'openai/text-embedding-3-large',
+    name: 'OpenAI Text Embedding 3 Large',
+    dimension: 3072,
+    scoreThreshold: 0.4,
+  },
+  {
+    id: 'openai/text-embedding-ada-002',
+    name: 'OpenAI Text Embedding Ada 002',
+    dimension: 1536,
+    scoreThreshold: 0.4,
+  },
+  { id: 'google/gemini-embedding-001', name: 'Gemini Embedding 001', dimension: 3072, scoreThreshold: 0.35 },
+  { id: 'qwen/qwen3-embedding-8b', name: 'Qwen3 Embedding 8B', dimension: 4096, scoreThreshold: 0.35 },
+  { id: 'qwen/qwen3-embedding-4b', name: 'Qwen3 Embedding 4B', dimension: 2560, scoreThreshold: 0.35 },
+  {
+    id: 'perplexity/pplx-embed-v1-4b',
+    name: 'Perplexity Embed V1 4B',
+    dimension: 2560,
+    scoreThreshold: 0.35,
+  },
+  {
+    id: 'perplexity/pplx-embed-v1-0.6b',
+    name: 'Perplexity Embed V1 0.6B',
+    dimension: 1024,
+    scoreThreshold: 0.35,
+  },
+  { id: 'baai/bge-m3', name: 'BAAI bge-m3', dimension: 1024, scoreThreshold: 0.35 },
+  { id: 'baai/bge-large-en-v1.5', name: 'BAAI bge-large-en-v1.5', dimension: 1024, scoreThreshold: 0.35 },
+  { id: 'baai/bge-base-en-v1.5', name: 'BAAI bge-base-en-v1.5', dimension: 768, scoreThreshold: 0.35 },
+  { id: 'thenlper/gte-large', name: 'GTE Large', dimension: 1024, scoreThreshold: 0.35 },
+  { id: 'thenlper/gte-base', name: 'GTE Base', dimension: 768, scoreThreshold: 0.35 },
+  { id: 'intfloat/e5-large-v2', name: 'E5 Large v2', dimension: 1024, scoreThreshold: 0.35 },
+  { id: 'intfloat/e5-base-v2', name: 'E5 Base v2', dimension: 768, scoreThreshold: 0.35 },
+  {
+    id: 'intfloat/multilingual-e5-large',
+    name: 'Multilingual E5 Large',
+    dimension: 1024,
+    scoreThreshold: 0.35,
+  },
+  {
+    id: 'sentence-transformers/all-mpnet-base-v2',
+    name: 'all-mpnet-base-v2',
+    dimension: 768,
+    scoreThreshold: 0.35,
+  },
+  {
+    id: 'sentence-transformers/all-minilm-l12-v2',
+    name: 'all-MiniLM-L12-v2',
+    dimension: 384,
+    scoreThreshold: 0.35,
+  },
+  {
+    id: 'sentence-transformers/all-minilm-l6-v2',
+    name: 'all-MiniLM-L6-v2',
+    dimension: 384,
+    scoreThreshold: 0.35,
+  },
+  {
+    id: 'sentence-transformers/paraphrase-minilm-l6-v2',
+    name: 'paraphrase-MiniLM-L6-v2',
+    dimension: 384,
+    scoreThreshold: 0.35,
+  },
+  {
+    id: 'sentence-transformers/multi-qa-mpnet-base-dot-v1',
+    name: 'multi-qa-mpnet-base-dot-v1',
+    dimension: 768,
+    scoreThreshold: 0.35,
+  },
+] satisfies KiloEmbeddingModel[];
+
+export const KILO_EMBEDDING_MODEL_ALIASES: Record<string, string> = {
+  'text-embedding-3-small': 'openai/text-embedding-3-small',
+  'text-embedding-3-large': 'openai/text-embedding-3-large',
+  'text-embedding-ada-002': 'openai/text-embedding-ada-002',
+  'codestral-embed-2505': KILO_DEFAULT_EMBEDDING_MODEL,
+  'mistral-embed-2312': 'mistralai/mistral-embed-2312',
+};
+
+export const KILO_EMBEDDING_MODEL_CATALOG = {
+  defaultModel: KILO_DEFAULT_EMBEDDING_MODEL,
+  models: KILO_EMBEDDING_MODELS,
+  aliases: KILO_EMBEDDING_MODEL_ALIASES,
+} satisfies KiloEmbeddingModelCatalog;
+
+export function normalizeKiloEmbeddingModelId(modelId: string | undefined): string | undefined {
+  if (!modelId) return undefined;
+  return KILO_EMBEDDING_MODEL_ALIASES[modelId] ?? modelId;
+}
+
+export function getKiloEmbeddingModel(modelId: string | undefined): KiloEmbeddingModel | undefined {
+  const id = normalizeKiloEmbeddingModelId(modelId);
+  return KILO_EMBEDDING_MODELS.find(model => model.id === id);
+}

--- a/packages/trpc/tsconfig.json
+++ b/packages/trpc/tsconfig.json
@@ -25,8 +25,6 @@
   "include": [
     "src/**/*",
     "../../apps/web/src/types/next-auth.d.ts",
-    "../../apps/web/src/types/next-page.d.ts",
-    "../../packages/db/src/kiloclaw-personal-subscription-collapse.ts",
-    "../../packages/db/src/kiloclaw-subscription-change-log.ts"
+    "../../apps/web/src/types/next-page.d.ts"
   ]
 }

--- a/packages/trpc/tsconfig.json
+++ b/packages/trpc/tsconfig.json
@@ -25,6 +25,8 @@
   "include": [
     "src/**/*",
     "../../apps/web/src/types/next-auth.d.ts",
-    "../../apps/web/src/types/next-page.d.ts"
+    "../../apps/web/src/types/next-page.d.ts",
+    "../../packages/db/src/kiloclaw-personal-subscription-collapse.ts",
+    "../../packages/db/src/kiloclaw-subscription-change-log.ts"
   ]
 }


### PR DESCRIPTION
## Summary

Expose the Kilo-hosted embedding model catalog through the gateway so clients can fetch supported indexing models from Cloud instead of hardcoding the list.

## Verification

Manual API testing was not run locally. The endpoint is static and covered by a focused route test.

## Visual Changes

N/A

## Reviewer Notes

This is paired with the kilocode PR that switches indexing settings to consume `/api/gateway/embedding-models` with a bundled fallback.