### PR TITLE
fix(code-review): retry sandbox prep

### DIFF
--- a/packages/worker-utils/src/cloud-agent-next-client.test.ts
+++ b/packages/worker-utils/src/cloud-agent-next-client.test.ts
@@ -98,6 +98,7 @@ describe('CloudAgentNextFetchClient billing error detection', () => {
       expect(error).toBeInstanceOf(CloudAgentNextBillingError);
       const billingError = error as CloudAgentNextBillingError;
       expect(billingError.terminalReason).toBe('billing');
+      expect(billingError.procedure).toBe('prepareSession');
       expect(billingError.status).toBe(402);
     }
   });
@@ -127,6 +128,29 @@ describe('CloudAgentNextFetchClient billing error detection', () => {
         }
       )
     ).rejects.not.toThrow(CloudAgentNextBillingError);
+  });
+
+  it('preserves procedure metadata on generic errors', async () => {
+    vi.stubGlobal('fetch', mockFetch(500, 'Internal Server Error'));
+    const client = createCloudAgentNextFetchClient(BASE_URL);
+
+    try {
+      await client.prepareSession(
+        {},
+        {
+          prompt: 'test',
+          mode: 'code',
+          model: 'test-model',
+        }
+      );
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(CloudAgentNextError);
+      const cloudAgentError = error as CloudAgentNextError;
+      expect(cloudAgentError.procedure).toBe('prepareSession');
+      expect(cloudAgentError.status).toBe(500);
+      expect(cloudAgentError.body).toBe('Internal Server Error');
+    }
   });
 
   it('throws generic CloudAgentNextError for 404', async () => {

--- a/packages/worker-utils/src/cloud-agent-next-client.ts
+++ b/packages/worker-utils/src/cloud-agent-next-client.ts
@@ -102,12 +102,14 @@ export type CloudAgentTerminalReason =
   | 'unknown';
 
 export class CloudAgentNextError extends Error {
+  readonly procedure: string;
   readonly status: number;
   readonly body: string;
 
   constructor(procedure: string, status: number, body: string) {
     super(`${procedure} failed (${status}): ${body}`);
     this.name = 'CloudAgentNextError';
+    this.procedure = procedure;
     this.status = status;
     this.body = body;
   }

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -50,7 +50,10 @@ import {
 } from '../../services/git-token-service-client.js';
 import { getPgDb } from '../../db/pg.js';
 import { repoFullNameFromGitUrl } from '@kilocode/worker-utils/git-url';
-import { destroySandboxAfterInternalServerError } from '../../sandbox-recovery.js';
+import {
+  destroySandboxAfterInternalServerError,
+  isSandboxInternalServerError,
+} from '../../sandbox-recovery.js';
 
 type SessionPrepareHandlers = {
   prepareSession: typeof prepareSessionHandler;
@@ -578,6 +581,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
       try {
         preparedWorkspace = await prepareWorkspace();
       } catch (error) {
+        const sandboxInternalServerError = isSandboxInternalServerError(error);
         await destroySandboxAfterInternalServerError(
           {
             sandbox,
@@ -587,6 +591,13 @@ const prepareSessionHandler = internalApiProtectedProcedure
           },
           error
         );
+        if (sandboxInternalServerError) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'Sandbox returned 500 during workspace preparation',
+            cause: { error: 'sandbox_internal_server_error', retryable: true },
+          });
+        }
         throw error;
       }
 

--- a/services/cloud-agent-next/src/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/session-prepare.test.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from '@trpc/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as schemas from './router/schemas.js';
 import * as schemaLimits from './schema.js';
@@ -28,6 +29,7 @@ const createMockSandbox = () => {
     createSession: vi.fn().mockResolvedValue(mockSession),
     listProcesses: vi.fn().mockResolvedValue([]),
     mkdir: vi.fn().mockResolvedValue(undefined),
+    destroy: vi.fn().mockResolvedValue(undefined),
   };
 };
 
@@ -480,6 +482,44 @@ describe('prepareSession endpoint', () => {
     // NOTE: CLI session creation (createCliSessionViaSessionIngest) is handled via session-ingest.
     // The kiloSessionId now comes from the kilo CLI server's POST /session API.
     // Tests for backend session creation error handling and rollback have been removed.
+
+    it('marks sandbox 500 preparation failures as retryable', async () => {
+      const sandbox = createMockSandbox();
+      const sandboxError = new Error('HTTP error! status: 500');
+      Object.assign(sandboxError, { name: 'SandboxError' });
+      vi.mocked(mockedCloneGitHubRepo).mockRejectedValueOnce(sandboxError);
+      const { getSandbox } = await import('@cloudflare/sandbox');
+      vi.mocked(getSandbox).mockReturnValueOnce(
+        sandbox as unknown as ReturnType<typeof getSandbox>
+      );
+
+      const doStub = createMockDOStub();
+      const ctx = createInternalApiContext({ doStub });
+      const caller = appRouter.createCaller(ctx);
+
+      try {
+        await caller.prepareSession({
+          prompt: 'Test prompt',
+          mode: 'code',
+          model: 'claude-3',
+          githubRepo: 'acme/repo',
+          githubToken: 'ghp_test_token',
+        });
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(TRPCError);
+        const trpcError = error as TRPCError;
+        expect(trpcError.code).toBe('INTERNAL_SERVER_ERROR');
+        expect(trpcError.message).toBe('Sandbox returned 500 during workspace preparation');
+        expect(trpcError.cause).toMatchObject({
+          error: 'sandbox_internal_server_error',
+          retryable: true,
+        });
+      }
+
+      expect(sandbox.destroy).toHaveBeenCalledOnce();
+      expect(doStub.prepare).not.toHaveBeenCalled();
+    });
   });
 
   describe('user-error mapping (HTTP 400)', () => {

--- a/services/code-review-infra/src/code-review-orchestrator.ts
+++ b/services/code-review-infra/src/code-review-orchestrator.ts
@@ -10,6 +10,7 @@ import { DurableObject } from 'cloudflare:workers';
 import {
   createCloudAgentNextFetchClient,
   CloudAgentNextBillingError,
+  CloudAgentNextError,
   type CloudAgentNextFetchClient,
   type CloudAgentTerminalReason,
 } from '@kilocode/worker-utils';
@@ -64,6 +65,67 @@ function findRiskyPattern(command: string): string | null {
   const normalized = command.toLowerCase();
   const match = RISKY_COMMAND_PATTERNS.find(pattern => normalized.includes(pattern));
   return match ?? null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function hasRetryableSandboxMarker(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (value.error === 'sandbox_internal_server_error' && value.retryable === true) {
+    return true;
+  }
+
+  return Object.values(value).some(nested => hasRetryableSandboxMarker(nested));
+}
+
+function parseJsonBody(body: string): unknown {
+  try {
+    return JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+}
+
+function isPrepareSessionSandboxInternalServerError(error: unknown): boolean {
+  if (error instanceof CloudAgentNextBillingError) {
+    return false;
+  }
+
+  if (!(error instanceof CloudAgentNextError)) {
+    return false;
+  }
+
+  if (error.procedure !== 'prepareSession' || error.status !== 500) {
+    return false;
+  }
+
+  if (/\b(cancelled|canceled)\b/i.test(error.body)) {
+    return false;
+  }
+
+  const parsedBody = parseJsonBody(error.body);
+  if (hasRetryableSandboxMarker(parsedBody)) {
+    return true;
+  }
+
+  const body = error.body.toLowerCase();
+  const hasSandboxSignal =
+    body.includes('sandboxerror') ||
+    body.includes('sandbox') ||
+    body.includes('container') ||
+    body.includes('cloudflare');
+  const hasInternalServerSignal =
+    body.includes('internal server error') ||
+    /http\s+error!\s+status:\s*500\b/i.test(error.body) ||
+    /\bstatus:\s*500\b/i.test(error.body) ||
+    /\bhttp\s*500\b/i.test(error.body);
+
+  return hasSandboxSignal && hasInternalServerSignal;
 }
 
 /**
@@ -786,6 +848,29 @@ export class CodeReviewOrchestrator extends DurableObject<Env> {
         note: 'Callback will update final status',
       });
     } catch (error) {
+      if (
+        isPrepareSessionSandboxInternalServerError(error) &&
+        this.state.sandboxRetryAttempted !== true &&
+        !this.cancelled &&
+        this.state.status !== 'cancelled'
+      ) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+        this.state.sandboxRetryAttempted = true;
+        this.state.previousCloudAgentSessionId = undefined;
+        this.state.updatedAt = new Date().toISOString();
+        await this.saveState();
+
+        console.warn('[CodeReviewOrchestrator] Retrying prepareSession after sandbox 500', {
+          reviewId: this.state.reviewId,
+          error: errorMessage,
+          sandboxRetryAttempted: true,
+        });
+
+        await this.runWithCloudAgentNext();
+        return;
+      }
+
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       const terminalReason = this.getTerminalReason(error);
 

--- a/services/code-review-infra/src/types.ts
+++ b/services/code-review-infra/src/types.ts
@@ -69,6 +69,7 @@ export interface CodeReview {
   agentVersion?: string;
   /** Cloud-agent session ID from a previous completed review, for session continuation */
   previousCloudAgentSessionId?: string;
+  sandboxRetryAttempted?: boolean;
 }
 
 export interface CodeReviewStatusResponse {

--- a/services/code-review-infra/test/integration/code-review-orchestrator.test.ts
+++ b/services/code-review-infra/test/integration/code-review-orchestrator.test.ts
@@ -39,6 +39,47 @@ function workerAuthHeaders(): HeadersInit {
   return { Authorization: 'Bearer test-backend-token' };
 }
 
+function trpcSuccess(data: unknown): Response {
+  return Response.json({ result: { data } });
+}
+
+function trpcError(status: number, message: string, code = 'INTERNAL_SERVER_ERROR'): Response {
+  return Response.json(
+    {
+      error: {
+        message,
+        code: -32603,
+        data: {
+          code,
+          httpStatus: status,
+          path: 'prepareSession',
+        },
+      },
+    },
+    { status }
+  );
+}
+
+function fetchCalls(fetchMock: ReturnType<typeof vi.fn>, path: string) {
+  return fetchMock.mock.calls.filter(([request]) => String(request).includes(path));
+}
+
+function lastStatusUpdateBody(fetchMock: ReturnType<typeof vi.fn>): Record<string, unknown> {
+  const statusCalls = fetchCalls(fetchMock, '/api/internal/code-review-status/');
+  const lastCall = statusCalls.at(-1);
+  expect(lastCall).toBeDefined();
+
+  const init = lastCall?.[1] as RequestInit | undefined;
+  expect(init?.body).toEqual(expect.any(String));
+  return JSON.parse(String(init?.body)) as Record<string, unknown>;
+}
+
+async function storedReview(stub: DurableObjectStub<CodeReviewOrchestrator>) {
+  return runInDurableObject(stub, async (_instance: CodeReviewOrchestrator, state) =>
+    state.storage.get<CodeReview>('state')
+  );
+}
+
 describe('CodeReviewOrchestrator recovery', () => {
   const originalFetch = globalThis.fetch;
 
@@ -143,6 +184,157 @@ describe('CodeReviewOrchestrator recovery', () => {
       'https://cloud-agent-next.example.test/trpc/initiateFromKilocodeSessionV2',
       expect.any(Object)
     );
+  });
+
+  it('retries prepareSession once after a sandbox 500 and initiates the retry session', async () => {
+    const stub = getReviewStub();
+    let prepareCalls = 0;
+    const fetchMock = vi.fn(async (request: RequestInfo | URL) => {
+      const url = String(request);
+      if (url.includes('/api/internal/code-review-status/')) {
+        return Response.json({ success: true });
+      }
+      if (url.includes('/trpc/prepareSession')) {
+        prepareCalls += 1;
+        if (prepareCalls === 1) {
+          return trpcError(500, 'SandboxError: HTTP error! status: 500 during setup');
+        }
+        return trpcSuccess({
+          cloudAgentSessionId: 'agent-retry-session',
+          kiloSessionId: 'ses_retry_session',
+        });
+      }
+      if (url.includes('/trpc/initiateFromKilocodeSessionV2')) {
+        return trpcSuccess({ executionId: 'exec-retry', status: 'running' });
+      }
+      return new Response('unexpected fetch', { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await runInDurableObject(stub, async (_instance: CodeReviewOrchestrator, state) => {
+      await state.storage.put('state', codeReview());
+      await state.storage.setAlarm(Date.now() + 30_000);
+    });
+
+    const ran = await runDurableObjectAlarm(stub);
+
+    expect(ran).toBe(true);
+    const status = await stub.status();
+    expect(status).toMatchObject({
+      status: 'running',
+      sessionId: 'agent-retry-session',
+      cliSessionId: 'ses_retry_session',
+    });
+
+    expect(fetchCalls(fetchMock, '/trpc/prepareSession')).toHaveLength(2);
+    const initiateCalls = fetchCalls(fetchMock, '/trpc/initiateFromKilocodeSessionV2');
+    expect(initiateCalls).toHaveLength(1);
+    const initiateInit = initiateCalls[0]?.[1] as RequestInit | undefined;
+    expect(JSON.parse(String(initiateInit?.body))).toEqual({
+      cloudAgentSessionId: 'agent-retry-session',
+    });
+
+    await expect(storedReview(stub)).resolves.toMatchObject({
+      sandboxRetryAttempted: true,
+      sessionId: 'agent-retry-session',
+      cliSessionId: 'ses_retry_session',
+    });
+  });
+
+  it('fails after a second sandbox 500 without initiating', async () => {
+    const stub = getReviewStub();
+    const fetchMock = vi.fn(async (request: RequestInfo | URL) => {
+      const url = String(request);
+      if (url.includes('/api/internal/code-review-status/')) {
+        return Response.json({ success: true });
+      }
+      if (url.includes('/trpc/prepareSession')) {
+        return trpcError(500, 'SandboxError: HTTP error! status: 500 during setup');
+      }
+      return new Response('unexpected fetch', { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await runInDurableObject(stub, async (_instance: CodeReviewOrchestrator, state) => {
+      await state.storage.put('state', codeReview());
+      await state.storage.setAlarm(Date.now() + 30_000);
+    });
+
+    const ran = await runDurableObjectAlarm(stub);
+
+    expect(ran).toBe(true);
+    await expect(stub.status()).resolves.toMatchObject({ status: 'failed' });
+    expect(fetchCalls(fetchMock, '/trpc/prepareSession')).toHaveLength(2);
+    expect(fetchCalls(fetchMock, '/trpc/initiateFromKilocodeSessionV2')).toHaveLength(0);
+    await expect(storedReview(stub)).resolves.toMatchObject({
+      status: 'failed',
+      sandboxRetryAttempted: true,
+    });
+  });
+
+  it('does not retry billing failures from prepareSession', async () => {
+    const stub = getReviewStub();
+    const fetchMock = vi.fn(async (request: RequestInfo | URL) => {
+      const url = String(request);
+      if (url.includes('/api/internal/code-review-status/')) {
+        return Response.json({ success: true });
+      }
+      if (url.includes('/trpc/prepareSession')) {
+        return trpcError(402, 'Insufficient credits: $1 minimum required', 'PAYMENT_REQUIRED');
+      }
+      return new Response('unexpected fetch', { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await runInDurableObject(stub, async (_instance: CodeReviewOrchestrator, state) => {
+      await state.storage.put('state', codeReview());
+      await state.storage.setAlarm(Date.now() + 30_000);
+    });
+
+    const ran = await runDurableObjectAlarm(stub);
+
+    expect(ran).toBe(true);
+    await expect(stub.status()).resolves.toMatchObject({ status: 'failed' });
+    expect(fetchCalls(fetchMock, '/trpc/prepareSession')).toHaveLength(1);
+    expect(fetchCalls(fetchMock, '/trpc/initiateFromKilocodeSessionV2')).toHaveLength(0);
+    expect(lastStatusUpdateBody(fetchMock)).toMatchObject({
+      status: 'failed',
+      terminalReason: 'billing',
+    });
+    await expect(storedReview(stub)).resolves.toMatchObject({
+      status: 'failed',
+      terminalReason: 'billing',
+    });
+  });
+
+  it('does not retry deterministic prepareSession 400 failures', async () => {
+    const stub = getReviewStub();
+    const fetchMock = vi.fn(async (request: RequestInfo | URL) => {
+      const url = String(request);
+      if (url.includes('/api/internal/code-review-status/')) {
+        return Response.json({ success: true });
+      }
+      if (url.includes('/trpc/prepareSession')) {
+        return trpcError(400, 'Branch not found: main', 'BAD_REQUEST');
+      }
+      return new Response('unexpected fetch', { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await runInDurableObject(stub, async (_instance: CodeReviewOrchestrator, state) => {
+      await state.storage.put('state', codeReview());
+      await state.storage.setAlarm(Date.now() + 30_000);
+    });
+
+    const ran = await runDurableObjectAlarm(stub);
+
+    expect(ran).toBe(true);
+    await expect(stub.status()).resolves.toMatchObject({ status: 'failed' });
+    expect(fetchCalls(fetchMock, '/trpc/prepareSession')).toHaveLength(1);
+    expect(fetchCalls(fetchMock, '/trpc/initiateFromKilocodeSessionV2')).toHaveLength(0);
+    const stored = await storedReview(stub);
+    expect(stored).toMatchObject({ status: 'failed' });
+    expect(stored?.sandboxRetryAttempted).toBeUndefined();
   });
 
   it('aborts alarm recovery before cloud-agent calls when DB is already terminal', async () => {


### PR DESCRIPTION
## Why

Some code reviews can fail when the sandbox has a short server problem while getting ready. A retry can make those reviews start instead of failing right away.

## What changed

Code reviews now try one more time when setup fails because the sandbox returned a server error. The retry uses a fresh session and remembers that it already retried, so it cannot loop forever. Billing problems, cancelled reviews, and clear setup mistakes still fail without a retry.

## How to test

1. Run `pnpm --filter @kilocode/worker-utils test -- src/cloud-agent-next-client.test.ts`.
2. Run `pnpm --filter kilo-code-review-worker test`.
3. Run `pnpm --filter cloud-agent-next test -- src/session-prepare.test.ts src/sandbox-recovery.test.ts`.
4. Run `pnpm --filter kilo-code-review-worker typecheck`.