### PR TITLE
fix(bot): make botRequestId required end-to-end so callbacks are never silently dropped

### DIFF
--- a/apps/web/src/lib/bot/agent-runner.ts
+++ b/apps/web/src/lib/bot/agent-runner.ts
@@ -55,7 +55,7 @@ type RunBotAgentParams = {
   rawMessage?: Message;
   platformIntegration: PlatformIntegration;
   user: User;
-  botRequestId: string | undefined;
+  botRequestId: string;
   prompt: string;
   /** Pre-uploaded image attachments from the user's message (already in R2). */
   images?: Images;
@@ -238,13 +238,11 @@ export async function runBotAgent(params: RunBotAgentParams): Promise<BotAgentCo
   const initialSteps = params.initialSteps ?? [];
   const completedStepCount = Math.max(params.completedStepCount ?? 0, initialSteps.length);
   const remainingIterations = getRemainingBotIterations(completedStepCount);
-  const spawnGroupId = params.botRequestId ? randomUUID() : undefined;
+  const spawnGroupId = randomUUID();
   const collectedSteps: BotRequestStep[] = [];
   let startedCloudAgentSession = false;
 
-  if (params.botRequestId) {
-    updateBotRequest(params.botRequestId, { modelUsed: modelSlug });
-  }
+  updateBotRequest(params.botRequestId, { modelUsed: modelSlug });
 
   if (remainingIterations <= 0) {
     return {
@@ -315,11 +313,9 @@ This tool returns an acknowledgement immediately. The final Cloud Agent result w
 
           // Persist the session link synchronously so callbacks can
           // correlate immediately — must complete before we return.
-          if (params.botRequestId && resolvedCloudAgentSessionId) {
+          if (resolvedCloudAgentSessionId) {
             await linkBotRequestToSession(params.botRequestId, resolvedCloudAgentSessionId);
-          }
 
-          if (params.botRequestId && spawnGroupId && resolvedCloudAgentSessionId) {
             await recordBotRequestCloudAgentSession({
               botRequestId: params.botRequestId,
               spawnGroupId,
@@ -338,9 +334,7 @@ This tool returns an acknowledgement immediately. The final Cloud Agent result w
     },
     onStepFinish: step => {
       collectedSteps.push(serializeStep(step, completedStepCount));
-      if (params.botRequestId) {
-        updateBotRequest(params.botRequestId, { steps: [...initialSteps, ...collectedSteps] });
-      }
+      updateBotRequest(params.botRequestId, { steps: [...initialSteps, ...collectedSteps] });
     },
   });
 

--- a/apps/web/src/lib/bot/request-logging.test.ts
+++ b/apps/web/src/lib/bot/request-logging.test.ts
@@ -1,5 +1,6 @@
 import { db } from '@/lib/drizzle';
 import {
+  createBotRequest as createBotRequestRow,
   linkBotRequestToSession,
   markBotRequestCloudAgentSessionTerminal,
   recordBotRequestCloudAgentSession,
@@ -305,5 +306,20 @@ describe('bot request logging', () => {
     );
 
     expect(row.cloud_agent_session_id).toBe(cloudAgentSessionId);
+  });
+
+  it('throws when the insert fails so callers can surface the error', async () => {
+    await expect(
+      createBotRequestRow({
+        createdBy: `nonexistent-user-${randomUUID()}`,
+        organizationId: null,
+        platformIntegrationId: randomUUID(),
+        platform: 'slack',
+        platformThreadId: `slack:T123:C456:${randomUUID()}`,
+        platformMessageId: `message-${randomUUID()}`,
+        userMessage: 'Please make a change',
+        modelUsed: undefined,
+      })
+    ).rejects.toThrow();
   });
 });

--- a/apps/web/src/lib/bot/request-logging.ts
+++ b/apps/web/src/lib/bot/request-logging.ts
@@ -24,33 +24,31 @@ type CreateBotRequestParams = {
 
 /**
  * Insert a pending bot_requests row at the start of message handling.
- * Returns the row ID on success, or undefined if the insert fails
- * (logging should never break the main flow).
+ * Throws on DB failure so the caller can capture context-rich Sentry
+ * events and surface a user-facing error — the callback pipeline depends
+ * on this row existing, so a silent failure here would drop the result.
  */
-export async function createBotRequest(
-  params: CreateBotRequestParams
-): Promise<string | undefined> {
-  try {
-    const [row] = await db
-      .insert(bot_requests)
-      .values({
-        created_by: params.createdBy,
-        organization_id: params.organizationId,
-        platform_integration_id: params.platformIntegrationId,
-        platform: params.platform,
-        platform_thread_id: params.platformThreadId,
-        platform_message_id: params.platformMessageId ?? null,
-        user_message: params.userMessage,
-        model_used: params.modelUsed ?? null,
-        status: 'pending',
-      })
-      .returning({ id: bot_requests.id });
+export async function createBotRequest(params: CreateBotRequestParams): Promise<string> {
+  const [row] = await db
+    .insert(bot_requests)
+    .values({
+      created_by: params.createdBy,
+      organization_id: params.organizationId,
+      platform_integration_id: params.platformIntegrationId,
+      platform: params.platform,
+      platform_thread_id: params.platformThreadId,
+      platform_message_id: params.platformMessageId ?? null,
+      user_message: params.userMessage,
+      model_used: params.modelUsed ?? null,
+      status: 'pending',
+    })
+    .returning({ id: bot_requests.id });
 
-    return row?.id;
-  } catch (error) {
-    captureException(error, { tags: { component: 'bot-request-log', op: 'create' } });
-    return undefined;
+  if (!row) {
+    throw new Error('createBotRequest: insert returned no row');
   }
+
+  return row.id;
 }
 
 type UpdateBotRequestParams = {

--- a/apps/web/src/lib/bot/run.ts
+++ b/apps/web/src/lib/bot/run.ts
@@ -18,16 +18,35 @@ export async function processLinkedMessage({
 }) {
   await thread.startTyping('Thinking...');
 
-  const botRequestId = await createBotRequest({
-    createdBy: user.id,
-    organizationId: platformIntegration.owned_by_organization_id ?? null,
-    platformIntegrationId: platformIntegration.id,
-    platform: thread.adapter.name,
-    platformThreadId: thread.id,
-    platformMessageId: message.id,
-    userMessage: message.text,
-    modelUsed: undefined,
-  });
+  let botRequestId: string;
+  try {
+    botRequestId = await createBotRequest({
+      createdBy: user.id,
+      organizationId: platformIntegration.owned_by_organization_id ?? null,
+      platformIntegrationId: platformIntegration.id,
+      platform: thread.adapter.name,
+      platformThreadId: thread.id,
+      platformMessageId: message.id,
+      userMessage: message.text,
+      modelUsed: undefined,
+    });
+  } catch (error) {
+    captureException(error, {
+      tags: { component: 'kilo-bot', op: 'create-bot-request' },
+      extra: {
+        platform: thread.adapter.name,
+        platformIntegrationId: platformIntegration.id,
+        userId: user.id,
+        threadId: thread.id,
+        messageId: message.id,
+      },
+    });
+    await thread.post({
+      markdown:
+        'Sorry, I could not start processing your message because of an internal error. Please try again in a moment.',
+    });
+    return;
+  }
 
   await processMessage({ thread, message, platformIntegration, user, botRequestId });
 }
@@ -43,7 +62,7 @@ async function processMessage({
   message: Message;
   platformIntegration: PlatformIntegration;
   user: User;
-  botRequestId: string | undefined;
+  botRequestId: string;
 }) {
   const startedAt = Date.now();
 
@@ -72,13 +91,11 @@ async function processMessage({
       images,
     });
 
-    if (botRequestId) {
-      updateBotRequest(botRequestId, {
-        ...(result.startedCloudAgentSession ? {} : { status: 'completed' }),
-        steps: [...result.collectedSteps],
-        responseTimeMs: result.responseTimeMs,
-      });
-    }
+    updateBotRequest(botRequestId, {
+      ...(result.startedCloudAgentSession ? {} : { status: 'completed' }),
+      steps: [...result.collectedSteps],
+      responseTimeMs: result.responseTimeMs,
+    });
 
     if (!result.startedCloudAgentSession) {
       await thread.post({ markdown: result.finalText });
@@ -86,13 +103,11 @@ async function processMessage({
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
 
-    if (botRequestId) {
-      updateBotRequest(botRequestId, {
-        status: 'error',
-        errorMessage: errMsg.slice(0, 2000),
-        responseTimeMs: Date.now() - startedAt,
-      });
-    }
+    updateBotRequest(botRequestId, {
+      status: 'error',
+      errorMessage: errMsg.slice(0, 2000),
+      responseTimeMs: Date.now() - startedAt,
+    });
 
     console.error(`[KiloBot] Error during bot run:`, errMsg, error);
 

--- a/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.ts
+++ b/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.ts
@@ -96,24 +96,32 @@ export default async function spawnCloudAgentSession(
   platformIntegration: PlatformIntegration,
   authToken: string,
   ticketUserId: string,
-  botRequestId: string | undefined,
+  botRequestId: string,
   onSessionReady?: RunSessionInput['onSessionReady'],
   options?: { prSignature?: string; chatPlatform?: string; currentStep?: number; images?: Images }
 ): Promise<SpawnCloudAgentResult> {
   console.log('[KiloBot] spawnCloudAgentSession called with args:', JSON.stringify(args, null, 2));
+
+  if (!INTERNAL_API_SECRET) {
+    const error = new Error(
+      'INTERNAL_API_SECRET missing — bot callbacks would be silently dropped'
+    );
+    captureException(error, {
+      tags: { component: 'kilo-bot', op: 'spawn-cloud-agent-session' },
+      extra: { botRequestId },
+    });
+    throw error;
+  }
 
   // Build platform-specific prepareInput and initiateInput
   let prepareInput: PrepareSessionInput;
   let initiateInput: { githubToken?: string; kilocodeOrganizationId?: string };
   const mode: AgentMode = args.mode;
   const chatPlatform = options?.chatPlatform ?? 'slack';
-  const callbackTarget =
-    botRequestId && INTERNAL_API_SECRET
-      ? {
-          url: buildBotCallbackUrl(botRequestId, options?.currentStep),
-          headers: { 'X-Bot-Callback-Token': deriveBotCallbackToken(botRequestId) },
-        }
-      : undefined;
+  const callbackTarget = {
+    url: buildBotCallbackUrl(botRequestId, options?.currentStep),
+    headers: { 'X-Bot-Callback-Token': deriveBotCallbackToken(botRequestId) },
+  };
 
   if (!args.githubRepo && !args.gitlabProject) {
     return { response: 'Error: You must specify either a githubRepo or a gitlabProject.' };


### PR DESCRIPTION
## Summary

`createBotRequest` previously swallowed DB errors and returned `undefined`, which propagated through `processLinkedMessage` → `processMessage` → `runBotAgent` → `spawnCloudAgentSession`. A falsy `botRequestId` caused `callbackTarget` to become `undefined`, so Cloud Agent sessions started **without a callback** and the bot never posted results back. A missing `INTERNAL_API_SECRET` had the same silent-drop failure mode.

- `createBotRequest` now returns `Promise<string>` and throws on failure (no more swallow-and-return-`undefined`).
- `processLinkedMessage` captures the failure to Sentry with rich context (`platform`, `platformIntegrationId`, `userId`, `threadId`, `messageId`) and posts a user-visible error message before returning.
- `botRequestId` is tightened to `string` in `processMessage`, `RunBotAgentParams`, and `spawnCloudAgentSession`. All `if (params.botRequestId)` guards are removed; only the `resolvedCloudAgentSessionId` check remains where it is genuinely needed.
- `spawnCloudAgentSession` now explicitly throws (with Sentry capture) when `INTERNAL_API_SECRET` is missing, and builds `callbackTarget` unconditionally.

## Verification

- Triggered a local bot mention and confirmed the `bot_requests` row is created and `callbackTarget` is populated on the spawned session.
- Manually simulated a `createBotRequest` failure by pointing at an invalid user — the user-visible error message posts and Sentry receives the capture with the expected context.

## Visual Changes

N/A — no UI changes.

## Reviewer Notes

- The previous swallow-and-continue behaviour was hiding the production bug being investigated. After this change, previously-hidden DB failures will surface as user-visible error messages and Sentry events. That is the intended outcome.
- `link-account/route.ts` (`reprocessLinkedMessage`) already has its own try/catch + Sentry capture, so the new throw path is covered there. No user message is possible there (the linking tab has closed) — acceptable.
- The `bot-session-callback` route already passes `botRequestId: string`, so the type tightening is a no-op at that call site.
- Discord bot has its own separate `spawnCloudAgentSession` in `lib/discord-bot.ts` — out of scope.
- Added a test that the public `createBotRequest` throws on FK violation (`src/lib/bot/request-logging.test.ts`). The full `pnpm typecheck` was skipped per `AGENTS.md`; `pnpm --filter web typecheck` covers the changed surface.