### PR TITLE
chore(kilo-pass): expire 2-month promotional period

### DIFF
--- a/apps/web/src/lib/kilo-pass/constants.ts
+++ b/apps/web/src/lib/kilo-pass/constants.ts
@@ -12,7 +12,7 @@ export const KILO_PASS_FIRST_MONTH_PROMO_BONUS_PERCENT = 0.5;
 
 // First-time subscribers receive a 50% bonus for the first 2 months if they started
 // strictly before this cutoff. (For PST, Incorporating DST)
-export const KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF = dayjs('2026-05-09T06:59:59Z').utc();
+export const KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF = dayjs('2026-05-07T15:53:43Z').utc();
 
 export const KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_BONUS_PERCENT = 0.5;
 


### PR DESCRIPTION
## Summary
Sets `KILO_PASS_MONTHLY_FIRST_2_MONTHS_PROMO_CUTOFF` to 5 minutes ago (2026-05-07T15:53:43Z) so the first 2 months 50% bonus promotion is no longer active for new subscriptions. It was no longer being offered on our marketing site this week either.

## Verification

<img width="1166" height="507" alt="image" src="https://github.com/user-attachments/assets/8c1b208a-951f-430a-ba8b-4a61711f680b" />


## Visual Changes

<img width="1166" height="507" alt="image" src="https://github.com/user-attachments/assets/5ea12c92-18ff-4cfd-8ca6-9764b6e0ff2d" />


## Reviewer Notes
N/A