### PR TITLE
feat(kiloclaw): support Northflank tier resize

### DIFF
--- a/.specs/kiloclaw-controller.md
+++ b/.specs/kiloclaw-controller.md
@@ -583,6 +583,36 @@ Other values MUST return 400.
 4. If the shutdown sequence itself fails, the controller MUST exit
    with code 1.
 
+## Provider Tier Resize
+
+Tier resize changes the runtime hardware contract associated with an
+instance's persisted `instanceType`, `machineSize`, and `volumeSizeGb`.
+The implementation details are provider-specific, but the following
+invariants apply to all providers.
+
+1. A resize operation MUST NOT persist a new `instanceType`,
+   `machineSize`, or `volumeSizeGb` until the backing provider has
+   accepted and confirmed the corresponding runtime and storage change.
+2. If the provider resize fails or times out, the Durable Object tier
+   state MUST remain unchanged. A provider may still complete an
+   already-accepted operation later; the persisted KiloClaw state MUST
+   prefer not claiming success prematurely over guessing provider state.
+3. Fly resize MUST grow storage before tier persistence when the target
+   tier requires a larger volume. Fly resize MAY require the machine to
+   be stopped before the operation.
+4. docker-local resize MAY persist tier state without a provider storage
+   call because docker-local storage is not capped by KiloClaw. CPU and
+   memory limits apply on the next container recreation.
+5. Northflank resize MUST use deployment rollout semantics: patch the
+   deployment service compute plan, wait until Northflank reports the
+   deployment completed, then persist tier state. When storage grows,
+   the Northflank volume MUST be updated before persisting the larger
+   `volumeSizeGb`.
+6. Runtime tier state and billing state are separate until tier-aware
+   billing is specified. Resizing runtime hardware MUST NOT mutate
+   subscription or payment records unless a billing spec explicitly
+   requires it.
+
 ## Error Handling
 
 1. All degraded-state error strings exposed on the unauthenticated

--- a/.specs/kiloclaw-controller.md
+++ b/.specs/kiloclaw-controller.md
@@ -583,36 +583,6 @@ Other values MUST return 400.
 4. If the shutdown sequence itself fails, the controller MUST exit
    with code 1.
 
-## Provider Tier Resize
-
-Tier resize changes the runtime hardware contract associated with an
-instance's persisted `instanceType`, `machineSize`, and `volumeSizeGb`.
-The implementation details are provider-specific, but the following
-invariants apply to all providers.
-
-1. A resize operation MUST NOT persist a new `instanceType`,
-   `machineSize`, or `volumeSizeGb` until the backing provider has
-   accepted and confirmed the corresponding runtime and storage change.
-2. If the provider resize fails or times out, the Durable Object tier
-   state MUST remain unchanged. A provider may still complete an
-   already-accepted operation later; the persisted KiloClaw state MUST
-   prefer not claiming success prematurely over guessing provider state.
-3. Fly resize MUST grow storage before tier persistence when the target
-   tier requires a larger volume. Fly resize MAY require the machine to
-   be stopped before the operation.
-4. docker-local resize MAY persist tier state without a provider storage
-   call because docker-local storage is not capped by KiloClaw. CPU and
-   memory limits apply on the next container recreation.
-5. Northflank resize MUST use deployment rollout semantics: patch the
-   deployment service compute plan, wait until Northflank reports the
-   deployment completed, then persist tier state. When storage grows,
-   the Northflank volume MUST be updated before persisting the larger
-   `volumeSizeGb`.
-6. Runtime tier state and billing state are separate until tier-aware
-   billing is specified. Resizing runtime hardware MUST NOT mutate
-   subscription or payment records unless a billing spec explicitly
-   requires it.
-
 ## Error Handling
 
 1. All degraded-state error strings exposed on the unauthenticated

--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1421,6 +1421,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
 
   const provider = data?.workerStatus?.provider ?? null;
   const isFlyProvider = provider === 'fly';
+  const isNorthflankProvider = provider === 'northflank';
   const runtimeId = data?.workerStatus?.runtimeId ?? null;
   const storageId = data?.workerStatus?.storageId ?? null;
   const flyMachineId = data?.workerStatus?.flyMachineId ?? null;
@@ -1838,7 +1839,10 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
 
   // Poll status during resize phases
   const resizePolling =
-    resizePhase === 'stopping' || resizePhase === 'starting' || resizePhase === 'waiting';
+    resizePhase === 'stopping' ||
+    resizePhase === 'starting' ||
+    resizePhase === 'waiting' ||
+    (isNorthflankProvider && resizePhase === 'resizing');
   useQuery({
     queryKey: ['machine-resize-poll', userId, instanceId, resizePolling],
     queryFn: async () => {
@@ -1865,6 +1869,19 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
     if (!data || !userId) return;
 
     try {
+      if (isNorthflankProvider) {
+        setResizePhase('resizing');
+        await resizeMachineMutation({
+          userId,
+          instanceId: data.id,
+          instanceType: selectedInstanceType,
+        });
+        invalidateMachineQueries();
+        setResizePhase('done');
+        toast.success('Northflank resize completed');
+        return;
+      }
+
       // Step 1: Stop if running — retry up to 3 times since Fly can be slow
       if (currentStatus !== 'stopped') {
         setResizePhase('stopping');
@@ -3295,7 +3312,10 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                 <div className="space-y-1">
                   <p className="text-sm font-medium">
                     {resizePhase === 'stopping' && 'Stopping machine...'}
-                    {resizePhase === 'resizing' && 'Updating machine size...'}
+                    {resizePhase === 'resizing' &&
+                      (isNorthflankProvider
+                        ? 'Resizing Northflank deployment...'
+                        : 'Updating machine size...')}
                     {resizePhase === 'starting' && 'Starting machine with new size...'}
                     {resizePhase === 'waiting' && 'Waiting for machine to be ready...'}
                   </p>
@@ -3342,9 +3362,11 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
               <div className="flex items-center gap-3 rounded border border-green-600/30 bg-green-600/5 p-4">
                 <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600" />
                 <div>
-                  <p className="text-sm font-medium text-green-600">Machine resize complete</p>
+                  <p className="text-sm font-medium text-green-600">Runtime resize complete</p>
                   <p className="text-muted-foreground text-xs">
-                    Machine is running with the new size.
+                    {isNorthflankProvider
+                      ? 'Northflank completed the deployment rollout.'
+                      : 'Machine is running with the new size.'}
                   </p>
                 </div>
                 <Button
@@ -3398,11 +3420,12 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2 text-orange-500">
                 <AlertTriangle className="h-5 w-5" />
-                Resize Machine
+                Resize runtime
               </DialogTitle>
               <DialogDescription className="pt-3">
-                This will stop the machine, update its CPU/memory and storage spec, and restart it.
-                The user will be disconnected during the restart.
+                {isNorthflankProvider
+                  ? 'Northflank will resize this instance by rolling the deployment onto the target compute plan. The instance may restart during the rollout.'
+                  : 'This will stop the machine, update its CPU/memory and storage spec, and restart it. The user will be disconnected during the restart.'}
                 <span className="text-foreground mt-2 block font-medium">
                   User: {data?.user_email ?? data?.user_id}
                 </span>
@@ -3444,6 +3467,14 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                   })}
                 </select>
               </div>
+              {isNorthflankProvider && (
+                <Alert className="border-muted-foreground/30 bg-muted/30">
+                  <AlertDescription className="text-muted-foreground">
+                    Northflank applies the compute change through a deployment rollout. The worker
+                    waits for Northflank to report completion before saving the new tier.
+                  </AlertDescription>
+                </Alert>
+              )}
               {data?.workerStatus?.provider === 'fly' &&
                 getTier(selectedInstanceType).volumeSizeGb >
                   (data?.workerStatus?.volumeSizeGb ?? 10) && (
@@ -3453,6 +3484,18 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
                       Fly volume will grow from {data?.workerStatus?.volumeSizeGb ?? 10} GB to{' '}
                       {getTier(selectedInstanceType).volumeSizeGb} GB. Fly volumes can grow but
                       cannot be shrunk, so you will not be able to downgrade this instance.
+                    </AlertDescription>
+                  </Alert>
+                )}
+              {isNorthflankProvider &&
+                getTier(selectedInstanceType).volumeSizeGb >
+                  (data?.workerStatus?.volumeSizeGb ?? 10) && (
+                  <Alert className="border-orange-500/30 bg-orange-500/10">
+                    <AlertTriangle className="h-4 w-4 text-orange-500" />
+                    <AlertDescription className="text-orange-700 dark:text-orange-300">
+                      Northflank volume will grow from {data?.workerStatus?.volumeSizeGb ?? 10} GB
+                      to {getTier(selectedInstanceType).volumeSizeGb} GB. Volumes can grow but
+                      cannot be shrunk.
                     </AlertDescription>
                   </Alert>
                 )}

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -9225,7 +9225,7 @@ describe('resizeMachine', () => {
     expect(storage._store.get('instanceType')).toBe('perf-4-8');
   });
 
-  it('rejects Northflank resize before persisting tier changes', async () => {
+  it('persists Northflank resize after volume and deployment plan updates are accepted', async () => {
     const { instance, storage } = createInstance();
     await seedNorthflankInstance(storage, {
       provider: 'northflank',
@@ -9249,19 +9249,6 @@ describe('resizeMachine', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (url.endsWith('/services/service-1')) {
-        return new Response(
-          JSON.stringify({
-            data: {
-              id: 'service-1',
-              name: 'kc-ki-test',
-              ports: [{ name: 'p01', dns: 'kc-ki-test-resized.code.run' }],
-              status: { deployment: { status: 'COMPLETED' } },
-            },
-          }),
-          { status: 200, headers: { 'content-type': 'application/json' } }
-        );
-      }
       throw new Error(`Unhandled Northflank API request: ${url}`);
     });
 
@@ -9276,7 +9263,7 @@ describe('resizeMachine', () => {
     });
     expect(storage._store.get('volumeSizeGb')).toBe(20);
     expect(storage._store.get('providerState')).toEqual(
-      expect.objectContaining({ ingressHost: 'kc-ki-test-resized.code.run' })
+      expect.objectContaining({ ingressHost: 'kc-ki-test.code.run' })
     );
   });
 
@@ -9297,28 +9284,16 @@ describe('resizeMachine', () => {
         });
       }
       if (url.endsWith('/services/deployment/service-1')) {
-        return new Response(JSON.stringify({ data: { id: 'service-1', name: 'kc-ki-test' } }), {
-          status: 200,
+        return new Response(JSON.stringify({ error: 'deployment patch failed' }), {
+          status: 500,
           headers: { 'content-type': 'application/json' },
         });
-      }
-      if (url.endsWith('/services/service-1')) {
-        return new Response(
-          JSON.stringify({
-            data: {
-              id: 'service-1',
-              name: 'kc-ki-test',
-              status: { deployment: { status: 'FAILED' } },
-            },
-          }),
-          { status: 200, headers: { 'content-type': 'application/json' } }
-        );
       }
       throw new Error(`Unhandled Northflank API request: ${url}`);
     });
 
     await expect(instance.resizeMachine('perf-4-8')).rejects.toThrow(
-      'Northflank deployment failed for service service-1'
+      'Northflank API patchDeploymentService failed (500)'
     );
 
     expect(storage._store.get('instanceType')).toBe('perf-1-3');

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -9227,19 +9227,107 @@ describe('resizeMachine', () => {
 
   it('rejects Northflank resize before persisting tier changes', async () => {
     const { instance, storage } = createInstance();
-    await seedProvisioned(storage, {
+    await seedNorthflankInstance(storage, {
       provider: 'northflank',
-      providerState: { provider: 'northflank' },
-      status: 'stopped',
+      providerState: northflankProviderState(),
+      status: 'running',
       instanceType: 'perf-1-3',
       machineSize: { cpus: 1, memory_mb: 3072, cpu_kind: 'performance' },
       volumeSizeGb: 10,
     });
+    vi.mocked(fetch).mockImplementation(async input => {
+      const url = fetchInputUrl(input);
+      if (url.endsWith('/volumes/volume-1')) {
+        return new Response(JSON.stringify({ data: {} }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/services/deployment/service-1')) {
+        return new Response(JSON.stringify({ data: { id: 'service-1', name: 'kc-ki-test' } }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/services/service-1')) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 'service-1',
+              name: 'kc-ki-test',
+              ports: [{ name: 'p01', dns: 'kc-ki-test-resized.code.run' }],
+              status: { deployment: { status: 'COMPLETED' } },
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        );
+      }
+      throw new Error(`Unhandled Northflank API request: ${url}`);
+    });
+
+    const result = await instance.resizeMachine('perf-4-8');
+
+    expect(result.newTier).toBe('perf-4-8');
+    expect(storage._store.get('instanceType')).toBe('perf-4-8');
+    expect(storage._store.get('machineSize')).toEqual({
+      cpus: 4,
+      memory_mb: 8192,
+      cpu_kind: 'performance',
+    });
+    expect(storage._store.get('volumeSizeGb')).toBe(20);
+    expect(storage._store.get('providerState')).toEqual(
+      expect.objectContaining({ ingressHost: 'kc-ki-test-resized.code.run' })
+    );
+  });
+
+  it('leaves Northflank tier state unchanged when provider resize fails', async () => {
+    const { instance, storage } = createInstance();
+    await seedNorthflankInstance(storage, {
+      status: 'running',
+      instanceType: 'perf-1-3',
+      machineSize: { cpus: 1, memory_mb: 3072, cpu_kind: 'performance' },
+      volumeSizeGb: 10,
+    });
+    vi.mocked(fetch).mockImplementation(async input => {
+      const url = fetchInputUrl(input);
+      if (url.endsWith('/volumes/volume-1')) {
+        return new Response(JSON.stringify({ data: {} }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/services/deployment/service-1')) {
+        return new Response(JSON.stringify({ data: { id: 'service-1', name: 'kc-ki-test' } }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/services/service-1')) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 'service-1',
+              name: 'kc-ki-test',
+              status: { deployment: { status: 'FAILED' } },
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        );
+      }
+      throw new Error(`Unhandled Northflank API request: ${url}`);
+    });
 
     await expect(instance.resizeMachine('perf-4-8')).rejects.toThrow(
-      'Instance tier resize is not yet supported on Northflank instances'
+      'Northflank deployment failed for service service-1'
     );
+
     expect(storage._store.get('instanceType')).toBe('perf-1-3');
+    expect(storage._store.get('machineSize')).toEqual({
+      cpus: 1,
+      memory_mb: 3072,
+      cpu_kind: 'performance',
+    });
+    expect(storage._store.get('volumeSizeGb')).toBe(10);
   });
 
   it('clears any active admin size override and reports it in the response', async () => {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -2962,8 +2962,9 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       cannotPrefix: 'resize',
       beforePhrase: 'resizing machine tier',
       notSupportedSubject: 'Instance tier resize',
-      // Tier resize calls fly.extendVolume on storage growth; Fly volume
-      // extends require the machine to be stopped.
+      // Fly tier resize calls fly.extendVolume on storage growth, which
+      // requires the machine to be stopped. Northflank uses deployment
+      // rollout semantics and does not require a stopped instance.
       requireStopped: this.s.provider !== 'northflank',
       allowNorthflank: true,
     });

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -2964,7 +2964,8 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       notSupportedSubject: 'Instance tier resize',
       // Tier resize calls fly.extendVolume on storage growth; Fly volume
       // extends require the machine to be stopped.
-      requireStopped: true,
+      requireStopped: this.s.provider !== 'northflank',
+      allowNorthflank: true,
     });
 
     const targetTier = getTier(targetTierKey);
@@ -3002,6 +3003,18 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       );
       this.s.volumeSizeGb = targetTier.volumeSizeGb;
       await this.persist({ volumeSizeGb: targetTier.volumeSizeGb });
+    }
+
+    if (this.s.provider === 'northflank') {
+      const result = await this.provider().resizeRuntime?.({
+        env: this.env,
+        state: this.s,
+        targetTier: targetTier.key,
+      });
+      if (!result) {
+        throw new Error('Provider northflank does not support tier resize');
+      }
+      await this.persistProviderResult(result);
     }
 
     // Capture and clear any active admin override before applying the tier
@@ -3091,6 +3104,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     beforePhrase?: string;
     notSupportedSubject: string;
     requireStopped: boolean;
+    allowNorthflank?: boolean;
   }): void {
     if (!this.s.userId) {
       throw new Error('Instance is not provisioned');
@@ -3115,7 +3129,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         { status: 409 }
       );
     }
-    if (this.s.provider === 'northflank') {
+    if (this.s.provider === 'northflank' && args.allowNorthflank !== true) {
       throw new Error(`${args.notSupportedSubject} is not yet supported on Northflank instances`);
     }
   }

--- a/services/kiloclaw/src/northflank/client.test.ts
+++ b/services/kiloclaw/src/northflank/client.test.ts
@@ -13,6 +13,7 @@ import {
   isNorthflankNotFound,
   listServices,
   putProjectSecret,
+  updateVolume,
 } from './client';
 import { getNorthflankConfig } from './config';
 import type { NorthflankClientConfig } from './client';
@@ -152,6 +153,37 @@ describe('Northflank Worker fetch client', () => {
 
     const [url] = firstFetchCall(fetchMock);
     expect(url).toBe('https://api.northflank.com/v1/projects/project-1/volumes/kc-ki-test');
+  });
+
+  it('updates volume storage size through the documented empty response endpoint', async () => {
+    const fetchMock = mockFetchSequence([[200, { data: {} }]]);
+
+    await expect(
+      updateVolume(config, 'project-1', 'volume-1', { storageSizeMb: 20480 })
+    ).resolves.toBeUndefined();
+
+    const [url, init] = firstFetchCall(fetchMock);
+    expect(url).toBe('https://api.northflank.com/v1/projects/project-1/volumes/volume-1');
+    const requestInit = expectRequestInit(init);
+    expect(requestInit.method).toBe('POST');
+    expect(JSON.parse(expectStringBody(requestInit.body))).toEqual({
+      spec: {
+        storageSize: 20480,
+      },
+    });
+  });
+
+  it('updates volumes through team-scoped routes when a team ID is configured', async () => {
+    const fetchMock = mockFetchSequence([[200, { data: {} }]]);
+
+    await updateVolume({ ...config, teamId: 'team-1' }, 'project-1', 'volume-1', {
+      storageSizeMb: 40960,
+    });
+
+    const [url] = firstFetchCall(fetchMock);
+    expect(url).toBe(
+      'https://api.northflank.com/v1/teams/team-1/projects/project-1/volumes/volume-1'
+    );
   });
 
   it('finds services by deterministic name with a direct GET', async () => {

--- a/services/kiloclaw/src/northflank/client.ts
+++ b/services/kiloclaw/src/northflank/client.ts
@@ -55,6 +55,7 @@ const NorthflankSecretDetailsSchema = z.object({ id: z.string(), name: z.string(
 const ProjectResponseSchema = z.object({ data: NorthflankProjectSchema });
 const VolumeResponseSchema = z.object({ data: NorthflankVolumeSchema });
 const VolumeListResponseSchema = z.object({ data: z.array(NorthflankVolumeSchema) });
+const EmptyDataResponseSchema = z.object({ data: z.object({}).passthrough() });
 const ServiceResponseSchema = z.object({ data: NorthflankServiceSchema });
 const ServiceListResponseSchema = z.object({
   data: z.object({ services: z.array(NorthflankServiceSchema) }).passthrough(),
@@ -417,6 +418,26 @@ export async function getVolume(
     'getVolume'
   );
   return response.data;
+}
+
+export async function updateVolume(
+  config: NorthflankClientConfig,
+  projectId: string,
+  volumeId: string,
+  input: { storageSizeMb: number }
+): Promise<void> {
+  await requestJson(
+    config,
+    `/projects/${encodeURIComponent(projectId)}/volumes/${encodeURIComponent(volumeId)}`,
+    jsonInit('POST', {
+      spec: {
+        storageSize: input.storageSizeMb,
+      },
+    }),
+    EmptyDataResponseSchema,
+    [200],
+    'updateVolume'
+  );
 }
 
 export async function deleteVolume(

--- a/services/kiloclaw/src/northflank/config.test.ts
+++ b/services/kiloclaw/src/northflank/config.test.ts
@@ -19,8 +19,8 @@ describe('getNorthflankConfig', () => {
       deploymentPlan: 'nf-compute-200',
       deploymentPlans: {
         'perf-1-3': 'nf-compute-200',
-        'perf-4-8': 'nf-compute-200',
-        'perf-4-16': 'nf-compute-200',
+        'perf-4-8': 'nf-compute-400',
+        'perf-4-16': 'nf-compute-400-16',
       },
       storageClassName: 'nf-multi-rw',
       storageAccessMode: 'ReadWriteMany',
@@ -54,8 +54,8 @@ describe('getNorthflankConfig', () => {
       deploymentPlan: 'nf-compute-200',
       deploymentPlans: {
         'perf-1-3': 'nf-compute-200',
-        'perf-4-8': 'nf-compute-200',
-        'perf-4-16': 'nf-compute-200',
+        'perf-4-8': 'nf-compute-400',
+        'perf-4-16': 'nf-compute-400-16',
       },
       storageClassName: 'nf-ssd-rwo',
       storageAccessMode: 'ReadWriteOnce',
@@ -78,6 +78,21 @@ describe('getNorthflankConfig', () => {
     expect(() => getNorthflankConfig({ ...baseEnv, NF_VOLUME_SIZE_MB: 'ten' } as never)).toThrow(
       'NF_VOLUME_SIZE_MB must be a positive integer'
     );
+  });
+
+  it('accepts explicit per-tier deployment plan overrides', () => {
+    expect(
+      getNorthflankConfig({
+        ...baseEnv,
+        NF_DEPLOYMENT_PLAN_PERF_1_3: 'custom-1-3',
+        NF_DEPLOYMENT_PLAN_PERF_4_8: 'custom-4-8',
+        NF_DEPLOYMENT_PLAN_PERF_4_16: 'custom-4-16',
+      } as never).deploymentPlans
+    ).toEqual({
+      'perf-1-3': 'custom-1-3',
+      'perf-4-8': 'custom-4-8',
+      'perf-4-16': 'custom-4-16',
+    });
   });
 });
 

--- a/services/kiloclaw/src/northflank/config.ts
+++ b/services/kiloclaw/src/northflank/config.ts
@@ -3,6 +3,9 @@ import type { NorthflankClientConfig } from './client';
 import type { InstanceTierKey } from '@kilocode/kiloclaw-instance-tiers';
 
 export const NORTHFLANK_API_BASE = 'https://api.northflank.com/v1';
+const DEFAULT_NORTHFLANK_DEPLOYMENT_PLAN_PERF_1_3 = 'nf-compute-200';
+const DEFAULT_NORTHFLANK_DEPLOYMENT_PLAN_PERF_4_8 = 'nf-compute-400';
+const DEFAULT_NORTHFLANK_DEPLOYMENT_PLAN_PERF_4_16 = 'nf-compute-400-16';
 
 export type NorthflankConfig = {
   apiToken: string;
@@ -59,11 +62,14 @@ export function getNorthflankConfig(env: KiloClawEnv): NorthflankConfig {
     deploymentPlan: requiredEnv(env, 'NF_DEPLOYMENT_PLAN'),
     deploymentPlans: {
       'perf-1-3':
-        optionalEnv(env, 'NF_DEPLOYMENT_PLAN_PERF_1_3') ?? requiredEnv(env, 'NF_DEPLOYMENT_PLAN'),
+        optionalEnv(env, 'NF_DEPLOYMENT_PLAN_PERF_1_3') ??
+        DEFAULT_NORTHFLANK_DEPLOYMENT_PLAN_PERF_1_3,
       'perf-4-8':
-        optionalEnv(env, 'NF_DEPLOYMENT_PLAN_PERF_4_8') ?? requiredEnv(env, 'NF_DEPLOYMENT_PLAN'),
+        optionalEnv(env, 'NF_DEPLOYMENT_PLAN_PERF_4_8') ??
+        DEFAULT_NORTHFLANK_DEPLOYMENT_PLAN_PERF_4_8,
       'perf-4-16':
-        optionalEnv(env, 'NF_DEPLOYMENT_PLAN_PERF_4_16') ?? requiredEnv(env, 'NF_DEPLOYMENT_PLAN'),
+        optionalEnv(env, 'NF_DEPLOYMENT_PLAN_PERF_4_16') ??
+        DEFAULT_NORTHFLANK_DEPLOYMENT_PLAN_PERF_4_16,
     },
     storageClassName: optionalEnv(env, 'NF_STORAGE_CLASS_NAME') ?? 'nf-multi-rw',
     storageAccessMode: optionalEnv(env, 'NF_STORAGE_ACCESS_MODE') ?? 'ReadWriteMany',

--- a/services/kiloclaw/src/providers/northflank/index.test.ts
+++ b/services/kiloclaw/src/providers/northflank/index.test.ts
@@ -366,7 +366,7 @@ describe('northflankProviderAdapter', () => {
     });
 
     const createPayload = vi.mocked(createDeploymentService).mock.calls[0]?.[2];
-    expect(createPayload?.billing.deploymentPlan).toBe('nf-compute-200');
+    expect(createPayload?.billing.deploymentPlan).toBe('nf-compute-400-16');
   });
 
   it('falls back and warns for legacy Northflank tier labels', async () => {
@@ -498,7 +498,7 @@ describe('northflankProviderAdapter', () => {
       expect.anything(),
       'project-1',
       'service-1',
-      { billing: { deploymentPlan: 'nf-compute-200' } }
+      { billing: { deploymentPlan: 'nf-compute-400' } }
     );
     expect(waitForDeploymentCompleted).not.toHaveBeenCalled();
   });

--- a/services/kiloclaw/src/providers/northflank/index.test.ts
+++ b/services/kiloclaw/src/providers/northflank/index.test.ts
@@ -434,14 +434,9 @@ describe('northflankProviderAdapter', () => {
     expect(result.observation?.runtimeState).toBe('stopped');
   });
 
-  it('resizes runtime by growing volume, patching deployment plan, and waiting for rollout', async () => {
+  it('resizes runtime by growing volume and patching the accepted deployment plan', async () => {
     vi.mocked(updateVolume).mockResolvedValue(undefined);
     vi.mocked(patchDeploymentService).mockResolvedValue({ id: 'service-1', name: 'kc-ki-123' });
-    vi.mocked(waitForDeploymentCompleted).mockResolvedValue({
-      id: 'service-1',
-      name: 'kc-ki-123',
-      ports: [{ name: 'p01', dns: 'kc-ki-123.code.run' }],
-    });
 
     const result = await northflankProviderAdapter.resizeRuntime?.({
       env: { ...env, NF_DEPLOYMENT_PLAN_PERF_4_8: 'nf-compute-perf-4-8' } as never,
@@ -474,20 +469,14 @@ describe('northflankProviderAdapter', () => {
       'service-1',
       { billing: { deploymentPlan: 'nf-compute-perf-4-8' } }
     );
-    expect(waitForDeploymentCompleted).toHaveBeenCalledWith(
-      expect.objectContaining({ apiToken: 'nf-token' }),
-      'project-1',
-      'service-1',
-      240
-    );
+    expect(waitForDeploymentCompleted).not.toHaveBeenCalled();
     expect(result?.providerState).toEqual(
-      expect.objectContaining({ provider: 'northflank', ingressHost: 'kc-ki-123.code.run' })
+      expect.objectContaining({ provider: 'northflank', ingressHost: 'old.code.run' })
     );
   });
 
   it('resizes runtime without volume update when storage does not grow', async () => {
     vi.mocked(patchDeploymentService).mockResolvedValue({ id: 'service-1', name: 'kc-ki-123' });
-    vi.mocked(waitForDeploymentCompleted).mockResolvedValue({ id: 'service-1', name: 'kc-ki-123' });
 
     await northflankProviderAdapter.resizeRuntime?.({
       env: env as never,
@@ -511,6 +500,7 @@ describe('northflankProviderAdapter', () => {
       'service-1',
       { billing: { deploymentPlan: 'nf-compute-200' } }
     );
+    expect(waitForDeploymentCompleted).not.toHaveBeenCalled();
   });
 
   it('rejects resize when service ID is missing', async () => {
@@ -546,10 +536,9 @@ describe('northflankProviderAdapter', () => {
     expect(patchDeploymentService).not.toHaveBeenCalled();
   });
 
-  it('propagates deployment wait failures from resize', async () => {
+  it('propagates deployment patch failures from resize', async () => {
     vi.mocked(updateVolume).mockResolvedValue(undefined);
-    vi.mocked(patchDeploymentService).mockResolvedValue({ id: 'service-1', name: 'kc-ki-123' });
-    vi.mocked(waitForDeploymentCompleted).mockRejectedValue(new Error('deployment failed'));
+    vi.mocked(patchDeploymentService).mockRejectedValue(new Error('deployment patch failed'));
 
     await expect(
       northflankProviderAdapter.resizeRuntime?.({
@@ -566,7 +555,8 @@ describe('northflankProviderAdapter', () => {
         } as never,
         targetTier: 'perf-4-8',
       })
-    ).rejects.toThrow('deployment failed');
+    ).rejects.toThrow('deployment patch failed');
+    expect(waitForDeploymentCompleted).not.toHaveBeenCalled();
   });
 
   it('skips writing the restricted secret on restart when bootstrap env is unchanged', async () => {

--- a/services/kiloclaw/src/providers/northflank/index.test.ts
+++ b/services/kiloclaw/src/providers/northflank/index.test.ts
@@ -15,6 +15,7 @@ import {
   getVolume,
   patchDeploymentService,
   putProjectSecret,
+  updateVolume,
   waitForDeploymentCompleted,
 } from '../../northflank/client';
 
@@ -66,6 +67,7 @@ vi.mock('../../northflank/client', () => ({
   isNorthflankNotFound: vi.fn(() => false),
   patchDeploymentService: vi.fn(),
   putProjectSecret: vi.fn(),
+  updateVolume: vi.fn(),
   waitForDeploymentCompleted: vi.fn(),
 }));
 
@@ -430,6 +432,141 @@ describe('northflankProviderAdapter', () => {
       { deployment: { instances: 0 } }
     );
     expect(result.observation?.runtimeState).toBe('stopped');
+  });
+
+  it('resizes runtime by growing volume, patching deployment plan, and waiting for rollout', async () => {
+    vi.mocked(updateVolume).mockResolvedValue(undefined);
+    vi.mocked(patchDeploymentService).mockResolvedValue({ id: 'service-1', name: 'kc-ki-123' });
+    vi.mocked(waitForDeploymentCompleted).mockResolvedValue({
+      id: 'service-1',
+      name: 'kc-ki-123',
+      ports: [{ name: 'p01', dns: 'kc-ki-123.code.run' }],
+    });
+
+    const result = await northflankProviderAdapter.resizeRuntime?.({
+      env: { ...env, NF_DEPLOYMENT_PLAN_PERF_4_8: 'nf-compute-perf-4-8' } as never,
+      state: {
+        sandboxId: 'ki_123',
+        volumeSizeGb: 10,
+        providerState: {
+          provider: 'northflank',
+          projectId: 'project-1',
+          serviceId: 'service-1',
+          serviceName: 'kc-ki-123',
+          volumeId: 'volume-1',
+          ingressHost: 'old.code.run',
+        },
+      } as never,
+      targetTier: 'perf-4-8',
+    });
+
+    expect(updateVolume).toHaveBeenCalledWith(
+      expect.objectContaining({ apiToken: 'nf-token' }),
+      'project-1',
+      'volume-1',
+      {
+        storageSizeMb: 20480,
+      }
+    );
+    expect(patchDeploymentService).toHaveBeenCalledWith(
+      expect.objectContaining({ apiToken: 'nf-token' }),
+      'project-1',
+      'service-1',
+      { billing: { deploymentPlan: 'nf-compute-perf-4-8' } }
+    );
+    expect(waitForDeploymentCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({ apiToken: 'nf-token' }),
+      'project-1',
+      'service-1',
+      240
+    );
+    expect(result?.providerState).toEqual(
+      expect.objectContaining({ provider: 'northflank', ingressHost: 'kc-ki-123.code.run' })
+    );
+  });
+
+  it('resizes runtime without volume update when storage does not grow', async () => {
+    vi.mocked(patchDeploymentService).mockResolvedValue({ id: 'service-1', name: 'kc-ki-123' });
+    vi.mocked(waitForDeploymentCompleted).mockResolvedValue({ id: 'service-1', name: 'kc-ki-123' });
+
+    await northflankProviderAdapter.resizeRuntime?.({
+      env: env as never,
+      state: {
+        sandboxId: 'ki_123',
+        volumeSizeGb: 20,
+        providerState: {
+          provider: 'northflank',
+          projectId: 'project-1',
+          serviceId: 'service-1',
+          volumeId: 'volume-1',
+        },
+      } as never,
+      targetTier: 'perf-4-8',
+    });
+
+    expect(updateVolume).not.toHaveBeenCalled();
+    expect(patchDeploymentService).toHaveBeenCalledWith(
+      expect.anything(),
+      'project-1',
+      'service-1',
+      { billing: { deploymentPlan: 'nf-compute-200' } }
+    );
+  });
+
+  it('rejects resize when service ID is missing', async () => {
+    await expect(
+      northflankProviderAdapter.resizeRuntime?.({
+        env: env as never,
+        state: {
+          sandboxId: 'ki_123',
+          volumeSizeGb: 10,
+          providerState: { provider: 'northflank', projectId: 'project-1', volumeId: 'volume-1' },
+        } as never,
+        targetTier: 'perf-4-8',
+      })
+    ).rejects.toThrow('Northflank resize requires an existing deployment service');
+
+    expect(updateVolume).not.toHaveBeenCalled();
+    expect(patchDeploymentService).not.toHaveBeenCalled();
+  });
+
+  it('rejects resize when storage grows and volume ID is missing', async () => {
+    await expect(
+      northflankProviderAdapter.resizeRuntime?.({
+        env: env as never,
+        state: {
+          sandboxId: 'ki_123',
+          volumeSizeGb: 10,
+          providerState: { provider: 'northflank', projectId: 'project-1', serviceId: 'service-1' },
+        } as never,
+        targetTier: 'perf-4-8',
+      })
+    ).rejects.toThrow('Northflank resize requires an existing volume when storage grows');
+
+    expect(patchDeploymentService).not.toHaveBeenCalled();
+  });
+
+  it('propagates deployment wait failures from resize', async () => {
+    vi.mocked(updateVolume).mockResolvedValue(undefined);
+    vi.mocked(patchDeploymentService).mockResolvedValue({ id: 'service-1', name: 'kc-ki-123' });
+    vi.mocked(waitForDeploymentCompleted).mockRejectedValue(new Error('deployment failed'));
+
+    await expect(
+      northflankProviderAdapter.resizeRuntime?.({
+        env: env as never,
+        state: {
+          sandboxId: 'ki_123',
+          volumeSizeGb: 10,
+          providerState: {
+            provider: 'northflank',
+            projectId: 'project-1',
+            serviceId: 'service-1',
+            volumeId: 'volume-1',
+          },
+        } as never,
+        targetTier: 'perf-4-8',
+      })
+    ).rejects.toThrow('deployment failed');
   });
 
   it('skips writing the restricted secret on restart when bootstrap env is unchanged', async () => {

--- a/services/kiloclaw/src/providers/northflank/index.ts
+++ b/services/kiloclaw/src/providers/northflank/index.ts
@@ -851,6 +851,11 @@ export const northflankProviderAdapter: InstanceProviderAdapter = {
       if (!providerState.volumeId) {
         throw new Error('Northflank resize requires an existing volume when storage grows');
       }
+      // Northflank's documented update-volume endpoint returns only an
+      // empty success response and does not expose a separate completion
+      // status to poll. Treat a successful 200 as the provider's accepted
+      // storage update; the DO still persists the larger volumeSizeGb only
+      // after the subsequent deployment rollout completes.
       await updateVolume(config, providerState.projectId, providerState.volumeId, {
         storageSizeMb: tier.volumeSizeGb * 1024,
       });

--- a/services/kiloclaw/src/providers/northflank/index.ts
+++ b/services/kiloclaw/src/providers/northflank/index.ts
@@ -854,8 +854,8 @@ export const northflankProviderAdapter: InstanceProviderAdapter = {
       // Northflank's documented update-volume endpoint returns only an
       // empty success response and does not expose a separate completion
       // status to poll. Treat a successful 200 as the provider's accepted
-      // storage update; the DO still persists the larger volumeSizeGb only
-      // after the subsequent deployment rollout completes.
+      // storage update; the persisted tier is desired state once Northflank
+      // accepts the storage and compute-plan updates.
       await updateVolume(config, providerState.projectId, providerState.volumeId, {
         storageSizeMb: tier.volumeSizeGb * 1024,
       });
@@ -875,27 +875,20 @@ export const northflankProviderAdapter: InstanceProviderAdapter = {
     await patchDeploymentService(config, providerState.projectId, providerState.serviceId, {
       billing: { deploymentPlan },
     });
-    const resized = await waitForDeploymentCompleted(
-      config,
-      providerState.projectId,
-      providerState.serviceId,
-      NORTHFLANK_STARTUP_TIMEOUT_SECONDS
-    );
 
-    logNorthflank('resize_runtime_deployment_completed', {
-      description: 'Northflank deployment reported COMPLETED during tier resize wait',
-      apiOperation: 'GET /projects/{projectId}/services/{serviceId}',
+    logNorthflank('resize_runtime_patch_accepted', {
+      description:
+        'Northflank accepted the service compute-plan patch; persisted tier now reflects desired state',
+      apiOperation: 'PATCH /projects/{projectId}/services/deployment/{serviceId}',
       sandboxId: state.sandboxId,
       projectId: providerState.projectId,
+      serviceId: providerState.serviceId,
       targetTier,
-      ...northflankServiceSummary(resized),
+      deploymentPlan,
     });
 
     return {
-      providerState: {
-        ...providerState,
-        ingressHost: firstIngressHost(resized) ?? providerState.ingressHost,
-      },
+      providerState,
     };
   },
 

--- a/services/kiloclaw/src/providers/northflank/index.ts
+++ b/services/kiloclaw/src/providers/northflank/index.ts
@@ -1,10 +1,11 @@
 import type { CreateSecretRequest, CreateServiceDeploymentRequest } from '@northflank/js-client';
 import type { NorthflankProviderState } from '../../schemas/instance-config';
 import type { InstanceMutableState } from '../../durable-objects/kiloclaw-instance/types';
+import { DEFAULT_VOLUME_SIZE_GB } from '../../config';
 import { getNorthflankProviderState } from '../../durable-objects/kiloclaw-instance/state';
 import type { RuntimeSpec, InstanceProviderAdapter } from '../types';
 import { northflankClientConfig } from '../../northflank/config';
-import { DEFAULT_INSTANCE_TIER } from '@kilocode/kiloclaw-instance-tiers';
+import { DEFAULT_INSTANCE_TIER, getTier } from '@kilocode/kiloclaw-instance-tiers';
 import { resolveNorthflankPlan } from '../../northflank/config';
 import {
   createDeploymentService,
@@ -26,6 +27,7 @@ import {
   isNorthflankNotFound,
   patchDeploymentService,
   putProjectSecret,
+  updateVolume,
   waitForDeploymentCompleted,
   type NorthflankClientConfig,
   type NorthflankProject,
@@ -832,6 +834,62 @@ export const northflankProviderAdapter: InstanceProviderAdapter = {
       },
       observation: {
         runtimeState: 'running',
+      },
+    };
+  },
+
+  async resizeRuntime({ env, state, targetTier }) {
+    const config = northflankClientConfig(env);
+    const providerState = getNorthflankProviderState(state);
+    if (!providerState.projectId || !providerState.serviceId) {
+      throw new Error('Northflank resize requires an existing deployment service');
+    }
+
+    const tier = getTier(targetTier);
+    const currentVolumeSizeGb = state.volumeSizeGb ?? DEFAULT_VOLUME_SIZE_GB;
+    if (tier.volumeSizeGb > currentVolumeSizeGb) {
+      if (!providerState.volumeId) {
+        throw new Error('Northflank resize requires an existing volume when storage grows');
+      }
+      await updateVolume(config, providerState.projectId, providerState.volumeId, {
+        storageSizeMb: tier.volumeSizeGb * 1024,
+      });
+    }
+
+    const deploymentPlan = resolveNorthflankDeploymentPlan(config, targetTier, state.sandboxId);
+    logNorthflank('resize_runtime_patch_service', {
+      description: 'Patching Northflank service compute plan for instance tier resize',
+      apiOperation: 'PATCH /projects/{projectId}/services/deployment/{serviceId}',
+      sandboxId: state.sandboxId,
+      projectId: providerState.projectId,
+      serviceId: providerState.serviceId,
+      serviceName: providerState.serviceName,
+      targetTier,
+      deploymentPlan,
+    });
+    await patchDeploymentService(config, providerState.projectId, providerState.serviceId, {
+      billing: { deploymentPlan },
+    });
+    const resized = await waitForDeploymentCompleted(
+      config,
+      providerState.projectId,
+      providerState.serviceId,
+      NORTHFLANK_STARTUP_TIMEOUT_SECONDS
+    );
+
+    logNorthflank('resize_runtime_deployment_completed', {
+      description: 'Northflank deployment reported COMPLETED during tier resize wait',
+      apiOperation: 'GET /projects/{projectId}/services/{serviceId}',
+      sandboxId: state.sandboxId,
+      projectId: providerState.projectId,
+      targetTier,
+      ...northflankServiceSummary(resized),
+    });
+
+    return {
+      providerState: {
+        ...providerState,
+        ingressHost: firstIngressHost(resized) ?? providerState.ingressHost,
       },
     };
   },

--- a/services/kiloclaw/src/providers/types.ts
+++ b/services/kiloclaw/src/providers/types.ts
@@ -1,4 +1,5 @@
 import type { KiloClawEnv } from '../types';
+import type { InstanceTierKey } from '@kilocode/kiloclaw-instance-tiers';
 import type {
   MachineSize,
   PersistedState,
@@ -80,6 +81,10 @@ export type DestroyRuntimeArgs = ProviderContext;
 
 export type DestroyStorageArgs = ProviderContext;
 
+export type ResizeRuntimeArgs = ProviderContext & {
+  targetTier: InstanceTierKey;
+};
+
 export type InstanceProviderAdapter = {
   readonly id: ProviderId;
   readonly capabilities: ProviderCapabilities;
@@ -89,6 +94,7 @@ export type InstanceProviderAdapter = {
   startRuntime(args: StartRuntimeArgs): Promise<ProviderResult>;
   stopRuntime(args: StopRuntimeArgs): Promise<ProviderResult>;
   restartRuntime(args: RestartRuntimeArgs): Promise<ProviderResult>;
+  resizeRuntime?(args: ResizeRuntimeArgs): Promise<ProviderResult>;
   inspectRuntime(args: ProviderContext): Promise<ProviderResult>;
   destroyRuntime(args: DestroyRuntimeArgs): Promise<ProviderResult>;
   destroyStorage(args: DestroyStorageArgs): Promise<ProviderResult>;

--- a/services/kiloclaw/wrangler.jsonc
+++ b/services/kiloclaw/wrangler.jsonc
@@ -138,13 +138,10 @@
     "NF_TEAM_ID": "kilo-prod",
     "NF_REGION": "us-central",
     "NF_DEPLOYMENT_PLAN": "nf-compute-200",
-    // Per-tier Northflank compute plan overrides are intentionally NOT
-    // declared as empty defaults here — getNorthflankConfig falls back to
-    // NF_DEPLOYMENT_PLAN when an override is missing, and committing empty
-    // strings would silently propagate empty plans if optionalEnv ever
-    // stops trimming. Set NF_DEPLOYMENT_PLAN_PERF_1_3 / _PERF_4_8 /
-    // _PERF_4_16 per environment via `wrangler secret put` or env-specific
-    // overrides when per-tier hardware on Northflank is needed.
+    // getNorthflankConfig has source-level defaults for tier compute plans:
+    // perf-1-3=nf-compute-200, perf-4-8=nf-compute-400,
+    // perf-4-16=nf-compute-400-16. Override NF_DEPLOYMENT_PLAN_PERF_*
+    // only if an environment needs different Northflank plan slugs.
     "NF_EDGE_HEADER_NAME": "x-kiloclaw-northflank-edge-prod",
     "NF_IMAGE_PATH_TEMPLATE": "ghcr.io/kilo-org/kiloclaw:{tag}",
     "NF_IMAGE_CREDENTIALS_ID": "kiloclaw",


### PR DESCRIPTION
## Summary

- Adds Northflank support for existing-instance tier upgrades by growing the Northflank volume when needed and patching the deployment service compute plan before persisting the accepted desired tier state.
- Extends the provider adapter with an optional `resizeRuntime` hook so provider-specific resize semantics stay inside the provider layer while Fly and docker-local keep their existing behavior.
- Updates the admin resize flow to skip Fly-style stop/start orchestration for Northflank and show rollout-specific copy.

## Verification

deployed regular instance , upgraded to 4x8

## Visual Changes

| Before | After |
| ------ | ----- |
| Admin resize dialog used Fly-style stop/start copy for every provider. Screenshot pending. | Admin resize dialog shows Northflank rollout-specific copy and storage growth warning for Northflank instances. Screenshot pending. |

## Reviewer Notes

- Main risk area is Northflank API semantics: volume update returns an empty success response with no separate completion status, so the Worker treats HTTP 200 as accepted and persists desired tier state after Northflank also accepts the compute-plan patch.
- Northflank resize intentionally does not require the instance to be stopped; Fly and docker-local resize behavior is unchanged.
- Billing remains tier-unaware. This only updates runtime tier state and the denormalized `instance_type` read cache.