### PR TITLE
fix(kiloclaw) inbound email hook

### DIFF
--- a/services/kiloclaw-inbound-email/README.md
+++ b/services/kiloclaw-inbound-email/README.md
@@ -1,0 +1,23 @@
+# kiloclaw-inbound-email
+
+Cloudflare Email Routing handler for `kiloclaw.ai`. Receives mail addressed to `<alias>@kiloclaw.ai`, looks up the alias in `kiloclaw_inbound_email_aliases`, parses the message, and enqueues a delivery for the consumer to forward to the platform worker's `/api/platform/inbound-email` endpoint.
+
+## Pipeline
+
+```
+Cloudflare Email Routing
+    → email() handler (this worker)
+        → resolveRecipient → lookupInstanceIdByAlias
+        → parseRawEmail
+        → INBOUND_EMAIL_QUEUE.send({ instanceId, alias, from, subject, text, ... })
+    → queue consumer (this worker)
+        → POST kiloclaw worker /api/platform/inbound-email
+            → POST instance controller /_kilo/hooks/email
+                → OpenClaw /hooks/email
+```
+
+## Observability
+
+`observability.enabled` in `wrangler.jsonc` only turns on script logs at the runtime level. Logs flow into Axiom only when the script is **also added to the account-level Logpush job's script-name filter** (configured in the Cloudflare dashboard, not in this repo).
+
+Any new worker added to this repo must be added to that filter or its logs will be invisible in Axiom — even if `observability.enabled = true`. Check the `cloudflare-logpush` Axiom dataset for `ScriptName == "<your-worker>"` after deploy to confirm.

--- a/services/kiloclaw-inbound-email/README.md
+++ b/services/kiloclaw-inbound-email/README.md
@@ -18,6 +18,11 @@ Cloudflare Email Routing
 
 ## Observability
 
-`observability.enabled` in `wrangler.jsonc` only turns on script logs at the runtime level. Logs flow into Axiom only when the script is **also added to the account-level Logpush job's script-name filter** (configured in the Cloudflare dashboard, not in this repo).
+To make logs reach Axiom, the worker needs **both** flags in `wrangler.jsonc`:
 
-Any new worker added to this repo must be added to that filter or its logs will be invisible in Axiom — even if `observability.enabled = true`. Check the `cloudflare-logpush` Axiom dataset for `ScriptName == "<your-worker>"` after deploy to confirm.
+```jsonc
+"observability": { "enabled": true },
+"logpush": true,
+```
+
+The account-level Logpush job is set to "all logs", but Cloudflare still requires each worker to opt in via `logpush: true`. `observability.enabled` alone isn't enough — without `logpush: true`, the worker's trace events stay inside Cloudflare and never reach the `cloudflare-logpush` Axiom dataset. Check `ScriptName == "<your-worker>"` in Axiom after deploy to confirm.

--- a/services/kiloclaw-inbound-email/README.md
+++ b/services/kiloclaw-inbound-email/README.md
@@ -25,4 +25,4 @@ To make logs reach Axiom, the worker needs **both** flags in `wrangler.jsonc`:
 "logpush": true,
 ```
 
-The account-level Logpush job is set to "all logs", but Cloudflare still requires each worker to opt in via `logpush: true`. `observability.enabled` alone isn't enough — without `logpush: true`, the worker's trace events stay inside Cloudflare and never reach the `cloudflare-logpush` Axiom dataset. Check `ScriptName == "<your-worker>"` in Axiom after deploy to confirm.
+The account-level Logpush job is set to "all logs", but Cloudflare still requires each worker to opt in via `logpush: true`. `observability.enabled` alone isn't enough: without `logpush: true`, the worker's trace events stay inside Cloudflare and never reach the `cloudflare-logpush` Axiom dataset. Check `ScriptName == "<your-worker>"` in Axiom after deploy to confirm.

--- a/services/kiloclaw-inbound-email/wrangler.jsonc
+++ b/services/kiloclaw-inbound-email/wrangler.jsonc
@@ -7,6 +7,7 @@
   "compatibility_flags": ["nodejs_compat"],
   "dev": { "port": 8810 },
   "observability": { "enabled": true },
+  "logpush": true,
   "placement": { "mode": "smart" },
   "hyperdrive": [
     {

--- a/services/kiloclaw/controller/src/bootstrap.test.ts
+++ b/services/kiloclaw/controller/src/bootstrap.test.ts
@@ -982,6 +982,57 @@ describe('runOnboardOrDoctor', () => {
     expect(preDoctorConfig.plugins?.entries).not.toHaveProperty('openclaw-channel-streamchat');
   });
 
+  it('back-fills hooks.allowRequestSessionKey on existing configs before doctor', () => {
+    const harness = fakeDeps();
+    harness.setConfigExists(true);
+    (harness.deps.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+      JSON.stringify({
+        hooks: {
+          enabled: true,
+          token: 'existing-token',
+          path: '/hooks',
+          mappings: [
+            {
+              id: 'cloudflare-email-inbound',
+              match: { path: 'email' },
+              action: 'agent',
+              wakeMode: 'now',
+              sessionKey: '{{payload.sessionKey}}',
+              messageTemplate: 'From: {{payload.from}}',
+              deliver: false,
+            },
+          ],
+        },
+      })
+    );
+
+    runOnboardOrDoctor(
+      {
+        KILOCODE_API_KEY: 'test-key',
+        OPENCLAW_GATEWAY_TOKEN: 'test-token',
+        AUTO_APPROVE_DEVICES: 'true',
+      },
+      harness.deps
+    );
+
+    const doctorCallIndex = (
+      harness.deps.execFileSync as ReturnType<typeof vi.fn>
+    ).mock.calls.findIndex(([_cmd, args]) => Array.isArray(args) && args.includes('doctor'));
+    expect(doctorCallIndex).not.toBe(-1);
+    const doctorCallOrder = (harness.deps.execFileSync as ReturnType<typeof vi.fn>).mock
+      .invocationCallOrder[doctorCallIndex];
+
+    const preDoctorWriteIndex = (
+      harness.deps.writeFileSync as ReturnType<typeof vi.fn>
+    ).mock.invocationCallOrder.findIndex(order => order < doctorCallOrder);
+    expect(preDoctorWriteIndex).not.toBe(-1);
+
+    const preDoctorConfig = JSON.parse(harness.writeCalls[preDoctorWriteIndex].data) as {
+      hooks?: { allowRequestSessionKey?: boolean };
+    };
+    expect(preDoctorConfig.hooks?.allowRequestSessionKey).toBe(true);
+  });
+
   it('migrates legacy plaintext kilocode key in auth-profiles.json to a keyRef', () => {
     // Integration check: runOnboardOrDoctor must drive the auth-profiles
     // migration. On a legacy doctor boot, a plaintext key in

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -15,6 +15,7 @@ import path from 'node:path';
 import { execFileSync as nodeExecFileSync } from 'node:child_process';
 import {
   generateBaseConfig,
+  ensureInboundEmailHookFlags,
   sanitizeLegacyStreamChatConfig,
   writeBaseConfig,
   writeMcporterConfig,
@@ -729,6 +730,7 @@ function sanitizeExistingConfigBeforeDoctor(deps: BootstrapDeps): void {
 
   const before = JSON.stringify(parsed);
   sanitizeLegacyStreamChatConfig(parsed);
+  ensureInboundEmailHookFlags(parsed);
   const serialized = JSON.stringify(parsed, null, 2);
   if (JSON.stringify(parsed) === before) {
     return;
@@ -745,7 +747,7 @@ function sanitizeExistingConfigBeforeDoctor(deps: BootstrapDeps): void {
     },
     { mode: 0o600 }
   );
-  console.log('Removed legacy Stream Chat config before doctor');
+  console.log('Sanitized existing config before doctor');
 }
 
 export function runOnboardOrDoctor(env: EnvLike, deps: BootstrapDeps = defaultDeps): void {

--- a/services/kiloclaw/controller/src/bootstrap.ts
+++ b/services/kiloclaw/controller/src/bootstrap.ts
@@ -728,17 +728,24 @@ function sanitizeExistingConfigBeforeDoctor(deps: BootstrapDeps): void {
     return;
   }
 
-  const before = JSON.stringify(parsed);
+  const initial = JSON.stringify(parsed);
+  const applied: string[] = [];
+
   sanitizeLegacyStreamChatConfig(parsed);
+  let snapshot = JSON.stringify(parsed);
+  if (snapshot !== initial) applied.push('streamChat');
+
   ensureInboundEmailHookFlags(parsed);
-  const serialized = JSON.stringify(parsed, null, 2);
-  if (JSON.stringify(parsed) === before) {
+  const final = JSON.stringify(parsed);
+  if (final !== snapshot) applied.push('inboundEmailFlags');
+
+  if (applied.length === 0) {
     return;
   }
 
   atomicWrite(
     CONFIG_PATH,
-    serialized,
+    JSON.stringify(parsed, null, 2),
     {
       writeFileSync: deps.writeFileSync,
       renameSync: deps.renameSync,
@@ -747,7 +754,7 @@ function sanitizeExistingConfigBeforeDoctor(deps: BootstrapDeps): void {
     },
     { mode: 0o600 }
   );
-  console.log('Sanitized existing config before doctor');
+  console.log(`Sanitized existing config before doctor: [${applied.join(', ')}]`);
 }
 
 export function runOnboardOrDoctor(env: EnvLike, deps: BootstrapDeps = defaultDeps): void {

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -1313,6 +1313,15 @@ describe('ensureInboundEmailHookFlags', () => {
     ensureInboundEmailHookFlags(config);
     expect(config.hooks.allowRequestSessionKey).toBe(true);
   });
+
+  it('overrides allowRequestSessionKey: false back to true', () => {
+    // Canonical-config policy: the inbound-email mapping is force-installed
+    // on every run, so the flag it requires must converge to true alongside
+    // it. An explicit `false` is treated as drift, not as admin intent.
+    const config = { hooks: { allowRequestSessionKey: false } };
+    ensureInboundEmailHookFlags(config);
+    expect(config.hooks.allowRequestSessionKey).toBe(true);
+  });
 });
 
 describe('setNestedValue', () => {

--- a/services/kiloclaw/controller/src/config-writer.test.ts
+++ b/services/kiloclaw/controller/src/config-writer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   backupConfigFile,
+  ensureInboundEmailHookFlags,
   generateBaseConfig,
   setNestedValue,
   writeBaseConfig,
@@ -974,6 +975,7 @@ describe('generateBaseConfig', () => {
     expect(config.hooks.enabled).toBe(true);
     expect(config.hooks.token).toBe('test-hooks-token');
     expect(config.hooks.path).toBe('/hooks');
+    expect(config.hooks.allowRequestSessionKey).toBe(true);
     expect(config.hooks.allowedSessionKeyPrefixes).toEqual(['hook:', 'inbound-email:']);
     expect(config.hooks.presets).toBeUndefined();
     expect(config.hooks.mappings).toContainEqual({
@@ -1286,6 +1288,30 @@ describe('generateBaseConfig', () => {
     const config = generateBaseConfig(minimalEnv(), '/tmp/openclaw.json', deps);
     expect(config.plugins.entries['memory-core'].config.dreaming).toBeUndefined();
     expect(config.plugins.entries['memory-core'].config.extra).toBe('keep-me');
+  });
+});
+
+describe('ensureInboundEmailHookFlags', () => {
+  it('sets allowRequestSessionKey on a hooks object that lacks it', () => {
+    const config = { hooks: { enabled: true, token: 'tok' } };
+    ensureInboundEmailHookFlags(config);
+    expect(config.hooks).toMatchObject({
+      enabled: true,
+      token: 'tok',
+      allowRequestSessionKey: true,
+    });
+  });
+
+  it('is a no-op when hooks block is absent (instance has no inbound hooks)', () => {
+    const config: Record<string, unknown> = { gateway: {} };
+    ensureInboundEmailHookFlags(config);
+    expect(config.hooks).toBeUndefined();
+  });
+
+  it('is idempotent when allowRequestSessionKey is already true', () => {
+    const config = { hooks: { allowRequestSessionKey: true } };
+    ensureInboundEmailHookFlags(config);
+    expect(config.hooks.allowRequestSessionKey).toBe(true);
   });
 });
 

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -114,6 +114,13 @@ type EnvLike = Record<string, string | undefined>;
 // `{{payload.sessionKey}}` so the platform worker can pre-compute a stable
 // key like `inbound-email:YYYY-MM-DD-<slug>` that coalesces emails on the
 // same thread into one agent session.
+//
+// Force-overrides any prior value (including `false`) on purpose: the
+// inbound-email mapping is canonical config — generateBaseConfig
+// unconditionally installs/overwrites it on every run — so the flag it
+// requires must converge to true alongside the mapping. If an admin needs
+// to disable inbound email handling, the right lever is the
+// kiloclaw_instances.inbound_email_enabled column, not flipping this flag.
 export function ensureInboundEmailHookFlags(config: ConfigObject): void {
   if (config.hooks && typeof config.hooks === 'object' && !Array.isArray(config.hooks)) {
     config.hooks.allowRequestSessionKey = true;

--- a/services/kiloclaw/controller/src/config-writer.ts
+++ b/services/kiloclaw/controller/src/config-writer.ts
@@ -109,6 +109,17 @@ type ConfigObject = Record<string, any>;
 
 type EnvLike = Record<string, string | undefined>;
 
+// OpenClaw refuses hook mappings that derive `sessionKey` from a request
+// payload unless this flag is set. The inbound-email mapping uses
+// `{{payload.sessionKey}}` so the platform worker can pre-compute a stable
+// key like `inbound-email:YYYY-MM-DD-<slug>` that coalesces emails on the
+// same thread into one agent session.
+export function ensureInboundEmailHookFlags(config: ConfigObject): void {
+  if (config.hooks && typeof config.hooks === 'object' && !Array.isArray(config.hooks)) {
+    config.hooks.allowRequestSessionKey = true;
+  }
+}
+
 export function sanitizeLegacyStreamChatConfig(config: ConfigObject): void {
   if (config.channels && typeof config.channels === 'object' && !Array.isArray(config.channels)) {
     delete config.channels.streamchat;
@@ -551,6 +562,7 @@ export function generateBaseConfig(
     config.hooks.enabled = true;
     config.hooks.token = env.KILOCLAW_HOOKS_TOKEN;
     config.hooks.path = '/hooks';
+    ensureInboundEmailHookFlags(config);
     config.hooks.allowedSessionKeyPrefixes = Array.isArray(config.hooks.allowedSessionKeyPrefixes)
       ? config.hooks.allowedSessionKeyPrefixes
       : [];

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -3034,12 +3034,23 @@ platform.post('/inbound-email', async c => {
     }
 
     const error = await response.text().catch(() => '');
+    let controllerErrorMessage: string | undefined;
+    try {
+      const parsed: unknown = JSON.parse(error);
+      if (parsed && typeof parsed === 'object' && 'error' in parsed) {
+        const candidate = (parsed as { error: unknown }).error;
+        if (typeof candidate === 'string') controllerErrorMessage = candidate;
+      }
+    } catch {
+      // body wasn't JSON; the raw `error` field below preserves it
+    }
     const controllerFailure = {
       ...logContext,
       userId: instance.userId,
       doKey,
       status: response.status,
-      error: error.slice(0, 500),
+      error: error.slice(0, 2000),
+      controllerErrorMessage,
       durationMs: performance.now() - startedAt,
     };
     if (response.status >= 500) {


### PR DESCRIPTION
## Summary

Every inbound email to a bot has been failing with HTTP 400 since the OpenClaw 2026.4.23 image finished rolling out. OpenClaw refuses any hook mapping that resolves `sessionKey` from a request body unless `hooks.allowRequestSessionKey: true` is set. The `cloudflare-email-inbound` mapping uses `sessionKey: '{{payload.sessionKey}}'` so the platform worker can compute a stable key like `inbound-email:YYYY-MM-DD-<slug>` and coalesce one thread into a single agent session. Without the flag, OpenClaw returned `{"error":"Hook rejected","hookStatus":400}` for every email, the controller faithfully proxied that, and the bot never woke.

This change sets the flag in `generateBaseConfig` and backfills it on existing configs via `sanitizeExistingConfigBeforeDoctor`, so running instances pick up the fix on the next controller restart with no manual reprovision.

While verifying the fix, two adjacent issues surfaced and are repaired in the same PR:

1. The `kiloclaw-inbound-email` worker was missing `logpush: true`, so its trace events never reached the `cloudflare-logpush` Axiom dataset even though `observability.enabled` was set. The other kiloclaw workers already had the flag. Added it and a short README explaining the requirement.
2. The platform worker captures the upstream rejection body but truncated it to 500 chars and stored it as a single opaque string. Bumped truncation to 2000 chars and promoted the parsed JSON `error` value to a structured log key `controllerErrorMessage`, so the next downstream regression is filterable in Axiom without needing to SSH into a running instance.

## Verification

- [x] Reproduced the regression: POST to `http://127.0.0.1:3001/hooks/email` from inside a Fly instance returned HTTP 400 with the exact `sessionKey is disabled for externally supplied hook payload values` body, confirming the root cause before applying any code change.
- [x] Confirmed blast radius: the same endpoint without `payload.sessionKey` returned 200 with an automatically generated session id, and unmapped paths like `/hooks/test` returned 404. The flag only widens acceptance for the existing inbound email mapping.
- [x] Grep across the repo confirmed `cloudflare-email-inbound` is the only mapping that templates `sessionKey` from payload, so other webhook flows are not in scope.
- [x] All controller test files pass (210 cases). New tests assert the flag is set in the generated config, that the helper overrides an explicit `false` back to `true`, and that the bootstrap sanitize step backfills the flag on an existing config that lacked it.
- [x] `pnpm run lint`, `pnpm run typecheck`, and `pnpm run format:check` all clean.
- [ ] After deploy, send a real email to a live alias, watch the platform worker log line `inbound email controller response { status: 200 }` in Axiom, and confirm the bot opens an `inbound-email:YYYY-MM-DD-<slug>` session.
- [ ] After deploy, query Axiom for `ScriptName == "kiloclaw-inbound-email"` to confirm the worker logs are now reaching the dataset.
- [ ] Drain `kiloclaw-inbound-email-dlq` once normal delivery is confirmed.

## Visual Changes

N/A

## Reviewer Notes

`ensureInboundEmailHookFlags` deliberately overrides any existing value of `hooks.allowRequestSessionKey`, including an explicit `false`. The reasoning lives in the function comment and a vitest case: the `cloudflare-email-inbound` mapping is force installed by `generateBaseConfig` on every run, so the flag it depends on must converge alongside the mapping. An operator who needs to disable inbound email entirely should clear the `kiloclaw_instances.inbound_email_enabled` column, not flip this flag.

A separate regression with the same symptom timeline (Apr 22 success, May 7 failure shown on the trigger requests page) was traced during this investigation to the same `feat(kilo-chat): rip out stream chat` commit. That regression sits in `services/webhook-agent-ingest`: the queue consumer at `queue-consumer.ts:175` still POSTs to `/api/platform/send-chat-message`, a route the same commit deleted with no replacement. The kiloclaw worker now returns "Authentication required" for that unmatched path, and captured webhook requests end up in the `failed` state. That fix is intentionally scoped to a separate PR because it requires reimplementing the chat delivery on top of the chat plugin and warrants coordination with the original author.
