### PR TITLE
chore(db): use catalog for drizzle-kit version

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -24,7 +24,7 @@
     "@types/pg": "^8.18.0",
     "@typescript/native-preview": "catalog:",
     "dotenv": "^17.3.1",
-    "drizzle-kit": "^0.31.9",
+    "drizzle-kit": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -993,7 +993,7 @@ importers:
         specifier: ^17.3.1
         version: 17.3.1
       drizzle-kit:
-        specifier: ^0.31.9
+        specifier: 'catalog:'
         version: 0.31.9
       typescript:
         specifier: 'catalog:'


### PR DESCRIPTION
## Summary

`packages/db` was the only consumer pinning `drizzle-kit` directly (`^0.31.9`) instead of going through the pnpm catalog like every other package in the monorepo. Switching it to `catalog:` means a single bump of `drizzle-kit` (and `drizzle-orm`) in `pnpm-workspace.yaml` will now upgrade the entire repo in lockstep — preparation for the upcoming Drizzle v1 upgrade.

The resolved version is unchanged (`0.31.9`, same as the catalog).

## Verification

- `pnpm install --frozen-lockfile` succeeds with the new specifier.
- `pnpm --filter @kilocode/db list drizzle-kit` resolves to `drizzle-kit@0.31.9` from the catalog.

## Visual Changes

N/A

## Reviewer Notes

The lockfile diff is intentionally minimal — only the `specifier` line for `drizzle-kit` under the `@kilocode/db` importer changes; the resolved version stays the same.