### PR TITLE
feat(kiloclaw) calendar admin gating

### DIFF
--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
@@ -334,14 +334,16 @@ describe('ClawOnboardingFlow state machine', () => {
 
   describe('when calendar step is hidden (non-admin user)', () => {
     test('drops calendar from total step count', () => {
-      const noPairing = getClawOnboardingFlowState(createInput({ hasCalendarStep: false }));
-      expect(noPairing.totalSteps).toBe(3);
-      expect(noPairing.hasCalendarStep).toBe(false);
+      const noCalendarNoPairing = getClawOnboardingFlowState(
+        createInput({ hasCalendarStep: false })
+      );
+      expect(noCalendarNoPairing.totalSteps).toBe(3);
+      expect(noCalendarNoPairing.hasCalendarStep).toBe(false);
 
-      const withPairing = getClawOnboardingFlowState(
+      const noCalendarWithPairing = getClawOnboardingFlowState(
         createInput({ hasCalendarStep: false, selectedChannelId: 'telegram' })
       );
-      expect(withPairing.totalSteps).toBe(4);
+      expect(noCalendarWithPairing.totalSteps).toBe(4);
     });
 
     test('redirects calendar render step to channels in create-first mode', () => {

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.test.ts
@@ -332,6 +332,93 @@ describe('ClawOnboardingFlow state machine', () => {
     ).toBe('provisioning');
   });
 
+  describe('when calendar step is hidden (non-admin user)', () => {
+    test('drops calendar from total step count', () => {
+      const noPairing = getClawOnboardingFlowState(createInput({ hasCalendarStep: false }));
+      expect(noPairing.totalSteps).toBe(3);
+      expect(noPairing.hasCalendarStep).toBe(false);
+
+      const withPairing = getClawOnboardingFlowState(
+        createInput({ hasCalendarStep: false, selectedChannelId: 'telegram' })
+      );
+      expect(withPairing.totalSteps).toBe(4);
+    });
+
+    test('redirects calendar render step to channels in create-first mode', () => {
+      const state = getClawOnboardingFlowState(
+        createInput({
+          createSetupStarted: true,
+          onboardingStep: 'calendar',
+          hasBotIdentity: true,
+          hasCalendarStep: false,
+        })
+      );
+
+      expect(state.renderStep).toBe('channels');
+    });
+
+    test('redirects calendar render step to channels in post-provisioning mode', () => {
+      const state = getClawOnboardingFlowState(
+        createInput({
+          mode: 'post-provisioning',
+          status: createStatus('running'),
+          onboardingStep: 'calendar',
+          hasBotIdentity: true,
+          gatewayState: 'running',
+          hasCalendarStep: false,
+        })
+      );
+
+      expect(state.renderStep).toBe('channels');
+    });
+
+    test('reports channels as step 2 of 3 even when stored onboardingStep is calendar', () => {
+      // A non-admin briefly sitting on onboardingStep='calendar' (e.g. via a
+      // stale URL) gets normalized for both the rendered step and the
+      // progress indicator so the header doesn't read "Step 0 of 3".
+      const state = getClawOnboardingFlowState(
+        createInput({
+          createSetupStarted: true,
+          onboardingStep: 'calendar',
+          hasBotIdentity: true,
+          hasCalendarStep: false,
+        })
+      );
+
+      expect(state.renderStep).toBe('channels');
+      expect(state.currentStep).toBe(2);
+      expect(state.totalSteps).toBe(3);
+    });
+
+    test('getClawOnboardingStepProgress positions remaining steps correctly without calendar', () => {
+      expect(getClawOnboardingStepProgress('identity', false, false)).toEqual({
+        currentStep: 1,
+        totalSteps: 3,
+      });
+      expect(getClawOnboardingStepProgress('channels', false, false)).toEqual({
+        currentStep: 2,
+        totalSteps: 3,
+      });
+      expect(getClawOnboardingStepProgress('provisioning', false, false)).toEqual({
+        currentStep: 3,
+        totalSteps: 3,
+      });
+      expect(getClawOnboardingStepProgress('done', false, false)).toEqual({
+        currentStep: 3,
+        totalSteps: 3,
+      });
+
+      expect(getClawOnboardingStepProgress('identity', true, false)).toEqual({
+        currentStep: 1,
+        totalSteps: 4,
+      });
+      expect(getClawOnboardingStepProgress('pairing', true, false)).toEqual({
+        currentStep: 4,
+        totalSteps: 4,
+      });
+    });
+  });
+
   test('renders calendar in post-provisioning mode when explicit resume is requested', () => {
     // After the OAuth full-page reload, the wizard often remounts in
     // post-provisioning mode because the instance row is now visible.

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
@@ -74,6 +74,14 @@ export type ClawOnboardingFlowStateInput = {
   hasBotIdentity: boolean;
   selectedChannelId: string | null;
   gatewayState?: GatewayProcessStatusResponse['state'] | null;
+  /**
+   * Whether the calendar step is available in the wizard. Calendar OAuth is
+   * gated to Kilo Code admins (the `/api/integrations/google/connect` and
+   * `/disconnect` routes both require `adminOnly: true`), so non-admins skip
+   * the step entirely. When false, the wizard advances identity → channels
+   * and `'calendar'` is mapped to `'channels'` in the render decision.
+   */
+  hasCalendarStep?: boolean;
   debugLogSource?: string;
 };
 
@@ -85,6 +93,7 @@ export type ClawOnboardingFlowState = {
   instanceRunning: boolean;
   createSetupActive: boolean;
   postProvisioningReady: boolean;
+  hasCalendarStep: boolean;
   hasPairingStep: boolean;
   currentStep: number;
   totalSteps: number;
@@ -107,18 +116,31 @@ export function isClawOnboardingErrorStatus(status: PopulatedClawStatus['status'
   return false;
 }
 
+function getActiveWizardSteps(hasCalendarStep: boolean, hasPairingStep: boolean): OnboardingStep[] {
+  const steps: OnboardingStep[] = ['identity'];
+  if (hasCalendarStep) steps.push('calendar');
+  steps.push('channels', 'provisioning');
+  if (hasPairingStep) steps.push('pairing');
+  return steps;
+}
+
 export function getClawOnboardingStepProgress(
   step: OnboardingStep,
-  hasPairingStep: boolean
+  hasPairingStep: boolean,
+  hasCalendarStep: boolean = true
 ): { currentStep: number; totalSteps: number } {
-  const wizardSteps: readonly OnboardingStep[] = CLAW_ONBOARDING_WIZARD_STEPS;
-  const totalSteps = hasPairingStep ? wizardSteps.length : wizardSteps.length - 1;
+  const wizardSteps = getActiveWizardSteps(hasCalendarStep, hasPairingStep);
+  const totalSteps = wizardSteps.length;
 
   if (step === 'done') {
     return { currentStep: totalSteps, totalSteps };
   }
 
-  const index = wizardSteps.indexOf(step);
+  // A non-admin sitting briefly on `onboardingStep === 'calendar'` (e.g. via
+  // a stale `?step=calendar` URL) gets normalized to channels for progress
+  // display, matching the renderStep redirect in getRenderStepDecision.
+  const lookupStep: OnboardingStep = step === 'calendar' && !hasCalendarStep ? 'channels' : step;
+  const index = wizardSteps.indexOf(lookupStep);
   const currentStep = index === -1 ? 0 : index + 1;
 
   return { currentStep, totalSteps };
@@ -133,6 +155,7 @@ export function getClawOnboardingFlowState({
   hasBotIdentity,
   selectedChannelId,
   gatewayState,
+  hasCalendarStep = true,
   debugLogSource = 'default',
 }: ClawOnboardingFlowStateInput): ClawOnboardingFlowState {
   const instanceStatus = hasPopulatedStatus(status) ? status : null;
@@ -143,7 +166,11 @@ export function getClawOnboardingFlowState({
   const createSetupActive =
     mode === 'create-first' && (createSetupStarted || instanceStatus !== null);
   const hasPairingStep = isPairingChannel(selectedChannelId);
-  const { currentStep, totalSteps } = getClawOnboardingStepProgress(onboardingStep, hasPairingStep);
+  const { currentStep, totalSteps } = getClawOnboardingStepProgress(
+    onboardingStep,
+    hasPairingStep,
+    hasCalendarStep
+  );
   const renderStepDecision = getRenderStepDecision({
     mode,
     createSetupStarted,
@@ -152,6 +179,7 @@ export function getClawOnboardingFlowState({
     postProvisioningReady,
     onboardingStep,
     hasBotIdentity,
+    hasCalendarStep,
     hasPairingStep,
   });
   const flowState = {
@@ -162,6 +190,7 @@ export function getClawOnboardingFlowState({
     instanceRunning,
     createSetupActive,
     postProvisioningReady,
+    hasCalendarStep,
     hasPairingStep,
     currentStep,
     totalSteps,
@@ -176,6 +205,7 @@ export function getClawOnboardingFlowState({
     hasBotIdentity,
     selectedChannelId,
     gatewayState,
+    hasCalendarStep,
     debugLogSource,
     instanceStatus,
     isRunning,
@@ -198,6 +228,7 @@ type RenderStepInput = Pick<
 > & {
   instanceStatus: PopulatedClawStatus | null;
   postProvisioningReady: boolean;
+  hasCalendarStep: boolean;
   hasPairingStep: boolean;
 };
 
@@ -208,6 +239,7 @@ type RenderStepDecision = {
 
 type ClawOnboardingFlowDebugLogInput = ClawOnboardingFlowStateInput & {
   debugLogSource: string;
+  hasCalendarStep: boolean;
   instanceStatus: PopulatedClawStatus | null;
   isRunning: boolean;
   gatewayReady: boolean;
@@ -237,6 +269,7 @@ function getRenderStepDecision({
   postProvisioningReady,
   onboardingStep,
   hasBotIdentity,
+  hasCalendarStep,
   hasPairingStep,
 }: RenderStepInput): RenderStepDecision {
   if (instanceStatus && isClawOnboardingErrorStatus(instanceStatus.status)) {
@@ -262,6 +295,13 @@ function getRenderStepDecision({
     // through to the default post-prov branch and skip channels, pairing,
     // and the provisioning UX entirely.
     if (onboardingStep === 'calendar') {
+      if (!hasCalendarStep) {
+        return {
+          renderStep: 'channels',
+          reason:
+            'calendar step is admin-only and the current user is not an admin; advance to channels',
+        };
+      }
       return {
         renderStep: 'calendar',
         reason: 'calendar resume requested; honor it even in post-provisioning mode',
@@ -321,6 +361,13 @@ function getRenderStepDecision({
   }
 
   if (onboardingStep === 'calendar') {
+    if (!hasCalendarStep) {
+      return {
+        renderStep: 'channels',
+        reason:
+          'calendar step is admin-only and the current user is not an admin; advance to channels',
+      };
+    }
     return {
       renderStep: 'calendar',
       reason: 'stored onboarding step is calendar',
@@ -363,6 +410,7 @@ function logClawOnboardingFlowStateDecision({
   hasBotIdentity,
   selectedChannelId,
   gatewayState,
+  hasCalendarStep,
   debugLogSource,
   instanceStatus,
   isRunning,
@@ -386,6 +434,7 @@ function logClawOnboardingFlowStateDecision({
       hasBotIdentity,
       selectedChannelId,
       gatewayState: gatewayState ?? null,
+      hasCalendarStep,
       status: status?.status ?? null,
       hasStatusResponse: status !== undefined,
     },

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.state.ts
@@ -116,7 +116,7 @@ export function isClawOnboardingErrorStatus(status: PopulatedClawStatus['status'
   return false;
 }
 
-function getActiveWizardSteps(hasCalendarStep: boolean, hasPairingStep: boolean): OnboardingStep[] {
+function getActiveWizardSteps(hasPairingStep: boolean, hasCalendarStep: boolean): OnboardingStep[] {
   const steps: OnboardingStep[] = ['identity'];
   if (hasCalendarStep) steps.push('calendar');
   steps.push('channels', 'provisioning');
@@ -129,7 +129,7 @@ export function getClawOnboardingStepProgress(
   hasPairingStep: boolean,
   hasCalendarStep: boolean = true
 ): { currentStep: number; totalSteps: number } {
-  const wizardSteps = getActiveWizardSteps(hasCalendarStep, hasPairingStep);
+  const wizardSteps = getActiveWizardSteps(hasPairingStep, hasCalendarStep);
   const totalSteps = wizardSteps.length;
 
   if (step === 'done') {

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -10,6 +10,7 @@ import { KILO_AUTO_BALANCED_MODEL } from '@/lib/ai-gateway/kilo-auto';
 import type { KiloClawDashboardStatus } from '@/lib/kiloclaw/types';
 import { useKiloClawGatewayStatus, useKiloClawMutations } from '@/hooks/useKiloClaw';
 import { useOrgKiloClawGatewayStatus, useOrgKiloClawMutations } from '@/hooks/useOrgKiloClaw';
+import { useUser } from '@/hooks/useUser';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -114,6 +115,12 @@ function ClawOnboardingFlowInner({
   const orgMutations = useOrgKiloClawMutations(organizationId ?? '');
   const mutations = organizationId ? orgMutations : personalMutations;
 
+  const { data: currentUser } = useUser();
+  // Calendar OAuth is admin-only — both `/api/integrations/google/connect` and
+  // `/disconnect` require `adminOnly: true`. Hide the calendar step from
+  // non-admins so the wizard advances identity → channels directly.
+  const hasCalendarStep = currentUser?.is_admin === true;
+
   const gatewayUrl = useGatewayUrl(status);
 
   // Lazy-init onboardingStep from `?step=` in the URL so first render already
@@ -145,6 +152,7 @@ function ClawOnboardingFlowInner({
     onboardingStep,
     hasBotIdentity: botIdentity !== null,
     selectedChannelId,
+    hasCalendarStep,
   };
   const preGatewayFlowState = getClawOnboardingFlowState({
     ...stateInput,
@@ -291,6 +299,14 @@ function ClawOnboardingFlowInner({
     if (hasResumedFromQuery.current) return;
     const stepParam = searchParams?.get('step');
     if (stepParam !== 'calendar') return;
+    // Calendar is admin-only; a non-admin landing here (e.g. via a stale
+    // shared URL) shouldn't trigger calendar-specific toasts or set
+    // onboardingStep to 'calendar'. Just strip the params and move on.
+    if (!hasCalendarStep) {
+      hasResumedFromQuery.current = true;
+      cleanupResumeQueryParams();
+      return;
+    }
     if (botIdentity === null) return;
     const successParam = searchParams?.get('success');
     const errorParamRaw = searchParams?.get('error');
@@ -313,7 +329,7 @@ function ClawOnboardingFlowInner({
       toast.error('Could not connect calendar — please try again or skip for now.');
     }
     cleanupResumeQueryParams();
-  }, [searchParams, botIdentity, posthog, cleanupResumeQueryParams]);
+  }, [searchParams, botIdentity, posthog, cleanupResumeQueryParams, hasCalendarStep]);
 
   // Watchdog: if `?step=calendar` is in the URL but botIdentity hydration
   // never completes (e.g. patchBotIdentity hadn't propagated to the DB
@@ -412,7 +428,12 @@ function ClawOnboardingFlowInner({
             defaulted: true,
           });
           setBotIdentity(identity);
-          setOnboardingStep('calendar');
+          if (hasCalendarStep) {
+            setOnboardingStep('calendar');
+          } else {
+            posthog?.capture('claw_setup_channels_viewed');
+            setOnboardingStep('channels');
+          }
         }}
       />
     );

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -309,15 +309,17 @@ function ClawOnboardingFlowInner({
     const stepParam = searchParams?.get('step');
     if (stepParam !== 'calendar') return;
     // The OAuth round-trip is a full-page reload, so `useUser` starts fresh
-    // and `currentUser` is undefined for the first render(s). Wait until the
-    // query resolves before deciding what to do — otherwise an admin
-    // returning from a successful OAuth would be treated as a non-admin,
-    // have `?step=calendar` stripped immediately, and never see the success
-    // toast or the calendar step again.
-    if (currentUser === undefined) return;
-    // Calendar is admin-only; a non-admin landing here (e.g. via a stale
-    // shared URL) shouldn't trigger calendar-specific toasts or set
-    // onboardingStep to 'calendar'. Just strip the params and move on.
+    // and the query is in-flight on the first render(s). Gate on `isPending`
+    // (not `currentUser === undefined`) so that a `/api/user` fetch that
+    // settles in error after retries — `data` stays undefined, `isPending`
+    // flips to false — still falls through to the cleanup branch below
+    // instead of stranding the URL params forever.
+    if (isUserPending) return;
+    // Calendar is admin-only; a non-admin (or any user we couldn't classify
+    // as admin, e.g. /api/user errored after retries) landing here shouldn't
+    // trigger calendar-specific toasts or set onboardingStep to 'calendar'.
+    // Strip the params and move on. An admin who just completed OAuth but
+    // had /api/user error can re-verify the connection in settings.
     if (!hasCalendarStep) {
       hasResumedFromQuery.current = true;
       cleanupResumeQueryParams();
@@ -345,7 +347,14 @@ function ClawOnboardingFlowInner({
       toast.error('Could not connect calendar — please try again or skip for now.');
     }
     cleanupResumeQueryParams();
-  }, [searchParams, botIdentity, posthog, cleanupResumeQueryParams, hasCalendarStep, currentUser]);
+  }, [
+    searchParams,
+    botIdentity,
+    posthog,
+    cleanupResumeQueryParams,
+    hasCalendarStep,
+    isUserPending,
+  ]);
 
   // Watchdog: if `?step=calendar` is in the URL but botIdentity hydration
   // never completes (e.g. patchBotIdentity hadn't propagated to the DB

--- a/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
+++ b/apps/web/src/app/(app)/claw/components/ClawOnboardingFlow.tsx
@@ -115,11 +115,20 @@ function ClawOnboardingFlowInner({
   const orgMutations = useOrgKiloClawMutations(organizationId ?? '');
   const mutations = organizationId ? orgMutations : personalMutations;
 
-  const { data: currentUser } = useUser();
+  const { data: currentUser, isPending: isUserPending } = useUser();
   // Calendar OAuth is admin-only — both `/api/integrations/google/connect` and
   // `/disconnect` require `adminOnly: true`. Hide the calendar step from
   // non-admins so the wizard advances identity → channels directly.
-  const hasCalendarStep = currentUser?.is_admin === true;
+  //
+  // While `useUser` is loading we default to `true` (admin assumption). This
+  // matters most for admins returning from the OAuth round-trip on a full
+  // page reload: defaulting to `false` would briefly flip the wizard into
+  // the 3-step non-admin layout and — if they race-clicked Continue before
+  // the query resolved — silently skip the calendar step entirely. The
+  // theoretical inverse (a non-admin race-clicking Continue and seeing one
+  // frame of the calendar UI before the state machine redirects to
+  // channels) is harmless: the connect endpoint enforces admin too.
+  const hasCalendarStep = isUserPending ? true : currentUser?.is_admin === true;
 
   const gatewayUrl = useGatewayUrl(status);
 
@@ -299,6 +308,13 @@ function ClawOnboardingFlowInner({
     if (hasResumedFromQuery.current) return;
     const stepParam = searchParams?.get('step');
     if (stepParam !== 'calendar') return;
+    // The OAuth round-trip is a full-page reload, so `useUser` starts fresh
+    // and `currentUser` is undefined for the first render(s). Wait until the
+    // query resolves before deciding what to do — otherwise an admin
+    // returning from a successful OAuth would be treated as a non-admin,
+    // have `?step=calendar` stripped immediately, and never see the success
+    // toast or the calendar step again.
+    if (currentUser === undefined) return;
     // Calendar is admin-only; a non-admin landing here (e.g. via a stale
     // shared URL) shouldn't trigger calendar-specific toasts or set
     // onboardingStep to 'calendar'. Just strip the params and move on.
@@ -329,7 +345,7 @@ function ClawOnboardingFlowInner({
       toast.error('Could not connect calendar — please try again or skip for now.');
     }
     cleanupResumeQueryParams();
-  }, [searchParams, botIdentity, posthog, cleanupResumeQueryParams, hasCalendarStep]);
+  }, [searchParams, botIdentity, posthog, cleanupResumeQueryParams, hasCalendarStep, currentUser]);
 
   // Watchdog: if `?step=calendar` is in the URL but botIdentity hydration
   // never completes (e.g. patchBotIdentity hadn't propagated to the DB


### PR DESCRIPTION

## Summary

- During the onboarding revamp, the connect a calendar feature was made available to all users and should have been gated.
## Verification

- [x] linting, etc
- [x] e2e tests and manual tests locally 
## Visual Changes
- Connect a calendar screen is now properly gated and won't be shown
## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
