### PR TITLE
fix(kiloclaw): update controller Bun lockfile

### DIFF
--- a/services/kiloclaw/controller/bun.lock
+++ b/services/kiloclaw/controller/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "kiloclaw-controller",
       "dependencies": {
-        "hono": "4.12.2",
+        "hono": "^4.12.18",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -16,7 +16,7 @@
   "packages": {
     "@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
-    "hono": ["hono@4.12.2", "", {}, "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg=="],
+    "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 


### PR DESCRIPTION
## Summary

Updates the KiloClaw controller Bun lockfile so Docker image builds can install dependencies with `--frozen-lockfile` again.

The production deploy failed because `services/kiloclaw/controller/package.json` requires `hono@^4.12.18`, while the nested Bun lockfile still resolved `hono@4.12.2`. This PR brings the lockfile back in sync with the controller package manifest.

## Verification

Reviewed the failing KiloClaw deploy logs and confirmed the Docker build failed in the controller builder stage during `bun install --frozen-lockfile` due to a stale lockfile.

## Visual Changes

N/A

## Reviewer Notes

Lockfile-only fix. No runtime controller code changes.
