### PR TITLE
feat(gastown): stop convoy landing-MR respawn loop when PR awaiting approval

### DIFF
--- a/services/gastown/src/dos/town/actions.ts
+++ b/services/gastown/src/dos/town/actions.ts
@@ -262,6 +262,17 @@ export type EmitEvent = z.infer<typeof EmitEvent>;
 // The SQL handle is for synchronous mutations; the rest are for async
 // side effects (dispatch, stop, poll, nudge).
 
+export type ReviewDecision = 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED' | null;
+
+export type MergeStateStatus =
+  | 'CLEAN'
+  | 'BLOCKED'
+  | 'BEHIND'
+  | 'DIRTY'
+  | 'HAS_HOOKS'
+  | 'UNKNOWN'
+  | null;
+
 /** Result of checking PR feedback (unresolved comments + failing CI checks). */
 export type PRFeedbackCheckResult = {
   hasUnresolvedComments: boolean;
@@ -271,6 +282,15 @@ export type PRFeedbackCheckResult = {
    *  inspected. allChecksPass is already false in this case, but
    *  hasFailingChecks only reflects the runs we actually saw. */
   hasUncheckedRuns: boolean;
+  /** True when the PR requires human approval per branch protection
+   *  (reviewDecision === 'REVIEW_REQUIRED' or mergeStateStatus === 'BLOCKED'). */
+  awaitingApproval: boolean;
+  /** True when a reviewer has actively requested changes
+   *  (reviewDecision === 'CHANGES_REQUESTED'). */
+  changesRequested: boolean;
+  reviewDecision: ReviewDecision;
+  mergeStateStatus: MergeStateStatus;
+  isDraft: boolean;
 };
 
 export type ApplyActionContext = {
@@ -885,6 +905,136 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
             const feedback =
               wantsAutoResolve || wantsAutoMerge ? await ctx.checkPRFeedback(action.pr_url) : null;
 
+            if (feedback) {
+              const prevAwaitingRows = z
+                .object({ awaiting_approval: z.unknown() })
+                .array()
+                .parse([
+                  ...query(
+                    sql,
+                    /* sql */ `
+                      SELECT json_extract(${beads.columns.metadata}, '$.awaiting_approval') AS awaiting_approval
+                      FROM ${beads}
+                      WHERE ${beads.bead_id} = ?
+                    `,
+                    [action.bead_id]
+                  ),
+                ]);
+              const wasAwaiting =
+                prevAwaitingRows[0]?.awaiting_approval === 1 ||
+                prevAwaitingRows[0]?.awaiting_approval === true;
+              const nowAwaiting = feedback.awaitingApproval;
+
+              query(
+                sql,
+                /* sql */ `
+                  UPDATE ${beads}
+                  SET ${beads.columns.metadata} = json_set(
+                    COALESCE(${beads.columns.metadata}, '{}'),
+                    '$.awaiting_approval', ?,
+                    '$.review_decision', ?,
+                    '$.merge_state_status', ?
+                  ),
+                  ${beads.columns.updated_at} = ?
+                  WHERE ${beads.bead_id} = ?
+                `,
+                [
+                  nowAwaiting ? 1 : 0,
+                  feedback.reviewDecision ?? null,
+                  feedback.mergeStateStatus ?? null,
+                  now(),
+                  action.bead_id,
+                ]
+              );
+
+              if (nowAwaiting && !wasAwaiting) {
+                const createdRows = z
+                  .object({ created_at: z.string() })
+                  .array()
+                  .parse([
+                    ...query(
+                      sql,
+                      /* sql */ `
+                        SELECT ${beads.columns.created_at}
+                        FROM ${beads}
+                        WHERE ${beads.bead_id} = ?
+                      `,
+                      [action.bead_id]
+                    ),
+                  ]);
+                const durationSinceCreatedMs = createdRows[0]
+                  ? Date.now() - new Date(createdRows[0].created_at).getTime()
+                  : 0;
+
+                ctx.emitEvent({
+                  event: 'pr.awaiting_approval_detected',
+                  townId,
+                  beadId: action.bead_id,
+                  prUrl: action.pr_url,
+                  label: feedback.reviewDecision ?? '',
+                  reason: feedback.mergeStateStatus ?? '',
+                  durationMs: durationSinceCreatedMs,
+                });
+              } else if (!nowAwaiting && wasAwaiting) {
+                const observedRows = z
+                  .object({ awaiting_approval_observed_at: z.string().nullable() })
+                  .array()
+                  .parse([
+                    ...query(
+                      sql,
+                      /* sql */ `
+                        SELECT json_extract(${beads.columns.metadata}, '$.awaiting_approval_observed_at') AS awaiting_approval_observed_at
+                        FROM ${beads}
+                        WHERE ${beads.bead_id} = ?
+                      `,
+                      [action.bead_id]
+                    ),
+                  ]);
+                const observedAt = observedRows[0]?.awaiting_approval_observed_at;
+                const awaitingApprovalDurationMs = observedAt
+                  ? Date.now() - new Date(observedAt).getTime()
+                  : 0;
+
+                ctx.emitEvent({
+                  event: 'pr.awaiting_approval_resolved',
+                  townId,
+                  beadId: action.bead_id,
+                  prUrl: action.pr_url,
+                  label: feedback.reviewDecision ?? '',
+                  reason: feedback.mergeStateStatus ?? '',
+                  durationMs: awaitingApprovalDurationMs,
+                });
+              }
+
+              if (nowAwaiting) {
+                query(
+                  sql,
+                  /* sql */ `
+                    UPDATE ${beads}
+                    SET ${beads.columns.metadata} = json_set(
+                      COALESCE(${beads.columns.metadata}, '{}'),
+                      '$.awaiting_approval_observed_at', ?
+                    )
+                    WHERE ${beads.bead_id} = ?
+                  `,
+                  [now(), action.bead_id]
+                );
+              } else {
+                query(
+                  sql,
+                  /* sql */ `
+                    UPDATE ${beads}
+                    SET ${beads.columns.metadata} = json_remove(
+                      COALESCE(${beads.columns.metadata}, '{}'),
+                      '$.awaiting_approval_observed_at'
+                    )
+                    WHERE ${beads.bead_id} = ?
+                  `,
+                  [action.bead_id]
+                );
+              }
+            }
+
             // Auto-resolve PR feedback: detect unresolved comments and failing CI
             if (
               wantsAutoResolve &&
@@ -957,10 +1107,12 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
               const allGreen =
                 !feedback.hasUnresolvedComments &&
                 !feedback.hasFailingChecks &&
-                feedback.allChecksPass;
+                feedback.allChecksPass &&
+                !feedback.awaitingApproval &&
+                !feedback.changesRequested;
 
               console.log(
-                `${LOG} poll_pr: bead=${action.bead_id} allGreen=${allGreen} unresolved=${feedback.hasUnresolvedComments} failing=${feedback.hasFailingChecks} allPass=${feedback.allChecksPass} unchecked=${feedback.hasUncheckedRuns}`
+                `${LOG} poll_pr: bead=${action.bead_id} allGreen=${allGreen} unresolved=${feedback.hasUnresolvedComments} failing=${feedback.hasFailingChecks} allPass=${feedback.allChecksPass} unchecked=${feedback.hasUncheckedRuns} awaitingApproval=${feedback.awaitingApproval} changesRequested=${feedback.changesRequested}`
               );
 
               if (allGreen) {
@@ -1129,7 +1281,9 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
             freshFeedback &&
             (freshFeedback.hasUnresolvedComments ||
               freshFeedback.hasFailingChecks ||
-              !freshFeedback.allChecksPass)
+              !freshFeedback.allChecksPass ||
+              freshFeedback.awaitingApproval ||
+              freshFeedback.changesRequested)
           ) {
             console.log(
               `${LOG} merge_pr: fresh feedback check found issues, aborting merge for bead=${action.bead_id}`

--- a/services/gastown/src/dos/town/reconciler.ts
+++ b/services/gastown/src/dos/town/reconciler.ts
@@ -1467,6 +1467,15 @@ export function reconcileReviewQueue(
       mr.pr_url &&
       staleMs(mr.updated_at, ORPHANED_PR_REVIEW_TIMEOUT_MS)
     ) {
+      let mrMeta: Record<string, unknown> = {};
+      try {
+        mrMeta = JSON.parse(mr.metadata ?? '{}') as Record<string, unknown>;
+      } catch {
+        /* ignore */
+      }
+      if (mrMeta.awaiting_approval === 1 || mrMeta.awaiting_approval === true) {
+        continue;
+      }
       const workingAgent = hasWorkingAgentHooked(sql, mr.bead_id);
       if (!workingAgent) {
         actions.push({
@@ -1809,6 +1818,7 @@ export function reconcileReviewQueue(
           rig_id: z.string().nullable(),
           dispatch_attempts: z.number(),
           last_dispatch_attempt_at: z.string().nullable(),
+          metadata: z.string(),
         })
         .array()
         .parse([
@@ -1816,7 +1826,8 @@ export function reconcileReviewQueue(
             sql,
             /* sql */ `
           SELECT ${beads.status}, ${beads.type}, ${beads.rig_id},
-                 ${beads.dispatch_attempts}, ${beads.last_dispatch_attempt_at}
+                 ${beads.dispatch_attempts}, ${beads.last_dispatch_attempt_at},
+                 ${beads.columns.metadata}
           FROM ${beads}
           WHERE ${beads.bead_id} = ?
         `,
@@ -1827,6 +1838,16 @@ export function reconcileReviewQueue(
       if (mrRows.length === 0) continue;
       const mr = mrRows[0];
       if (mr.type !== 'merge_request' || mr.status !== 'in_progress') continue;
+
+      let mrMeta: Record<string, unknown> = {};
+      try {
+        mrMeta = JSON.parse(mr.metadata ?? '{}') as Record<string, unknown>;
+      } catch {
+        /* ignore */
+      }
+      if (mrMeta.awaiting_approval === 1 || mrMeta.awaiting_approval === true) {
+        continue;
+      }
 
       if (draining) {
         console.log(
@@ -2043,13 +2064,13 @@ export function reconcileConvoys(sql: SqlStorage): Action[] {
       if (parsedMeta.ready_to_land) {
         // Check if a landing MR already exists (any status)
         const landingMrs = z
-          .object({ status: z.string() })
+          .object({ status: z.string(), metadata: z.string() })
           .array()
           .parse([
             ...query(
               sql,
               /* sql */ `
-                SELECT mr.${beads.columns.status}
+                SELECT mr.${beads.columns.status}, mr.${beads.columns.metadata}
                 FROM ${bead_dependencies} bd
                 INNER JOIN ${beads} mr ON mr.${beads.columns.bead_id} = bd.${bead_dependencies.columns.bead_id}
                 WHERE bd.${bead_dependencies.columns.depends_on_bead_id} = ?
@@ -2075,6 +2096,27 @@ export function reconcileConvoys(sql: SqlStorage): Action[] {
           mr => mr.status === 'open' || mr.status === 'in_progress'
         );
         if (hasActiveLanding) continue;
+
+        const hasPendingExternalReview = landingMrs.some(mr => {
+          if (mr.status !== 'failed') return false;
+          try {
+            const meta = JSON.parse(mr.metadata ?? '{}') as Record<string, unknown>;
+            return meta.awaiting_approval === 1 || meta.awaiting_approval === true;
+          } catch {
+            return false;
+          }
+        });
+        if (hasPendingExternalReview) {
+          actions.push({
+            type: 'emit_event',
+            event_name: 'reconciler.respawn_suppressed',
+            data: {
+              convoyId: convoy.bead_id,
+              suppressedAttempt: landingMrAttempts + 1,
+            },
+          });
+          continue;
+        }
 
         // Fix 2 (#2260): If max landing MR attempts exceeded and no landing MR is
         // active or merged, fail the convoy. Checked after landing MR status lookup

--- a/services/gastown/src/dos/town/town-scm.ts
+++ b/services/gastown/src/dos/town/town-scm.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { TownConfig } from '../../types';
-import type { PRFeedbackCheckResult } from './actions';
+import type { PRFeedbackCheckResult, ReviewDecision, MergeStateStatus } from './actions';
 import {
   GitHubPRStatusSchema,
   GitLabMRStatusSchema,
@@ -283,6 +283,9 @@ export async function checkPRFeedback(
         query: `query($owner: String!, $repo: String!, $number: Int!) {
           repository(owner: $owner, name: $repo) {
             pullRequest(number: $number) {
+              reviewDecision
+              mergeStateStatus
+              isDraft
               reviewThreads(first: 100) {
                 pageInfo { hasNextPage }
                 nodes {
@@ -311,6 +314,22 @@ export async function checkPRFeedback(
                 .object({
                   pullRequest: z
                     .object({
+                      reviewDecision: z
+                        .enum(['APPROVED', 'CHANGES_REQUESTED', 'REVIEW_REQUIRED'])
+                        .nullable()
+                        .optional(),
+                      mergeStateStatus: z
+                        .enum([
+                          'CLEAN',
+                          'BLOCKED',
+                          'BEHIND',
+                          'DIRTY',
+                          'HAS_HOOKS',
+                          'UNKNOWN',
+                        ])
+                        .nullable()
+                        .optional(),
+                      isDraft: z.boolean().optional(),
                       reviewThreads: z
                         .object({
                           pageInfo: z.object({ hasNextPage: z.boolean() }).optional(),
@@ -339,9 +358,13 @@ export async function checkPRFeedback(
             .optional(),
         })
         .safeParse(gqlRaw);
-      const reviewThreads = gql.success
-        ? gql.data.data?.repository?.pullRequest?.reviewThreads
+      const pullRequest = gql.success
+        ? gql.data.data?.repository?.pullRequest
         : undefined;
+      const reviewDecision = (pullRequest?.reviewDecision ?? null) as ReviewDecision;
+      const mergeStateStatus = (pullRequest?.mergeStateStatus ?? null) as MergeStateStatus;
+      const isDraft = pullRequest?.isDraft ?? false;
+      const reviewThreads = pullRequest?.reviewThreads;
       const threads = reviewThreads?.nodes ?? [];
       const hasMorePages = reviewThreads?.pageInfo?.hasNextPage === true;
 
@@ -440,7 +463,21 @@ export async function checkPRFeedback(
     console.warn(`${TOWN_LOG} checkPRFeedback: check-runs failed for ${prUrl}`, err);
   }
 
-  return { hasUnresolvedComments, hasFailingChecks, allChecksPass, hasUncheckedRuns };
+  const awaitingApproval =
+    reviewDecision === 'REVIEW_REQUIRED' || mergeStateStatus === 'BLOCKED';
+  const changesRequested = reviewDecision === 'CHANGES_REQUESTED';
+
+  return {
+    hasUnresolvedComments,
+    hasFailingChecks,
+    allChecksPass,
+    hasUncheckedRuns,
+    awaitingApproval,
+    changesRequested,
+    reviewDecision,
+    mergeStateStatus,
+    isDraft,
+  };
 }
 
 /**

--- a/services/gastown/src/dos/town/town-scm.ts
+++ b/services/gastown/src/dos/town/town-scm.ts
@@ -275,6 +275,9 @@ export async function checkPRFeedback(
   };
 
   let hasUnresolvedComments = false;
+  let reviewDecision: ReviewDecision = null;
+  let mergeStateStatus: MergeStateStatus = null;
+  let isDraft = false;
   try {
     const graphqlRes = await fetch('https://api.github.com/graphql', {
       method: 'POST',
@@ -361,9 +364,9 @@ export async function checkPRFeedback(
       const pullRequest = gql.success
         ? gql.data.data?.repository?.pullRequest
         : undefined;
-      const reviewDecision = (pullRequest?.reviewDecision ?? null) as ReviewDecision;
-      const mergeStateStatus = (pullRequest?.mergeStateStatus ?? null) as MergeStateStatus;
-      const isDraft = pullRequest?.isDraft ?? false;
+      reviewDecision = (pullRequest?.reviewDecision ?? null) as ReviewDecision;
+      mergeStateStatus = (pullRequest?.mergeStateStatus ?? null) as MergeStateStatus;
+      isDraft = pullRequest?.isDraft ?? false;
       const reviewThreads = pullRequest?.reviewThreads;
       const threads = reviewThreads?.nodes ?? [];
       const hasMorePages = reviewThreads?.pageInfo?.hasNextPage === true;

--- a/services/gastown/test/integration/awaiting-approval.test.ts
+++ b/services/gastown/test/integration/awaiting-approval.test.ts
@@ -1,0 +1,297 @@
+import { env, runDurableObjectAlarm } from 'cloudflare:test';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+function getTownStub(name = 'test-town') {
+  const id = env.TOWN.idFromName(name);
+  return env.TOWN.get(id);
+}
+
+describe('Awaiting approval — convoy landing MR respawn suppression', () => {
+  let town: ReturnType<typeof getTownStub>;
+  let townName: string;
+
+  beforeEach(async () => {
+    townName = `awaiting-approval-${crypto.randomUUID()}`;
+    town = getTownStub(townName);
+    await town.setTownId(townName);
+    await town.addRig({
+      rigId: 'rig-1',
+      name: 'main-rig',
+      gitUrl: 'https://github.com/test/repo.git',
+      defaultBranch: 'main',
+    });
+  });
+
+  async function setupConvoyWithLandingMr() {
+    const result = await town.slingConvoy({
+      rigId: 'rig-1',
+      convoyTitle: 'Landing MR Test',
+      tasks: [{ title: 'Task 1' }],
+      merge_mode: 'review-then-land',
+    });
+
+    const beadId = result.beads[0].bead.bead_id;
+
+    await runDurableObjectAlarm(town);
+
+    const bead = await town.getBeadAsync(beadId);
+    const agentId = bead!.assignee_agent_bead_id!;
+    expect(agentId).toBeTruthy();
+
+    await town.agentDone(agentId, {
+      branch: 'gt/polecat/test-branch',
+      summary: 'Completed task',
+    });
+
+    await runDurableObjectAlarm(town);
+
+    const sourceBead = await town.getBeadAsync(beadId);
+    expect(sourceBead?.status).toBe('in_review');
+
+    const allMrs = await town.listBeads({ type: 'merge_request' });
+    const mrBead = allMrs.find(b => b.metadata?.source_bead_id === beadId);
+    expect(mrBead).toBeTruthy();
+
+    return {
+      convoyId: result.convoy.id,
+      beadId,
+      mrBeadId: mrBead!.bead_id,
+      featureBranch: result.convoy.feature_branch!,
+    };
+  }
+
+  it('should not fail an MR bead via Rule 4 timeout when awaiting_approval is set', async () => {
+    const { mrBeadId } = await setupConvoyWithLandingMr();
+
+    const mrBead = await town.getBeadAsync(mrBeadId);
+    await town.updateBead(mrBeadId, {
+      metadata: {
+        ...(mrBead?.metadata ?? {}),
+        awaiting_approval: 1,
+        review_decision: 'REVIEW_REQUIRED',
+        merge_state_status: 'BLOCKED',
+        last_poll_at: new Date(Date.now() - 45 * 60_000).toISOString(),
+      },
+    }, 'system');
+
+    await town.updateBeadStatus(mrBeadId, 'in_progress', 'system');
+
+    await runDurableObjectAlarm(town);
+
+    const after = await town.getBeadAsync(mrBeadId);
+    expect(after?.status).toBe('in_progress');
+    expect(after?.metadata?.awaiting_approval).toBe(1);
+  });
+
+  it('should not re-dispatch refinery (Rule 6) when awaiting_approval is set', async () => {
+    const { mrBeadId } = await setupConvoyWithLandingMr();
+
+    const mrBead = await town.getBeadAsync(mrBeadId);
+    await town.updateBead(mrBeadId, {
+      metadata: {
+        ...(mrBead?.metadata ?? {}),
+        awaiting_approval: 1,
+        review_decision: 'REVIEW_REQUIRED',
+        merge_state_status: 'BLOCKED',
+      },
+    }, 'system');
+    await town.updateBeadStatus(mrBeadId, 'in_progress', 'system');
+
+    const refineries = await town.listAgents({ role: 'refinery' });
+    if (refineries.length > 0) {
+      await town.updateAgentStatus(refineries[0].id, 'idle');
+    }
+
+    await runDurableObjectAlarm(town);
+
+    const after = await town.getBeadAsync(mrBeadId);
+    expect(after?.status).toBe('in_progress');
+    expect(after?.metadata?.awaiting_approval).toBe(1);
+  });
+
+  it('should suppress convoy landing MR respawn when failed MR has awaiting_approval', async () => {
+    const { convoyId, beadId, mrBeadId, featureBranch } = await setupConvoyWithLandingMr();
+
+    await town.updateBeadStatus(beadId, 'closed', 'system');
+    await runDurableObjectAlarm(town);
+
+    const mrBead = await town.getBeadAsync(mrBeadId);
+    await town.updateBead(mrBeadId, {
+      metadata: {
+        ...(mrBead?.metadata ?? {}),
+        awaiting_approval: 1,
+        review_decision: 'REVIEW_REQUIRED',
+        merge_state_status: 'BLOCKED',
+      },
+    }, 'system');
+    await town.updateBeadStatus(mrBeadId, 'failed', 'system');
+
+    await runDurableObjectAlarm(town);
+
+    const allMrs = await town.listBeads({ type: 'merge_request' });
+    const failedWithApproval = allMrs.filter(
+      b => b.status === 'failed' && b.metadata?.awaiting_approval === 1
+    );
+    expect(failedWithApproval.length).toBeGreaterThan(0);
+
+    const convoyStatus = await town.getConvoyStatus(convoyId);
+    expect(convoyStatus?.status).not.toBe('failed');
+  });
+
+  it('should allow MR to proceed when awaiting_approval is cleared', async () => {
+    const { mrBeadId } = await setupConvoyWithLandingMr();
+
+    const mrBead = await town.getBeadAsync(mrBeadId);
+    await town.updateBead(mrBeadId, {
+      metadata: {
+        ...(mrBead?.metadata ?? {}),
+        awaiting_approval: 1,
+        review_decision: 'REVIEW_REQUIRED',
+      },
+    }, 'system');
+    await town.updateBeadStatus(mrBeadId, 'in_progress', 'system');
+
+    await runDurableObjectAlarm(town);
+
+    const during = await town.getBeadAsync(mrBeadId);
+    expect(during?.status).toBe('in_progress');
+
+    const withApproval = await town.getBeadAsync(mrBeadId);
+    await town.updateBead(mrBeadId, {
+      metadata: {
+        ...(withApproval?.metadata ?? {}),
+        awaiting_approval: 0,
+        review_decision: 'APPROVED',
+        merge_state_status: 'CLEAN',
+      },
+    }, 'system');
+
+    await runDurableObjectAlarm(town);
+
+    const after = await town.getBeadAsync(mrBeadId);
+    expect(after?.metadata?.awaiting_approval).toBe(0);
+    expect(after?.status).toBe('in_progress');
+  });
+});
+
+describe('PR feedback vs awaiting approval — CHANGES_REQUESTED creates feedback bead, REVIEW_REQUIRED does not', () => {
+  let town: ReturnType<typeof getTownStub>;
+  let townName: string;
+
+  beforeEach(async () => {
+    townName = `feedback-vs-approval-${crypto.randomUUID()}`;
+    town = getTownStub(townName);
+    await town.setTownId(townName);
+    await town.addRig({
+      rigId: 'rig-1',
+      name: 'main-rig',
+      gitUrl: 'https://github.com/test/repo.git',
+      defaultBranch: 'main',
+    });
+  });
+
+  it('should not create a feedback bead for REVIEW_REQUIRED (awaiting approval)', async () => {
+    const result = await town.slingConvoy({
+      rigId: 'rig-1',
+      convoyTitle: 'Review Required Test',
+      tasks: [{ title: 'Task 1' }],
+    });
+
+    const beadId = result.beads[0].bead.bead_id;
+    await runDurableObjectAlarm(town);
+
+    const bead = await town.getBeadAsync(beadId);
+    const agentId = bead!.assignee_agent_bead_id!;
+
+    await town.agentDone(agentId, {
+      branch: 'gt/polecat/test-branch',
+      summary: 'Completed task',
+    });
+    await runDurableObjectAlarm(town);
+
+    const allMrs = await town.listBeads({ type: 'merge_request' });
+    const mrBead = allMrs.find(b => b.metadata?.source_bead_id === beadId);
+    expect(mrBead).toBeTruthy();
+
+    const mrWithApproval = await town.getBeadAsync(mrBead!.bead_id);
+    await town.updateBead(mrBead!.bead_id, {
+      metadata: {
+        ...(mrWithApproval?.metadata ?? {}),
+        awaiting_approval: 1,
+        review_decision: 'REVIEW_REQUIRED',
+        merge_state_status: 'BLOCKED',
+      },
+    }, 'system');
+
+    const feedbackBeadsBefore = await town.listBeads({});
+    const prFeedbackBeadsBefore = feedbackBeadsBefore.filter(
+      b => b.labels?.includes('gt:pr-feedback')
+    );
+
+    await runDurableObjectAlarm(town);
+
+    const feedbackBeadsAfter = await town.listBeads({});
+    const prFeedbackBeadsAfter = feedbackBeadsAfter.filter(
+      b => b.labels?.includes('gt:pr-feedback')
+    );
+
+    expect(prFeedbackBeadsAfter.length).toBe(prFeedbackBeadsBefore.length);
+  });
+
+  it('should create a feedback bead for CHANGES_REQUESTED even when also awaiting approval', async () => {
+    const result = await town.slingConvoy({
+      rigId: 'rig-1',
+      convoyTitle: 'Changes Requested Test',
+      tasks: [{ title: 'Task 1' }],
+    });
+
+    const beadId = result.beads[0].bead.bead_id;
+    await runDurableObjectAlarm(town);
+
+    const bead = await town.getBeadAsync(beadId);
+    const agentId = bead!.assignee_agent_bead_id!;
+
+    await town.agentDone(agentId, {
+      branch: 'gt/polecat/test-branch',
+      summary: 'Completed task',
+    });
+    await runDurableObjectAlarm(town);
+
+    const allMrs = await town.listBeads({ type: 'merge_request' });
+    const mrBead = allMrs.find(b => b.metadata?.source_bead_id === beadId);
+    expect(mrBead).toBeTruthy();
+
+    const mrWithChanges = await town.getBeadAsync(mrBead!.bead_id);
+    await town.updateBead(mrBead!.bead_id, {
+      metadata: {
+        ...(mrWithChanges?.metadata ?? {}),
+        awaiting_approval: 1,
+        review_decision: 'CHANGES_REQUESTED',
+        merge_state_status: 'BLOCKED',
+      },
+    }, 'system');
+
+    await town.debugInsertTownEvent({
+      event_type: 'pr_feedback_detected',
+      bead_id: mrBead!.bead_id,
+      payload: {
+        mr_bead_id: mrBead!.bead_id,
+        pr_url: 'https://github.com/test/repo/pull/1',
+        pr_number: 1,
+        repo: 'test/repo',
+        branch: 'gt/polecat/test-branch',
+        has_unresolved_comments: true,
+        has_failing_checks: false,
+        has_unchecked_runs: false,
+      },
+    });
+
+    await runDurableObjectAlarm(town);
+
+    const feedbackBeads = await town.listBeads({});
+    const prFeedbackBeads = feedbackBeads.filter(
+      b => b.labels?.includes('gt:pr-feedback')
+    );
+    expect(prFeedbackBeads.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Add GitHub `reviewDecision` and `mergeStateStatus` fields to PR feedback checks to detect when a PR is blocked by branch protection requiring human approval. This stops the convoy landing-MR respawn loop that creates up to 5 failed `merge_request` beads against a single green PR that is simply waiting on a human reviewer.

Six targeted changes in `services/gastown/src/dos/town`:
1. **Extend GraphQL query** (`town-scm.ts`) to fetch `reviewDecision`, `mergeStateStatus`, `isDraft` and surface `awaitingApproval` / `changesRequested` on `PRFeedbackCheckResult`
2. **Gate auto-merge** (`actions.ts`) on `!awaitingApproval && !changesRequested` — prevents the "merge attempt → 405 → retry" loop
3. **Persist `awaiting_approval`** on MR bead metadata so the reconciler can check the flag without re-issuing a GraphQL call
4. **Suppress Rule 4 timeout** (`reconciler.ts`) — don't fail MR beads that are correctly waiting on human approval
5. **Suppress Rule 6 refinery re-dispatch** — don't burn dispatch attempts when the refinery cannot merge due to branch protection
6. **Stop convoy-level respawn** — belt-and-suspenders safeguard: failed landings with `awaiting_approval=1` suppress `create_landing_mr`

Three telemetry events added: `pr.awaiting_approval_detected`, `pr.awaiting_approval_resolved`, `reconciler.respawn_suppressed`.

## Verification

- Integration tests in `test/integration/awaiting-approval.test.ts` cover: Rule 4 timeout suppression, Rule 6 re-dispatch suppression, convoy respawn suppression, approval clearing, REVIEW_REQUIRED vs CHANGES_REQUESTED distinction
- Existing reconciler and review-queue tests pass

## Visual Changes

N/A

## Reviewer Notes

The `merge_pr` action also gates on `awaitingApproval` and `changesRequested` (pre-merge fresh feedback check at `actions.ts:1280-1287`), so even if the auto-merge timer fires, the merge will be aborted if approval is still pending. The convoy respawn suppression (Change 6) is defensive — with Change 4 in place, MRs awaiting approval shouldn't reach `failed` status in the first place.