### PR TITLE
fix(kiloclaw): avoid controller probes for stopped runtimes

### DIFF
--- a/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
+++ b/apps/web/src/app/admin/components/KiloclawInstances/KiloclawInstanceDetail.tsx
@@ -1452,7 +1452,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
   });
 
   const gatewayControlsEnabled =
-    data?.destroyed_at === null && !!runtimeId && data?.workerStatus?.status !== 'restoring';
+    data?.destroyed_at === null && !!runtimeId && data?.workerStatus?.status === 'running';
 
   const {
     data: gatewayStatus,
@@ -4071,7 +4071,7 @@ export function KiloclawInstanceDetail({ instanceId }: { instanceId: string }) {
             <CardContent className="space-y-4">
               {!gatewayControlsEnabled && (
                 <p className="text-muted-foreground text-sm">
-                  Gateway process controls are available when the instance has a runtime ID.
+                  Gateway process controls are available when the instance runtime is running.
                 </p>
               )}
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -2386,7 +2386,7 @@ describe('createNewMachine: persist ID before waitForState', () => {
 });
 
 describe('gateway process control via controller', () => {
-  it('allows gateway status calls when machine ID exists even if DO status is stale', async () => {
+  it('rejects gateway status calls when DO status is stopped even if machine ID exists', async () => {
     const { instance, storage } = createInstance();
     await seedProvisioned(storage, {
       status: 'stopped',
@@ -2394,22 +2394,18 @@ describe('gateway process control via controller', () => {
       flyAppName: 'acct-test',
     });
 
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          state: 'running',
-          pid: 123,
-          uptime: 42,
-          restarts: 1,
-          lastExit: null,
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
-    );
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
-    const status = await instance.getGatewayProcessStatus();
-    expect(status.state).toBe('running');
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    await expect(instance.getGatewayProcessStatus()).rejects.toSatisfy((err: unknown) => {
+      if (typeof err !== 'object' || err === null) return false;
+      return (
+        'status' in err &&
+        (err as { status: number }).status === 409 &&
+        'message' in err &&
+        (err as { message: string }).message.includes('Instance is not running')
+      );
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
     fetchSpy.mockRestore();
   });
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.test.ts
@@ -36,6 +36,7 @@ describe('gateway controller routing', () => {
   it('routes controller RPCs through provider transport headers', async () => {
     const state = createMutableState();
     state.provider = 'fly';
+    state.status = 'running';
     state.sandboxId = 'sandbox-1';
     state.flyAppName = 'test-app';
     state.flyMachineId = 'machine-1';
@@ -82,6 +83,7 @@ describe('gateway controller routing', () => {
   it('uses provider routing for health probes', async () => {
     const state = createMutableState();
     state.provider = 'fly';
+    state.status = 'running';
     state.sandboxId = 'sandbox-1';
     state.flyAppName = 'test-app';
     state.flyMachineId = 'machine-1';
@@ -122,6 +124,7 @@ describe('gateway controller routing', () => {
   it('returns warm-up payload for morning-briefing status when gateway is warming up', async () => {
     const state = createMutableState();
     state.provider = 'fly';
+    state.status = 'running';
     state.sandboxId = 'sandbox-1';
     state.flyAppName = 'test-app';
     state.flyMachineId = 'machine-1';
@@ -151,6 +154,7 @@ describe('gateway controller routing', () => {
   it('does not mask 401 auth failures as warm-up for morning-briefing status', async () => {
     const state = createMutableState();
     state.provider = 'fly';
+    state.status = 'running';
     state.sandboxId = 'sandbox-1';
     state.flyAppName = 'test-app';
     state.flyMachineId = 'machine-1';
@@ -174,6 +178,7 @@ describe('gateway controller routing', () => {
   it('accepts run response with delivery metadata', async () => {
     const state = createMutableState();
     state.provider = 'fly';
+    state.status = 'running';
     state.sandboxId = 'sandbox-1';
     state.flyAppName = 'test-app';
     state.flyMachineId = 'machine-1';
@@ -213,5 +218,51 @@ describe('gateway controller routing', () => {
       ],
     });
     expect(timeoutSpy).toHaveBeenCalledWith(120_000);
+  });
+
+  it('fails controller RPCs before fetching when instance state is not running', async () => {
+    const state = createMutableState();
+    state.provider = 'fly';
+    state.status = 'stopped';
+    state.sandboxId = 'sandbox-1';
+    state.flyAppName = 'test-app';
+    state.flyMachineId = 'machine-1';
+
+    const fetchMock: FetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getGatewayProcessStatus(state, {
+        GATEWAY_TOKEN_SECRET: 'gateway-secret',
+        FLY_APP_NAME: 'fallback-app',
+      } as never)
+    ).rejects.toMatchObject({ status: 409, message: 'Instance is not running' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns warm-up payload for morning-briefing status when instance is stopped', async () => {
+    const state = createMutableState();
+    state.provider = 'fly';
+    state.status = 'stopped';
+    state.sandboxId = 'sandbox-1';
+    state.flyAppName = 'test-app';
+    state.flyMachineId = 'machine-1';
+
+    const fetchMock: FetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await getMorningBriefingStatus(state, {
+      GATEWAY_TOKEN_SECRET: 'gateway-secret',
+      FLY_APP_NAME: 'fallback-app',
+    } as never);
+
+    expect(result).toEqual({
+      ok: true,
+      reconcileState: 'in_progress',
+      error: 'Gateway warming up, retrying shortly.',
+      code: 'gateway_warming_up',
+      retryAfterSec: 2,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/gateway.ts
@@ -39,6 +39,9 @@ async function requireGatewayControllerContext(
   if (!state.sandboxId) {
     throw new GatewayControllerError(409, 'Instance not provisioned');
   }
+  if (state.status !== 'running') {
+    throw new GatewayControllerError(409, 'Instance is not running');
+  }
 
   let routingTarget: ProviderRoutingTarget;
   try {
@@ -281,6 +284,7 @@ function isMorningBriefingWarmupControllerError(error: unknown): boolean {
   return (
     message.includes('instance has no machine id') ||
     message.includes('instance not provisioned') ||
+    message.includes('instance is not running') ||
     message.includes('gateway not running') ||
     message.includes('failed to reach gateway') ||
     message.includes('operation was aborted due to timeout')

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -1962,6 +1962,7 @@ function isMorningBriefingWarmupError(
   const normalized = raw.replace(/^(?:[A-Za-z]+Error:\s*)+/, '');
   if (
     normalized.includes('Gateway not running') ||
+    normalized.includes('Instance is not running') ||
     normalized.includes('Failed to reach gateway')
   ) {
     return true;


### PR DESCRIPTION
## Summary

- Add a Durable Object-level guard so gateway/controller RPCs fail fast unless the KiloClaw instance state is `running`, preventing stopped runtimes from being probed through provider routing.
- Keep morning briefing status polling graceful by treating the new non-running guard as a warm-up/unavailable state instead of surfacing repeated errors.
- Tighten the admin instance detail polling gate so gateway status and controller version queries only run when the DO-reported runtime state is `running`.

## Verification

- [x] stopped instance, messed with admin ui
- [x] stopped instance, cruised around user ui

## Visual Changes

none 

## Reviewer Notes

- The main behavior change is architectural: controller RPC safety now lives in `requireGatewayControllerContext`, so future controller-backed UI paths inherit the stopped-runtime protection automatically.
- `waitForHealthy()` is intentionally unchanged because lifecycle/start reconciliation still needs to probe while a runtime is starting.
- User/admin controller mutations now return a 409 conflict when the DO state is not `running` instead of attempting provider routing.