### PR TITLE
feat(wasteland): add Claims page with listClaims procedure and ClaimsClient

### DIFF
--- a/apps/web/src/app/(app)/wasteland/[wastelandId]/claims/ClaimsClient.tsx
+++ b/apps/web/src/app/(app)/wasteland/[wastelandId]/claims/ClaimsClient.tsx
@@ -55,6 +55,10 @@ function useSlowOperationToast(isPending: boolean) {
     }
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
+      if (toastIdRef.current !== null) {
+        toast.dismiss(toastIdRef.current);
+        toastIdRef.current = null;
+      }
     };
   }, [isPending]);
 }
@@ -396,14 +400,18 @@ function ClaimRowComponent({
         {item.type ?? 'other'}
       </Badge>
 
-      <Link
-        href={`/wasteland/${wastelandId}/rigs/${item.claimed_by}`}
-        className="shrink-0 font-mono text-[10px] text-white/50 underline decoration-white/10 decoration-dotted underline-offset-2 transition-colors hover:text-white/80 hover:decoration-white/40"
-        onClick={e => e.stopPropagation()}
-        data-claim-action
-      >
-        {item.claimed_by}
-      </Link>
+      {item.claimed_by ? (
+        <Link
+          href={`/wasteland/${wastelandId}/rigs/${item.claimed_by}`}
+          className="shrink-0 font-mono text-[10px] text-white/50 underline decoration-white/10 decoration-dotted underline-offset-2 transition-colors hover:text-white/80 hover:decoration-white/40"
+          onClick={e => e.stopPropagation()}
+          data-claim-action
+        >
+          {item.claimed_by}
+        </Link>
+      ) : (
+        <span className="shrink-0 font-mono text-[10px] text-white/25">unclaimed</span>
+      )}
 
       {(() => {
         const ts = parseDoltDate(item.updated_at);

--- a/apps/web/src/app/(app)/wasteland/[wastelandId]/claims/ClaimsClient.tsx
+++ b/apps/web/src/app/(app)/wasteland/[wastelandId]/claims/ClaimsClient.tsx
@@ -1,5 +1,537 @@
 'use client';
 
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useWastelandTRPC } from '@/lib/wasteland/trpc';
+import type { WastelandOutputs } from '@/lib/wasteland/trpc';
+import { useSetWastelandPageHeader } from '../WastelandPageHeaderContext';
+import { useDrawerStack } from '@/components/wasteland/drawer/WastelandDrawerStack';
+import { Badge } from '@/components/ui/badge';
+import {
+  ArrowUpDown,
+  ExternalLink,
+  Hourglass,
+  MoreHorizontal,
+  RefreshCw,
+  Search,
+  ShieldAlert,
+  ScrollText,
+} from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import { AnimatePresence, motion } from 'motion/react';
+import { toast } from 'sonner';
+import { parseDoltDate } from '@/lib/wasteland/date';
+import { STATUS_DOT, PRIORITY_COLORS, TYPE_COLORS } from '@/lib/wasteland/status-colors';
+import Link from 'next/link';
+
+type ClaimRow = WastelandOutputs['wasteland']['listClaims'][number];
+type ClaimItem = ClaimRow['item'];
+
+type SortMode = 'recent' | 'priority' | 'stale';
+
+const PR_KIND_LABELS: Record<string, string> = {
+  claim: 'claim PR',
+  done: 'done PR',
+  unclaim: 'unclaim PR',
+};
+
+const COLD_START_DELAY_MS = 3000;
+
+function useSlowOperationToast(isPending: boolean) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const toastIdRef = useRef<string | number | null>(null);
+
+  useEffect(() => {
+    if (isPending) {
+      timerRef.current = setTimeout(() => {
+        toastIdRef.current = toast.loading('Starting wasteland container...');
+      }, COLD_START_DELAY_MS);
+    } else {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (toastIdRef.current !== null) {
+        toast.dismiss(toastIdRef.current);
+        toastIdRef.current = null;
+      }
+    }
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [isPending]);
+}
+
 export function ClaimsClient({ wastelandId }: { wastelandId: string }) {
-  return <div>Wasteland claims coming soon (wasteland: {wastelandId})</div>;
+  const trpc = useWastelandTRPC();
+  const queryClient = useQueryClient();
+  const { open: openDrawer } = useDrawerStack();
+
+  const [search, setSearch] = useState('');
+  const [sortMode, setSortMode] = useState<SortMode>('recent');
+  const [rigHandleFilter, setRigHandleFilter] = useState<string | null>(null);
+  const [pendingPrOnly, setPendingPrOnly] = useState(false);
+  const [activeMenuItemId, setActiveMenuItemId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!activeMenuItemId) return;
+    const handler = () => setActiveMenuItemId(null);
+    document.addEventListener('click', handler);
+    return () => document.removeEventListener('click', handler);
+  }, [activeMenuItemId]);
+
+  const claimsQuery = useQuery({
+    ...trpc.wasteland.listClaims.queryOptions({
+      wastelandId,
+      ...(rigHandleFilter ? { rigHandle: rigHandleFilter } : {}),
+    }),
+    refetchInterval: 30_000,
+  });
+
+  const credentialQuery = useQuery(
+    trpc.wasteland.getCredentialStatus.queryOptions({ wastelandId })
+  );
+  const isAdmin = credentialQuery.data?.is_upstream_admin ?? false;
+
+  useSlowOperationToast(claimsQuery.isLoading && !claimsQuery.data);
+
+  const claims = claimsQuery.data ?? [];
+
+  const rigHandles = useMemo(
+    () => Array.from(new Set(claims.map(c => c.item.claimed_by).filter(Boolean))) as string[],
+    [claims]
+  );
+
+  const filteredClaims = useMemo(() => {
+    let result = claims;
+
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        c =>
+          c.item.title.toLowerCase().includes(q) ||
+          c.item.id.toLowerCase().includes(q) ||
+          (c.item.claimed_by ?? '').toLowerCase().includes(q)
+      );
+    }
+
+    if (pendingPrOnly) {
+      result = result.filter(c => c.pending_pr !== null);
+    }
+
+    result = [...result].sort((a, b) => {
+      if (sortMode === 'priority') {
+        const priorityOrder: Record<string, number> = {
+          critical: 0,
+          high: 1,
+          medium: 2,
+          low: 3,
+        };
+        const aP = priorityOrder[String(a.item.priority ?? 'medium')] ?? 2;
+        const bP = priorityOrder[String(b.item.priority ?? 'medium')] ?? 2;
+        return aP - bP;
+      }
+      if (sortMode === 'stale') {
+        const aTime = parseDoltDate(a.item.updated_at)?.getTime() ?? 0;
+        const bTime = parseDoltDate(b.item.updated_at)?.getTime() ?? 0;
+        return aTime - bTime;
+      }
+      const aTime = parseDoltDate(a.item.updated_at)?.getTime() ?? 0;
+      const bTime = parseDoltDate(b.item.updated_at)?.getTime() ?? 0;
+      return bTime - aTime;
+    });
+
+    return result;
+  }, [claims, search, sortMode, pendingPrOnly]);
+
+  const stats = useMemo(() => {
+    const total = claims.length;
+    const pendingPr = claims.filter(c => c.pending_pr !== null).length;
+    const staleThreshold = Date.now() - 24 * 60 * 60 * 1000;
+    const stale = claims.filter(c => {
+      const updated = parseDoltDate(c.item.updated_at)?.getTime() ?? 0;
+      return updated > 0 && updated < staleThreshold;
+    }).length;
+    return { total, pendingPr, stale };
+  }, [claims]);
+
+  const handleRefresh = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: trpc.wasteland.listClaims.queryKey({
+        wastelandId,
+        ...(rigHandleFilter ? { rigHandle: rigHandleFilter } : {}),
+      }),
+    });
+  }, [queryClient, trpc, wastelandId, rigHandleFilter]);
+
+  const handleOpenItem = useCallback(
+    (item: ClaimItem) => {
+      openDrawer({
+        type: 'wanted-item',
+        wastelandId,
+        item,
+        actions: {
+          isAdmin,
+          onDone: () => {},
+          onAccept: () => {},
+          onReject: () => {},
+          onCloseItem: () => {},
+          onUnclaim: () => {},
+        },
+      });
+    },
+    [openDrawer, wastelandId, isAdmin]
+  );
+
+  const cycleSort = useCallback(() => {
+    setSortMode(prev => {
+      if (prev === 'recent') return 'priority';
+      if (prev === 'priority') return 'stale';
+      return 'recent';
+    });
+  }, []);
+
+  const sortLabel: Record<SortMode, string> = {
+    recent: 'Recently claimed',
+    priority: 'Priority',
+    stale: 'Stale (oldest first)',
+  };
+
+  useSetWastelandPageHeader({
+    title: 'Claims',
+    icon: <ShieldAlert className="size-4 text-[color:oklch(70%_0.15_30_/_0.6)]" />,
+    count: claims.length,
+    actions: (
+      <>
+        <span className="inline-flex items-center gap-1 rounded-md border border-white/[0.08] bg-white/[0.03] px-2.5 py-1.5 text-xs text-white/40">
+          {claims.length} active claim{claims.length !== 1 ? 's' : ''}
+        </span>
+        <button
+          type="button"
+          onClick={handleRefresh}
+          disabled={claimsQuery.isLoading}
+          className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-2.5 py-1.5 text-xs text-white/60 transition-colors hover:bg-white/[0.06] hover:text-white/80 disabled:opacity-50"
+        >
+          <RefreshCw className={`size-3 ${claimsQuery.isFetching ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </>
+    ),
+  });
+
+  return (
+    <div className="flex h-full">
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {/* Filter bar */}
+        <div className="flex items-center gap-3 border-b border-white/[0.06] px-6 py-2">
+          <div className="flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-2.5 py-1.5">
+            <Search className="size-3 text-white/30" />
+            <input
+              type="text"
+              placeholder="Search claims..."
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              className="w-48 bg-transparent text-xs text-white/80 outline-none placeholder:text-white/25"
+            />
+          </div>
+
+          {/* Rig handle filter */}
+          <select
+            value={rigHandleFilter ?? ''}
+            onChange={e => setRigHandleFilter(e.target.value || null)}
+            className="rounded-md border border-white/[0.08] bg-white/[0.03] px-2.5 py-1.5 text-xs text-white/60 outline-none focus:border-white/20"
+          >
+            <option value="">All rigs</option>
+            {rigHandles.map(handle => (
+              <option key={handle} value={handle}>
+                {handle}
+              </option>
+            ))}
+          </select>
+
+          {/* Pending PR only toggle */}
+          <label className="inline-flex cursor-pointer items-center gap-1.5 text-[10px] text-white/40">
+            <input
+              type="checkbox"
+              checked={pendingPrOnly}
+              onChange={e => setPendingPrOnly(e.target.checked)}
+              className="accent-amber-400"
+            />
+            Pending PR only
+          </label>
+
+          {/* Sort */}
+          <button
+            type="button"
+            onClick={cycleSort}
+            className="ml-auto inline-flex items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium text-white/30 transition-colors hover:bg-white/[0.04] hover:text-white/50"
+          >
+            <ArrowUpDown className="size-3" />
+            {sortLabel[sortMode]}
+          </button>
+        </div>
+
+        {/* Stats strip */}
+        <div className="flex gap-3 border-b border-white/[0.06] px-6 py-2">
+          <StatsCard label="Total claims" value={stats.total} />
+          <StatsCard label="Pending PR" value={stats.pendingPr} />
+          <StatsCard label="Stale claims" value={stats.stale} highlight={stats.stale > 0} />
+        </div>
+
+        {/* Claims table */}
+        <div className="flex-1 overflow-y-auto">
+          {claimsQuery.isLoading && <ClaimsTableSkeleton />}
+
+          {!claimsQuery.isLoading && claimsQuery.isError && (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <p className="mb-2 text-sm text-red-400">Failed to load claims</p>
+              <button
+                type="button"
+                onClick={handleRefresh}
+                className="text-xs text-white/50 underline underline-offset-2 hover:text-white/70"
+              >
+                Retry
+              </button>
+            </div>
+          )}
+
+          {!claimsQuery.isLoading && !claimsQuery.isError && filteredClaims.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <ScrollText className="mb-3 size-8 text-white/10" />
+              <p className="text-sm text-white/30">
+                {search || rigHandleFilter || pendingPrOnly
+                  ? 'No claims match your filters.'
+                  : 'No active claims right now'}
+              </p>
+              {!search && !rigHandleFilter && !pendingPrOnly && (
+                <>
+                  <p className="mt-1 text-xs text-white/20">
+                    When a rig claims a wanted item, it&apos;ll appear here
+                  </p>
+                  <Link
+                    href="../wanted"
+                    className="mt-4 inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-3 py-1.5 text-xs text-white/60 transition-colors hover:bg-white/[0.06] hover:text-white/80"
+                  >
+                    Browse the wanted board
+                  </Link>
+                </>
+              )}
+            </div>
+          )}
+
+          <AnimatePresence mode="popLayout">
+            {filteredClaims.map((claim, i) => (
+              <ClaimRowComponent
+                key={claim.item.id}
+                claim={claim}
+                wastelandId={wastelandId}
+                isAdmin={isAdmin}
+                onClick={() => handleOpenItem(claim.item)}
+                activeMenuItemId={activeMenuItemId}
+                setActiveMenuItemId={setActiveMenuItemId}
+                delay={Math.min(i * 0.02, 0.3)}
+              />
+            ))}
+          </AnimatePresence>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ClaimRowComponent({
+  claim,
+  wastelandId,
+  isAdmin,
+  onClick,
+  activeMenuItemId,
+  setActiveMenuItemId,
+  delay,
+}: {
+  claim: ClaimRow;
+  wastelandId: string;
+  isAdmin: boolean;
+  onClick: () => void;
+  activeMenuItemId: string | null;
+  setActiveMenuItemId: (id: string | null) => void;
+  delay: number;
+}) {
+  const { item, pending_pr: pendingPr } = claim;
+  const menuOpen = activeMenuItemId === item.id;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ delay, duration: 0.15 }}
+      className="group flex cursor-pointer items-center gap-3 border-b border-white/[0.04] px-6 py-2.5 transition-colors hover:bg-white/[0.02]"
+      onClick={e => {
+        if ((e.target as HTMLElement).closest('[data-claim-action]')) return;
+        onClick();
+      }}
+    >
+      <span className={`size-2 shrink-0 rounded-full ${STATUS_DOT.claimed}`} />
+      <span className="shrink-0 text-[10px] text-amber-400/60">claimed</span>
+
+      <button
+        type="button"
+        onClick={onClick}
+        className="shrink-0 font-mono text-[10px] text-white/40 underline decoration-white/10 decoration-dotted underline-offset-2 transition-colors hover:text-white/70 hover:decoration-white/40"
+      >
+        {item.id}
+      </button>
+
+      <span className="min-w-0 max-w-[240px] truncate text-sm text-white/80">
+        {item.title.length > 60 ? `${item.title.slice(0, 60)}…` : item.title}
+      </span>
+
+      <span
+        className={`shrink-0 text-[10px] font-medium ${PRIORITY_COLORS[String(item.priority ?? 'medium')] ?? 'text-white/40'}`}
+      >
+        {String(item.priority ?? 'medium')}
+      </span>
+
+      <Badge
+        variant="outline"
+        className={`shrink-0 text-[9px] ${TYPE_COLORS[item.type ?? 'other'] ?? TYPE_COLORS.other}`}
+      >
+        {item.type ?? 'other'}
+      </Badge>
+
+      <Link
+        href={`/wasteland/${wastelandId}/rigs/${item.claimed_by}`}
+        className="shrink-0 font-mono text-[10px] text-white/50 underline decoration-white/10 decoration-dotted underline-offset-2 transition-colors hover:text-white/80 hover:decoration-white/40"
+        onClick={e => e.stopPropagation()}
+        data-claim-action
+      >
+        {item.claimed_by}
+      </Link>
+
+      {(() => {
+        const ts = parseDoltDate(item.updated_at);
+        if (!ts) return <span className="shrink-0 text-[10px] text-white/25">—</span>;
+        return (
+          <span className="shrink-0 text-[10px] text-white/30">
+            {formatDistanceToNow(ts, { addSuffix: true })}
+          </span>
+        );
+      })()}
+
+      {pendingPr && (
+        <Badge
+          variant="outline"
+          className="shrink-0 gap-1 border-amber-500/20 bg-amber-500/10 text-[9px] text-amber-300"
+        >
+          <Hourglass className="size-2.5" />
+          {PR_KIND_LABELS[pendingPr.kind] ?? 'PR'}
+        </Badge>
+      )}
+
+      {/* Kebab menu */}
+      <div className="relative ml-auto shrink-0" data-claim-action>
+        <button
+          type="button"
+          onClick={e => {
+            e.stopPropagation();
+            setActiveMenuItemId(menuOpen ? null : item.id);
+          }}
+          className="rounded p-0.5 text-white/20 transition-colors hover:bg-white/[0.06] hover:text-white/50"
+        >
+          <MoreHorizontal className="size-3.5" />
+        </button>
+
+        {menuOpen && (
+          <div className="absolute right-0 top-full z-10 mt-1 min-w-[160px] rounded-md border border-white/[0.08] bg-[color:oklch(0.18_0_0)] p-1 shadow-lg">
+            {pendingPr && (
+              <a
+                href={pendingPr.pr_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 rounded px-2.5 py-1.5 text-xs text-white/60 transition-colors hover:bg-white/[0.06] hover:text-white/80"
+                onClick={e => e.stopPropagation()}
+              >
+                <ExternalLink className="size-3" />
+                View on DoltHub
+              </a>
+            )}
+            {isAdmin && (
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 rounded px-2.5 py-1.5 text-xs text-red-400/70 transition-colors hover:bg-red-500/10 hover:text-red-400"
+                onClick={e => {
+                  e.stopPropagation();
+                  setActiveMenuItemId(null);
+                  toast.info('Force unclaim will be available in a future update');
+                }}
+              >
+                <ShieldAlert className="size-3" />
+                Force unclaim
+              </button>
+            )}
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded px-2.5 py-1.5 text-xs text-white/60 transition-colors hover:bg-white/[0.06] hover:text-white/80"
+              onClick={e => {
+                e.stopPropagation();
+                setActiveMenuItemId(null);
+                onClick();
+              }}
+            >
+              <ScrollText className="size-3" />
+              Open drawer
+            </button>
+          </div>
+        )}
+      </div>
+    </motion.div>
+  );
+}
+
+function StatsCard({
+  label,
+  value,
+  highlight,
+}: {
+  label: string;
+  value: number;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={`flex items-center gap-2 rounded-md border px-3 py-1.5 ${
+        highlight
+          ? 'border-amber-500/20 bg-amber-500/[0.04]'
+          : 'border-white/[0.06] bg-white/[0.02]'
+      }`}
+    >
+      <span className={`text-[10px] ${highlight ? 'text-amber-300/60' : 'text-white/30'}`}>
+        {label}
+      </span>
+      <span
+        className={`font-mono text-xs font-medium ${highlight ? 'text-amber-300' : 'text-white/60'}`}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function ClaimsTableSkeleton() {
+  return (
+    <div className="space-y-0">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div
+          key={i}
+          className="flex animate-pulse items-center gap-3 border-b border-white/[0.04] px-6 py-3"
+        >
+          <div className="size-2 rounded-full bg-white/10" />
+          <div className="h-2.5 w-12 rounded bg-white/5" />
+          <div className="h-2.5 w-16 rounded bg-white/5" />
+          <div className="flex-1 space-y-1.5">
+            <div className="h-3 w-48 rounded bg-white/5" />
+          </div>
+          <div className="h-3 w-10 rounded bg-white/5" />
+          <div className="h-3 w-14 rounded bg-white/5" />
+        </div>
+      ))}
+    </div>
+  );
 }

--- a/apps/web/src/lib/wasteland/status-colors.ts
+++ b/apps/web/src/lib/wasteland/status-colors.ts
@@ -1,0 +1,31 @@
+export const STATUS_COLORS: Record<string, string> = {
+  open: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+  claimed: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+  in_review: 'bg-violet-500/10 text-violet-400 border-violet-500/20',
+  completed: 'bg-sky-500/10 text-sky-400 border-sky-500/20',
+  done: 'bg-sky-500/10 text-sky-400 border-sky-500/20',
+  withdrawn: 'bg-white/[0.04] text-white/40 border-white/10',
+};
+
+export const STATUS_DOT: Record<string, string> = {
+  open: 'bg-emerald-400',
+  claimed: 'bg-amber-400',
+  in_review: 'bg-violet-400',
+  completed: 'bg-sky-400',
+  done: 'bg-sky-400',
+  withdrawn: 'bg-white/20',
+};
+
+export const PRIORITY_COLORS: Record<string, string> = {
+  low: 'text-white/55',
+  medium: 'text-sky-300',
+  high: 'text-amber-300',
+  critical: 'text-red-300',
+};
+
+export const TYPE_COLORS: Record<string, string> = {
+  feature: 'bg-violet-500/10 text-violet-400 border-violet-500/20',
+  bug: 'bg-red-500/10 text-red-400 border-red-500/20',
+  docs: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  other: 'bg-white/[0.04] text-white/40 border-white/10',
+};

--- a/apps/web/src/lib/wasteland/types/router.d.ts
+++ b/apps/web/src/lib/wasteland/types/router.d.ts
@@ -338,6 +338,39 @@ export declare const wastelandRouter: import('@trpc/server').TRPCBuiltRouter<
       };
       meta: object;
     }>;
+    listClaims: import('@trpc/server').TRPCQueryProcedure<{
+      input: {
+        wastelandId: string;
+        rigHandle?: string | undefined;
+      };
+      output: {
+        item: {
+          id: string;
+          title: string;
+          description: string | null;
+          project: string | null;
+          type: string | null;
+          priority: string | number | null;
+          tags: string | null;
+          posted_by: string | null;
+          claimed_by: string | null;
+          status: string;
+          effort_level: string | null;
+          evidence_url: string | null;
+          sandbox_required: string | number | null;
+          sandbox_scope: string | null;
+          sandbox_min_tier: string | null;
+          created_at: string | null;
+          updated_at: string | null;
+        };
+        pending_pr: {
+          pull_id: string;
+          pr_url: string;
+          kind: 'claim' | 'done' | 'unclaim';
+        } | null;
+      }[];
+      meta: object;
+    }>;
     claimWantedItem: import('@trpc/server').TRPCMutationProcedure<{
       input: {
         wastelandId: string;
@@ -1091,6 +1124,39 @@ export declare const wrappedWastelandRouter: import('@trpc/server').TRPCBuiltRou
               updated_at: string | null;
             }>;
           };
+          meta: object;
+        }>;
+        listClaims: import('@trpc/server').TRPCQueryProcedure<{
+          input: {
+            wastelandId: string;
+            rigHandle?: string | undefined;
+          };
+          output: {
+            item: {
+              id: string;
+              title: string;
+              description: string | null;
+              project: string | null;
+              type: string | null;
+              priority: string | number | null;
+              tags: string | null;
+              posted_by: string | null;
+              claimed_by: string | null;
+              status: string;
+              effort_level: string | null;
+              evidence_url: string | null;
+              sandbox_required: string | number | null;
+              sandbox_scope: string | null;
+              sandbox_min_tier: string | null;
+              created_at: string | null;
+              updated_at: string | null;
+            };
+            pending_pr: {
+              pull_id: string;
+              pr_url: string;
+              kind: 'claim' | 'done' | 'unclaim';
+            } | null;
+          }[];
           meta: object;
         }>;
         claimWantedItem: import('@trpc/server').TRPCMutationProcedure<{

--- a/services/wasteland/src/trpc/router.ts
+++ b/services/wasteland/src/trpc/router.ts
@@ -1072,7 +1072,7 @@ export const wastelandRouter = router({
         );
 
         const claimedItemIds = new Set(
-          claimed.map(item => (typeof item.id === 'string' ? item.id : ''))
+          claimed.map(item => (typeof item.id === 'string' ? item.id : '')).filter(Boolean)
         );
 
         for (const detail of details) {

--- a/services/wasteland/src/trpc/router.ts
+++ b/services/wasteland/src/trpc/router.ts
@@ -32,6 +32,7 @@ import {
   RpcUpstreamRigOutput,
   RpcRigDetailOutput,
   RpcRigActivityOutput,
+  RpcClaimRowOutput,
   WantedBoardRowOutput,
 } from './schemas';
 import type { TRPCContext } from './init';
@@ -1023,6 +1024,95 @@ export const wastelandRouter = router({
       } catch {
         return { items: [] };
       }
+    }),
+
+  // ── Claims page (claimed items with pending-PR enrichment) ─────────
+
+  listClaims: procedure
+    .input(
+      z.object({
+        wastelandId: z.string().uuid(),
+        rigHandle: z.string().optional(),
+      })
+    )
+    .output(z.array(RpcClaimRowOutput))
+    .query(async ({ ctx, input }) => {
+      await resolveWastelandOwnership(ctx.env, ctx, input.wastelandId);
+
+      let allItems: Array<Record<string, unknown>>;
+      try {
+        allItems = await wantedBoard.browseWantedBoard(ctx.env, input.wastelandId, ctx.userId);
+      } catch (err) {
+        if (err instanceof WantedBoardOpError && err.code === 'PRECONDITION_FAILED') {
+          return [];
+        }
+        return wantedBoardErrorToTRPC(err);
+      }
+
+      let claimed = allItems.filter(
+        item => typeof item.status === 'string' && item.status === 'claimed'
+      );
+
+      if (input.rigHandle) {
+        claimed = claimed.filter(
+          item => typeof item.claimed_by === 'string' && item.claimed_by === input.rigHandle
+        );
+      }
+
+      const prByItemId = new Map<
+        string,
+        { pull_id: string; pr_url: string; kind: 'claim' | 'done' | 'unclaim' }
+      >();
+
+      try {
+        const { token, upstream } = await loadAdminContext(ctx.env, input.wastelandId, ctx.userId);
+        const openPulls = await doltApi.listPulls(upstream, token, { state: 'Open' });
+        const details = await doltApi.mapWithLimit(openPulls, 6, p =>
+          doltApi.getPull(upstream, token, p.pull_id).catch(() => null)
+        );
+
+        const claimedItemIds = new Set(
+          claimed.map(item => (typeof item.id === 'string' ? item.id : ''))
+        );
+
+        for (const detail of details) {
+          if (!detail) continue;
+          const parsed = doltApi.parseWlBranch(detail.from_branch_name);
+          if (!parsed) continue;
+          if (!claimedItemIds.has(parsed.itemId)) continue;
+
+          const parsedCommit = inbox.parseCommitSubject(detail.title);
+          let kind: 'claim' | 'done' | 'unclaim' = 'claim';
+          if (parsedCommit.kind === 'wl') {
+            if (parsedCommit.verb === 'done') {
+              kind = 'done';
+            } else if (parsedCommit.verb === 'unclaim') {
+              kind = 'unclaim';
+            }
+          }
+
+          if (!prByItemId.has(parsed.itemId)) {
+            prByItemId.set(parsed.itemId, {
+              pull_id: detail.pull_id,
+              pr_url: doltApi.buildPullWebUrl(upstream, detail.pull_id),
+              kind,
+            });
+          }
+        }
+      } catch {
+        // PR enrichment is best-effort
+      }
+
+      return claimed.map(item => {
+        const itemId = typeof item.id === 'string' ? item.id : '';
+        const parsed = WantedBoardRowOutput.safeParse(item);
+        return {
+          item: parsed.success
+            ? parsed.data
+            : WantedBoardRowOutput.parse({ id: itemId, title: '', status: 'claimed' }),
+          pending_pr: prByItemId.get(itemId) ?? null,
+        };
+      });
     }),
 
   // ── Wanted Board Mutations ────────────────────────────────────────

--- a/services/wasteland/src/trpc/schemas.ts
+++ b/services/wasteland/src/trpc/schemas.ts
@@ -308,3 +308,19 @@ export const RpcRigDetailOutput = rpcSafe(RigDetailOutput);
 export const RpcCompletionOutput = rpcSafe(CompletionOutput);
 export const RpcStampOutput = rpcSafe(StampOutput);
 export const RpcRigActivityOutput = rpcSafe(RigActivityOutput);
+
+// ── Claims page: pending PR enrichment ────────────────────────────────
+
+export const PendingPrOutput = z.object({
+  pull_id: z.string(),
+  pr_url: z.string(),
+  kind: z.enum(['claim', 'done', 'unclaim']),
+});
+
+export const ClaimRowOutput = z.object({
+  item: WantedBoardRowOutput,
+  pending_pr: PendingPrOutput.nullable(),
+});
+
+export const RpcPendingPrOutput = rpcSafe(PendingPrOutput);
+export const RpcClaimRowOutput = rpcSafe(ClaimRowOutput);


### PR DESCRIPTION
## Summary

- Add `listClaims` tRPC procedure that filters `browseWantedBoard` results to claimed items, supports optional `rigHandle` server-side filter, and enriches each claim with pending PR information from DoltHub open pulls (kind: claim/done/unclaim)
- Replace the 5-line `ClaimsClient` stub with a full claims overview page including: page header with count badge and refresh, filter bar (search, rig handle dropdown, pending PR toggle, sort cycling), stats strip (total/pending PR/stale claims), claims table with status dots, item ID, title, priority/type chips, claimed-by links, time-ago labels, pending PR badges, and kebab menus, plus empty state with CTA, loading skeleton, and error state with retry
- Extract shared `STATUS_COLORS`, `STATUS_DOT`, `PRIORITY_COLORS`, `TYPE_COLORS` constants to `apps/web/src/lib/wasteland/status-colors.ts`
- Update frontend type declarations (`router.d.ts`) with `listClaims` procedure output types
- Add `PendingPrOutput` and `ClaimRowOutput` Zod schemas to backend schemas

## Verification

- `pnpm --filter web typecheck` passes
- `pnpm --filter web lint` passes
- `pnpm --filter cloudflare-wasteland typecheck` passes
- `pnpm --filter cloudflare-wasteland lint` passes
- `pnpm format` applied

## Visual Changes

N/A — new page, no before/after

## Reviewer Notes

- The `listClaims` procedure calls `browseWantedBoard` internally then filters, which means two `loadContext` calls (one in browse, one for PR enrichment). This is acceptable for now — the credential is cached in the DO.
- PR kind determination uses `parseCommitSubject` on the PR title. If the title doesn't match the `wl` commit subject pattern, it defaults to "claim" which is the most common case.
- Force unclaim in the kebab menu currently shows a toast placeholder — the actual mutation will be added in the follow-up bead (84c6229b).