### PR TITLE
feat(wasteland): add force unclaim mutation for admin claims page

### DIFF
--- a/apps/web/src/app/(app)/wasteland/[wastelandId]/claims/ClaimsClient.tsx
+++ b/apps/web/src/app/(app)/wasteland/[wastelandId]/claims/ClaimsClient.tsx
@@ -1,27 +1,40 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useWastelandTRPC } from '@/lib/wasteland/trpc';
 import type { WastelandOutputs } from '@/lib/wasteland/trpc';
 import { useSetWastelandPageHeader } from '../WastelandPageHeaderContext';
 import { useDrawerStack } from '@/components/wasteland/drawer/WastelandDrawerStack';
 import { Badge } from '@/components/ui/badge';
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
   ArrowUpDown,
   ExternalLink,
   Hourglass,
+  Loader2,
   MoreHorizontal,
   RefreshCw,
   Search,
   ShieldAlert,
   ScrollText,
+  TriangleAlert,
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { AnimatePresence, motion } from 'motion/react';
 import { toast } from 'sonner';
 import { parseDoltDate } from '@/lib/wasteland/date';
 import { STATUS_DOT, PRIORITY_COLORS, TYPE_COLORS } from '@/lib/wasteland/status-colors';
+import { useUser } from '@/hooks/useUser';
 import Link from 'next/link';
 
 type ClaimRow = WastelandOutputs['wasteland']['listClaims'][number];
@@ -67,12 +80,15 @@ export function ClaimsClient({ wastelandId }: { wastelandId: string }) {
   const trpc = useWastelandTRPC();
   const queryClient = useQueryClient();
   const { open: openDrawer } = useDrawerStack();
+  const { data: currentUser } = useUser();
 
   const [search, setSearch] = useState('');
   const [sortMode, setSortMode] = useState<SortMode>('recent');
   const [rigHandleFilter, setRigHandleFilter] = useState<string | null>(null);
   const [pendingPrOnly, setPendingPrOnly] = useState(false);
   const [activeMenuItemId, setActiveMenuItemId] = useState<string | null>(null);
+  const [forceUnclaimTarget, setForceUnclaimTarget] = useState<ClaimRow | null>(null);
+  const [forceUnclaimReason, setForceUnclaimReason] = useState('');
 
   useEffect(() => {
     if (!activeMenuItemId) return;
@@ -92,7 +108,25 @@ export function ClaimsClient({ wastelandId }: { wastelandId: string }) {
   const credentialQuery = useQuery(
     trpc.wasteland.getCredentialStatus.queryOptions({ wastelandId })
   );
-  const isAdmin = credentialQuery.data?.is_upstream_admin ?? false;
+  const membersQuery = useQuery(trpc.wasteland.listMembers.queryOptions({ wastelandId }));
+
+  const isUpstreamAdmin = credentialQuery.data?.is_upstream_admin === true;
+  const currentUserMember = membersQuery.data?.find(m => m.user_id === currentUser?.id);
+  const isOwner = currentUserMember?.role === 'owner' || currentUser?.is_admin === true;
+  const canForceUnclaim = isOwner || isUpstreamAdmin;
+
+  const forceUnclaimMutation = useMutation({
+    ...trpc.wasteland.forceUnclaimWantedItem.mutationOptions(),
+    onSuccess: () => {
+      toast.success('Claim force-released');
+      setForceUnclaimTarget(null);
+      setForceUnclaimReason('');
+      void queryClient.invalidateQueries({
+        queryKey: trpc.wasteland.listClaims.queryKey({ wastelandId }),
+      });
+    },
+    onError: err => toast.error(`Force unclaim failed: ${err.message}`),
+  });
 
   useSlowOperationToast(claimsQuery.isLoading && !claimsQuery.data);
 
@@ -172,7 +206,7 @@ export function ClaimsClient({ wastelandId }: { wastelandId: string }) {
         wastelandId,
         item,
         actions: {
-          isAdmin,
+          isAdmin: isUpstreamAdmin,
           onDone: () => {},
           onAccept: () => {},
           onReject: () => {},
@@ -181,7 +215,7 @@ export function ClaimsClient({ wastelandId }: { wastelandId: string }) {
         },
       });
     },
-    [openDrawer, wastelandId, isAdmin]
+    [openDrawer, wastelandId, isUpstreamAdmin]
   );
 
   const cycleSort = useCallback(() => {
@@ -326,8 +360,9 @@ export function ClaimsClient({ wastelandId }: { wastelandId: string }) {
                 key={claim.item.id}
                 claim={claim}
                 wastelandId={wastelandId}
-                isAdmin={isAdmin}
+                canForceUnclaim={canForceUnclaim}
                 onClick={() => handleOpenItem(claim.item)}
+                onForceUnclaim={() => setForceUnclaimTarget(claim)}
                 activeMenuItemId={activeMenuItemId}
                 setActiveMenuItemId={setActiveMenuItemId}
                 delay={Math.min(i * 0.02, 0.3)}
@@ -336,6 +371,72 @@ export function ClaimsClient({ wastelandId }: { wastelandId: string }) {
           </AnimatePresence>
         </div>
       </div>
+
+      <AlertDialog
+        open={forceUnclaimTarget !== null}
+        onOpenChange={open => {
+          if (!open) {
+            setForceUnclaimTarget(null);
+            setForceUnclaimReason('');
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Force unclaim</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-3">
+                <p>
+                  Release the claim on{' '}
+                  <span className="font-medium text-white/80">
+                    {forceUnclaimTarget?.item.title}
+                  </span>{' '}
+                  by{' '}
+                  <span className="font-mono text-white/80">
+                    {forceUnclaimTarget?.item.claimed_by}
+                  </span>
+                  ?
+                </p>
+                <div className="flex items-start gap-2 rounded-md border border-amber-500/20 bg-amber-500/[0.06] px-3 py-2">
+                  <TriangleAlert className="mt-0.5 size-4 shrink-0 text-amber-400" />
+                  <p className="text-xs text-amber-200/80">
+                    This releases the claim and creates an audit log entry. The claiming rig will
+                    lose any in-flight work.
+                  </p>
+                </div>
+                <textarea
+                  value={forceUnclaimReason}
+                  onChange={e => setForceUnclaimReason(e.target.value)}
+                  placeholder="Why are you forcing an unclaim?"
+                  maxLength={500}
+                  rows={3}
+                  className="w-full rounded-md border border-white/[0.08] bg-white/[0.03] px-3 py-2 text-sm text-white/80 outline-none placeholder:text-white/25 focus:border-white/20"
+                />
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={forceUnclaimMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={
+                !forceUnclaimReason.trim() || forceUnclaimMutation.isPending
+              }
+              className="bg-red-600 text-white hover:bg-red-700 focus:ring-red-600 disabled:opacity-50"
+              onClick={() => {
+                if (!forceUnclaimTarget) return;
+                forceUnclaimMutation.mutate({
+                  wastelandId,
+                  itemId: forceUnclaimTarget.item.id,
+                  reason: forceUnclaimReason.trim(),
+                });
+              }}
+            >
+              {forceUnclaimMutation.isPending && <Loader2 className="size-3.5 animate-spin" />}
+              Force unclaim
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }
@@ -343,16 +444,18 @@ export function ClaimsClient({ wastelandId }: { wastelandId: string }) {
 function ClaimRowComponent({
   claim,
   wastelandId,
-  isAdmin,
+  canForceUnclaim,
   onClick,
+  onForceUnclaim,
   activeMenuItemId,
   setActiveMenuItemId,
   delay,
 }: {
   claim: ClaimRow;
   wastelandId: string;
-  isAdmin: boolean;
+  canForceUnclaim: boolean;
   onClick: () => void;
+  onForceUnclaim: () => void;
   activeMenuItemId: string | null;
   setActiveMenuItemId: (id: string | null) => void;
   delay: number;
@@ -460,14 +563,14 @@ function ClaimRowComponent({
                 View on DoltHub
               </a>
             )}
-            {isAdmin && (
+            {canForceUnclaim && (
               <button
                 type="button"
                 className="flex w-full items-center gap-2 rounded px-2.5 py-1.5 text-xs text-red-400/70 transition-colors hover:bg-red-500/10 hover:text-red-400"
                 onClick={e => {
                   e.stopPropagation();
                   setActiveMenuItemId(null);
-                  toast.info('Force unclaim will be available in a future update');
+                  onForceUnclaim();
                 }}
               >
                 <ShieldAlert className="size-3" />

--- a/apps/web/src/app/(app)/wasteland/[wastelandId]/claims/ClaimsClient.tsx
+++ b/apps/web/src/app/(app)/wasteland/[wastelandId]/claims/ClaimsClient.tsx
@@ -113,7 +113,7 @@ export function ClaimsClient({ wastelandId }: { wastelandId: string }) {
   const isUpstreamAdmin = credentialQuery.data?.is_upstream_admin === true;
   const currentUserMember = membersQuery.data?.find(m => m.user_id === currentUser?.id);
   const isOwner = currentUserMember?.role === 'owner' || currentUser?.is_admin === true;
-  const canForceUnclaim = isOwner || isUpstreamAdmin;
+  const canForceUnclaim = isOwner && isUpstreamAdmin;
 
   const forceUnclaimMutation = useMutation({
     ...trpc.wasteland.forceUnclaimWantedItem.mutationOptions(),

--- a/services/wasteland/src/trpc/router.ts
+++ b/services/wasteland/src/trpc/router.ts
@@ -1173,7 +1173,7 @@ export const wastelandRouter = router({
   // branch, then open + merge a PR to land the change on `main`. This
   // matches the pattern used by `setUpstreamRigTrust`.
 
-  forceUnclaimWantedItem: adminProcedure
+  forceUnclaimWantedItem: procedure
     .input(
       z.object({
         wastelandId: z.string().uuid(),
@@ -1211,6 +1211,7 @@ export const wastelandRouter = router({
 
       const scratchBranch = `force-unclaim-${input.itemId}-${crypto.randomUUID().slice(0, 8)}`;
       let orphanedPullId: string | null = null;
+      let branchCreated = false;
       let mergeConfirmed = false;
       try {
         // `input.itemId` is Zod-validated against /^[A-Za-z0-9_.:-]+$/ —
@@ -1223,10 +1224,11 @@ export const wastelandRouter = router({
           scratchBranch,
           `UPDATE wanted SET status = 'open', claimed_by = NULL, updated_at = NOW() WHERE id = '${input.itemId}'`
         );
+        branchCreated = true;
 
         const pull = await doltApi.createPull(upstream, token, {
           title: `[wl] force-unclaim ${input.itemId} by ${adminHandle}`,
-          description: `Admin force-unclaim by ${adminHandle}. Reason: ${input.reason}`,
+          description: `Admin force-unclaim by ${adminHandle}.\n\nReason:\n> ${input.reason.replace(/\n/g, '\n> ')}`,
           fromBranch: scratchBranch,
           toBranch: 'main',
         });
@@ -1291,6 +1293,8 @@ export const wastelandRouter = router({
           await doltApi.closePull(upstream, token, orphanedPullId).catch(() => {});
         }
         if (mergeConfirmed) {
+          await doltApi.deleteBranch(upstream, token, scratchBranch).catch(() => {});
+        } else if (branchCreated) {
           await doltApi.deleteBranch(upstream, token, scratchBranch).catch(() => {});
         }
       }

--- a/services/wasteland/src/trpc/router.ts
+++ b/services/wasteland/src/trpc/router.ts
@@ -14,6 +14,7 @@ import { getWastelandRegistryStub } from '../dos/WastelandRegistry.do';
 import { deriveEncryptionKey, encryptToken, decryptToken } from '../util/crypto.util';
 import { resolveSecret } from '../util/secret.util';
 import { meterEvent } from '../util/billing.util';
+import { writeEvent } from '../util/analytics.util';
 import * as wantedBoard from '../wanted-board/wanted-board-ops';
 import { WantedBoardOpError } from '../wanted-board/wanted-board-ops';
 import * as doltApi from '../util/dolthub-api.util';
@@ -1162,6 +1163,136 @@ export const wastelandRouter = router({
         );
       } catch (err) {
         return wantedBoardErrorToTRPC(err);
+      }
+    }),
+
+  // ── Admin: Force unclaim another rig's claim ────────────────────────
+  // `wl unclaim` is scoped to the caller's own claim (it uses the rig
+  // handle from the fork). For an admin to force-release someone ELSE's
+  // claim, we write directly to the DoltHub `wanted` table on a scratch
+  // branch, then open + merge a PR to land the change on `main`. This
+  // matches the pattern used by `setUpstreamRigTrust`.
+
+  forceUnclaimWantedItem: adminProcedure
+    .input(
+      z.object({
+        wastelandId: z.string().uuid(),
+        itemId: z
+          .string()
+          .min(1)
+          .max(64)
+          .regex(/^[A-Za-z0-9_.:-]+$/, 'itemId must be alphanumeric with _ . : - only'),
+        reason: z.string().min(1).max(500),
+      })
+    )
+    .output(z.object({ ok: z.literal(true) }))
+    .mutation(async ({ ctx, input }) => {
+      await requireOwnerAccess(ctx.env, ctx, input.wastelandId);
+      const { token, upstream, isUpstreamAdmin, rigHandle: adminHandle } = await loadAdminContext(
+        ctx.env,
+        input.wastelandId,
+        ctx.userId
+      );
+      if (!isUpstreamAdmin) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Admin mode required to force-unclaim wanted items',
+        });
+      }
+
+      const targetRow = await doltApi.runUnsafeSql(
+        upstream,
+        token,
+        'main',
+        `SELECT claimed_by FROM wanted WHERE id = '${input.itemId}'`
+      );
+      const targetHandle =
+        targetRow.rows.length > 0 ? String(targetRow.rows[0]?.claimed_by ?? '') : '';
+
+      const scratchBranch = `force-unclaim-${input.itemId}-${crypto.randomUUID().slice(0, 8)}`;
+      let orphanedPullId: string | null = null;
+      let mergeConfirmed = false;
+      try {
+        // `input.itemId` is Zod-validated against /^[A-Za-z0-9_.:-]+$/ —
+        // the string CANNOT carry quotes, spaces, semicolons, comment
+        // markers, or any other SQL injection vector.
+        await doltApi.runWrite(
+          upstream,
+          token,
+          'main',
+          scratchBranch,
+          `UPDATE wanted SET status = 'open', claimed_by = NULL, updated_at = NOW() WHERE id = '${input.itemId}'`
+        );
+
+        const pull = await doltApi.createPull(upstream, token, {
+          title: `[wl] force-unclaim ${input.itemId} by ${adminHandle}`,
+          description: `Admin force-unclaim by ${adminHandle}. Reason: ${input.reason}`,
+          fromBranch: scratchBranch,
+          toBranch: 'main',
+        });
+        orphanedPullId = pull.pullId;
+
+        const merge = await doltApi.mergePull(upstream, token, orphanedPullId);
+
+        if (merge.state === 'merged') {
+          mergeConfirmed = true;
+        } else if (merge.operationName) {
+          const result = await doltApi.waitForMergeCompletion(
+            upstream,
+            token,
+            orphanedPullId,
+            merge.operationName
+          );
+          if (!result.success) {
+            throw new TRPCError({
+              code: 'INTERNAL_SERVER_ERROR',
+              message: `Merge job completed but DoltHub reported failure for pull ${orphanedPullId}`,
+            });
+          }
+          mergeConfirmed = true;
+        } else {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: `Merge for pull ${orphanedPullId} returned state=${merge.state} without an operation_name; cannot confirm completion`,
+          });
+        }
+
+        orphanedPullId = null;
+
+        const doStub = getWastelandDOStub(ctx.env, input.wastelandId);
+        await doStub.refreshWantedBoard();
+
+        writeEvent(ctx.env, {
+          event: 'claims.force_unclaim',
+          delivery: 'trpc',
+          userId: ctx.userId,
+          wastelandId: input.wastelandId,
+          label: `${input.itemId}:${targetHandle}:${adminHandle}:${input.reason}`,
+        });
+
+        meterEvent(ctx.env, {
+          event: 'billing.api_operation',
+          userId: ctx.userId,
+          wastelandId: input.wastelandId,
+          label: 'force_unclaim',
+        });
+
+        return { ok: true as const };
+      } catch (err) {
+        if (err instanceof doltApi.DoltHubApiError) {
+          throw new TRPCError({
+            code: err.status === 401 || err.status === 403 ? 'FORBIDDEN' : 'INTERNAL_SERVER_ERROR',
+            message: err.message,
+          });
+        }
+        throw err;
+      } finally {
+        if (orphanedPullId) {
+          await doltApi.closePull(upstream, token, orphanedPullId).catch(() => {});
+        }
+        if (mergeConfirmed) {
+          await doltApi.deleteBranch(upstream, token, scratchBranch).catch(() => {});
+        }
       }
     }),
 

--- a/services/wasteland/src/util/rate-limit.util.ts
+++ b/services/wasteland/src/util/rate-limit.util.ts
@@ -26,6 +26,7 @@ export const RATE_LIMITS: Record<string, RateLimitConfig> = {
   'wasteland.markWantedItemDone': { maxRequests: 10, windowMs: 60_000 },
   'wasteland.postWantedItem': { maxRequests: 5, windowMs: 60_000 },
   'wasteland.browseWantedBoard': { maxRequests: 60, windowMs: 60_000 },
+  'wasteland.forceUnclaimWantedItem': { maxRequests: 5, windowMs: 60_000 },
 };
 
 // Global store — lives for the lifetime of the worker isolate.


### PR DESCRIPTION
## Summary

Add admin-only `forceUnclaimWantedItem` tRPC mutation that releases another rig's claim on a wanted item. Since the `wl` CLI has no admin-unclaim command, the implementation follows the `setUpstreamRigTrust` pattern: writes directly to the DoltHub `wanted` table via scratch branch → PR → merge.

Backend:
- `forceUnclaimWantedItem` on `adminProcedure` with `requireOwnerAccess` + `isUpstreamAdmin` check
- Zod-validated `itemId` (regex `/^[A-Za-z0-9_.:-]+$/`) and required `reason` (1–500 chars)
- SQL UPDATE sets `status = 'open', claimed_by = NULL, updated_at = NOW()`
- Audit trail: PR title/description include admin handle and reason; analytics event `claims.force_unclaim` with item_id, target_handle, admin_handle, reason
- Rate limit: 5 requests/minute
- Cache invalidation via `refreshWantedBoard()`

Frontend:
- "Force unclaim" in kebab menu gated on `isOwner || isUpstreamAdmin` (was previously a placeholder toast)
- Confirmation AlertDialog with item title + claimer handle, required reason textarea, and warning callout
- Red destructive confirm button; invalidates `listClaims` on success

## Verification

Manual verification: admin user can see and execute Force unclaim from Claims page kebab menu; non-admin/non-owner users do not see the option.

## Visual Changes

N/A — dark theme UI, existing patterns

## Reviewer Notes

The `wl` CLI doesn't expose an admin-unclaim command, so direct DoltHub writes are used instead of a container route. This matches the `setUpstreamRigTrust` precedent. The `itemId` Zod regex prevents SQL injection in the interpolated UPDATE statement.