### PR TITLE
feat(wasteland): add Claims page tRPC tests + docs

### DIFF
--- a/services/wasteland/docs/admin-mode.md
+++ b/services/wasteland/docs/admin-mode.md
@@ -488,6 +488,66 @@ Documented at length in `e2e-testing.md`; quick recap:
   `GET /pulls/:id` after `POST /merge` and display an intermediate
   state until `state === 'Merged'`.
 
+## Claims page
+
+The Claims page (`/wasteland/<id>/claims`) shows all wanted items
+currently in `claimed` status across the wasteland. It is the central
+view for monitoring active work and spotting stalled or orphaned claims.
+
+### What it shows
+
+- Every wanted item whose `status` column on DoltHub equals `claimed`,
+  with the claimer's rig handle, item title, priority, type, and last
+  activity timestamp.
+- An optional `rigHandle` filter (dropdown) to scope the list to one
+  rig's claims.
+- A `pending_pr` badge per item when an open DoltHub PR exists on a
+  `wl/<rigHandle>/<itemId>` branch. The badge shows the PR kind —
+  `claim PR`, `done PR`, or `unclaim PR` — derived from the first
+  commit subject via `inbox.parseCommitSubject`. A "View on DoltHub"
+  link opens the PR directly.
+- Stats strip: total claims, claims with a pending PR, and stale claims
+  (not updated in >24h).
+
+### Force unclaim
+
+Owners who also have `is_upstream_admin = true` see a "Force unclaim"
+option in each claim row's kebab menu. This calls the
+`forceUnclaimWantedItem` tRPC procedure, which:
+
+1. Verifies `requireOwnerAccess` (wasteland owner or org owner + site
+   admin).
+2. Loads the caller's credential via `loadAdminContext` and checks
+   `is_upstream_admin`. Non-admins receive `FORBIDDEN`.
+3. Writes a `SET status='open', claimed_by=NULL` update on a scratch
+   branch, opens a PR, and merges it to `main` on DoltHub.
+4. Refreshes the wanted-board cache on the DO.
+5. Emits a `claims.force_unclaim` analytics event containing
+   `<itemId>:<targetHandle>:<adminHandle>:<reason>` for audit.
+
+The PR title and description encode the admin handle and the mandatory
+reason string (1–500 chars), producing a durable audit trail on the
+DoltHub repo. If the merge fails, the scratch branch is cleaned up and
+the orphaned PR is closed.
+
+### `pending_pr` and in-flight DoltHub PRs
+
+`listClaims` enriches each claimed item with `pending_pr` by:
+
+1. Calling `loadAdminContext` to get a decrypted DoltHub token + the
+   upstream repo. If the caller has no credential or no upstream is
+   configured, enrichment is skipped and `pending_pr` is `null`.
+2. Listing all open pulls on the upstream via `doltApi.listPulls`.
+3. For each PR whose `from_branch` matches `wl/<rigHandle>/<itemId>`,
+   parsing the first commit subject to determine the PR kind (claim /
+   done / unclaim).
+4. Matching PRs against claimed item IDs and attaching the first
+   matching PR per item.
+
+Enrichment is best-effort: if DoltHub is unreachable or the credential
+is invalid, `pending_pr` is simply `null` and the claims list still
+renders.
+
 ## Open design questions
 
 None blocking. Things we might revisit after landing the above:

--- a/services/wasteland/src/trpc/init.ts
+++ b/services/wasteland/src/trpc/init.ts
@@ -17,6 +17,7 @@ export type TRPCContext = {
 const t = initTRPC.context<TRPCContext>().create();
 
 export const router = t.router;
+export const createCallerFactory = t.createCallerFactory;
 
 // tRPC procedure paths that correspond to key operations for Sentry breadcrumbs
 const BREADCRUMB_OPERATIONS = new Set([

--- a/services/wasteland/src/trpc/router.test.ts
+++ b/services/wasteland/src/trpc/router.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { TRPCError } from '@trpc/server';
 import { createCallerFactory } from './init';
 import { wastelandRouter } from './router';
 
@@ -319,20 +318,7 @@ describe('forceUnclaimWantedItem', () => {
         itemId: 'w-1',
         reason: 'Stale claim',
       })
-    ).rejects.toThrow(TRPCError);
-
-    const err = await caller.forceUnclaimWantedItem({
-      wastelandId: WASTELAND_ID,
-      itemId: 'w-1',
-      reason: 'Stale claim',
-    }).then(
-      () => { throw new Error('Expected rejection') },
-      (e: unknown) => e,
-    );
-    expect(err).toBeInstanceOf(TRPCError);
-    if (err instanceof TRPCError) {
-      expect(err.code).toBe('FORBIDDEN');
-    }
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
   });
 
   it('rejects itemId with invalid characters', async () => {

--- a/services/wasteland/src/trpc/router.test.ts
+++ b/services/wasteland/src/trpc/router.test.ts
@@ -183,9 +183,10 @@ describe('listClaims', () => {
     const result = await caller.listClaims({ wastelandId: WASTELAND_ID });
 
     expect(result).toHaveLength(1);
-    expect(result[0].pending_pr).not.toBeNull();
-    expect(result[0].pending_pr!.kind).toBe('claim');
-    expect(result[0].pending_pr!.pull_id).toBe('pr-1');
+    const pr = result[0].pending_pr;
+    expect(pr).not.toBeNull();
+    expect(pr?.kind).toBe('claim');
+    expect(pr?.pull_id).toBe('pr-1');
   });
 
   it('returns pending_pr with kind=done for done PRs', async () => {
@@ -229,7 +230,7 @@ describe('listClaims', () => {
     const result = await caller.listClaims({ wastelandId: WASTELAND_ID });
 
     expect(result).toHaveLength(1);
-    expect(result[0].pending_pr!.kind).toBe('done');
+    expect(result[0].pending_pr?.kind).toBe('done');
   });
 
   it('returns empty array when DoltHub enrichment fails', async () => {
@@ -320,14 +321,17 @@ describe('forceUnclaimWantedItem', () => {
       })
     ).rejects.toThrow(TRPCError);
 
-    try {
-      await caller.forceUnclaimWantedItem({
-        wastelandId: WASTELAND_ID,
-        itemId: 'w-1',
-        reason: 'Stale claim',
-      });
-    } catch (err) {
-      expect((err as TRPCError).code).toBe('FORBIDDEN');
+    const err = await caller.forceUnclaimWantedItem({
+      wastelandId: WASTELAND_ID,
+      itemId: 'w-1',
+      reason: 'Stale claim',
+    }).then(
+      () => { throw new Error('Expected rejection') },
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(TRPCError);
+    if (err instanceof TRPCError) {
+      expect(err.code).toBe('FORBIDDEN');
     }
   });
 

--- a/services/wasteland/src/trpc/router.test.ts
+++ b/services/wasteland/src/trpc/router.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+import { createCallerFactory } from './init';
+import { wastelandRouter } from './router';
+
+vi.mock('./ownership', () => ({
+  resolveWastelandOwnership: vi.fn(),
+}));
+
+vi.mock('../dos/Wasteland.do', () => ({
+  getWastelandDOStub: vi.fn(),
+}));
+
+vi.mock('../dos/WastelandContainer.do', () => ({
+  getWastelandContainerStub: vi.fn(),
+}));
+
+vi.mock('../dos/WastelandRegistry.do', () => ({
+  getWastelandRegistryStub: vi.fn(),
+}));
+
+vi.mock('../wanted-board/wanted-board-ops', () => ({
+  browseWantedBoard: vi.fn(),
+  WantedBoardOpError: class WantedBoardOpError extends Error {
+    code: string;
+    constructor(message: string, code: string) {
+      super(message);
+      this.name = 'WantedBoardOpError';
+      this.code = code;
+    }
+  },
+}));
+
+vi.mock('../util/dolthub-api.util', () => ({
+  listPulls: vi.fn(),
+  getPull: vi.fn(),
+  mapWithLimit: vi.fn(),
+  parseWlBranch: vi.fn(),
+  buildPullWebUrl: vi.fn(() => 'https://www.dolthub.com/repositories/o/d/pulls/1'),
+  runUnsafeSql: vi.fn(),
+  runWrite: vi.fn(),
+  createPull: vi.fn(),
+  mergePull: vi.fn(),
+  waitForMergeCompletion: vi.fn(),
+  closePull: vi.fn(),
+  deleteBranch: vi.fn(),
+  DoltHubApiError: class DoltHubApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = 'DoltHubApiError';
+      this.status = status;
+    }
+  },
+}));
+
+vi.mock('../util/crypto.util', () => ({
+  deriveEncryptionKey: vi.fn(),
+  encryptToken: vi.fn(),
+  decryptToken: vi.fn(),
+}));
+
+vi.mock('../util/secret.util', () => ({
+  resolveSecret: vi.fn(),
+}));
+
+vi.mock('../util/billing.util', () => ({
+  meterEvent: vi.fn(),
+}));
+
+vi.mock('../util/analytics.util', () => ({
+  writeEvent: vi.fn(),
+}));
+
+vi.mock('../inbox/inbox-classifier', () => ({
+  parseCommitSubject: vi.fn(),
+}));
+
+import { resolveWastelandOwnership } from './ownership';
+import { getWastelandDOStub } from '../dos/Wasteland.do';
+import * as wantedBoard from '../wanted-board/wanted-board-ops';
+import * as doltApi from '../util/dolthub-api.util';
+import { resolveSecret } from '../util/secret.util';
+import { decryptToken } from '../util/crypto.util';
+
+const WASTELAND_ID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';
+const USER_ID = 'user-001';
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    env: { WASTELAND_ENCRYPTION_KEY: 'test-key' } as unknown as Env,
+    userId: USER_ID,
+    isAdmin: false,
+    apiTokenPepper: null,
+    orgMemberships: [],
+    ...overrides,
+  };
+}
+
+const createCaller = createCallerFactory(wastelandRouter);
+
+describe('listClaims', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('filters claimed items by rigHandle', async () => {
+    vi.mocked(resolveWastelandOwnership).mockResolvedValue({ type: 'user', userId: USER_ID });
+    vi.mocked(wantedBoard.browseWantedBoard).mockResolvedValue([
+      { id: 'w-1', title: 'Item 1', status: 'claimed', claimed_by: 'rig-alpha' },
+      { id: 'w-2', title: 'Item 2', status: 'claimed', claimed_by: 'rig-beta' },
+      { id: 'w-3', title: 'Item 3', status: 'open', claimed_by: null },
+    ]);
+    vi.mocked(resolveSecret).mockResolvedValue(null);
+
+    const caller = createCaller(makeCtx());
+    const result = await caller.listClaims({
+      wastelandId: WASTELAND_ID,
+      rigHandle: 'rig-alpha',
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].item.id).toBe('w-1');
+    expect(result[0].item.claimed_by).toBe('rig-alpha');
+  });
+
+  it('returns only claimed items when no rigHandle filter', async () => {
+    vi.mocked(resolveWastelandOwnership).mockResolvedValue({ type: 'user', userId: USER_ID });
+    vi.mocked(wantedBoard.browseWantedBoard).mockResolvedValue([
+      { id: 'w-1', title: 'Item 1', status: 'claimed', claimed_by: 'rig-alpha' },
+      { id: 'w-2', title: 'Item 2', status: 'open', claimed_by: null },
+      { id: 'w-3', title: 'Item 3', status: 'claimed', claimed_by: 'rig-beta' },
+    ]);
+    vi.mocked(resolveSecret).mockResolvedValue(null);
+
+    const caller = createCaller(makeCtx());
+    const result = await caller.listClaims({ wastelandId: WASTELAND_ID });
+
+    expect(result).toHaveLength(2);
+    const ids = result.map(r => r.item.id);
+    expect(ids).toContain('w-1');
+    expect(ids).toContain('w-3');
+  });
+
+  it('returns pending_pr when DoltHub has matching open claim PR', async () => {
+    vi.mocked(resolveWastelandOwnership).mockResolvedValue({ type: 'user', userId: USER_ID });
+    vi.mocked(wantedBoard.browseWantedBoard).mockResolvedValue([
+      { id: 'w-1', title: 'Item 1', status: 'claimed', claimed_by: 'rig-alpha' },
+    ]);
+
+    const mockStub = {
+      getConfig: vi.fn().mockResolvedValue({ dolthub_upstream: 'org/repo', owner_user_id: USER_ID }),
+      getCredential: vi.fn().mockResolvedValue({
+        encrypted_token: 'enc',
+        dolthub_org: 'org',
+        rig_handle: 'rig-alpha',
+        is_upstream_admin: true,
+      }),
+    };
+    vi.mocked(getWastelandDOStub).mockReturnValue(mockStub as never);
+    vi.mocked(resolveSecret).mockResolvedValue('secret-key');
+    vi.mocked(decryptToken).mockResolvedValue('dolt-token');
+    vi.mocked(doltApi.listPulls).mockResolvedValue([
+      { pull_id: 'pr-1', creator_name: 'rig-alpha' },
+    ]);
+    vi.mocked(doltApi.mapWithLimit).mockImplementation(async (items, _limit, fn) => {
+      return Promise.all(items.map(fn));
+    });
+    vi.mocked(doltApi.getPull).mockResolvedValue({
+      pull_id: 'pr-1',
+      from_branch_name: 'wl/rig-alpha/w-1',
+      title: 'wl claim: w-1',
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+    });
+    vi.mocked(doltApi.parseWlBranch).mockReturnValue({ rigHandle: 'rig-alpha', itemId: 'w-1' });
+    vi.mocked(doltApi.buildPullWebUrl).mockReturnValue('https://www.dolthub.com/repositories/org/repo/pulls/pr-1');
+
+    const { parseCommitSubject } = await import('../inbox/inbox-classifier');
+    vi.mocked(parseCommitSubject).mockReturnValue({ kind: 'wl', verb: 'claim', itemId: 'w-1' });
+
+    const caller = createCaller(makeCtx());
+    const result = await caller.listClaims({ wastelandId: WASTELAND_ID });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].pending_pr).not.toBeNull();
+    expect(result[0].pending_pr!.kind).toBe('claim');
+    expect(result[0].pending_pr!.pull_id).toBe('pr-1');
+  });
+
+  it('returns pending_pr with kind=done for done PRs', async () => {
+    vi.mocked(resolveWastelandOwnership).mockResolvedValue({ type: 'user', userId: USER_ID });
+    vi.mocked(wantedBoard.browseWantedBoard).mockResolvedValue([
+      { id: 'w-2', title: 'Item 2', status: 'claimed', claimed_by: 'rig-alpha' },
+    ]);
+
+    const mockStub = {
+      getConfig: vi.fn().mockResolvedValue({ dolthub_upstream: 'org/repo', owner_user_id: USER_ID }),
+      getCredential: vi.fn().mockResolvedValue({
+        encrypted_token: 'enc',
+        dolthub_org: 'org',
+        rig_handle: 'rig-alpha',
+        is_upstream_admin: true,
+      }),
+    };
+    vi.mocked(getWastelandDOStub).mockReturnValue(mockStub as never);
+    vi.mocked(resolveSecret).mockResolvedValue('secret-key');
+    vi.mocked(decryptToken).mockResolvedValue('dolt-token');
+    vi.mocked(doltApi.listPulls).mockResolvedValue([
+      { pull_id: 'pr-2', creator_name: 'rig-alpha' },
+    ]);
+    vi.mocked(doltApi.mapWithLimit).mockImplementation(async (items, _limit, fn) => {
+      return Promise.all(items.map(fn));
+    });
+    vi.mocked(doltApi.getPull).mockResolvedValue({
+      pull_id: 'pr-2',
+      from_branch_name: 'wl/rig-alpha/w-2',
+      title: 'wl done: w-2',
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+    });
+    vi.mocked(doltApi.parseWlBranch).mockReturnValue({ rigHandle: 'rig-alpha', itemId: 'w-2' });
+    vi.mocked(doltApi.buildPullWebUrl).mockReturnValue('https://www.dolthub.com/repositories/org/repo/pulls/pr-2');
+
+    const { parseCommitSubject } = await import('../inbox/inbox-classifier');
+    vi.mocked(parseCommitSubject).mockReturnValue({ kind: 'wl', verb: 'done', itemId: 'w-2' });
+
+    const caller = createCaller(makeCtx());
+    const result = await caller.listClaims({ wastelandId: WASTELAND_ID });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].pending_pr!.kind).toBe('done');
+  });
+
+  it('returns empty array when DoltHub enrichment fails', async () => {
+    vi.mocked(resolveWastelandOwnership).mockResolvedValue({ type: 'user', userId: USER_ID });
+
+    const { WantedBoardOpError } = await import('../wanted-board/wanted-board-ops');
+    vi.mocked(wantedBoard.browseWantedBoard).mockRejectedValue(
+      new WantedBoardOpError('Not configured', 'PRECONDITION_FAILED')
+    );
+
+    const caller = createCaller(makeCtx());
+    const result = await caller.listClaims({ wastelandId: WASTELAND_ID });
+
+    expect(result).toEqual([]);
+  });
+
+  it('sets pending_pr to null when credential loading fails', async () => {
+    vi.mocked(resolveWastelandOwnership).mockResolvedValue({ type: 'user', userId: USER_ID });
+    vi.mocked(wantedBoard.browseWantedBoard).mockResolvedValue([
+      { id: 'w-1', title: 'Item 1', status: 'claimed', claimed_by: 'rig-alpha' },
+    ]);
+
+    const mockStub = {
+      getConfig: vi.fn().mockResolvedValue({ dolthub_upstream: null }),
+    };
+    vi.mocked(getWastelandDOStub).mockReturnValue(mockStub as never);
+
+    const caller = createCaller(makeCtx());
+    const result = await caller.listClaims({ wastelandId: WASTELAND_ID });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].pending_pr).toBeNull();
+  });
+});
+
+describe('forceUnclaimWantedItem', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects empty reason via Zod validation', async () => {
+    const caller = createCaller(makeCtx());
+    await expect(
+      caller.forceUnclaimWantedItem({
+        wastelandId: WASTELAND_ID,
+        itemId: 'w-1',
+        reason: '',
+      })
+    ).rejects.toThrow();
+  });
+
+  it('rejects whitespace-only reason', async () => {
+    const caller = createCaller(makeCtx());
+    await expect(
+      caller.forceUnclaimWantedItem({
+        wastelandId: WASTELAND_ID,
+        itemId: 'w-1',
+        reason: '   ',
+      })
+    ).rejects.toThrow();
+  });
+
+  it('requires upstream admin (isUpstreamAdmin=false yields FORBIDDEN)', async () => {
+    vi.mocked(resolveWastelandOwnership).mockResolvedValue({ type: 'user', userId: USER_ID });
+
+    const mockStub = {
+      getConfig: vi.fn().mockResolvedValue({
+        dolthub_upstream: 'org/repo',
+        owner_user_id: USER_ID,
+      }),
+      getCredential: vi.fn().mockResolvedValue({
+        encrypted_token: 'enc',
+        dolthub_org: 'org',
+        rig_handle: 'admin-rig',
+        is_upstream_admin: false,
+      }),
+    };
+    vi.mocked(getWastelandDOStub).mockReturnValue(mockStub as never);
+    vi.mocked(resolveSecret).mockResolvedValue('secret-key');
+    vi.mocked(decryptToken).mockResolvedValue('dolt-token');
+
+    const caller = createCaller(makeCtx());
+    await expect(
+      caller.forceUnclaimWantedItem({
+        wastelandId: WASTELAND_ID,
+        itemId: 'w-1',
+        reason: 'Stale claim',
+      })
+    ).rejects.toThrow(TRPCError);
+
+    try {
+      await caller.forceUnclaimWantedItem({
+        wastelandId: WASTELAND_ID,
+        itemId: 'w-1',
+        reason: 'Stale claim',
+      });
+    } catch (err) {
+      expect((err as TRPCError).code).toBe('FORBIDDEN');
+    }
+  });
+
+  it('rejects itemId with invalid characters', async () => {
+    const caller = createCaller(makeCtx());
+    await expect(
+      caller.forceUnclaimWantedItem({
+        wastelandId: WASTELAND_ID,
+        itemId: 'w-1; DROP TABLE wanted--',
+        reason: 'SQL injection test',
+      })
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Add tRPC procedure tests and documentation for the Claims page.

**Tests** (`services/wasteland/src/trpc/router.test.ts`):
- `listClaims` with rigHandle filter
- `listClaims` returns only claimed items
- `listClaims` returns pending_pr with correct kind (claim/done) when DoltHub has matching open PRs
- `listClaims` returns empty array when DoltHub enrichment fails (PRECONDITION_FAILED)
- `listClaims` sets pending_pr to null when credential loading fails
- `forceUnclaimWantedItem` rejects empty/whitespace-only reason (Zod validation)
- `forceUnclaimWantedItem` rejects itemId with invalid characters (Zod regex)
- `forceUnclaimWantedItem` requires upstream admin (FORBIDDEN when isUpstreamAdmin=false)

**Component tests**: Skipped — no `*.test.tsx` pattern exists in the wasteland app area (project doesn't do RTL component tests there).

**Playwright e2e**: Skipped — existing e2e tests require a running app with full auth; can't meaningfully test claims page without full wasteland infrastructure.

**Docs** (`services/wasteland/docs/admin-mode.md`):
- Added "Claims page" section covering what the page shows, force unclaim workflow and audit trail, and how pending_pr enrichment works with in-flight DoltHub PRs.

**Infra** (`services/wasteland/src/trpc/init.ts`):
- Exported `createCallerFactory` from the tRPC instance for test use.

## Verification

- `pnpm --filter cloudflare-wasteland test` passes (22/22 tests)

## Visual Changes

N/A

## Reviewer Notes

The test file uses `vi.mock` to stub DO stubs, DoltHub API, and crypto helpers — necessary because the router procedures depend on Cloudflare Durable Object bindings and external DoltHub API calls that can't run in a Node test environment.