### PR TITLE
fix(gastown): distinguish null causes in PR status polling (#3149)

### DIFF
--- a/services/gastown/src/dos/town/actions.ts
+++ b/services/gastown/src/dos/town/actions.ts
@@ -22,7 +22,7 @@ import * as reviewQueue from './review-queue';
 import * as patrol from './patrol';
 import { getRig } from './rigs';
 import { parseGitUrl } from '../../util/platform-pr.util';
-import type { PRStatusResult } from './town-scm';
+import type { PRStatusOutcome, PRStatusError } from './town-scm';
 
 // ── Bead mutations ──────────────────────────────────────────────────
 
@@ -300,8 +300,8 @@ export type ApplyActionContext = {
   dispatchAgent: (agentId: string, beadId: string, rigId: string) => Promise<boolean>;
   /** Stop an agent's container process. */
   stopAgent: (agentId: string) => Promise<void>;
-  /** Check a PR's status via GitHub/GitLab API. Returns PRStatusResult or null. */
-  checkPRStatus: (prUrl: string) => Promise<PRStatusResult | null>;
+  /** Check a PR's status via GitHub/GitLab API. Returns PRStatusOutcome. */
+  checkPRStatus: (prUrl: string) => Promise<PRStatusOutcome>;
   /** Check PR for unresolved review comments and failing CI checks. */
   checkPRFeedback: (prUrl: string) => Promise<PRFeedbackCheckResult | null>;
   /** Merge a PR via GitHub/GitLab API. */
@@ -330,8 +330,56 @@ const LOG = '[actions]';
 /** Fail MR bead after this many consecutive null poll results (#1632). */
 const PR_POLL_NULL_THRESHOLD = 10;
 
+/** Fail MR bead after this many consecutive non-transient errors (invalid_response, unrecognized_url, host_mismatch). */
+const PR_POLL_NON_TRANSIENT_THRESHOLD = 3;
+
 /** Minimum interval between PR polls per MR bead (ms) (#1632). */
 export const PR_POLL_INTERVAL_MS = 60_000; // 1 minute
+
+function failureMessageFor(error: PRStatusError): string {
+  switch (error.kind) {
+    case 'no_token':
+      return (
+        `No GitHub token resolved for this town. Tried (in order): ` +
+        error.resolutionChain.map(s => `\`${s}\``).join(', ') +
+        `. Configure one of these in town or rig settings. ` +
+        `Note: polecat agents use their own container credentials and ` +
+        `may have created the PR successfully — that does not imply the ` +
+        `town worker can poll PR status.`
+      );
+    case 'http_error':
+      if (error.status === 401) {
+        return `Town's GitHub token is invalid or expired (HTTP 401). Refresh the token in town settings.`;
+      }
+      if (error.status === 403) {
+        return `Town's GitHub token lacks permission for this PR (HTTP 403). Ensure the token has \`pull-requests: read\` scope on the repo, or check for a secondary rate limit.`;
+      }
+      if (error.status === 404) {
+        return `PR not found (HTTP 404). Was the branch deleted before the PR could be polled, or is the PR URL wrong?`;
+      }
+      return `${error.provider} API returned HTTP ${error.status} ${error.statusText}. ${error.transient ? 'Retrying.' : 'Not retryable.'}`;
+    case 'invalid_response':
+      return (
+        `${error.provider} API returned an unexpected response shape ` +
+        `(${error.reason})${error.sampleKeys ? `; top-level keys: ${error.sampleKeys.join(', ')}` : ''}. ` +
+        `Please file a bug — the API contract may have drifted.`
+      );
+    case 'unrecognized_url':
+      return `PR URL format not recognized: ${error.url}. Expected GitHub PR or GitLab MR URL.`;
+    case 'host_mismatch':
+      return `Refusing to send GitLab token to unexpected host \`${error.got}\` (configured: \`${error.expected}\`).`;
+  }
+}
+
+function shouldFailImmediately(error: PRStatusError): boolean {
+  if (error.kind === 'no_token') return true;
+  if (error.kind === 'http_error' && !error.transient) return true;
+  return false;
+}
+
+function shouldCountAsTransient(error: PRStatusError): boolean {
+  return error.kind === 'http_error' && error.transient;
+}
 
 function now(): string {
   return new Date().toISOString();
@@ -745,22 +793,23 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
 
       return async () => {
         try {
-          const prStatusResult = await ctx.checkPRStatus(action.pr_url);
-          if (prStatusResult !== null) {
-            // Any non-null result resets the consecutive null counter
+          const outcome = await ctx.checkPRStatus(action.pr_url);
+          if (outcome.ok) {
+            // Successful poll — reset consecutive null counter
             query(
               sql,
               /* sql */ `
                 UPDATE ${beads}
                 SET ${beads.columns.metadata} = json_set(
                   COALESCE(${beads.columns.metadata}, '{}'),
-                  '$.poll_null_count', 0
+                  '$.poll_null_count', 0,
+                  '$.poll_error_kind', NULL
                 )
                 WHERE ${beads.bead_id} = ?
               `,
               [action.bead_id]
             );
-            const { status, mergeable_state } = prStatusResult;
+            const { status, mergeable_state } = outcome.result;
             if (status !== 'open') {
               ctx.insertEvent('pr_status_changed', {
                 bead_id: action.bead_id,
@@ -1048,10 +1097,10 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
               // If the PR was merged externally during that window, inserting
               // pr_feedback_detected would create a feedback bead for a merged
               // PR — leading to a duplicate PR on an already-merged branch.
-              const freshStatusResult = await ctx.checkPRStatus(action.pr_url);
-              if (freshStatusResult?.status !== 'open') {
+              const freshOutcome = await ctx.checkPRStatus(action.pr_url);
+              if (!freshOutcome.ok || freshOutcome.result.status !== 'open') {
                 console.log(
-                  `${LOG} poll_pr: PR status changed to '${freshStatusResult?.status ?? 'null'}' during feedback check, skipping feedback for bead=${action.bead_id}`
+                  `${LOG} poll_pr: PR status changed to '${freshOutcome.ok ? freshOutcome.result.status : 'error'}' during feedback check, skipping feedback for bead=${action.bead_id}`
                 );
               } else {
                 const existingFeedback = hasExistingFeedbackBead(sql, action.bead_id);
@@ -1179,39 +1228,41 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
               }
             }
           } else {
-            // Null result — GitHub API unreachable (token missing, expired, rate-limited, or 5xx).
-            // Increment consecutive null counter; fail the bead after PR_POLL_NULL_THRESHOLD.
+            const error = outcome.error;
+
+            // Store the latest error kind for analytics
             query(
               sql,
               /* sql */ `
                 UPDATE ${beads}
                 SET ${beads.columns.metadata} = json_set(
                   COALESCE(${beads.columns.metadata}, '{}'),
-                  '$.poll_null_count',
-                  COALESCE(
-                    json_extract(${beads.columns.metadata}, '$.poll_null_count'),
-                    0
-                  ) + 1
+                  '$.poll_error_kind', ?
                 )
                 WHERE ${beads.bead_id} = ?
               `,
-              [action.bead_id]
+              [error.kind, action.bead_id]
             );
-            const rows = [
-              ...query(
-                sql,
-                /* sql */ `
-                  SELECT json_extract(${beads.columns.metadata}, '$.poll_null_count') AS null_count
-                  FROM ${beads}
-                  WHERE ${beads.bead_id} = ?
-                `,
-                [action.bead_id]
-              ),
-            ];
-            const nullCount = Number(rows[0]?.null_count ?? 0);
-            if (nullCount >= PR_POLL_NULL_THRESHOLD) {
+
+            const failRigRows = z
+              .object({ rig_id: z.string().nullable() })
+              .array()
+              .parse([
+                ...query(
+                  sql,
+                  /* sql */ `
+                    SELECT ${beads.columns.rig_id}
+                    FROM ${beads}
+                    WHERE ${beads.bead_id} = ?
+                  `,
+                  [action.bead_id]
+                ),
+              ]);
+            const failRigId = failRigRows[0]?.rig_id ?? '';
+
+            if (shouldFailImmediately(error)) {
               console.warn(
-                `${LOG} poll_pr: ${nullCount} consecutive null results for bead=${action.bead_id}, failing`
+                `${LOG} poll_pr: immediate-fail error kind=${error.kind} for bead=${action.bead_id}, failing`
               );
               beadOps.updateBeadStatus(sql, action.bead_id, 'failed', 'system');
               query(
@@ -1221,15 +1272,141 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
                   SET ${beads.columns.metadata} = json_set(
                     COALESCE(${beads.columns.metadata}, '{}'),
                     '$.failureReason', 'pr_poll_failed',
+                    '$.failureKind', ?,
                     '$.failureMessage', ?
                   )
                   WHERE ${beads.bead_id} = ?
                 `,
-                [
-                  `Cannot poll PR status — GitHub API returned null ${nullCount} consecutive times. Check that a valid GitHub token is configured in town settings and that the GitHub API is reachable.`,
-                  action.bead_id,
-                ]
+                [error.kind, failureMessageFor(error), action.bead_id]
               );
+              ctx.emitEvent({
+                event: 'pr.poll_failed',
+                townId,
+                beadId: action.bead_id,
+                rigId: failRigId,
+                reason: error.kind,
+                label: 'provider' in error ? error.provider : '',
+                statusCode: error.kind === 'http_error' ? error.status : undefined,
+              });
+            } else if (shouldCountAsTransient(error)) {
+              // Transient HTTP errors (5xx, 429) count toward the existing 10-strike threshold
+              query(
+                sql,
+                /* sql */ `
+                  UPDATE ${beads}
+                  SET ${beads.columns.metadata} = json_set(
+                    COALESCE(${beads.columns.metadata}, '{}'),
+                    '$.poll_null_count',
+                    COALESCE(
+                      json_extract(${beads.columns.metadata}, '$.poll_null_count'),
+                      0
+                    ) + 1
+                  )
+                  WHERE ${beads.bead_id} = ?
+                `,
+                [action.bead_id]
+              );
+              const rows = [
+                ...query(
+                  sql,
+                  /* sql */ `
+                    SELECT json_extract(${beads.columns.metadata}, '$.poll_null_count') AS null_count
+                    FROM ${beads}
+                    WHERE ${beads.bead_id} = ?
+                  `,
+                  [action.bead_id]
+                ),
+              ];
+              const nullCount = Number(rows[0]?.null_count ?? 0);
+              if (nullCount >= PR_POLL_NULL_THRESHOLD) {
+                console.warn(
+                  `${LOG} poll_pr: ${nullCount} consecutive transient errors for bead=${action.bead_id}, failing`
+                );
+                beadOps.updateBeadStatus(sql, action.bead_id, 'failed', 'system');
+                query(
+                  sql,
+                  /* sql */ `
+                    UPDATE ${beads}
+                    SET ${beads.columns.metadata} = json_set(
+                      COALESCE(${beads.columns.metadata}, '{}'),
+                      '$.failureReason', 'pr_poll_failed',
+                      '$.failureKind', ?,
+                      '$.failureMessage', ?
+                    )
+                    WHERE ${beads.bead_id} = ?
+                  `,
+                  [error.kind, failureMessageFor(error), action.bead_id]
+                );
+                ctx.emitEvent({
+                  event: 'pr.poll_failed',
+                  townId,
+                  beadId: action.bead_id,
+                  rigId: failRigId,
+                  reason: error.kind,
+                  label: 'provider' in error ? error.provider : '',
+                  statusCode: error.kind === 'http_error' ? error.status : undefined,
+                });
+              }
+            } else {
+              // Non-transient, non-immediate errors (invalid_response, unrecognized_url, host_mismatch)
+              // count toward a lower 3-strike threshold
+              query(
+                sql,
+                /* sql */ `
+                  UPDATE ${beads}
+                  SET ${beads.columns.metadata} = json_set(
+                    COALESCE(${beads.columns.metadata}, '{}'),
+                    '$.poll_null_count',
+                    COALESCE(
+                      json_extract(${beads.columns.metadata}, '$.poll_null_count'),
+                      0
+                    ) + 1
+                  )
+                  WHERE ${beads.bead_id} = ?
+                `,
+                [action.bead_id]
+              );
+              const rows = [
+                ...query(
+                  sql,
+                  /* sql */ `
+                    SELECT json_extract(${beads.columns.metadata}, '$.poll_null_count') AS null_count
+                    FROM ${beads}
+                    WHERE ${beads.bead_id} = ?
+                  `,
+                  [action.bead_id]
+                ),
+              ];
+              const nullCount = Number(rows[0]?.null_count ?? 0);
+              if (nullCount >= PR_POLL_NON_TRANSIENT_THRESHOLD) {
+                console.warn(
+                  `${LOG} poll_pr: ${nullCount} consecutive non-transient errors kind=${error.kind} for bead=${action.bead_id}, failing`
+                );
+                beadOps.updateBeadStatus(sql, action.bead_id, 'failed', 'system');
+                query(
+                  sql,
+                  /* sql */ `
+                    UPDATE ${beads}
+                    SET ${beads.columns.metadata} = json_set(
+                      COALESCE(${beads.columns.metadata}, '{}'),
+                      '$.failureReason', 'pr_poll_failed',
+                      '$.failureKind', ?,
+                      '$.failureMessage', ?
+                    )
+                    WHERE ${beads.bead_id} = ?
+                  `,
+                  [error.kind, failureMessageFor(error), action.bead_id]
+                );
+                ctx.emitEvent({
+                  event: 'pr.poll_failed',
+                  townId,
+                  beadId: action.bead_id,
+                  rigId: failRigId,
+                  reason: error.kind,
+                  label: 'provider' in error ? error.provider : '',
+                  statusCode: error.kind === 'http_error' ? error.status : undefined,
+                });
+              }
             }
           }
           // status === 'open' — no action needed, poll again next tick
@@ -1483,3 +1660,4 @@ function parsePrUrl(prUrl: string): { repo: string; prNumber: number } | null {
 
 // Exported for testing
 export { hasExistingFeedbackBead as _hasExistingFeedbackBead, parsePrUrl as _parsePrUrl };
+export { failureMessageFor as _failureMessageFor, shouldFailImmediately as _shouldFailImmediately, shouldCountAsTransient as _shouldCountAsTransient };

--- a/services/gastown/src/dos/town/town-scm.ts
+++ b/services/gastown/src/dos/town/town-scm.ts
@@ -22,27 +22,48 @@ export type SCMContext = {
   platformIntegrationId?: string;
 };
 
+export type GitHubTokenResolution =
+  | { ok: true; token: string; source: string }
+  | { ok: false; tried: string[] };
+
 /**
  * Resolve a GitHub API token from the town config.
  * Fallback chain: github_token → github_cli_pat → town platform integration → rig platform integration.
  */
-export async function resolveGitHubToken(ctx: SCMContext): Promise<string | null> {
+export async function resolveGitHubToken(ctx: SCMContext): Promise<GitHubTokenResolution> {
+  const tried: string[] = [];
   const townConfig = await ctx.getTownConfig();
-  let token = townConfig.git_auth?.github_token ?? townConfig.github_cli_pat;
-  if (!token) {
-    const integrationId = townConfig.git_auth?.platform_integration_id ?? ctx.platformIntegrationId;
-    if (integrationId && ctx.env.GIT_TOKEN_SERVICE) {
-      try {
-        token = await ctx.env.GIT_TOKEN_SERVICE.getToken(integrationId);
-      } catch (err) {
-        console.warn(
-          `${TOWN_LOG} resolveGitHubToken: platform integration token lookup failed for ${integrationId}`,
-          err
-        );
-      }
-    }
+
+  if (townConfig.git_auth?.github_token) {
+    return { ok: true, token: townConfig.git_auth.github_token, source: 'town.git_auth.github_token' };
   }
-  return token ?? null;
+  tried.push('town.git_auth.github_token');
+
+  if (townConfig.github_cli_pat) {
+    return { ok: true, token: townConfig.github_cli_pat, source: 'town.github_cli_pat' };
+  }
+  tried.push('town.github_cli_pat');
+
+  const integrationId = townConfig.git_auth?.platform_integration_id ?? ctx.platformIntegrationId;
+  const sourceLabel = townConfig.git_auth?.platform_integration_id
+    ? 'town platform integration'
+    : 'rig platform integration';
+  if (integrationId && ctx.env.GIT_TOKEN_SERVICE) {
+    tried.push(sourceLabel);
+    try {
+      const token = await ctx.env.GIT_TOKEN_SERVICE.getToken(integrationId);
+      if (token) return { ok: true, token, source: sourceLabel };
+    } catch (err) {
+      console.warn(
+        `${TOWN_LOG} resolveGitHubToken: platform integration token lookup failed for ${integrationId}`,
+        err
+      );
+    }
+  } else if (!integrationId) {
+    tried.push('platform integration (none configured)');
+  }
+
+  return { ok: false, tried };
 }
 
 export type PRStatusResult = {
@@ -50,32 +71,47 @@ export type PRStatusResult = {
   mergeable_state?: string;
 };
 
+export type PRStatusError =
+  | { kind: 'no_token'; provider: 'github' | 'gitlab'; resolutionChain: string[] }
+  | { kind: 'unrecognized_url'; url: string }
+  | { kind: 'http_error'; provider: 'github' | 'gitlab'; status: number; statusText: string; transient: boolean }
+  | { kind: 'invalid_response'; provider: 'github' | 'gitlab'; reason: 'json_parse' | 'schema_mismatch'; sampleKeys?: string[] }
+  | { kind: 'host_mismatch'; provider: 'gitlab'; expected: string; got: string };
+
+export type PRStatusOutcome =
+  | { ok: true; result: PRStatusResult }
+  | { ok: false; error: PRStatusError };
+
+function isTransientHttpStatus(status: number): boolean {
+  return status >= 500 || status === 429;
+}
+
 /**
  * Check the status of a PR/MR via its URL.
- * Returns a PRStatusResult with status and optional mergeable_state (GitHub only),
- * or null if the status cannot be determined.
+ * Returns a PRStatusOutcome discriminated union — { ok: true, result } on success,
+ * or { ok: false, error } with a structured PRStatusError describing why.
  */
 export async function checkPRStatus(
   ctx: SCMContext,
   prUrl: string
-): Promise<PRStatusResult | null> {
+): Promise<PRStatusOutcome> {
   const townConfig = await ctx.getTownConfig();
 
   // GitHub PR URL format: https://github.com/{owner}/{repo}/pull/{number}
   const ghMatch = prUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
   if (ghMatch) {
     const [, owner, repo, numberStr] = ghMatch;
-    const token = await resolveGitHubToken(ctx);
-    if (!token) {
+    const resolution = await resolveGitHubToken(ctx);
+    if (!resolution.ok) {
       console.warn(`${TOWN_LOG} checkPRStatus: no GitHub token available, cannot poll ${prUrl}`);
-      return null;
+      return { ok: false, error: { kind: 'no_token', provider: 'github', resolutionChain: resolution.tried } };
     }
 
     const response = await fetch(
       `https://api.github.com/repos/${owner}/${repo}/pulls/${numberStr}`,
       {
         headers: {
-          Authorization: `token ${token}`,
+          Authorization: `token ${resolution.token}`,
           Accept: 'application/vnd.github.v3+json',
           'User-Agent': 'Gastown-Refinery/1.0',
         },
@@ -85,17 +121,27 @@ export async function checkPRStatus(
       console.warn(
         `${TOWN_LOG} checkPRStatus: GitHub API returned ${response.status} for ${prUrl}`
       );
-      return null;
+      return {
+        ok: false,
+        error: { kind: 'http_error', provider: 'github', status: response.status, statusText: response.statusText, transient: isTransientHttpStatus(response.status) },
+      };
     }
 
     const json = await response.json().catch(() => null);
-    if (!json) return null;
+    if (!json) {
+      return { ok: false, error: { kind: 'invalid_response', provider: 'github', reason: 'json_parse' } };
+    }
     const data = GitHubPRStatusSchema.safeParse(json);
-    if (!data.success) return null;
+    if (!data.success) {
+      return {
+        ok: false,
+        error: { kind: 'invalid_response', provider: 'github', reason: 'schema_mismatch', sampleKeys: Object.keys(json).slice(0, 8) },
+      };
+    }
 
-    if (data.data.merged) return { status: 'merged' };
-    if (data.data.state === 'closed') return { status: 'closed' };
-    return { status: 'open', mergeable_state: data.data.mergeable_state };
+    if (data.data.merged) return { ok: true, result: { status: 'merged' } };
+    if (data.data.state === 'closed') return { ok: true, result: { status: 'closed' } };
+    return { ok: true, result: { status: 'open', mergeable_state: data.data.mergeable_state } };
   }
 
   // GitLab MR URL format: https://{host}/{path}/-/merge_requests/{iid}
@@ -105,7 +151,7 @@ export async function checkPRStatus(
     const token = townConfig.git_auth?.gitlab_token;
     if (!token) {
       console.warn(`${TOWN_LOG} checkPRStatus: no gitlab_token configured, cannot poll ${prUrl}`);
-      return null;
+      return { ok: false, error: { kind: 'no_token', provider: 'gitlab', resolutionChain: ['town.git_auth.gitlab_token'] } };
     }
 
     // Validate the host against known GitLab hosts to prevent SSRF/token leak.
@@ -117,7 +163,10 @@ export async function checkPRStatus(
       console.warn(
         `${TOWN_LOG} checkPRStatus: refusing to send gitlab_token to unknown host: ${prHost}`
       );
-      return null;
+      return {
+        ok: false,
+        error: { kind: 'host_mismatch', provider: 'gitlab', expected: configuredHost ?? 'gitlab.com', got: prHost },
+      };
     }
 
     const encodedPath = encodeURIComponent(projectPath);
@@ -131,21 +180,31 @@ export async function checkPRStatus(
       console.warn(
         `${TOWN_LOG} checkPRStatus: GitLab API returned ${response.status} for ${prUrl}`
       );
-      return null;
+      return {
+        ok: false,
+        error: { kind: 'http_error', provider: 'gitlab', status: response.status, statusText: response.statusText, transient: isTransientHttpStatus(response.status) },
+      };
     }
 
     const glJson = await response.json().catch(() => null);
-    if (!glJson) return null;
+    if (!glJson) {
+      return { ok: false, error: { kind: 'invalid_response', provider: 'gitlab', reason: 'json_parse' } };
+    }
     const data = GitLabMRStatusSchema.safeParse(glJson);
-    if (!data.success) return null;
+    if (!data.success) {
+      return {
+        ok: false,
+        error: { kind: 'invalid_response', provider: 'gitlab', reason: 'schema_mismatch', sampleKeys: Object.keys(glJson).slice(0, 8) },
+      };
+    }
 
-    if (data.data.state === 'merged') return { status: 'merged' };
-    if (data.data.state === 'closed') return { status: 'closed' };
-    return { status: 'open' };
+    if (data.data.state === 'merged') return { ok: true, result: { status: 'merged' } };
+    if (data.data.state === 'closed') return { ok: true, result: { status: 'closed' } };
+    return { ok: true, result: { status: 'open' } };
   }
 
   console.warn(`${TOWN_LOG} checkPRStatus: unrecognized PR URL format: ${prUrl}`);
-  return null;
+  return { ok: false, error: { kind: 'unrecognized_url', url: prUrl } };
 }
 
 /**
@@ -261,11 +320,11 @@ export async function checkPRFeedback(
   }
 
   const [, owner, repo, numberStr] = ghMatch;
-  const token = await resolveGitHubToken(ctx);
-  if (!token) return null;
+  const resolution = await resolveGitHubToken(ctx);
+  if (!resolution.ok) return null;
 
   const headers = {
-    Authorization: `token ${token}`,
+    Authorization: `token ${resolution.token}`,
     Accept: 'application/vnd.github.v3+json',
     'User-Agent': 'Gastown-Refinery/1.0',
   };
@@ -481,15 +540,15 @@ export async function mergePR(ctx: SCMContext, prUrl: string): Promise<boolean> 
   }
 
   const [, owner, repo, numberStr] = ghMatch;
-  const token = await resolveGitHubToken(ctx);
-  if (!token) {
+  const resolution = await resolveGitHubToken(ctx);
+  if (!resolution.ok) {
     console.warn(`${TOWN_LOG} mergePR: no GitHub token available`);
     return false;
   }
 
   const mergeUrl = `https://api.github.com/repos/${owner}/${repo}/pulls/${numberStr}/merge`;
   const mergeHeaders = {
-    Authorization: `token ${token}`,
+    Authorization: `token ${resolution.token}`,
     Accept: 'application/vnd.github.v3+json',
     'Content-Type': 'application/json',
     'User-Agent': 'Gastown-Refinery/1.0',
@@ -538,8 +597,8 @@ export async function createConvoyBranch(
     featureBranch: string;
   }
 ): Promise<void> {
-  const token = await resolveGitHubToken(ctx);
-  if (!token) {
+  const resolution = await resolveGitHubToken(ctx);
+  if (!resolution.ok) {
     console.warn(
       `${TOWN_LOG} createConvoyBranch: no GitHub token available — skipping branch creation for ${opts.featureBranch}`
     );
@@ -548,15 +607,13 @@ export async function createConvoyBranch(
 
   const coords = parseGitUrl(opts.gitUrl);
   if (!coords || coords.platform !== 'github') {
-    // Non-GitHub repos or unparseable URLs: skip silently (GitLab uses a
-    // different flow; nothing breaks if the branch doesn't pre-exist there).
     return;
   }
 
   const { owner, repo } = coords;
   const apiBase = `https://api.github.com/repos/${owner}/${repo}`;
   const headers = {
-    Authorization: `token ${token}`,
+    Authorization: `token ${resolution.token}`,
     Accept: 'application/vnd.github.v3+json',
     'User-Agent': 'Gastown/1.0',
     'Content-Type': 'application/json',

--- a/services/gastown/src/handlers/refresh-git-token.handler.ts
+++ b/services/gastown/src/handlers/refresh-git-token.handler.ts
@@ -52,7 +52,7 @@ export async function handleRefreshGitToken(
     platformIntegrationId: rigConfig?.platformIntegrationId,
   });
 
-  if (!freshToken) {
+  if (!freshToken.ok) {
     console.warn(
       `[refresh-git-token] no token available for town=${params.townId} rig=${params.rigId}`
     );
@@ -62,5 +62,5 @@ export async function handleRefreshGitToken(
   console.log(
     `[refresh-git-token] refreshed git token for town=${params.townId} rig=${params.rigId}`
   );
-  return c.json(resSuccess({ token: freshToken }), 200);
+  return c.json(resSuccess({ token: freshToken.token }), 200);
 }

--- a/services/gastown/test/integration/pr-poll-errors.test.ts
+++ b/services/gastown/test/integration/pr-poll-errors.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Integration tests for PR poll error discrimination (#3149).
+ *
+ * Tests verify that the poll_pr action handler correctly handles the
+ * discriminated PRStatusOutcome: immediate-fail for no_token / non-transient
+ * HTTP errors, 3-strike threshold for invalid_response / unrecognized_url /
+ * host_mismatch, and 10-strike threshold for transient HTTP errors (5xx, 429).
+ *
+ * The no-token test runs fully end-to-end through the DO alarm. HTTP error
+ * scenarios are covered by unit tests (test/unit/pr-poll-*.test.ts) since
+ * mocking fetch is not practical in the Cloudflare Workers test runtime.
+ */
+
+import { env, runDurableObjectAlarm } from 'cloudflare:test';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+function getTownStub(name = 'test-town') {
+  const id = env.TOWN.idFromName(name);
+  return env.TOWN.get(id);
+}
+
+describe('PR poll error discrimination (#3149)', () => {
+  let town: ReturnType<typeof getTownStub>;
+  let townName: string;
+
+  beforeEach(async () => {
+    townName = `pr-poll-${crypto.randomUUID()}`;
+    town = getTownStub(townName);
+    await town.setTownId(townName);
+  });
+
+  async function setupMrBeadWithPrUrl(prUrl: string) {
+    await town.addRig({
+      rigId: 'rig-1',
+      name: 'main-rig',
+      gitUrl: 'https://github.com/test/repo.git',
+      defaultBranch: 'main',
+    });
+
+    const result = await town.slingConvoy({
+      rigId: 'rig-1',
+      convoyTitle: 'PR Poll Test',
+      tasks: [{ title: 'Task 1' }],
+    });
+
+    await runDurableObjectAlarm(town);
+
+    const beadId = result.beads[0].bead.bead_id;
+    const bead = await town.getBeadAsync(beadId);
+    const agentId = bead!.assignee_agent_bead_id!;
+    expect(agentId).toBeTruthy();
+
+    await town.agentDone(agentId, {
+      branch: 'gt/polecat/test-branch',
+      summary: 'Completed task',
+    });
+
+    await runDurableObjectAlarm(town);
+
+    const allMrs = await town.listBeads({ type: 'merge_request' });
+    const mrBead = allMrs.find(b => b.metadata?.source_bead_id === beadId);
+    expect(mrBead).toBeTruthy();
+
+    // Set the PR URL and put the MR bead back to in_progress so the
+    // reconciler will schedule a poll_pr action on the next alarm tick.
+    await town.updateBead(
+      mrBead!.bead_id,
+      {
+        metadata: {
+          ...(mrBead!.metadata ?? {}),
+          pr_url: prUrl,
+        },
+      },
+      'system'
+    );
+    await town.updateBeadStatus(mrBead!.bead_id, 'in_progress', 'system');
+
+    return { beadId, mrBeadId: mrBead!.bead_id, agentId, convoyId: result.convoy.id };
+  }
+
+  describe('no_token: town with no GitHub token', () => {
+    it('should fail the MR bead immediately (1 strike) with failureKind "no_token"', async () => {
+      // Town is set up with no git_auth, so resolveGitHubToken will return
+      // { ok: false, tried: [...] } and checkPRStatus will return a no_token error.
+      const { mrBeadId } = await setupMrBeadWithPrUrl(
+        'https://github.com/test/repo/pull/1'
+      );
+
+      // Run alarm — the reconciler should generate a poll_pr action, which
+      // calls checkPRStatus and gets a no_token error. Since no_token is an
+      // immediate-fail error, the bead should fail on the first poll.
+      await runDurableObjectAlarm(town);
+
+      const mrBead = await town.getBeadAsync(mrBeadId);
+      expect(mrBead?.status).toBe('failed');
+      expect(mrBead?.metadata?.failureReason).toBe('pr_poll_failed');
+      expect(mrBead?.metadata?.failureKind).toBe('no_token');
+      expect(mrBead?.metadata?.failureMessage).toContain('No GitHub token resolved');
+      expect(mrBead?.metadata?.failureMessage).toContain('town.git_auth.github_token');
+      expect(mrBead?.metadata?.failureMessage).toContain('town.github_cli_pat');
+    });
+  });
+});

--- a/services/gastown/test/unit/pr-poll-errors.test.ts
+++ b/services/gastown/test/unit/pr-poll-errors.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  checkPRStatus,
+  resolveGitHubToken,
+  type SCMContext,
+  type PRStatusOutcome,
+} from '../../src/dos/town/town-scm';
+import type { TownConfig } from '../../src/types';
+
+function mockSCMContext(overrides: Partial<SCMContext> = {}): SCMContext {
+  return {
+    env: {} as SCMContext['env'],
+    townId: 'test-town',
+    getTownConfig: async () => ({}) as TownConfig,
+    ...overrides,
+  };
+}
+
+describe('resolveGitHubToken', () => {
+  it('returns ok:true with source when github_token is configured', async () => {
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({ git_auth: { github_token: 'ghp_abc123' } }) as TownConfig,
+    });
+    const result = await resolveGitHubToken(ctx);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.token).toBe('ghp_abc123');
+      expect(result.source).toBe('town.git_auth.github_token');
+    }
+  });
+
+  it('returns ok:true with source when github_cli_pat is configured', async () => {
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({ github_cli_pat: 'ghp_pat123' }) as TownConfig,
+    });
+    const result = await resolveGitHubToken(ctx);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.token).toBe('ghp_pat123');
+      expect(result.source).toBe('town.github_cli_pat');
+    }
+  });
+
+  it('returns ok:false with resolution chain when no token is configured', async () => {
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({}) as TownConfig,
+    });
+    const result = await resolveGitHubToken(ctx);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.tried).toContain('town.git_auth.github_token');
+      expect(result.tried).toContain('town.github_cli_pat');
+      expect(result.tried).toContain('platform integration (none configured)');
+    }
+  });
+
+  it('includes platform integration source label in resolution chain', async () => {
+    const ctx = mockSCMContext({
+      platformIntegrationId: 'integration-123',
+      env: { GIT_TOKEN_SERVICE: { getToken: async () => null } } as unknown as SCMContext['env'],
+      getTownConfig: async () =>
+        ({ git_auth: { platform_integration_id: 'integration-123' } }) as TownConfig,
+    });
+    const result = await resolveGitHubToken(ctx);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.tried).toContain('town platform integration');
+    }
+  });
+
+  it('uses rig platform integration label when town has no platform_integration_id', async () => {
+    const ctx = mockSCMContext({
+      platformIntegrationId: 'rig-integration-456',
+      env: { GIT_TOKEN_SERVICE: { getToken: async () => null } } as unknown as SCMContext['env'],
+      getTownConfig: async () => ({}) as TownConfig,
+    });
+    const result = await resolveGitHubToken(ctx);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.tried).toContain('rig platform integration');
+    }
+  });
+});
+
+describe('checkPRStatus', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns no_token error when no GitHub token is available', async () => {
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({}) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error.kind).toBe('no_token');
+      expect(outcome.error.provider).toBe('github');
+      if (outcome.error.kind === 'no_token') {
+        expect(outcome.error.resolutionChain).toContain('town.git_auth.github_token');
+        expect(outcome.error.resolutionChain).toContain('town.github_cli_pat');
+      }
+    }
+  });
+
+  it('returns http_error with transient:true for 5xx status', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Server Error', { status: 503, statusText: 'Service Unavailable' })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok && outcome.error.kind === 'http_error') {
+      expect(outcome.error.status).toBe(503);
+      expect(outcome.error.transient).toBe(true);
+      expect(outcome.error.provider).toBe('github');
+    }
+  });
+
+  it('returns http_error with transient:true for 429 status', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Rate Limited', { status: 429, statusText: 'Too Many Requests' })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok && outcome.error.kind === 'http_error') {
+      expect(outcome.error.status).toBe(429);
+      expect(outcome.error.transient).toBe(true);
+    }
+  });
+
+  it('returns http_error with transient:false for 401 status', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({ git_auth: { github_token: 'ghp_bad' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok && outcome.error.kind === 'http_error') {
+      expect(outcome.error.status).toBe(401);
+      expect(outcome.error.transient).toBe(false);
+    }
+  });
+
+  it('returns http_error with transient:false for 403 status', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Forbidden', { status: 403, statusText: 'Forbidden' })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({ git_auth: { github_token: 'ghp_limited' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok && outcome.error.kind === 'http_error') {
+      expect(outcome.error.status).toBe(403);
+      expect(outcome.error.transient).toBe(false);
+    }
+  });
+
+  it('returns http_error with transient:false for 404 status', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Not Found', { status: 404, statusText: 'Not Found' })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok && outcome.error.kind === 'http_error') {
+      expect(outcome.error.status).toBe(404);
+      expect(outcome.error.transient).toBe(false);
+    }
+  });
+
+  it('returns invalid_response with json_parse when response body is not JSON', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('not json', {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+      })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok && outcome.error.kind === 'invalid_response') {
+      expect(outcome.error.reason).toBe('json_parse');
+      expect(outcome.error.provider).toBe('github');
+    }
+  });
+
+  it('returns invalid_response with schema_mismatch and sampleKeys when response shape is wrong', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 42, title: 'not a PR', random_field: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok && outcome.error.kind === 'invalid_response') {
+      expect(outcome.error.reason).toBe('schema_mismatch');
+      expect(outcome.error.sampleKeys).toBeDefined();
+      expect(outcome.error.sampleKeys!.length).toBeGreaterThan(0);
+      expect(outcome.error.provider).toBe('github');
+    }
+  });
+
+  it('returns unrecognized_url for non-GitHub/GitLab URLs', async () => {
+    const ctx = mockSCMContext({
+      getTownConfig: async () => ({}) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://example.com/something');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok && outcome.error.kind === 'unrecognized_url') {
+      expect(outcome.error.url).toBe('https://example.com/something');
+    }
+  });
+
+  it('returns ok:true with merged status for merged PR', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ state: 'closed', merged: true, mergeable_state: 'clean' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('merged');
+    }
+  });
+
+  it('returns ok:true with open status for open PR', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({ state: 'open', merged: false, mergeable_state: 'clean' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({ git_auth: { github_token: 'ghp_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://github.com/owner/repo/pull/1');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('open');
+      expect(outcome.result.mergeable_state).toBe('clean');
+    }
+  });
+
+  it('returns host_mismatch for GitLab URL with unknown host', async () => {
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({
+          git_auth: {
+            gitlab_token: 'glpat_test',
+            gitlab_instance_url: 'https://gitlab.mycompany.com',
+          },
+        }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://gitlab.evil.com/group/project/-/merge_requests/5');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok && outcome.error.kind === 'host_mismatch') {
+      expect(outcome.error.got).toBe('gitlab.evil.com');
+      expect(outcome.error.expected).toBe('gitlab.mycompany.com');
+    }
+  });
+
+  it('allows gitlab.com without host validation', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ state: 'merged' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const ctx = mockSCMContext({
+      getTownConfig: async () =>
+        ({ git_auth: { gitlab_token: 'glpat_test' } }) as TownConfig,
+    });
+    const outcome = await checkPRStatus(ctx, 'https://gitlab.com/group/project/-/merge_requests/5');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe('merged');
+    }
+  });
+});

--- a/services/gastown/test/unit/pr-poll-thresholds.test.ts
+++ b/services/gastown/test/unit/pr-poll-thresholds.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest';
+import {
+  _failureMessageFor,
+  _shouldFailImmediately,
+  _shouldCountAsTransient,
+} from '../../src/dos/town/actions';
+import type { PRStatusError } from '../../src/dos/town/town-scm';
+
+describe('failureMessageFor', () => {
+  it('produces actionable message for no_token with resolution chain', () => {
+    const error: PRStatusError = {
+      kind: 'no_token',
+      provider: 'github',
+      resolutionChain: [
+        'town.git_auth.github_token',
+        'town.github_cli_pat',
+        'town platform integration',
+        'rig platform integration',
+      ],
+    };
+    const msg = _failureMessageFor(error);
+    expect(msg).toContain('No GitHub token resolved');
+    expect(msg).toContain('`town.git_auth.github_token`');
+    expect(msg).toContain('`town.github_cli_pat`');
+    expect(msg).toContain('`town platform integration`');
+    expect(msg).toContain('`rig platform integration`');
+    expect(msg).toContain('polecat agents use their own container credentials');
+  });
+
+  it('produces specific message for HTTP 401', () => {
+    const error: PRStatusError = {
+      kind: 'http_error',
+      provider: 'github',
+      status: 401,
+      statusText: 'Unauthorized',
+      transient: false,
+    };
+    const msg = _failureMessageFor(error);
+    expect(msg).toContain('invalid or expired');
+    expect(msg).toContain('HTTP 401');
+  });
+
+  it('produces specific message for HTTP 403', () => {
+    const error: PRStatusError = {
+      kind: 'http_error',
+      provider: 'github',
+      status: 403,
+      statusText: 'Forbidden',
+      transient: false,
+    };
+    const msg = _failureMessageFor(error);
+    expect(msg).toContain('lacks permission');
+    expect(msg).toContain('HTTP 403');
+  });
+
+  it('produces specific message for HTTP 404', () => {
+    const error: PRStatusError = {
+      kind: 'http_error',
+      provider: 'github',
+      status: 404,
+      statusText: 'Not Found',
+      transient: false,
+    };
+    const msg = _failureMessageFor(error);
+    expect(msg).toContain('not found');
+    expect(msg).toContain('HTTP 404');
+  });
+
+  it('produces generic HTTP message for other status codes', () => {
+    const error: PRStatusError = {
+      kind: 'http_error',
+      provider: 'github',
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      transient: false,
+    };
+    const msg = _failureMessageFor(error);
+    expect(msg).toContain('HTTP 422');
+    expect(msg).toContain('Not retryable');
+  });
+
+  it('indicates Retrying for transient HTTP errors', () => {
+    const error: PRStatusError = {
+      kind: 'http_error',
+      provider: 'github',
+      status: 503,
+      statusText: 'Service Unavailable',
+      transient: true,
+    };
+    const msg = _failureMessageFor(error);
+    expect(msg).toContain('Retrying');
+  });
+
+  it('produces message with sampleKeys for schema_mismatch', () => {
+    const error: PRStatusError = {
+      kind: 'invalid_response',
+      provider: 'github',
+      reason: 'schema_mismatch',
+      sampleKeys: ['id', 'title', 'random_field'],
+    };
+    const msg = _failureMessageFor(error);
+    expect(msg).toContain('unexpected response shape');
+    expect(msg).toContain('schema_mismatch');
+    expect(msg).toContain('id, title, random_field');
+    expect(msg).toContain('file a bug');
+  });
+
+  it('produces message without sampleKeys for json_parse', () => {
+    const error: PRStatusError = {
+      kind: 'invalid_response',
+      provider: 'github',
+      reason: 'json_parse',
+    };
+    const msg = _failureMessageFor(error);
+    expect(msg).toContain('json_parse');
+    expect(msg).not.toContain('top-level keys');
+  });
+
+  it('produces message for unrecognized_url', () => {
+    const error: PRStatusError = {
+      kind: 'unrecognized_url',
+      url: 'https://bitbucket.org/repo/pull/1',
+    };
+    const msg = _failureMessageFor(error);
+    expect(msg).toContain('not recognized');
+    expect(msg).toContain('https://bitbucket.org/repo/pull/1');
+  });
+
+  it('produces message for host_mismatch', () => {
+    const error: PRStatusError = {
+      kind: 'host_mismatch',
+      provider: 'gitlab',
+      expected: 'gitlab.mycompany.com',
+      got: 'gitlab.evil.com',
+    };
+    const msg = _failureMessageFor(error);
+    expect(msg).toContain('Refusing to send GitLab token');
+    expect(msg).toContain('gitlab.evil.com');
+    expect(msg).toContain('gitlab.mycompany.com');
+  });
+});
+
+describe('shouldFailImmediately', () => {
+  it('returns true for no_token', () => {
+    const error: PRStatusError = { kind: 'no_token', provider: 'github', resolutionChain: [] };
+    expect(_shouldFailImmediately(error)).toBe(true);
+  });
+
+  it('returns true for http_error with transient:false (401)', () => {
+    const error: PRStatusError = {
+      kind: 'http_error',
+      provider: 'github',
+      status: 401,
+      statusText: 'Unauthorized',
+      transient: false,
+    };
+    expect(_shouldFailImmediately(error)).toBe(true);
+  });
+
+  it('returns true for http_error with transient:false (403)', () => {
+    const error: PRStatusError = {
+      kind: 'http_error',
+      provider: 'github',
+      status: 403,
+      statusText: 'Forbidden',
+      transient: false,
+    };
+    expect(_shouldFailImmediately(error)).toBe(true);
+  });
+
+  it('returns true for http_error with transient:false (404)', () => {
+    const error: PRStatusError = {
+      kind: 'http_error',
+      provider: 'github',
+      status: 404,
+      statusText: 'Not Found',
+      transient: false,
+    };
+    expect(_shouldFailImmediately(error)).toBe(true);
+  });
+
+  it('returns false for http_error with transient:true (5xx)', () => {
+    const error: PRStatusError = {
+      kind: 'http_error',
+      provider: 'github',
+      status: 503,
+      statusText: 'Service Unavailable',
+      transient: true,
+    };
+    expect(_shouldFailImmediately(error)).toBe(false);
+  });
+
+  it('returns false for invalid_response', () => {
+    const error: PRStatusError = {
+      kind: 'invalid_response',
+      provider: 'github',
+      reason: 'schema_mismatch',
+    };
+    expect(_shouldFailImmediately(error)).toBe(false);
+  });
+
+  it('returns false for unrecognized_url', () => {
+    const error: PRStatusError = { kind: 'unrecognized_url', url: 'https://example.com' };
+    expect(_shouldFailImmediately(error)).toBe(false);
+  });
+
+  it('returns false for host_mismatch', () => {
+    const error: PRStatusError = {
+      kind: 'host_mismatch',
+      provider: 'gitlab',
+      expected: 'gitlab.com',
+      got: 'evil.com',
+    };
+    expect(_shouldFailImmediately(error)).toBe(false);
+  });
+});
+
+describe('shouldCountAsTransient', () => {
+  it('returns true for http_error with transient:true (5xx)', () => {
+    const error: PRStatusError = {
+      kind: 'http_error',
+      provider: 'github',
+      status: 503,
+      statusText: 'Service Unavailable',
+      transient: true,
+    };
+    expect(_shouldCountAsTransient(error)).toBe(true);
+  });
+
+  it('returns true for http_error with transient:true (429)', () => {
+    const error: PRStatusError = {
+      kind: 'http_error',
+      provider: 'github',
+      status: 429,
+      statusText: 'Too Many Requests',
+      transient: true,
+    };
+    expect(_shouldCountAsTransient(error)).toBe(true);
+  });
+
+  it('returns false for http_error with transient:false', () => {
+    const error: PRStatusError = {
+      kind: 'http_error',
+      provider: 'github',
+      status: 401,
+      statusText: 'Unauthorized',
+      transient: false,
+    };
+    expect(_shouldCountAsTransient(error)).toBe(false);
+  });
+
+  it('returns false for non-http_error kinds', () => {
+    const error: PRStatusError = { kind: 'no_token', provider: 'github', resolutionChain: [] };
+    expect(_shouldCountAsTransient(error)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the `null` return from `checkPRStatus` with a discriminated `PRStatusOutcome` union (`{ ok: true, result }` | `{ ok: false, error }`), and similarly updates `resolveGitHubToken` to return `GitHubTokenResolution` that captures the resolution chain. This ensures each distinct failure mode (no token, HTTP errors, invalid response, unrecognized URL, host mismatch) surfaces a specific, actionable failure message instead of a generic "null" after 10 polls.

Key changes:
- **`checkPRStatus`** returns `PRStatusOutcome` with structured `PRStatusError` variants (no_token, http_error, invalid_response, unrecognized_url, host_mismatch)
- **`resolveGitHubToken`** returns `GitHubTokenResolution` tracking which sources were tried
- **Three-bucket failure strategy**: no_token/non-transient HTTP fail immediately (1 strike), invalid_response/unrecognized_url/host_mismatch fail after 3 strikes, transient 5xx/429 keep existing 10-strike behavior
- **`poll_null_count` resets to 0** on successful poll
- **AE telemetry**: `pr.poll_failed` event emitted on terminal failure
- Updated all callers including `refresh-git-token.handler.ts` and `Town.do.ts`

Fixes #3149.

## Verification

- Unit tests cover `checkPRStatus` error discrimination (no_token, 401/403/404, 5xx/429 transient, invalid_response, unrecognized_url, host_mismatch)
- Unit tests cover `failureMessageFor` producing actionable messages for each error kind
- Unit tests cover `shouldFailImmediately` and `shouldCountAsTransient` threshold logic
- Integration test covers end-to-end no_token failure through DO alarm

## Visual Changes

N/A

## Reviewer Notes

The `platformIntegrationId` is not passed in the `Town.do.ts` `checkPRStatus` context — this matches the pre-existing behavior. The `refresh-git-token.handler.ts` does pass it, which is the intended pattern for rig-level token resolution.