### PR TITLE
fix(kiloclaw): reduce complementary AI inference window from 6 to 2 hours

### DIFF
--- a/apps/web/src/emails/clawComplementaryInferenceEnded.html
+++ b/apps/web/src/emails/clawComplementaryInferenceEnded.html
@@ -51,7 +51,7 @@
                       sans-serif;
                   "
                 >
-                  The 6 hours of complimentary AI usage included with your KiloClaw trial have now
+                  The 2 hours of complimentary AI usage included with your KiloClaw trial have now
                   ended. Your instance is still running. AI model requests will use credits from
                   your account balance going forward.
                 </p>

--- a/apps/web/src/emails/clawInstanceReady.html
+++ b/apps/web/src/emails/clawInstanceReady.html
@@ -52,7 +52,7 @@
                   "
                 >
                   Your KiloClaw instance is now ready to use. Hosting is free for 7 days and AI
-                  inference is for the first 6 hours. After that, inference is at cost: you pick the
+                  inference is for the first 2 hours. After that, inference is at cost: you pick the
                   model, you pay only what the AI provider charges us.
                 </p>
                 <!-- CTA -->

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -2573,7 +2573,7 @@ async function runEarlybirdWarningSweep(
   }
 }
 
-const COMPLEMENTARY_INFERENCE_WINDOW_MS = 6 * 60 * 60 * 1000;
+const COMPLEMENTARY_INFERENCE_WINDOW_MS = 2 * 60 * 60 * 1000;
 const COMPLEMENTARY_INFERENCE_INSTANCE_READY_CUTOFF_ISO = '2026-04-10T00:00:00.000Z';
 const INSTANCE_READY_EMAIL_TYPE = 'claw_instance_ready';
 const COMPLEMENTARY_INFERENCE_ENDED_EMAIL_TYPE = 'claw_complementary_inference_ended';


### PR DESCRIPTION
## Summary
Reduces the KiloClaw complementary AI inference window from 6 hours to 2 hours. Updates the lifecycle constant that controls when the "inference ended" email is triggered, and updates both email templates to reflect the new duration.

## Verification
- Verified no other references to "6 hours" of free inference exist in the codebase.
- The `COMPLEMENTARY_INFERENCE_WINDOW_MS` constant in `lifecycle.ts` now correctly triggers the ended email after 2 hours.

## Visual Changes
N/A

## Reviewer Notes
Three touch points updated in sync:
- `services/kiloclaw-billing/src/lifecycle.ts` — `COMPLEMENTARY_INFERENCE_WINDOW_MS` changed from `6 * 60 * 60 * 1000` to `2 * 60 * 60 * 1000`
- `apps/web/src/emails/clawInstanceReady.html` — copy updated from "6 hours" to "2 hours"
- `apps/web/src/emails/clawComplementaryInferenceEnded.html` — copy updated from "6 hours" to "2 hours"