### PR TITLE
fix(cloud-agent): use execution heartbeat for idle cleanup instead of kiloServerLastActivity

### DIFF
--- a/services/cloud-agent-next/src/execution/orchestrator.ts
+++ b/services/cloud-agent-next/src/execution/orchestrator.ts
@@ -169,19 +169,7 @@ export class ExecutionOrchestrator {
         );
       }
 
-      // 5. Record activity for idle timeout tracking
-      try {
-        await withDORetry(
-          () => this.deps.getSessionStub(userId, sessionId),
-          stub => stub.recordKiloServerActivity(),
-          'recordKiloServerActivity'
-        );
-      } catch {
-        // Non-fatal - log but continue
-        logger.warn('Failed to record kilo server activity');
-      }
-
-      // 6. Download images from R2 to sandbox if provided
+      // 5. Download images from R2 to sandbox if provided
       const fileParts = await downloadImagePromptParts({
         env: this.deps.env,
         session: prepared.session,
@@ -204,7 +192,7 @@ export class ExecutionOrchestrator {
         prepareExecution
       );
 
-    // 7. Send prompt with execution binding (async - returns messageId immediately)
+    // 6. Send prompt with execution binding (async - returns messageId immediately)
     const ingestUrl = this.deps.getIngestUrl(sessionId, userId);
     const ingestToken = executionId;
     const kilocodeToken = this.getKilocodeToken(plan);

--- a/services/cloud-agent-next/src/execution/orchestrator.ts
+++ b/services/cloud-agent-next/src/execution/orchestrator.ts
@@ -22,7 +22,6 @@ import { logger } from '../logger.js';
 import { logSandboxOperationTimeout } from '../sandbox-timeout-logging.js';
 import { updateGitRemoteToken } from '../workspace.js';
 import { WrapperClient, type WrapperPromptOptions } from '../kilo/wrapper-client.js';
-import { withDORetry } from '../utils/do-retry.js';
 import { normalizeAgentMode } from '../schema.js';
 import { buildImagePromptParts, downloadImagePromptParts } from './image-prompt-parts.js';
 import { withTimeout } from '@kilocode/worker-utils';

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -779,26 +779,6 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
     await this.updateMetadata(updated);
   }
 
-  /**
-   * Record kilo server activity for idle timeout tracking.
-   * Called by the queue consumer after each successful execution.
-   * Resets the idle timeout clock.
-   */
-  async recordKiloServerActivity(): Promise<void> {
-    const metadata = await this.getMetadata();
-    if (!metadata) {
-      throw new Error('Cannot record kilo server activity: session metadata not found');
-    }
-
-    const updated = {
-      ...metadata,
-      kiloServerLastActivity: Date.now(),
-      version: Date.now(),
-    };
-
-    await this.updateMetadata(updated);
-  }
-
   // ---------------------------------------------------------------------------
   // Wrapper Communication Methods
   // ---------------------------------------------------------------------------
@@ -1161,8 +1141,6 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
         await cleanupCliSession();
         return;
       }
-
-      await this.recordKiloServerActivity();
 
       // 11. Auto-initiate if requested, then emit ready only on success.
       // Emitting 'ready' before startExecutionV2 would let the client
@@ -1719,39 +1697,31 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
    * Called by the alarm handler to free up sandbox resources.
    */
   private async cleanupIdleKiloServer(now: number): Promise<void> {
+    const activeExecutionId = await this.executionQueries.getActiveExecutionId();
+    if (activeExecutionId !== null) {
+      return;
+    }
+
+    const executions = await this.executionQueries.getAll();
+    const latestExecution = executions[executions.length - 1];
+    if (!latestExecution) {
+      return;
+    }
+
+    const lastActivity =
+      latestExecution.lastHeartbeat ?? latestExecution.completedAt ?? latestExecution.startedAt;
+    const idleMs = now - lastActivity;
+    const idleTimeoutMs = this.getKiloServerIdleTimeoutMs();
+
+    if (idleMs < idleTimeoutMs) {
+      return;
+    }
+
     const metadata = await this.getMetadata();
     if (!metadata) {
       return;
     }
 
-    const lastActivity = metadata.kiloServerLastActivity;
-    if (!lastActivity) {
-      // No kilo server activity recorded, nothing to clean up
-      return;
-    }
-
-    const idleMs = now - lastActivity;
-    const idleTimeoutMs = this.getKiloServerIdleTimeoutMs();
-
-    if (idleMs < idleTimeoutMs) {
-      // Server is still within idle threshold
-      return;
-    }
-
-    // Check if there's an active execution - don't stop the server mid-run
-    const activeExecutionId = await this.executionQueries.getActiveExecutionId();
-    if (activeExecutionId !== null) {
-      logger
-        .withFields({
-          sessionId: this.sessionId,
-          executionId: activeExecutionId,
-          idleMs,
-        })
-        .debug('Skipping idle kilo server cleanup - execution is active');
-      return;
-    }
-
-    // Server has been idle too long and no active execution, stop it
     logger
       .withFields({
         sessionId: this.sessionId,
@@ -1782,15 +1752,6 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
       logger
         .withFields({ sessionId: this.sessionId, sandboxId, rpcElapsedMs: Date.now() - rpcStart })
         .debug('stopKiloServer RPC completed');
-
-      // Clear the activity timestamp since server is stopped
-      // Must merge with existing metadata since updateMetadata validates the full schema
-      const updated = {
-        ...metadata,
-        kiloServerLastActivity: undefined,
-        version: Date.now(),
-      };
-      await this.updateMetadata(updated);
 
       logger
         .withFields({ sessionId: this.sessionId, sandboxId })

--- a/services/cloud-agent-next/src/persistence/schemas.ts
+++ b/services/cloud-agent-next/src/persistence/schemas.ts
@@ -367,9 +367,6 @@ export const MetadataSchema = z.object({
   // Image attachments
   images: ImagesSchema.optional(),
 
-  // Kilo server lifecycle tracking
-  kiloServerLastActivity: z.number().optional(),
-
   // Workspace metadata (set during prepareSession)
   workspacePath: z.string().optional(),
   sessionHome: z.string().optional(),

--- a/services/cloud-agent-next/src/persistence/types.ts
+++ b/services/cloud-agent-next/src/persistence/types.ts
@@ -178,10 +178,6 @@ export type CloudAgentSessionState = {
   /** Optional image attachments to download from R2 to the sandbox */
   images?: Images;
 
-  // Kilo server lifecycle tracking
-  /** Timestamp of last kilo server activity (for idle timeout cleanup) */
-  kiloServerLastActivity?: number;
-
   // Workspace metadata (set during prepareSession)
   /** Workspace path where the repo was cloned */
   workspacePath?: string;

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -41,7 +41,6 @@ import {
   setupWorkspace,
 } from '../../workspace.js';
 import { WrapperClient } from '../../kilo/wrapper-client.js';
-import { withDORetry } from '../../utils/do-retry.js';
 import { generateKiloSessionId } from '../../utils/kilo-session-id.js';
 import { SANDBOX_SLEEP_AFTER_SECONDS } from '../../core/lease.js';
 import {

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -702,20 +702,6 @@ const prepareSessionHandler = internalApiProtectedProcedure
         });
       }
 
-      // 15. Record kilo server activity for idle timeout tracking
-      try {
-        await withDORetry(
-          () => ctx.env.CLOUD_AGENT_SESSION.get(doId),
-          s => s.recordKiloServerActivity(),
-          'recordKiloServerActivity'
-        );
-      } catch (error) {
-        // Non-fatal - log but continue
-        logger
-          .withFields({ error: error instanceof Error ? error.message : String(error) })
-          .warn('Failed to record kilo server activity');
-      }
-
       logger.info('Session prepared successfully');
 
       // 16. Return both IDs


### PR DESCRIPTION
## Summary

The `kiloServerLastActivity` field in session metadata was only set at session prepare and wrapper start time — never updated during an active execution. After 15 minutes (the idle timeout), `cleanupIdleKiloServer` would see a stale timestamp and SIGTERM the container, even though the execution was actively running and heartbeating every 30s. This caused false "Container shutdown: SIGTERM" interruptions for any session running longer than 15 minutes.

Replace `kiloServerLastActivity` with execution-level data:
- If there's an active execution, skip cleanup immediately (no point checking idle when something is running)
- Otherwise, derive the last activity timestamp from the latest execution's `lastHeartbeat`, `completedAt`, or `startedAt` (in that priority order)

This removes the need for the separate `kiloServerLastActivity` field and the `recordKiloServerActivity()` RPC method entirely, along with all its call sites in the router and orchestrator.

## Verification

Triggered a Cloud Agent session on `Kilo-Org/kilocode` and confirmed via Axiom logs that:
- All Worker outcomes were `ok` with zero exceptions
- The session was killed by our own `cleanupIdleKiloServer` at the 15-minute mark (`idleMs=959890`, `idleTimeoutMs=900000`)
- The `No wrapper found to stop` log confirmed the container was already gone by the time the alarm tried to stop it
- Callback was delivered with status `interrupted` and reason `Container shutdown: SIGTERM`

## Visual Changes

N/A

## Reviewer Notes

The `kiloServerLastActivity` field is being removed from the session metadata schema. Existing sessions in DO storage that have this field set will simply have it ignored — the zod schema uses `.optional()` and no code path reads it anymore. No migration is needed.