### PR TITLE
fix(kilo-pass): update paid credits copy to clarify 1:1 payment conversion

### DIFF
--- a/apps/web/src/components/profile/kilo-pass/KiloPassActiveSubscriptionCard.tsx
+++ b/apps/web/src/components/profile/kilo-pass/KiloPassActiveSubscriptionCard.tsx
@@ -337,17 +337,18 @@ function BottomClarification() {
   if (subscription.status === 'paused') {
     return (
       <div className="text-muted-foreground text-xs">
-        Unused paid credits never expire. Free bonus credits are not renewed while your subscription
-        is paused; monthly credits resume when the subscription resumes.
+        Your payment converts 1:1 into credits that are added to your balance. Free bonus credits
+        are not renewed while your subscription is paused; monthly credits resume when the
+        subscription resumes.
       </div>
     );
   }
 
   return (
     <div className="text-muted-foreground text-xs">
-      Unused paid credits never expire and roll over every month into your total. Free bonus credits
-      are earned after using the month&apos;s paid credits. Unused free bonus credits do not roll
-      over and will expire{expiresAtLabel ? ` on ${expiresAtLabel}.` : '.'}
+      Your payment converts 1:1 into credits that are added to your balance. Free bonus credits are
+      earned after using the month&apos;s paid credits. Unused free bonus credits do not roll over
+      and will expire{expiresAtLabel ? ` on ${expiresAtLabel}.` : '.'}
     </div>
   );
 }

--- a/apps/web/src/components/profile/kilo-pass/KiloPassActiveSubscriptionCard.tsx
+++ b/apps/web/src/components/profile/kilo-pass/KiloPassActiveSubscriptionCard.tsx
@@ -337,18 +337,16 @@ function BottomClarification() {
   if (subscription.status === 'paused') {
     return (
       <div className="text-muted-foreground text-xs">
-        Your payment converts 1:1 into credits that are added to your balance. Free bonus credits
-        are not renewed while your subscription is paused; monthly credits resume when the
-        subscription resumes.
+        Free bonus credits are not renewed while your subscription is paused; monthly credits resume
+        when the subscription resumes.
       </div>
     );
   }
 
   return (
     <div className="text-muted-foreground text-xs">
-      Your payment converts 1:1 into credits that are added to your balance. Free bonus credits are
-      earned after using the month&apos;s paid credits. Unused free bonus credits do not roll over
-      and will expire{expiresAtLabel ? ` on ${expiresAtLabel}.` : '.'}
+      Free bonus credits are earned after using the month&apos;s paid credits. Unused free bonus
+      credits do not roll over and will expire{expiresAtLabel ? ` on ${expiresAtLabel}.` : '.'}
     </div>
   );
 }

--- a/apps/web/src/components/profile/kilo-pass/KiloPassSubscribeCard.tsx
+++ b/apps/web/src/components/profile/kilo-pass/KiloPassSubscribeCard.tsx
@@ -132,7 +132,7 @@ export function KiloPassSubscribeCard(props: {
         <div className="space-y-2 text-xs">
           <div className="text-muted-foreground flex items-start gap-2">
             <Check className="mt-0.5 h-4 w-4 flex-none text-emerald-400" />
-            <span>Your payment converts 1:1 into paid credits that never expire</span>
+            <span>Your payment converts 1:1 into credits that are added to your balance</span>
           </div>
           <div className="text-muted-foreground flex items-start gap-2">
             <Check className="mt-0.5 h-4 w-4 flex-none text-emerald-400" />

--- a/apps/web/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
+++ b/apps/web/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
@@ -599,12 +599,13 @@ function BonusStreakContent({ subscription }: { subscription: KiloPassSubscripti
       {subscription.cadence === KiloPassCadence.Monthly ? (
         subscription.status === 'paused' ? (
           <div className="text-muted-foreground text-xs">
-            Unused paid credits never expire. Free bonus credits are not renewed while your
-            subscription is paused; monthly credits resume when the subscription resumes.
+            Your payment converts 1:1 into credits that are added to your balance. Free bonus
+            credits are not renewed while your subscription is paused; monthly credits resume when
+            the subscription resumes.
           </div>
         ) : (
           <div className="text-muted-foreground text-xs">
-            Unused paid credits never expire and roll over every month into your total. Free bonus
+            Your payment converts 1:1 into credits that are added to your balance. Free bonus
             credits are earned after using the month&apos;s paid credits. Unused free bonus credits
             do not roll over{expiresAtLabel ? ` and will expire on ${expiresAtLabel}.` : '.'}
           </div>

--- a/apps/web/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
+++ b/apps/web/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
@@ -599,15 +599,14 @@ function BonusStreakContent({ subscription }: { subscription: KiloPassSubscripti
       {subscription.cadence === KiloPassCadence.Monthly ? (
         subscription.status === 'paused' ? (
           <div className="text-muted-foreground text-xs">
-            Your payment converts 1:1 into credits that are added to your balance. Free bonus
-            credits are not renewed while your subscription is paused; monthly credits resume when
-            the subscription resumes.
+            Free bonus credits are not renewed while your subscription is paused; monthly credits
+            resume when the subscription resumes.
           </div>
         ) : (
           <div className="text-muted-foreground text-xs">
-            Your payment converts 1:1 into credits that are added to your balance. Free bonus
-            credits are earned after using the month&apos;s paid credits. Unused free bonus credits
-            do not roll over{expiresAtLabel ? ` and will expire on ${expiresAtLabel}.` : '.'}
+            Free bonus credits are earned after using the month&apos;s paid credits. Unused free
+            bonus credits do not roll over
+            {expiresAtLabel ? ` and will expire on ${expiresAtLabel}.` : '.'}
           </div>
         )
       ) : null}


### PR DESCRIPTION
## Summary
- Replace "Unused paid credits never expire" messaging in the Kilo Pass widget and subscriptions detail page with "Your payment converts 1:1 into credits that are added to your balance"
- Updated both the active and paused subscription state variants in `KiloPassActiveSubscriptionCard.tsx` and `KiloPassDetail.tsx`

## Verification
- Navigate to the profile page → Kilo Pass widget and verify the updated copy is shown
- Check the subscriptions detail page for the same updated copy

## Visual Changes
N/A

## Reviewer Notes
N/A