### PR TITLE
fix(kiloclaw) resize shared to perf

### DIFF
--- a/packages/kiloclaw-instance-tiers/src/__tests__/catalog.test.ts
+++ b/packages/kiloclaw-instance-tiers/src/__tests__/catalog.test.ts
@@ -72,6 +72,18 @@ describe('instance tier catalog', () => {
         targetTier: 'perf-1-3',
       })
     ).toBe(false);
+    // Legacy shared → performance is allowed regardless of CPU count, because
+    // a performance CPU is strictly stronger than a shared CPU.
+    expect(
+      canUpgradeTo({
+        currentType: 'shared-2-3',
+        currentSize: { cpus: 2, memory_mb: 3072, cpu_kind: 'shared' },
+        currentVolumeSizeGb: 10,
+        targetTier: 'perf-1-3',
+      })
+    ).toBe(true);
+    // But memory/volume constraints still apply: shared-2-4 has 4 GB which
+    // exceeds perf-1-3's 3 GB, so this move is blocked.
     expect(
       canUpgradeTo({
         currentType: 'shared-2-4',
@@ -80,6 +92,14 @@ describe('instance tier catalog', () => {
         targetTier: 'perf-1-3',
       })
     ).toBe(false);
+    expect(
+      canUpgradeTo({
+        currentType: 'shared-2-4',
+        currentSize: { cpus: 2, memory_mb: 4096, cpu_kind: 'shared' },
+        currentVolumeSizeGb: 10,
+        targetTier: 'perf-4-8',
+      })
+    ).toBe(true);
     expect(
       canUpgradeTo({
         currentType: 'custom',

--- a/packages/kiloclaw-instance-tiers/src/helpers.ts
+++ b/packages/kiloclaw-instance-tiers/src/helpers.ts
@@ -83,8 +83,16 @@ export function canUpgradeTo(args: {
   const currentCpus = args.currentSize?.cpus ?? baseline.machineSize.cpus;
   const currentMemoryMb = args.currentSize?.memory_mb ?? baseline.machineSize.memory_mb;
   const currentVolumeSizeGb = args.currentVolumeSizeGb ?? DEFAULT_VOLUME_SIZE_GB;
+  const currentCpuKind = args.currentSize ? normalizedCpuKind(args.currentSize) : 'performance';
+  const targetCpuKind = normalizedCpuKind(target.machineSize);
+  // A performance CPU is strictly stronger than a shared CPU, so a shared →
+  // performance move is allowed regardless of CPU count.
+  const cpusOk =
+    currentCpuKind === 'shared' && targetCpuKind === 'performance'
+      ? true
+      : target.machineSize.cpus >= currentCpus;
   return (
-    target.machineSize.cpus >= currentCpus &&
+    cpusOk &&
     target.machineSize.memory_mb >= currentMemoryMb &&
     target.volumeSizeGb >= currentVolumeSizeGb
   );

--- a/packages/kiloclaw-instance-tiers/src/helpers.ts
+++ b/packages/kiloclaw-instance-tiers/src/helpers.ts
@@ -88,9 +88,8 @@ export function canUpgradeTo(args: {
   // A performance CPU is strictly stronger than a shared CPU, so a shared →
   // performance move is allowed regardless of CPU count.
   const cpusOk =
-    currentCpuKind === 'shared' && targetCpuKind === 'performance'
-      ? true
-      : target.machineSize.cpus >= currentCpus;
+    (currentCpuKind === 'shared' && targetCpuKind === 'performance') ||
+    target.machineSize.cpus >= currentCpus;
   return (
     cpusOk &&
     target.machineSize.memory_mb >= currentMemoryMb &&


### PR DESCRIPTION
## Summary

`canUpgradeTo` compared raw CPU counts when the current tier was a legacy shared tier. This blocked `perf-1-3` (one performance CPU) as a resize target from `shared-2-3` (two shared CPUs), even though a performance CPU is categorically stronger than a shared CPU. The fix skips the CPU count check on shared to performance transitions while still enforcing memory and volume floors.

## Verification

- [x] Unit tests in `packages/kiloclaw-instance-tiers` cover the new boundary cases: `shared-2-3` to `perf-1-3` is allowed (memory equal, volume equal), `shared-2-4` to `perf-1-3` stays blocked (4 GB memory exceeds the 3 GB floor), and `shared-2-4` to `perf-4-8` stays allowed
- [x] Workspace lint, typecheck, and format check pass
- [ ] No manual UI verification performed. The dropdown gating in the admin UI calls `canUpgradeTo` directly with no additional logic, so the change flows through unchanged

## Visual Changes

N/A

## Reviewer Notes

Both the admin UI dropdown gate and the backend resize guard in the kiloclaw durable object call `canUpgradeTo`, so the new behavior applies at both call sites. The change only affects the legacy and custom branch of `canUpgradeTo`; the offered to offered branch using `compareTierRank` is untouched, so downgrades between offered tiers remain blocked.