### PR TITLE
feat(kiloclaw): add fleet upgrade scheduler

### DIFF
--- a/apps/web/src/app/admin/components/KiloclawScheduler/KiloclawSchedulerTab.tsx
+++ b/apps/web/src/app/admin/components/KiloclawScheduler/KiloclawSchedulerTab.tsx
@@ -973,7 +973,7 @@ export function KiloclawSchedulerTab() {
           if (!open) setViewingActionId(null);
         }}
       >
-        <DialogContent className="max-h-[80vh] sm:max-w-3xl">
+        <DialogContent className="grid max-h-[calc(100vh-3rem)] w-[calc(100vw-2rem)] grid-rows-[auto_minmax(0,1fr)] overflow-hidden sm:max-w-6xl">
           <DialogHeader>
             <DialogTitle>Scheduled action detail</DialogTitle>
             <DialogDescription>
@@ -990,7 +990,7 @@ export function KiloclawSchedulerTab() {
           )}
 
           {detail.data && (
-            <div className="space-y-4 overflow-y-auto">
+            <div className="min-h-0 space-y-4 overflow-y-auto pr-1">
               <div className="bg-muted/30 rounded-md border p-3 text-sm">
                 <div className="grid grid-cols-2 gap-x-6 gap-y-1">
                   <div>
@@ -1051,9 +1051,9 @@ export function KiloclawSchedulerTab() {
               )}
 
               <div className="text-sm font-medium">Targets ({detail.data.targets.length})</div>
-              <div className="rounded-lg border">
-                <Table>
-                  <TableHeader>
+              <div className="max-h-[42vh] overflow-auto rounded-lg border">
+                <Table className="min-w-[920px]">
+                  <TableHeader className="bg-card sticky top-0 z-10">
                     <TableRow>
                       <TableHead>Tranche</TableHead>
                       <TableHead>Instance</TableHead>

--- a/apps/web/src/app/admin/components/KiloclawScheduler/KiloclawSchedulerTab.tsx
+++ b/apps/web/src/app/admin/components/KiloclawScheduler/KiloclawSchedulerTab.tsx
@@ -206,8 +206,6 @@ export function KiloclawSchedulerTab() {
         startsAt: fleetStartsAt,
         tranchePercent: fleetTranchePercent,
         intervalDays: fleetIntervalDays,
-        reason: fleetReason.trim(),
-        notify: fleetNotify,
       }),
     [
       fleetVersionBelow,
@@ -216,8 +214,6 @@ export function KiloclawSchedulerTab() {
       fleetStartsAt,
       fleetTranchePercent,
       fleetIntervalDays,
-      fleetReason,
-      fleetNotify,
     ]
   );
 

--- a/apps/web/src/app/admin/components/KiloclawScheduler/KiloclawSchedulerTab.tsx
+++ b/apps/web/src/app/admin/components/KiloclawScheduler/KiloclawSchedulerTab.tsx
@@ -48,6 +48,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { toast } from 'sonner';
 import { formatRelativeTime } from '../KiloclawInstances/shared';
 import {
   defaultScheduledAt,
@@ -66,6 +67,25 @@ const statusBadgeClass: Record<string, string> = {
   completed: 'border-transparent bg-green-500/20 text-green-400 ring-1 ring-green-500/20',
   cancelled: 'border-transparent bg-zinc-500/20 text-zinc-400 ring-1 ring-zinc-500/20',
   failed: 'border-transparent bg-red-500/20 text-red-400 ring-1 ring-red-500/20',
+};
+
+type FleetPreview = {
+  counts: {
+    eligible: number;
+    actionable: number;
+    pinned: number;
+    conflicts: number;
+    alreadyOnTarget: number;
+    unknownVersion: number;
+  };
+  stages: Array<{ stageIndex: number; scheduledAt: string; targetCount: number }>;
+  actionableInstanceIds: string[];
+  excluded: {
+    pinnedInstanceIds: string[];
+    conflictInstanceIds: string[];
+    alreadyOnTargetInstanceIds: string[];
+    unknownVersionInstanceIds: string[];
+  };
 };
 
 // defaultScheduledAt is shared with the Change Version dialogs (bulk
@@ -88,6 +108,22 @@ export function KiloclawSchedulerTab() {
   const [vcScheduledAt, setVcScheduledAt] = useState(defaultScheduledAt);
   const [vcReason, setVcReason] = useState('');
   const [vcNotify, setVcNotify] = useState<NotifyFormState>(defaultNotifyFormState);
+
+  // Fleet-upgrade form state
+  const [fleetVersionBelow, setFleetVersionBelow] = useState('');
+  const [fleetTargetImageTag, setFleetTargetImageTag] = useState('');
+  const [fleetOverridePins, setFleetOverridePins] = useState(false);
+  const [fleetStartsAt, setFleetStartsAt] = useState(defaultScheduledAt);
+  const [fleetTranchePercent, setFleetTranchePercent] = useState(20);
+  const [fleetIntervalDays, setFleetIntervalDays] = useState(2);
+  const [fleetReason, setFleetReason] = useState('');
+  const [fleetNotify, setFleetNotify] = useState<NotifyFormState>(defaultNotifyFormState);
+  const [fleetConfirmation, setFleetConfirmation] = useState('');
+  const [fleetPreview, setFleetPreview] = useState<{ key: string; data: FleetPreview } | null>(
+    null
+  );
+  const [fleetPreviewError, setFleetPreviewError] = useState<string | null>(null);
+  const [isFleetPreviewing, setIsFleetPreviewing] = useState(false);
 
   // Client-side sort over the current page of listScheduledActions.
   // The list is paginated server-side (limit 50) and ordered by
@@ -161,12 +197,61 @@ export function KiloclawSchedulerTab() {
     })
   );
 
+  const fleetFormKey = useMemo(
+    () =>
+      JSON.stringify({
+        versionBelow: fleetVersionBelow,
+        targetImageTag: fleetTargetImageTag,
+        overridePins: fleetOverridePins,
+        startsAt: fleetStartsAt,
+        tranchePercent: fleetTranchePercent,
+        intervalDays: fleetIntervalDays,
+        reason: fleetReason.trim(),
+        notify: fleetNotify,
+      }),
+    [
+      fleetVersionBelow,
+      fleetTargetImageTag,
+      fleetOverridePins,
+      fleetStartsAt,
+      fleetTranchePercent,
+      fleetIntervalDays,
+      fleetReason,
+      fleetNotify,
+    ]
+  );
+
+  const currentFleetPreview = fleetPreview?.key === fleetFormKey ? fleetPreview.data : null;
+  const fleetConfirmationRequired =
+    (currentFleetPreview?.counts.actionable ?? 0) > 10 || fleetOverridePins;
+  const fleetCreateDisabled =
+    !currentFleetPreview ||
+    currentFleetPreview.counts.actionable === 0 ||
+    currentFleetPreview.counts.conflicts > 0 ||
+    (fleetConfirmationRequired && fleetConfirmation.trim().toLowerCase() !== 'upgrade');
+
   const schedule = useMutation(
     trpc.admin.kiloclawInstances.scheduleAction.mutationOptions({
       onSuccess: () => {
         void queryClient.invalidateQueries({
           queryKey: trpc.admin.kiloclawInstances.listScheduledActions.queryKey(),
         });
+      },
+    })
+  );
+
+  const createFleet = useMutation(
+    trpc.admin.kiloclawInstances.createFleetUpgrade.mutationOptions({
+      onSuccess: data => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.admin.kiloclawInstances.listScheduledActions.queryKey(),
+        });
+        setViewingActionId(data.id);
+        setFleetConfirmation('');
+        toast.success('Fleet upgrade scheduled');
+      },
+      onError: error => {
+        toast.error(error.message || 'Failed to schedule fleet upgrade');
       },
     })
   );
@@ -238,6 +323,44 @@ export function KiloclawSchedulerTab() {
         },
       }
     );
+  };
+
+  const buildFleetInput = () => ({
+    versionBelow: fleetVersionBelow,
+    targetImageTag: fleetTargetImageTag,
+    overridePins: fleetOverridePins,
+    startsAt: new Date(fleetStartsAt).toISOString(),
+    tranchePercent: fleetTranchePercent,
+    intervalDays: fleetIntervalDays,
+    reason: fleetReason.trim() || undefined,
+    notify: fleetNotify.notify,
+    noticeLeadHours: fleetNotify.noticeLeadHours,
+    noticeSubject: fleetNotify.noticeSubject,
+    noticeBody: fleetNotify.noticeBody,
+    noticeChannels: fleetNotify.noticeChannels,
+  });
+
+  const onPreviewFleet = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const input = buildFleetInput();
+    setIsFleetPreviewing(true);
+    setFleetPreviewError(null);
+    try {
+      const data = await queryClient.fetchQuery(
+        trpc.admin.kiloclawInstances.previewFleetUpgrade.queryOptions(input)
+      );
+      setFleetPreview({ key: fleetFormKey, data });
+      setFleetConfirmation('');
+    } catch (err) {
+      setFleetPreview(null);
+      setFleetPreviewError(err instanceof Error ? err.message : 'Failed to preview fleet upgrade');
+    } finally {
+      setIsFleetPreviewing(false);
+    }
+  };
+
+  const onCreateFleet = () => {
+    createFleet.mutate(buildFleetInput());
   };
 
   return (
@@ -400,6 +523,211 @@ export function KiloclawSchedulerTab() {
                 {schedule.isPending ? 'Scheduling…' : 'Schedule version change'}
               </Button>
             </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Fleet upgrade</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={onPreviewFleet} className="flex flex-col gap-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+              <div className="space-y-2">
+                <Label htmlFor="fleet-version-below">Current version below</Label>
+                <Select value={fleetVersionBelow} onValueChange={setFleetVersionBelow}>
+                  <SelectTrigger id="fleet-version-below">
+                    <SelectValue placeholder="Select cutoff…" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Array.from(
+                      new Set((versions.data?.items ?? []).map(version => version.openclaw_version))
+                    ).map(version => (
+                      <SelectItem key={version} value={version}>
+                        {version}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="fleet-target-image-tag">Target version</Label>
+                <Select value={fleetTargetImageTag} onValueChange={setFleetTargetImageTag}>
+                  <SelectTrigger id="fleet-target-image-tag">
+                    <SelectValue placeholder="Select target…" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(versions.data?.items ?? []).map(v => (
+                      <SelectItem key={v.image_tag} value={v.image_tag}>
+                        <span>
+                          <span className="font-medium">{v.openclaw_version}</span>
+                          <span className="text-muted-foreground ml-2 font-mono text-xs">
+                            {v.image_tag}
+                          </span>
+                          {v.is_latest ? (
+                            <span className="text-muted-foreground ml-2 text-xs">(latest)</span>
+                          ) : null}
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="fleet-starts-at">Start at (local time)</Label>
+                <Input
+                  id="fleet-starts-at"
+                  type="datetime-local"
+                  value={fleetStartsAt}
+                  onChange={e => setFleetStartsAt(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="fleet-tranche-percent">Tranche size percent</Label>
+                <Input
+                  id="fleet-tranche-percent"
+                  type="number"
+                  min={1}
+                  max={100}
+                  step={1}
+                  value={fleetTranchePercent}
+                  onChange={e =>
+                    setFleetTranchePercent(Math.max(1, Math.min(100, Number(e.target.value) || 1)))
+                  }
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="fleet-interval-days">Every N days</Label>
+                <Input
+                  id="fleet-interval-days"
+                  type="number"
+                  min={1}
+                  max={30}
+                  step={1}
+                  value={fleetIntervalDays}
+                  onChange={e =>
+                    setFleetIntervalDays(Math.max(1, Math.min(30, Number(e.target.value) || 1)))
+                  }
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="fleet-reason">Reason (optional)</Label>
+                <Input
+                  id="fleet-reason"
+                  value={fleetReason}
+                  onChange={e => setFleetReason(e.target.value)}
+                  maxLength={256}
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="fleet-override-pins"
+                checked={fleetOverridePins}
+                onCheckedChange={checked => setFleetOverridePins(checked === true)}
+              />
+              <Label htmlFor="fleet-override-pins" className="cursor-pointer text-sm font-normal">
+                Override existing pins at apply time
+              </Label>
+            </div>
+
+            <ScheduleNotifyFields
+              idPrefix="fleet"
+              state={fleetNotify}
+              onChange={setFleetNotify}
+              disabled={isFleetPreviewing || createFleet.isPending}
+            />
+
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="submit"
+                variant="outline"
+                disabled={
+                  isFleetPreviewing ||
+                  createFleet.isPending ||
+                  !fleetVersionBelow ||
+                  !fleetTargetImageTag
+                }
+              >
+                {isFleetPreviewing ? 'Previewing…' : 'Preview fleet'}
+              </Button>
+              <Button
+                type="button"
+                onClick={onCreateFleet}
+                disabled={fleetCreateDisabled || createFleet.isPending}
+              >
+                {createFleet.isPending ? 'Scheduling…' : 'Schedule fleet upgrade'}
+              </Button>
+            </div>
+
+            {fleetPreviewError && (
+              <Alert variant="destructive">
+                <AlertTitle>Fleet preview failed</AlertTitle>
+                <AlertDescription>{fleetPreviewError}</AlertDescription>
+              </Alert>
+            )}
+
+            {currentFleetPreview && (
+              <div className="space-y-3 rounded-md border border-border/50 bg-muted/20 p-3">
+                <div className="grid grid-cols-2 gap-3 text-sm md:grid-cols-6">
+                  <FleetPreviewStat
+                    label="Actionable"
+                    value={currentFleetPreview.counts.actionable}
+                  />
+                  <FleetPreviewStat label="Eligible" value={currentFleetPreview.counts.eligible} />
+                  <FleetPreviewStat label="Pinned" value={currentFleetPreview.counts.pinned} />
+                  <FleetPreviewStat
+                    label="Conflicts"
+                    value={currentFleetPreview.counts.conflicts}
+                  />
+                  <FleetPreviewStat
+                    label="Already target"
+                    value={currentFleetPreview.counts.alreadyOnTarget}
+                  />
+                  <FleetPreviewStat
+                    label="Unknown"
+                    value={currentFleetPreview.counts.unknownVersion}
+                  />
+                </div>
+                {currentFleetPreview.stages.length > 0 ? (
+                  <div className="text-muted-foreground text-xs">
+                    {currentFleetPreview.stages.length} tranche
+                    {currentFleetPreview.stages.length === 1 ? '' : 's'} from{' '}
+                    {new Date(currentFleetPreview.stages[0].scheduledAt).toLocaleString()} to{' '}
+                    {new Date(
+                      currentFleetPreview.stages[currentFleetPreview.stages.length - 1].scheduledAt
+                    ).toLocaleString()}
+                  </div>
+                ) : (
+                  <div className="text-muted-foreground text-xs">
+                    No actionable targets match the selected filters.
+                  </div>
+                )}
+                {currentFleetPreview.counts.conflicts > 0 && (
+                  <p className="text-xs text-yellow-400">
+                    Cancel conflicting scheduled actions before creating this fleet upgrade.
+                  </p>
+                )}
+                {fleetConfirmationRequired && (
+                  <div className="max-w-sm space-y-1">
+                    <Label htmlFor="fleet-confirmation" className="text-xs">
+                      Type upgrade to confirm
+                    </Label>
+                    <Input
+                      id="fleet-confirmation"
+                      value={fleetConfirmation}
+                      onChange={e => setFleetConfirmation(e.target.value)}
+                      disabled={createFleet.isPending}
+                    />
+                  </div>
+                )}
+              </div>
+            )}
           </form>
         </CardContent>
       </Card>
@@ -586,7 +914,15 @@ export function KiloclawSchedulerTab() {
                         }
                       >
                         {action.scheduled_at ? (
-                          <span>{new Date(action.scheduled_at).toLocaleString()}</span>
+                          <span className="flex flex-col">
+                            <span>{new Date(action.scheduled_at).toLocaleString()}</span>
+                            {action.stage_count > 1 && action.latest_scheduled_at ? (
+                              <span className="text-muted-foreground">
+                                {action.stage_count} tranches, last{' '}
+                                {new Date(action.latest_scheduled_at).toLocaleString()}
+                              </span>
+                            ) : null}
+                          </span>
                         ) : (
                           <span>—</span>
                         )}
@@ -693,11 +1029,33 @@ export function KiloclawSchedulerTab() {
                 </div>
               </div>
 
+              {detail.data.stages.length > 1 && (
+                <div className="rounded-md border p-3 text-xs">
+                  <div className="mb-2 text-sm font-medium">Tranches</div>
+                  <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                    {detail.data.stages.map(stage => (
+                      <div
+                        key={stage.id}
+                        className="flex items-center justify-between gap-3 rounded-md bg-muted/30 px-2 py-1.5"
+                      >
+                        <span className="text-muted-foreground">
+                          Tranche {stage.stage_index + 1}
+                        </span>
+                        <span className="font-mono">
+                          {new Date(stage.scheduled_at).toLocaleString()}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
               <div className="text-sm font-medium">Targets ({detail.data.targets.length})</div>
               <div className="rounded-lg border">
                 <Table>
                   <TableHeader>
                     <TableRow>
+                      <TableHead>Tranche</TableHead>
                       <TableHead>Instance</TableHead>
                       <TableHead>User</TableHead>
                       <TableHead>From → To</TableHead>
@@ -706,51 +1064,60 @@ export function KiloclawSchedulerTab() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {detail.data.targets.map(t => (
-                      <TableRow key={t.id}>
-                        <TableCell className="font-mono text-xs">
-                          {t.instance_sandbox_id ? (
-                            <span title={t.instance_id}>{t.instance_sandbox_id}</span>
-                          ) : (
-                            <span title={t.instance_id}>{t.instance_id}</span>
-                          )}
-                        </TableCell>
-                        <TableCell className="text-xs">
-                          <span className="text-muted-foreground">{t.user_email ?? t.user_id}</span>
-                        </TableCell>
-                        <TableCell className="font-mono text-xs">
-                          {t.target_image_tag ? (
-                            <span>
+                    {[...detail.data.targets]
+                      .sort((a, b) => (a.stage_index ?? 0) - (b.stage_index ?? 0))
+                      .map(t => (
+                        <TableRow key={t.id}>
+                          <TableCell className="text-muted-foreground font-mono text-xs">
+                            {t.stage_index === null || t.stage_index === undefined
+                              ? '—'
+                              : t.stage_index + 1}
+                          </TableCell>
+                          <TableCell className="font-mono text-xs">
+                            {t.instance_sandbox_id ? (
+                              <span title={t.instance_id}>{t.instance_sandbox_id}</span>
+                            ) : (
+                              <span title={t.instance_id}>{t.instance_id}</span>
+                            )}
+                          </TableCell>
+                          <TableCell className="text-xs">
+                            <span className="text-muted-foreground">
+                              {t.user_email ?? t.user_id}
+                            </span>
+                          </TableCell>
+                          <TableCell className="font-mono text-xs">
+                            {t.target_image_tag ? (
+                              <span>
+                                <span className="text-muted-foreground">
+                                  {t.source_image_tag ?? '—'}
+                                </span>
+                                <span className="text-muted-foreground mx-1">→</span>
+                                <span>{t.target_image_tag}</span>
+                              </span>
+                            ) : (
+                              // scheduled_restart targets have no target tag.
                               <span className="text-muted-foreground">
                                 {t.source_image_tag ?? '—'}
                               </span>
-                              <span className="text-muted-foreground mx-1">→</span>
-                              <span>{t.target_image_tag}</span>
-                            </span>
-                          ) : (
-                            // scheduled_restart targets have no target tag.
-                            <span className="text-muted-foreground">
-                              {t.source_image_tag ?? '—'}
-                            </span>
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          <Badge variant="outline" className={statusBadgeClass[t.status] ?? ''}>
-                            {t.status}
-                          </Badge>
-                        </TableCell>
-                        <TableCell className="text-muted-foreground text-xs">
-                          {t.skip_reason && <span>skip: {t.skip_reason}</span>}
-                          {t.error_message && (
-                            <span className="text-red-400" title={t.error_message}>
-                              {t.error_message.length > 80
-                                ? t.error_message.slice(0, 80) + '…'
-                                : t.error_message}
-                            </span>
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    ))}
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant="outline" className={statusBadgeClass[t.status] ?? ''}>
+                              {t.status}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-muted-foreground text-xs">
+                            {t.skip_reason && <span>skip: {t.skip_reason}</span>}
+                            {t.error_message && (
+                              <span className="text-red-400" title={t.error_message}>
+                                {t.error_message.length > 80
+                                  ? t.error_message.slice(0, 80) + '…'
+                                  : t.error_message}
+                              </span>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      ))}
                   </TableBody>
                 </Table>
               </div>
@@ -758,6 +1125,15 @@ export function KiloclawSchedulerTab() {
           )}
         </DialogContent>
       </Dialog>
+    </div>
+  );
+}
+
+function FleetPreviewStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <div className="text-muted-foreground text-xs">{label}</div>
+      <div className="font-mono text-sm tabular-nums">{value}</div>
     </div>
   );
 }

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -29,6 +29,7 @@ const mockCancelKiloCliRun: jest.Mock<any, any> = jest.fn();
 const mockStartKiloCliRun: jest.Mock<any, any> = jest.fn();
 const mockStart: jest.Mock<any, any> = jest.fn();
 const mockUserClientRestartMachine: jest.Mock<any, any> = jest.fn();
+const mockWakeScheduledAction: jest.Mock<any, any> = jest.fn();
 const startedResponse = {
   ok: true,
   started: true,
@@ -46,6 +47,7 @@ function mockKiloClawInternalClient() {
     cancelKiloCliRun: mockCancelKiloCliRun,
     startKiloCliRun: mockStartKiloCliRun,
     start: mockStart,
+    wakeScheduledAction: mockWakeScheduledAction,
   }));
 }
 
@@ -57,6 +59,7 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => ({
     cancelKiloCliRun: mockCancelKiloCliRun,
     startKiloCliRun: mockStartKiloCliRun,
     start: mockStart,
+    wakeScheduledAction: mockWakeScheduledAction,
   })),
   KiloClawApiError: class KiloClawApiError extends Error {
     statusCode: number;
@@ -160,6 +163,8 @@ beforeEach(async () => {
   mockStart.mockResolvedValue(startedResponse);
   mockUserClientRestartMachine.mockReset();
   mockUserClientRestartMachine.mockResolvedValue({ success: true, message: 'restarting' });
+  mockWakeScheduledAction.mockReset();
+  mockWakeScheduledAction.mockResolvedValue({ ok: true });
   mockKiloClawInternalClient();
 });
 
@@ -1869,6 +1874,58 @@ describe('admin.kiloclawInstances.bulkChangeVersion', () => {
 
 describe('admin.kiloclawInstances scheduled actions', () => {
   let testInstanceId: string;
+  const fleetCatalogTags: string[] = [];
+
+  async function insertFleetCatalogEntry(params: {
+    openclawVersion: string;
+    imageTag?: string;
+    status?: 'available' | 'disabled';
+  }) {
+    const imageTag = params.imageTag ?? `fleet-test-${crypto.randomUUID()}`;
+    fleetCatalogTags.push(imageTag);
+    await db.insert(kiloclaw_image_catalog).values({
+      openclaw_version: params.openclawVersion,
+      variant: 'default',
+      image_tag: imageTag,
+      image_digest: `sha256:${crypto.randomUUID()}`,
+      status: params.status ?? 'available',
+      published_at: new Date().toISOString(),
+    });
+    return imageTag;
+  }
+
+  async function insertFleetInstance(params: {
+    trackedImageTag: string | null;
+    userId?: string;
+    pinned?: boolean;
+    inactiveTrialStopped?: boolean;
+    suspended?: boolean;
+  }) {
+    const instanceId = crypto.randomUUID();
+    const userId = params.userId ?? regularUser.id;
+    await db.insert(kiloclaw_instances).values({
+      id: instanceId,
+      user_id: userId,
+      sandbox_id: `ki_${instanceId.replace(/-/g, '')}`,
+      tracked_image_tag: params.trackedImageTag,
+      inactive_trial_stopped_at: params.inactiveTrialStopped ? '2026-04-20T12:00:00.000Z' : null,
+    });
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: userId,
+      instance_id: instanceId,
+      plan: 'trial',
+      status: 'trialing',
+      suspended_at: params.suspended ? '2026-04-20T12:00:00.000Z' : null,
+    });
+    if (params.pinned && params.trackedImageTag) {
+      await db.insert(kiloclaw_version_pins).values({
+        instance_id: instanceId,
+        image_tag: params.trackedImageTag,
+        pinned_by: userId,
+      });
+    }
+    return instanceId;
+  }
 
   beforeEach(async () => {
     const [instance] = await db
@@ -1904,6 +1961,15 @@ describe('admin.kiloclawInstances scheduled actions', () => {
       await db
         .delete(kiloclaw_scheduled_actions)
         .where(inArray(kiloclaw_scheduled_actions.id, ids));
+    }
+    if (fleetCatalogTags.length > 0) {
+      await db
+        .delete(kiloclaw_version_pins)
+        .where(inArray(kiloclaw_version_pins.image_tag, [...fleetCatalogTags]));
+      await db
+        .delete(kiloclaw_image_catalog)
+        .where(inArray(kiloclaw_image_catalog.image_tag, [...fleetCatalogTags]));
+      fleetCatalogTags.length = 0;
     }
     await db.delete(kiloclaw_instances).where(eq(kiloclaw_instances.id, testInstanceId));
     /* eslint-enable drizzle/enforce-delete-with-where */
@@ -2354,6 +2420,213 @@ describe('admin.kiloclawInstances scheduled actions', () => {
       expect(detail.stages).toHaveLength(1);
       expect(detail.targets).toHaveLength(1);
       expect(detail.targets[0].instance_id).toBe(testInstanceId);
+    });
+  });
+
+  describe('fleet upgrade', () => {
+    it('throws FORBIDDEN for non-admin preview callers', async () => {
+      const targetTag = await insertFleetCatalogEntry({ openclawVersion: '2026.2.10' });
+      const caller = await createCallerForUser(regularUser.id);
+
+      await expect(
+        caller.admin.kiloclawInstances.previewFleetUpgrade({
+          versionBelow: '2026.2.10',
+          targetImageTag: targetTag,
+          overridePins: false,
+          startsAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+          tranchePercent: 50,
+          intervalDays: 2,
+          notify: false,
+        })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+
+    it('previews eligibility buckets with numeric CalVer comparison', async () => {
+      const oldTag = await insertFleetCatalogEntry({ openclawVersion: '2026.2.9' });
+      const newerTag = await insertFleetCatalogEntry({ openclawVersion: '2026.2.10' });
+      const targetTag = await insertFleetCatalogEntry({ openclawVersion: '2026.3.1' });
+      const unknownTag = `fleet-missing-${crypto.randomUUID()}`;
+
+      const actionableId = await insertFleetInstance({ trackedImageTag: oldTag });
+      const pinnedId = await insertFleetInstance({ trackedImageTag: oldTag, pinned: true });
+      const conflictId = await insertFleetInstance({ trackedImageTag: oldTag });
+      await insertFleetInstance({ trackedImageTag: newerTag });
+      await insertFleetInstance({ trackedImageTag: targetTag });
+      await insertFleetInstance({ trackedImageTag: unknownTag });
+      await insertFleetInstance({ trackedImageTag: null });
+
+      const caller = await createCallerForUser(adminUser.id);
+      await caller.admin.kiloclawInstances.scheduleAction({
+        actionType: 'scheduled_restart',
+        instanceIds: [conflictId],
+        scheduledAt: new Date(Date.now() + 90 * 60_000).toISOString(),
+        notify: false,
+      });
+
+      const preview = await caller.admin.kiloclawInstances.previewFleetUpgrade({
+        versionBelow: '2026.2.10',
+        targetImageTag: targetTag,
+        overridePins: false,
+        startsAt: new Date(Date.now() + 120 * 60_000).toISOString(),
+        tranchePercent: 50,
+        intervalDays: 2,
+        notify: false,
+      });
+
+      expect(preview.counts).toMatchObject({
+        eligible: 3,
+        actionable: 1,
+        pinned: 1,
+        conflicts: 1,
+        alreadyOnTarget: 1,
+        unknownVersion: 2,
+      });
+      expect(preview.actionableInstanceIds).toEqual([actionableId]);
+      expect(preview.excluded.pinnedInstanceIds).toEqual([pinnedId]);
+      expect(preview.excluded.conflictInstanceIds).toEqual([conflictId]);
+      expect(preview.stages).toHaveLength(1);
+      expect(preview.stages[0]).toMatchObject({ stageIndex: 0, targetCount: 1 });
+    });
+
+    it('creates one version-change parent split across deterministic stages', async () => {
+      const oldTag = await insertFleetCatalogEntry({ openclawVersion: '2026.2.1' });
+      const targetTag = await insertFleetCatalogEntry({ openclawVersion: '2026.3.1' });
+      const instanceIds = await Promise.all(
+        Array.from({ length: 5 }, () => insertFleetInstance({ trackedImageTag: oldTag }))
+      );
+      const startsAt = new Date(Date.now() + 120 * 60_000).toISOString();
+
+      const caller = await createCallerForUser(adminUser.id);
+      const created = await caller.admin.kiloclawInstances.createFleetUpgrade({
+        versionBelow: '2026.2.10',
+        targetImageTag: targetTag,
+        overridePins: true,
+        startsAt,
+        tranchePercent: 40,
+        intervalDays: 3,
+        reason: 'fleet rollout test',
+        notify: true,
+        noticeLeadHours: 12,
+        noticeSubject: 'Maintenance window',
+        noticeBody: 'A version update is scheduled.',
+        noticeChannels: ['email', 'webapp'],
+      });
+
+      expect(created.targetCount).toBe(5);
+      expect(created.stageIds).toHaveLength(3);
+
+      const [parent] = await db
+        .select()
+        .from(kiloclaw_scheduled_actions)
+        .where(eq(kiloclaw_scheduled_actions.id, created.id));
+      expect(parent).toMatchObject({
+        action_type: 'version_change',
+        target_image_tag: targetTag,
+        override_pins: true,
+        reason: 'fleet rollout test',
+        total_count: 5,
+        notice_lead_hours: 12,
+        notice_subject: 'Maintenance window',
+        notice_body: 'A version update is scheduled.',
+      });
+
+      const stages = await db
+        .select()
+        .from(kiloclaw_scheduled_action_stages)
+        .where(eq(kiloclaw_scheduled_action_stages.scheduled_action_id, created.id));
+      expect(stages.map(s => s.stage_index).sort()).toEqual([0, 1, 2]);
+      expect(stages.map(s => new Date(s.scheduled_at).toISOString()).sort()).toEqual([
+        new Date(startsAt).toISOString(),
+        new Date(new Date(startsAt).getTime() + 3 * 86_400_000).toISOString(),
+        new Date(new Date(startsAt).getTime() + 6 * 86_400_000).toISOString(),
+      ]);
+
+      const targets = await db
+        .select()
+        .from(kiloclaw_scheduled_action_targets)
+        .where(eq(kiloclaw_scheduled_action_targets.scheduled_action_id, created.id));
+      expect(targets).toHaveLength(5);
+      expect(new Set(targets.map(t => t.instance_id))).toEqual(new Set(instanceIds));
+      expect(new Set(targets.map(t => t.target_image_tag))).toEqual(new Set([targetTag]));
+
+      const stageSizes = new Map(stages.map(stage => [stage.id, 0]));
+      for (const target of targets) {
+        stageSizes.set(target.stage_id ?? '', (stageSizes.get(target.stage_id ?? '') ?? 0) + 1);
+      }
+      expect(Array.from(stageSizes.values()).sort()).toEqual([1, 2, 2]);
+
+      const notices = await db
+        .select()
+        .from(kiloclaw_scheduled_action_notifications)
+        .innerJoin(
+          kiloclaw_scheduled_action_targets,
+          eq(
+            kiloclaw_scheduled_action_targets.id,
+            kiloclaw_scheduled_action_notifications.target_id
+          )
+        )
+        .where(eq(kiloclaw_scheduled_action_targets.scheduled_action_id, created.id));
+      expect(notices).toHaveLength(10);
+
+      const logs = await db
+        .select()
+        .from(kiloclaw_admin_audit_logs)
+        .where(
+          and(
+            eq(kiloclaw_admin_audit_logs.actor_id, adminUser.id),
+            eq(kiloclaw_admin_audit_logs.action, 'kiloclaw.fleet_upgrade.created')
+          )
+        );
+      expect(logs).toHaveLength(1);
+      expect(logs[0].metadata).toMatchObject({
+        scheduledActionId: created.id,
+        versionBelow: '2026.2.10',
+        targetImageTag: targetTag,
+        tranchePercent: 40,
+        intervalDays: 3,
+        targetCount: 5,
+        stageSizes: [2, 2, 1],
+      });
+
+      const list = await caller.admin.kiloclawInstances.listScheduledActions({});
+      const row = list.items.find(item => item.id === created.id);
+      expect(row).toMatchObject({
+        target_count: 5,
+        stage_count: 3,
+        latest_scheduled_at: expect.any(String),
+      });
+
+      const detail = await caller.admin.kiloclawInstances.getScheduledAction({ id: created.id });
+      expect(detail.stages).toHaveLength(3);
+      expect(detail.targets.map(target => target.stage_index).sort()).toEqual([0, 0, 1, 1, 2]);
+    });
+
+    it('rejects create when an actionable target has a pending scheduled action', async () => {
+      const oldTag = await insertFleetCatalogEntry({ openclawVersion: '2026.2.1' });
+      const targetTag = await insertFleetCatalogEntry({ openclawVersion: '2026.3.1' });
+      const instanceId = await insertFleetInstance({ trackedImageTag: oldTag });
+      const caller = await createCallerForUser(adminUser.id);
+      await caller.admin.kiloclawInstances.scheduleAction({
+        actionType: 'scheduled_restart',
+        instanceIds: [instanceId],
+        scheduledAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+        notify: false,
+      });
+
+      await expect(
+        caller.admin.kiloclawInstances.createFleetUpgrade({
+          versionBelow: '2026.2.10',
+          targetImageTag: targetTag,
+          overridePins: false,
+          startsAt: new Date(Date.now() + 120 * 60_000).toISOString(),
+          tranchePercent: 50,
+          intervalDays: 2,
+          notify: false,
+        })
+      ).rejects.toMatchObject({
+        code: 'CONFLICT',
+        message: expect.stringContaining('pending or in-flight scheduled actions'),
+      });
     });
   });
 

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -732,9 +732,9 @@ async function getFleetUpgradePlan(input: z.infer<typeof FleetUpgradeFilterSchem
   ].join('|');
   const actionableRows = preConflictRows
     .filter(row => !conflictIdSet.has(row.instance.id))
-    .sort((a, b) =>
-      fleetSortKey(seed, a.instance.id).localeCompare(fleetSortKey(seed, b.instance.id))
-    );
+    .map(row => ({ row, sortKey: fleetSortKey(seed, row.instance.id) }))
+    .sort((a, b) => a.sortKey.localeCompare(b.sortKey))
+    .map(({ row }) => row);
   const stages = buildFleetStagePlan({
     targetCount: actionableRows.length,
     startsAt: input.startsAt,

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -1,6 +1,7 @@
 import { adminProcedure, createTRPCRouter, UpstreamApiError } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
 import { insertKiloClawSubscriptionChangeLog } from '@kilocode/db';
+import { createHash } from 'crypto';
 import {
   kiloclaw_instances,
   kiloclaw_subscriptions,
@@ -74,6 +75,7 @@ import {
 
 const initiatingAdminUsers = alias(kilocode_users, 'initiating_admin_users');
 const pinnedByUsers = alias(kilocode_users, 'pinned_by_users');
+const fleetSourceCatalog = alias(kiloclaw_image_catalog, 'fleet_source_catalog');
 
 /**
  * Validate the JSONB `admin_size_override` column via the shared Zod
@@ -151,6 +153,37 @@ const GatewayProcessSchema = z.object({
 
 const StatsSchema = z.object({
   days: z.number().min(1).max(365).default(30),
+});
+
+const NoticeConfigSchema = z.object({
+  notify: z.boolean().default(true),
+  noticeLeadHours: z.number().int().min(0).max(168).default(24),
+  noticeSubject: z.string().max(120).default(''),
+  noticeBody: z.string().max(2000).default(''),
+  noticeChannels: z
+    .array(z.enum(['email', 'webapp', 'mobile_push']))
+    .min(1)
+    .default(['email', 'webapp', 'mobile_push']),
+});
+
+const ImageTagSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/);
+
+const CalVerSchema = z
+  .string()
+  .regex(/^\d{4}\.\d{1,2}\.\d{1,2}$/, 'Version must use YYYY.M.D format');
+
+const FleetUpgradeFilterSchema = NoticeConfigSchema.extend({
+  versionBelow: CalVerSchema,
+  targetImageTag: ImageTagSchema,
+  overridePins: z.boolean().default(false),
+  startsAt: z.string().datetime(),
+  tranchePercent: z.number().int().min(1).max(100),
+  intervalDays: z.number().int().min(1).max(30),
+  reason: z.string().max(256).optional(),
 });
 
 type KiloclawTrpcCode =
@@ -404,6 +437,331 @@ export type AdminKiloclawInstanceDetail = AdminKiloclawInstance & {
   workerStatus: PlatformDebugStatusResponse | null;
   workerStatusError: string | null;
 };
+
+type NoticeChannel = z.infer<typeof NoticeConfigSchema>['noticeChannels'][number];
+type ScheduledActionType = 'scheduled_restart' | 'version_change';
+type ScheduledActionInstanceRow = {
+  instance: typeof kiloclaw_instances.$inferSelect;
+  owner_id: string;
+};
+type ScheduledActionTargetRow = ScheduledActionInstanceRow & {
+  stageIndex: number;
+};
+type ScheduledActionStageInput = {
+  stageIndex: number;
+  scheduledAt: string;
+};
+
+function assertScheduledTimeInFuture(value: string, fieldName: string) {
+  const scheduledAtMs = new Date(value).getTime();
+  if (Number.isNaN(scheduledAtMs) || scheduledAtMs - Date.now() < 60_000) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `${fieldName} must be at least 1 minute in the future`,
+    });
+  }
+}
+
+async function validateAvailableImageTag(imageTag: string) {
+  const [catalogEntry] = await db
+    .select({
+      image_tag: kiloclaw_image_catalog.image_tag,
+      status: kiloclaw_image_catalog.status,
+    })
+    .from(kiloclaw_image_catalog)
+    .where(eq(kiloclaw_image_catalog.image_tag, imageTag))
+    .limit(1);
+
+  if (!catalogEntry) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `Target image tag not found in catalog: ${imageTag}`,
+    });
+  }
+  if (catalogEntry.status === 'disabled') {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `Target image tag is disabled: ${imageTag}`,
+    });
+  }
+}
+
+async function findPendingScheduledActionConflicts(instanceIds: string[]) {
+  if (instanceIds.length === 0) return [];
+  const existingPending = await db
+    .select({
+      instance_id: kiloclaw_scheduled_action_targets.instance_id,
+      scheduled_action_id: kiloclaw_scheduled_action_targets.scheduled_action_id,
+    })
+    .from(kiloclaw_scheduled_action_targets)
+    .innerJoin(
+      kiloclaw_scheduled_actions,
+      eq(kiloclaw_scheduled_actions.id, kiloclaw_scheduled_action_targets.scheduled_action_id)
+    )
+    .where(
+      and(
+        inArray(kiloclaw_scheduled_action_targets.instance_id, instanceIds),
+        inArray(kiloclaw_scheduled_action_targets.status, ['pending', 'running']),
+        inArray(kiloclaw_scheduled_actions.status, ['scheduled', 'running'])
+      )
+    );
+  return Array.from(new Set(existingPending.map(e => e.instance_id)));
+}
+
+async function createScheduledActionRows(params: {
+  actionType: ScheduledActionType;
+  targetImageTag: string | null;
+  overridePins: boolean;
+  noticeLeadHours: number;
+  noticeSubject: string;
+  noticeBody: string;
+  reason: string | null;
+  createdBy: string;
+  stages: ScheduledActionStageInput[];
+  targets: ScheduledActionTargetRow[];
+  notify: boolean;
+  noticeChannels: NoticeChannel[];
+}) {
+  const liveInstanceIds = Array.from(new Set(params.targets.map(row => row.instance.id)));
+  if (liveInstanceIds.length === 0) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'No target instances to schedule',
+    });
+  }
+
+  return db.transaction(
+    async tx => {
+      const existingPending = await tx
+        .select({
+          instance_id: kiloclaw_scheduled_action_targets.instance_id,
+          scheduled_action_id: kiloclaw_scheduled_action_targets.scheduled_action_id,
+        })
+        .from(kiloclaw_scheduled_action_targets)
+        .innerJoin(
+          kiloclaw_scheduled_actions,
+          eq(kiloclaw_scheduled_actions.id, kiloclaw_scheduled_action_targets.scheduled_action_id)
+        )
+        .where(
+          and(
+            inArray(kiloclaw_scheduled_action_targets.instance_id, liveInstanceIds),
+            inArray(kiloclaw_scheduled_action_targets.status, ['pending', 'running']),
+            inArray(kiloclaw_scheduled_actions.status, ['scheduled', 'running'])
+          )
+        );
+
+      if (existingPending.length > 0) {
+        const conflictIds = Array.from(new Set(existingPending.map(e => e.instance_id)));
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message:
+            conflictIds.length === 1
+              ? `Instance ${conflictIds[0]} already has a pending or in-flight scheduled action; cancel it first`
+              : `${conflictIds.length} instances already have pending or in-flight scheduled actions; cancel those first: ${conflictIds.join(', ')}`,
+        });
+      }
+
+      const [parentRow] = await tx
+        .insert(kiloclaw_scheduled_actions)
+        .values({
+          action_type: params.actionType,
+          target_image_tag: params.targetImageTag,
+          override_pins: params.overridePins,
+          notice_lead_hours: params.noticeLeadHours,
+          notice_subject: params.noticeSubject,
+          notice_body: params.noticeBody,
+          reason: params.reason,
+          status: 'scheduled',
+          created_by: params.createdBy,
+          total_count: liveInstanceIds.length,
+        })
+        .returning({ id: kiloclaw_scheduled_actions.id });
+
+      const stageRows = await tx
+        .insert(kiloclaw_scheduled_action_stages)
+        .values(
+          params.stages.map(stage => ({
+            scheduled_action_id: parentRow.id,
+            stage_index: stage.stageIndex,
+            scheduled_at: stage.scheduledAt,
+            status: 'pending' as const,
+          }))
+        )
+        .returning({
+          id: kiloclaw_scheduled_action_stages.id,
+          stage_index: kiloclaw_scheduled_action_stages.stage_index,
+        });
+
+      const stageIdByIndex = new Map(stageRows.map(stage => [stage.stage_index, stage.id]));
+
+      const insertedTargets = await tx
+        .insert(kiloclaw_scheduled_action_targets)
+        .values(
+          params.targets.map(row => {
+            const stageId = stageIdByIndex.get(row.stageIndex);
+            if (!stageId) throw new Error(`Missing stage id for stage ${row.stageIndex}`);
+            return {
+              scheduled_action_id: parentRow.id,
+              stage_id: stageId,
+              instance_id: row.instance.id,
+              source_image_tag: row.instance.tracked_image_tag,
+              target_image_tag: params.targetImageTag,
+              user_id: row.owner_id,
+              status: 'pending' as const,
+            };
+          })
+        )
+        .returning({
+          id: kiloclaw_scheduled_action_targets.id,
+          instance_id: kiloclaw_scheduled_action_targets.instance_id,
+        });
+
+      if (params.notify && params.noticeChannels.length > 0) {
+        const notificationRows: NewKiloClawScheduledActionNotification[] = [];
+        for (const target of insertedTargets) {
+          for (const channel of params.noticeChannels) {
+            notificationRows.push({
+              target_id: target.id,
+              channel,
+              kind: 'notice',
+              status: 'pending',
+            });
+          }
+        }
+        await tx.insert(kiloclaw_scheduled_action_notifications).values(notificationRows);
+      }
+
+      return {
+        id: parentRow.id,
+        stageIds: stageRows.sort((a, b) => a.stage_index - b.stage_index).map(stage => stage.id),
+        insertedTargets,
+      };
+    },
+    { isolationLevel: 'serializable' }
+  );
+}
+
+function buildFleetStagePlan(params: {
+  targetCount: number;
+  startsAt: string;
+  tranchePercent: number;
+  intervalDays: number;
+}) {
+  if (params.targetCount === 0) return [];
+  const trancheSize = Math.max(1, Math.ceil((params.targetCount * params.tranchePercent) / 100));
+  const startsAtMs = new Date(params.startsAt).getTime();
+  const stages: Array<{ stageIndex: number; scheduledAt: string; targetCount: number }> = [];
+  let remaining = params.targetCount;
+  let stageIndex = 0;
+  while (remaining > 0) {
+    const targetCount = Math.min(trancheSize, remaining);
+    stages.push({
+      stageIndex,
+      scheduledAt: new Date(
+        startsAtMs + stageIndex * params.intervalDays * 86_400_000
+      ).toISOString(),
+      targetCount,
+    });
+    remaining -= targetCount;
+    stageIndex += 1;
+  }
+  return stages;
+}
+
+function fleetSortKey(seed: string, instanceId: string) {
+  return createHash('sha256').update(`${seed}:${instanceId}`).digest('hex');
+}
+
+async function getFleetUpgradePlan(input: z.infer<typeof FleetUpgradeFilterSchema>) {
+  await validateAvailableImageTag(input.targetImageTag);
+
+  const rows = await db
+    .select({
+      instance: kiloclaw_instances,
+      owner_id: kilocode_users.id,
+      source_openclaw_version: fleetSourceCatalog.openclaw_version,
+      source_is_below_cutoff: sql<boolean | null>`
+        string_to_array(${fleetSourceCatalog.openclaw_version}, '.')::int[]
+        < string_to_array(${input.versionBelow}, '.')::int[]
+      `,
+      pin_id: kiloclaw_version_pins.id,
+    })
+    .from(kiloclaw_instances)
+    .innerJoin(kilocode_users, eq(kiloclaw_instances.user_id, kilocode_users.id))
+    .innerJoin(
+      kiloclaw_subscriptions,
+      eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id)
+    )
+    .leftJoin(
+      fleetSourceCatalog,
+      eq(kiloclaw_instances.tracked_image_tag, fleetSourceCatalog.image_tag)
+    )
+    .leftJoin(kiloclaw_version_pins, eq(kiloclaw_version_pins.instance_id, kiloclaw_instances.id))
+    .where(
+      and(
+        isNull(kiloclaw_instances.destroyed_at),
+        isNull(kiloclaw_instances.inactive_trial_stopped_at),
+        isNull(kiloclaw_subscriptions.suspended_at)
+      )
+    );
+
+  const unknownVersionRows = rows.filter(
+    row => !row.instance.tracked_image_tag || !row.source_openclaw_version
+  );
+  const alreadyOnTargetRows = rows.filter(
+    row => row.instance.tracked_image_tag === input.targetImageTag
+  );
+  const eligibleRows = rows.filter(
+    row =>
+      row.source_openclaw_version &&
+      row.source_is_below_cutoff === true &&
+      row.instance.tracked_image_tag !== input.targetImageTag
+  );
+  const pinnedRows = eligibleRows.filter(row => row.pin_id !== null);
+  const preConflictRows = eligibleRows.filter(row => input.overridePins || row.pin_id === null);
+  const conflictInstanceIds = await findPendingScheduledActionConflicts(
+    preConflictRows.map(row => row.instance.id)
+  );
+  const conflictIdSet = new Set(conflictInstanceIds);
+  const seed = [
+    input.versionBelow,
+    input.targetImageTag,
+    input.startsAt,
+    input.tranchePercent,
+    input.intervalDays,
+  ].join('|');
+  const actionableRows = preConflictRows
+    .filter(row => !conflictIdSet.has(row.instance.id))
+    .sort((a, b) =>
+      fleetSortKey(seed, a.instance.id).localeCompare(fleetSortKey(seed, b.instance.id))
+    );
+  const stages = buildFleetStagePlan({
+    targetCount: actionableRows.length,
+    startsAt: input.startsAt,
+    tranchePercent: input.tranchePercent,
+    intervalDays: input.intervalDays,
+  });
+
+  return {
+    counts: {
+      eligible: eligibleRows.length,
+      actionable: actionableRows.length,
+      pinned: pinnedRows.length,
+      conflicts: conflictInstanceIds.length,
+      alreadyOnTarget: alreadyOnTargetRows.length,
+      unknownVersion: unknownVersionRows.length,
+    },
+    stages,
+    actionableRows,
+    actionableInstanceIds: actionableRows.map(row => row.instance.id),
+    excluded: {
+      pinnedInstanceIds: pinnedRows.map(row => row.instance.id),
+      conflictInstanceIds,
+      alreadyOnTargetInstanceIds: alreadyOnTargetRows.map(row => row.instance.id),
+      unknownVersionInstanceIds: unknownVersionRows.map(row => row.instance.id),
+    },
+  };
+}
 
 export const adminKiloclawInstancesRouter = createTRPCRouter({
   get: adminProcedure.input(GetInstanceSchema).query(async ({ input }) => {
@@ -1822,39 +2180,13 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       // Validate scheduledAt > now() + 1 minute so admins can't
       // accidentally schedule something that fires immediately.
-      const scheduledAtMs = new Date(input.scheduledAt).getTime();
-      if (scheduledAtMs - Date.now() < 60_000) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'scheduledAt must be at least 1 minute in the future',
-        });
-      }
+      assertScheduledTimeInFuture(input.scheduledAt, 'scheduledAt');
 
       // For version_change, validate the target image tag matches the
       // catalog rules bulkChangeVersion uses (must exist + status='available').
       // We do this BEFORE inserting any rows so a bad tag fails fast.
       if (input.actionType === 'version_change') {
-        const [catalogEntry] = await db
-          .select({
-            image_tag: kiloclaw_image_catalog.image_tag,
-            status: kiloclaw_image_catalog.status,
-          })
-          .from(kiloclaw_image_catalog)
-          .where(eq(kiloclaw_image_catalog.image_tag, input.imageTag))
-          .limit(1);
-
-        if (!catalogEntry) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: `Target image tag not found in catalog: ${input.imageTag}`,
-          });
-        }
-        if (catalogEntry.status === 'disabled') {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: `Target image tag is disabled: ${input.imageTag}`,
-          });
-        }
+        await validateAvailableImageTag(input.imageTag);
       }
 
       // Dedupe instance ids — duplicate target rows would violate
@@ -1907,129 +2239,21 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       // schedule requests on the same instance can both observe "no
       // pending" outside any transaction and then both insert separate
       // scheduled actions, violating the one-pending-action-per-instance
-      // invariant. SSI in Postgres detects the conflict and aborts the
-      // losing tx with 40001; the admin retries (the click) and the
-      // second attempt sees the now-committed pending row and rejects
-      // with the normal CONFLICT message. We don't add an in-procedure
-      // retry loop — admin-initiated path, low contention, retry-by-
-      // clicking is fine.
-      const result = await db.transaction(
-        async tx => {
-          // Filter must include 'running' as well as 'pending'. The DO
-          // apply path flips the target to 'running' via
-          // claimScheduledActionTarget right before invoking the side
-          // effect; if a second schedule request lands during that
-          // window and we filter on 'pending' alone, we'd miss the
-          // in-flight target and create a duplicate parent action.
-          const existingPending = await tx
-            .select({
-              instance_id: kiloclaw_scheduled_action_targets.instance_id,
-              scheduled_action_id: kiloclaw_scheduled_action_targets.scheduled_action_id,
-            })
-            .from(kiloclaw_scheduled_action_targets)
-            .innerJoin(
-              kiloclaw_scheduled_actions,
-              eq(
-                kiloclaw_scheduled_actions.id,
-                kiloclaw_scheduled_action_targets.scheduled_action_id
-              )
-            )
-            .where(
-              and(
-                inArray(kiloclaw_scheduled_action_targets.instance_id, liveInstanceIds),
-                inArray(kiloclaw_scheduled_action_targets.status, ['pending', 'running']),
-                inArray(kiloclaw_scheduled_actions.status, ['scheduled', 'running'])
-              )
-            );
-
-          if (existingPending.length > 0) {
-            const conflictIds = Array.from(new Set(existingPending.map(e => e.instance_id)));
-            throw new TRPCError({
-              code: 'CONFLICT',
-              message:
-                conflictIds.length === 1
-                  ? `Instance ${conflictIds[0]} already has a pending or in-flight scheduled action; cancel it first`
-                  : `${conflictIds.length} instances already have pending or in-flight scheduled actions; cancel those first: ${conflictIds.join(', ')}`,
-            });
-          }
-
-          const [parentRow] = await tx
-            .insert(kiloclaw_scheduled_actions)
-            .values({
-              action_type: input.actionType,
-              target_image_tag: parentTargetImageTag,
-              override_pins: parentOverridePins,
-              notice_lead_hours: input.noticeLeadHours,
-              notice_subject: input.noticeSubject,
-              notice_body: input.noticeBody,
-              reason: input.reason ?? null,
-              status: 'scheduled',
-              created_by: ctx.user.id,
-              total_count: liveInstanceIds.length,
-            })
-            .returning({ id: kiloclaw_scheduled_actions.id });
-
-          const [stageRow] = await tx
-            .insert(kiloclaw_scheduled_action_stages)
-            .values({
-              scheduled_action_id: parentRow.id,
-              stage_index: 0,
-              scheduled_at: input.scheduledAt,
-              status: 'pending',
-            })
-            .returning({ id: kiloclaw_scheduled_action_stages.id });
-
-          const insertedTargets = await tx
-            .insert(kiloclaw_scheduled_action_targets)
-            .values(
-              liveInstanceIds.map(id => {
-                const row = liveResolvedById.get(id);
-                // liveResolvedById is built from liveInstanceRows (filtered
-                // above), so every id resolves.
-                if (!row) throw new Error(`unresolved instance ${id}`);
-                return {
-                  scheduled_action_id: parentRow.id,
-                  stage_id: stageRow.id,
-                  instance_id: row.instance.id,
-                  source_image_tag: row.instance.tracked_image_tag,
-                  // For version_change targets we stamp the target tag so the
-                  // DO apply path can read it from the target row directly
-                  // without having to join back to the parent.
-                  target_image_tag: parentTargetImageTag,
-                  user_id: row.owner_id,
-                  status: 'pending' as const,
-                };
-              })
-            )
-            .returning({
-              id: kiloclaw_scheduled_action_targets.id,
-              instance_id: kiloclaw_scheduled_action_targets.instance_id,
-            });
-
-          // Fan out one notification row per (target, channel) when
-          // notify=true. The sweep selects pending rows whose stage's
-          // (scheduled_at - notice_lead_hours) is in the past. Channels
-          // dispatch independently; one failed channel doesn't poison
-          // the others.
-          if (input.notify && input.noticeChannels.length > 0) {
-            const notificationRows: NewKiloClawScheduledActionNotification[] = [];
-            for (const target of insertedTargets) {
-              for (const channel of input.noticeChannels) {
-                notificationRows.push({
-                  target_id: target.id,
-                  channel,
-                  kind: 'notice',
-                  status: 'pending',
-                });
-              }
-            }
-            await tx.insert(kiloclaw_scheduled_action_notifications).values(notificationRows);
-          }
-
-          return { id: parentRow.id, stageId: stageRow.id };
-        },
-        { isolationLevel: 'serializable' }
-      );
+      // invariant.
+      const result = await createScheduledActionRows({
+        actionType: input.actionType,
+        targetImageTag: parentTargetImageTag,
+        overridePins: parentOverridePins,
+        noticeLeadHours: input.noticeLeadHours,
+        noticeSubject: input.noticeSubject,
+        noticeBody: input.noticeBody,
+        reason: input.reason ?? null,
+        createdBy: ctx.user.id,
+        stages: [{ stageIndex: 0, scheduledAt: input.scheduledAt }],
+        targets: liveInstanceRows.map(row => ({ ...row, stageIndex: 0 })),
+        notify: input.notify,
+        noticeChannels: input.noticeChannels,
+      });
 
       // Audit log fire-and-forget. Multi-user actions still use the
       // actor's id as the target_user_id sentinel since the column is
@@ -2119,7 +2343,115 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         );
       }
 
-      return { id: result.id, stageId: result.stageId };
+      return { id: result.id, stageId: result.stageIds[0] };
+    }),
+
+  previewFleetUpgrade: adminProcedure.input(FleetUpgradeFilterSchema).query(async ({ input }) => {
+    assertScheduledTimeInFuture(input.startsAt, 'startsAt');
+    const plan = await getFleetUpgradePlan(input);
+
+    return {
+      counts: plan.counts,
+      stages: plan.stages,
+      actionableInstanceIds: plan.actionableInstanceIds,
+      excluded: plan.excluded,
+    };
+  }),
+
+  createFleetUpgrade: adminProcedure
+    .input(FleetUpgradeFilterSchema)
+    .mutation(async ({ input, ctx }) => {
+      assertScheduledTimeInFuture(input.startsAt, 'startsAt');
+      const plan = await getFleetUpgradePlan(input);
+
+      if (plan.excluded.conflictInstanceIds.length > 0) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: `${plan.excluded.conflictInstanceIds.length} instances already have pending or in-flight scheduled actions; cancel those first: ${plan.excluded.conflictInstanceIds.join(', ')}`,
+        });
+      }
+
+      if (plan.actionableRows.length === 0) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'No actionable fleet upgrade targets match the selected filters',
+        });
+      }
+
+      const stageTargets: ScheduledActionTargetRow[] = [];
+      let offset = 0;
+      for (const stage of plan.stages) {
+        const rows = plan.actionableRows.slice(offset, offset + stage.targetCount);
+        stageTargets.push(...rows.map(row => ({ ...row, stageIndex: stage.stageIndex })));
+        offset += stage.targetCount;
+      }
+
+      const result = await createScheduledActionRows({
+        actionType: 'version_change',
+        targetImageTag: input.targetImageTag,
+        overridePins: input.overridePins,
+        noticeLeadHours: input.noticeLeadHours,
+        noticeSubject: input.noticeSubject,
+        noticeBody: input.noticeBody,
+        reason: input.reason ?? null,
+        createdBy: ctx.user.id,
+        stages: plan.stages.map(stage => ({
+          stageIndex: stage.stageIndex,
+          scheduledAt: stage.scheduledAt,
+        })),
+        targets: stageTargets,
+        notify: input.notify,
+        noticeChannels: input.noticeChannels,
+      });
+
+      try {
+        await createKiloClawAdminAuditLog({
+          action: 'kiloclaw.fleet_upgrade.created',
+          actor_id: ctx.user.id,
+          actor_email: ctx.user.google_user_email,
+          actor_name: ctx.user.google_user_name,
+          target_user_id: ctx.user.id,
+          message: `Created fleet upgrade to ${input.targetImageTag} for ${stageTargets.length} instances in ${plan.stages.length} tranches`,
+          metadata: {
+            scheduledActionId: result.id,
+            versionBelow: input.versionBelow,
+            targetImageTag: input.targetImageTag,
+            overridePins: input.overridePins,
+            startsAt: input.startsAt,
+            tranchePercent: input.tranchePercent,
+            intervalDays: input.intervalDays,
+            targetCount: stageTargets.length,
+            counts: plan.counts,
+            stageSizes: plan.stages.map(stage => stage.targetCount),
+          },
+        });
+      } catch (auditErr) {
+        console.error('Failed to write audit log for createFleetUpgrade:', auditErr);
+      }
+
+      const internalClient = new KiloClawInternalClient();
+      const wakeConcurrency = 20;
+      for (let i = 0; i < plan.actionableRows.length; i += wakeConcurrency) {
+        const batch = plan.actionableRows.slice(i, i + wakeConcurrency);
+        await Promise.all(
+          batch.map(async row => {
+            try {
+              await internalClient.wakeScheduledAction(row.owner_id, row.instance.id);
+            } catch (wakeErr) {
+              console.error(
+                `Failed to wake DO after createFleetUpgrade (instance=${row.instance.id}):`,
+                wakeErr
+              );
+            }
+          })
+        );
+      }
+
+      return {
+        id: result.id,
+        stageIds: result.stageIds,
+        targetCount: stageTargets.length,
+      };
     }),
 
   /**
@@ -2191,19 +2523,25 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
           ? await db
               .select({
                 scheduled_action_id: kiloclaw_scheduled_action_stages.scheduled_action_id,
-                scheduled_at: kiloclaw_scheduled_action_stages.scheduled_at,
+                scheduled_at: sql<string>`MIN(${kiloclaw_scheduled_action_stages.scheduled_at})`,
+                stage_count: sql<number>`COUNT(*)::int`,
+                latest_scheduled_at: sql<string>`MAX(${kiloclaw_scheduled_action_stages.scheduled_at})`,
               })
               .from(kiloclaw_scheduled_action_stages)
               .where(inArray(kiloclaw_scheduled_action_stages.scheduled_action_id, actionIds))
-              .orderBy(asc(kiloclaw_scheduled_action_stages.scheduled_at))
+              .groupBy(kiloclaw_scheduled_action_stages.scheduled_action_id)
           : [];
       const scheduledAtByAction = new Map<string, string>();
+      const stageSummaryByAction = new Map<
+        string,
+        { stage_count: number; latest_scheduled_at: string }
+      >();
       for (const s of stageRows) {
-        // First stage we see per action wins (rows are ordered ascending
-        // so this captures the earliest scheduled_at).
-        if (!scheduledAtByAction.has(s.scheduled_action_id)) {
-          scheduledAtByAction.set(s.scheduled_action_id, s.scheduled_at);
-        }
+        scheduledAtByAction.set(s.scheduled_action_id, s.scheduled_at);
+        stageSummaryByAction.set(s.scheduled_action_id, {
+          stage_count: s.stage_count,
+          latest_scheduled_at: s.latest_scheduled_at,
+        });
       }
 
       const totalCountResult = await db
@@ -2216,6 +2554,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
       return {
         items: rows.map(r => {
           const summary = targetSummaryByAction.get(r.id);
+          const stageSummary = stageSummaryByAction.get(r.id);
           return {
             ...r,
             target_count: summary?.count ?? 0,
@@ -2223,6 +2562,8 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
             // "N instances" otherwise.
             first_instance_id: summary?.first_instance_id ?? null,
             scheduled_at: scheduledAtByAction.get(r.id) ?? null,
+            stage_count: stageSummary?.stage_count ?? 0,
+            latest_scheduled_at: stageSummary?.latest_scheduled_at ?? null,
           };
         }),
         pagination: {
@@ -2265,12 +2606,18 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
           target: kiloclaw_scheduled_action_targets,
           user_email: kilocode_users.google_user_email,
           instance_sandbox_id: kiloclaw_instances.sandbox_id,
+          stage_index: kiloclaw_scheduled_action_stages.stage_index,
+          stage_scheduled_at: kiloclaw_scheduled_action_stages.scheduled_at,
         })
         .from(kiloclaw_scheduled_action_targets)
         .leftJoin(kilocode_users, eq(kilocode_users.id, kiloclaw_scheduled_action_targets.user_id))
         .leftJoin(
           kiloclaw_instances,
           eq(kiloclaw_instances.id, kiloclaw_scheduled_action_targets.instance_id)
+        )
+        .leftJoin(
+          kiloclaw_scheduled_action_stages,
+          eq(kiloclaw_scheduled_action_stages.id, kiloclaw_scheduled_action_targets.stage_id)
         )
         .where(eq(kiloclaw_scheduled_action_targets.scheduled_action_id, input.id));
 
@@ -2281,6 +2628,8 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
           ...t.target,
           user_email: t.user_email,
           instance_sandbox_id: t.instance_sandbox_id,
+          stage_index: t.stage_index,
+          stage_scheduled_at: t.stage_scheduled_at,
         })),
       };
     }),

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -349,6 +349,7 @@ export const KiloClawAdminAuditAction = z.enum([
   'kiloclaw.orphan.destroy',
   'kiloclaw.instances.bulk_change_version',
   'kiloclaw.scheduled_action.created',
+  'kiloclaw.fleet_upgrade.created',
   'kiloclaw.scheduled_action.cancelled',
 ]);
 


### PR DESCRIPTION
## Summary

Adds an admin fleet-upgrade flow that previews active KiloClaw instances below a selected OpenClaw version cutoff, partitions actionable targets into deterministic tranches, and creates multi-stage `version_change` scheduled actions using the existing scheduled-action apply path.

Updates the Scheduler tab with a compact fleet form, explicit preview, large/override confirmation, multi-stage list/detail summaries, and shared audit metadata for created fleet actions.

## Verification

Fully local on PR worktree `/Users/igor/Projects/.worktrees/kiloclaw-fleet-upgrade`:

- Started the local dev stack with `pnpm dev:start all` and used `http://localhost:3000` against local Postgres and local KiloClaw services.
- Seeded a local fleet with 12 actionable source-version instances plus pinned, conflicting, already-on-target, unknown-version, inactive-trial, and suspended exclusion cases.
- In the admin KiloClaw Scheduler tab, previewed the fleet upgrade and verified the actionable, eligible, pinned, and conflict counts plus the tranche preview.
- Cleared the seeded conflict locally, re-previewed from the browser, scheduled the fleet upgrade, opened the scheduled-action detail dialog, and verified 12 targets across 4 tranches.
- Verified the created local database rows for the parent scheduled action, stages, targets with source/target tag mirrors, and the fleet-upgrade audit-log metadata.
- Stopped the local dev stack after verification.

## Visual Changes

<img width="1420" height="851" alt="image" src="https://github.com/user-attachments/assets/93177031-8541-442e-bb10-5a7771745b51" />
<img width="1171" height="813" alt="image" src="https://github.com/user-attachments/assets/f79c8f8a-3b6e-4b72-a03a-eb102ae0012b" />

## Reviewer Notes

The fleet create path intentionally rejects if any actionable target already has a pending/running scheduled action. The actual upgrade executor is unchanged: each target remains a scheduled `version_change` target applied by the existing KiloClaw Durable Object path.
