### PR TITLE
fix(kiloclaw): surface pending destroy cleanup

### DIFF
--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -920,6 +920,17 @@ rows renew.
 4. The system MUST send an instance-destroyed notification.
 5. If the destroy operation fails (e.g., no instance exists), the system
    MUST still proceed with the state transition.
+6. Destroy request acceptance and provider cleanup finalization are
+   distinct. The lifecycle sweep MAY proceed with the local instance and
+   subscription state transition once the provider lifecycle owner has
+   accepted the destroy request or the sweep has logged the failed
+   attempt, provided any unfinalized provider cleanup remains durably
+   tracked by the provider lifecycle owner.
+7. When provider cleanup is not finalized immediately, the provider
+   lifecycle owner MUST retain enough durable state to retry cleanup and
+   MUST emit telemetry identifying pending provider resources and the
+   latest provider error, if any. A provider 404 for a resource counts as
+   confirmed deletion of that resource.
 
 ### Past-Due Payment Enforcement
 

--- a/apps/web/src/lib/kiloclaw/types.ts
+++ b/apps/web/src/lib/kiloclaw/types.ts
@@ -271,6 +271,8 @@ export type PlatformDebugStatusResponse = PlatformStatusResponse & {
   adminMachineSizeOverrideMetadata: AdminMachineSizeOverrideMetadata | null;
   pendingDestroyMachineId: string | null;
   pendingDestroyVolumeId: string | null;
+  destroyStartedAt: number | null;
+  lastDestroyPendingEventAt: number | null;
   pendingPostgresMarkOnFinalize: boolean;
   lastMetadataRecoveryAt: number | null;
   lastLiveCheckAt: number | null;

--- a/services/kiloclaw-billing/src/lifecycle.test.ts
+++ b/services/kiloclaw-billing/src/lifecycle.test.ts
@@ -25,6 +25,21 @@ import type { BillingWorkerEnv } from './types.js';
 
 let loggedValues: unknown[] = [];
 
+function destroyResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    finalized: true,
+    destroyedUserId: 'user-1',
+    destroyedSandboxId: 'ki_11111111111141118111111111111111',
+    pendingMachineId: null,
+    pendingVolumeId: null,
+    lastDestroyErrorOp: null,
+    lastDestroyErrorStatus: null,
+    lastDestroyErrorAt: null,
+    ...overrides,
+  };
+}
+
 type SelectBuilder = {
   from: ReturnType<typeof vi.fn>;
   innerJoin: ReturnType<typeof vi.fn>;
@@ -238,7 +253,7 @@ describe('interrupted auto-resume sweep', () => {
           reason: 'interrupted_auto_resume',
         });
       }
-      return new Response(JSON.stringify({ ok: true }), {
+      return new Response(JSON.stringify(destroyResponse()), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       });
@@ -814,7 +829,7 @@ describe('instance destruction sweep', () => {
           reason: 'destruction_deadline_elapsed',
         });
       }
-      return new Response(JSON.stringify({ ok: true }), {
+      return new Response(JSON.stringify(destroyResponse()), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       });
@@ -851,6 +866,15 @@ describe('instance destruction sweep', () => {
     expect(txUpdates[0]?.destroyed_at).toEqual(expect.any(String));
     expect(updates).toEqual([{ destruction_deadline: null }]);
     expect(deletes).toHaveLength(1);
+    expect(loggedValues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: 'instance_destroy_confirmed',
+          outcome: 'completed',
+          instanceId,
+        }),
+      ])
+    );
   });
 
   it('treats platform destroy 404 as already gone and continues with later rows', async () => {
@@ -912,7 +936,7 @@ describe('instance destruction sweep', () => {
         })
       )
       .mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: true }), {
+        new Response(JSON.stringify(destroyResponse({ destroyedUserId: 'user-2' })), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         })
@@ -963,6 +987,91 @@ describe('instance destruction sweep', () => {
     expect(txUpdates[1]?.destroyed_at).toEqual(expect.any(String));
     expect(updates).toEqual([{ destruction_deadline: null }, { destruction_deadline: null }]);
     expect(deletes).toHaveLength(2);
+  });
+
+  it('logs pending platform cleanup and still preserves billing state transition', async () => {
+    const instanceId = '11111111-1111-4111-8111-111111111111';
+    const { db, updates, txUpdates, inserts, deletes } = createMockDb([
+      [
+        {
+          id: 'sub-1',
+          user_id: 'user-1',
+          instance_id: instanceId,
+          sandbox_id: 'ki_11111111111141118111111111111111',
+          status: 'canceled',
+          email: 'user-1@example.com',
+        },
+      ],
+      [
+        {
+          id: instanceId,
+          userId: 'user-1',
+          sandboxId: 'ki_11111111111141118111111111111111',
+          organizationId: null,
+          name: null,
+          inboundEmailEnabled: false,
+          destroyedAt: null,
+        },
+      ],
+      [],
+      [{ id: 'sub-1', user_id: 'user-1', instance_id: instanceId }],
+    ]);
+    mockGetWorkerDb.mockReturnValue(db);
+    const fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify(
+            destroyResponse({
+              finalized: false,
+              pendingVolumeId: 'vol-1',
+              lastDestroyErrorOp: 'volume',
+              lastDestroyErrorStatus: 412,
+              lastDestroyErrorAt: 1_777_777_777,
+            })
+          ),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+    );
+
+    const summary = await runSweep(
+      createEnv(fetch),
+      {
+        runId: '10101010-1010-4010-8010-101010101010',
+        sweep: 'instance_destruction',
+      },
+      1
+    );
+
+    expect(summary.errors).toBe(0);
+    expect(summary.sweep3_instance_destruction).toBe(1);
+    expect(txUpdates).toHaveLength(1);
+    expect(txUpdates[0]?.destroyed_at).toEqual(expect.any(String));
+    expect(updates).toEqual([{ destruction_deadline: null }]);
+    expect(deletes).toHaveLength(1);
+    expect(inserts).toEqual(
+      expect.arrayContaining([
+        {
+          user_id: 'user-1',
+          instance_id: instanceId,
+          email_type: 'claw_instance_destroyed',
+        },
+      ])
+    );
+    expect(loggedValues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: 'instance_destroy_pending',
+          outcome: 'retry',
+          instanceId,
+          pendingVolumeId: 'vol-1',
+          lastDestroyErrorOp: 'volume',
+          lastDestroyErrorStatus: 412,
+        }),
+      ])
+    );
   });
 
   it('logs non-404 platform destroy failures and preserves billing state transition', async () => {
@@ -1040,6 +1149,8 @@ describe('instance destruction sweep', () => {
         }),
         expect.objectContaining({
           message: 'Destroy instance during billing enforcement failed',
+          event: 'instance_destroy_request_failed',
+          outcome: 'failed',
           statusCode: 500,
         }),
       ])

--- a/services/kiloclaw-billing/src/lifecycle.ts
+++ b/services/kiloclaw-billing/src/lifecycle.ts
@@ -276,6 +276,18 @@ type StopInstanceResponse = {
   stoppedAt: number | null;
 };
 
+type DestroyInstanceResponse = {
+  ok: true;
+  finalized: boolean;
+  destroyedUserId: string | null;
+  destroyedSandboxId: string | null;
+  pendingMachineId: string | null;
+  pendingVolumeId: string | null;
+  lastDestroyErrorOp: 'machine' | 'volume' | 'recover' | null;
+  lastDestroyErrorStatus: number | null;
+  lastDestroyErrorAt: number | null;
+};
+
 function createSummary(): BillingSummary {
   return {
     credit_renewals: 0,
@@ -811,11 +823,11 @@ async function destroyInstance(
   userId: string,
   instanceId?: string,
   reason?: KiloclawDestroyReason
-): Promise<void> {
+): Promise<DestroyInstanceResponse | null> {
   const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
   const path = `/api/platform/destroy${params}`;
   try {
-    await requestKiloClaw<{ ok: true }>(
+    return await requestKiloClaw<DestroyInstanceResponse>(
       env,
       context,
       path,
@@ -838,7 +850,7 @@ async function destroyInstance(
         userId,
         instanceId,
       });
-      return;
+      return null;
     }
 
     throw error;
@@ -1670,25 +1682,51 @@ async function destroyInstanceForEnforcement(
     instance_id: string | null;
     sandbox_id: string | null;
   }
-): Promise<void> {
-  if (!row.instance_id) return;
+): Promise<DestroyInstanceResponse | null> {
+  if (!row.instance_id) return null;
 
   try {
-    await destroyInstance(
+    const result = await destroyInstance(
       env,
       context,
       row.user_id,
       workerInstanceId({ id: row.instance_id, sandbox_id: row.sandbox_id }),
       'destruction_deadline_elapsed'
     );
+    if (!result) return null;
+
+    if (result.finalized) {
+      log('info', 'Destroy instance during billing enforcement confirmed cleanup', {
+        event: 'instance_destroy_confirmed',
+        outcome: 'completed',
+        userId: row.user_id,
+        instanceId: row.instance_id,
+      });
+    } else {
+      log('warn', 'Destroy instance during billing enforcement still has pending cleanup', {
+        event: 'instance_destroy_pending',
+        outcome: 'retry',
+        userId: row.user_id,
+        instanceId: row.instance_id,
+        pendingMachineId: result.pendingMachineId,
+        pendingVolumeId: result.pendingVolumeId,
+        lastDestroyErrorOp: result.lastDestroyErrorOp,
+        lastDestroyErrorStatus: result.lastDestroyErrorStatus,
+        lastDestroyErrorAt: result.lastDestroyErrorAt,
+      });
+    }
+    return result;
   } catch (error) {
     const isExpected = error instanceof KiloClawApiError && error.statusCode === 409;
     log(isExpected ? 'info' : 'error', 'Destroy instance during billing enforcement failed', {
+      event: 'instance_destroy_request_failed',
+      outcome: isExpected ? 'skipped' : 'failed',
       userId: row.user_id,
       instanceId: row.instance_id,
       statusCode: error instanceof KiloClawApiError ? error.statusCode : null,
       error: error instanceof Error ? error.message : String(error),
     });
+    return null;
   }
 }
 

--- a/services/kiloclaw/src/config.ts
+++ b/services/kiloclaw/src/config.ts
@@ -87,6 +87,10 @@ export const RESTARTING_MAX_TIMEOUT_MS = 15 * 60 * 1000; // 15 min
 export const RECOVERING_TIMEOUT_MS = 10 * 60 * 1000; // 10 min
 /** Destroying: retry pending deletes quickly */
 export const ALARM_INTERVAL_DESTROYING_MS = 60 * 1000; // 1 min
+/** Pending destroy age before emitting stuck-destroy telemetry */
+export const DESTROY_STUCK_THRESHOLD_MS = 15 * 60 * 1000; // 15 min
+/** Minimum interval between repeated stuck-destroy telemetry events */
+export const DESTROY_STUCK_TELEMETRY_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 /** Provisioned/stopped: slow drift detection */
 export const ALARM_INTERVAL_IDLE_MS = 30 * 60 * 1000; // 30 min
 /** Random jitter added to alarm scheduling to prevent Fly API bursts */

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -801,6 +801,95 @@ describe('two-phase destroy', () => {
     expect(storage._store.size).toBe(0);
     expect(storage._getAlarm()).toBeNull();
   });
+
+  it('emits throttled destroy_stuck telemetry for aged docker-local pending destroys', async () => {
+    const env = {
+      ...createFakeEnv(),
+      DOCKER_LOCAL_API_BASE: 'http://127.0.0.1:23750',
+    };
+    const { storage } = createInstance(undefined, env);
+    await seedProvisioned(storage, {
+      provider: 'docker-local',
+      status: 'destroying',
+      flyMachineId: null,
+      flyVolumeId: null,
+      flyRegion: null,
+      providerState: {
+        provider: 'docker-local',
+        containerName: null,
+        volumeName: 'kiloclaw-root-sandbox-1',
+        hostPort: null,
+      },
+      pendingDestroyMachineId: null,
+      pendingDestroyVolumeId: 'kiloclaw-root-sandbox-1',
+      destroyStartedAt: Date.now() - 16 * 60 * 1000,
+    });
+
+    vi.mocked(fetch).mockImplementation(async input => {
+      const url = fetchInputUrl(input);
+      if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
+        return new Response('volume busy', { status: 409 });
+      }
+      throw new Error(`Unhandled Docker API request: ${url}`);
+    });
+
+    const { instance } = createInstance(storage, env);
+    await instance.alarm();
+
+    const stuckEvents = analyticsEventsByName(env, 'reconcile.destroy_stuck');
+    expect(stuckEvents).toHaveLength(1);
+    expect(stuckEvents[0]?.blobs).toEqual(expect.arrayContaining(['volume']));
+    expect(storage._store.get('lastDestroyPendingEventAt')).toBeTypeOf('number');
+
+    const { instance: retryInstance } = createInstance(storage, env);
+    await retryInstance.alarm();
+
+    expect(analyticsEventsByName(env, 'reconcile.destroy_stuck')).toHaveLength(1);
+  });
+
+  it('preserves docker-local runtime destroy errors when storage delete succeeds', async () => {
+    const env = {
+      ...createFakeEnv(),
+      DOCKER_LOCAL_API_BASE: 'http://127.0.0.1:23750',
+    };
+    const { storage } = createInstance(undefined, env);
+    await seedProvisioned(storage, {
+      provider: 'docker-local',
+      status: 'destroying',
+      flyMachineId: null,
+      flyVolumeId: null,
+      flyRegion: null,
+      providerState: {
+        provider: 'docker-local',
+        containerName: 'kiloclaw-sandbox-1',
+        volumeName: 'kiloclaw-root-sandbox-1',
+        hostPort: 45001,
+      },
+      pendingDestroyMachineId: 'kiloclaw-sandbox-1',
+      pendingDestroyVolumeId: 'kiloclaw-root-sandbox-1',
+      destroyStartedAt: Date.now() - 16 * 60 * 1000,
+    });
+
+    vi.mocked(fetch).mockImplementation(async input => {
+      const url = fetchInputUrl(input);
+      if (url.endsWith('/containers/kiloclaw-sandbox-1?force=true')) {
+        return new Response('container busy', { status: 409 });
+      }
+      if (url.endsWith('/volumes/kiloclaw-root-sandbox-1')) {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unhandled Docker API request: ${url}`);
+    });
+
+    const { instance } = createInstance(storage, env);
+    await instance.alarm();
+
+    expect(storage._store.get('pendingDestroyMachineId')).toBe('kiloclaw-sandbox-1');
+    expect(storage._store.get('pendingDestroyVolumeId')).toBeNull();
+    expect(storage._store.get('lastDestroyErrorOp')).toBe('machine');
+    expect(storage._store.get('lastDestroyErrorStatus')).toBe(409);
+    expect(analyticsEventsByName(env, 'reconcile.destroy_stuck')).toHaveLength(1);
+  });
 });
 
 describe('destroy: recover bound machine from volume', () => {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -571,9 +571,9 @@ describe('two-phase destroy', () => {
         pendingVolumeId: null,
         lastDestroyErrorOp: 'machine',
         lastDestroyErrorStatus: 500,
-        lastDestroyErrorAt: expect.any(Number),
       })
     );
+    expect(result.lastDestroyErrorAt).toEqual(expect.any(Number));
     expect(storage._store.get('pendingDestroyMachineId')).toBe('machine-1');
     expect(storage._store.get('pendingDestroyVolumeId')).toBeNull();
     expect(storage._store.get('destroyStartedAt')).toBeTypeOf('number');

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -561,14 +561,43 @@ describe('two-phase destroy', () => {
     );
     (flyClient.deleteVolume as Mock).mockResolvedValue(undefined);
 
-    await instance.destroy();
+    const result = await instance.destroy();
 
     // Storage NOT cleared — pending machine ID preserved
+    expect(result).toEqual(
+      expect.objectContaining({
+        finalized: false,
+        pendingMachineId: 'machine-1',
+        pendingVolumeId: null,
+        lastDestroyErrorOp: 'machine',
+        lastDestroyErrorStatus: 500,
+        lastDestroyErrorAt: expect.any(Number),
+      })
+    );
     expect(storage._store.get('pendingDestroyMachineId')).toBe('machine-1');
     expect(storage._store.get('pendingDestroyVolumeId')).toBeNull();
+    expect(storage._store.get('destroyStartedAt')).toBeTypeOf('number');
     expect(storage._store.get('status')).toBe('destroying');
     // Alarm scheduled for retry
     expect(storage._getAlarm()).not.toBeNull();
+  });
+
+  it('emits destroy_pending telemetry when inline destroy does not finalize', async () => {
+    const env = createFakeEnv();
+    const { instance, storage } = createInstance(createFakeStorage(), env);
+    await seedRunning(storage);
+
+    (flyClient.destroyMachine as Mock).mockResolvedValue(undefined);
+    (flyClient.deleteVolume as Mock).mockRejectedValue(
+      new FlyApiError('server error', 500, 'fail')
+    );
+
+    await instance.destroy();
+
+    const pendingEvents = analyticsEventsByName(env, 'reconcile.destroy_pending');
+    expect(pendingEvents).toHaveLength(1);
+    expect(pendingEvents[0]?.blobs).toEqual(expect.arrayContaining(['volume']));
+    expect(pendingEvents[0]?.doubles).toEqual(expect.arrayContaining([expect.any(Number)]));
   });
 
   it('keeps pendingDestroyVolumeId when volume delete fails', async () => {
@@ -1055,6 +1084,39 @@ describe('destroy error tracking', () => {
     expect(storage._store.get('lastDestroyErrorStatus')).toBe(412);
     expect(storage._store.get('lastDestroyErrorMessage')).toContain('failed_precondition');
     expect(storage._store.get('lastDestroyErrorAt')).toBeTypeOf('number');
+  });
+
+  it('emits throttled destroy_stuck telemetry for aged pending destroys', async () => {
+    const env = createFakeEnv();
+    const { storage } = createInstance(createFakeStorage(), env);
+    await seedProvisioned(storage, {
+      status: 'destroying',
+      flyMachineId: null,
+      flyVolumeId: 'vol-1',
+      pendingDestroyMachineId: null,
+      pendingDestroyVolumeId: 'vol-1',
+      destroyStartedAt: Date.now() - 16 * 60 * 1000,
+    });
+
+    (flyClient.getVolume as Mock).mockResolvedValue({
+      id: 'vol-1',
+      attached_machine_id: null,
+      state: 'detached',
+    });
+    (flyClient.deleteVolume as Mock).mockRejectedValue(new FlyApiError('server error', 500, '{}'));
+
+    const { instance } = createInstance(storage, env);
+    await instance.alarm();
+
+    const stuckEvents = analyticsEventsByName(env, 'reconcile.destroy_stuck');
+    expect(stuckEvents).toHaveLength(1);
+    expect(stuckEvents[0]?.blobs).toEqual(expect.arrayContaining(['volume']));
+    expect(storage._store.get('lastDestroyPendingEventAt')).toBeTypeOf('number');
+
+    const { instance: retryInstance } = createInstance(storage, env);
+    await retryInstance.alarm();
+
+    expect(analyticsEventsByName(env, 'reconcile.destroy_stuck')).toHaveLength(1);
   });
 
   it('clears destroy error on successful delete', async () => {

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -108,6 +108,7 @@ import {
   finalizeDestroyIfComplete,
   reconcileMachineMount,
   markRestartSuccessful,
+  emitDestroyPendingTelemetry,
 } from './reconcile';
 import {
   restoreFromPostgres,
@@ -418,7 +419,27 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         await this.persistProviderResultWithPatch(result, {
           pendingDestroyMachineId: null,
         });
+        this.s.lastDestroyErrorOp = null;
+        this.s.lastDestroyErrorStatus = null;
+        this.s.lastDestroyErrorMessage = null;
+        this.s.lastDestroyErrorAt = null;
+        await this.persist({
+          lastDestroyErrorOp: null,
+          lastDestroyErrorStatus: null,
+          lastDestroyErrorMessage: null,
+          lastDestroyErrorAt: null,
+        });
       } catch (err) {
+        this.s.lastDestroyErrorOp = 'machine';
+        this.s.lastDestroyErrorStatus = null;
+        this.s.lastDestroyErrorMessage = err instanceof Error ? err.message : String(err);
+        this.s.lastDestroyErrorAt = Date.now();
+        await this.persist({
+          lastDestroyErrorOp: 'machine',
+          lastDestroyErrorStatus: null,
+          lastDestroyErrorMessage: this.s.lastDestroyErrorMessage,
+          lastDestroyErrorAt: this.s.lastDestroyErrorAt,
+        });
         doWarn(this.s, 'Non-Fly runtime destroy failed, alarm will retry', {
           provider: this.s.provider,
           runtimeId: this.s.pendingDestroyMachineId,
@@ -437,7 +458,27 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         await this.persistProviderResultWithPatch(result, {
           pendingDestroyVolumeId: null,
         });
+        this.s.lastDestroyErrorOp = null;
+        this.s.lastDestroyErrorStatus = null;
+        this.s.lastDestroyErrorMessage = null;
+        this.s.lastDestroyErrorAt = null;
+        await this.persist({
+          lastDestroyErrorOp: null,
+          lastDestroyErrorStatus: null,
+          lastDestroyErrorMessage: null,
+          lastDestroyErrorAt: null,
+        });
       } catch (err) {
+        this.s.lastDestroyErrorOp = 'volume';
+        this.s.lastDestroyErrorStatus = null;
+        this.s.lastDestroyErrorMessage = err instanceof Error ? err.message : String(err);
+        this.s.lastDestroyErrorAt = Date.now();
+        await this.persist({
+          lastDestroyErrorOp: 'volume',
+          lastDestroyErrorStatus: null,
+          lastDestroyErrorMessage: this.s.lastDestroyErrorMessage,
+          lastDestroyErrorAt: this.s.lastDestroyErrorAt,
+        });
         doWarn(this.s, 'Non-Fly storage destroy failed, alarm will retry', {
           provider: this.s.provider,
           storageId: this.s.pendingDestroyVolumeId,
@@ -2412,15 +2453,20 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     const machineUptimeMs = this.s.lastStartedAt ? Date.now() - this.s.lastStartedAt : 0;
     const runtimeId = getRuntimeId(this.s);
     const storageId = getStorageId(this.s);
+    const destroyStartedAt = this.s.destroyStartedAt ?? Date.now();
 
     this.s.pendingDestroyMachineId = runtimeId;
     this.s.pendingDestroyVolumeId = storageId;
+    this.s.destroyStartedAt = destroyStartedAt;
+    this.s.lastDestroyPendingEventAt = null;
     this.s.status = 'destroying';
 
     await this.persist({
       status: 'destroying',
       pendingDestroyMachineId: this.s.pendingDestroyMachineId,
       pendingDestroyVolumeId: this.s.pendingDestroyVolumeId,
+      destroyStartedAt,
+      lastDestroyPendingEventAt: null,
     });
 
     this.emitEvent({
@@ -2521,10 +2567,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     }
 
     if (!finalized.finalized) {
-      doWarn(this.s, 'Destroy incomplete, alarm will retry', {
-        pendingMachineId: this.s.pendingDestroyMachineId,
-        pendingVolumeId: this.s.pendingDestroyVolumeId,
-      });
+      emitDestroyPendingTelemetry(this.s, destroyRctx);
       await this.scheduleAlarm();
     }
 
@@ -2673,6 +2716,8 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     gmailNotificationsEnabled: boolean;
     pendingDestroyMachineId: string | null;
     pendingDestroyVolumeId: string | null;
+    destroyStartedAt: number | null;
+    lastDestroyPendingEventAt: number | null;
     pendingPostgresMarkOnFinalize: boolean;
     lastMetadataRecoveryAt: number | null;
     lastLiveCheckAt: number | null;
@@ -2764,6 +2809,8 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       gmailNotificationsEnabled: this.s.gmailNotificationsEnabled,
       pendingDestroyMachineId: this.s.pendingDestroyMachineId,
       pendingDestroyVolumeId: this.s.pendingDestroyVolumeId,
+      destroyStartedAt: this.s.destroyStartedAt,
+      lastDestroyPendingEventAt: this.s.lastDestroyPendingEventAt,
       pendingPostgresMarkOnFinalize: this.s.pendingPostgresMarkOnFinalize,
       lastMetadataRecoveryAt: this.s.lastMetadataRecoveryAt,
       lastLiveCheckAt: this.s.lastLiveCheckAt,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -404,6 +404,12 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     });
   }
 
+  private providerErrorStatus(err: unknown): number | null {
+    if (typeof err !== 'object' || err === null || !('status' in err)) return null;
+    const status = err.status;
+    return typeof status === 'number' ? status : null;
+  }
+
   private async retryNonFlyDestroy(): Promise<void> {
     if (this.s.provider === 'fly') {
       throw new Error('retryNonFlyDestroy should not be used for Fly providers');
@@ -431,12 +437,12 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         });
       } catch (err) {
         this.s.lastDestroyErrorOp = 'machine';
-        this.s.lastDestroyErrorStatus = null;
+        this.s.lastDestroyErrorStatus = this.providerErrorStatus(err);
         this.s.lastDestroyErrorMessage = err instanceof Error ? err.message : String(err);
         this.s.lastDestroyErrorAt = Date.now();
         await this.persist({
           lastDestroyErrorOp: 'machine',
-          lastDestroyErrorStatus: null,
+          lastDestroyErrorStatus: this.s.lastDestroyErrorStatus,
           lastDestroyErrorMessage: this.s.lastDestroyErrorMessage,
           lastDestroyErrorAt: this.s.lastDestroyErrorAt,
         });
@@ -470,12 +476,12 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         });
       } catch (err) {
         this.s.lastDestroyErrorOp = 'volume';
-        this.s.lastDestroyErrorStatus = null;
+        this.s.lastDestroyErrorStatus = this.providerErrorStatus(err);
         this.s.lastDestroyErrorMessage = err instanceof Error ? err.message : String(err);
         this.s.lastDestroyErrorAt = Date.now();
         await this.persist({
           lastDestroyErrorOp: 'volume',
-          lastDestroyErrorStatus: null,
+          lastDestroyErrorStatus: this.s.lastDestroyErrorStatus,
           lastDestroyErrorMessage: this.s.lastDestroyErrorMessage,
           lastDestroyErrorAt: this.s.lastDestroyErrorAt,
         });

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -109,6 +109,7 @@ import {
   reconcileMachineMount,
   markRestartSuccessful,
   emitDestroyPendingTelemetry,
+  maybeEmitDestroyStuckTelemetry,
 } from './reconcile';
 import {
   restoreFromPostgres,
@@ -425,16 +426,18 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         await this.persistProviderResultWithPatch(result, {
           pendingDestroyMachineId: null,
         });
-        this.s.lastDestroyErrorOp = null;
-        this.s.lastDestroyErrorStatus = null;
-        this.s.lastDestroyErrorMessage = null;
-        this.s.lastDestroyErrorAt = null;
-        await this.persist({
-          lastDestroyErrorOp: null,
-          lastDestroyErrorStatus: null,
-          lastDestroyErrorMessage: null,
-          lastDestroyErrorAt: null,
-        });
+        if (!this.s.pendingDestroyVolumeId) {
+          this.s.lastDestroyErrorOp = null;
+          this.s.lastDestroyErrorStatus = null;
+          this.s.lastDestroyErrorMessage = null;
+          this.s.lastDestroyErrorAt = null;
+          await this.persist({
+            lastDestroyErrorOp: null,
+            lastDestroyErrorStatus: null,
+            lastDestroyErrorMessage: null,
+            lastDestroyErrorAt: null,
+          });
+        }
       } catch (err) {
         this.s.lastDestroyErrorOp = 'machine';
         this.s.lastDestroyErrorStatus = this.providerErrorStatus(err);
@@ -464,16 +467,18 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
         await this.persistProviderResultWithPatch(result, {
           pendingDestroyVolumeId: null,
         });
-        this.s.lastDestroyErrorOp = null;
-        this.s.lastDestroyErrorStatus = null;
-        this.s.lastDestroyErrorMessage = null;
-        this.s.lastDestroyErrorAt = null;
-        await this.persist({
-          lastDestroyErrorOp: null,
-          lastDestroyErrorStatus: null,
-          lastDestroyErrorMessage: null,
-          lastDestroyErrorAt: null,
-        });
+        if (!this.s.pendingDestroyMachineId) {
+          this.s.lastDestroyErrorOp = null;
+          this.s.lastDestroyErrorStatus = null;
+          this.s.lastDestroyErrorMessage = null;
+          this.s.lastDestroyErrorAt = null;
+          await this.persist({
+            lastDestroyErrorOp: null,
+            lastDestroyErrorStatus: null,
+            lastDestroyErrorMessage: null,
+            lastDestroyErrorAt: null,
+          });
+        }
       } catch (err) {
         this.s.lastDestroyErrorOp = 'volume';
         this.s.lastDestroyErrorStatus = this.providerErrorStatus(err);
@@ -4119,13 +4124,17 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       if (this.s.provider !== 'fly') {
         if (this.s.status === 'destroying') {
           await this.retryNonFlyDestroy();
-          await finalizeDestroyIfComplete(
+          const destroyRctx = createReconcileContext(this.s, this.env, 'alarm_destroy');
+          const result = await finalizeDestroyIfComplete(
             this.ctx,
             this.s,
-            createReconcileContext(this.s, this.env, 'alarm_destroy'),
+            destroyRctx,
             (userId, sandboxId) =>
               markDestroyedInPostgresHelper(this.env, this.ctx, this.s, userId, sandboxId)
           );
+          if (!result.finalized) {
+            await maybeEmitDestroyStuckTelemetry(this.ctx, this.s, destroyRctx);
+          }
         } else {
           await this.reconcileNonFlyRuntimeFromAlarm();
         }

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/postgres.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/postgres.ts
@@ -212,6 +212,8 @@ export async function restoreFromPostgres(
         healthCheckFailCount: 0,
         pendingDestroyMachineId: null,
         pendingDestroyVolumeId: null,
+        destroyStartedAt: null,
+        lastDestroyPendingEventAt: null,
         pendingPostgresMarkOnFinalize: false,
         openclawVersion: null,
         imageVariant: null,
@@ -238,6 +240,8 @@ export async function restoreFromPostgres(
     state.healthCheckFailCount = 0;
     state.pendingDestroyMachineId = null;
     state.pendingDestroyVolumeId = null;
+    state.destroyStartedAt = null;
+    state.lastDestroyPendingEventAt = null;
     state.pendingPostgresMarkOnFinalize = false;
     state.lastMetadataRecoveryAt = null;
     state.openclawVersion = null;

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
@@ -110,7 +110,7 @@ export function emitDestroyPendingTelemetry(
   doWarn(state, 'Destroy incomplete, alarm will retry', details);
 }
 
-async function maybeEmitDestroyStuckTelemetry(
+export async function maybeEmitDestroyStuckTelemetry(
   ctx: DurableObjectState,
   state: InstanceMutableState,
   rctx: ReconcileContext

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
@@ -11,6 +11,8 @@ import {
   RESTARTING_MAX_TIMEOUT_MS,
   RECOVERING_TIMEOUT_MS,
   WORKER_CONTROLLER_CAPABILITIES_VERSION,
+  DESTROY_STUCK_THRESHOLD_MS,
+  DESTROY_STUCK_TELEMETRY_INTERVAL_MS,
   getProactiveRefreshThresholdMs,
 } from '../../config';
 import { resolveInstanceTypeLabel } from '@kilocode/kiloclaw-instance-tiers';
@@ -60,6 +62,84 @@ export type ReconcileWithFlyResult = {
     durationMs?: number;
   };
 };
+
+function pendingDestroyLabel(state: InstanceMutableState): string {
+  if (state.pendingDestroyMachineId && state.pendingDestroyVolumeId) return 'machine+volume';
+  if (state.pendingDestroyMachineId) return 'machine';
+  if (state.pendingDestroyVolumeId) return 'volume';
+  return 'none';
+}
+
+function destroyPendingDetails(
+  state: InstanceMutableState,
+  now = Date.now()
+): Record<string, unknown> {
+  const ageMs = state.destroyStartedAt ? now - state.destroyStartedAt : 0;
+  return {
+    label: pendingDestroyLabel(state),
+    value: ageMs,
+    pendingMachineId: state.pendingDestroyMachineId,
+    pendingVolumeId: state.pendingDestroyVolumeId,
+    destroyStartedAt: state.destroyStartedAt,
+    ageMs,
+    lastDestroyErrorOp: state.lastDestroyErrorOp,
+    lastDestroyErrorStatus: state.lastDestroyErrorStatus,
+    lastDestroyErrorAt: state.lastDestroyErrorAt,
+  };
+}
+
+export function destroyResultFromState(
+  state: InstanceMutableState,
+  result: Pick<DestroyResult, 'finalized' | 'destroyedUserId' | 'destroyedSandboxId'>
+): DestroyResult {
+  return {
+    ...result,
+    pendingMachineId: state.pendingDestroyMachineId,
+    pendingVolumeId: state.pendingDestroyVolumeId,
+    lastDestroyErrorOp: state.lastDestroyErrorOp,
+    lastDestroyErrorStatus: state.lastDestroyErrorStatus,
+    lastDestroyErrorAt: state.lastDestroyErrorAt,
+  };
+}
+
+export function emitDestroyPendingTelemetry(
+  state: InstanceMutableState,
+  rctx: ReconcileContext
+): void {
+  const details = destroyPendingDetails(state);
+  rctx.log('destroy_pending', details);
+  doWarn(state, 'Destroy incomplete, alarm will retry', details);
+}
+
+async function maybeEmitDestroyStuckTelemetry(
+  ctx: DurableObjectState,
+  state: InstanceMutableState,
+  rctx: ReconcileContext
+): Promise<void> {
+  if (!state.pendingDestroyMachineId && !state.pendingDestroyVolumeId) return;
+
+  const now = Date.now();
+  if (!state.destroyStartedAt) {
+    state.destroyStartedAt = state.lastDestroyErrorAt ?? now;
+    await ctx.storage.put(storageUpdate({ destroyStartedAt: state.destroyStartedAt }));
+  }
+
+  const ageMs = now - state.destroyStartedAt;
+  if (ageMs < DESTROY_STUCK_THRESHOLD_MS) return;
+  if (
+    state.lastDestroyPendingEventAt &&
+    now - state.lastDestroyPendingEventAt < DESTROY_STUCK_TELEMETRY_INTERVAL_MS
+  ) {
+    return;
+  }
+
+  const details = destroyPendingDetails(state, now);
+  rctx.log('destroy_stuck', details);
+  doWarn(state, 'Destroy still pending after repeated retries', details);
+
+  state.lastDestroyPendingEventAt = now;
+  await ctx.storage.put(storageUpdate({ lastDestroyPendingEventAt: now }));
+}
 
 /**
  * Record a start-attempt failure: write the analytics event and dispatch the
@@ -1318,7 +1398,10 @@ async function retryPendingDestroy(
   await recoverBoundMachineForDestroy(flyConfig, ctx, state, rctx);
   await tryDeleteMachine(flyConfig, ctx, state, rctx);
   await tryDeleteVolume(flyConfig, ctx, state, rctx);
-  await finalizeDestroyIfComplete(ctx, state, rctx, markDestroyedInPostgres);
+  const result = await finalizeDestroyIfComplete(ctx, state, rctx, markDestroyedInPostgres);
+  if (!result.finalized) {
+    await maybeEmitDestroyStuckTelemetry(ctx, state, rctx);
+  }
 }
 
 async function recoverBoundMachineForDestroy(
@@ -1427,7 +1510,9 @@ export async function tryDeleteMachine(
       syncProviderStateForStorage(state, { pendingDestroyMachineId: null, flyMachineId: null })
     )
   );
-  await clearDestroyError(ctx, state);
+  if (!state.pendingDestroyVolumeId) {
+    await clearDestroyError(ctx, state);
+  }
 }
 
 export async function tryDeleteVolume(
@@ -1467,7 +1552,9 @@ export async function tryDeleteVolume(
       syncProviderStateForStorage(state, { pendingDestroyVolumeId: null, flyVolumeId: null })
     )
   );
-  await clearDestroyError(ctx, state);
+  if (!state.pendingDestroyMachineId) {
+    await clearDestroyError(ctx, state);
+  }
 }
 
 async function persistDestroyError(
@@ -1520,19 +1607,19 @@ export async function finalizeDestroyIfComplete(
   markDestroyedInPostgres?: (userId: string, sandboxId: string) => Promise<boolean>
 ): Promise<DestroyResult> {
   if (state.pendingDestroyMachineId || state.pendingDestroyVolumeId) {
-    return {
+    return destroyResultFromState(state, {
       finalized: false,
       destroyedUserId: null,
       destroyedSandboxId: null,
-    };
+    });
   }
 
   if (!state.userId || !state.sandboxId) {
-    return {
+    return destroyResultFromState(state, {
       finalized: false,
       destroyedUserId: null,
       destroyedSandboxId: null,
-    };
+    });
   }
 
   const destroyedUserId = state.userId;
@@ -1541,7 +1628,11 @@ export async function finalizeDestroyIfComplete(
   if (state.pendingPostgresMarkOnFinalize && markDestroyedInPostgres) {
     const marked = await markDestroyedInPostgres(destroyedUserId, destroyedSandboxId);
     if (!marked) {
-      return { finalized: false, destroyedUserId, destroyedSandboxId };
+      return destroyResultFromState(state, {
+        finalized: false,
+        destroyedUserId,
+        destroyedSandboxId,
+      });
     }
   }
 
@@ -1555,5 +1646,5 @@ export async function finalizeDestroyIfComplete(
   await ctx.storage.deleteAll();
   resetMutableState(state);
 
-  return { finalized: true, destroyedUserId, destroyedSandboxId };
+  return destroyResultFromState(state, { finalized: true, destroyedUserId, destroyedSandboxId });
 }

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/reconcile.ts
@@ -81,7 +81,6 @@ function destroyPendingDetails(
     pendingMachineId: state.pendingDestroyMachineId,
     pendingVolumeId: state.pendingDestroyVolumeId,
     destroyStartedAt: state.destroyStartedAt,
-    ageMs,
     lastDestroyErrorOp: state.lastDestroyErrorOp,
     lastDestroyErrorStatus: state.lastDestroyErrorStatus,
     lastDestroyErrorAt: state.lastDestroyErrorAt,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/state.ts
@@ -297,6 +297,8 @@ export async function loadState(ctx: DurableObjectState, s: InstanceMutableState
     s.healthCheckFailCount = d.healthCheckFailCount;
     s.pendingDestroyMachineId = d.pendingDestroyMachineId;
     s.pendingDestroyVolumeId = d.pendingDestroyVolumeId;
+    s.destroyStartedAt = d.destroyStartedAt;
+    s.lastDestroyPendingEventAt = d.lastDestroyPendingEventAt;
     s.pendingPostgresMarkOnFinalize = d.pendingPostgresMarkOnFinalize;
     s.lastMetadataRecoveryAt = d.lastMetadataRecoveryAt;
     s.openclawVersion = d.openclawVersion;
@@ -405,6 +407,8 @@ export function resetMutableState(s: InstanceMutableState): void {
   s.healthCheckFailCount = 0;
   s.pendingDestroyMachineId = null;
   s.pendingDestroyVolumeId = null;
+  s.destroyStartedAt = null;
+  s.lastDestroyPendingEventAt = null;
   s.pendingPostgresMarkOnFinalize = false;
   s.lastMetadataRecoveryAt = null;
   s.openclawVersion = null;
@@ -499,6 +503,8 @@ export function createMutableState(): InstanceMutableState {
     healthCheckFailCount: 0,
     pendingDestroyMachineId: null,
     pendingDestroyVolumeId: null,
+    destroyStartedAt: null,
+    lastDestroyPendingEventAt: null,
     pendingPostgresMarkOnFinalize: false,
     lastMetadataRecoveryAt: null,
     openclawVersion: null,

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/types.ts
@@ -27,6 +27,11 @@ export type DestroyResult = {
   finalized: boolean;
   destroyedUserId: string | null;
   destroyedSandboxId: string | null;
+  pendingMachineId: string | null;
+  pendingVolumeId: string | null;
+  lastDestroyErrorOp: 'machine' | 'volume' | 'recover' | null;
+  lastDestroyErrorStatus: number | null;
+  lastDestroyErrorAt: number | null;
 };
 
 /**
@@ -101,6 +106,8 @@ export type InstanceMutableState = {
   healthCheckFailCount: number;
   pendingDestroyMachineId: string | null;
   pendingDestroyVolumeId: string | null;
+  destroyStartedAt: number | null;
+  lastDestroyPendingEventAt: number | null;
   pendingPostgresMarkOnFinalize: boolean;
   lastMetadataRecoveryAt: number | null;
   openclawVersion: string | null;

--- a/services/kiloclaw/src/routes/platform-destroy.test.ts
+++ b/services/kiloclaw/src/routes/platform-destroy.test.ts
@@ -7,7 +7,16 @@ vi.mock('cloudflare:workers', () => ({
 }));
 
 function makeEnv(overrides: Record<string, unknown> = {}) {
-  const destroy = vi.fn().mockResolvedValue({ ok: true });
+  const destroy = vi.fn().mockResolvedValue({
+    finalized: true,
+    destroyedUserId: 'user-1',
+    destroyedSandboxId: 'ki_11111111111141118111111111111111',
+    pendingMachineId: null,
+    pendingVolumeId: null,
+    lastDestroyErrorOp: null,
+    lastDestroyErrorStatus: null,
+    lastDestroyErrorAt: null,
+  });
   return {
     env: {
       KILOCLAW_INSTANCE: {
@@ -67,7 +76,17 @@ describe('POST /destroy', () => {
     const response = await platform.request(path, init, env);
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ ok: true });
+    expect(await response.json()).toEqual({
+      ok: true,
+      finalized: true,
+      destroyedUserId: 'user-1',
+      destroyedSandboxId: 'ki_11111111111141118111111111111111',
+      pendingMachineId: null,
+      pendingVolumeId: null,
+      lastDestroyErrorOp: null,
+      lastDestroyErrorStatus: null,
+      lastDestroyErrorAt: null,
+    });
     expect(destroy).toHaveBeenCalledWith({ reason: 'manual_user_request' });
   });
 
@@ -80,8 +99,40 @@ describe('POST /destroy', () => {
     const response = await platform.request(path, init, env);
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ ok: true });
+    expect(await response.json()).toEqual(expect.objectContaining({ ok: true, finalized: true }));
     expect(destroy).toHaveBeenCalledWith(undefined);
+  });
+
+  it('returns pending destroy cleanup details from the DO', async () => {
+    const { env, destroy } = makeEnv();
+    destroy.mockResolvedValueOnce({
+      finalized: false,
+      destroyedUserId: null,
+      destroyedSandboxId: null,
+      pendingMachineId: null,
+      pendingVolumeId: 'vol-1',
+      lastDestroyErrorOp: 'volume',
+      lastDestroyErrorStatus: 412,
+      lastDestroyErrorAt: 1_777_777_777,
+    });
+    const { path, init } = postJson('/destroy?instanceId=11111111-1111-4111-8111-111111111111', {
+      userId: 'user-1',
+    });
+
+    const response = await platform.request(path, init, env);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      finalized: false,
+      destroyedUserId: null,
+      destroyedSandboxId: null,
+      pendingMachineId: null,
+      pendingVolumeId: 'vol-1',
+      lastDestroyErrorOp: 'volume',
+      lastDestroyErrorStatus: 412,
+      lastDestroyErrorAt: 1_777_777_777,
+    });
   });
 
   it('rejects unknown destroy reasons', async () => {

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -2840,7 +2840,7 @@ platform.post('/destroy', async c => {
 
   try {
     const destroyOptions = result.data.reason ? { reason: result.data.reason } : undefined;
-    await withResolvedDORetry(
+    const destroyResult = await withResolvedDORetry(
       c.env,
       userId,
       instanceId,
@@ -2890,7 +2890,7 @@ platform.post('/destroy', async c => {
       console.error('[platform] Registry destroy failed (non-fatal):', registryErr);
     }
 
-    return c.json({ ok: true });
+    return c.json({ ok: true, ...destroyResult });
   } catch (err) {
     const { message, status } = sanitizeError(err, 'destroy');
     return jsonError(message, status);

--- a/services/kiloclaw/src/schemas/instance-config.ts
+++ b/services/kiloclaw/src/schemas/instance-config.ts
@@ -350,6 +350,8 @@ export const PersistedStateSchema = z.object({
   // Two-phase destroy: IDs pending deletion on Fly. Cleared once Fly confirms.
   pendingDestroyMachineId: z.string().nullable().default(null),
   pendingDestroyVolumeId: z.string().nullable().default(null),
+  destroyStartedAt: z.number().nullable().default(null),
+  lastDestroyPendingEventAt: z.number().nullable().default(null),
   // For stale auto-destroy only: defer DO state wipe until Postgres row is marked destroyed.
   pendingPostgresMarkOnFinalize: z.boolean().default(false),
   // Cooldown: last time we attempted metadata-based machine recovery from Fly.

--- a/services/kiloclaw/src/utils/analytics.ts
+++ b/services/kiloclaw/src/utils/analytics.ts
@@ -71,6 +71,8 @@ export type KiloClawEventName =
   | 'reconcile.repair_mount'
   | 'reconcile.recover_bound_machine_for_destroy'
   | 'reconcile.restart_self_healed'
+  | 'reconcile.destroy_pending'
+  | 'reconcile.destroy_stuck'
   | 'reconcile.destroy_complete'
   // Region capacity management
   | 'region.capacity_eviction'


### PR DESCRIPTION
## Summary

- Surface whether KiloClaw instance destruction has fully finalized provider cleanup or still has pending machine/volume resources.
- Add durable destroy timing state plus `reconcile.destroy_pending` / throttled `reconcile.destroy_stuck` telemetry so non-finalized cleanup remains visible while DO alarms keep retrying.
- Propagate the DO destroy result through `/api/platform/destroy`, log confirmed/pending/request-failed outcomes in the billing lifecycle sweep, and clarify the billing spec’s accepted-destroy vs provider-finalized semantics.

## Verification

- No manual verification was performed; this change is backend lifecycle telemetry/contract behavior and was verified with automated service tests and type checks instead.
- [ ] Add any additional manual verification details before merge.

## Visual Changes

N/A

## Reviewer Notes

- Billing still proceeds with local destroyed-state transitions per the existing spec; this PR makes pending provider cleanup explicit rather than blocking billing on immediate Fly deletion.
- The DO remains the retry owner: pending IDs stay in durable state, provider 404 counts as confirmed deletion, and stuck telemetry is throttled after 15 minutes and then hourly.