### PR TITLE
CloudAgent - Fix idle cleanup skipping sessions with no executions

### DIFF
--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -1702,23 +1702,26 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
       return;
     }
 
-    const executions = await this.executionQueries.getAll();
-    const latestExecution = executions[executions.length - 1];
-    if (!latestExecution) {
+    const metadata = await this.getMetadata();
+    if (!metadata) {
       return;
     }
 
-    const lastActivity =
-      latestExecution.lastHeartbeat ?? latestExecution.completedAt ?? latestExecution.startedAt;
+    const executions = await this.executionQueries.getAll();
+    const latestExecution = executions[executions.length - 1];
+
+    const lastActivity = latestExecution
+      ? (latestExecution.lastHeartbeat ?? latestExecution.completedAt ?? latestExecution.startedAt)
+      : (metadata.preparedAt ?? metadata.timestamp);
+
+    if (!lastActivity) {
+      return;
+    }
+
     const idleMs = now - lastActivity;
     const idleTimeoutMs = this.getKiloServerIdleTimeoutMs();
 
     if (idleMs < idleTimeoutMs) {
-      return;
-    }
-
-    const metadata = await this.getMetadata();
-    if (!metadata) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Fix a regression from #3176 where `cleanupIdleKiloServer` returned early for sessions with zero executions, leaving their containers running indefinitely. When no executions exist, the method now falls back to `metadata.preparedAt` (set when the session is prepared and the container starts) to compute idle time. If neither executions nor `preparedAt` exist, it returns early — those sessions genuinely have nothing to clean up.

This caused both "Session has not been initiated yet" errors (containers alive but preparation never completed) and containers hanging around without being killed (the reaper alarm skipped them every cycle).

## Verification

Confirmed via Axiom logs that the success rate for `prepareSession` collapsed from ~80% to ~12% starting at 15:30 UTC today, exactly when #3176 was deployed.
