### PR TITLE
ci(kiloclaw): always run deploy-kiloclaw on push to main

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -151,28 +151,7 @@ jobs:
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
 
-  check-kiloclaw-changes:
-    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
-    timeout-minutes: 5
-    outputs:
-      changed: ${{ steps.changes.outputs.kiloclaw }}
-    steps:
-      - name: Checkout code
-        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
-        with:
-          fetch-depth: 0
-
-      - name: Check for kiloclaw changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: changes
-        with:
-          filters: |
-            kiloclaw:
-              - 'services/kiloclaw/**'
-
   deploy-kiloclaw:
-    needs: [check-kiloclaw-changes]
-    if: needs.check-kiloclaw-changes.outputs.changed == 'true'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

- Remove path filter

This change removes a check-kiloclaw-changes job that used dorny/paths-filter to conditionally skip deploy-kiloclaw when no files under services/kiloclaw/** had changed. With the guard removed, deploy-kiloclaw now runs unconditionally on every push to main. The motivation is that the paths-filter approach was incorrectly skipping deploys (e.g., when shared package changes warranted a kiloclaw redeploy), making "always deploy" the safer default.


## Verification


- [ ]

## Visual Changes

N/A

## Reviewer Notes

Will it break anything?
- No. The deploy-kiloclaw.yml workflow already has its own internal skip logic that makes unconditional triggering safe:

Why did we have a filter before, and why is it OK to not have one now?

Why the filter existed: 
- To avoid running a slow Docker build job on every push. It made sense in theory — only rebuild when kiloclaw source changes.

Why it was broken: 
- The filter only watched services/kiloclaw/**. The kiloclaw worker bundles workspace packages at deploy time via pnpm workspaces. PR #3180 only touched packages/kiloclaw-instance-tiers/ — the filter returned false, the job was skipped, and the bug fix never reached production even though it was on main.

Why removing it is better than expanding it:
- The expanded-filter approach (what the plan proposed) is also fragile. It requires manually maintaining a list of every workspace package kiloclaw imports. If someone adds a new packages/foo/ dependency to kiloclaw without updating the filter, you get the same silent skip bug again.

The "always deploy" approach is self-correcting — you never have a missed deploy because you forgot to update a list. The expensive part (Docker build) is protected by the content-hash cache inside deploy-kiloclaw.yml, so you get the efficiency benefit without the maintenance burden of the filter list.

TL;DR: The filter was optimizing at the wrong layer. The real optimization already exists inside deploy-kiloclaw.yml via content hashing. Removing the outer filter is simpler, more correct, and won't silently miss deploys again.
