### PR TITLE
feat(kiloclaw): plumb actor to resize-machine for worker side audit

### DIFF
--- a/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
+++ b/apps/web/src/lib/kiloclaw/kiloclaw-internal-client.ts
@@ -1023,6 +1023,7 @@ export class KiloClawInternalClient {
   async resizeMachine(
     userId: string,
     instanceType: InstanceTierKey,
+    actor: { actorId: string; actorEmail: string },
     instanceId?: string
   ): Promise<ResizeMachineResponse> {
     const params = instanceId ? `?instanceId=${encodeURIComponent(instanceId)}` : '';
@@ -1030,7 +1031,7 @@ export class KiloClawInternalClient {
       `/api/platform/resize-machine${params}`,
       {
         method: 'POST',
-        body: JSON.stringify({ userId, instanceType }),
+        body: JSON.stringify({ userId, instanceType, ...actor }),
       },
       { userId }
     );

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -3440,6 +3440,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         const result = await client.resizeMachine(
           input.userId,
           input.instanceType,
+          { actorId: ctx.user.id, actorEmail: ctx.user.google_user_email },
           workerInstanceId(instance)
         );
 

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -9012,34 +9012,52 @@ describe('getDebugState live-check dispatch', () => {
 describe('resizeMachine', () => {
   it('rejects when instance is not provisioned', async () => {
     const { instance } = createInstance();
-    await expect(instance.resizeMachine('perf-4-8')).rejects.toThrow('Instance is not provisioned');
+    await expect(
+      instance.resizeMachine({
+        targetTierKey: 'perf-4-8',
+        actorId: 'test-admin',
+        actorEmail: 'alice@example.com',
+      })
+    ).rejects.toThrow('Instance is not provisioned');
   });
 
   it('rejects when instance is being destroyed', async () => {
     const { instance, storage } = createInstance();
     await seedProvisioned(storage, { status: 'destroying' });
 
-    await expect(instance.resizeMachine('perf-4-8')).rejects.toThrow(
-      'Cannot resize: instance is being destroyed'
-    );
+    await expect(
+      instance.resizeMachine({
+        targetTierKey: 'perf-4-8',
+        actorId: 'test-admin',
+        actorEmail: 'alice@example.com',
+      })
+    ).rejects.toThrow('Cannot resize: instance is being destroyed');
   });
 
   it('rejects when instance is restoring', async () => {
     const { instance, storage } = createInstance();
     await seedProvisioned(storage, { status: 'restoring' });
 
-    await expect(instance.resizeMachine('perf-4-8')).rejects.toThrow(
-      'Cannot resize: instance is restoring from snapshot'
-    );
+    await expect(
+      instance.resizeMachine({
+        targetTierKey: 'perf-4-8',
+        actorId: 'test-admin',
+        actorEmail: 'alice@example.com',
+      })
+    ).rejects.toThrow('Cannot resize: instance is restoring from snapshot');
   });
 
   it('rejects when instance is recovering', async () => {
     const { instance, storage } = createInstance();
     await seedProvisioned(storage, { status: 'recovering' });
 
-    await expect(instance.resizeMachine('perf-4-8')).rejects.toThrow(
-      'Cannot resize: instance is recovering'
-    );
+    await expect(
+      instance.resizeMachine({
+        targetTierKey: 'perf-4-8',
+        actorId: 'test-admin',
+        actorEmail: 'alice@example.com',
+      })
+    ).rejects.toThrow('Cannot resize: instance is recovering');
   });
 
   it('persists new tier and returns previous tier', async () => {
@@ -9051,7 +9069,11 @@ describe('resizeMachine', () => {
       status: 'stopped',
     });
 
-    const result = await instance.resizeMachine('perf-4-8');
+    const result = await instance.resizeMachine({
+      targetTierKey: 'perf-4-8',
+      actorId: 'test-admin',
+      actorEmail: 'alice@example.com',
+    });
 
     expect(result.previousTier).toBe('shared-2-3');
     expect(result.newTier).toBe('perf-4-8');
@@ -9064,7 +9086,11 @@ describe('resizeMachine', () => {
     const { instance, storage } = createInstance();
     await seedProvisioned(storage, { status: 'stopped' });
 
-    const result = await instance.resizeMachine('perf-4-8');
+    const result = await instance.resizeMachine({
+      targetTierKey: 'perf-4-8',
+      actorId: 'test-admin',
+      actorEmail: 'alice@example.com',
+    });
 
     expect(result.previousTier).toBeNull();
     expect(result.machineSize).toEqual({ cpus: 4, memory_mb: 8192, cpu_kind: 'performance' });
@@ -9077,9 +9103,13 @@ describe('resizeMachine', () => {
       machineSize: { cpus: 1, memory_mb: 3072, cpu_kind: 'performance' },
     });
 
-    await expect(instance.resizeMachine('perf-4-8')).rejects.toThrow(
-      'Instance must be stopped before resizing machine tier'
-    );
+    await expect(
+      instance.resizeMachine({
+        targetTierKey: 'perf-4-8',
+        actorId: 'test-admin',
+        actorEmail: 'alice@example.com',
+      })
+    ).rejects.toThrow('Instance must be stopped before resizing machine tier');
   });
 
   it('allows resize when instance is stopped', async () => {
@@ -9091,7 +9121,11 @@ describe('resizeMachine', () => {
       volumeSizeGb: 10,
     });
 
-    const result = await instance.resizeMachine('perf-4-8');
+    const result = await instance.resizeMachine({
+      targetTierKey: 'perf-4-8',
+      actorId: 'test-admin',
+      actorEmail: 'alice@example.com',
+    });
 
     expect(result.newTier).toBe('perf-4-8');
     expect(result.machineSize).toEqual({ cpus: 4, memory_mb: 8192, cpu_kind: 'performance' });
@@ -9106,9 +9140,13 @@ describe('resizeMachine', () => {
       volumeSizeGb: 20,
     });
 
-    await expect(instance.resizeMachine('perf-1-3')).rejects.toThrow(
-      'downgrades and sidegrades are not allowed'
-    );
+    await expect(
+      instance.resizeMachine({
+        targetTierKey: 'perf-1-3',
+        actorId: 'test-admin',
+        actorEmail: 'alice@example.com',
+      })
+    ).rejects.toThrow('downgrades and sidegrades are not allowed');
   });
 
   it('rejects offered-tier sidegrades', async () => {
@@ -9120,18 +9158,26 @@ describe('resizeMachine', () => {
       volumeSizeGb: 10,
     });
 
-    await expect(instance.resizeMachine('perf-1-3')).rejects.toThrow(
-      'downgrades and sidegrades are not allowed'
-    );
+    await expect(
+      instance.resizeMachine({
+        targetTierKey: 'perf-1-3',
+        actorId: 'test-admin',
+        actorEmail: 'alice@example.com',
+      })
+    ).rejects.toThrow('downgrades and sidegrades are not allowed');
   });
 
   it('rejects legacy tiers as resize targets', async () => {
     const { instance, storage } = createInstance();
     await seedProvisioned(storage, { status: 'stopped' });
 
-    await expect(instance.resizeMachine('shared-2-3')).rejects.toThrow(
-      'is not an offerable resize target'
-    );
+    await expect(
+      instance.resizeMachine({
+        targetTierKey: 'shared-2-3',
+        actorId: 'test-admin',
+        actorEmail: 'alice@example.com',
+      })
+    ).rejects.toThrow('is not an offerable resize target');
   });
 
   it('extends volume and persists volume size before tier state', async () => {
@@ -9144,7 +9190,11 @@ describe('resizeMachine', () => {
       flyVolumeId: 'vol-1',
     });
 
-    const result = await instance.resizeMachine('perf-4-16');
+    const result = await instance.resizeMachine({
+      targetTierKey: 'perf-4-16',
+      actorId: 'test-admin',
+      actorEmail: 'alice@example.com',
+    });
 
     expect(flyClient.extendVolume).toHaveBeenCalledWith(
       { apiToken: 'test-token', appName: 'test-app' },
@@ -9167,7 +9217,13 @@ describe('resizeMachine', () => {
     });
     (flyClient.extendVolume as Mock).mockRejectedValueOnce(new Error('extend failed'));
 
-    await expect(instance.resizeMachine('perf-4-8')).rejects.toThrow('extend failed');
+    await expect(
+      instance.resizeMachine({
+        targetTierKey: 'perf-4-8',
+        actorId: 'test-admin',
+        actorEmail: 'alice@example.com',
+      })
+    ).rejects.toThrow('extend failed');
 
     expect(storage._store.get('volumeSizeGb')).toBe(10);
     expect(storage._store.get('instanceType')).toBe('perf-1-3');
@@ -9190,7 +9246,11 @@ describe('resizeMachine', () => {
     const db = await import('../db');
     (db.syncInstanceType as Mock).mockRejectedValueOnce(new Error('postgres down'));
 
-    await instance.resizeMachine('perf-4-8');
+    await instance.resizeMachine({
+      targetTierKey: 'perf-4-8',
+      actorId: 'test-admin',
+      actorEmail: 'alice@example.com',
+    });
     await Promise.allSettled(waitUntilPromises);
 
     expect(storage._store.get('instanceType')).toBe('perf-4-8');
@@ -9214,7 +9274,11 @@ describe('resizeMachine', () => {
       flyMachineId: null,
     });
 
-    const result = await instance.resizeMachine('perf-4-8');
+    const result = await instance.resizeMachine({
+      targetTierKey: 'perf-4-8',
+      actorId: 'test-admin',
+      actorEmail: 'alice@example.com',
+    });
 
     expect(result.newTier).toBe('perf-4-8');
     expect(flyClient.extendVolume).not.toHaveBeenCalled();
@@ -9248,7 +9312,11 @@ describe('resizeMachine', () => {
       throw new Error(`Unhandled Northflank API request: ${url}`);
     });
 
-    const result = await instance.resizeMachine('perf-4-8');
+    const result = await instance.resizeMachine({
+      targetTierKey: 'perf-4-8',
+      actorId: 'test-admin',
+      actorEmail: 'alice@example.com',
+    });
 
     expect(result.newTier).toBe('perf-4-8');
     expect(storage._store.get('instanceType')).toBe('perf-4-8');
@@ -9288,9 +9356,13 @@ describe('resizeMachine', () => {
       throw new Error(`Unhandled Northflank API request: ${url}`);
     });
 
-    await expect(instance.resizeMachine('perf-4-8')).rejects.toThrow(
-      'Northflank API patchDeploymentService failed (500)'
-    );
+    await expect(
+      instance.resizeMachine({
+        targetTierKey: 'perf-4-8',
+        actorId: 'test-admin',
+        actorEmail: 'alice@example.com',
+      })
+    ).rejects.toThrow('Northflank API patchDeploymentService failed (500)');
 
     expect(storage._store.get('instanceType')).toBe('perf-1-3');
     expect(storage._store.get('machineSize')).toEqual({
@@ -9320,7 +9392,11 @@ describe('resizeMachine', () => {
     const dbModule = await import('../db');
     (dbModule.syncAdminSizeOverride as Mock).mockClear();
 
-    const result = await instance.resizeMachine('perf-4-8');
+    const result = await instance.resizeMachine({
+      targetTierKey: 'perf-4-8',
+      actorId: 'test-admin',
+      actorEmail: 'alice@example.com',
+    });
     await Promise.allSettled(waitUntilPromises);
 
     expect(result.clearedOverride).toEqual({

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -2962,7 +2962,11 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
 
   // ── Machine resize (admin) ─────────────────────────────────────────
 
-  async resizeMachine(targetTierKey: InstanceTierKey): Promise<{
+  async resizeMachine(input: {
+    targetTierKey: InstanceTierKey;
+    actorId: string;
+    actorEmail: string;
+  }): Promise<{
     previousTier: InstanceType | null;
     newTier: InstanceTierKey;
     previousVolumeSizeGb: number | null;
@@ -2973,6 +2977,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       metadata: NonNullable<InstanceMutableState['adminMachineSizeOverrideMetadata']>;
     } | null;
   }> {
+    const { targetTierKey, actorId, actorEmail } = input;
     await this.loadState();
     this.assertAdminSizeChangeAllowed({
       cannotPrefix: 'resize',
@@ -3074,7 +3079,7 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
     }
 
     console.log(
-      `[admin-machine-resize] userId=${this.s.userId} ` +
+      `[admin-machine-resize] userId=${this.s.userId} actor=${actorEmail} (${actorId}) ` +
         `previousTier=${previousTier ?? 'unknown'} newTier=${targetTier.key} ` +
         `previousVolume=${previousVolumeSizeGb ?? 'unknown'} newVolume=${targetTier.volumeSizeGb}` +
         (clearedOverride

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -3434,6 +3434,8 @@ platform.post('/reassociate-volume', async c => {
 const ResizeMachineSchema = z.object({
   userId: z.string().min(1),
   instanceType: InstanceTierKeySchema,
+  actorId: z.string().min(1),
+  actorEmail: z.string().email(),
 });
 
 platform.post('/resize-machine', async c => {
@@ -3448,7 +3450,12 @@ platform.post('/resize-machine', async c => {
       c.env,
       result.data.userId,
       iidResult.instanceId,
-      stub => stub.resizeMachine(result.data.instanceType),
+      stub =>
+        stub.resizeMachine({
+          targetTierKey: result.data.instanceType,
+          actorId: result.data.actorId,
+          actorEmail: result.data.actorEmail,
+        }),
       'resizeMachine'
     );
     return c.json(response);


### PR DESCRIPTION
## Summary

A recent resize attempt showed two POST /api/platform/resize-machine calls back to back in Axiom, with no actor in the worker logs. apps/web already writes a Postgres audit row and logs the actor at the tRPC layer, but none of that reaches the kiloclaw worker, so anyone looking at Axiom cannot answer "who clicked which tier."

This change plumbs the acting admin identity through to the worker so the `[admin-machine-resize]` log line includes them, matching the existing pattern used by `setAdminMachineSizeOverride` and `clearAdminMachineSizeOverride`.

Changes:

* `ResizeMachineSchema` now requires `actorId` and `actorEmail`
* `resizeMachine` DO method signature accepts `{ targetTierKey, actorId, actorEmail }` and includes the actor in the worker log line
* `KiloClawInternalClient.resizeMachine` forwards actor in the request body
* admin tRPC `resizeMachine` mutation passes `ctx.user.id` and `ctx.user.google_user_email`
* DO tests updated for the new signature

Intentionally out of scope (followups):

* `/destroy-fly-machine` (also admin only, same pattern applies)
* `/start`, `/stop`, `/destroy` (these are shared by customer and admin flows, so actor semantics for the customer path is its own design question)

## Verification

* `pnpm --filter kiloclaw typecheck`
* `pnpm --filter web typecheck`
* `pnpm --filter kiloclaw test -t resizeMachine` (18 passed)
* `pnpm run format:check`
* `pnpm --filter kiloclaw lint`

No manual testing in production. The change is mechanical (schema field plus plumbing) and the existing DO tests cover the new signature. Will verify in Axiom on the next admin resize that the actor appears in the `[admin-machine-resize]` line.

- [ ] Confirmed actor appears in Axiom after next production admin resize

## Visual Changes

N/A

## Reviewer Notes