### PR TITLE
fix(gateway): strip embedding dimensions before upstream requests

### DIFF
--- a/apps/web/src/lib/ai-gateway/embeddings/embedding-request.test.ts
+++ b/apps/web/src/lib/ai-gateway/embeddings/embedding-request.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from '@jest/globals';
 import { buildUpstreamBody } from './embedding-request';
 
 describe('buildUpstreamBody', () => {
-  it('should forward all standard fields and strip Mistral-specific and deprecated fields', () => {
+  it('should forward supported fields and strip client-only, Mistral-specific, and deprecated fields', () => {
     const result = buildUpstreamBody({
       model: 'google/text-embedding-004',
       input: ['text1', 'text2'],
@@ -19,11 +19,11 @@ describe('buildUpstreamBody', () => {
       model: 'google/text-embedding-004',
       input: ['text1', 'text2'],
       encoding_format: 'float',
-      dimensions: 768,
       safety_identifier: 'hash-abc',
       provider: { order: ['Google'] },
       input_type: 'search_document',
     });
+    expect(result).not.toHaveProperty('dimensions');
     expect(result).not.toHaveProperty('output_dtype');
     expect(result).not.toHaveProperty('output_dimension');
   });

--- a/apps/web/src/lib/ai-gateway/embeddings/embedding-request.ts
+++ b/apps/web/src/lib/ai-gateway/embeddings/embedding-request.ts
@@ -19,7 +19,12 @@ export type EmbeddingProxyRequest = {
 export function buildUpstreamBody(
   body: EmbeddingProxyRequest & { user?: string }
 ): Record<string, unknown> {
-  const { dimensions: _, output_dtype: __, output_dimension: ___, user: ____, ...upstreamBody } =
-    body;
+  const {
+    dimensions: _,
+    output_dtype: __,
+    output_dimension: ___,
+    user: ____,
+    ...upstreamBody
+  } = body;
   return upstreamBody;
 }

--- a/apps/web/src/lib/ai-gateway/embeddings/embedding-request.ts
+++ b/apps/web/src/lib/ai-gateway/embeddings/embedding-request.ts
@@ -19,6 +19,7 @@ export type EmbeddingProxyRequest = {
 export function buildUpstreamBody(
   body: EmbeddingProxyRequest & { user?: string }
 ): Record<string, unknown> {
-  const { output_dtype: _, output_dimension: __, user: ___, ...upstreamBody } = body;
+  const { dimensions: _, output_dtype: __, output_dimension: ___, user: ____, ...upstreamBody } =
+    body;
   return upstreamBody;
 }


### PR DESCRIPTION
The Kilo indexing client uses the catalog's `dimension` metadata to size local vector stores. That value is client/control-plane metadata, not a safe upstream request parameter for every embedding provider.

After restoring the catalog response in https://github.com/Kilo-Org/cloud/pull/3193, clients can again hydrate `modelDimension` from Cloud and send `dimensions` to `/api/openrouter/embeddings`. The gateway then forwarded that field unchanged to OpenRouter/provider APIs. Models like Mistral/Codestral reject it with `extra_forbidden` because their embeddings endpoint does not accept a `dimensions` override.

This strips `dimensions` from the upstream request body in the same place we already strip deprecated/client-only fields like `user` and Mistral-specific `output_dimension`/`output_dtype`. The gateway can still accept the field from clients for compatibility, but upstreams only receive supported payload fields.