### PR TITLE
fix(code-reviews): improve metric and session log displays

### DIFF
--- a/apps/web/src/app/admin/components/CodeReviewDailyChart.tsx
+++ b/apps/web/src/app/admin/components/CodeReviewDailyChart.tsx
@@ -51,6 +51,11 @@ type CustomTooltipProps = {
   label?: string;
 };
 
+function formatStatusBreakdown(count: number, total: number): string {
+  const percentage = total > 0 ? (count / total) * 100 : 0;
+  return `${percentage.toFixed(1)}% (${count.toLocaleString()})`;
+}
+
 export function CodeReviewDailyChart({ data }: { data: DailyData[] }) {
   const chartData: ChartDataPoint[] = data.map(item => ({
     day: format(parseISO(item.day), 'MM/dd'),
@@ -75,35 +80,47 @@ export function CodeReviewDailyChart({ data }: { data: DailyData[] }) {
           <div className="mt-2 space-y-1">
             <p className="text-sm">
               <span className="text-muted-foreground">Total:</span>{' '}
-              <span className="font-medium">{data.total}</span>
+              <span className="font-medium tabular-nums">{data.total.toLocaleString()}</span>
             </p>
             <p className="text-sm">
               <span className="text-muted-foreground">Completed:</span>{' '}
-              <span className="font-medium text-green-600">{data.completed}</span>
+              <span className="font-medium tabular-nums text-green-600">
+                {formatStatusBreakdown(data.completed, data.total)}
+              </span>
             </p>
             <p className="text-sm">
               <span className="text-muted-foreground">Failed:</span>{' '}
-              <span className="font-medium text-red-600">{data.failed}</span>
+              <span className="font-medium tabular-nums text-red-600">
+                {formatStatusBreakdown(data.failed, data.total)}
+              </span>
             </p>
             <p className="text-sm">
               <span className="text-muted-foreground">Cancelled:</span>{' '}
-              <span className="font-medium text-yellow-600">{data.cancelled}</span>
+              <span className="font-medium tabular-nums text-yellow-600">
+                {formatStatusBreakdown(data.cancelled, data.total)}
+              </span>
             </p>
             <p className="text-sm">
               <span className="text-muted-foreground">Interrupted:</span>{' '}
-              <span className="font-medium text-orange-600">{data.interrupted}</span>
+              <span className="font-medium tabular-nums text-orange-600">
+                {formatStatusBreakdown(data.interrupted, data.total)}
+              </span>
             </p>
             <p className="text-sm">
               <span className="text-muted-foreground">Billing Errors:</span>{' '}
-              <span className="font-medium text-amber-500">{data.billingErrors}</span>
+              <span className="font-medium tabular-nums text-amber-500">
+                {formatStatusBreakdown(data.billingErrors, data.total)}
+              </span>
             </p>
             <p className="text-sm">
               <span className="text-muted-foreground">In Progress:</span>{' '}
-              <span className="font-medium text-blue-600">{data.inProgress}</span>
+              <span className="font-medium tabular-nums text-blue-600">
+                {formatStatusBreakdown(data.inProgress, data.total)}
+              </span>
             </p>
             <p className="text-sm">
               <span className="text-muted-foreground">Success Rate:</span>{' '}
-              <span className="font-medium">{data.successRate.toFixed(1)}%</span>
+              <span className="font-medium tabular-nums">{data.successRate.toFixed(1)}%</span>
             </p>
           </div>
         </div>

--- a/apps/web/src/app/admin/components/CodeReviewStats.tsx
+++ b/apps/web/src/app/admin/components/CodeReviewStats.tsx
@@ -128,10 +128,14 @@ export function CodeReviewStats({ data }: { data: StatsData }) {
       <Card>
         <CardHeader className="pb-2">
           <CardTitle className="text-sm font-medium">Billing Errors</CardTitle>
-          <CardDescription>{data.billingRate.toFixed(1)}% of terminal outcomes</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="text-3xl font-bold text-orange-500">{data.billingErrorCount}</div>
+          <div className="text-3xl font-bold tabular-nums text-orange-500">
+            {data.billingRate.toFixed(1)}%
+          </div>
+          <div className="text-muted-foreground mt-1 text-xs tabular-nums">
+            {data.billingErrorCount.toLocaleString()} billing errors
+          </div>
         </CardContent>
       </Card>
 
@@ -161,10 +165,11 @@ export function CodeReviewStats({ data }: { data: StatsData }) {
       <Card>
         <CardHeader className="pb-2">
           <CardTitle className="text-sm font-medium">In Progress</CardTitle>
-          <CardDescription>Pending/Queued/Running</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="text-3xl font-bold text-blue-600">{data.inProgressCount}</div>
+          <div className="text-3xl font-bold tabular-nums text-blue-600">
+            {data.inProgressCount.toLocaleString()}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/apps/web/src/components/code-reviews/CodeReviewStreamView.tsx
+++ b/apps/web/src/components/code-reviews/CodeReviewStreamView.tsx
@@ -401,12 +401,20 @@ export function CodeReviewStreamView({ reviewId, onComplete }: CodeReviewStreamV
   return (
     <Card className="border-l-4 border-l-blue-500">
       <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
             <Terminal className="h-4 w-4" />
-            <CardTitle className="text-sm font-medium">
+            <CardTitle className="shrink-0 text-sm font-medium">
               {isTerminal ? 'Session Log' : 'Code Review Progress'}
             </CardTitle>
+            {isTerminal && cloudAgentSessionId && (
+              <span
+                title={cloudAgentSessionId}
+                className="bg-muted text-muted-foreground max-w-[min(20rem,50vw)] truncate rounded px-2 py-0.5 font-mono text-xs font-normal"
+              >
+                {cloudAgentSessionId}
+              </span>
+            )}
           </div>
           {isComplete ? (
             reviewStatus === 'failed' ? (


### PR DESCRIPTION
## Summary
- Show status percentages alongside raw counts in the admin Reviews Per Day tooltip.
- Make the Billing Errors KPI emphasize rate first while keeping the raw count visible.
- Remove the long in-progress subtitle and show the Session Log cloud agent session ID when available.

## Verification
N/A

## Visual Changes
N/A

## Reviewer Notes
- Display-only UI changes; no data model, router, or authorization changes.
- Full repo typecheck was not run locally because repo guidance recommends targeted checks for touched areas.