### PR TITLE
feat(integrations): add DoltHub platform constant + dev-gated platform definition

### DIFF
--- a/apps/web/src/lib/integrations/core/constants.ts
+++ b/apps/web/src/lib/integrations/core/constants.ts
@@ -149,6 +149,7 @@ export const PLATFORM = {
   SLACK: 'slack',
   DISCORD: 'discord',
   LINEAR: 'linear',
+  DOLTHUB: 'dolthub',
 } as const;
 
 /**

--- a/apps/web/src/lib/integrations/platform-definitions.ts
+++ b/apps/web/src/lib/integrations/platform-definitions.ts
@@ -1,6 +1,14 @@
 import { PLATFORM } from '@/lib/integrations/core/constants';
+import { IS_DEVELOPMENT } from '@/lib/constants';
 
-export type PlatformType = 'github' | 'gitlab' | 'bitbucket' | 'slack' | 'discord' | 'linear';
+export type PlatformType =
+  | 'github'
+  | 'gitlab'
+  | 'bitbucket'
+  | 'slack'
+  | 'discord'
+  | 'linear'
+  | 'dolthub';
 
 export type PlatformStatus = 'installed' | 'not_installed' | 'coming_soon';
 
@@ -70,6 +78,14 @@ export const PLATFORM_DEFINITIONS: PlatformDefinition[] = [
     orgRoute: organizationId => `/organizations/${organizationId}/integrations/linear`,
   },
   {
+    id: PLATFORM.DOLTHUB,
+    name: 'DoltHub',
+    description: 'Query Dolt-versioned data directly from your workspace',
+    enabled: IS_DEVELOPMENT,
+    personalRoute: '/integrations/dolthub',
+    orgRoute: organizationId => `/organizations/${organizationId}/integrations/dolthub`,
+  },
+  {
     id: 'bitbucket',
     name: 'Bitbucket',
     description: 'Integrate Bitbucket repositories for intelligent code analysis and automation',
@@ -83,6 +99,7 @@ type InstallationStatus = {
   gitlab?: { installed: boolean };
   discord?: { installed: boolean };
   linear?: { installed: boolean };
+  dolthub?: { installed: boolean };
 };
 
 function getStatus(id: PlatformType, installations: InstallationStatus): PlatformStatus {


### PR DESCRIPTION
## Summary

Add DoltHub as a recognized integration platform, gated to dev only.

- Add `PLATFORM.DOLTHUB = 'dolthub'` to integration constants.
- Add DoltHub entry to `PLATFORM_DEFINITIONS` with `enabled: IS_DEVELOPMENT`, personal/org routes, and a description about querying Dolt-versioned data.
- Extend `PlatformType` and `InstallationStatus` unions to include `dolthub`.
- No production code paths consume the new constant yet; subsequent beads will wire routes and UI.

## Verification

- `pnpm --filter web typecheck` passes.
- DoltHub shows `status: 'coming_soon'` in production builds because `enabled: false`.

## Visual Changes

N/A

## Reviewer Notes

N/A