### PR TITLE
fix(kiloclaw): retry startup on stale Fly volumes

### DIFF
--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance.test.ts
@@ -4298,6 +4298,57 @@ describe('start: volume region validation', () => {
     expect(storage._store.get('status')).toBe('running');
   });
 
+  it('handles volume gone during createMachine by clearing stale volume and retrying once', async () => {
+    const { instance, storage } = createInstance();
+    await seedProvisioned(storage, {
+      flyMachineId: null,
+      flyVolumeId: 'vol-stale',
+      flyRegion: 'iad',
+    });
+
+    (flyClient.getVolume as Mock).mockResolvedValue({ id: 'vol-stale', region: 'iad' });
+    (flyClient.createVolumeWithFallback as Mock).mockResolvedValue({
+      id: 'vol-new',
+      region: 'dfw',
+    });
+    (flyClient.createMachine as Mock)
+      .mockRejectedValueOnce(
+        new FlyApiError(
+          'Fly API createMachine failed (400): {"error":"volume not found"}',
+          400,
+          '{"error":"volume not found"}'
+        )
+      )
+      .mockResolvedValueOnce({ id: 'machine-1', region: 'dfw' });
+    (flyClient.waitForState as Mock).mockResolvedValue(undefined);
+
+    await instance.start('user-1');
+
+    expect(flyClient.createMachine).toHaveBeenCalledTimes(2);
+    expect(flyClient.createVolumeWithFallback).toHaveBeenCalledTimes(1);
+    expect((flyClient.createMachine as Mock).mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        mounts: [{ volume: 'vol-stale', path: '/root' }],
+      })
+    );
+    expect((flyClient.createMachine as Mock).mock.calls[1][1]).toEqual(
+      expect.objectContaining({
+        mounts: [{ volume: 'vol-new', path: '/root' }],
+      })
+    );
+    expect(storage._store.get('flyVolumeId')).toBe('vol-new');
+    expect(storage._store.get('flyRegion')).toBe('dfw');
+    expect(storage._store.get('flyMachineId')).toBe('machine-1');
+    expect(storage._store.get('status')).toBe('running');
+
+    const warnCall = (console.warn as Mock).mock.calls.find(
+      call =>
+        typeof call[0] === 'string' &&
+        call[0].includes('Volume not found during machine creation, clearing')
+    );
+    expect(warnCall).toBeDefined();
+  });
+
   it('performs region check even when machine already exists', async () => {
     const { instance, storage } = createInstance();
     await seedRunning(storage, { status: 'stopped' });

--- a/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
+++ b/services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts
@@ -2101,31 +2101,61 @@ export class KiloClawInstance extends DurableObject<KiloClawEnv> {
       this.s.provider
     );
 
-    const startResult = await this.provider().startRuntime({
-      env: this.env,
-      state: this.s,
-      runtimeSpec,
-      minSecretsVersion,
-      preferredRegion: this.env.FLY_REGION,
-      onProviderResult: result => this.persistProviderResult(result),
-      onCapacityRecovery: async err => {
-        const code = err instanceof fly.FlyApiError ? err.status : 0;
-        const errorMessage = err instanceof Error ? err.message : String(err);
-        this.emitStartCapacityRecovery(errorMessage, this.capacityRecoveryLabel(err));
-        doError(this.s, 'Insufficient resources, replacing stranded volume', {
-          statusCode: code,
-          region: this.s.flyRegion ?? 'unknown',
-        });
+    const startRuntime = () =>
+      this.provider().startRuntime({
+        env: this.env,
+        state: this.s,
+        runtimeSpec,
+        minSecretsVersion,
+        preferredRegion: this.env.FLY_REGION,
+        onProviderResult: result => this.persistProviderResult(result),
+        onCapacityRecovery: async err => {
+          const code = err instanceof fly.FlyApiError ? err.status : 0;
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          this.emitStartCapacityRecovery(errorMessage, this.capacityRecoveryLabel(err));
+          doError(this.s, 'Insufficient resources, replacing stranded volume', {
+            statusCode: code,
+            region: this.s.flyRegion ?? 'unknown',
+          });
 
-        if (code === 403 && this.s.flyRegion) {
-          await regionHelpers.evictCapacityRegionFromKV(
-            this.env.KV_CLAW_CACHE,
-            this.env,
-            this.s.flyRegion
-          );
-        }
-      },
-    });
+          if (code === 403 && this.s.flyRegion) {
+            await regionHelpers.evictCapacityRegionFromKV(
+              this.env.KV_CLAW_CACHE,
+              this.env,
+              this.s.flyRegion
+            );
+          }
+        },
+      });
+
+    let startResult: ProviderResult;
+    try {
+      startResult = await startRuntime();
+    } catch (err) {
+      if (!isFlyProvider || this.s.flyMachineId || !fly.isFlyMissingVolume(err)) {
+        throw err;
+      }
+
+      const flyState = getFlyProviderState(this.s);
+      doWarn(this.s, 'Volume not found during machine creation, clearing', {
+        volumeId: flyState.volumeId,
+      });
+      await this.persistProviderResult({
+        providerState: {
+          ...flyState,
+          volumeId: null,
+          region: null,
+        },
+      });
+      await this.persistProviderResult(
+        await this.provider().ensureStorage({
+          env: this.env,
+          state: this.s,
+          reason: 'start_missing_volume_recovery',
+        })
+      );
+      startResult = await startRuntime();
+    }
     await this.persistProviderResult(startResult);
 
     if (getRuntimeId(this.s)) {

--- a/services/kiloclaw/src/providers/fly/index.ts
+++ b/services/kiloclaw/src/providers/fly/index.ts
@@ -157,6 +157,7 @@ export const flyProviderAdapter: InstanceProviderAdapter = {
         providerState = result.providerState;
       }
     } catch (err) {
+      if (fly.isFlyMissingVolume(err)) throw err;
       if (!fly.isFlyInsufficientResources(err)) throw err;
 
       await onCapacityRecovery?.(err);


### PR DESCRIPTION
## Summary
This PR adds a one-time recovery path for Fly machine startup when a stored volume ID is stale and Fly returns `400 volume not found` during `createMachine`.

### Why this change is needed
Fly can report an existing volume via `getVolume()` and still reject machine creation for that same ID if the volume was deleted or soft-deleted in the interim. Before this change, that failure bubbled out of startup, got sanitized to a generic start error, and left the instance stuck on the stale volume forever.

### How this is addressed
- Detect the missing-volume error during machine creation with the existing Fly missing-volume predicate.
- Clear the stale Fly volume/region from Durable Object state, persist the cleanup, provision a fresh volume, and retry startup once.
- Keep the existing capacity-recovery path unchanged so 409/412-style failures still follow the stranded-volume flow.
- Add unit coverage for the stale-volume startup path.

## Human Verification
- Verified the new path with `pnpm --filter kiloclaw test -- src/durable-objects/kiloclaw-instance.test.ts`.
- Reviewed the change against the existing Fly region-check recovery path to confirm the retry behavior is one-shot and scoped to missing-volume errors.

## Reviewer Notes
### Human Reviewer Flags
- The recovery is intentionally limited to a single retry to avoid masking a persistent Fly-side failure.
- Capacity recovery remains routed through the existing stranded-volume logic; this change only handles stale/missing volume IDs.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- `services/kiloclaw/src/providers/fly/index.ts` now lets missing-volume errors escape before capacity recovery so `startRuntime()` can distinguish them from 409/412 resource failures.
- `services/kiloclaw/src/durable-objects/kiloclaw-instance/index.ts` clears `flyVolumeId` and `flyRegion`, persists the reset, calls `ensureStorage()` again, and retries startup once.
- The new test covers the stale-volume case end to end and asserts the retry uses the replacement volume.

</details>
