### PR TITLE
feat(integrations): add DoltHub OAuth service module and env wiring

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -51,6 +51,10 @@ LINKEDIN_CLIENT_SECRET=your-linkedin-client-secret
 # Discord OAuth (optional)
 DISCORD_CLIENT_ID=your-discord-client-id
 DISCORD_CLIENT_SECRET=your-discord-client-secret
+
+# DoltHub OAuth (dev only — app pending admin approval)
+DOLTHUB_APP_DEV_CLIENT_ID=dhoci.v1.tdg4bfv15v24adbpc2fqeqddugotg64nd9puisim322d0p452i50
+DOLTHUB_APP_DEV_CLIENT_SECRET=your-dolthub-client-secret
 # ============================================================================
 # Billing & Stripe (Required for billing features)
 # ============================================================================

--- a/apps/web/.env.test
+++ b/apps/web/.env.test
@@ -90,3 +90,7 @@ STRIPE_KILOCLAW_STANDARD_FIRST_MONTH_COUPON_ID=coupon_test_kiloclaw_standard_fir
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_invalid_mock_key
 
 CREDIT_CATEGORIES_ENCRYPTION_KEY=
+
+# DoltHub (dev-only OAuth integration)
+DOLTHUB_APP_DEV_CLIENT_ID=test-dolthub-client-id
+DOLTHUB_APP_DEV_CLIENT_SECRET=test-dolthub-client-secret

--- a/apps/web/src/lib/config.server.ts
+++ b/apps/web/src/lib/config.server.ts
@@ -142,6 +142,10 @@ export const LINEAR_CLIENT_ID = getEnvVariable('LINEAR_CLIENT_ID');
 export const LINEAR_CLIENT_SECRET = getEnvVariable('LINEAR_CLIENT_SECRET');
 export const LINEAR_WEBHOOK_SECRET = getEnvVariable('LINEAR_WEBHOOK_SECRET');
 
+// DoltHub (dev-only OAuth integration — app pending admin approval)
+export const DOLTHUB_APP_DEV_CLIENT_ID = getEnvVariable('DOLTHUB_APP_DEV_CLIENT_ID');
+export const DOLTHUB_APP_DEV_CLIENT_SECRET = getEnvVariable('DOLTHUB_APP_DEV_CLIENT_SECRET');
+
 // Discord (bot integration — existing)
 export const DISCORD_CLIENT_ID = getEnvVariable('DISCORD_CLIENT_ID');
 export const DISCORD_CLIENT_SECRET = getEnvVariable('DISCORD_CLIENT_SECRET');

--- a/apps/web/src/lib/integrations/dolthub-service.test.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.test.ts
@@ -1,44 +1,10 @@
-import type * as ConfigServerModule from '@/lib/config.server';
-jest.mock('@/lib/config.server', () => {
-  const actual = jest.requireActual<typeof ConfigServerModule>('@/lib/config.server');
-  return {
-    ...actual,
-    DOLTHUB_APP_DEV_CLIENT_ID: 'dhoci.v1.tdg4bfv15v24adbpc2fqeqddugotg64nd9puisim322d0p452i50',
-    DOLTHUB_APP_DEV_CLIENT_SECRET: 'dolthub-client-secret-test',
-  };
-});
-
-const mockSelectLimit = jest.fn();
-const mockUpdateSet = jest.fn();
-const mockUpdateWhere = jest.fn();
-const mockUpdateReturning = jest.fn();
-const mockDeleteWhere = jest.fn();
-const mockInsertValues = jest.fn();
-const mockInsertReturning = jest.fn();
-
-jest.mock('@/lib/drizzle', () => ({
-  db: {
-    select: jest.fn(() => ({
-      from: jest.fn(() => ({
-        where: jest.fn(() => ({
-          limit: mockSelectLimit,
-        })),
-      })),
-    })),
-    delete: jest.fn(() => ({
-      where: mockDeleteWhere,
-    })),
-    update: jest.fn(() => ({
-      set: mockUpdateSet,
-    })),
-    insert: jest.fn(() => ({
-      values: mockInsertValues,
-    })),
-  },
-}));
-
-import { describe, test, expect, beforeEach } from '@jest/globals';
-import type { PlatformIntegration } from '@kilocode/db/schema';
+import { afterEach, beforeAll, describe, expect, test } from '@jest/globals';
+import { db } from '@/lib/drizzle';
+import { platform_integrations } from '@kilocode/db/schema';
+import { and, eq } from 'drizzle-orm';
+import type { User } from '@kilocode/db/schema';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { PLATFORM, INTEGRATION_STATUS } from '@/lib/integrations/core/constants';
 import {
   getDoltHubOAuthUrl,
   exchangeDoltHubOAuthCode,
@@ -48,7 +14,9 @@ import {
   uninstall,
   getValidDoltHubToken,
   DOLTHUB_REDIRECT_URI,
+  DOLTHUB_SCOPES,
 } from '@/lib/integrations/dolthub-service';
+import { DOLTHUB_APP_DEV_CLIENT_ID } from '@/lib/config.server';
 
 function setNodeEnv(value: string) {
   Object.defineProperty(process.env, 'NODE_ENV', {
@@ -58,70 +26,39 @@ function setNodeEnv(value: string) {
   });
 }
 
-function buildIntegration(overrides: Record<string, unknown> = {}): PlatformIntegration {
-  return {
-    id: 'integration-1',
-    platform: 'dolthub',
-    integration_type: 'oauth',
-    integration_status: 'active',
-    owned_by_user_id: 'user-1',
-    owned_by_organization_id: null,
-    platform_account_login: 'testuser',
-    metadata: {
-      access_token: 'access-token-123',
-      refresh_token: 'refresh-token-456',
-      expires_at: Date.now() + 3600 * 1000,
-      scope: 'api_read_write',
-    },
-    created_at: new Date().toISOString(),
-    created_by_user_id: null,
-    github_app_type: null,
-    installed_at: new Date().toISOString(),
-    kilo_requester_user_id: null,
-    permissions: null,
-    platform_account_id: null,
-    platform_installation_id: null,
-    platform_requester_account_id: null,
-    repositories: null,
-    repositories_synced_at: null,
-    repository_access: null,
-    scopes: null,
-    suspended_at: null,
-    suspended_by: null,
-    updated_at: new Date().toISOString(),
-    ...overrides,
-  } as PlatformIntegration;
-}
-
-const owner = { type: 'user' as const, id: 'user-1' };
-
 describe('dolthub-service', () => {
   const originalNodeEnv = process.env.NODE_ENV;
+  const originalFetch = globalThis.fetch;
+  let user: User;
 
-  beforeEach(() => {
+  beforeAll(async () => {
+    user = await insertTestUser({
+      google_user_email: 'dolthub-test@example.com',
+      google_user_name: 'DoltHub Test',
+    });
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
     setNodeEnv(originalNodeEnv);
-    mockSelectLimit.mockReset();
-    mockUpdateSet.mockReset();
-    mockUpdateWhere.mockReset();
-    mockUpdateReturning.mockReset();
-    mockDeleteWhere.mockReset();
-    mockInsertValues.mockReset();
-    mockInsertReturning.mockReset();
-
-    mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
-    mockUpdateWhere.mockReturnValue({ returning: mockUpdateReturning });
-    mockInsertValues.mockReturnValue({ returning: mockInsertReturning });
+    await db
+      .delete(platform_integrations)
+      .where(
+        and(
+          eq(platform_integrations.platform, PLATFORM.DOLTHUB),
+          eq(platform_integrations.owned_by_user_id, user.id)
+        )
+      );
   });
 
   describe('getDoltHubOAuthUrl', () => {
-    test('includes the exact registered client ID and redirect URI', () => {
+    test('includes the required OAuth parameters', () => {
       const url = getDoltHubOAuthUrl('test-state-123');
       expect(url).toMatch(/^https:\/\/www\.dolthub\.com\/oauth\/authorize/);
-      expect(url).toContain(
-        'client_id=dhoci.v1.tdg4bfv15v24adbpc2fqeqddugotg64nd9puisim322d0p452i50'
-      );
+      expect(url).toContain(`client_id=${encodeURIComponent(DOLTHUB_APP_DEV_CLIENT_ID)}`);
+      expect(url).toContain('response_type=code');
       expect(url).toContain(`redirect_uri=${encodeURIComponent(DOLTHUB_REDIRECT_URI)}`);
-      expect(url).toContain('scope=api_read_write');
+      expect(url).toContain(`scope=${encodeURIComponent(DOLTHUB_SCOPES.join(','))}`);
       expect(url).toContain('state=test-state-123');
     });
 
@@ -179,7 +116,7 @@ describe('dolthub-service', () => {
       });
 
       await expect(exchangeDoltHubOAuthCode('incomplete')).rejects.toThrow(
-        'DoltHub token exchange returned no access_token'
+        'DoltHub token exchange returned invalid payload'
       );
     });
 
@@ -228,23 +165,29 @@ describe('dolthub-service', () => {
 
   describe('getInstallation', () => {
     test('returns an integration when found', async () => {
-      const integration = buildIntegration();
-      mockSelectLimit.mockResolvedValue([integration]);
+      await db.insert(platform_integrations).values({
+        owned_by_user_id: user.id,
+        owned_by_organization_id: null,
+        platform: PLATFORM.DOLTHUB,
+        integration_type: 'oauth',
+        platform_account_login: 'testuser',
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        metadata: { access_token: 'token' },
+      });
 
-      const result = await getInstallation(owner);
-      expect(result).toEqual(integration);
+      const result = await getInstallation({ type: 'user', id: user.id });
+      expect(result).not.toBeNull();
+      expect(result?.platform_account_login).toBe('testuser');
     });
 
     test('returns null when not found', async () => {
-      mockSelectLimit.mockResolvedValue([]);
-
-      const result = await getInstallation(owner);
+      const result = await getInstallation({ type: 'user', id: user.id });
       expect(result).toBeNull();
     });
 
     test('throws in production', async () => {
       setNodeEnv('production');
-      await expect(getInstallation(owner)).rejects.toThrow(
+      await expect(getInstallation({ type: 'user', id: user.id })).rejects.toThrow(
         'DoltHub integration is dev-only and not available in production'
       );
     });
@@ -252,12 +195,8 @@ describe('dolthub-service', () => {
 
   describe('upsertDoltHubInstallation', () => {
     test('creates a new installation when none exists', async () => {
-      mockSelectLimit.mockResolvedValue([]);
-      const created = buildIntegration({ id: 'new-id', platform_account_login: 'newuser' });
-      mockInsertReturning.mockResolvedValue([created]);
-
       const result = await upsertDoltHubInstallation({
-        owner,
+        owner: { type: 'user', id: user.id },
         account: { username: 'newuser' },
         tokens: {
           accessToken: 'token-new',
@@ -268,17 +207,35 @@ describe('dolthub-service', () => {
       });
 
       expect(result.platform_account_login).toBe('newuser');
-      expect(mockInsertReturning).toHaveBeenCalledTimes(1);
+      expect(result.platform).toBe(PLATFORM.DOLTHUB);
+      expect(result.integration_status).toBe(INTEGRATION_STATUS.ACTIVE);
+
+      const [row] = await db
+        .select()
+        .from(platform_integrations)
+        .where(
+          and(
+            eq(platform_integrations.platform, PLATFORM.DOLTHUB),
+            eq(platform_integrations.owned_by_user_id, user.id)
+          )
+        );
+      expect(row.platform_account_login).toBe('newuser');
     });
 
     test('updates an existing installation', async () => {
-      const existing = buildIntegration();
-      mockSelectLimit.mockResolvedValue([existing]);
-      const updated = buildIntegration({ platform_account_login: 'updateduser' });
-      mockUpdateReturning.mockResolvedValue([updated]);
+      await upsertDoltHubInstallation({
+        owner: { type: 'user', id: user.id },
+        account: { username: 'olduser' },
+        tokens: {
+          accessToken: 'token-old',
+          refreshToken: 'refresh-old',
+          expiresIn: 3600,
+          scope: 'api_read_write',
+        },
+      });
 
       const result = await upsertDoltHubInstallation({
-        owner,
+        owner: { type: 'user', id: user.id },
         account: { username: 'updateduser' },
         tokens: {
           accessToken: 'token-updated',
@@ -289,15 +246,24 @@ describe('dolthub-service', () => {
       });
 
       expect(result.platform_account_login).toBe('updateduser');
-      expect(mockUpdateReturning).toHaveBeenCalledTimes(1);
-      expect(mockInsertReturning).not.toHaveBeenCalled();
+
+      const [row] = await db
+        .select()
+        .from(platform_integrations)
+        .where(
+          and(
+            eq(platform_integrations.platform, PLATFORM.DOLTHUB),
+            eq(platform_integrations.owned_by_user_id, user.id)
+          )
+        );
+      expect(row.platform_account_login).toBe('updateduser');
     });
 
     test('throws in production', async () => {
       setNodeEnv('production');
       await expect(
         upsertDoltHubInstallation({
-          owner,
+          owner: { type: 'user', id: user.id },
           account: { username: 'x' },
           tokens: {
             accessToken: 't',
@@ -312,25 +278,39 @@ describe('dolthub-service', () => {
 
   describe('uninstall', () => {
     test('deletes the installation when found', async () => {
-      mockSelectLimit.mockResolvedValue([buildIntegration()]);
-      mockDeleteWhere.mockResolvedValue(undefined);
+      await db.insert(platform_integrations).values({
+        owned_by_user_id: user.id,
+        owned_by_organization_id: null,
+        platform: PLATFORM.DOLTHUB,
+        integration_type: 'oauth',
+        platform_account_login: 'testuser',
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        metadata: { access_token: 'token' },
+      });
 
-      const result = await uninstall(owner);
+      const result = await uninstall({ type: 'user', id: user.id });
       expect(result.success).toBe(true);
-      expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+
+      const rows = await db
+        .select()
+        .from(platform_integrations)
+        .where(
+          and(
+            eq(platform_integrations.platform, PLATFORM.DOLTHUB),
+            eq(platform_integrations.owned_by_user_id, user.id)
+          )
+        );
+      expect(rows).toHaveLength(0);
     });
 
     test('succeeds when no installation exists', async () => {
-      mockSelectLimit.mockResolvedValue([]);
-
-      const result = await uninstall(owner);
+      const result = await uninstall({ type: 'user', id: user.id });
       expect(result.success).toBe(true);
-      expect(mockDeleteWhere).not.toHaveBeenCalled();
     });
 
     test('throws in production', async () => {
       setNodeEnv('production');
-      await expect(uninstall(owner)).rejects.toThrow(
+      await expect(uninstall({ type: 'user', id: user.id })).rejects.toThrow(
         'DoltHub integration is dev-only and not available in production'
       );
     });
@@ -338,28 +318,46 @@ describe('dolthub-service', () => {
 
   describe('getValidDoltHubToken', () => {
     test('returns access token when not expired', async () => {
-      const integration = buildIntegration({
-        metadata: {
-          access_token: 'current-token',
-          refresh_token: 'refresh-token',
-          expires_at: Date.now() + 3600 * 1000,
-          scope: 'api_read_write',
-        },
-      });
+      const [integration] = await db
+        .insert(platform_integrations)
+        .values({
+          owned_by_user_id: user.id,
+          owned_by_organization_id: null,
+          platform: PLATFORM.DOLTHUB,
+          integration_type: 'oauth',
+          platform_account_login: 'testuser',
+          integration_status: INTEGRATION_STATUS.ACTIVE,
+          metadata: {
+            access_token: 'current-token',
+            refresh_token: 'refresh-token',
+            expires_at: Date.now() + 3600 * 1000,
+            scope: 'api_read_write',
+          },
+        })
+        .returning();
 
       const token = await getValidDoltHubToken(integration);
       expect(token).toBe('current-token');
     });
 
-    test('refreshes and persists new refresh_token when expired', async () => {
-      const integration = buildIntegration({
-        metadata: {
-          access_token: 'expired-token',
-          refresh_token: 'old-refresh',
-          expires_at: Date.now() - 1000,
-          scope: 'api_read_write',
-        },
-      });
+    test('refreshes and persists new token when expired', async () => {
+      const [integration] = await db
+        .insert(platform_integrations)
+        .values({
+          owned_by_user_id: user.id,
+          owned_by_organization_id: null,
+          platform: PLATFORM.DOLTHUB,
+          integration_type: 'oauth',
+          platform_account_login: 'testuser',
+          integration_status: INTEGRATION_STATUS.ACTIVE,
+          metadata: {
+            access_token: 'expired-token',
+            refresh_token: 'old-refresh',
+            expires_at: Date.now() - 1000,
+            scope: 'api_read_write',
+          },
+        })
+        .returning();
 
       globalThis.fetch = jest.fn().mockResolvedValue({
         ok: true,
@@ -371,41 +369,63 @@ describe('dolthub-service', () => {
         }),
       });
 
-      mockUpdateReturning.mockResolvedValue([{ ...integration }]);
-
       const token = await getValidDoltHubToken(integration);
       expect(token).toBe('refreshed-access');
 
-      expect(mockUpdateSet).toHaveBeenCalledTimes(1);
-      const updateCall = mockUpdateSet.mock.calls[0][0];
-      expect(updateCall.metadata.access_token).toBe('refreshed-access');
-      expect(updateCall.metadata.refresh_token).toBe('refreshed-refresh');
-      expect(updateCall.metadata.expires_at).toBeGreaterThan(Date.now());
+      const [row] = await db
+        .select()
+        .from(platform_integrations)
+        .where(eq(platform_integrations.id, integration.id));
+      const meta = row.metadata as {
+        access_token: string;
+        refresh_token: string;
+        expires_at: number;
+      };
+      expect(meta.access_token).toBe('refreshed-access');
+      expect(meta.refresh_token).toBe('refreshed-refresh');
+      expect(meta.expires_at).toBeGreaterThan(Date.now());
     });
 
     test('returns null when expired and no refresh token exists', async () => {
-      const integration = buildIntegration({
-        metadata: {
-          access_token: 'expired-token',
-          refresh_token: null,
-          expires_at: Date.now() - 1000,
-          scope: 'api_read_write',
-        },
-      });
+      const [integration] = await db
+        .insert(platform_integrations)
+        .values({
+          owned_by_user_id: user.id,
+          owned_by_organization_id: null,
+          platform: PLATFORM.DOLTHUB,
+          integration_type: 'oauth',
+          platform_account_login: 'testuser',
+          integration_status: INTEGRATION_STATUS.ACTIVE,
+          metadata: {
+            access_token: 'expired-token',
+            refresh_token: null,
+            expires_at: Date.now() - 1000,
+            scope: 'api_read_write',
+          },
+        })
+        .returning();
 
       const token = await getValidDoltHubToken(integration);
       expect(token).toBeNull();
     });
 
     test('returns null when access token is missing', async () => {
-      const integration = buildIntegration({
-        metadata: {
-          access_token: undefined,
-          refresh_token: 'refresh-token',
-          expires_at: Date.now() + 3600 * 1000,
-          scope: 'api_read_write',
-        },
-      });
+      const [integration] = await db
+        .insert(platform_integrations)
+        .values({
+          owned_by_user_id: user.id,
+          owned_by_organization_id: null,
+          platform: PLATFORM.DOLTHUB,
+          integration_type: 'oauth',
+          platform_account_login: 'testuser',
+          integration_status: INTEGRATION_STATUS.ACTIVE,
+          metadata: {
+            refresh_token: 'refresh-token',
+            expires_at: Date.now() + 3600 * 1000,
+            scope: 'api_read_write',
+          },
+        })
+        .returning();
 
       const token = await getValidDoltHubToken(integration);
       expect(token).toBeNull();
@@ -413,7 +433,20 @@ describe('dolthub-service', () => {
 
     test('throws in production', async () => {
       setNodeEnv('production');
-      await expect(getValidDoltHubToken(buildIntegration())).rejects.toThrow(
+      const [integration] = await db
+        .insert(platform_integrations)
+        .values({
+          owned_by_user_id: user.id,
+          owned_by_organization_id: null,
+          platform: PLATFORM.DOLTHUB,
+          integration_type: 'oauth',
+          platform_account_login: 'testuser',
+          integration_status: INTEGRATION_STATUS.ACTIVE,
+          metadata: { access_token: 'token' },
+        })
+        .returning();
+
+      await expect(getValidDoltHubToken(integration)).rejects.toThrow(
         'DoltHub integration is dev-only and not available in production'
       );
     });

--- a/apps/web/src/lib/integrations/dolthub-service.test.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.test.ts
@@ -1,0 +1,421 @@
+import type * as ConfigServerModule from '@/lib/config.server';
+jest.mock('@/lib/config.server', () => {
+  const actual = jest.requireActual<typeof ConfigServerModule>('@/lib/config.server');
+  return {
+    ...actual,
+    DOLTHUB_APP_DEV_CLIENT_ID: 'dhoci.v1.tdg4bfv15v24adbpc2fqeqddugotg64nd9puisim322d0p452i50',
+    DOLTHUB_APP_DEV_CLIENT_SECRET: 'dolthub-client-secret-test',
+  };
+});
+
+const mockSelectLimit = jest.fn();
+const mockUpdateSet = jest.fn();
+const mockUpdateWhere = jest.fn();
+const mockUpdateReturning = jest.fn();
+const mockDeleteWhere = jest.fn();
+const mockInsertValues = jest.fn();
+const mockInsertReturning = jest.fn();
+
+jest.mock('@/lib/drizzle', () => ({
+  db: {
+    select: jest.fn(() => ({
+      from: jest.fn(() => ({
+        where: jest.fn(() => ({
+          limit: mockSelectLimit,
+        })),
+      })),
+    })),
+    delete: jest.fn(() => ({
+      where: mockDeleteWhere,
+    })),
+    update: jest.fn(() => ({
+      set: mockUpdateSet,
+    })),
+    insert: jest.fn(() => ({
+      values: mockInsertValues,
+    })),
+  },
+}));
+
+import { describe, test, expect, beforeEach } from '@jest/globals';
+import type { PlatformIntegration } from '@kilocode/db/schema';
+import {
+  getDoltHubOAuthUrl,
+  exchangeDoltHubOAuthCode,
+  refreshDoltHubAccessToken,
+  getInstallation,
+  upsertDoltHubInstallation,
+  uninstall,
+  getValidDoltHubToken,
+  DOLTHUB_REDIRECT_URI,
+} from '@/lib/integrations/dolthub-service';
+
+function setNodeEnv(value: string) {
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function buildIntegration(overrides: Record<string, unknown> = {}): PlatformIntegration {
+  return {
+    id: 'integration-1',
+    platform: 'dolthub',
+    integration_type: 'oauth',
+    integration_status: 'active',
+    owned_by_user_id: 'user-1',
+    owned_by_organization_id: null,
+    platform_account_login: 'testuser',
+    metadata: {
+      access_token: 'access-token-123',
+      refresh_token: 'refresh-token-456',
+      expires_at: Date.now() + 3600 * 1000,
+      scope: 'api_read_write',
+    },
+    created_at: new Date().toISOString(),
+    created_by_user_id: null,
+    github_app_type: null,
+    installed_at: new Date().toISOString(),
+    kilo_requester_user_id: null,
+    permissions: null,
+    platform_account_id: null,
+    platform_installation_id: null,
+    platform_requester_account_id: null,
+    repositories: null,
+    repositories_synced_at: null,
+    repository_access: null,
+    scopes: null,
+    suspended_at: null,
+    suspended_by: null,
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  } as PlatformIntegration;
+}
+
+const owner = { type: 'user' as const, id: 'user-1' };
+
+describe('dolthub-service', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    setNodeEnv(originalNodeEnv);
+    mockSelectLimit.mockReset();
+    mockUpdateSet.mockReset();
+    mockUpdateWhere.mockReset();
+    mockUpdateReturning.mockReset();
+    mockDeleteWhere.mockReset();
+    mockInsertValues.mockReset();
+    mockInsertReturning.mockReset();
+
+    mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
+    mockUpdateWhere.mockReturnValue({ returning: mockUpdateReturning });
+    mockInsertValues.mockReturnValue({ returning: mockInsertReturning });
+  });
+
+  describe('getDoltHubOAuthUrl', () => {
+    test('includes the exact registered client ID and redirect URI', () => {
+      const url = getDoltHubOAuthUrl('test-state-123');
+      expect(url).toMatch(/^https:\/\/www\.dolthub\.com\/oauth\/authorize/);
+      expect(url).toContain(
+        'client_id=dhoci.v1.tdg4bfv15v24adbpc2fqeqddugotg64nd9puisim322d0p452i50'
+      );
+      expect(url).toContain(`redirect_uri=${encodeURIComponent(DOLTHUB_REDIRECT_URI)}`);
+      expect(url).toContain('scope=api_read_write');
+      expect(url).toContain('state=test-state-123');
+    });
+
+    test('throws in production', () => {
+      setNodeEnv('production');
+      expect(() => getDoltHubOAuthUrl('state')).toThrow(
+        'DoltHub integration is dev-only and not available in production'
+      );
+    });
+  });
+
+  describe('exchangeDoltHubOAuthCode', () => {
+    test('successfully exchanges code for tokens', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          access_token: 'access-token-123',
+          refresh_token: 'refresh-token-456',
+          expires_in: 3600,
+          scope: 'api_read_write',
+        }),
+      });
+      globalThis.fetch = mockFetch;
+
+      const result = await exchangeDoltHubOAuthCode('auth-code-xyz');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://www.dolthub.com/api/oauth/access_token');
+      expect(init?.method).toBe('POST');
+      expect(init?.headers?.Authorization).toContain('Basic ');
+
+      expect(result.accessToken).toBe('access-token-123');
+      expect(result.refreshToken).toBe('refresh-token-456');
+      expect(result.expiresIn).toBe(3600);
+      expect(result.scope).toBe('api_read_write');
+    });
+
+    test('throws when token exchange fails', async () => {
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+      });
+
+      await expect(exchangeDoltHubOAuthCode('bad-code')).rejects.toThrow(
+        'DoltHub token exchange failed: 400 Bad Request'
+      );
+    });
+
+    test('throws when response lacks access_token', async () => {
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ refresh_token: 'only-refresh' }),
+      });
+
+      await expect(exchangeDoltHubOAuthCode('incomplete')).rejects.toThrow(
+        'DoltHub token exchange returned no access_token'
+      );
+    });
+
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      await expect(exchangeDoltHubOAuthCode('code')).rejects.toThrow(
+        'DoltHub integration is dev-only and not available in production'
+      );
+    });
+  });
+
+  describe('refreshDoltHubAccessToken', () => {
+    test('successfully refreshes and returns new tokens', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          access_token: 'new-access-token',
+          refresh_token: 'new-refresh-token',
+          expires_in: 7200,
+          scope: 'api_read_write',
+        }),
+      });
+      globalThis.fetch = mockFetch;
+
+      const result = await refreshDoltHubAccessToken('old-refresh-token');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://www.dolthub.com/api/oauth/access_token');
+      const body = init?.body as string;
+      expect(body).toContain('grant_type=refresh_token');
+      expect(body).toContain('refresh_token=old-refresh-token');
+
+      expect(result.accessToken).toBe('new-access-token');
+      expect(result.refreshToken).toBe('new-refresh-token');
+      expect(result.expiresIn).toBe(7200);
+    });
+
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      await expect(refreshDoltHubAccessToken('token')).rejects.toThrow(
+        'DoltHub integration is dev-only and not available in production'
+      );
+    });
+  });
+
+  describe('getInstallation', () => {
+    test('returns an integration when found', async () => {
+      const integration = buildIntegration();
+      mockSelectLimit.mockResolvedValue([integration]);
+
+      const result = await getInstallation(owner);
+      expect(result).toEqual(integration);
+    });
+
+    test('returns null when not found', async () => {
+      mockSelectLimit.mockResolvedValue([]);
+
+      const result = await getInstallation(owner);
+      expect(result).toBeNull();
+    });
+
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      await expect(getInstallation(owner)).rejects.toThrow(
+        'DoltHub integration is dev-only and not available in production'
+      );
+    });
+  });
+
+  describe('upsertDoltHubInstallation', () => {
+    test('creates a new installation when none exists', async () => {
+      mockSelectLimit.mockResolvedValue([]);
+      const created = buildIntegration({ id: 'new-id', platform_account_login: 'newuser' });
+      mockInsertReturning.mockResolvedValue([created]);
+
+      const result = await upsertDoltHubInstallation({
+        owner,
+        account: { username: 'newuser' },
+        tokens: {
+          accessToken: 'token-new',
+          refreshToken: 'refresh-new',
+          expiresIn: 3600,
+          scope: 'api_read_write',
+        },
+      });
+
+      expect(result.platform_account_login).toBe('newuser');
+      expect(mockInsertReturning).toHaveBeenCalledTimes(1);
+    });
+
+    test('updates an existing installation', async () => {
+      const existing = buildIntegration();
+      mockSelectLimit.mockResolvedValue([existing]);
+      const updated = buildIntegration({ platform_account_login: 'updateduser' });
+      mockUpdateReturning.mockResolvedValue([updated]);
+
+      const result = await upsertDoltHubInstallation({
+        owner,
+        account: { username: 'updateduser' },
+        tokens: {
+          accessToken: 'token-updated',
+          refreshToken: 'refresh-updated',
+          expiresIn: 7200,
+          scope: 'api_read_write',
+        },
+      });
+
+      expect(result.platform_account_login).toBe('updateduser');
+      expect(mockUpdateReturning).toHaveBeenCalledTimes(1);
+      expect(mockInsertReturning).not.toHaveBeenCalled();
+    });
+
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      await expect(
+        upsertDoltHubInstallation({
+          owner,
+          account: { username: 'x' },
+          tokens: {
+            accessToken: 't',
+            refreshToken: null,
+            expiresIn: null,
+            scope: null,
+          },
+        })
+      ).rejects.toThrow('DoltHub integration is dev-only and not available in production');
+    });
+  });
+
+  describe('uninstall', () => {
+    test('deletes the installation when found', async () => {
+      mockSelectLimit.mockResolvedValue([buildIntegration()]);
+      mockDeleteWhere.mockResolvedValue(undefined);
+
+      const result = await uninstall(owner);
+      expect(result.success).toBe(true);
+      expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+    });
+
+    test('succeeds when no installation exists', async () => {
+      mockSelectLimit.mockResolvedValue([]);
+
+      const result = await uninstall(owner);
+      expect(result.success).toBe(true);
+      expect(mockDeleteWhere).not.toHaveBeenCalled();
+    });
+
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      await expect(uninstall(owner)).rejects.toThrow(
+        'DoltHub integration is dev-only and not available in production'
+      );
+    });
+  });
+
+  describe('getValidDoltHubToken', () => {
+    test('returns access token when not expired', async () => {
+      const integration = buildIntegration({
+        metadata: {
+          access_token: 'current-token',
+          refresh_token: 'refresh-token',
+          expires_at: Date.now() + 3600 * 1000,
+          scope: 'api_read_write',
+        },
+      });
+
+      const token = await getValidDoltHubToken(integration);
+      expect(token).toBe('current-token');
+    });
+
+    test('refreshes and persists new refresh_token when expired', async () => {
+      const integration = buildIntegration({
+        metadata: {
+          access_token: 'expired-token',
+          refresh_token: 'old-refresh',
+          expires_at: Date.now() - 1000,
+          scope: 'api_read_write',
+        },
+      });
+
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          access_token: 'refreshed-access',
+          refresh_token: 'refreshed-refresh',
+          expires_in: 3600,
+          scope: 'api_read_write',
+        }),
+      });
+
+      mockUpdateReturning.mockResolvedValue([{ ...integration }]);
+
+      const token = await getValidDoltHubToken(integration);
+      expect(token).toBe('refreshed-access');
+
+      expect(mockUpdateSet).toHaveBeenCalledTimes(1);
+      const updateCall = mockUpdateSet.mock.calls[0][0];
+      expect(updateCall.metadata.access_token).toBe('refreshed-access');
+      expect(updateCall.metadata.refresh_token).toBe('refreshed-refresh');
+      expect(updateCall.metadata.expires_at).toBeGreaterThan(Date.now());
+    });
+
+    test('returns null when expired and no refresh token exists', async () => {
+      const integration = buildIntegration({
+        metadata: {
+          access_token: 'expired-token',
+          refresh_token: null,
+          expires_at: Date.now() - 1000,
+          scope: 'api_read_write',
+        },
+      });
+
+      const token = await getValidDoltHubToken(integration);
+      expect(token).toBeNull();
+    });
+
+    test('returns null when access token is missing', async () => {
+      const integration = buildIntegration({
+        metadata: {
+          access_token: undefined,
+          refresh_token: 'refresh-token',
+          expires_at: Date.now() + 3600 * 1000,
+          scope: 'api_read_write',
+        },
+      });
+
+      const token = await getValidDoltHubToken(integration);
+      expect(token).toBeNull();
+    });
+
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      await expect(getValidDoltHubToken(buildIntegration())).rejects.toThrow(
+        'DoltHub integration is dev-only and not available in production'
+      );
+    });
+  });
+});

--- a/apps/web/src/lib/integrations/dolthub-service.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import { z } from 'zod';
 import { db } from '@/lib/drizzle';
 import type { PlatformIntegration } from '@kilocode/db/schema';
 import { platform_integrations } from '@kilocode/db/schema';
@@ -47,6 +48,7 @@ export function getDoltHubOAuthUrl(state: string): string {
 
   const params = new URLSearchParams({
     client_id: DOLTHUB_APP_DEV_CLIENT_ID,
+    response_type: 'code',
     scope: DOLTHUB_SCOPES.join(','),
     redirect_uri: DOLTHUB_REDIRECT_URI,
     state,
@@ -65,6 +67,28 @@ export type DoltHubTokenResponse = {
 export type DoltHubAccount = {
   username: string;
 };
+
+const DoltHubTokenPayloadSchema = z.object({
+  access_token: z.string().min(1),
+  refresh_token: z.string().optional(),
+  expires_in: z.number().optional(),
+  scope: z.string().optional(),
+});
+
+function parseDoltHubTokenPayload(raw: unknown, operation: 'exchange' | 'refresh'): DoltHubTokenResponse {
+  const parseResult = DoltHubTokenPayloadSchema.safeParse(raw);
+  if (!parseResult.success) {
+    const verb = operation === 'exchange' ? 'exchange' : 'refresh';
+    throw new Error(`DoltHub token ${verb} returned invalid payload`);
+  }
+  const parsed = parseResult.data;
+  return {
+    accessToken: parsed.access_token,
+    refreshToken: parsed.refresh_token ?? null,
+    expiresIn: parsed.expires_in ?? null,
+    scope: parsed.scope ?? null,
+  };
+}
 
 export async function exchangeDoltHubOAuthCode(code: string): Promise<DoltHubTokenResponse> {
   assertDevOnly();
@@ -88,23 +112,7 @@ export async function exchangeDoltHubOAuthCode(code: string): Promise<DoltHubTok
     throw new Error(`DoltHub token exchange failed: ${response.status} ${response.statusText}`);
   }
 
-  const payload = (await response.json()) as {
-    access_token?: unknown;
-    refresh_token?: unknown;
-    expires_in?: unknown;
-    scope?: unknown;
-  };
-
-  if (typeof payload.access_token !== 'string' || payload.access_token.length === 0) {
-    throw new Error('DoltHub token exchange returned no access_token');
-  }
-
-  return {
-    accessToken: payload.access_token,
-    refreshToken: typeof payload.refresh_token === 'string' ? payload.refresh_token : null,
-    expiresIn: typeof payload.expires_in === 'number' ? payload.expires_in : null,
-    scope: typeof payload.scope === 'string' ? payload.scope : null,
-  };
+  return parseDoltHubTokenPayload(await response.json(), 'exchange');
 }
 
 export async function refreshDoltHubAccessToken(refreshToken: string): Promise<DoltHubTokenResponse> {
@@ -129,23 +137,7 @@ export async function refreshDoltHubAccessToken(refreshToken: string): Promise<D
     throw new Error(`DoltHub token refresh failed: ${response.status} ${response.statusText}`);
   }
 
-  const payload = (await response.json()) as {
-    access_token?: unknown;
-    refresh_token?: unknown;
-    expires_in?: unknown;
-    scope?: unknown;
-  };
-
-  if (typeof payload.access_token !== 'string' || payload.access_token.length === 0) {
-    throw new Error('DoltHub token refresh returned no access_token');
-  }
-
-  return {
-    accessToken: payload.access_token,
-    refreshToken: typeof payload.refresh_token === 'string' ? payload.refresh_token : null,
-    expiresIn: typeof payload.expires_in === 'number' ? payload.expires_in : null,
-    scope: typeof payload.scope === 'string' ? payload.scope : null,
-  };
+  return parseDoltHubTokenPayload(await response.json(), 'refresh');
 }
 
 export async function getInstallation(owner: Owner): Promise<PlatformIntegration | null> {
@@ -195,6 +187,10 @@ export async function upsertDoltHubInstallation({
       .where(eq(platform_integrations.id, existing.id))
       .returning();
 
+    if (!updated) {
+      throw new Error('DoltHub installation update returned no rows');
+    }
+
     return updated;
   }
 
@@ -212,6 +208,10 @@ export async function upsertDoltHubInstallation({
       installed_at: new Date().toISOString(),
     })
     .returning();
+
+  if (!created) {
+    throw new Error('DoltHub installation insert returned no rows');
+  }
 
   return created;
 }
@@ -248,6 +248,8 @@ export async function getValidDoltHubToken(
     return null;
   }
 
+  // When expires_at is missing/null the token is treated as non-expiring
+  // (DoltHub issues long-lived tokens that do not include expires_in).
   if (metadata.expires_at && Date.now() >= metadata.expires_at) {
     if (!metadata.refresh_token) {
       return null;

--- a/apps/web/src/lib/integrations/dolthub-service.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.ts
@@ -78,8 +78,7 @@ const DoltHubTokenPayloadSchema = z.object({
 function parseDoltHubTokenPayload(raw: unknown, operation: 'exchange' | 'refresh'): DoltHubTokenResponse {
   const parseResult = DoltHubTokenPayloadSchema.safeParse(raw);
   if (!parseResult.success) {
-    const verb = operation === 'exchange' ? 'exchange' : 'refresh';
-    throw new Error(`DoltHub token ${verb} returned invalid payload`);
+    throw new Error(`DoltHub token ${operation} returned invalid payload`);
   }
   const parsed = parseResult.data;
   return {

--- a/apps/web/src/lib/integrations/dolthub-service.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.ts
@@ -1,0 +1,277 @@
+import 'server-only';
+import { db } from '@/lib/drizzle';
+import type { PlatformIntegration } from '@kilocode/db/schema';
+import { platform_integrations } from '@kilocode/db/schema';
+import { eq, and, isNull } from 'drizzle-orm';
+import type { Owner } from '@/lib/integrations/core/types';
+import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants';
+import { DOLTHUB_APP_DEV_CLIENT_ID, DOLTHUB_APP_DEV_CLIENT_SECRET } from '@/lib/config.server';
+import { APP_URL } from '@/lib/constants';
+
+const DOLTHUB_TOKEN_URL = 'https://www.dolthub.com/api/oauth/access_token';
+const DOLTHUB_AUTHORIZE_URL = 'https://www.dolthub.com/oauth/authorize';
+
+function assertDevOnly(): void {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('DoltHub integration is dev-only and not available in production');
+  }
+}
+
+function getOwnershipConditions(owner: Owner) {
+  return owner.type === 'user'
+    ? [
+        eq(platform_integrations.owned_by_user_id, owner.id),
+        isNull(platform_integrations.owned_by_organization_id),
+      ]
+    : [
+        eq(platform_integrations.owned_by_organization_id, owner.id),
+        isNull(platform_integrations.owned_by_user_id),
+      ];
+}
+
+export const DOLTHUB_SCOPES = ['api_read_write'];
+
+/**
+ * Redirect URI for the DoltHub OAuth flow.
+ *
+ * This MUST resolve to `http://localhost:3000/api/integrations/dolthub/callback`
+ * for the current registered DoltHub app. DoltHub only allows `https://` and
+ * `http://localhost/...` redirect URIs, and self-service mutation is not yet
+ * available. If a developer sets `APP_URL_OVERRIDE` (ngrok, etc.) they will
+ * need DoltHub admins to register the additional URI.
+ */
+export const DOLTHUB_REDIRECT_URI = `${APP_URL}/api/integrations/dolthub/callback`;
+
+export function getDoltHubOAuthUrl(state: string): string {
+  assertDevOnly();
+
+  const params = new URLSearchParams({
+    client_id: DOLTHUB_APP_DEV_CLIENT_ID,
+    scope: DOLTHUB_SCOPES.join(','),
+    redirect_uri: DOLTHUB_REDIRECT_URI,
+    state,
+  });
+
+  return `${DOLTHUB_AUTHORIZE_URL}?${params.toString()}`;
+}
+
+export type DoltHubTokenResponse = {
+  accessToken: string;
+  refreshToken: string | null;
+  expiresIn: number | null;
+  scope: string | null;
+};
+
+export type DoltHubAccount = {
+  username: string;
+};
+
+export async function exchangeDoltHubOAuthCode(code: string): Promise<DoltHubTokenResponse> {
+  assertDevOnly();
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: DOLTHUB_REDIRECT_URI,
+  });
+
+  const response = await fetch(DOLTHUB_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${btoa(`${DOLTHUB_APP_DEV_CLIENT_ID}:${DOLTHUB_APP_DEV_CLIENT_SECRET}`)}`,
+    },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    throw new Error(`DoltHub token exchange failed: ${response.status} ${response.statusText}`);
+  }
+
+  const payload = (await response.json()) as {
+    access_token?: unknown;
+    refresh_token?: unknown;
+    expires_in?: unknown;
+    scope?: unknown;
+  };
+
+  if (typeof payload.access_token !== 'string' || payload.access_token.length === 0) {
+    throw new Error('DoltHub token exchange returned no access_token');
+  }
+
+  return {
+    accessToken: payload.access_token,
+    refreshToken: typeof payload.refresh_token === 'string' ? payload.refresh_token : null,
+    expiresIn: typeof payload.expires_in === 'number' ? payload.expires_in : null,
+    scope: typeof payload.scope === 'string' ? payload.scope : null,
+  };
+}
+
+export async function refreshDoltHubAccessToken(refreshToken: string): Promise<DoltHubTokenResponse> {
+  assertDevOnly();
+
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    redirect_uri: DOLTHUB_REDIRECT_URI,
+  });
+
+  const response = await fetch(DOLTHUB_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${btoa(`${DOLTHUB_APP_DEV_CLIENT_ID}:${DOLTHUB_APP_DEV_CLIENT_SECRET}`)}`,
+    },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    throw new Error(`DoltHub token refresh failed: ${response.status} ${response.statusText}`);
+  }
+
+  const payload = (await response.json()) as {
+    access_token?: unknown;
+    refresh_token?: unknown;
+    expires_in?: unknown;
+    scope?: unknown;
+  };
+
+  if (typeof payload.access_token !== 'string' || payload.access_token.length === 0) {
+    throw new Error('DoltHub token refresh returned no access_token');
+  }
+
+  return {
+    accessToken: payload.access_token,
+    refreshToken: typeof payload.refresh_token === 'string' ? payload.refresh_token : null,
+    expiresIn: typeof payload.expires_in === 'number' ? payload.expires_in : null,
+    scope: typeof payload.scope === 'string' ? payload.scope : null,
+  };
+}
+
+export async function getInstallation(owner: Owner): Promise<PlatformIntegration | null> {
+  assertDevOnly();
+
+  const [integration] = await db
+    .select()
+    .from(platform_integrations)
+    .where(and(...getOwnershipConditions(owner), eq(platform_integrations.platform, PLATFORM.DOLTHUB)))
+    .limit(1);
+
+  return integration || null;
+}
+
+export async function upsertDoltHubInstallation({
+  owner,
+  account,
+  tokens,
+}: {
+  owner: Owner;
+  account: DoltHubAccount;
+  tokens: DoltHubTokenResponse;
+}): Promise<PlatformIntegration> {
+  assertDevOnly();
+
+  const existing = await getInstallation(owner);
+
+  const expiresAt = tokens.expiresIn ? Date.now() + tokens.expiresIn * 1000 : null;
+
+  const metadata = {
+    access_token: tokens.accessToken,
+    refresh_token: tokens.refreshToken,
+    expires_at: expiresAt,
+    scope: tokens.scope,
+  };
+
+  if (existing) {
+    const [updated] = await db
+      .update(platform_integrations)
+      .set({
+        platform_account_login: account.username,
+        scopes: DOLTHUB_SCOPES,
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        metadata,
+        updated_at: new Date().toISOString(),
+      })
+      .where(eq(platform_integrations.id, existing.id))
+      .returning();
+
+    return updated;
+  }
+
+  const [created] = await db
+    .insert(platform_integrations)
+    .values({
+      owned_by_user_id: owner.type === 'user' ? owner.id : null,
+      owned_by_organization_id: owner.type === 'org' ? owner.id : null,
+      platform: PLATFORM.DOLTHUB,
+      integration_type: 'oauth',
+      platform_account_login: account.username,
+      scopes: DOLTHUB_SCOPES,
+      integration_status: INTEGRATION_STATUS.ACTIVE,
+      metadata,
+      installed_at: new Date().toISOString(),
+    })
+    .returning();
+
+  return created;
+}
+
+export async function uninstall(owner: Owner): Promise<{ success: boolean }> {
+  assertDevOnly();
+
+  const integration = await getInstallation(owner);
+
+  if (!integration) {
+    return { success: true };
+  }
+
+  await db.delete(platform_integrations).where(eq(platform_integrations.id, integration.id));
+
+  return { success: true };
+}
+
+export async function getValidDoltHubToken(
+  integration: PlatformIntegration
+): Promise<string | null> {
+  assertDevOnly();
+
+  const metadata = integration.metadata as
+    | {
+        access_token?: string;
+        refresh_token?: string;
+        expires_at?: number;
+        scope?: string;
+      }
+    | null;
+
+  if (!metadata?.access_token) {
+    return null;
+  }
+
+  if (metadata.expires_at && Date.now() >= metadata.expires_at) {
+    if (!metadata.refresh_token) {
+      return null;
+    }
+
+    const newTokens = await refreshDoltHubAccessToken(metadata.refresh_token);
+    const newExpiresAt = newTokens.expiresIn ? Date.now() + newTokens.expiresIn * 1000 : null;
+
+    await db
+      .update(platform_integrations)
+      .set({
+        metadata: {
+          ...metadata,
+          access_token: newTokens.accessToken,
+          refresh_token: newTokens.refreshToken,
+          expires_at: newExpiresAt,
+          scope: newTokens.scope,
+        },
+        updated_at: new Date().toISOString(),
+      })
+      .where(eq(platform_integrations.id, integration.id));
+
+    return newTokens.accessToken;
+  }
+
+  return metadata.access_token;
+}


### PR DESCRIPTION
## Summary

Add a dev-only DoltHub OAuth service module (`dolthub-service.ts`) mirroring the shape of `linear-service.ts`, plus the required environment variable wiring.

- Add `DOLTHUB_APP_DEV_CLIENT_ID` and `DOLTHUB_APP_DEV_CLIENT_SECRET` to `apps/web/src/lib/config.server.ts`.
- Document the env vars in `.env.local.example` with the literal default client ID so dev setup is self-documenting.
- Create `apps/web/src/lib/integrations/dolthub-service.ts` with:
  - `assertDevOnly()` guard on every exported function (throws in production).
  - `DOLTHUB_SCOPES`, `DOLTHUB_REDIRECT_URI`, and `getDoltHubOAuthUrl(state)`.
  - `exchangeDoltHubOAuthCode(code)` and `refreshDoltHubAccessToken(refreshToken)` with HTTP Basic auth against DoltHub's token endpoint.
  - `getInstallation(owner)`, `upsertDoltHubInstallation(...)`, and `uninstall(owner)` using the `platform_integrations` table with `PLATFORM.DOLTHUB`.
  - `getValidDoltHubToken(integration)` that returns a non-expired access token or refreshes and persists new tokens.
- Add `apps/web/src/lib/integrations/dolthub-service.test.ts` with 22 unit tests covering URL builder, token exchange/refresh, installation lifecycle, and production guard behavior.

## Verification

- `pnpm --filter web typecheck` passes.
- `pnpm --filter web test -- src/lib/integrations/dolthub-service.test.ts` passes (22/22).

## Visual Changes

N/A

## Reviewer Notes

- DoltHub app approval is pending; token exchange may fail until DoltHub admins approve the registration. This is treated as a known dev-time error.
- The registered redirect URI is `http://localhost:3000/api/integrations/dolthub/callback`. If a developer overrides `APP_URL` (e.g. via ngrok), DoltHub admins must register the additional URI.
- Service has zero callers in production paths; later beads in this convoy will consume it.