### PR TITLE
feat(cloud-agent-next): increase max execution runtime from 30 to 60 minutes

### DIFF
--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -109,8 +109,8 @@ const LAST_ACTIVITY_KEY = 'last_activity';
 /** Kilo server idle timeout: 15 minutes */
 const KILO_SERVER_IDLE_TIMEOUT_MS_DEFAULT = 15 * 60 * 1000;
 
-/** Default per-execution wall-clock deadline: 30 minutes */
-const DEFAULT_MAX_RUNTIME_MS = 1_800_000;
+/** Default per-execution wall-clock deadline: 60 minutes */
+const DEFAULT_MAX_RUNTIME_MS = 3_600_000;
 
 /** Hung execution timeout: no non-heartbeat events for 5 minutes */
 const HUNG_EXECUTION_TIMEOUT_MS = 5 * 60 * 1000;
@@ -1638,7 +1638,7 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
 
   /**
    * Fail a running execution that has exceeded its wall-clock deadline
-   * (DEFAULT_MAX_RUNTIME_MS = 30 min).
+   * (DEFAULT_MAX_RUNTIME_MS = 60 min).
    */
   private async checkMaxRuntime(now: number): Promise<void> {
     const activeExecutionId = await this.executionQueries.getActiveExecutionId();


### PR DESCRIPTION
## Summary
Increase `DEFAULT_MAX_RUNTIME_MS` from 30 minutes (1_800_000ms) to 60 minutes (3_600_000ms). Code-review agents on large PRs are hitting the 30-minute wall-clock deadline while actively working (step 82 in one case), getting SIGTERM'd mid-stream by the DO's `checkMaxRuntime` alarm.

## Verification
- Confirmed `agent_c5775f0e-8c34-458b-b522-3a4a1171a436` was killed at exactly 32 min by `checkMaxRuntime` after reaching the 30-min limit while still actively processing (step 82, streaming LLM deltas)
- `pnpm --filter cloud-agent-next typecheck` passes
- Pre-push lint failures are all pre-existing `apps/mobile` issues unrelated to this change

## Visual Changes
N/A

## Reviewer Notes
- The 30-min limit was originally set conservatively; 60 min gives large code reviews enough runway without risking indefinite hangs (the `checkHungExecution` 5-min no-heartbeat timeout still guards against truly stuck executions)
- Note: container-level SIGTERM (Cloudflare runtime limit ~15 min) remains a separate issue — this change only affects the DO's own wall-clock deadline