### PR TITLE
feat(integrations): add tRPC dolthub-router with getInstallation, disconnect, and verifyToken

### DIFF
--- a/apps/web/src/routers/dolthub-router.test.ts
+++ b/apps/web/src/routers/dolthub-router.test.ts
@@ -1,0 +1,209 @@
+// Mock config.server so dolthub-service imports don't fail on missing env vars
+import type * as ConfigServerModule from '@/lib/config.server';
+jest.mock('@/lib/config.server', () => {
+  const actual = jest.requireActual<typeof ConfigServerModule>('@/lib/config.server');
+  return {
+    ...actual,
+    DOLTHUB_APP_DEV_CLIENT_ID: 'dolthub-client-id-test',
+    DOLTHUB_APP_DEV_CLIENT_SECRET: 'dolthub-client-secret-test',
+  };
+});
+
+import { describe, test, expect, beforeAll, afterEach } from '@jest/globals';
+import { TRPCError } from '@trpc/server';
+import type { User } from '@kilocode/db/schema';
+import { db } from '@/lib/drizzle';
+import { platform_integrations } from '@kilocode/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { createCallerForUser } from '@/routers/test-utils';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { PLATFORM, INTEGRATION_STATUS } from '@/lib/integrations/core/constants';
+
+function setNodeEnv(value: string) {
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe('dolthubRouter', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalFetch = globalThis.fetch;
+  let user: User;
+
+  beforeAll(async () => {
+    user = await insertTestUser({
+      google_user_email: 'dolthub-router-test@example.com',
+      google_user_name: 'DoltHub Router Test',
+    });
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    setNodeEnv(originalNodeEnv);
+    await db
+      .delete(platform_integrations)
+      .where(
+        and(
+          eq(platform_integrations.platform, PLATFORM.DOLTHUB),
+          eq(platform_integrations.owned_by_user_id, user.id)
+        )
+      );
+  });
+
+  describe('getInstallation', () => {
+    test('returns installed: false in production', async () => {
+      setNodeEnv('production');
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.dolthub.getInstallation();
+      expect(result).toEqual({ installed: false, installation: null });
+    });
+
+    test('returns the persisted row when present in dev', async () => {
+      await db.insert(platform_integrations).values({
+        owned_by_user_id: user.id,
+        owned_by_organization_id: null,
+        platform: PLATFORM.DOLTHUB,
+        integration_type: 'oauth',
+        platform_account_login: 'testuser',
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        scopes: ['api_read_write'],
+        metadata: { access_token: 'token' },
+        installed_at: new Date().toISOString(),
+      });
+
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.dolthub.getInstallation();
+      expect(result.installed).toBe(true);
+      expect(result.installation).toMatchObject({
+        username: 'testuser',
+        status: 'active',
+        scopes: ['api_read_write'],
+      });
+      expect(result.installation?.installedAt).toBeTruthy();
+    });
+
+    test('returns installed: false when no integration exists in dev', async () => {
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.dolthub.getInstallation();
+      expect(result).toEqual({ installed: false, installation: null });
+    });
+  });
+
+  describe('disconnect', () => {
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      const caller = await createCallerForUser(user.id);
+      await expect(caller.dolthub.disconnect()).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+      });
+    });
+
+    test('removes the integration in dev', async () => {
+      await db.insert(platform_integrations).values({
+        owned_by_user_id: user.id,
+        owned_by_organization_id: null,
+        platform: PLATFORM.DOLTHUB,
+        integration_type: 'oauth',
+        platform_account_login: 'testuser',
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        metadata: { access_token: 'token' },
+      });
+
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.dolthub.disconnect();
+      expect(result.success).toBe(true);
+
+      const rows = await db
+        .select()
+        .from(platform_integrations)
+        .where(
+          and(
+            eq(platform_integrations.platform, PLATFORM.DOLTHUB),
+            eq(platform_integrations.owned_by_user_id, user.id)
+          )
+        );
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  describe('verifyToken', () => {
+    test('throws in production', async () => {
+      setNodeEnv('production');
+      const caller = await createCallerForUser(user.id);
+      await expect(caller.dolthub.verifyToken()).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+      });
+    });
+
+    test('makes the expected HTTP call with Authorization: Bearer ...', async () => {
+      await db.insert(platform_integrations).values({
+        owned_by_user_id: user.id,
+        owned_by_organization_id: null,
+        platform: PLATFORM.DOLTHUB,
+        integration_type: 'oauth',
+        platform_account_login: 'testuser',
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        metadata: {
+          access_token: 'test-access-token',
+          refresh_token: 'refresh-token',
+          expires_at: Date.now() + 3600 * 1000,
+          scope: 'api_read_write',
+        },
+      });
+
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [{ '1': 1 }],
+      });
+      globalThis.fetch = mockFetch;
+
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.dolthub.verifyToken();
+      expect(result.ok).toBe(true);
+      expect(result.sample).toEqual({ '1': 1 });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://www.dolthub.com/api/v1alpha1/dolthub/profile?q=select+1');
+      expect(init?.headers?.Authorization).toBe('Bearer test-access-token');
+    });
+
+    test('rejects when the smoke test fails', async () => {
+      await db.insert(platform_integrations).values({
+        owned_by_user_id: user.id,
+        owned_by_organization_id: null,
+        platform: PLATFORM.DOLTHUB,
+        integration_type: 'oauth',
+        platform_account_login: 'testuser',
+        integration_status: INTEGRATION_STATUS.ACTIVE,
+        metadata: {
+          access_token: 'bad-token',
+          refresh_token: 'refresh-token',
+          expires_at: Date.now() + 3600 * 1000,
+          scope: 'api_read_write',
+        },
+      });
+
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      });
+
+      const caller = await createCallerForUser(user.id);
+      await expect(caller.dolthub.verifyToken()).rejects.toBeInstanceOf(TRPCError);
+      await expect(caller.dolthub.verifyToken()).rejects.toMatchObject({
+        code: 'UNAUTHORIZED',
+      });
+    });
+
+    test('rejects when no integration exists', async () => {
+      const caller = await createCallerForUser(user.id);
+      await expect(caller.dolthub.verifyToken()).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+      });
+    });
+  });
+});

--- a/apps/web/src/routers/dolthub-router.test.ts
+++ b/apps/web/src/routers/dolthub-router.test.ts
@@ -193,8 +193,9 @@ describe('dolthubRouter', () => {
       });
 
       const caller = await createCallerForUser(user.id);
-      await expect(caller.dolthub.verifyToken()).rejects.toBeInstanceOf(TRPCError);
-      await expect(caller.dolthub.verifyToken()).rejects.toMatchObject({
+      const rejection = caller.dolthub.verifyToken();
+      await expect(rejection).rejects.toBeInstanceOf(TRPCError);
+      await expect(rejection).rejects.toMatchObject({
         code: 'UNAUTHORIZED',
       });
     });

--- a/apps/web/src/routers/dolthub-router.ts
+++ b/apps/web/src/routers/dolthub-router.ts
@@ -1,0 +1,97 @@
+import 'server-only';
+import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
+import { TRPCError } from '@trpc/server';
+import {
+  resolveOwner,
+  resolveAuthorizedOwner,
+  optionalOrgInput,
+} from '@/lib/integrations/resolve-owner';
+import { ensureOrganizationAccess } from '@/routers/organizations/utils';
+import * as dolthubService from '@/lib/integrations/dolthub-service';
+
+export const dolthubRouter = createTRPCRouter({
+  getInstallation: baseProcedure.input(optionalOrgInput).query(async ({ ctx, input }) => {
+    if (process.env.NODE_ENV === 'production') {
+      return { installed: false, installation: null };
+    }
+
+    if (input?.organizationId) {
+      await ensureOrganizationAccess(ctx, input.organizationId);
+    }
+    const owner = resolveOwner(ctx, input?.organizationId);
+    const integration = await dolthubService.getInstallation(owner);
+
+    if (!integration) {
+      return { installed: false, installation: null };
+    }
+
+    return {
+      installed: integration.integration_status === 'active',
+      installation: {
+        username: integration.platform_account_login,
+        status: integration.integration_status,
+        installedAt: integration.installed_at,
+        scopes: integration.scopes,
+      },
+    };
+  }),
+
+  disconnect: baseProcedure.input(optionalOrgInput).mutation(async ({ ctx, input }) => {
+    if (process.env.NODE_ENV === 'production') {
+      throw new TRPCError({ code: 'NOT_FOUND' });
+    }
+
+    const owner = await resolveAuthorizedOwner(ctx, input?.organizationId);
+    return dolthubService.uninstall(owner);
+  }),
+
+  verifyToken: baseProcedure.input(optionalOrgInput).mutation(async ({ ctx, input }) => {
+    if (process.env.NODE_ENV === 'production') {
+      throw new TRPCError({ code: 'NOT_FOUND' });
+    }
+
+    if (input?.organizationId) {
+      await ensureOrganizationAccess(ctx, input.organizationId);
+    }
+    const owner = resolveOwner(ctx, input?.organizationId);
+    const integration = await dolthubService.getInstallation(owner);
+
+    if (!integration) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'DoltHub integration not found',
+      });
+    }
+
+    const token = await dolthubService.getValidDoltHubToken(integration);
+    if (!token) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'DoltHub access token is invalid or expired',
+      });
+    }
+
+    const response = await fetch(
+      'https://www.dolthub.com/api/v1alpha1/dolthub/profile?q=select+1',
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: `DoltHub token verification failed: ${response.status} ${response.statusText}`,
+      });
+    }
+
+    const data = (await response.json()) as unknown;
+    // The DoltHub profile API returns rows; grab the first row as a sample.
+    const rows = Array.isArray(data) ? data : (data as Record<string, unknown> | null)?.rows;
+    const sample = Array.isArray(rows) ? rows[0] : null;
+
+    return { ok: true as const, sample };
+  }),
+});

--- a/apps/web/src/routers/dolthub-router.ts
+++ b/apps/web/src/routers/dolthub-router.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import { z } from 'zod';
 import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import { TRPCError } from '@trpc/server';
 import {
@@ -87,10 +88,19 @@ export const dolthubRouter = createTRPCRouter({
       });
     }
 
-    const data = (await response.json()) as unknown;
-    // The DoltHub profile API returns rows; grab the first row as a sample.
-    const rows = Array.isArray(data) ? data : (data as Record<string, unknown> | null)?.rows;
-    const sample = Array.isArray(rows) ? rows[0] : null;
+    const data = await response.json();
+
+    const DoltHubProfileResponseSchema = z.union([
+      z.array(z.record(z.unknown())),
+      z.object({ rows: z.array(z.record(z.unknown())).optional() }),
+    ]);
+    const parsed = DoltHubProfileResponseSchema.safeParse(data);
+    const rows = parsed.success
+      ? Array.isArray(parsed.data)
+        ? parsed.data
+        : parsed.data.rows ?? []
+      : [];
+    const sample = rows[0] ?? null;
 
     return { ok: true as const, sample };
   }),

--- a/apps/web/src/routers/root-router.ts
+++ b/apps/web/src/routers/root-router.ts
@@ -15,6 +15,7 @@ import { githubAppsRouter } from '@/routers/github-apps-router';
 import { gitlabRouter } from '@/routers/gitlab-router';
 import { slackRouter } from '@/routers/slack-router';
 import { linearRouter } from '@/routers/linear-router';
+import { dolthubRouter } from '@/routers/dolthub-router';
 import { discordRouter } from '@/routers/discord-router';
 import { codeReviewRouter } from '@/routers/code-reviews/code-reviews-router';
 import { personalReviewAgentRouter } from '@/routers/code-reviews-router';
@@ -52,6 +53,7 @@ export const rootRouter = createTRPCRouter({
   gitlab: gitlabRouter,
   slack: slackRouter,
   linear: linearRouter,
+  dolthub: dolthubRouter,
   discord: discordRouter,
   cloudAgent: cloudAgentRouter,
   cloudAgentNext: cloudAgentNextRouter,


### PR DESCRIPTION
## Summary

Adds a tRPC router exposing the DoltHub integration to the UI, mirroring the pattern used by the linear router.

- `dolthub.getInstallation` — returns installation status and details (dev-only; returns `installed: false` in production so the UI treats DoltHub as coming soon).
- `dolthub.disconnect` — uninstalls the DoltHub integration for the resolved owner (dev-only; throws `NOT_FOUND` in production).
- `dolthub.verifyToken` — fetches a valid access token and runs a smoke test against the DoltHub API (dev-only; throws `NOT_FOUND` in production, `UNAUTHORIZED` on auth failure).

The router is registered in `root-router.ts` behind the same auth/session middleware as other integration routers.

## Verification

- `pnpm --filter web typecheck` passes.
- Tests are provided in `dolthub-router.test.ts` mirroring `linear-router.test.ts`. They require a running Postgres instance (unavailable in this environment) but were verified to be structurally correct.

## Visual Changes

N/A

## Reviewer Notes

All three procedures short-circuit in production so the DoltHub integration remains dev-only until the DoltHub app is approved.