### PR TITLE
fix(web): show correct active web search provider in Settings

### DIFF
--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -1805,11 +1805,15 @@ export function SettingsTab({
   const configuredSecrets = config?.configuredSecrets ?? {};
   const kiloExaSearchMode = config?.kiloExaSearchMode ?? null;
   const braveSearchConfigured = configuredSecrets['brave-search'] ?? false;
-  // Mirrors controller arbitration in services/kiloclaw/controller/src/config-writer.ts.
+  // Reflects which provider is actually active. Mirrors controller arbitration
+  // in services/kiloclaw/controller/src/config-writer.ts.
   const exaSearchConfigured =
     supportsExaSearchUi &&
     (kiloExaSearchMode === 'kilo-proxy' || (kiloExaSearchMode === null && !braveSearchConfigured));
-  const exaSearchDisplayMode = exaSearchConfigured ? 'kilo-proxy' : 'disabled';
+  // Editor reflects stored intent, not the resolved active provider, so users
+  // can persist an explicit choice when their mode is unset.
+  const exaSearchDisplayMode =
+    supportsExaSearchUi && kiloExaSearchMode === null ? 'kilo-proxy' : kiloExaSearchMode;
   const braveSearchEnabled = braveSearchConfigured && !exaSearchConfigured;
   const toolEntries = getEntriesByCategory('tool');
   const googleCalendarConnectHref = useMemo(() => {

--- a/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
+++ b/apps/web/src/app/(app)/claw/components/SettingsTab.tsx
@@ -1805,10 +1805,11 @@ export function SettingsTab({
   const configuredSecrets = config?.configuredSecrets ?? {};
   const kiloExaSearchMode = config?.kiloExaSearchMode ?? null;
   const braveSearchConfigured = configuredSecrets['brave-search'] ?? false;
+  // Mirrors controller arbitration in services/kiloclaw/controller/src/config-writer.ts.
   const exaSearchConfigured =
-    supportsExaSearchUi && (kiloExaSearchMode === 'kilo-proxy' || kiloExaSearchMode === null);
-  const exaSearchDisplayMode =
-    supportsExaSearchUi && kiloExaSearchMode === null ? 'kilo-proxy' : kiloExaSearchMode;
+    supportsExaSearchUi &&
+    (kiloExaSearchMode === 'kilo-proxy' || (kiloExaSearchMode === null && !braveSearchConfigured));
+  const exaSearchDisplayMode = exaSearchConfigured ? 'kilo-proxy' : 'disabled';
   const braveSearchEnabled = braveSearchConfigured && !exaSearchConfigured;
   const toolEntries = getEntriesByCategory('tool');
   const googleCalendarConnectHref = useMemo(() => {


### PR DESCRIPTION
## Summary

The Settings page reported the wrong active web search provider for users who had Brave configured before Exa was added as a default. The UI treated Exa as active whenever `kiloExaSearchMode` was `null`, which is the default state for users who never explicitly chose Exa. Brave users saw Brave shown as off and Exa shown as on, even though their instance was still running Brave under the hood.

OpenClaw supports one active web search provider at a time. The dashboard exposes two configurable providers (Brave via `BRAVE_API_KEY` and Exa via `kiloExaSearchMode`), and the controller in `services/kiloclaw/controller/src/config-writer.ts` arbitrates between them. This change updates the Settings UI to mirror that arbitration so the dashboard reflects which provider is actually winning:

| `kiloExaSearchMode` | Brave key | Active provider |
| ------------------- | --------- | --------------- |
| `'kilo-proxy'`      | any       | Exa             |
| `null`              | yes       | Brave           |
| `null`              | no        | Exa (auto assigned) |
| `'disabled'`        | yes       | Brave           |
| `'disabled'`        | no        | neither         |

## Verification

- [ ] Loaded Settings on an instance with `BRAVE_API_KEY` configured and `kiloExaSearchMode` unset, confirmed Brave is shown as active and Exa as off.
- [ ] Loaded Settings on an instance with no Brave key and `kiloExaSearchMode` unset, confirmed Exa is shown as active.
- [ ] Loaded Settings on an instance with Brave configured and `kiloExaSearchMode = kilo-proxy`, confirmed Exa is shown as active and the "Enable Brave and disable Exa" confirmation appears when toggling Brave on.

## Visual Changes

N/A

## Reviewer Notes

Arbitration logic now lives in two places: the UI block in `SettingsTab.tsx` and `generateBaseConfig()` in the controller. The code comment in the UI block flags this. If the controller rules change, the UI block must change with them.

The dashboard cannot see two pieces of live OpenClaw config that the controller considers: an explicit provider string written directly into `openclaw.json` by hand, or `tools.web.search.enabled === false`. Users who have edited those fields out of band of the dashboard will still see a mismatch. Solving that would require a controller fetch on every Settings load, which felt heavy for the size of the population affected.
