### PR TITLE
feat(integrations): add DoltHubIntegrationDetails page and wire dev-only card into IntegrationsHub

### DIFF
--- a/apps/web/src/app/(app)/integrations/dolthub/page.tsx
+++ b/apps/web/src/app/(app)/integrations/dolthub/page.tsx
@@ -1,0 +1,56 @@
+import { Suspense } from 'react';
+import { getUserFromAuthOrRedirect } from '@/lib/user.server';
+import { DoltHubIntegrationDetails } from '@/components/integrations/DoltHubIntegrationDetails';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import { Card, CardContent } from '@/components/ui/card';
+import { PageLayout } from '@/components/PageLayout';
+import { IS_DEVELOPMENT } from '@/lib/constants';
+import { notFound } from 'next/navigation';
+
+export default async function UserDoltHubIntegrationPage({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    success?: string;
+    error?: string;
+  }>;
+}) {
+  if (!IS_DEVELOPMENT) {
+    notFound();
+  }
+
+  await getUserFromAuthOrRedirect('/users/sign_in');
+  const search = await searchParams;
+
+  return (
+    <PageLayout
+      title="DoltHub Integration"
+      subtitle="Connect your DoltHub account to query versioned data"
+      headerActions={
+        <Link href="/integrations">
+          <Button variant="ghost" size="sm" className="gap-2">
+            <ArrowLeft className="h-4 w-4" />
+            Back to Integrations
+          </Button>
+        </Link>
+      }
+    >
+      <Suspense
+        fallback={
+          <Card>
+            <CardContent className="pt-6">
+              <div className="animate-pulse space-y-4">
+                <div className="bg-muted h-20 rounded" />
+                <div className="bg-muted h-32 rounded" />
+              </div>
+            </CardContent>
+          </Card>
+        }
+      >
+        <DoltHubIntegrationDetails success={search.success === 'installed'} error={search.error} />
+      </Suspense>
+    </PageLayout>
+  );
+}

--- a/apps/web/src/app/(app)/organizations/[id]/integrations/dolthub/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/integrations/dolthub/page.tsx
@@ -1,0 +1,68 @@
+import { Suspense } from 'react';
+import { DoltHubIntegrationDetails } from '@/components/integrations/DoltHubIntegrationDetails';
+import { Button } from '@/components/ui/button';
+import { SetPageTitle } from '@/components/SetPageTitle';
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import { Card, CardContent } from '@/components/ui/card';
+import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import { IS_DEVELOPMENT } from '@/lib/constants';
+import { notFound } from 'next/navigation';
+
+export default async function OrgDoltHubIntegrationPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{
+    success?: string;
+    error?: string;
+  }>;
+}) {
+  if (!IS_DEVELOPMENT) {
+    notFound();
+  }
+
+  const search = await searchParams;
+
+  return (
+    <OrganizationByPageLayout
+      params={params}
+      render={({ organization }) => (
+        <>
+          <div className="space-y-4">
+            <Link href={`/organizations/${organization.id}/integrations`}>
+              <Button variant="ghost" size="sm" className="gap-2">
+                <ArrowLeft className="h-4 w-4" />
+                Back to Integrations
+              </Button>
+            </Link>
+            <SetPageTitle title="DoltHub Integration" />
+            <p className="text-muted-foreground">
+              Manage DoltHub integration for {organization.name}
+            </p>
+          </div>
+
+          <Suspense
+            fallback={
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="animate-pulse space-y-4">
+                    <div className="bg-muted h-20 rounded" />
+                    <div className="bg-muted h-32 rounded" />
+                  </div>
+                </CardContent>
+              </Card>
+            }
+          >
+            <DoltHubIntegrationDetails
+              organizationId={organization.id}
+              success={search.success === 'installed'}
+              error={search.error}
+            />
+          </Suspense>
+        </>
+      )}
+    />
+  );
+}

--- a/apps/web/src/app/api/integrations/dolthub/callback/route.ts
+++ b/apps/web/src/app/api/integrations/dolthub/callback/route.ts
@@ -1,0 +1,151 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getUserFromAuth } from '@/lib/user.server';
+import { ensureOrganizationAccess } from '@/routers/organizations/utils';
+import type { Owner } from '@/lib/integrations/core/types';
+import { captureException, captureMessage } from '@sentry/nextjs';
+import {
+  exchangeDoltHubOAuthCode,
+  fetchDoltHubUser,
+  upsertDoltHubInstallation,
+} from '@/lib/integrations/dolthub-service';
+import { verifyOAuthState } from '@/lib/integrations/oauth-state';
+import { APP_URL } from '@/lib/constants';
+
+function buildDoltHubRedirectPath(state: string | null, queryParam: string): string {
+  const verified = state ? verifyOAuthState(state) : null;
+  const owner = verified?.owner;
+
+  if (owner?.startsWith('org_')) {
+    return `/organizations/${owner.replace('org_', '')}/integrations/dolthub?${queryParam}`;
+  }
+  if (owner?.startsWith('user_')) {
+    return `/integrations/dolthub?${queryParam}`;
+  }
+  return `/integrations?${queryParam}`;
+}
+
+/**
+ * DoltHub OAuth Callback
+ *
+ * Called when user completes the DoltHub OAuth flow.
+ * Exchanges the authorization code for tokens and stores the integration.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
+    if (authFailedResponse) {
+      return NextResponse.redirect(new URL('/users/sign_in', APP_URL));
+    }
+
+    const searchParams = request.nextUrl.searchParams;
+    const code = searchParams.get('code');
+    const state = searchParams.get('state');
+    const error = searchParams.get('error');
+
+    if (error) {
+      captureMessage('DoltHub OAuth error', {
+        level: 'warning',
+        tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
+        extra: { error, state },
+      });
+
+      return NextResponse.redirect(
+        new URL(buildDoltHubRedirectPath(state, `error=${encodeURIComponent(error)}`), APP_URL)
+      );
+    }
+
+    if (!code) {
+      captureMessage('DoltHub callback missing code', {
+        level: 'warning',
+        tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
+        extra: { state, allParams: Object.fromEntries(searchParams.entries()) },
+      });
+
+      return NextResponse.redirect(
+        new URL(buildDoltHubRedirectPath(state, 'error=missing_code'), APP_URL)
+      );
+    }
+
+    const verified = verifyOAuthState(state);
+    if (!verified) {
+      captureMessage('DoltHub callback invalid or tampered state signature', {
+        level: 'warning',
+        tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
+        extra: { code: '***', state, allParams: Object.fromEntries(searchParams.entries()) },
+      });
+      return NextResponse.redirect(new URL('/integrations?error=invalid_state', APP_URL));
+    }
+
+    if (verified.userId !== user.id) {
+      captureMessage('DoltHub callback user mismatch (possible CSRF)', {
+        level: 'warning',
+        tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
+        extra: { stateUserId: verified.userId, sessionUserId: user.id },
+      });
+      return NextResponse.redirect(new URL('/integrations?error=unauthorized', APP_URL));
+    }
+
+    let owner: Owner;
+    const ownerStr = verified.owner;
+
+    if (ownerStr.startsWith('org_')) {
+      const ownerId = ownerStr.replace('org_', '');
+      owner = { type: 'org', id: ownerId };
+    } else if (ownerStr.startsWith('user_')) {
+      const ownerId = ownerStr.replace('user_', '');
+      owner = { type: 'user', id: ownerId };
+    } else {
+      captureMessage('DoltHub callback missing or invalid owner in state', {
+        level: 'warning',
+        tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
+        extra: { code: '***', owner: ownerStr },
+      });
+      return NextResponse.redirect(new URL('/integrations?error=invalid_state', APP_URL));
+    }
+
+    if (owner.type === 'org') {
+      await ensureOrganizationAccess({ user }, owner.id);
+    } else if (user.id !== owner.id) {
+      return NextResponse.redirect(new URL('/integrations?error=unauthorized', APP_URL));
+    }
+
+    const tokens = await exchangeDoltHubOAuthCode(code);
+
+    const userInfo = await fetchDoltHubUser(tokens.accessToken);
+    const username = userInfo?.username ?? 'unknown';
+
+    await upsertDoltHubInstallation({
+      owner,
+      account: { username },
+      tokens,
+    });
+
+    const successPath =
+      owner.type === 'org'
+        ? `/organizations/${owner.id}/integrations/dolthub?success=installed`
+        : `/integrations/dolthub?success=installed`;
+
+    return NextResponse.redirect(new URL(successPath, APP_URL));
+  } catch (error) {
+    console.error('Error handling DoltHub OAuth callback:', error);
+
+    const searchParams = request.nextUrl.searchParams;
+    const state = searchParams.get('state');
+
+    captureException(error, {
+      tags: {
+        endpoint: 'dolthub/callback',
+        source: 'dolthub_oauth',
+      },
+      extra: {
+        state,
+        hasCode: !!searchParams.get('code'),
+      },
+    });
+
+    return NextResponse.redirect(
+      new URL(buildDoltHubRedirectPath(state, 'error=installation_failed'), APP_URL)
+    );
+  }
+}

--- a/apps/web/src/app/api/integrations/dolthub/callback/route.ts
+++ b/apps/web/src/app/api/integrations/dolthub/callback/route.ts
@@ -4,6 +4,7 @@ import { getUserFromAuth } from '@/lib/user.server';
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import type { Owner } from '@/lib/integrations/core/types';
 import { captureException, captureMessage } from '@sentry/nextjs';
+import { IS_DEVELOPMENT } from '@/lib/constants';
 import {
   exchangeDoltHubOAuthCode,
   fetchDoltHubUser,
@@ -32,6 +33,10 @@ function buildDoltHubRedirectPath(state: string | null, queryParam: string): str
  * Exchanges the authorization code for tokens and stores the integration.
  */
 export async function GET(request: NextRequest) {
+  if (!IS_DEVELOPMENT) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+
   try {
     const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
     if (authFailedResponse) {
@@ -114,6 +119,13 @@ export async function GET(request: NextRequest) {
 
     const userInfo = await fetchDoltHubUser(tokens.accessToken);
     const username = userInfo?.username ?? 'unknown';
+
+    if (username === 'unknown') {
+      captureMessage('DoltHub user info fetch returned no username', {
+        level: 'warning',
+        tags: { endpoint: 'dolthub/callback', source: 'dolthub_oauth' },
+      });
+    }
 
     await upsertDoltHubInstallation({
       owner,

--- a/apps/web/src/app/api/integrations/dolthub/connect/route.ts
+++ b/apps/web/src/app/api/integrations/dolthub/connect/route.ts
@@ -1,0 +1,61 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getUserFromAuth } from '@/lib/user.server';
+import { ensureOrganizationAccess } from '@/routers/organizations/utils';
+import { captureException } from '@sentry/nextjs';
+import { createOAuthState } from '@/lib/integrations/oauth-state';
+import { getDoltHubOAuthUrl } from '@/lib/integrations/dolthub-service';
+import { APP_URL } from '@/lib/constants';
+
+/**
+ * DoltHub OAuth Connect
+ *
+ * Initiates the DoltHub OAuth authorization flow.
+ * Redirects the user to DoltHub's authorization page.
+ *
+ * Query parameters:
+ * - organizationId: (optional) Organization ID for org-owned integrations
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
+    if (authFailedResponse) {
+      return authFailedResponse;
+    }
+
+    const searchParams = request.nextUrl.searchParams;
+    const organizationId = searchParams.get('organizationId');
+
+    let stateOwner: string;
+
+    if (organizationId) {
+      await ensureOrganizationAccess({ user }, organizationId);
+      stateOwner = `org_${organizationId}`;
+    } else {
+      stateOwner = `user_${user.id}`;
+    }
+
+    const state = createOAuthState(stateOwner, user.id);
+    const oauthUrl = getDoltHubOAuthUrl(state);
+
+    return NextResponse.redirect(oauthUrl);
+  } catch (error) {
+    console.error('Error initiating DoltHub OAuth:', error);
+
+    captureException(error, {
+      tags: {
+        endpoint: 'dolthub/connect',
+        source: 'dolthub_oauth',
+      },
+    });
+
+    const searchParams = request.nextUrl.searchParams;
+    const organizationId = searchParams.get('organizationId');
+
+    const errorPath = organizationId
+      ? `/organizations/${organizationId}/integrations/dolthub?error=oauth_init_failed`
+      : '/integrations/dolthub?error=oauth_init_failed';
+
+    return NextResponse.redirect(new URL(errorPath, APP_URL));
+  }
+}

--- a/apps/web/src/app/api/integrations/dolthub/connect/route.ts
+++ b/apps/web/src/app/api/integrations/dolthub/connect/route.ts
@@ -5,7 +5,7 @@ import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import { captureException } from '@sentry/nextjs';
 import { createOAuthState } from '@/lib/integrations/oauth-state';
 import { getDoltHubOAuthUrl } from '@/lib/integrations/dolthub-service';
-import { APP_URL } from '@/lib/constants';
+import { APP_URL, IS_DEVELOPMENT } from '@/lib/constants';
 
 /**
  * DoltHub OAuth Connect
@@ -17,6 +17,10 @@ import { APP_URL } from '@/lib/constants';
  * - organizationId: (optional) Organization ID for org-owned integrations
  */
 export async function GET(request: NextRequest) {
+  if (!IS_DEVELOPMENT) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+
   try {
     const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
     if (authFailedResponse) {

--- a/apps/web/src/components/integrations/DoltHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/DoltHubIntegrationDetails.tsx
@@ -64,11 +64,15 @@ export function DoltHubIntegrationDetails({
 
   const handleConnect = () => {
     setIsStartingConnection(true);
-    const url = new URL('/api/integrations/dolthub/connect', window.location.origin);
-    if (organizationId) {
-      url.searchParams.set('organizationId', organizationId);
+    try {
+      const url = new URL('/api/integrations/dolthub/connect', window.location.origin);
+      if (organizationId) {
+        url.searchParams.set('organizationId', organizationId);
+      }
+      window.location.href = url.toString();
+    } catch {
+      setIsStartingConnection(false);
     }
-    window.location.href = url.toString();
   };
 
   const handleDisconnect = () => {

--- a/apps/web/src/components/integrations/DoltHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/DoltHubIntegrationDetails.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { CheckCircle2, XCircle, Database, RefreshCw, Info } from 'lucide-react';
+import { toast } from 'sonner';
+import { useEffect, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
+
+type DoltHubIntegrationDetailsProps = {
+  organizationId?: string;
+  success?: boolean;
+  error?: string;
+};
+
+export function DoltHubIntegrationDetails({
+  organizationId,
+  success,
+  error,
+}: DoltHubIntegrationDetailsProps) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const input = organizationId ? { organizationId } : undefined;
+
+  const {
+    data: installationData,
+    isLoading,
+    refetch,
+  } = useQuery(trpc.dolthub.getInstallation.queryOptions(input));
+
+  const [isStartingConnection, setIsStartingConnection] = useState(false);
+
+  const disconnect = useMutation(
+    trpc.dolthub.disconnect.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.dolthub.getInstallation.queryKey(input),
+        });
+      },
+    })
+  );
+
+  const verifyToken = useMutation(
+    trpc.dolthub.verifyToken.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: trpc.dolthub.getInstallation.queryKey(input),
+        });
+      },
+    })
+  );
+
+  useEffect(() => {
+    if (success) {
+      toast.success('DoltHub connected successfully!');
+    }
+    if (error) {
+      toast.error(`Connection failed: ${error}`);
+    }
+  }, [success, error]);
+
+  const handleConnect = () => {
+    setIsStartingConnection(true);
+    const url = new URL('/api/integrations/dolthub/connect', window.location.origin);
+    if (organizationId) {
+      url.searchParams.set('organizationId', organizationId);
+    }
+    window.location.href = url.toString();
+  };
+
+  const handleDisconnect = () => {
+    if (confirm('Are you sure you want to disconnect DoltHub?')) {
+      disconnect.mutate(input, {
+        onSuccess: async () => {
+          toast.success('DoltHub disconnected');
+          await refetch();
+        },
+        onError: err => {
+          toast.error('Failed to disconnect DoltHub', {
+            description: err.message,
+          });
+        },
+      });
+    }
+  };
+
+  const handleVerifyToken = () => {
+    verifyToken.mutate(input, {
+      onSuccess: () => {
+        toast.success('DoltHub token is valid');
+      },
+      onError: err => {
+        toast.error('DoltHub token verification failed', {
+          description: err.message,
+        });
+      },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <div className="animate-pulse space-y-4">
+            <div className="bg-muted h-20 rounded" />
+            <div className="bg-muted h-32 rounded" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const isInstalled = installationData?.installed;
+  const installation = installationData?.installation;
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <Alert variant="destructive">
+          <XCircle className="h-4 w-4" />
+          <AlertTitle>Could not connect DoltHub</AlertTitle>
+          <AlertDescription>Connection failed: {error}</AlertDescription>
+        </Alert>
+      )}
+
+      <Alert variant="default" className="bg-blue-50 text-blue-900 border-blue-200">
+        <Info className="h-4 w-4 text-blue-600" />
+        <AlertTitle>Dev-only integration</AlertTitle>
+        <AlertDescription>DoltHub app pending approval</AlertDescription>
+      </Alert>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle className="flex items-center gap-2">
+                <Database className="h-5 w-5" />
+                DoltHub Integration
+              </CardTitle>
+              <CardDescription>
+                Query Dolt-versioned data directly from your workspace
+              </CardDescription>
+            </div>
+            {isInstalled ? (
+              <Badge variant="default" className="flex items-center gap-1">
+                <CheckCircle2 className="h-3 w-3" />
+                Connected
+              </Badge>
+            ) : (
+              <Badge variant="secondary" className="flex items-center gap-1">
+                <XCircle className="h-3 w-3" />
+                Not Connected
+              </Badge>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {installation ? (
+            <>
+              <div className="space-y-3 rounded-lg border p-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium">Username:</span>
+                  <span className="text-sm">{installation.username}</span>
+                </div>
+                {installation.scopes && installation.scopes.length > 0 && (
+                  <div className="space-y-2">
+                    <span className="text-sm font-medium">Permissions:</span>
+                    <div className="flex flex-wrap gap-2">
+                      {installation.scopes.map((scope: string) => (
+                        <Badge key={scope} variant="secondary" className="text-xs">
+                          {scope}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium">Connected:</span>
+                  <span className="text-sm">
+                    {installation.installedAt
+                      ? new Date(installation.installedAt).toLocaleDateString()
+                      : 'Unknown'}
+                  </span>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex flex-wrap gap-3">
+                  <Button
+                    variant="outline"
+                    onClick={handleVerifyToken}
+                    disabled={verifyToken.isPending}
+                  >
+                    <RefreshCw className="mr-2 h-4 w-4" />
+                    {verifyToken.isPending ? 'Verifying...' : 'Verify token'}
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    onClick={handleDisconnect}
+                    disabled={disconnect.isPending}
+                  >
+                    {disconnect.isPending ? 'Disconnecting...' : 'Disconnect'}
+                  </Button>
+                </div>
+              </div>
+            </>
+          ) : (
+            <>
+              <Alert>
+                <AlertDescription>
+                  Connect DoltHub to query versioned data directly from your workspace.
+                </AlertDescription>
+              </Alert>
+
+              <div className="space-y-2 rounded-lg border p-4">
+                <h4 className="font-medium">What you&apos;ll get:</h4>
+                <ul className="text-muted-foreground space-y-1 text-sm">
+                  <li>✓ Query Dolt-versioned databases from your workspace</li>
+                  <li>✓ Direct integration with DoltHub repositories</li>
+                </ul>
+              </div>
+
+              <Button
+                onClick={handleConnect}
+                size="lg"
+                className="w-full"
+                disabled={isStartingConnection}
+              >
+                <Database className="mr-2 h-4 w-4" />
+                {isStartingConnection ? 'Loading...' : 'Connect DoltHub'}
+              </Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/integrations/IntegrationsHub.tsx
+++ b/apps/web/src/components/integrations/IntegrationsHub.tsx
@@ -34,9 +34,17 @@ export function IntegrationsHub({ organizationId }: IntegrationsHubProps) {
   const { data: linearInstallation, isLoading: linearLoading } = useQuery(
     trpc.linear.getInstallation.queryOptions(input)
   );
+  const { data: dolthubInstallation, isLoading: dolthubLoading } = useQuery(
+    trpc.dolthub.getInstallation.queryOptions(input)
+  );
 
   const isLoading =
-    githubLoading || slackLoading || discordLoading || gitlabLoading || linearLoading;
+    githubLoading ||
+    slackLoading ||
+    discordLoading ||
+    gitlabLoading ||
+    linearLoading ||
+    dolthubLoading;
 
   if (isLoading) {
     return (
@@ -62,6 +70,7 @@ export function IntegrationsHub({ organizationId }: IntegrationsHubProps) {
       discord: discordInstallation,
       gitlab: gitlabInstallation,
       linear: linearInstallation,
+      dolthub: dolthubInstallation,
     },
     organizationId
   );

--- a/apps/web/src/lib/integrations/dolthub-service.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.ts
@@ -236,6 +236,19 @@ export async function uninstall(owner: Owner): Promise<{ success: boolean }> {
   return { success: true };
 }
 
+const DoltHubUserResponseSchema = z.object({
+  data: z
+    .object({
+      currentUser: z
+        .object({
+          username: z.string().min(1),
+        })
+        .optional(),
+    })
+    .optional(),
+  errors: z.array(z.unknown()).optional(),
+});
+
 export async function fetchDoltHubUser(accessToken: string): Promise<{ username: string } | null> {
   assertDevOnly();
 
@@ -255,12 +268,13 @@ export async function fetchDoltHubUser(accessToken: string): Promise<{ username:
       return null;
     }
 
-    const data = (await response.json()) as {
-      data?: { currentUser?: { username?: string } };
-      errors?: unknown[];
-    };
+    const raw = await response.json();
+    const parseResult = DoltHubUserResponseSchema.safeParse(raw);
+    if (!parseResult.success) {
+      return null;
+    }
 
-    const username = data.data?.currentUser?.username;
+    const username = parseResult.data.data?.currentUser?.username;
     if (username) {
       return { username };
     }

--- a/apps/web/src/lib/integrations/dolthub-service.ts
+++ b/apps/web/src/lib/integrations/dolthub-service.ts
@@ -75,7 +75,10 @@ const DoltHubTokenPayloadSchema = z.object({
   scope: z.string().optional(),
 });
 
-function parseDoltHubTokenPayload(raw: unknown, operation: 'exchange' | 'refresh'): DoltHubTokenResponse {
+function parseDoltHubTokenPayload(
+  raw: unknown,
+  operation: 'exchange' | 'refresh'
+): DoltHubTokenResponse {
   const parseResult = DoltHubTokenPayloadSchema.safeParse(raw);
   if (!parseResult.success) {
     throw new Error(`DoltHub token ${operation} returned invalid payload`);
@@ -114,7 +117,9 @@ export async function exchangeDoltHubOAuthCode(code: string): Promise<DoltHubTok
   return parseDoltHubTokenPayload(await response.json(), 'exchange');
 }
 
-export async function refreshDoltHubAccessToken(refreshToken: string): Promise<DoltHubTokenResponse> {
+export async function refreshDoltHubAccessToken(
+  refreshToken: string
+): Promise<DoltHubTokenResponse> {
   assertDevOnly();
 
   const body = new URLSearchParams({
@@ -145,7 +150,9 @@ export async function getInstallation(owner: Owner): Promise<PlatformIntegration
   const [integration] = await db
     .select()
     .from(platform_integrations)
-    .where(and(...getOwnershipConditions(owner), eq(platform_integrations.platform, PLATFORM.DOLTHUB)))
+    .where(
+      and(...getOwnershipConditions(owner), eq(platform_integrations.platform, PLATFORM.DOLTHUB))
+    )
     .limit(1);
 
   return integration || null;
@@ -229,19 +236,52 @@ export async function uninstall(owner: Owner): Promise<{ success: boolean }> {
   return { success: true };
 }
 
+export async function fetchDoltHubUser(accessToken: string): Promise<{ username: string } | null> {
+  assertDevOnly();
+
+  try {
+    const response = await fetch('https://www.dolthub.com/graphql', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        query: '{ currentUser { username } }',
+      }),
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as {
+      data?: { currentUser?: { username?: string } };
+      errors?: unknown[];
+    };
+
+    const username = data.data?.currentUser?.username;
+    if (username) {
+      return { username };
+    }
+  } catch {
+    // Ignore errors and fall through
+  }
+
+  return null;
+}
+
 export async function getValidDoltHubToken(
   integration: PlatformIntegration
 ): Promise<string | null> {
   assertDevOnly();
 
-  const metadata = integration.metadata as
-    | {
-        access_token?: string;
-        refresh_token?: string;
-        expires_at?: number;
-        scope?: string;
-      }
-    | null;
+  const metadata = integration.metadata as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_at?: number;
+    scope?: string;
+  } | null;
 
   if (!metadata?.access_token) {
     return null;

--- a/apps/web/src/routers/dolthub-router.ts
+++ b/apps/web/src/routers/dolthub-router.ts
@@ -91,14 +91,14 @@ export const dolthubRouter = createTRPCRouter({
     const data = await response.json();
 
     const DoltHubProfileResponseSchema = z.union([
-      z.array(z.record(z.unknown())),
-      z.object({ rows: z.array(z.record(z.unknown())).optional() }),
+      z.array(z.record(z.string(), z.unknown())),
+      z.object({ rows: z.array(z.record(z.string(), z.unknown())).optional() }),
     ]);
     const parsed = DoltHubProfileResponseSchema.safeParse(data);
     const rows = parsed.success
       ? Array.isArray(parsed.data)
         ? parsed.data
-        : parsed.data.rows ?? []
+        : (parsed.data.rows ?? [])
       : [];
     const sample = rows[0] ?? null;
 


### PR DESCRIPTION
## Summary

Adds the user-facing UI for the DoltHub OAuth integration (dev-only):

- `DoltHubIntegrationDetails` component mirroring `LinearIntegrationDetails`
- Personal and org integration pages under `/integrations/dolthub` and `/organizations/[id]/integrations/dolthub`
- DoltHub connect and callback API routes to complete the OAuth flow
- Wiring into `IntegrationsHub` to display the DoltHub card

The integration is gated behind `IS_DEVELOPMENT` — pages call `notFound()` in production, and the platform definition has `enabled: IS_DEVELOPMENT` so the hub card shows as "coming_soon" in production.

## Verification

- `pnpm --filter web typecheck` passes
- Verified the component structure matches existing integration patterns

## Visual Changes

N/A

## Reviewer Notes

- The DoltHub callback route fetches the username via DoltHub's GraphQL API (`currentUser { username }`). If this fails, it falls back to `'unknown'`.
- Fixed an existing type error in `dolthub-router.ts` where `z.record(z.unknown())` was missing the key schema argument required by the current Zod version.